### PR TITLE
Gateway: refresh plugin fallback context after hot reload

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { PluginRegistry } from "../plugins/registry.js";
-import type { PluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import {
+  withPluginRuntimeGatewayRequestScope,
+  type PluginRuntimeGatewayRequestScope,
+} from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import type { PluginDiagnostic } from "../plugins/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "./server-methods/types.js";
@@ -82,6 +85,10 @@ function getLastDispatchedClientScopes(): string[] {
   const call = handleGatewayRequest.mock.calls.at(-1)?.[0];
   const scopes = call?.client?.connect?.scopes;
   return Array.isArray(scopes) ? scopes : [];
+}
+
+function getLastDispatchCall(): HandleGatewayRequestOptions | undefined {
+  return handleGatewayRequest.mock.calls.at(-1)?.[0];
 }
 
 async function importServerPluginsModule(): Promise<ServerPluginsModule> {
@@ -557,20 +564,58 @@ describe("loadGatewayPlugins", () => {
     expect(getLastDispatchedContext()).toBe(secondContext);
   });
 
-  test("reflects fallback context object mutation at dispatch time", async () => {
+  test("reflects fallback context field replacement at dispatch time", async () => {
     const serverPlugins = await importServerPluginsModule();
     const runtime = await createSubagentRuntime(serverPlugins);
-    const context = { marker: "before-mutation" } as GatewayRequestContext & {
-      marker: string;
+    const beforeReloadCron = { id: "before-reload" } as unknown as GatewayRequestContext["cron"] & {
+      id: string;
+    };
+    const afterReloadCron = { id: "after-reload" } as unknown as GatewayRequestContext["cron"] & {
+      id: string;
+    };
+    const context = {
+      cron: beforeReloadCron,
+      cronStorePath: "/tmp/before-reload.json",
+    } as GatewayRequestContext & {
+      cron: { id: string };
+      cronStorePath: string;
     };
 
     serverPlugins.setFallbackGatewayContext(context);
-    context.marker = "after-mutation";
+    context.cron = afterReloadCron;
+    context.cronStorePath = "/tmp/after-reload.json";
 
     await runtime.run({ sessionKey: "s-3", message: "mutated context" });
     const dispatched = getLastDispatchedContext() as
-      | (GatewayRequestContext & { marker: string })
+      | (GatewayRequestContext & {
+          cron: { id: string };
+          cronStorePath: string;
+        })
       | undefined;
-    expect(dispatched?.marker).toBe("after-mutation");
+    expect(dispatched?.cron).toBe(afterReloadCron);
+    expect(dispatched?.cronStorePath).toBe("/tmp/after-reload.json");
+  });
+
+  test("prefers request-scoped context over the fallback context", async () => {
+    const serverPlugins = await importServerPluginsModule();
+    const runtime = await createSubagentRuntime(serverPlugins);
+    const fallbackContext = createTestContext("fallback");
+    const requestScopedContext = createTestContext("request-scope");
+    const requestScopedIsWebchatConnect = vi.fn(() => true);
+
+    serverPlugins.setFallbackGatewayContext(fallbackContext);
+
+    await withPluginRuntimeGatewayRequestScope(
+      {
+        context: requestScopedContext,
+        isWebchatConnect: requestScopedIsWebchatConnect,
+      },
+      async () => {
+        await runtime.run({ sessionKey: "s-4", message: "request scoped context" });
+      },
+    );
+
+    expect(getLastDispatchedContext()).toBe(requestScopedContext);
+    expect(getLastDispatchCall()?.isWebchatConnect).toBe(requestScopedIsWebchatConnect);
   });
 });

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -46,7 +46,8 @@ const fallbackGatewayContextState = (() => {
 })();
 
 export function setFallbackGatewayContext(ctx: GatewayRequestContext): void {
-  // TODO: This startup snapshot can become stale if runtime config/context changes.
+  // Keep a shared live reference so existing runtimes survive module reloads;
+  // callers can update hot-swapped fields in place when server state changes.
   fallbackGatewayContextState.context = ctx;
 }
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -46,8 +46,8 @@ const fallbackGatewayContextState = (() => {
 })();
 
 export function setFallbackGatewayContext(ctx: GatewayRequestContext): void {
-  // Keep a shared live reference so existing runtimes survive module reloads;
-  // callers can update hot-swapped fields in place when server state changes.
+  // Existing runtimes read this shared pointer at dispatch time, so callers
+  // can replace the fallback context when gateway state is hot-swapped.
   fallbackGatewayContextState.context = ctx;
 }
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1211,6 +1211,10 @@ export async function startGatewayServer(
             cronState = nextState.cronState;
             cron = cronState.cron;
             cronStorePath = cronState.storePath;
+            // Keep the shared fallback context live for non-request-scoped
+            // plugin subagent dispatch after hot reload swaps cron state.
+            gatewayRequestContext.cron = cron;
+            gatewayRequestContext.cronStorePath = cronStorePath;
             browserControl = nextState.browserControl;
             channelHealthMonitor = nextState.channelHealthMonitor;
           },

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1097,10 +1097,17 @@ export async function startGatewayServer(
     broadcastVoiceWakeChanged,
   };
 
+  const buildFallbackGatewayContext =
+    (): import("./server-methods/types.js").GatewayRequestContext => ({
+      ...gatewayRequestContext,
+      cron,
+      cronStorePath,
+    });
+
   // Store the gateway context as a fallback for plugin subagent dispatch
   // in non-WS paths (Telegram polling, WhatsApp, etc.) where no per-request
   // scope is set via AsyncLocalStorage.
-  setFallbackGatewayContext(gatewayRequestContext);
+  setFallbackGatewayContext(buildFallbackGatewayContext());
 
   attachGatewayWsHandlers({
     wss,
@@ -1211,10 +1218,9 @@ export async function startGatewayServer(
             cronState = nextState.cronState;
             cron = cronState.cron;
             cronStorePath = cronState.storePath;
-            // Keep the shared fallback context live for non-request-scoped
-            // plugin subagent dispatch after hot reload swaps cron state.
-            gatewayRequestContext.cron = cron;
-            gatewayRequestContext.cronStorePath = cronStorePath;
+            // Refresh the plugin fallback context without mutating the
+            // long-lived WS request context object.
+            setFallbackGatewayContext(buildFallbackGatewayContext());
             browserControl = nextState.browserControl;
             channelHealthMonitor = nextState.channelHealthMonitor;
           },

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -569,12 +569,12 @@ describe("gateway hot reload", () => {
     });
   });
 
-  it("keeps fallback gateway context aligned with hot-reloaded cron state", async () => {
+  it("replaces the fallback gateway context when hot reload swaps cron state", async () => {
     await withGatewayServer(async () => {
-      const fallbackContext = hoisted.setFallbackGatewayContext.mock.calls.at(-1)?.[0] as
+      const startupFallbackContext = hoisted.setFallbackGatewayContext.mock.calls.at(-1)?.[0] as
         | { cron?: unknown; cronStorePath?: unknown }
         | undefined;
-      expect(fallbackContext).toBeDefined();
+      expect(startupFallbackContext).toBeDefined();
       const startupCronCount = hoisted.cronInstances.length;
       const startupCron = hoisted.cronInstances.at(-1);
       expect(startupCron).toBeDefined();
@@ -603,8 +603,18 @@ describe("gateway hot reload", () => {
 
       expect(hoisted.cronInstances.length).toBe(startupCronCount + 1);
       expect(hoisted.cronInstances.at(-1)).not.toBe(startupCron);
-      expect(fallbackContext?.cron).toBe(hoisted.cronInstances.at(-1));
-      expect(fallbackContext?.cronStorePath).toBe("/tmp/cron-hot-reload.json");
+      expect(hoisted.setFallbackGatewayContext).toHaveBeenCalledTimes(2);
+
+      const nextFallbackContext = hoisted.setFallbackGatewayContext.mock.calls.at(-1)?.[0] as
+        | { cron?: unknown; cronStorePath?: unknown }
+        | undefined;
+      expect(nextFallbackContext).toBeDefined();
+      expect(nextFallbackContext).not.toBe(startupFallbackContext);
+      expect(nextFallbackContext?.cron).toBe(hoisted.cronInstances.at(-1));
+      expect(nextFallbackContext?.cronStorePath).toBe("/tmp/cron-hot-reload.json");
+
+      expect(startupFallbackContext?.cron).toBe(startupCron);
+      expect(startupFallbackContext?.cronStorePath).not.toBe("/tmp/cron-hot-reload.json");
     });
   });
 

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -128,6 +128,8 @@ const hoisted = vi.hoisted(() => {
     },
   );
 
+  const setFallbackGatewayContext = vi.fn();
+
   return {
     CronService: CronServiceMock,
     cronInstances,
@@ -141,6 +143,7 @@ const hoisted = vi.hoisted(() => {
     providerManager,
     createChannelManager,
     startGatewayConfigReloader,
+    setFallbackGatewayContext,
     reloaderStop,
     getOnHotReload: () => onHotReload,
     getOnRestart: () => onRestart,
@@ -172,6 +175,14 @@ vi.mock("./config-reload.js", () => ({
   startGatewayConfigReloader: hoisted.startGatewayConfigReloader,
 }));
 
+vi.mock("./server-plugins.js", async () => {
+  const actual = await vi.importActual<typeof import("./server-plugins.js")>("./server-plugins.js");
+  return {
+    ...actual,
+    setFallbackGatewayContext: hoisted.setFallbackGatewayContext,
+  };
+});
+
 installGatewayTestHooks({ scope: "suite" });
 
 describe("gateway hot reload", () => {
@@ -182,6 +193,7 @@ describe("gateway hot reload", () => {
   let prevGeminiApiKey: string | undefined;
 
   beforeEach(() => {
+    hoisted.setFallbackGatewayContext.mockReset();
     prevSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
     prevSkipGmail = process.env.OPENCLAW_SKIP_GMAIL_WATCHER;
     prevSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
@@ -554,6 +566,45 @@ describe("gateway hot reload", () => {
       await Promise.resolve(restartResult);
 
       expect(signalSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("keeps fallback gateway context aligned with hot-reloaded cron state", async () => {
+    await withGatewayServer(async () => {
+      const fallbackContext = hoisted.setFallbackGatewayContext.mock.calls.at(-1)?.[0] as
+        | { cron?: unknown; cronStorePath?: unknown }
+        | undefined;
+      expect(fallbackContext).toBeDefined();
+      const startupCronCount = hoisted.cronInstances.length;
+      const startupCron = hoisted.cronInstances.at(-1);
+      expect(startupCron).toBeDefined();
+
+      const onHotReload = hoisted.getOnHotReload();
+      expect(onHotReload).toBeTypeOf("function");
+
+      await onHotReload?.(
+        {
+          changedPaths: ["cron.enabled", "cron.store"],
+          restartGateway: false,
+          restartReasons: [],
+          hotReasons: ["cron.enabled", "cron.store"],
+          reloadHooks: false,
+          restartGmailWatcher: false,
+          restartBrowserControl: false,
+          restartCron: true,
+          restartHeartbeat: false,
+          restartChannels: new Set(),
+          noopPaths: [],
+        },
+        {
+          cron: { enabled: true, store: "/tmp/cron-hot-reload.json" },
+        },
+      );
+
+      expect(hoisted.cronInstances.length).toBe(startupCronCount + 1);
+      expect(hoisted.cronInstances.at(-1)).not.toBe(startupCron);
+      expect(fallbackContext?.cron).toBe(hoisted.cronInstances.at(-1));
+      expect(fallbackContext?.cronStorePath).toBe("/tmp/cron-hot-reload.json");
     });
   });
 


### PR DESCRIPTION
## Summary

- Problem: plugin subagent fallback gateway dispatch keeps a shared `GatewayRequestContext`, but gateway hot reload can swap `cron` and `cronStorePath` later in the same server lifetime.
- Why it matters: non-request-scoped plugin subagent calls could keep using startup-era cron state after a hot reload.
- What changed: sync the fallback context's hot-reloaded cron fields in `src/gateway/server.impl.ts`, add regression coverage for hot reload alignment in `src/gateway/server.reload.test.ts`, and confirm request-scoped context still wins in `src/gateway/server-plugins.test.ts`.
- What did NOT change (scope boundary): no plugin runtime API changes, no plugin loading refactor, and no behavior changes outside this fallback-context path.
- AI assistance: Codex-assisted; changes were reviewed and verified locally before push.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None.

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm worktree
- Model/provider: n/a
- Integration/channel (if any): gateway plugin runtime
- Relevant config (redacted): default gateway test config via test helpers

### Steps

1. Start the gateway and capture the fallback context registered for plugin subagent dispatch.
2. Trigger a hot reload that restarts cron with a new store path.
3. Exercise plugin dispatch with and without a request-scoped gateway context.

### Expected

- Fallback dispatch uses the latest hot-reloaded cron instance and cron store path.
- Request-scoped context still wins when present.

### Actual

- Verified by regression coverage in `src/gateway/server.reload.test.ts` and `src/gateway/server-plugins.test.ts`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `npx pnpm test src/gateway/server.reload.test.ts src/gateway/server-plugins.test.ts`
- Edge cases checked: existing runtimes after module reload, explicit fallback replacement, in-place fallback field replacement, request-scoped dispatch priority, hot-reloaded cron replacement
- What you did **not** verify: live channel/manual hot reload behavior outside the test harness

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `a372fbd96`
- Files/config to restore: `src/gateway/server.impl.ts`, `src/gateway/server-plugins.ts`, `src/gateway/server-plugins.test.ts`, `src/gateway/server.reload.test.ts`
- Known bad symptoms reviewers should watch for: plugin subagent fallback dispatch still observing stale cron state after a gateway hot reload

## Risks and Mitigations

- Risk: future hot-reloaded `GatewayRequestContext` fields could drift if they are later made replaceable without the same in-place sync.
  - Mitigation: this patch keeps the synchronization local to the hot reload state swap, and the regression test covers the current cron replacement path.
