### PR TITLE
fix(compaction): use file logger instead of console.warn (#26010)

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -726,7 +726,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       // Use a WeakSet to track which session managers have already logged the warning.
       if (!ctx.model && !runtime?.model && !missedModelWarningSessions.has(ctx.sessionManager)) {
         missedModelWarningSessions.add(ctx.sessionManager);
-        console.warn(
+        log.warn(
           "[compaction-safeguard] Both ctx.model and runtime.model are undefined. " +
             "Compaction summarization will not run. This indicates extensionRunner.initialize() " +
             "was not called and model was not passed through runtime registry.",
@@ -737,7 +737,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
 
     const apiKey = await ctx.modelRegistry.getApiKey(model);
     if (!apiKey) {
-      console.warn(
+      log.warn(
         "Compaction safeguard: no API key available; cancelling compaction to preserve history.",
       );
       return { cancel: true };


### PR DESCRIPTION
## Summary

Replace `console.warn` with `log.warn` in the `session_before_compact` handler in `compaction-safeguard.ts`.

## Problem

In issue #26010, the compaction safeguard silently cancels when the summarization model's API key can't be resolved. The problem is that `console.warn` does NOT go to the file logger, so there's zero evidence in production logs that compaction was cancelled.

## Fix

Changed 2 instances of `console.warn` to `log.warn`:

1. Line ~729: Model undefined warning  
2. Line ~740: API key unavailable warning

This ensures cancellation events appear in the file logger for production debugging.

## Related

- #26010
- Issue: "Compaction safeguard silently cancels when API key unavailable — sessions grow unbounded"