### PR TITLE
fix(agents): respect user-configured supportsUsageInStreaming on non-native endpoints

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -262,13 +262,25 @@ describe("normalizeModelCompat", () => {
     expect(supportsDeveloperRole(normalized)).toBe(false);
   });
 
-  it("overrides explicit supportsUsageInStreaming true on non-native endpoints", () => {
+  it("respects explicit supportsUsageInStreaming true on non-native endpoints", () => {
     const model = {
       ...baseModel(),
       provider: "custom-cpa",
       baseUrl: "https://proxy.example.com/v1",
       compat: { supportsUsageInStreaming: true },
     };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+  });
+
+  it("defaults supportsUsageInStreaming to false when not explicitly set", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom-cpa",
+      baseUrl: "https://proxy.example.com/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
     const normalized = normalizeModelCompat(model);
     expect(supportsUsageInStreaming(normalized)).toBe(false);
   });

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -55,17 +55,24 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   // The `developer` role and stream usage chunks are OpenAI-native behaviors.
   // Many OpenAI-compatible backends reject `developer` and/or emit usage-only
   // chunks that break strict parsers expecting choices[0]. For non-native
-  // openai-completions endpoints, force both compat flags off.
+  // openai-completions endpoints, default both compat flags to off but respect
+  // explicit user overrides from config.
   const compat = model.compat ?? undefined;
   // When baseUrl is empty the pi-ai library defaults to api.openai.com, so
   // leave compat unchanged and let default native behavior apply.
-  // Note: explicit true values are intentionally overridden for non-native
-  // endpoints for safety.
   const needsForce = baseUrl ? !isOpenAINativeEndpoint(baseUrl) : false;
   if (!needsForce) {
     return model;
   }
-  if (compat?.supportsDeveloperRole === false && compat?.supportsUsageInStreaming === false) {
+
+  // Honour explicit user opt-in: if the user has set supportsUsageInStreaming
+  // to true in their model config, keep it enabled.  This lets proxies that
+  // correctly implement usage streaming (e.g. LiteLLM) report token counts.
+  const keepUsage = compat?.supportsUsageInStreaming === true;
+  if (
+    compat?.supportsDeveloperRole === false &&
+    (compat?.supportsUsageInStreaming === false || keepUsage)
+  ) {
     return model;
   }
 
@@ -73,7 +80,7 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   return {
     ...model,
     compat: compat
-      ? { ...compat, supportsDeveloperRole: false, supportsUsageInStreaming: false }
+      ? { ...compat, supportsDeveloperRole: false, supportsUsageInStreaming: keepUsage }
       : { supportsDeveloperRole: false, supportsUsageInStreaming: false },
   } as typeof model;
 }


### PR DESCRIPTION
## Summary

- #8714 unconditionally forces `supportsUsageInStreaming=false` for **all** non-native `openai-completions` endpoints. This breaks token counting for proxies like LiteLLM that correctly implement usage streaming — context utilization displays as `0` in `/status`.
- This PR honours explicit `compat.supportsUsageInStreaming: true` set by users in their model config, while keeping the safe default of `false` for endpoints that do not opt in.

## Problem

After #8714, any user connecting through a compliant proxy (e.g. LiteLLM) that supports `stream_options: { include_usage: true }` loses all token counting because the normalisation layer silently overrides their config. The `totalTokens` field stays at 0, `totalTokensFresh` is set to `false`, and context utilisation is shown as unknown/0.

## Fix

In `normalizeModelCompat()`, check whether the user has explicitly set `supportsUsageInStreaming: true` in their model compat config. If so, preserve that intent instead of forcing it off. The default behaviour (force off) is unchanged for models without an explicit opt-in, so endpoints that emit malformed usage-only chunks (the original #8714 bug) remain protected.

## Test plan

- [x] Updated existing test: respects explicit supportsUsageInStreaming true on non-native endpoints
- [x] Added new test: defaults supportsUsageInStreaming to false when not explicitly set
- [x] All 33 tests in model-compat.test.ts pass
