### PR TITLE
[AI-assisted] Agents: add UTC time to session status

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -97,6 +97,28 @@ function getSessionStatusTool(agentSessionKey = "main") {
 }
 
 describe("session_status tool", () => {
+  it("includes a machine-readable UTC time in the status card", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T10:15:00Z"));
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+      },
+    });
+
+    try {
+      const tool = getSessionStatusTool();
+
+      const result = await tool.execute("call-time", {});
+      const details = result.details as { ok?: boolean; statusText?: string };
+      expect(details.ok).toBe(true);
+      expect(details.statusText).toContain("2026-03-09 10:15 UTC");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("returns a status card for the current session", async () => {
     resetSessionStore({
       main: {

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 
 const loadSessionStoreMock = vi.fn();
 const updateSessionStoreMock = vi.fn();
+const { formatUserTimeMock, realFormatUserTime } = vi.hoisted(() => ({
+  formatUserTimeMock: vi.fn(),
+  realFormatUserTime: vi.fn(),
+}));
 
 vi.mock("../config/sessions.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/sessions.js")>();
@@ -76,6 +80,16 @@ vi.mock("../infra/provider-usage.js", () => ({
   formatUsageSummaryLine: () => null,
 }));
 
+vi.mock("../agents/date-time.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/date-time.js")>();
+  realFormatUserTime.mockImplementation(actual.formatUserTime);
+  return {
+    ...actual,
+    formatUserTime: (...args: Parameters<typeof actual.formatUserTime>) =>
+      formatUserTimeMock(...args),
+  };
+});
+
 import "./test-helpers/fast-core-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 
@@ -83,6 +97,10 @@ function resetSessionStore(store: Record<string, unknown>) {
   loadSessionStoreMock.mockClear();
   updateSessionStoreMock.mockClear();
   loadSessionStoreMock.mockReturnValue(store);
+  formatUserTimeMock.mockReset();
+  formatUserTimeMock.mockImplementation((date, timeZone, format) =>
+    realFormatUserTime(date, timeZone, format),
+  );
 }
 
 function getSessionStatusTool(agentSessionKey = "main") {
@@ -113,6 +131,30 @@ describe("session_status tool", () => {
       const result = await tool.execute("call-time", {});
       const details = result.details as { ok?: boolean; statusText?: string };
       expect(details.ok).toBe(true);
+      expect(details.statusText).toContain("2026-03-09 10:15 UTC");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("includes a machine-readable UTC time even when localized time formatting fails", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T10:15:00Z"));
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+      },
+    });
+    formatUserTimeMock.mockReturnValueOnce(undefined);
+
+    try {
+      const tool = getSessionStatusTool();
+
+      const result = await tool.execute("call-time-fallback", {});
+      const details = result.details as { ok?: boolean; statusText?: string };
+      expect(details.ok).toBe(true);
+      expect(details.statusText).toContain("🕒 Time zone:");
       expect(details.statusText).toContain("2026-03-09 10:15 UTC");
     } finally {
       vi.useRealTimers();

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -341,11 +341,13 @@ export function createSessionStatusTool(opts?: {
         resolved.entry.queueDebounceMs ?? resolved.entry.queueCap ?? resolved.entry.queueDrop,
       );
 
+      const nowMs = Date.now();
       const userTimezone = resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
       const userTimeFormat = resolveUserTimeFormat(cfg.agents?.defaults?.timeFormat);
-      const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+      const userTime = formatUserTime(new Date(nowMs), userTimezone, userTimeFormat);
+      const utcTime = new Date(nowMs).toISOString().replace("T", " ").slice(0, 16) + " UTC";
       const timeLine = userTime
-        ? `🕒 Time: ${userTime} (${userTimezone})`
+        ? `🕒 Time: ${userTime} (${userTimezone}) / ${utcTime}`
         : `🕒 Time zone: ${userTimezone}`;
 
       const agentDefaults = cfg.agents?.defaults ?? {};

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -348,7 +348,7 @@ export function createSessionStatusTool(opts?: {
       const utcTime = new Date(nowMs).toISOString().replace("T", " ").slice(0, 16) + " UTC";
       const timeLine = userTime
         ? `🕒 Time: ${userTime} (${userTimezone}) / ${utcTime}`
-        : `🕒 Time zone: ${userTimezone}`;
+        : `🕒 Time zone: ${userTimezone} / ${utcTime}`;
 
       const agentDefaults = cfg.agents?.defaults ?? {};
       const defaultLabel = `${configured.provider}/${configured.model}`;


### PR DESCRIPTION
## Summary

Add a machine-readable UTC timestamp to `session_status` so agents can reliably infer the current time from the status card, instead of parsing only the localized human-readable string.

## Why

Some reminder and scheduling flows depend on the agent understanding "current time" precisely. The existing `session_status` output included localized time, but not a stable UTC representation. This makes time parsing more fragile across locales and formats.

## What changed

- append a `YYYY-MM-DD HH:MM UTC` timestamp to the `🕒 Time:` line in `session_status`
- add a regression test that freezes time and asserts the UTC marker is present

## Testing

- fully tested
- `npx pnpm@10.23.0 vitest run src/agents/openclaw-tools.session-status.test.ts`

## AI assistance

This PR was AI-assisted. I reviewed the change and understand what it does.
