### PR TITLE
fix(bluebubbles): trim leading newlines from message text

### DIFF
--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -292,12 +292,13 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
       return { ok: true, to: trimmed };
     },
     sendText: async ({ cfg, to, text, accountId, replyToId }) => {
+      const trimmedText = text.trimStart();
       const rawReplyToId = typeof replyToId === "string" ? replyToId.trim() : "";
       // Resolve short ID (e.g., "5") to full UUID
       const replyToMessageGuid = rawReplyToId
         ? resolveBlueBubblesMessageId(rawReplyToId, { requireKnownShortId: true })
         : "";
-      const result = await sendMessageBlueBubbles(to, text, {
+      const result = await sendMessageBlueBubbles(to, trimmedText, {
         cfg: cfg,
         accountId: accountId ?? undefined,
         replyToMessageGuid: replyToMessageGuid || undefined,

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -363,7 +363,7 @@ export async function sendMessageBlueBubbles(
   text: string,
   opts: BlueBubblesSendOpts = {},
 ): Promise<BlueBubblesSendResult> {
-  const trimmedText = text ?? "";
+  const trimmedText = (text ?? "").trimStart();
   if (!trimmedText.trim()) {
     throw new Error("BlueBubbles send requires text");
   }

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -114,7 +114,9 @@ export function createBlockReplyCoalescer(params: {
       bufferAudioAsVoice = payload.audioAsVoice;
     }
 
-    const nextText = bufferText ? `${bufferText}${joiner}${text}` : text;
+    const nextText = bufferText
+      ? `${bufferText}${joiner}${joiner ? text.trimStart() : text}`
+      : text.trimStart();
     if (nextText.length > maxChars) {
       if (bufferText) {
         void flush({ force: true });


### PR DESCRIPTION
## Summary

Fixes #12770 - BlueBubbles messages with leading newlines

## Changes

- **extensions/bluebubbles/src/send.ts**: Add  to text before sending
- **extensions/bluebubbles/src/channel.ts**: Trim text in  before calling   
- **src/auto-reply/reply/block-reply-coalescer.ts**: Trim leading whitespace when joining text chunks with joiner

## Testing

All 287 BlueBubbles tests pass.

## Impact

iMessages sent via BlueBubbles after tool calls will no longer have leading blank lines.