### PR TITLE
Skip plugin reinstalls when npm updates are already current

### DIFF
--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -200,6 +200,84 @@ async function findPackedArchiveInDir(cwd: string): Promise<string | undefined> 
   return sortedByMtime[0]?.name;
 }
 
+function parseJsonCandidate(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const objectStart = trimmed.indexOf("{");
+  const arrayStart = trimmed.indexOf("[");
+  const starts = [objectStart, arrayStart].filter((value) => value >= 0).toSorted((a, b) => a - b);
+  const candidates = [trimmed, ...starts.map((index) => trimmed.slice(index))];
+
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+  }
+
+  return undefined;
+}
+
+export async function resolveNpmSpecMetadata(params: {
+  spec: string;
+  timeoutMs: number;
+  cwd?: string;
+}): Promise<
+  | {
+      ok: true;
+      metadata: NpmSpecResolution;
+    }
+  | {
+      ok: false;
+      error: string;
+    }
+> {
+  const res = await runCommandWithTimeout(
+    ["npm", "view", params.spec, "version", "dist.integrity", "dist.shasum", "name", "--json"],
+    {
+      timeoutMs: Math.max(params.timeoutMs, 60_000),
+      cwd: params.cwd ?? os.tmpdir(),
+      env: {
+        COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+      },
+    },
+  );
+  if (res.code !== 0) {
+    const raw = res.stderr.trim() || res.stdout.trim();
+    if (/E404|is not in this registry|No match found for version/i.test(raw)) {
+      return {
+        ok: false,
+        error: `Package not found on npm: ${params.spec}. See https://docs.openclaw.ai/tools/plugin for installable plugins.`,
+      };
+    }
+    return { ok: false, error: `npm view failed: ${raw}` };
+  }
+
+  const parsed = parseJsonCandidate(res.stdout || "");
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, error: "npm view returned invalid metadata" };
+  }
+
+  const rec = parsed as Record<string, unknown>;
+  const name = toOptionalString(rec.name);
+  const version = toOptionalString(rec.version);
+  return {
+    ok: true,
+    metadata: {
+      name,
+      version,
+      resolvedSpec: name && version ? `${name}@${version}` : undefined,
+      integrity: toOptionalString(rec["dist.integrity"]),
+      shasum: toOptionalString(rec["dist.shasum"]),
+      resolvedAt: new Date().toISOString(),
+    },
+  };
+}
+
 export async function packNpmSpecToArchive(params: {
   spec: string;
   timeoutMs: number;

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -239,7 +239,7 @@ export async function resolveNpmSpecMetadata(params: {
   const res = await runCommandWithTimeout(
     ["npm", "view", params.spec, "version", "dist.integrity", "dist.shasum", "name", "--json"],
     {
-      timeoutMs: Math.max(params.timeoutMs, 60_000),
+      timeoutMs: Math.max(params.timeoutMs, 60_000), // keep registry metadata probes above flaky short timeouts
       cwd: params.cwd ?? os.tmpdir(),
       env: {
         COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -249,6 +249,74 @@ describe("updateNpmInstalledPlugins", () => {
     expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to the installed manifest version when the installer omits version metadata", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-update-manifest-"));
+    tempDirs.push(root);
+    const installPath = path.join(root, "plugin");
+    await fs.mkdir(installPath, { recursive: true });
+    await fs.writeFile(
+      path.join(installPath, "package.json"),
+      JSON.stringify({ name: "@openclaw/test-plugin", version: "0.2.6" }),
+    );
+    resolveNpmSpecMetadataMock.mockResolvedValueOnce({
+      ok: true,
+      metadata: {
+        name: "@openclaw/test-plugin",
+        version: "0.2.7",
+        resolvedSpec: "@openclaw/test-plugin@0.2.7",
+        integrity: "sha512-registry",
+        shasum: "registry-shasum",
+      },
+    });
+    installPluginFromNpmSpecMock.mockImplementationOnce(async () => {
+      await fs.writeFile(
+        path.join(installPath, "package.json"),
+        JSON.stringify({ name: "@openclaw/test-plugin", version: "0.2.7" }),
+      );
+      return {
+        ok: true,
+        pluginId: "test",
+        targetDir: installPath,
+        version: undefined,
+        extensions: ["index.ts"],
+        npmResolution: {
+          name: "@openclaw/test-plugin",
+          version: "0.2.7",
+          resolvedSpec: "@openclaw/test-plugin@0.2.7",
+          integrity: "sha512-registry",
+          shasum: "registry-shasum",
+          resolvedAt: "2026-03-09T00:00:00.000Z",
+        },
+      };
+    });
+
+    const { updateNpmInstalledPlugins } = await import("./update.js");
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          installs: {
+            test: {
+              source: "npm",
+              spec: "@openclaw/test-plugin",
+              installPath,
+            },
+          },
+        },
+      },
+      pluginIds: ["test"],
+    });
+
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "test",
+        status: "updated",
+        currentVersion: "0.2.6",
+        nextVersion: "0.2.7",
+        message: "Updated test: 0.2.6 -> 0.2.7.",
+      },
+    ]);
+  });
+
   it("skips integrity drift checks for unpinned npm specs during dry-run updates", async () => {
     installPluginFromNpmSpecMock.mockResolvedValue({
       ok: true,

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1,7 +1,11 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const installPluginFromNpmSpecMock = vi.fn();
 const resolveBundledPluginSourcesMock = vi.fn();
+const resolveNpmSpecMetadataMock = vi.fn();
 
 vi.mock("./install.js", () => ({
   installPluginFromNpmSpec: (...args: unknown[]) => installPluginFromNpmSpecMock(...args),
@@ -15,10 +19,121 @@ vi.mock("./bundled-sources.js", () => ({
   resolveBundledPluginSources: (...args: unknown[]) => resolveBundledPluginSourcesMock(...args),
 }));
 
+vi.mock("../infra/install-source-utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/install-source-utils.js")>();
+  return {
+    ...actual,
+    resolveNpmSpecMetadata: (...args: unknown[]) => resolveNpmSpecMetadataMock(...args),
+  };
+});
+
 describe("updateNpmInstalledPlugins", () => {
   beforeEach(() => {
     installPluginFromNpmSpecMock.mockReset();
     resolveBundledPluginSourcesMock.mockReset();
+    resolveNpmSpecMetadataMock.mockReset();
+    resolveNpmSpecMetadataMock.mockResolvedValue({
+      ok: true,
+      metadata: {
+        name: "@openclaw/test-plugin",
+        version: "0.2.6",
+        resolvedSpec: "@openclaw/test-plugin@0.2.6",
+        integrity: "sha512-registry",
+        shasum: "registry-shasum",
+      },
+    });
+  });
+
+  it("skips reinstalling already up-to-date plugins before download", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-update-"));
+    const installPath = path.join(root, "plugin");
+    await fs.mkdir(installPath, { recursive: true });
+    await fs.writeFile(
+      path.join(installPath, "package.json"),
+      JSON.stringify({ name: "@openclaw/test-plugin", version: "0.2.6" }),
+    );
+
+    const { updateNpmInstalledPlugins } = await import("./update.js");
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          installs: {
+            test: {
+              source: "npm",
+              spec: "@openclaw/test-plugin",
+              installPath,
+            },
+          },
+        },
+      },
+      pluginIds: ["test"],
+    });
+
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "test",
+        status: "unchanged",
+        currentVersion: "0.2.6",
+        nextVersion: "0.2.6",
+        message: "test already at 0.2.6.",
+      },
+    ]);
+  });
+
+  it("does not skip pinned installs when npm metadata shows integrity drift", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-update-drift-"));
+    const installPath = path.join(root, "plugin");
+    await fs.mkdir(installPath, { recursive: true });
+    await fs.writeFile(
+      path.join(installPath, "package.json"),
+      JSON.stringify({ name: "@openclaw/test-plugin", version: "0.2.6" }),
+    );
+    resolveNpmSpecMetadataMock.mockResolvedValueOnce({
+      ok: true,
+      metadata: {
+        name: "@openclaw/test-plugin",
+        version: "0.2.6",
+        resolvedSpec: "@openclaw/test-plugin@0.2.6",
+        integrity: "sha512-new",
+        shasum: "new-shasum",
+      },
+    });
+    installPluginFromNpmSpecMock.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "test",
+      targetDir: installPath,
+      version: "0.2.6",
+      extensions: ["index.ts"],
+      npmResolution: {
+        name: "@openclaw/test-plugin",
+        version: "0.2.6",
+        resolvedSpec: "@openclaw/test-plugin@0.2.6",
+        integrity: "sha512-new",
+        shasum: "new-shasum",
+        resolvedAt: "2026-03-09T00:00:00.000Z",
+      },
+    });
+
+    const { updateNpmInstalledPlugins } = await import("./update.js");
+    await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          installs: {
+            test: {
+              source: "npm",
+              spec: "@openclaw/test-plugin@0.2.6",
+              integrity: "sha512-old",
+              shasum: "old-shasum",
+              installPath,
+            },
+          },
+        },
+      },
+      pluginIds: ["test"],
+    });
+
+    expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
   });
 
   it("skips integrity drift checks for unpinned npm specs during dry-run updates", async () => {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1,11 +1,12 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const installPluginFromNpmSpecMock = vi.fn();
 const resolveBundledPluginSourcesMock = vi.fn();
 const resolveNpmSpecMetadataMock = vi.fn();
+let tempDirs: string[] = [];
 
 vi.mock("./install.js", () => ({
   installPluginFromNpmSpec: (...args: unknown[]) => installPluginFromNpmSpecMock(...args),
@@ -28,6 +29,11 @@ vi.mock("../infra/install-source-utils.js", async (importOriginal) => {
 });
 
 describe("updateNpmInstalledPlugins", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+    tempDirs = [];
+  });
+
   beforeEach(() => {
     installPluginFromNpmSpecMock.mockReset();
     resolveBundledPluginSourcesMock.mockReset();
@@ -46,6 +52,7 @@ describe("updateNpmInstalledPlugins", () => {
 
   it("skips reinstalling already up-to-date plugins before download", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-update-"));
+    tempDirs.push(root);
     const installPath = path.join(root, "plugin");
     await fs.mkdir(installPath, { recursive: true });
     await fs.writeFile(
@@ -83,6 +90,7 @@ describe("updateNpmInstalledPlugins", () => {
 
   it("does not skip pinned installs when npm metadata shows integrity drift", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-update-drift-"));
+    tempDirs.push(root);
     const installPath = path.join(root, "plugin");
     await fs.mkdir(installPath, { recursive: true });
     await fs.writeFile(
@@ -133,6 +141,111 @@ describe("updateNpmInstalledPlugins", () => {
       pluginIds: ["test"],
     });
 
+    expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the installer when probe metadata no longer matches the last validated artifact", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-update-mismatch-"));
+    tempDirs.push(root);
+    const installPath = path.join(root, "plugin");
+    await fs.mkdir(installPath, { recursive: true });
+    await fs.writeFile(
+      path.join(installPath, "package.json"),
+      JSON.stringify({ name: "@openclaw/original-plugin", version: "0.2.6" }),
+    );
+    resolveNpmSpecMetadataMock.mockResolvedValueOnce({
+      ok: true,
+      metadata: {
+        name: "@openclaw/other-plugin",
+        version: "0.2.6",
+        resolvedSpec: "@openclaw/other-plugin@0.2.6",
+        integrity: "sha512-other",
+        shasum: "other-shasum",
+      },
+    });
+    installPluginFromNpmSpecMock.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "test",
+      targetDir: installPath,
+      version: "0.2.6",
+      extensions: ["index.ts"],
+      npmResolution: {
+        name: "@openclaw/other-plugin",
+        version: "0.2.6",
+        resolvedSpec: "@openclaw/other-plugin@0.2.6",
+        integrity: "sha512-other",
+        shasum: "other-shasum",
+        resolvedAt: "2026-03-09T00:00:00.000Z",
+      },
+    });
+
+    const { updateNpmInstalledPlugins } = await import("./update.js");
+    await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          installs: {
+            test: {
+              source: "npm",
+              spec: "@openclaw/other-plugin",
+              resolvedSpec: "@openclaw/original-plugin@0.2.6",
+              resolvedName: "@openclaw/original-plugin",
+              resolvedVersion: "0.2.6",
+              installPath,
+            },
+          },
+        },
+      },
+      pluginIds: ["test"],
+    });
+
+    expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the installer when the probe throws", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-update-probe-error-"));
+    tempDirs.push(root);
+    const installPath = path.join(root, "plugin");
+    await fs.mkdir(installPath, { recursive: true });
+    await fs.writeFile(
+      path.join(installPath, "package.json"),
+      JSON.stringify({ name: "@openclaw/test-plugin", version: "0.2.6" }),
+    );
+    resolveNpmSpecMetadataMock.mockRejectedValueOnce(new Error("spawn npm ENOENT"));
+    installPluginFromNpmSpecMock.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "test",
+      targetDir: installPath,
+      version: "0.2.6",
+      extensions: ["index.ts"],
+      npmResolution: {
+        name: "@openclaw/test-plugin",
+        version: "0.2.6",
+        resolvedSpec: "@openclaw/test-plugin@0.2.6",
+        integrity: "sha512-registry",
+        shasum: "registry-shasum",
+        resolvedAt: "2026-03-09T00:00:00.000Z",
+      },
+    });
+    const warn = vi.fn();
+
+    const { updateNpmInstalledPlugins } = await import("./update.js");
+    await updateNpmInstalledPlugins({
+      logger: { warn },
+      config: {
+        plugins: {
+          installs: {
+            test: {
+              source: "npm",
+              spec: "@openclaw/test-plugin",
+              installPath,
+            },
+          },
+        },
+      },
+      pluginIds: ["test"],
+    });
+
+    expect(warn).toHaveBeenCalledWith('Skipping pre-check for "test": Error: spawn npm ENOENT');
     expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -505,7 +505,8 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
 
-    const nextVersion = result.version ?? (await readInstalledPackageVersion(result.targetDir));
+    const nextVersion =
+      result.version ?? (await readInstalledPackageManifest(result.targetDir)).version ?? null;
     next = recordPluginInstall(next, {
       pluginId,
       source: "npm",

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -2,6 +2,7 @@ import fsSync from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
+import { resolveNpmSpecMetadata, type NpmSpecResolution } from "../infra/install-source-utils.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveBundledPluginSources } from "./bundled-sources.js";
@@ -100,6 +101,63 @@ function expectedIntegrityForUpdate(
     return undefined;
   }
   return integrity;
+}
+
+function hasIntegrityDrift(params: {
+  expectedIntegrity?: string;
+  expectedShasum?: string;
+  metadata: NpmSpecResolution;
+}): boolean {
+  if (params.expectedIntegrity) {
+    if (!params.metadata.integrity) {
+      return true;
+    }
+    return params.expectedIntegrity !== params.metadata.integrity;
+  }
+  if (params.expectedShasum) {
+    if (!params.metadata.shasum) {
+      return true;
+    }
+    return params.expectedShasum !== params.metadata.shasum;
+  }
+  return false;
+}
+
+async function probeNpmUpdateTarget(params: {
+  spec: string;
+  currentVersion?: string;
+  expectedIntegrity?: string;
+  expectedShasum?: string;
+}): Promise<
+  { ok: true; unchanged: boolean; metadata: NpmSpecResolution } | { ok: false; error: string }
+> {
+  const probe = await resolveNpmSpecMetadata({
+    spec: params.spec,
+    timeoutMs: 120_000,
+  });
+  if (!probe.ok) {
+    return probe;
+  }
+
+  const sameVersion =
+    !!params.currentVersion &&
+    !!probe.metadata.version &&
+    params.currentVersion === probe.metadata.version;
+  if (!sameVersion) {
+    return { ok: true, unchanged: false, metadata: probe.metadata };
+  }
+
+  if (
+    hasIntegrityDrift({
+      expectedIntegrity: params.expectedIntegrity,
+      expectedShasum: params.expectedShasum,
+      metadata: probe.metadata,
+    })
+  ) {
+    return { ok: true, unchanged: false, metadata: probe.metadata };
+  }
+
+  return { ok: true, unchanged: true, metadata: probe.metadata };
 }
 
 async function readInstalledPackageVersion(dir: string): Promise<string | undefined> {
@@ -259,6 +317,24 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
     const currentVersion = await readInstalledPackageVersion(installPath);
+    const expectedIntegrity = expectedIntegrityForUpdate(record.spec, record.integrity);
+    const versionProbe = await probeNpmUpdateTarget({
+      spec: record.spec,
+      currentVersion,
+      expectedIntegrity,
+      expectedShasum: record.shasum,
+    });
+    if (versionProbe.ok && versionProbe.unchanged) {
+      const version = versionProbe.metadata.version ?? currentVersion ?? "unknown";
+      outcomes.push({
+        pluginId,
+        status: "unchanged",
+        currentVersion: currentVersion ?? undefined,
+        nextVersion: versionProbe.metadata.version ?? undefined,
+        message: `${pluginId} already at ${version}.`,
+      });
+      continue;
+    }
 
     if (params.dryRun) {
       let probe: Awaited<ReturnType<typeof installPluginFromNpmSpec>>;
@@ -268,7 +344,7 @@ export async function updateNpmInstalledPlugins(params: {
           mode: "update",
           dryRun: true,
           expectedPluginId: pluginId,
-          expectedIntegrity: expectedIntegrityForUpdate(record.spec, record.integrity),
+          expectedIntegrity,
           onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
             pluginId,
             dryRun: true,
@@ -327,7 +403,7 @@ export async function updateNpmInstalledPlugins(params: {
         spec: record.spec,
         mode: "update",
         expectedPluginId: pluginId,
-        expectedIntegrity: expectedIntegrityForUpdate(record.spec, record.integrity),
+        expectedIntegrity,
         onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
           pluginId,
           dryRun: false,

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -103,6 +103,39 @@ function expectedIntegrityForUpdate(
   return integrity;
 }
 
+function matchesPreviouslyValidatedArtifact(params: {
+  record: {
+    resolvedSpec?: string;
+    resolvedName?: string;
+    resolvedVersion?: string;
+    integrity?: string;
+    shasum?: string;
+  };
+  metadata: NpmSpecResolution;
+}): boolean {
+  if (params.record.resolvedSpec && params.metadata.resolvedSpec) {
+    return params.record.resolvedSpec === params.metadata.resolvedSpec;
+  }
+  if (
+    params.record.resolvedName &&
+    params.record.resolvedVersion &&
+    params.metadata.name &&
+    params.metadata.version
+  ) {
+    return (
+      params.record.resolvedName === params.metadata.name &&
+      params.record.resolvedVersion === params.metadata.version
+    );
+  }
+  if (params.record.integrity && params.metadata.integrity) {
+    return params.record.integrity === params.metadata.integrity;
+  }
+  if (params.record.shasum && params.metadata.shasum) {
+    return params.record.shasum === params.metadata.shasum;
+  }
+  return false;
+}
+
 function hasIntegrityDrift(params: {
   expectedIntegrity?: string;
   expectedShasum?: string;
@@ -128,6 +161,13 @@ async function probeNpmUpdateTarget(params: {
   currentVersion?: string;
   expectedIntegrity?: string;
   expectedShasum?: string;
+  validatedArtifact: {
+    resolvedSpec?: string;
+    resolvedName?: string;
+    resolvedVersion?: string;
+    integrity?: string;
+    shasum?: string;
+  };
 }): Promise<
   { ok: true; unchanged: boolean; metadata: NpmSpecResolution } | { ok: false; error: string }
 > {
@@ -148,6 +188,15 @@ async function probeNpmUpdateTarget(params: {
   }
 
   if (
+    !matchesPreviouslyValidatedArtifact({
+      record: params.validatedArtifact,
+      metadata: probe.metadata,
+    })
+  ) {
+    return { ok: true, unchanged: false, metadata: probe.metadata };
+  }
+
+  if (
     hasIntegrityDrift({
       expectedIntegrity: params.expectedIntegrity,
       expectedShasum: params.expectedShasum,
@@ -160,7 +209,10 @@ async function probeNpmUpdateTarget(params: {
   return { ok: true, unchanged: true, metadata: probe.metadata };
 }
 
-async function readInstalledPackageVersion(dir: string): Promise<string | undefined> {
+async function readInstalledPackageManifest(dir: string): Promise<{
+  name?: string;
+  version?: string;
+}> {
   const manifestPath = path.join(dir, "package.json");
   const opened = openBoundaryFileSync({
     absolutePath: manifestPath,
@@ -168,14 +220,17 @@ async function readInstalledPackageVersion(dir: string): Promise<string | undefi
     boundaryLabel: "installed plugin directory",
   });
   if (!opened.ok) {
-    return undefined;
+    return {};
   }
   try {
     const raw = fsSync.readFileSync(opened.fd, "utf-8");
-    const parsed = JSON.parse(raw) as { version?: unknown };
-    return typeof parsed.version === "string" ? parsed.version : undefined;
+    const parsed = JSON.parse(raw) as { name?: unknown; version?: unknown };
+    return {
+      name: typeof parsed.name === "string" ? parsed.name : undefined,
+      version: typeof parsed.version === "string" ? parsed.version : undefined,
+    };
   } catch {
-    return undefined;
+    return {};
   } finally {
     fsSync.closeSync(opened.fd);
   }
@@ -316,15 +371,31 @@ export async function updateNpmInstalledPlugins(params: {
       });
       continue;
     }
-    const currentVersion = await readInstalledPackageVersion(installPath);
+    const currentManifest = await readInstalledPackageManifest(installPath);
+    const currentVersion = currentManifest.version;
     const expectedIntegrity = expectedIntegrityForUpdate(record.spec, record.integrity);
-    const versionProbe = await probeNpmUpdateTarget({
-      spec: record.spec,
-      currentVersion,
-      expectedIntegrity,
-      expectedShasum: record.shasum,
-    });
-    if (versionProbe.ok && versionProbe.unchanged) {
+    let versionProbe: Awaited<ReturnType<typeof probeNpmUpdateTarget>> | null = null;
+    try {
+      versionProbe = await probeNpmUpdateTarget({
+        spec: record.spec,
+        currentVersion,
+        expectedIntegrity,
+        expectedShasum: record.shasum,
+        validatedArtifact: {
+          resolvedSpec: record.resolvedSpec,
+          resolvedName: record.resolvedName ?? currentManifest.name,
+          resolvedVersion: record.resolvedVersion ?? currentVersion,
+          integrity: record.integrity,
+          shasum: record.shasum,
+        },
+      });
+    } catch (err) {
+      logger.warn?.(`Skipping pre-check for "${pluginId}": ${String(err)}`);
+    }
+    if (versionProbe && !versionProbe.ok) {
+      logger.warn?.(`Skipping pre-check for "${pluginId}": ${versionProbe.error}`);
+    }
+    if (versionProbe?.ok && versionProbe.unchanged) {
       const version = versionProbe.metadata.version ?? currentVersion ?? "unknown";
       outcomes.push({
         pluginId,


### PR DESCRIPTION
Fixes #40912

## Summary

`openclaw plugins update --all` currently goes straight into the full download/extract/install path before discovering that a plugin is already current.

This change adds a lightweight npm registry metadata probe before the installer path:

- fetch the current registry version/integrity with `npm view`
- skip the reinstall path when the installed version already matches the registry metadata
- still fall back to the existing install flow when the version differs, the integrity differs for pinned installs, or the metadata probe cannot make a safe decision

## Verification

```bash
pnpm vitest run src/plugins/update.test.ts
```
