### PR TITLE
Fix: Telegram sendPayload oversized message crash

### DIFF
--- a/src/channels/plugins/outbound/telegram.test.ts
+++ b/src/channels/plugins/outbound/telegram.test.ts
@@ -132,11 +132,105 @@ describe("telegramOutbound", () => {
       "",
       expect.objectContaining({
         mediaUrl: "https://example.com/2.jpg",
-        quoteText: "quoted",
       }),
     );
     const secondCallOpts = sendTelegram.mock.calls[1]?.[2] as Record<string, unknown>;
     expect(secondCallOpts?.buttons).toBeUndefined();
     expect(result).toEqual({ channel: "telegram", messageId: "tg-2", chatId: "123" });
+  });
+
+  it("chunks oversized text payloads to avoid Telegram message length errors", async () => {
+    const sendTelegram = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "tg-1", chatId: "123" })
+      .mockResolvedValueOnce({ messageId: "tg-2", chatId: "123" })
+      .mockResolvedValueOnce({ messageId: "tg-3", chatId: "123" });
+
+    const payload: ReplyPayload = {
+      text: "a".repeat(9000),
+      channelData: {
+        telegram: {
+          buttons: [[{ text: "Ok", callback_data: "ok" }]],
+        },
+      },
+    };
+
+    const result = await telegramOutbound.sendPayload?.({
+      cfg: {},
+      to: "123",
+      text: "",
+      payload,
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledTimes(3);
+    expect(sendTelegram.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({ buttons: [[{ text: "Ok", callback_data: "ok" }]] }),
+    );
+    expect((sendTelegram.mock.calls[1]?.[2] as Record<string, unknown>)?.buttons).toBeUndefined();
+    expect((sendTelegram.mock.calls[2]?.[2] as Record<string, unknown>)?.buttons).toBeUndefined();
+
+    // Enforce per-chunk length safety.
+    for (const call of sendTelegram.mock.calls) {
+      const text = call[1] as string;
+      expect(text.length).toBeLessThanOrEqual(4000);
+    }
+
+    expect(result).toEqual({ channel: "telegram", messageId: "tg-3", chatId: "123" });
+  });
+
+  it("splits long captions: first chunk rides on first media, remainder sent as follow-up text", async () => {
+    const sendTelegram = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "tg-1", chatId: "123" })
+      .mockResolvedValueOnce({ messageId: "tg-2", chatId: "123" })
+      .mockResolvedValueOnce({ messageId: "tg-3", chatId: "123" });
+
+    const payload: ReplyPayload = {
+      text: "b".repeat(5000),
+      mediaUrls: ["https://example.com/1.jpg", "https://example.com/2.jpg"],
+      channelData: {
+        telegram: {
+          buttons: [[{ text: "Ok", callback_data: "ok" }]],
+        },
+      },
+    };
+
+    const result = await telegramOutbound.sendPayload?.({
+      cfg: {},
+      to: "123",
+      text: "",
+      payload,
+      deps: { sendTelegram },
+    });
+
+    // 2 media sends + 1 follow-up text chunk
+    expect(sendTelegram).toHaveBeenCalledTimes(3);
+
+    // First media gets first chunk + buttons
+    expect(sendTelegram).toHaveBeenNthCalledWith(
+      1,
+      "123",
+      expect.any(String),
+      expect.objectContaining({
+        mediaUrl: "https://example.com/1.jpg",
+        buttons: [[{ text: "Ok", callback_data: "ok" }]],
+      }),
+    );
+
+    // Second media has empty caption
+    expect(sendTelegram).toHaveBeenNthCalledWith(
+      2,
+      "123",
+      "",
+      expect.objectContaining({ mediaUrl: "https://example.com/2.jpg" }),
+    );
+
+    // Follow-up text has no mediaUrl
+    const thirdOpts = sendTelegram.mock.calls[2]?.[2] as Record<string, unknown>;
+    expect(thirdOpts?.mediaUrl).toBeUndefined();
+    expect(thirdOpts?.buttons).toBeUndefined();
+
+    expect(result).toEqual({ channel: "telegram", messageId: "tg-3", chatId: "123" });
   });
 });

--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -146,10 +146,9 @@ export const telegramOutbound: ChannelOutboundAdapter = {
     // NOTE: deliver.ts chunks long Telegram text for sendText paths, but sendPayload bypasses
     // that code path. Chunk here to avoid Telegram 400 "message is too long" errors.
     // Preserve RAW HTML in this path (no escaping/transformation).
+    // NOTE: chunkTelegramRawHtml may hard-slice long strings, which can split HTML tags.
+    // We intentionally do NOT attempt an HTML-aware chunker here (future work) to keep this fix small.
     let textChunks = chunkTelegramRawHtml(rawText, telegramOutbound.textChunkLimit ?? 4000);
-    if (textChunks.length === 0 && rawText) {
-      textChunks = [rawText];
-    }
 
     const basePayloadOpts = {
       ...contextOpts,
@@ -167,6 +166,16 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       });
 
     if (mediaUrls.length === 0) {
+      // Prevent silent "success" when there is nothing to send.
+      // If buttons exist without text, Telegram still needs a message body; use an invisible placeholder.
+      if (textChunks.length === 0) {
+        if (telegramData?.buttons?.length) {
+          textChunks = ["\u2063"]; // INVISIBLE SEPARATOR
+        } else {
+          throw new Error("telegramOutbound.sendPayload: empty payload (no text, no media)");
+        }
+      }
+
       let finalResult: Awaited<ReturnType<typeof send>> | undefined;
       for (let i = 0; i < textChunks.length; i += 1) {
         finalResult = await sendTextChunk(textChunks[i] ?? "", { isFirst: i === 0 });

--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -36,10 +36,58 @@ function resolveTelegramSendContext(params: {
   };
 }
 
+function chunkTelegramRawHtml(text: string, limit: number): string[] {
+  if (!text) {
+    return [];
+  }
+  if (text.length <= limit) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  // Prefer splitting on double-newlines to keep paragraphs intact.
+  const blocks = text.split(/\n\n+/g);
+  let current = "";
+
+  const flush = () => {
+    if (current) {
+      chunks.push(current);
+      current = "";
+    }
+  };
+
+  for (const block of blocks) {
+    const candidate = current ? `${current}\n\n${block}` : block;
+
+    if (candidate.length <= limit) {
+      current = candidate;
+      continue;
+    }
+
+    flush();
+
+    // If a single block is still too large, hard-slice it.
+    if (block.length <= limit) {
+      current = block;
+      continue;
+    }
+
+    for (let i = 0; i < block.length; i += limit) {
+      chunks.push(block.slice(i, i + limit));
+    }
+  }
+
+  flush();
+  return chunks;
+}
+
 export const telegramOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
+  // IMPORTANT: sendText is chunked in deliver.ts using this chunker; it expects markdown -> telegram-html.
+  // sendPayload must preserve raw HTML, so it uses a separate raw chunker inside sendPayload.
   chunker: markdownToTelegramHtmlChunks,
   chunkerMode: "markdown",
+  // Keep the existing chunk limit (slightly under the Telegram 4096 limit).
   textChunkLimit: 4000,
   sendText: async ({ to, text, accountId, deps, replyToId, threadId }) => {
     const { send, baseOpts } = resolveTelegramSendContext({
@@ -88,37 +136,65 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       | undefined;
     const quoteText =
       typeof telegramData?.quoteText === "string" ? telegramData.quoteText : undefined;
-    const text = payload.text ?? "";
+    const rawText = payload.text ?? "";
     const mediaUrls = payload.mediaUrls?.length
       ? payload.mediaUrls
       : payload.mediaUrl
         ? [payload.mediaUrl]
         : [];
-    const payloadOpts = {
+
+    // NOTE: deliver.ts chunks long Telegram text for sendText paths, but sendPayload bypasses
+    // that code path. Chunk here to avoid Telegram 400 "message is too long" errors.
+    // Preserve RAW HTML in this path (no escaping/transformation).
+    let textChunks = chunkTelegramRawHtml(rawText, telegramOutbound.textChunkLimit ?? 4000);
+    if (textChunks.length === 0 && rawText) {
+      textChunks = [rawText];
+    }
+
+    const basePayloadOpts = {
       ...contextOpts,
-      quoteText,
       mediaLocalRoots,
     };
 
-    if (mediaUrls.length === 0) {
-      const result = await send(to, text, {
-        ...payloadOpts,
-        buttons: telegramData?.buttons,
+    const sendTextChunk = async (text: string, opts: { isFirst: boolean }) =>
+      send(to, text, {
+        ...basePayloadOpts,
+        quoteText: opts.isFirst ? quoteText : undefined,
+        // Only attach inline buttons to the first message to preserve current behaviour.
+        ...(opts.isFirst ? { buttons: telegramData?.buttons } : {}),
+        // Only reply-to on the first chunk; thread context stays for all chunks.
+        ...(opts.isFirst ? {} : { replyToMessageId: undefined }),
       });
-      return { channel: "telegram", ...result };
+
+    if (mediaUrls.length === 0) {
+      let finalResult: Awaited<ReturnType<typeof send>> | undefined;
+      for (let i = 0; i < textChunks.length; i += 1) {
+        finalResult = await sendTextChunk(textChunks[i] ?? "", { isFirst: i === 0 });
+      }
+      return { channel: "telegram", ...(finalResult ?? { messageId: "unknown", chatId: to }) };
     }
 
     // Telegram allows reply_markup on media; attach buttons only to first send.
+    // If text exceeds the limit, we attach the first chunk to the first media caption,
+    // then send remaining chunks as follow-up text messages.
     let finalResult: Awaited<ReturnType<typeof send>> | undefined;
     for (let i = 0; i < mediaUrls.length; i += 1) {
       const mediaUrl = mediaUrls[i];
-      const isFirst = i === 0;
-      finalResult = await send(to, isFirst ? text : "", {
-        ...payloadOpts,
+      const isFirstMedia = i === 0;
+      const caption = isFirstMedia ? (textChunks[0] ?? "") : "";
+      finalResult = await send(to, caption, {
+        ...basePayloadOpts,
+        quoteText: isFirstMedia ? quoteText : undefined,
         mediaUrl,
-        ...(isFirst ? { buttons: telegramData?.buttons } : {}),
+        ...(isFirstMedia ? { buttons: telegramData?.buttons } : {}),
+        ...(isFirstMedia ? {} : { replyToMessageId: undefined }),
       });
     }
+
+    for (let i = 1; i < textChunks.length; i += 1) {
+      finalResult = await sendTextChunk(textChunks[i] ?? "", { isFirst: false });
+    }
+
     return { channel: "telegram", ...(finalResult ?? { messageId: "unknown", chatId: to }) };
   },
 };


### PR DESCRIPTION
Fixes Telegram outbound sendPayload path sending >4096 chars without chunking. Preserves raw HTML and button placement while chunking long payloads.