### PR TITLE
feat(content): add thought leadership content pipeline

### DIFF
--- a/.claude/commands/ai-signal.md
+++ b/.claude/commands/ai-signal.md
@@ -1,0 +1,286 @@
+Generate a weekly edition of "The AI Signal" newsletter — signal vs noise for technology and business leaders.
+
+$ARGUMENTS
+
+## Purpose
+
+Research this week's top AI stories, draft the full newsletter in The AI Signal format, save the archive copy, and create a Gmail draft ready to review and send to ssdash7.newsletters@gmail.com.
+
+## Parameters (from $ARGUMENTS)
+
+- `--issue <n>` — override issue number (default: auto-detect from archive count)
+- `--date <YYYY-MM-DD>` — override issue date (default: today)
+- `--dry-run` — skip Gmail draft creation, just save and print
+
+## Process
+
+### Step 1 — Research (run 3 web searches in parallel)
+
+Search for this week's top AI stories across three angles:
+
+1. `"AI news [this week / current date]"` — general top stories
+2. `"AI enterprise tools announcements [this week]"` — enterprise/B2B angle
+3. `"AI model releases research breakthroughs [this week]"` — technical/model angle
+
+Collect all results. De-duplicate. Shortlist the **6 best stories** by this priority order:
+
+1. Highest real-world business/leadership impact
+2. Most surprising or counterintuitive development
+3. Enterprise tool or workflow relevance
+4. Regulatory or policy movement
+5. Model capability leap
+
+Drop consumer novelty stories unless they have clear enterprise implications.
+
+### Step 2 — Determine issue number
+
+Count `.md` files in `outputs/content/newsletters/` (excluding `.gitkeep`).
+Issue number = count + 1. Override with `--issue` if provided.
+
+### Step 3 — Draft the newsletter
+
+Read `memory/brand/writing_style.md` before drafting. Apply the voice throughout: clear, direct, executive, practitioner-not-theorist. Short paragraphs. Specifics over vague claims.
+
+Use this exact structure:
+
+```
+---
+THE AI SIGNAL
+Separating signal from noise that matters for leadership.
+Issue #[N] | [Day, Month DD, YYYY]
+---
+
+[LEAD HEADLINE — written like a tweet, not a press release. Lead with the most surprising/impactful story. Use an active verb. Max 10 words.]
+
+[SUBHEADLINE — one line teasing the other 5 stories, comma-separated, ending with "...and more"]
+
+---
+
+**[Story 1 Headline — action-oriented, no jargon]**
+
+[Para 1: What happened — 2 sentences, plain English, specific numbers/names]
+
+[Para 2: Why it matters — 1-2 sentences connecting to leadership/enterprise impact]
+
+[Para 3: The implication — 1 sentence, forward-looking or provocative]
+
+> **Practitioner Take:** [One bold, specific, actionable sentence. Tell them exactly what to do or watch.]
+
+---
+
+[Repeat for stories 2–6]
+
+---
+
+That's the signal this week. If one of these changes how you're thinking, hit reply.
+
+— The AI Signal
+```
+
+Story headline rules:
+
+- No "X announces Y" — use the outcome instead ("X makes Y obsolete")
+- No buzzwords (revolutionary, game-changing, groundbreaking)
+- Must be readable without context
+
+Per-story word count: 120–180 words + Practitioner Take (1 sentence).
+Total target: 900–1,200 words.
+
+### Step 4 — Quality gate
+
+Before saving, verify:
+
+- [ ] Lead headline would make someone open the email
+- [ ] Every story has a specific number, name, or fact (no vague claims)
+- [ ] Every Practitioner Take is actionable (starts with a verb or tells them what to do)
+- [ ] No paragraph exceeds 3 sentences
+- [ ] No buzzwords: revolutionary, game-changing, groundbreaking, unprecedented, paradigm shift
+- [ ] Subheadline accurately reflects the 5 remaining stories
+
+### Step 5 — Save archive copy
+
+Save to: `outputs/content/newsletters/ai-signal-[YYYY-MM-DD].md`
+
+File format:
+
+```
+---
+issue: [N]
+date: [YYYY-MM-DD]
+headline: [lead headline text]
+stories: [comma-separated story slugs]
+---
+
+[full newsletter text]
+```
+
+Create the `outputs/content/newsletters/` directory if it doesn't exist.
+
+### Step 6 — Create Gmail draft (skip if --dry-run)
+
+Use `gmail_create_draft` to create a draft with:
+
+- **To:** ssdash7.newsletters@gmail.com
+- **Subject:** `The AI Signal #[N]: [Lead Headline]`
+- **Body:** HTML-formatted newsletter using the template below
+
+HTML email template:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        font-family: Georgia, "Times New Roman", serif;
+        background: #f9f9f7;
+        margin: 0;
+        padding: 0;
+      }
+      .wrapper {
+        max-width: 620px;
+        margin: 32px auto;
+        background: #ffffff;
+        border: 1px solid #e8e8e4;
+      }
+      .header {
+        background: #0d0d0d;
+        padding: 28px 36px;
+      }
+      .header h1 {
+        color: #ffffff;
+        font-size: 22px;
+        font-weight: 700;
+        margin: 0;
+        letter-spacing: 2px;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+      }
+      .header p {
+        color: #999999;
+        font-size: 12px;
+        margin: 6px 0 0;
+        letter-spacing: 1px;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        text-transform: uppercase;
+      }
+      .issue-line {
+        background: #f0f0ec;
+        padding: 10px 36px;
+        font-size: 12px;
+        color: #666;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        border-bottom: 1px solid #e0e0da;
+      }
+      .lead {
+        padding: 28px 36px 8px;
+      }
+      .lead h2 {
+        font-size: 26px;
+        line-height: 1.3;
+        color: #0d0d0d;
+        margin: 0 0 8px;
+      }
+      .lead p.sub {
+        font-size: 14px;
+        color: #666;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        margin: 0;
+      }
+      .divider {
+        border: none;
+        border-top: 2px solid #0d0d0d;
+        margin: 20px 36px;
+      }
+      .story {
+        padding: 20px 36px;
+        border-bottom: 1px solid #f0f0ec;
+      }
+      .story h3 {
+        font-size: 17px;
+        font-weight: 700;
+        color: #0d0d0d;
+        margin: 0 0 12px;
+        line-height: 1.4;
+      }
+      .story p {
+        font-size: 15px;
+        line-height: 1.7;
+        color: #333;
+        margin: 0 0 10px;
+      }
+      .practitioner {
+        background: #f5f5f0;
+        border-left: 3px solid #0d0d0d;
+        padding: 10px 14px;
+        margin-top: 14px;
+      }
+      .practitioner p {
+        font-size: 13px;
+        color: #0d0d0d;
+        margin: 0;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+      }
+      .practitioner strong {
+        font-weight: 700;
+      }
+      .footer {
+        padding: 24px 36px;
+        background: #f9f9f7;
+      }
+      .footer p {
+        font-size: 13px;
+        color: #888;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        margin: 0 0 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="header">
+        <h1>THE AI SIGNAL</h1>
+        <p>Separating signal from noise that matters for leadership</p>
+      </div>
+      <div class="issue-line">Issue #[N] &nbsp;·&nbsp; [Day, Month DD, YYYY]</div>
+      <div class="lead">
+        <h2>[Lead Headline]</h2>
+        <p class="sub">[Subheadline / story teasers]</p>
+      </div>
+      <hr class="divider" />
+      <!-- Repeat this block for each story -->
+      <div class="story">
+        <h3>[Story Headline]</h3>
+        <p>[Para 1]</p>
+        <p>[Para 2]</p>
+        <p>[Para 3]</p>
+        <div class="practitioner">
+          <p><strong>Practitioner Take:</strong> [Actionable sentence]</p>
+        </div>
+      </div>
+      <!-- End story block -->
+      <div class="footer">
+        <p>That's the signal this week. If one of these changes how you're thinking, hit reply.</p>
+        <p>— The AI Signal</p>
+      </div>
+    </div>
+  </body>
+</html>
+```
+
+Populate the HTML template with actual newsletter content before creating the draft.
+
+### Step 7 — Confirm and report
+
+Print a confirmation block:
+
+```
+✓ The AI Signal #[N] — [Date]
+  Headline: [lead headline]
+  Stories: [N] stories drafted
+  Archive: outputs/content/newsletters/ai-signal-[YYYY-MM-DD].md
+  Gmail draft: [created / skipped (--dry-run)]
+  To: ssdash7.newsletters@gmail.com
+  Subject: The AI Signal #[N]: [Lead Headline]
+```

--- a/.claude/commands/ai-signal.md
+++ b/.claude/commands/ai-signal.md
@@ -4,40 +4,128 @@ $ARGUMENTS
 
 ## Purpose
 
-Research this week's top AI stories, draft the full newsletter in The AI Signal format, save the archive copy, and create a Gmail draft ready to review and send to ssdash7.newsletters@gmail.com.
+Sync new subscribers from Gmail → Notion, research this week's top AI stories weighted by subscriber interests, draft the full newsletter with clickable source links, save the archive copy, and create a Gmail draft ready to review and send to ssdash7.newsletters@gmail.com.
 
 ## Parameters (from $ARGUMENTS)
 
 - `--issue <n>` — override issue number (default: auto-detect from archive count)
 - `--date <YYYY-MM-DD>` — override issue date (default: today)
 - `--dry-run` — skip Gmail draft creation, just save and print
+- `--skip-sync` — skip Gmail subscriber sync step
+
+## Subscriber Interest Categories (from narwal.one subscription form)
+
+- Artificial Intelligence
+- Digital Transformation
+- Data Analytics
+- Supply Chain Optimization
+- Customer Experience
+- Sales & Marketing Technology
+- Cloud Computing
+- Cybersecurity
+
+## Story → Interest Tag Mapping
+
+When tagging each story, map to one or more of the above categories:
+
+- AI models, agents, LLMs → Artificial Intelligence
+- Enterprise AI adoption, org change, strategy → Digital Transformation
+- Data platforms, analytics tools, BI → Data Analytics
+- Logistics, inventory, procurement AI → Supply Chain Optimization
+- CX tools, personalization, chatbots → Customer Experience
+- Martech, sales AI, revenue tools → Sales & Marketing Technology
+- Cloud infrastructure, GPU, compute → Cloud Computing
+- Security AI, compliance, regulation → Cybersecurity
+
+---
 
 ## Process
 
-### Step 1 — Research (run 3 web searches in parallel)
+### Step 0 — Sync subscribers from Gmail (skip if --skip-sync)
+
+Search Gmail for new subscription notification emails from narwal.one in the last 7 days:
+
+```
+gmail_search_messages query="from:narwal.one OR subject:\"New Subscriber\" OR subject:\"newsletter subscription\" newer_than:7d" max=20
+```
+
+For each result:
+
+1. Read the email body to extract: Full Name, Email, Position/Title, Industry, Areas of Interest (checkboxes selected)
+2. Search Notion DB `9094f55e-ccda-44c4-b862-8d41be4b8461` for existing entry with matching email
+3. If NOT found: create a new page in Notion with all extracted fields + Status=Active + today's Subscribed Date
+4. If found: skip (already synced)
+
+After sync, print: `Subscribers synced: [N] new added`
+
+If no subscription emails found, print: `No new subscribers this week` and continue.
+
+---
+
+### Step 1 — Read subscriber interest distribution
+
+Query all Active subscribers from Notion data source `9094f55e-ccda-44c4-b862-8d41be4b8461`.
+
+Count frequency of each interest tag across all active subscribers. Example output:
+
+```
+Artificial Intelligence: 24 subscribers
+Digital Transformation: 18 subscribers
+Cybersecurity: 15 subscribers
+Data Analytics: 12 subscribers
+Cloud Computing: 10 subscribers
+Customer Experience: 8 subscribers
+Sales & Marketing Technology: 6 subscribers
+Supply Chain Optimization: 4 subscribers
+```
+
+Store as ranked interest list. Use the **top 4 interests** to bias story selection in Step 2.
+
+If no subscribers yet (first run), use default weights: AI > Digital Transformation > Data Analytics > Cybersecurity.
+
+---
+
+### Step 2 — Research (run 3 web searches in parallel)
 
 Search for this week's top AI stories across three angles:
 
-1. `"AI news [this week / current date]"` — general top stories
-2. `"AI enterprise tools announcements [this week]"` — enterprise/B2B angle
-3. `"AI model releases research breakthroughs [this week]"` — technical/model angle
+1. `"top AI news [current date / this week] 2026"` — general top stories
+2. `"AI enterprise tools announcements [this week] 2026"` — enterprise/B2B angle
+3. `"AI model releases research breakthroughs [this week] 2026"` — technical/model angle
 
-Collect all results. De-duplicate. Shortlist the **6 best stories** by this priority order:
+For each story shortlisted, **capture the best source URL** (the original article, not a news aggregator) — this is required for Step 5.
+
+Shortlist the **6 best stories** using this priority order:
 
 1. Highest real-world business/leadership impact
-2. Most surprising or counterintuitive development
-3. Enterprise tool or workflow relevance
-4. Regulatory or policy movement
-5. Model capability leap
+2. Stories matching top 4 subscriber interests (from Step 1) — bias selection here
+3. Most surprising or counterintuitive development
+4. Enterprise tool or workflow relevance
+5. Regulatory or policy movement
+6. Model capability leap
 
 Drop consumer novelty stories unless they have clear enterprise implications.
 
-### Step 2 — Determine issue number
+For each of the 6 selected stories, produce:
+
+```
+story_slug: [kebab-case slug]
+headline_draft: [working headline]
+source_url: [best original source URL — required]
+interest_tags: [list from the 8 categories above]
+summary: [2-3 sentence summary of the story]
+```
+
+---
+
+### Step 3 — Determine issue number
 
 Count `.md` files in `outputs/content/newsletters/` (excluding `.gitkeep`).
 Issue number = count + 1. Override with `--issue` if provided.
 
-### Step 3 — Draft the newsletter
+---
+
+### Step 4 — Draft the newsletter
 
 Read `memory/brand/writing_style.md` before drafting. Apply the voice throughout: clear, direct, executive, practitioner-not-theorist. Short paragraphs. Specifics over vague claims.
 
@@ -56,7 +144,7 @@ Issue #[N] | [Day, Month DD, YYYY]
 
 ---
 
-**[Story 1 Headline — action-oriented, no jargon]**
+**[Story 1 Headline]** [Source: [Domain Name]([source_url])]
 
 [Para 1: What happened — 2 sentences, plain English, specific numbers/names]
 
@@ -65,6 +153,8 @@ Issue #[N] | [Day, Month DD, YYYY]
 [Para 3: The implication — 1 sentence, forward-looking or provocative]
 
 > **Practitioner Take:** [One bold, specific, actionable sentence. Tell them exactly what to do or watch.]
+
+*Tags: [comma-separated interest tags]*
 
 ---
 
@@ -86,7 +176,9 @@ Story headline rules:
 Per-story word count: 120–180 words + Practitioner Take (1 sentence).
 Total target: 900–1,200 words.
 
-### Step 4 — Quality gate
+---
+
+### Step 5 — Quality gate
 
 Before saving, verify:
 
@@ -96,12 +188,14 @@ Before saving, verify:
 - [ ] No paragraph exceeds 3 sentences
 - [ ] No buzzwords: revolutionary, game-changing, groundbreaking, unprecedented, paradigm shift
 - [ ] Subheadline accurately reflects the 5 remaining stories
+- [ ] Every story has a valid source_url captured
+- [ ] Interest tags assigned to all 6 stories
 
-### Step 5 — Save archive copy
+---
+
+### Step 6 — Save archive copy
 
 Save to: `outputs/content/newsletters/ai-signal-[YYYY-MM-DD].md`
-
-File format:
 
 ```
 ---
@@ -109,22 +203,28 @@ issue: [N]
 date: [YYYY-MM-DD]
 headline: [lead headline text]
 stories: [comma-separated story slugs]
+subscriber_count: [N active subscribers]
+top_interests: [top 4 interest tags]
 ---
 
-[full newsletter text]
+[full newsletter text with tags]
 ```
 
-Create the `outputs/content/newsletters/` directory if it doesn't exist.
+---
 
-### Step 6 — Create Gmail draft (skip if --dry-run)
+### Step 7 — Create Gmail draft (skip if --dry-run)
 
-Use `gmail_create_draft` to create a draft with:
+Use `gmail_create_draft` with:
 
 - **To:** ssdash7.newsletters@gmail.com
 - **Subject:** `The AI Signal #[N]: [Lead Headline]`
-- **Body:** HTML-formatted newsletter using the template below
+- **Body:** HTML formatted with the template below
 
-HTML email template:
+**HTML template rules:**
+
+- Story `<h3>` must be a clickable link to the source URL: `<h3><a href="[source_url]" style="color:#0d0d0d;text-decoration:none;">[Story Headline]</a></h3>`
+- Add a "Read more →" link at the bottom of each story block: `<p class="readmore"><a href="[source_url]">Read more →</a></p>`
+- Interest tags shown as small pill badges below each Practitioner Take box
 
 ```html
 <!DOCTYPE html>
@@ -204,6 +304,13 @@ HTML email template:
         margin: 0 0 12px;
         line-height: 1.4;
       }
+      .story h3 a {
+        color: #0d0d0d;
+        text-decoration: none;
+      }
+      .story h3 a:hover {
+        text-decoration: underline;
+      }
       .story p {
         font-size: 15px;
         line-height: 1.7;
@@ -225,15 +332,44 @@ HTML email template:
       .practitioner strong {
         font-weight: 700;
       }
+      .readmore {
+        margin-top: 10px;
+        font-size: 13px;
+      }
+      .readmore a {
+        color: #0d0d0d;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        font-weight: 600;
+      }
+      .tags {
+        margin-top: 8px;
+      }
+      .tag {
+        display: inline-block;
+        background: #f0f0ec;
+        border-radius: 3px;
+        padding: 2px 7px;
+        font-size: 11px;
+        color: #666;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        margin-right: 4px;
+      }
       .footer {
         padding: 24px 36px;
         background: #f9f9f7;
+        border-top: 1px solid #e8e8e4;
       }
       .footer p {
         font-size: 13px;
         color: #888;
         font-family: "Helvetica Neue", Arial, sans-serif;
         margin: 0 0 6px;
+      }
+      .subscriber-note {
+        font-size: 11px;
+        color: #aaa;
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        margin-top: 12px;
       }
     </style>
   </head>
@@ -243,44 +379,63 @@ HTML email template:
         <h1>THE AI SIGNAL</h1>
         <p>Separating signal from noise that matters for leadership</p>
       </div>
-      <div class="issue-line">Issue #[N] &nbsp;·&nbsp; [Day, Month DD, YYYY]</div>
+      <div class="issue-line">
+        Issue #[N] &nbsp;·&nbsp; [Day, Month DD, YYYY] &nbsp;·&nbsp; [N] subscribers
+      </div>
       <div class="lead">
         <h2>[Lead Headline]</h2>
         <p class="sub">[Subheadline / story teasers]</p>
       </div>
       <hr class="divider" />
-      <!-- Repeat this block for each story -->
+
+      <!-- Story block — repeat for each of 6 stories -->
       <div class="story">
-        <h3>[Story Headline]</h3>
+        <h3><a href="[source_url]">[Story Headline]</a></h3>
         <p>[Para 1]</p>
         <p>[Para 2]</p>
         <p>[Para 3]</p>
         <div class="practitioner">
           <p><strong>Practitioner Take:</strong> [Actionable sentence]</p>
         </div>
+        <p class="readmore"><a href="[source_url]">Read more →</a></p>
+        <div class="tags">
+          <span class="tag">[Interest Tag 1]</span>
+          <span class="tag">[Interest Tag 2]</span>
+        </div>
       </div>
       <!-- End story block -->
+
       <div class="footer">
         <p>That's the signal this week. If one of these changes how you're thinking, hit reply.</p>
         <p>— The AI Signal</p>
+        <p class="subscriber-note">
+          You're receiving this because you subscribed at
+          <a href="https://narwal.one" style="color:#aaa;">narwal.one</a>. To unsubscribe, reply
+          with "unsubscribe".
+        </p>
       </div>
     </div>
   </body>
 </html>
 ```
 
-Populate the HTML template with actual newsletter content before creating the draft.
+Populate all placeholders with actual content. Every story headline must be a live `<a href>` link.
 
-### Step 7 — Confirm and report
+---
 
-Print a confirmation block:
+### Step 8 — Confirm and report
 
 ```
 ✓ The AI Signal #[N] — [Date]
   Headline: [lead headline]
-  Stories: [N] stories drafted
+  Stories: 6 stories drafted
+  Sources: all 6 stories have clickable links ✓
+  Active subscribers: [N]
+  Top interests this issue: [top 4]
+  New subscribers synced: [N]
   Archive: outputs/content/newsletters/ai-signal-[YYYY-MM-DD].md
   Gmail draft: [created / skipped (--dry-run)]
   To: ssdash7.newsletters@gmail.com
   Subject: The AI Signal #[N]: [Lead Headline]
+  Notion DB: https://www.notion.so/86e5e24d7f5b4dc6a5f586fd1188ddab
 ```

--- a/.claude/commands/ai-signal.md
+++ b/.claude/commands/ai-signal.md
@@ -46,7 +46,7 @@ When tagging each story, map to one or more of the above categories:
 Search Gmail for new subscription notification emails from narwal.one in the last 7 days:
 
 ```
-gmail_search_messages query="from:narwal.one OR subject:\"New Subscriber\" OR subject:\"newsletter subscription\" newer_than:7d" max=20
+gmail_search_messages query="to:ss.dash7@gmail.com from:narwal.one newer_than:7d" max=20
 ```
 
 For each result:

--- a/.claude/commands/build-source-pack.md
+++ b/.claude/commands/build-source-pack.md
@@ -1,0 +1,49 @@
+Build a research pack for the given topic using the researcher subagent.
+
+$ARGUMENTS
+
+If no topic is provided, read `outputs/content/ideas.md` and use the top-ranked idea.
+
+Process:
+
+1. Use the researcher subagent to gather evidence, signals, and sources
+2. Focus on the past 12 months of content
+3. Prioritize: specific data points, real case studies, named company examples, practitioner quotes
+
+Output format:
+
+```
+# Research Pack — [Topic]
+Generated: [Date]
+
+## Summary
+[3–4 sentence overview of the landscape]
+
+## Key Findings
+- [Finding 1 + source]
+- [Finding 2 + source]
+- [Finding 3 + source]
+- [Finding 4 + source]
+- [Finding 5 + source]
+
+## Supporting Evidence
+### Data Points
+- [Stat: source, date]
+
+### Case Studies
+- [Company/example: what happened, outcome]
+
+### Quotes
+- "[Quote]" — [Name, Title, Source]
+
+## Sources
+- [Full references]
+
+## Angles for Article
+- [Angle 1 — the provocative take]
+- [Angle 2 — the contrarian take]
+- [Angle 3 — the practical take]
+```
+
+Save to `outputs/content/source-pack.md` (overwrite if exists).
+Confirm when saved.

--- a/.claude/commands/collect-feedback.md
+++ b/.claude/commands/collect-feedback.md
@@ -1,0 +1,27 @@
+Close the content pipeline feedback loop after publishing.
+
+$ARGUMENTS
+
+## What this does
+
+Compares what was published against the original draft, extracts style learnings from your edits, and updates `memory/brand/writing_style.md` so future drafts need fewer changes.
+
+## Process
+
+1. Load originals from `outputs/content/article.md` and `outputs/content/linkedin-posts.md`
+2. If a Medium URL is in $ARGUMENTS — fetch the published article
+3. If LinkedIn post text is in $ARGUMENTS — use as the final post
+4. If neither is in $ARGUMENTS — ask for at least one before continuing
+5. Compare draft vs final across: title, hook, structure, length, voice, evidence, conclusion
+6. For LinkedIn: note which variant was used and how the hook was edited
+7. Extract style learnings as actionable rules
+8. Append learnings to `memory/brand/writing_style.md` under `## Learned from Published Posts`
+9. Log the full round to `memory/brand/feedback-log.md`
+
+## Output
+
+Confirm:
+
+- Number of learnings extracted
+- 3 most impactful rules added
+- Paths updated

--- a/.claude/commands/content-scan.md
+++ b/.claude/commands/content-scan.md
@@ -3,10 +3,10 @@ Scan for the top 5 thought leadership article ideas relevant to AI, enterprise t
 Use the researcher subagent to:
 
 1. Identify emerging themes from the past 2 weeks in AI and technology
-2. Score each theme on: relevance to technology leaders, timeliness, originality, Sunil's expertise
+2. Score each theme on: relevance to technology leaders, timeliness, originality, the author's expertise
 3. Generate 5 article ideas with a working title, 2-sentence description, and why it matters now
 
-Read `memory/brand/writing_style.md` to ensure ideas match Sunil's voice and audience.
+Read `memory/brand/writing_style.md` to ensure ideas match the author's voice and audience.
 
 Output format:
 

--- a/.claude/commands/content-scan.md
+++ b/.claude/commands/content-scan.md
@@ -22,6 +22,11 @@ Output format:
 ...
 ```
 
-Save the full output to `outputs/content/ideas.md` (overwrite if exists).
+Save the full output to two locations:
 
-Confirm when saved and print the top idea with a one-line summary.
+1. `outputs/content/ideas.md` — overwrite with latest (used by downstream pipeline steps)
+2. `outputs/content/ideas/[YYYY-MM-DD-HH-MM]-[topic-slug].md` — dated archive copy that is never overwritten
+
+The topic slug is a 3-5 word kebab-case summary of the scan topic or top idea title (e.g. `geo-search-cpg-brands`, `ai-governance-enterprise`, `general-scan`).
+
+Confirm both save paths and print the top idea with a one-line summary.

--- a/.claude/commands/content-scan.md
+++ b/.claude/commands/content-scan.md
@@ -1,32 +1,104 @@
-Scan for the top 5 thought leadership article ideas relevant to AI, enterprise technology, and business strategy.
+Scan for the top frontier AI developments with strong enterprise thought leadership potential.
+
+Read `memory/brand/editorial_brain.md` for the enterprise editorial lens before scanning.
+Read `memory/brand/writing_style.md` for audience and voice context.
 
 Use the researcher subagent to:
 
-1. Identify emerging themes from the past 2 weeks in AI and technology
-2. Score each theme on: relevance to technology leaders, timeliness, originality, the author's expertise
-3. Generate 5 article ideas with a working title, 2-sentence description, and why it matters now
+1. Collect recent AI developments from the past 7 days
+2. Cluster duplicates referring to the same underlying development
+3. Evaluate each development using the scoring rubric below
+4. Return only stories scoring above 75
 
-Read `memory/brand/writing_style.md` to ensure ideas match the author's voice and audience.
+---
 
-Output format:
+## Scoring Rubric (100 points total)
+
+| Dimension                                        | Points |
+| ------------------------------------------------ | ------ |
+| Novelty                                          | 15     |
+| Strategic Importance                             | 15     |
+| Enterprise Relevance                             | 20     |
+| Practical Applicability                          | 15     |
+| Thought Leadership Potential                     | 10     |
+| Audience Fit (CIOs, CTOs, enterprise architects) | 10     |
+| Evidence Quality                                 | 10     |
+| Cross-Platform Reuse Potential                   | 5      |
+
+---
+
+## Detection Targets
+
+Prioritize signals that reveal meaningful shifts in:
+
+- AI capabilities (agents, reasoning, multimodal)
+- Enterprise adoption patterns
+- AI infrastructure and platform architecture
+- Agent systems and orchestration
+- Enterprise productivity and workflow transformation
+- AI governance and regulation
+- Data platform readiness
+
+Prefer primary sources: AI lab announcements, research papers, arXiv, GitHub trending, enterprise deployment stories.
+
+---
+
+## Output Structure
+
+For each story above 75, return:
 
 ```
-# Top 5 Article Ideas — [Date]
+---
+story_id: [slug]
+headline: [clear descriptive headline]
+source_links: [URLs]
+published_date: [date]
+category: [AI Capabilities / Enterprise Adoption / Infrastructure / Governance / Productivity]
+sub_category: [specific tag]
 
-## 1. [Title]
-**Why now:** [1 sentence]
-**Core insight:** [1–2 sentences]
-**Audience hook:** [What will make technology leaders stop and read]
+summary_1line: [one sentence]
+summary_5line: [five sentences — what happened, why it matters, enterprise angle, market gap, implication]
 
-## 2. [Title]
-...
+novelty_score: [0–15]
+enterprise_relevance_score: [0–20]
+thought_leadership_score: [0–10]
+total_score: [0–100]
+
+why_it_matters_for_leaders: [2–3 sentences]
+why_it_matters_for_tech_teams: [2–3 sentences]
+
+editorial_angles:
+  angle_1_strategy: [strategic leadership insight]
+  angle_2_operating_model: [enterprise operating model implication]
+  angle_3_platform: [technical or platform capability shift]
+
+possible_contrarian_angles: [1–2 non-obvious takes]
+
+recommended_formats:
+  - x_post
+  - linkedin_post
+  - medium_article
+
+risk_flags: [hype / unsupported claims / single source / etc.]
+duplicate_of: [story_id if applicable]
+---
 ```
 
-Save the full output to two locations:
+---
 
-1. `outputs/content/ideas.md` — overwrite with latest (used by downstream pipeline steps)
-2. `outputs/content/ideas/[YYYY-MM-DD-HH-MM]-[topic-slug].md` — dated archive copy that is never overwritten
+## Filter Rules
 
-The topic slug is a 3-5 word kebab-case summary of the scan topic or top idea title (e.g. `geo-search-cpg-brands`, `ai-governance-enterprise`, `general-scan`).
+Only return stories scoring above 75.
+Prioritize developments that reveal deeper shifts in enterprise AI adoption.
+Reject low-signal stories per the editorial brain rejection rules.
 
-Confirm both save paths and print the top idea with a one-line summary.
+---
+
+## Save Output
+
+Save the full structured output to:
+
+1. `outputs/content/scan-results.md` — overwrite with latest (used by orchestrator)
+2. `outputs/content/ideas/[YYYY-MM-DD-HH-MM]-scan.md` — dated archive copy (never overwrite)
+
+Confirm both save paths and print the top-scoring story with its recommended formats.

--- a/.claude/commands/content-scan.md
+++ b/.claude/commands/content-scan.md
@@ -39,7 +39,7 @@ Prioritize signals that reveal meaningful shifts in:
 - AI governance and regulation
 - Data platform readiness
 
-Prefer primary sources: AI lab announcements, research papers, arXiv, GitHub trending, enterprise deployment stories.
+Prefer primary sources: AI lab announcements, research papers, arXiv, GitHub trending, enterprise deployment stories, 
 
 ---
 

--- a/.claude/commands/content-scan.md
+++ b/.claude/commands/content-scan.md
@@ -1,0 +1,27 @@
+Scan for the top 5 thought leadership article ideas relevant to AI, enterprise technology, and business strategy.
+
+Use the researcher subagent to:
+
+1. Identify emerging themes from the past 2 weeks in AI and technology
+2. Score each theme on: relevance to technology leaders, timeliness, originality, Sunil's expertise
+3. Generate 5 article ideas with a working title, 2-sentence description, and why it matters now
+
+Read `memory/brand/writing_style.md` to ensure ideas match Sunil's voice and audience.
+
+Output format:
+
+```
+# Top 5 Article Ideas — [Date]
+
+## 1. [Title]
+**Why now:** [1 sentence]
+**Core insight:** [1–2 sentences]
+**Audience hook:** [What will make technology leaders stop and read]
+
+## 2. [Title]
+...
+```
+
+Save the full output to `outputs/content/ideas.md` (overwrite if exists).
+
+Confirm when saved and print the top idea with a one-line summary.

--- a/.claude/commands/draft-medium.md
+++ b/.claude/commands/draft-medium.md
@@ -2,28 +2,68 @@ Generate a full Medium article draft using the researcher → writer → editor 
 
 $ARGUMENTS
 
-Process:
+Read `memory/brand/editorial_brain.md` for the enterprise editorial lens.
+Read `memory/brand/writing_style.md` to ensure voice matches throughout.
 
-1. If a topic is provided in $ARGUMENTS, run the researcher subagent to build a quick source pack first
-2. If no topic provided, read `outputs/content/source-pack.md` for existing research
-3. Use the writer subagent to draft the full article (800–1200 words)
+---
+
+## Process
+
+1. If a topic is provided in $ARGUMENTS, run the researcher subagent to build a source pack first
+2. If no topic provided, read `outputs/content/scan-results.md` for existing scan results, or fall back to `outputs/content/source-pack.md`
+3. Use the writer subagent to draft the full article (1000–1300 words)
 4. Use the editor subagent to sharpen the draft
-5. Read `memory/brand/writing_style.md` to ensure voice matches throughout
 
-Quality gate before saving:
+---
 
-- [ ] Hook grabs attention in the first sentence
-- [ ] Thesis is clear within the first 150 words
-- [ ] At least 3 pieces of specific evidence
-- [ ] Actionable takeaway in the conclusion
-- [ ] No paragraphs over 3 sentences
+## Article Structure (9 sections)
 
-Output format:
+Every article must follow this structure:
+
+1. **Opening claim** — Bold, specific, enterprise-relevant. The thesis in 1–2 sentences.
+2. **What triggered this article** — The development, announcement, or shift that prompted writing now.
+3. **What the market is seeing** — The mainstream interpretation and prevailing narrative.
+4. **What the market is missing** — The deeper signal, contrarian angle, or overlooked implication.
+5. **Enterprise implications** — Concrete impact on enterprise organizations, technology strategy, or investment priorities.
+6. **Organizational implications** — How this affects teams, roles, workflows, or capability building.
+7. **Operating model shifts required** — What leaders need to change about how their organization runs.
+8. **Leadership actions** — 3–5 specific things a CIO, CTO, or enterprise leader should do or reconsider.
+9. **Conclusion** — Forward-looking or provocative closing thought. No summary rehash.
+
+---
+
+## Writing Rules
+
+- Avoid repeating obvious industry commentary
+- Focus on insight derived from enterprise operating experience
+- Tie every development back to leadership decisions
+- Every claim needs supporting evidence or reasoning
+- No paragraphs over 3 sentences
+- Active voice throughout
+- Concrete numbers over vague claims
+
+---
+
+## Quality Gate Before Saving
+
+- [ ] Opening claim grabs attention and states the thesis clearly
+- [ ] Thesis restated or reinforced within the first 150 words
+- [ ] At least 3 pieces of specific evidence or concrete examples
+- [ ] "What the market is missing" section has a genuine non-obvious angle
+- [ ] Leadership actions are specific and actionable (not generic advice)
+- [ ] Conclusion lands with impact — forward-looking or provocative
+- [ ] No buzzwords: "leveraging", "synergies", "ecosystem", "game-changing"
+- [ ] Word count: 1000–1300 words
+
+---
+
+## Output Format
 
 ```
 # [Article Title]
+## [Subheadline — one sentence that deepens the headline]
 
-[Full article text — 800–1200 words]
+[Full article — 1000–1300 words across 9 sections]
 
 ---
 **Sources**
@@ -36,6 +76,6 @@ Output format:
 ```
 
 Save to `outputs/content/article.md` (overwrite if exists).
-Also archive a copy to `data/research/[date]-[slug].md`.
+Also archive to `outputs/content/ideas/[YYYY-MM-DD]-[slug].md`.
 
-Confirm when saved and print the title + hook.
+Confirm when saved and print the title, subheadline, and opening claim.

--- a/.claude/commands/draft-medium.md
+++ b/.claude/commands/draft-medium.md
@@ -1,0 +1,41 @@
+Generate a full Medium article draft using the researcher → writer → editor pipeline.
+
+$ARGUMENTS
+
+Process:
+
+1. If a topic is provided in $ARGUMENTS, run the researcher subagent to build a quick source pack first
+2. If no topic provided, read `outputs/content/source-pack.md` for existing research
+3. Use the writer subagent to draft the full article (800–1200 words)
+4. Use the editor subagent to sharpen the draft
+5. Read `memory/brand/writing_style.md` to ensure voice matches throughout
+
+Quality gate before saving:
+
+- [ ] Hook grabs attention in the first sentence
+- [ ] Thesis is clear within the first 150 words
+- [ ] At least 3 pieces of specific evidence
+- [ ] Actionable takeaway in the conclusion
+- [ ] No paragraphs over 3 sentences
+
+Output format:
+
+```
+# [Article Title]
+
+[Full article text — 800–1200 words]
+
+---
+**Sources**
+- [References]
+
+---
+*Word count: [N]*
+*Topic: [Topic]*
+*Generated: [Date]*
+```
+
+Save to `outputs/content/article.md` (overwrite if exists).
+Also archive a copy to `data/research/[date]-[slug].md`.
+
+Confirm when saved and print the title + hook.

--- a/.claude/commands/gmail-digest.md
+++ b/.claude/commands/gmail-digest.md
@@ -1,0 +1,90 @@
+Fetch a compact Gmail digest using the MCP Gmail tools.
+
+$ARGUMENTS
+
+## Purpose
+
+Return structured email summaries with minimal token usage — only the fields needed, never full bodies unless explicitly requested.
+
+## Parameters (from $ARGUMENTS)
+
+- `--query <string>` — Gmail search query (required)
+- `--max <n>` — max emails to return (default: 20)
+- `--account <email>` — Gmail account to search (default: currently authenticated)
+- `--body` — include truncated body snippet (default: subject+from+date+attachments only)
+- `--full-body <id>` — fetch full body of a single message by ID only
+
+## Process
+
+### Default mode (no --body flag)
+
+1. Call `gmail_search_messages` with the provided query and max limit
+2. For each result extract ONLY:
+   - `id` — message ID
+   - `from` — sender name + email
+   - `subject` — subject line
+   - `date` — received date (YYYY-MM-DD HH:MM)
+   - `attachments` — list of filenames only (not content)
+3. Return as compact JSON array — do NOT read message body or thread
+
+### With --body flag
+
+1. Same as above but also extract a 200-character snippet from the body
+2. Still do NOT fetch full message content
+
+### With --full-body <id>
+
+1. Fetch the single message by ID using `gmail_read_message`
+2. Return full body for that one message only
+
+## Output Format
+
+```json
+{
+  "query": "<the search query used>",
+  "account": "<account searched>",
+  "count": 5,
+  "messages": [
+    {
+      "id": "18f3a...",
+      "from": "Meralco Billing <billing@meralco.com.ph>",
+      "subject": "Your January 2025 Electric Bill",
+      "date": "2025-01-10 08:23",
+      "attachments": ["Meralco_Jan2025.pdf"]
+    }
+  ]
+}
+```
+
+## Token Rules
+
+- NEVER load email body unless `--body` or `--full-body` is specified
+- NEVER include raw HTML, headers dump, or full thread in output
+- Cap snippet at 200 characters even with `--body`
+- If >20 emails match, note count and ask user to narrow query before fetching more
+
+## Usage Examples
+
+Search for utility bills:
+
+```
+/gmail-digest --query "from:(meralco.com.ph OR pldt.com.ph OR globe.com.ph) newer_than:3m" --max 10
+```
+
+Search for flight tickets:
+
+```
+/gmail-digest --query "subject:(e-ticket OR \"booking confirmation\" OR itinerary) newer_than:7d" --max 20
+```
+
+Search for lab results:
+
+```
+/gmail-digest --query "subject:(lab results OR blood test OR health report) has:attachment newer_than:6m" --max 5
+```
+
+Fetch body of one specific email:
+
+```
+/gmail-digest --full-body 18f3a2b4c5d6e7f8
+```

--- a/.claude/commands/orchestrate-content.md
+++ b/.claude/commands/orchestrate-content.md
@@ -1,0 +1,100 @@
+Run the full Enterprise AI Content Engine pipeline from signal discovery to platform-ready content.
+
+$ARGUMENTS
+
+Read `memory/brand/editorial_brain.md` for the enterprise editorial lens before doing anything.
+Read `memory/brand/writing_style.md` for voice and audience context.
+
+---
+
+## Pipeline Steps
+
+### Step 1 — Signal Discovery
+
+If $ARGUMENTS contains a specific topic or story, use that as the input signal.
+
+Otherwise, read `outputs/content/scan-results.md` for existing scan results.
+If the file is empty or older than 24 hours, run `/content-scan` first.
+
+### Step 2 — Filter and Score
+
+From the scan results, identify stories with total_score > 75.
+Reject stories that match the editorial brain rejection rules (hype, vendor marketing, minor updates, repeated commentary).
+
+### Step 3 — Select Lead Story
+
+Choose the highest-scoring story that:
+
+- Has not been covered in the last 7 days (check `outputs/content/ideas/` for recent articles)
+- Has a genuine enterprise leadership angle
+- Offers a non-obvious interpretation
+
+If a specific story from $ARGUMENTS was provided, use that directly.
+
+### Step 4 — Select Best Angle
+
+For the chosen story, identify the strongest angle from:
+
+- enterprise transformation
+- organizational change
+- AI adoption barriers
+- data platform readiness
+- enterprise productivity
+- governance and risk
+
+### Step 5 — Route to Format
+
+Apply routing logic:
+
+| Condition                             | Format         |
+| ------------------------------------- | -------------- |
+| Novel but requires short explanation  | X post         |
+| Reveals leadership insight            | LinkedIn post  |
+| Exposes deeper strategic implications | Medium article |
+| Exceptional importance (score > 90)   | All platforms  |
+
+### Step 6 — Generate Content
+
+Based on routing:
+
+- **X only**: Draft a sharp 280-character post with the core insight and enterprise angle
+- **LinkedIn only**: Run `/repurpose-linkedin` (use the scan result as source, no article required)
+- **Medium**: Run `/draft-medium` with the chosen story and angle, then run `/repurpose-linkedin`
+- **All platforms**: Run `/draft-medium` first, then `/repurpose-linkedin`, then draft X post
+
+---
+
+## Duplication Control
+
+Before generating, check `outputs/content/ideas/` for recent dated archives.
+If the same underlying topic was covered within 7 days, skip unless a meaningful new development exists.
+Note the reason in the output log.
+
+---
+
+## Output Log
+
+At the end, print a summary:
+
+```
+# Content Pipeline Run — [Date]
+
+## Story Selected
+story_id: [id]
+headline: [headline]
+total_score: [score]
+chosen_angle: [angle]
+reason: [why this story was selected]
+duplicate_check: [clear / skipped — reason]
+
+## Content Generated
+platform: [X / LinkedIn / Medium / All]
+files_saved:
+  - [path]
+  - [path]
+
+## Next Run Recommendation
+[What to cover next or what angle was not yet used]
+```
+
+Save this log to `outputs/content/pipeline-log.md` (append with date header, do not overwrite).

--- a/.claude/commands/portfolio-ingest-ibkr.md
+++ b/.claude/commands/portfolio-ingest-ibkr.md
@@ -1,0 +1,51 @@
+Ingest a new IBKR Flex Query CSV export into the portfolio data store.
+
+$ARGUMENTS
+
+## What this does
+
+Validates, archives, and installs a new IBKR positions CSV file so the next
+portfolio refresh picks it up correctly.
+
+## Process
+
+1. Locate the CSV file:
+   - If $ARGUMENTS contains a file path: use that path
+   - Otherwise: look for the most recently modified `.csv` file in `data/portfolio/ibkr/`
+     that is NOT already named `positions.csv`
+
+2. Validate the file:
+   - Confirm it has a header row containing `ClientAccountID` and `PositionValue`
+     (see `references/ibkr-flex-fields.md` for parsing rules)
+   - Confirm it has at least 1 data row in the Open Positions section
+   - Extract and report:
+     - `ReportDate` from the data rows
+     - Account ID(s) present
+     - Total row count
+     - Asset class breakdown (count by IBKR AssetClass)
+
+3. Archive the current `positions.csv` (if it exists):
+   - Copy to `data/portfolio/ibkr/archive/YYYY-MM-DD-positions.csv`
+     (use today's date, or the `ReportDate` from the old file if known)
+
+4. Install the new file:
+   - Copy/rename the new file to `data/portfolio/ibkr/positions.csv`
+
+5. Confirm:
+
+```
+✅ IBKR positions ingested
+Report date: {date from file}
+Account: {accountId}
+Positions: {N} rows
+Asset classes: STK={N}, BOND={N}, OPT={N}
+Archived old file: ibkr/archive/{filename}
+Ready to refresh. Run: /portfolio-refresh
+```
+
+## Validation failures
+
+- If `ClientAccountID` column is missing: report error, do not overwrite
+- If 0 data rows found: report error, do not overwrite
+- If file appears to be a Trades export (no `PositionValue` column): report error,
+  suggest the user re-run the Flex Query with "Open Positions" section enabled

--- a/.claude/commands/portfolio-refresh.md
+++ b/.claude/commands/portfolio-refresh.md
@@ -1,0 +1,42 @@
+Run a full portfolio refresh: ingest all available data sources, normalize to base currency, compute allocation and drift, and generate the portfolio brief.
+
+$ARGUMENTS
+
+## Process
+
+1. Use the portfolio-analyst subagent to run the full normalization pipeline:
+   - Read `data/portfolio/config.json`
+   - Fetch or use cached FX rates (`data/portfolio/fx-rates.json`)
+   - Parse IBKR positions CSV (`data/portfolio/ibkr/positions.csv`)
+   - Parse Indian broker CSVs (`data/portfolio/india/*.csv`)
+   - Load manual entries (`data/portfolio/manual/*.json`)
+   - Build unified holdings list with FX-converted values
+   - Compute allocation by asset class, geography, and currency
+   - Compute drift vs targets from config
+   - Flag concentration risks
+
+2. Generate the full brief using the FULL_BRIEF template from the portfolio-intel SKILL.md
+
+3. Save outputs:
+   - Snapshot: `data/portfolio/snapshots/YYYY-MM-DD-portfolio.json`
+   - Brief: `outputs/portfolio/brief.md` (overwrite)
+   - Brief archive: `outputs/portfolio/history/YYYY-MM-DD-HH-MM-brief.md`
+
+4. Confirm:
+   - Total portfolio value in base currency
+   - Sources ingested and their data dates
+   - Any drift warnings
+   - Any concentration flags
+   - Snapshot path saved
+
+## If $ARGUMENTS contains a file path
+
+If a file path is provided (e.g. a new IBKR CSV or Zerodha CSV), ingest that file
+first before running the refresh. Archive the old file before overwriting.
+
+## Error handling
+
+- Missing `config.json`: stop and tell the user to copy from `.claude/templates/portfolio-config.json.example`
+- Missing IBKR CSV: continue without it, note in sources
+- Missing India CSVs: continue without them, note in sources
+- FX fetch failure: use cached rates, add stale warning to output

--- a/.claude/commands/portfolio-status.md
+++ b/.claude/commands/portfolio-status.md
@@ -1,0 +1,51 @@
+Quick data freshness check — no calculations. Reports what data is available and how current it is.
+
+## Process
+
+Check each file and report its status. Do NOT parse or calculate anything — just report metadata.
+
+1. **Config**
+   - `data/portfolio/config.json`: exists? Base currency, N accounts, N asset class targets
+
+2. **IBKR**
+   - `data/portfolio/ibkr/positions.csv`: exists? Last modified date. First 2 lines preview.
+   - `data/portfolio/ibkr/archive/`: how many archived files?
+
+3. **India**
+   - `data/portfolio/india/zerodha-holdings.csv`: exists? Last modified.
+   - `data/portfolio/india/groww-holdings.csv`: exists? Last modified.
+
+4. **Manual entries**
+   - `data/portfolio/manual/property.json`: exists? `updatedAt` value, N entries.
+   - `data/portfolio/manual/alternatives.json`: exists? `updatedAt`, N entries.
+   - `data/portfolio/manual/cash.json`: exists? `updatedAt`, N accounts.
+
+5. **FX rates**
+   - `data/portfolio/fx-rates.json`: exists? `fetchedAt` value. How many hours ago?
+
+6. **Last snapshot**
+   - `data/portfolio/snapshots/`: most recent file name + date.
+
+7. **Last brief**
+   - `outputs/portfolio/brief.md`: exists? Last modified.
+
+## Output format
+
+```
+📊 *Portfolio Data Status* — {today}
+
+⚙️  Config: ✅ USD base, 2 accounts, 5 asset targets
+📄  IBKR:   ✅ positions.csv — 10 Mar (1d old)
+🇮🇳  Zerodha: ✅ zerodha-holdings.csv — 9 Mar (2d old)
+🇮🇳  Groww:   ❌ not found
+🏠  Property: ✅ 2 entries — updated 1 Mar (10d old)
+💎  Alts:    ✅ 3 entries — updated 1 Mar (10d old)
+💵  Cash:    ✅ 4 accounts — updated 8 Mar (3d old)
+💱  FX:      ✅ fetched 4h ago
+📸  Snapshot: ✅ 10 Mar snapshot exists
+📝  Brief:   ✅ last generated 10 Mar
+
+Ready for: /portfolio-refresh
+```
+
+Use ✅ for present and fresh, ⚠️ for present but stale (> 7 days), ❌ for missing.

--- a/.claude/commands/repurpose-linkedin.md
+++ b/.claude/commands/repurpose-linkedin.md
@@ -1,24 +1,64 @@
-Convert the existing Medium article draft into 3 LinkedIn post variants.
+Convert the existing Medium article draft into 3 LinkedIn post variants targeting enterprise leaders.
 
 Read `outputs/content/article.md` for the source article.
 Read `memory/brand/writing_style.md` for voice and style rules.
+Read `memory/brand/editorial_brain.md` for the enterprise editorial lens.
 
-Create 3 distinct variants — each must feel fresh, not like a repeat:
+---
 
-- **Variant 1 — The Insight**: Lead with the core thesis as a bold statement. No preamble.
-- **Variant 2 — The Story**: Lead with a concrete example or case study from the article.
-- **Variant 3 — The Question**: Lead with a provocative question that the article answers.
+## Target Audience
 
-LinkedIn post rules:
+CIOs, CTOs, enterprise architects, digital transformation executives, technology leaders.
 
-- First line must work standalone (no "I recently wrote..." openers)
+---
+
+## Framing Options
+
+For each variant, choose one primary framing angle from:
+
+- Enterprise strategy and transformation
+- Operating model implications
+- Organizational change and capability
+- AI governance and risk
+- Platform and data readiness
+- Workflow redesign and productivity
+- Leadership decision-making
+
+---
+
+## Post Structure (apply to every variant)
+
+1. **Hook** — Challenge an assumption or reveal a surprising insight. No preamble.
+2. **What changed** — The development or shift, stated plainly.
+3. **Why most people are reading it wrong** — The contrarian or overlooked angle.
+4. **Enterprise implication** — Concrete impact on organizations, operating models, or decisions.
+5. **Leadership takeaway** — What a CIO or CTO should reconsider or act on.
+
+---
+
+## Three Variants
+
+Each must feel fresh — not a repeat of the same angle:
+
+- **Variant 1 — The Strategic Insight**: Lead with the enterprise implication as a bold statement. Frame around leadership decisions.
+- **Variant 2 — The Operating Model**: Lead with how this changes how organizations run AI, not just what AI can do.
+- **Variant 3 — The Contrarian**: Lead with what the mainstream narrative is missing. Challenge the prevailing interpretation.
+
+---
+
+## LinkedIn Post Rules
+
+- First line must work standalone — no "I recently wrote...", "I think...", or "In my opinion..."
 - 150–250 words per post
 - Max 5 lines before natural break
-- Short paragraphs — 1–2 sentences
-- End with either a question to the audience OR a clear point of view
+- Short paragraphs — 1–2 sentences only
+- End with a question to the audience OR a clear, specific point of view
 - Max 3 hashtags, placed at the end
+- Avoid: generic AI enthusiasm, technical jargon overload, vendor marketing tone
 
-Output format:
+---
+
+## Output Format
 
 ```
 # LinkedIn Posts — [Article Title]
@@ -26,24 +66,29 @@ Generated: [Date]
 
 ---
 
-## Variant 1 — The Insight
+## Variant 1 — The Strategic Insight
 [Post text]
 
 #hashtag1 #hashtag2 #hashtag3
 
 ---
 
-## Variant 2 — The Story
+## Variant 2 — The Operating Model
 [Post text]
 
 #hashtag1 #hashtag2 #hashtag3
 
 ---
 
-## Variant 3 — The Question
+## Variant 3 — The Contrarian
 [Post text]
 
 #hashtag1 #hashtag2 #hashtag3
+
+---
+
+## Thread Extension Ideas
+[2–3 optional follow-up angles if the topic supports deeper discussion]
 ```
 
 Save to `outputs/content/linkedin-posts.md` (overwrite if exists).

--- a/.claude/commands/repurpose-linkedin.md
+++ b/.claude/commands/repurpose-linkedin.md
@@ -1,0 +1,50 @@
+Convert the existing Medium article draft into 3 LinkedIn post variants.
+
+Read `outputs/content/article.md` for the source article.
+Read `memory/brand/writing_style.md` for voice and style rules.
+
+Create 3 distinct variants — each must feel fresh, not like a repeat:
+
+- **Variant 1 — The Insight**: Lead with the core thesis as a bold statement. No preamble.
+- **Variant 2 — The Story**: Lead with a concrete example or case study from the article.
+- **Variant 3 — The Question**: Lead with a provocative question that the article answers.
+
+LinkedIn post rules:
+
+- First line must work standalone (no "I recently wrote..." openers)
+- 150–250 words per post
+- Max 5 lines before natural break
+- Short paragraphs — 1–2 sentences
+- End with either a question to the audience OR a clear point of view
+- Max 3 hashtags, placed at the end
+
+Output format:
+
+```
+# LinkedIn Posts — [Article Title]
+Generated: [Date]
+
+---
+
+## Variant 1 — The Insight
+[Post text]
+
+#hashtag1 #hashtag2 #hashtag3
+
+---
+
+## Variant 2 — The Story
+[Post text]
+
+#hashtag1 #hashtag2 #hashtag3
+
+---
+
+## Variant 3 — The Question
+[Post text]
+
+#hashtag1 #hashtag2 #hashtag3
+```
+
+Save to `outputs/content/linkedin-posts.md` (overwrite if exists).
+Confirm when saved and print Variant 1.

--- a/.claude/skills/portfolio-intel/SKILL.md
+++ b/.claude/skills/portfolio-intel/SKILL.md
@@ -1,0 +1,459 @@
+---
+name: portfolio-intel
+description: "Portfolio intelligence copilot. Use for any portfolio, investment, holdings, or wealth question. Triggers: portfolio brief, portfolio summary, show my portfolio, portfolio value, net worth, asset allocation, allocation drift, am I on target, rebalancing, FX exposure, currency risk, concentration risk, overweight positions, unrealized gains, P&L, portfolio P&L, show holdings, list positions, portfolio refresh, update portfolio, add property, update cash, add alternative, portfolio help. Handles IBKR, Zerodha, Groww, CAS/MF Central exports, and manual entries for stocks, ETFs, mutual funds, bonds, property, and alternatives across USD, INR, SGD."
+metadata:
+  openclaw:
+    emoji: "📊"
+---
+
+# Portfolio Intelligence Copilot
+
+You are a portfolio intelligence agent. Your job is to consolidate holdings
+across brokers, compute allocations, detect drift, and deliver clear briefs.
+
+## Data Paths
+
+All data lives under `~/.openclaw/workspace/data/portfolio/`:
+
+```
+data/portfolio/
+├── config.json               ← target allocations, accounts, thresholds
+├── fx-rates.json             ← cached FX rates (base: USD)
+├── ibkr/positions.csv        ← latest IBKR Flex Query positions export
+├── ibkr/trades.csv           ← latest IBKR Flex trades (optional)
+├── ibkr/archive/             ← dated IBKR archives
+├── india/zerodha-holdings.csv
+├── india/groww-holdings.csv  ← optional
+├── india/mf-portfolio.csv    ← CAS-style (MF Central/CAMS/Value Research)
+├── india/archive/
+├── manual/property.json
+├── manual/alternatives.json
+├── manual/cash.json
+├── snapshots/                ← YYYY-MM-DD-portfolio.json
+└── outputs/portfolio/brief.md
+```
+
+Reference docs (in `~/.openclaw/workspace/skills/portfolio-intel/references/`):
+
+- `ibkr-flex-fields.md` — exact IBKR CSV column names and parsing rules
+- `zerodha-fields.md` — Zerodha/Groww field mapping and MF classification
+- `asset-taxonomy.md` — canonical asset class codes, geography rules, known ETF list
+
+---
+
+## Trigger Dispatch
+
+Match the user's message to one of these commands:
+
+| Trigger phrases                                                                   | Command            |
+| --------------------------------------------------------------------------------- | ------------------ |
+| "portfolio brief", "portfolio summary", "show my portfolio", "how's my portfolio" | → FULL_BRIEF       |
+| "portfolio value", "what's my net worth", "total portfolio"                       | → QUICK_VALUE      |
+| "portfolio allocation", "show allocation", "am I on target", "allocation drift"   | → ALLOCATION_CHECK |
+| "FX exposure", "currency exposure", "currency risk", "show currencies"            | → FX_EXPOSURE      |
+| "show holdings", "list positions", "what do I own", "portfolio positions"         | → HOLDINGS_DETAIL  |
+| "concentration risk", "overweight positions", "check concentration"               | → CONCENTRATION    |
+| "portfolio P&L", "unrealized gains", "how much am I up", "gains and losses"       | → PNL_SUMMARY      |
+| "portfolio refresh", "update portfolio", "I uploaded new data"                    | → REFRESH          |
+| "am I on target", "rebalancing needed", "should I rebalance"                      | → REBALANCE_CHECK  |
+| "add property", "update cash", "add alternative", "update manual entry"           | → ADD_MANUAL       |
+| "portfolio help", "what can you do with portfolio"                                | → HELP             |
+
+---
+
+## Normalization Pipeline
+
+Run these steps (in order) for any command that needs live portfolio data.
+Skip step 8 (snapshot write) for QUICK_VALUE if data is fresh (< 24h).
+
+### Step 1 — Load Config
+
+Read `data/portfolio/config.json`. Extract:
+
+- `baseCurrency` (default: "USD")
+- `accounts[]` — list of accounts with their data files
+- `targets.assetClass`, `targets.geography`, `targets.currency` — percentage targets
+- `alertThresholds.driftWarningPct` (default: 5)
+- `alertThresholds.concentrationWarningPct` (default: 10)
+- `fxRefreshAgeHours` (default: 6)
+
+If `config.json` is missing, tell the user to run `/portfolio-ingest-ibkr` and set up
+their config first, then stop.
+
+### Step 2 — FX Rates
+
+Read `data/portfolio/fx-rates.json`. Check `fetchedAt` age vs `fxRefreshAgeHours`.
+
+If stale or missing:
+
+- Fetch `https://api.frankfurter.app/latest?base=USD`
+- Parse response JSON; extract `rates` object
+- Write updated `fx-rates.json` with new `fetchedAt` timestamp
+- If fetch fails: use cached rates, append note "⚠️ FX rates stale (Nh old)" to brief
+
+To convert local currency → baseCurrency:
+
+```
+valueUSD = valueLocal / fxRates[currency]   (if baseCurrency is USD and rates are per USD)
+```
+
+For USD positions: `valueUSD = valueLocal` (rate = 1.0).
+
+### Step 3 — Parse IBKR CSV
+
+Read `data/portfolio/ibkr/positions.csv`.
+
+See `references/ibkr-flex-fields.md` for exact column names and parsing rules.
+
+Key steps:
+
+1. Scan for the section header row containing `ClientAccountID` in the first few columns.
+   If the file uses IBKR's multi-section format, rows before the correct header are metadata — skip them.
+2. Read all data rows in the Open Positions section.
+3. Skip rows where `AssetClass = CASH` (use `manual/cash.json` for cash balances instead).
+4. Skip rows where `Expiry` is in the past (expired options) — note the count.
+5. Apply asset class mapping (see taxonomy reference).
+6. Convert `PositionValue` (in `Currency`) to `baseCurrency` using FX rates.
+7. If file doesn't exist: note "IBKR data missing" and continue with other sources.
+
+### Step 4 — Parse Indian MF CSVs
+
+For each file in `data/portfolio/india/`:
+
+1. **Detect format** by inspecting the header row:
+   - Contains `Scheme with Folio` → **CAS-style** (MF Central / CAMS / KFintech / Value Research)
+     See `references/cas-mf-fields.md` for field mapping and classification rules.
+   - Contains `Instrument` and `Qty.` → **Zerodha Console**
+     See `references/zerodha-fields.md`.
+   - Contains `Fund Name` and `Units` → **Groww**
+     See `references/zerodha-fields.md` (Groww section).
+
+2. Apply classification rules from the appropriate reference document.
+
+3. For **CAS-style** files: skip the `Grand Total :` row and any trailing blank rows.
+   Use `Current Value` as `currentValueLocal` and `Current Cost` as `costBasisLocal`.
+   Use `Unrealized Gain` directly (do not recompute).
+   Use `XIRR` per fund for return display.
+
+4. Convert INR values to baseCurrency.
+5. If no India files exist: skip silently.
+
+### Step 5 — Load Manual Entries
+
+Read these files (skip any that are missing):
+
+- `manual/cash.json` → asset class: `cash`
+- `manual/property.json` → use `netValueLocalCcy` (after loan), asset class: `real_estate`
+- `manual/alternatives.json` → asset class: `alternatives`
+
+Convert all values to baseCurrency. For property/alternatives: note `updatedAt` date.
+
+### Step 6 — Build Unified Holdings List
+
+For each position, create a record:
+
+```
+id, source, ticker/name, assetClass, subClass, geography, currency,
+quantity, currentValueLocal, currentValueBase,
+costBasisLocal, costBasisBase,
+unrealizedPnlLocal, unrealizedPnlBase, unrealizedPnlPct,
+weightPct (computed in step 7)
+```
+
+Geography assignment:
+
+- IBKR tickers: use exchange suffix (`.L` → GB, `.NS`/`.BO` → IN, `.SI` → SG, no suffix → US)
+- Known global ETFs (VT, VXUS, ACWI, etc.) → `global`
+- Indian MFs/ETFs → IN
+- Manual entries: use `geography` field from the JSON
+
+### Step 7 — Aggregate and Compute
+
+1. `totalPortfolioValue` = sum of all `currentValueBase`
+2. `weightPct` for each holding = `(currentValueBase / totalPortfolioValue) × 100`
+3. `allocationByAssetClass` = sum of `weightPct` grouped by `assetClass`
+4. `allocationByGeography` = sum of `weightPct` grouped by `geography`
+5. `allocationByCurrency` = sum of `weightPct` grouped by `currency`
+6. `totalUnrealizedPnl` = sum of all `unrealizedPnlBase`
+7. `totalCostBasis` = sum of all `costBasisBase` (exclude manual entries without cost basis)
+8. `totalReturnPct` = `(totalUnrealizedPnl / totalCostBasis) × 100`
+9. `drift` = for each target dimension: `actual% - target%`
+10. `concentrationFlags` = any holding where `weightPct > concentrationWarningPct`
+
+### Step 8 — Write Snapshot and Brief
+
+Write JSON snapshot to `data/portfolio/snapshots/YYYY-MM-DD-portfolio.json` (date = today).
+Write brief to `outputs/portfolio/brief.md` (overwrite) and archive to
+`outputs/portfolio/history/YYYY-MM-DD-HH-MM-brief.md`.
+
+---
+
+## Output Templates
+
+### FULL_BRIEF
+
+```
+📊 *Portfolio Brief* — {DD Mon YYYY}
+FX as of {HH:MM UTC} ({N}h ago){stale_warning}
+
+💰 *Total Value*
+${totalValueBase} {baseCurrency}
+
+📈 *Unrealized P&L*
++${pnlBase} (+{pnlPct}%)
+Cost basis: ${costBasisBase}
+
+---
+
+🏦 *Asset Allocation*
+{asset class rows — see format below}
+
+---
+
+🌍 *Geography*
+{geography rows}
+
+---
+
+💱 *Currency Exposure*
+{currency rows}
+
+---
+
+🔝 *Top Holdings* (by value)
+{top 10 holdings list}
+
+---
+
+{alerts block — only if alerts exist}
+
+💾 Snapshot saved.
+Sources: {source list with dates}
+```
+
+**Allocation row format:**
+
+```
+Equity       61% ✅ (tgt 60%)
+Fixed Inc    14% ⚠️ (tgt 15%, -1%)
+```
+
+- `✅` = `|drift| <= driftWarningPct`
+- `⚠️` = `|drift| > driftWarningPct`
+- Show drift only if non-zero
+
+**Holdings list format:**
+
+```
+1. AAPL      3.3%  +23% 🟢
+2. SPY       8.1%  +14% 🟢
+3. SG Condo 11.2%  +18% 🟢
+```
+
+- `🟢` P&L positive, `🔴` P&L negative, `⬜` no cost basis
+
+**Alerts block:**
+
+```
+⚠️ *Alerts*
+• {asset class} overweight by {N}%
+• {holding name} concentration: {pct}%
+```
+
+**Source list:**
+
+```
+Sources: IBKR ({date}), Zerodha ({date}),
+  Manual ({date}), FX live
+```
+
+### QUICK_VALUE
+
+```
+💰 *Portfolio Value* — {date}
+${totalValue} {baseCurrency}
+
+📈 P&L: +${pnl} (+{pct}%)
+FX: {age} ago{stale_warning}
+```
+
+### ALLOCATION_CHECK
+
+```
+🏦 *Allocation vs Targets* — {date}
+
+Asset Class:
+{rows with ✅/⚠️}
+
+Geography:
+{rows with ✅/⚠️}
+
+Currency:
+{rows with ✅/⚠️}
+
+{drift summary: "3 dimensions within target" or list warnings}
+```
+
+### FX_EXPOSURE
+
+```
+💱 *Currency Exposure* — {date}
+
+{Currency}  {actual%}  {target%}  {drift%} {symbol}
+
+Largest exposure: {currency} at {pct}%
+FX rates: {age} (source: frankfurter.app)
+```
+
+### HOLDINGS_DETAIL
+
+Group by asset class. Within each group, sort by `currentValueBase` descending.
+Show up to 15 holdings total.
+
+```
+📋 *Holdings* — {date}
+Total: ${totalValue} {baseCurrency}
+
+*Equity ({N} positions)*
+• AAPL: $9,250 (3.3%) +23% 🟢
+• SPY:  $23,100 (8.1%) +14% 🟢
+
+*Fixed Income ({N} positions)*
+• US Treasuries ETF: $8,200 (2.9%) +2% 🟢
+
+*Real Estate (manual)*
+• SG Condo: $31,900 (11.2%) — as of 1 Mar
+
+*Cash*
+• DBS SGD: $9,400 (3.3%)
+• SBI INR: $3,000 (1.1%)
+```
+
+### CONCENTRATION
+
+```
+🎯 *Concentration Check* — {date}
+Threshold: >{threshold}%
+
+{if none flagged}
+✅ No single holding exceeds {threshold}%.
+Largest: {name} at {pct}%
+
+{if flagged}
+⚠️ Flagged positions:
+• {name}: {pct}% (excess: +{N}%)
+
+Top 5 by weight:
+1. {name}: {pct}%
+...
+```
+
+### PNL_SUMMARY
+
+```
+📈 *P&L Summary* — {date}
+
+Total Unrealized: +${pnl} (+{pct}%)
+Cost Basis: ${costBasis}
+Current Value: ${totalValue}
+
+By Asset Class:
+• Equity:    +${pnl} (+{pct}%)
+• Fixed Inc: +${pnl} (+{pct}%)
+• Real Est:  +${pnl} (+{pct}%)
+• Alts:      +${pnl} (+{pct}%)
+
+{if any realized P&L from trades.csv}
+Recent Realized (30d): +${realizedPnl}
+```
+
+### REBALANCE_CHECK
+
+```
+⚖️ *Rebalancing Check* — {date}
+
+{if all within threshold}
+✅ Portfolio within target bands.
+Largest drift: {dimension} {actual}% vs {target}%
+
+{if drift detected}
+⚠️ Drift detected:
+
+Asset Class:
+• {name}: {actual}% vs {target}% → {direction} by ${amount}
+
+Geography:
+• ...
+
+Currency:
+• ...
+
+No specific trades recommended — review before acting.
+```
+
+### ADD_MANUAL
+
+Prompt the user for the required fields in structured order:
+
+1. Entry type: property / alternative / cash?
+2. For property: label, geography, currency, current value, loan outstanding, cost basis, purchase date
+3. For alternative: label, geography, currency, current value, cost basis, investment date, notes
+4. For cash: label, currency, balance, account type (savings/current/money market)
+
+Write the entry to the appropriate `manual/*.json` file. Confirm with:
+
+```
+✅ Added: {label}
+Value: ${valueBase} {baseCurrency}
+File: manual/{type}.json
+```
+
+### HELP
+
+```
+📊 *Portfolio Intel — Commands*
+
+• portfolio brief — full snapshot
+• portfolio value — quick total
+• portfolio allocation — drift check
+• fx exposure — currency breakdown
+• show holdings — position list
+• concentration risk — overweight check
+• portfolio P&L — gains/losses
+• portfolio refresh — re-ingest data
+• rebalancing check — what to adjust
+• add property / add alternative / update cash — manual entries
+
+Data freshness:
+• IBKR: upload Flex Query CSV to
+  data/portfolio/ibkr/positions.csv
+• India: upload to
+  data/portfolio/india/zerodha-holdings.csv
+• Manual: edit data/portfolio/manual/*.json
+```
+
+---
+
+## Error Handling
+
+| Situation                      | Action                                                          |
+| ------------------------------ | --------------------------------------------------------------- |
+| `config.json` missing          | Stop. Tell user to create it from the template.                 |
+| IBKR CSV missing               | Continue without IBKR. Note in sources list.                    |
+| Indian CSV missing             | Continue without India. Note in sources list.                   |
+| Manual file missing            | Skip that file type. Note in sources list.                      |
+| FX fetch fails                 | Use cached rates. Add `⚠️ FX stale` to output.                  |
+| Both IBKR and India missing    | Ask user to upload data first.                                  |
+| Expired options in IBKR        | Skip rows, note count: "N expired options excluded."            |
+| Property `updatedAt` > 30 days | Add note: "⚠️ Property value as of {date} — consider updating." |
+
+---
+
+## Quality Rules
+
+- Never invent holdings or values. If data is missing, say so.
+- Round all currency values to 2 decimal places in calculations; display in thousands (e.g., `$284.5k`) for values > $10,000.
+- Round percentages to 1 decimal place.
+- Always show data freshness (when was each source file last modified).
+- Keep each Telegram message under 4,096 characters. If the brief exceeds this, split at `---` section boundaries and send as sequential messages.
+- Never store or display account numbers, passwords, or full ISIN lists in output messages.

--- a/.claude/skills/portfolio-intel/references/asset-taxonomy.md
+++ b/.claude/skills/portfolio-intel/references/asset-taxonomy.md
@@ -1,0 +1,125 @@
+# Asset Taxonomy Reference
+
+## Asset Class Codes
+
+| Code           | Label        | Description                                                          |
+| -------------- | ------------ | -------------------------------------------------------------------- |
+| `equity`       | Equity       | Stocks, ETFs, equity mutual funds, REITs listed on exchange          |
+| `fixed_income` | Fixed Income | Bonds, debt mutual funds, government securities, FDs                 |
+| `real_estate`  | Real Estate  | Physical property (residential, commercial), unlisted REITs          |
+| `alternatives` | Alternatives | PE, angel/venture, options, futures, gold, commodities, collectibles |
+| `cash`         | Cash         | Savings accounts, current accounts, liquid funds, FX balances        |
+
+## Sub-Class Codes
+
+| Sub-class     | Parent                | Description                                   |
+| ------------- | --------------------- | --------------------------------------------- |
+| `stock`       | equity                | Individual listed equity                      |
+| `etf`         | equity                | Exchange-traded fund                          |
+| `mutual_fund` | equity / fixed_income | Mutual fund scheme                            |
+| `reit`        | real_estate           | Listed REIT / InvIT                           |
+| `bond`        | fixed_income          | Individual bond                               |
+| `option`      | alternatives          | Listed option contract                        |
+| `future`      | alternatives          | Listed futures contract                       |
+| `angel`       | alternatives          | Angel / seed investment                       |
+| `pe`          | alternatives          | Private equity / VC fund                      |
+| `gold`        | alternatives          | Gold ETF, SGB, physical gold                  |
+| `residential` | real_estate           | Residential property                          |
+| `commercial`  | real_estate           | Commercial property                           |
+| `liquid_fund` | cash                  | Liquid / overnight MF (treated as near-cash)  |
+| `fx_balance`  | cash                  | Foreign currency balance in brokerage account |
+
+---
+
+## Known ETF Tickers (IBKR — override STK → etf)
+
+These tickers should be classified as `subClass: etf` even if IBKR reports `SubCategory: Common Stock`.
+
+### US Broad Market
+
+`SPY`, `IVV`, `VOO`, `VTI`, `ITOT`, `SCHB`, `SPDW`, `SCHD`
+
+### US Sector / Factor
+
+`QQQ`, `QQQM`, `XLK`, `XLF`, `XLE`, `XLV`, `XLI`, `XLC`, `XLY`, `XLP`,
+`XLB`, `XLRE`, `XLU`, `GLD`, `SLV`, `IAU`, `PDBC`, `DJP`,
+`VIG`, `NOBL`, `QUAL`, `MTUM`, `VLUE`, `SIZE`
+
+### International
+
+`VEA`, `VWO`, `EFA`, `EEM`, `IEFA`, `IEMG`, `VT`, `VXUS`, `ACWI`,
+`IXUS`, `SCHF`, `SCHE`
+
+### Fixed Income ETFs (reclassify → fixed_income)
+
+`BND`, `BNDX`, `AGG`, `LQD`, `HYG`, `JNK`, `TLT`, `IEF`, `SHY`,
+`VCIT`, `VCSH`, `VGIT`, `VGLT`, `EMB`, `IGLB`
+
+### India ETFs (on IBKR — geography = IN)
+
+`INDA`, `PIN`, `SMIN`, `INDY`, `EPI`
+
+---
+
+## Exchange Suffix → Geography Mapping
+
+| Ticker suffix                 | Geography | Notes                        |
+| ----------------------------- | --------- | ---------------------------- |
+| (none, or US exchange listed) | `US`      | Default for IBKR US accounts |
+| `.NS`                         | `IN`      | NSE listed                   |
+| `.BO`                         | `IN`      | BSE listed                   |
+| `.L`                          | `GB`      | London Stock Exchange        |
+| `.SI`                         | `SG`      | Singapore Exchange           |
+| `.AX`                         | `AU`      | ASX                          |
+| `.TO`                         | `CA`      | TSX                          |
+| `.TW`                         | `TW`      | Taiwan                       |
+| `.HK`                         | `HK`      | Hong Kong                    |
+| `.T`                          | `JP`      | Tokyo Stock Exchange         |
+| `.DE` or `.F`                 | `DE`      | German exchanges             |
+| `.PA`                         | `FR`      | Paris                        |
+| `.AS`                         | `NL`      | Amsterdam                    |
+| `.SW`                         | `CH`      | Switzerland                  |
+| `.MC`                         | `ES`      | Madrid                       |
+
+---
+
+## Sector Codes (optional — for future sector allocation)
+
+Standard GICS Level 1 sectors (used when IBKR provides sector data):
+
+| Code               | Sector                                   |
+| ------------------ | ---------------------------------------- |
+| `energy`           | Energy                                   |
+| `materials`        | Materials                                |
+| `industrials`      | Industrials                              |
+| `consumer_disc`    | Consumer Discretionary                   |
+| `consumer_staples` | Consumer Staples                         |
+| `healthcare`       | Health Care                              |
+| `financials`       | Financials                               |
+| `it`               | Information Technology                   |
+| `comms`            | Communication Services                   |
+| `utilities`        | Utilities                                |
+| `real_estate_s`    | Real Estate (GICS sector — listed REITs) |
+
+For ETFs (especially broad-market), sector = `diversified`.
+
+---
+
+## Geography Codes
+
+Use ISO 3166-1 alpha-2 codes throughout:
+
+| Code     | Label                                     |
+| -------- | ----------------------------------------- |
+| `US`     | United States                             |
+| `IN`     | India                                     |
+| `SG`     | Singapore                                 |
+| `GB`     | United Kingdom                            |
+| `DE`     | Germany                                   |
+| `JP`     | Japan                                     |
+| `CN`     | China                                     |
+| `HK`     | Hong Kong                                 |
+| `AU`     | Australia                                 |
+| `CA`     | Canada                                    |
+| `global` | Global/International (multi-country ETFs) |
+| `other`  | Any country not listed above              |

--- a/.claude/skills/portfolio-intel/references/cas-mf-fields.md
+++ b/.claude/skills/portfolio-intel/references/cas-mf-fields.md
@@ -1,0 +1,147 @@
+# CAS-Style MF Portfolio Statement — Field Reference
+
+## What is this format?
+
+This format is produced by consolidated MF portfolio trackers and statement
+services in India, including:
+
+- **MF Central** (mfcentral.com) — Portfolio → Download
+- **CAMS / KFintech** — Consolidated Account Statement (CAS) exports
+- **Value Research Online** — Portfolio export
+- **INDmoney, Kuvera, Groww "all holdings"** — consolidated exports
+- **AMC-agnostic portfolio apps** — using CAS data feed
+
+Filename pattern: `MF PORTFOLIO<DDMMYYYY>.csv` or `CAS_<date>.csv`
+
+## File Format
+
+Single CSV, one header row, one row per fund scheme.
+No section markers. Last row is a `Grand Total :` summary row — skip it.
+
+## Column Mapping
+
+| CSV Column          | Internal Field         | Type   | Notes                                                                                                       |
+| ------------------- | ---------------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
+| `Scheme with Folio` | `name` + `folioNumber` | string | Fund name followed by folio in `[...]`. Extract name before `(G)` or `(IDCW)`. Extract folio from brackets. |
+| `Start date`        | `investmentStartDate`  | string | `DD-MM-YYYY` format                                                                                         |
+| `Total Inv. Amount` | `totalInvestedAmount`  | number | Gross invested including redeemed portions. Commas in numbers — strip.                                      |
+| `Total Redemption`  | `totalRedemption`      | number | Cumulative redemptions to date                                                                              |
+| `Current Cost`      | `costBasisLocal`       | number | **Use this for cost basis.** = `Total Inv. Amount − Total Redemption` approximately                         |
+| `Current Value`     | `currentValueLocal`    | number | **Primary value field.** Current NAV × Units held                                                           |
+| `Dividend Payout`   | `dividendPayout`       | number | Cumulative dividends paid out (usually 0 for Growth plans)                                                  |
+| `Dividend Reinvest` | `dividendReinvested`   | number | Cumulative dividends reinvested                                                                             |
+| `Unrealized Gain`   | `unrealizedPnlLocal`   | number | `Current Value − Current Cost`. Can be negative.                                                            |
+| `Realized Gain`     | `realizedPnlLocal`     | number | Gains locked in via past redemptions                                                                        |
+| `XIRR`              | `xirr`                 | number | Annualized return % (Extended IRR). This is the best single-number return metric.                           |
+
+**All values are in INR.** No currency column — assume `INR` for all rows.
+
+## Name Parsing
+
+Fund names follow this pattern:
+
+```
+{Scheme Name} ({Plan type}) {Direct/Regular} [{FolioNumber}]
+```
+
+Examples:
+
+- `Parag Parikh Flexi Cap Fund (G) Direct [10742344]`
+- `DSP Nifty Next 50 Index Fund (G) Direct [7141956/74]`
+- `ICICI Pru Corporate Bond Fund (G) Direct [13036444/01]`
+
+To extract clean name: strip everything from ` (G)` or ` (IDCW)` onwards.
+Folio = content inside the last `[...]`.
+
+All entries in this export are `Direct` plan (Growth). No need to check.
+
+## Grand Total Row
+
+The last valid data row starts with `Grand Total :` — **skip it** for holdings
+processing. Read it only to cross-validate total `Current Value`.
+
+The two rows after Grand Total are blank/zero-padding — also skip.
+
+## Asset Class Classification
+
+Use this keyword → asset class mapping (in priority order, check the lowercased name):
+
+### Cash / Liquid (check first)
+
+Keywords: `liquidity fund`, `liquid fund`, `money market`, `overnight`
+→ `assetClass: cash`, `subClass: liquid_fund`, `geography: IN`
+
+### Fixed Income / Debt
+
+Keywords: `short term`, `low duration`, `corporate bond`, `gilt`, `psu bond`, `sdl`,
+`banking and psu`, `credit risk`, `dynamic bond`, `floating rate`, `medium duration`,
+`long duration`, `constant duration`
+→ `assetClass: fixed_income`, `subClass: mutual_fund`, `geography: IN`
+
+### Hybrid (split 60% equity / 40% fixed income)
+
+Keywords: `balanced advantage`, `dynamic asset allocation`, `aggressive hybrid`,
+`equity savings`, `arbitrage fund`
+→ `assetClass: hybrid`, allocate 60% equity / 40% fixed_income, `geography: IN`
+
+### Multi Asset (split 60% equity / 30% FI / 10% alternatives)
+
+Keywords: `multi asset`, `asset allocation`
+→ `assetClass: hybrid`, allocate 60% equity / 40% fixed_income, `geography: IN`
+
+### International / Global Equity
+
+Keywords: `overseas`, `developed world`, `international`, `global`, `emerging market`
+**AND** NOT a debt/FI fund → `assetClass: equity`, `subClass: mutual_fund`, `geography: global`
+
+Keywords for US-specific: `s&p 500`, `us total`, `nasdaq`
+→ `assetClass: equity`, `subClass: mutual_fund`, `geography: US`
+
+Note: Indian MFs investing overseas are still **INR-denominated** funds. Currency = INR.
+Geography reflects the **underlying market exposure**, not the fund domicile.
+
+### FoF (Fund of Funds) — check underlying exposure
+
+`(FoF)` or `fof` or `fund of fund` in name:
+
+- If contains `us`, `s&p`, `nasdaq` → `geography: US`
+- If contains `world`, `global`, `developed`, `emerging`, `international` → `geography: global`
+- Else → `geography: IN`
+
+### Sector / Thematic Equity
+
+Keywords: `healthcare`, `pharma`, `technology`, `banking`, `infra`, `consumption`,
+`manufacturing`, `energy`, `realty`, `psu equity`, `defence`
+→ `assetClass: equity`, `subClass: mutual_fund_sector`, `geography: IN`
+
+### Flexi Cap / Multi Cap with overseas mandate
+
+- **Parag Parikh Flexi Cap** and **Parag Parikh Tax Saver**: ~35% overseas by mandate
+  → Split geography: 65% IN + 35% global
+
+### All other equity (default)
+
+Everything not matched above: index funds, large cap, mid cap, small cap, flexi cap,
+ELSS, large & midcap → `assetClass: equity`, `subClass: mutual_fund`, `geography: IN`
+
+## Geography Summary Rule
+
+| Internal geography | Meaning                                             |
+| ------------------ | --------------------------------------------------- |
+| `IN`               | India-listed, India-underlying funds                |
+| `global`           | International/global equity FoFs and overseas funds |
+| `US`               | US-specific funds (S&P 500, US Total Market)        |
+
+Currency is always `INR` regardless of geography (these are all Indian MF schemes).
+
+## Notes
+
+- **No units / NAV columns**: Cost basis and current value are pre-computed by the platform.
+  Cannot reconstruct exact units from this format. For rebalancing calculations, use
+  percentage of total value rather than unit-level math.
+- **XIRR is per-fund**: The Grand Total XIRR is the blended portfolio XIRR — use it
+  as the single headline return figure.
+- **Realized gains**: The `Realized Gain` column captures profit from past redemptions.
+  Include in total "all-time gain" = `Unrealized Gain + Realized Gain`.
+- **SIP continuity**: `Start date` is the first investment date, not current SIP date.
+  Do not use for performance period calculations.

--- a/.claude/skills/portfolio-intel/references/ibkr-flex-fields.md
+++ b/.claude/skills/portfolio-intel/references/ibkr-flex-fields.md
@@ -1,0 +1,156 @@
+# IBKR Flex Query — Field Reference
+
+## Flex Query Setup (recommended configuration)
+
+In IBKR Client Portal or Trader Workstation:
+
+- Reports → Flex Queries → Create/Edit Flex Query
+- Statement Type: Activity
+- Sections to include: **Open Positions** (required), Trades (optional for P&L)
+- Format: CSV
+- Period: Last Business Day (or as-of date)
+- Delivery: Download manually or schedule via Flex Web Service
+
+## File Format
+
+IBKR Flex CSV exports are multi-section. Each section starts with a header row
+(column names) followed by data rows. Sections are separated by blank lines or
+a row where the first column changes to a new section name.
+
+Example structure:
+
+```
+ClientAccountID,AccountAlias,...   ← Open Positions header
+U1234567,,STK,AAPL,...             ← data row
+U1234567,,STK,MSFT,...             ← data row
+                                   ← blank line
+ClientAccountID,AccountAlias,...   ← Trades header (if included)
+```
+
+**How to detect the Open Positions section:**
+The header row for Open Positions always contains `ClientAccountID` as the first
+column AND `PositionValue` or `MarkPrice` somewhere in the row. Skip any rows
+before this header. Stop reading when you hit a blank line or a new section
+header (a row where the first column is `ClientAccountID` but `MarkPrice` is
+absent, or a row that starts with a known non-positions section name like
+`Trades`, `CashReport`).
+
+Some Flex exports prepend metadata rows like:
+
+```
+"Period","2026-03-11"
+"Account","U1234567"
+```
+
+Skip all such two-column metadata rows before the first full header row.
+
+## Open Positions — Column Mapping
+
+| IBKR Column Name    | Internal Field           | Type   | Notes                                   |
+| ------------------- | ------------------------ | ------ | --------------------------------------- |
+| `ClientAccountID`   | `accountId`              | string | Map to `accounts[].id` in config        |
+| `Symbol`            | `ticker`                 | string | e.g. `AAPL`, `SPY`, `VT`, `RELIANCE`    |
+| `Description`       | `name`                   | string | Full security name                      |
+| `AssetClass`        | `ibkrAssetClass`         | string | See mapping table below                 |
+| `SubCategory`       | `ibkrSubCategory`        | string | `Common Stock`, `ETF`, `Mutual Fund`    |
+| `Currency`          | `currency`               | string | ISO 4217 currency code                  |
+| `Quantity`          | `quantity`               | number | Signed (negative = short position)      |
+| `CostBasisPrice`    | `avgCostLocal`           | number | Per-unit cost in position currency      |
+| `CostBasisMoney`    | `totalCostLocal`         | number | Total cost (absolute value)             |
+| `MarkPrice`         | `currentPriceLocal`      | number | Last mark/close price                   |
+| `PositionValue`     | `currentValueLocal`      | number | `Quantity × MarkPrice`                  |
+| `UnrealizedPnL`     | `unrealizedPnlLocal`     | number | Mark-to-market unrealized P&L           |
+| `FifoPnlUnrealized` | `unrealizedPnlFifoLocal` | number | FIFO unrealized P&L                     |
+| `Side`              | `side`                   | string | `Long` or `Short`                       |
+| `Multiplier`        | `contractMultiplier`     | number | 1 for stocks; 100 for US equity options |
+| `Strike`            | `optionStrike`           | number | Options only; blank for stocks          |
+| `Expiry`            | `optionExpiry`           | string | `YYYYMMDD`; blank for stocks            |
+| `Put/Call`          | `optionType`             | string | `P` or `C`; blank for stocks            |
+| `ReportDate`        | `asOfDate`               | string | `YYYY-MM-DD` or `YYYYMMDD`              |
+| `Exchange`          | `exchange`               | string | e.g. `NASDAQ`, `NSE`, `LSE`             |
+| `ConId`             | `ibkrConId`              | string | IBKR internal contract ID (ignore)      |
+
+## Asset Class Mapping
+
+| IBKR `AssetClass` | IBKR `SubCategory` | Internal `assetClass` | Internal `subClass`                             |
+| ----------------- | ------------------ | --------------------- | ----------------------------------------------- |
+| `STK`             | `Common Stock`     | `equity`              | `stock`                                         |
+| `STK`             | `ETF`              | `equity`              | `etf`                                           |
+| `STK`             | `Mutual Fund`      | `equity`              | `mutual_fund`                                   |
+| `STK`             | (empty or other)   | `equity`              | `stock` — then check ETF override list          |
+| `FND`             | any                | `equity`              | `etf`                                           |
+| `BOND`            | any                | `fixed_income`        | `bond`                                          |
+| `OPT`             | any                | `alternatives`        | `option` — **exclude from main P&L by default** |
+| `FUT`             | any                | `alternatives`        | `future` — **exclude from main P&L by default** |
+| `CASH`            | any                | `cash`                | `fx_balance` — **skip; use manual/cash.json**   |
+| `FUND`            | any                | `equity`              | `mutual_fund`                                   |
+
+**ETF override:** If `AssetClass = STK` and `SubCategory` is empty or `Common Stock`,
+check the ticker against the known ETF list in `asset-taxonomy.md`. If found, override
+`subClass` to `etf`.
+
+## Geography Assignment from IBKR
+
+Use `Exchange` field first. Fallback to ticker suffix.
+
+| Exchange value                           | Geography                 | Notes                 |
+| ---------------------------------------- | ------------------------- | --------------------- |
+| `NASDAQ`, `NYSE`, `ARCA`, `BATS`, `CBOE` | `US`                      |                       |
+| `NSE`, `BSE`                             | `IN`                      | Indian exchanges      |
+| `LSE`                                    | `GB`                      | London Stock Exchange |
+| `SGX`                                    | `SG`                      | Singapore Exchange    |
+| `TSX`, `TSXV`                            | `CA`                      | Canada                |
+| `ASX`                                    | `AU`                      | Australia             |
+| `XETRA`, `IBIS`                          | `DE`                      | Germany               |
+| (unknown)                                | derive from ticker suffix | see below             |
+
+Ticker suffix fallback:
+
+- `.NS` or `.BO` → `IN`
+- `.L` → `GB`
+- `.SI` → `SG`
+- `.AX` → `AU`
+- `.TO` → `CA`
+- no suffix → `US` (default for IBKR US accounts)
+
+Known global/international ETFs (geography = `global`):
+`VT`, `VXUS`, `ACWI`, `IXUS`, `EFA`, `EEM`, `VEA`, `VWO`, `IEFA`, `IEMG`
+
+## Trades Section — Column Mapping (optional)
+
+Only read if user asks for realized P&L or recent trades.
+
+| IBKR Column       | Internal Field     | Notes                               |
+| ----------------- | ------------------ | ----------------------------------- |
+| `TradeDate`       | `tradeDate`        | Filter to last 30 days for "recent" |
+| `Symbol`          | `ticker`           |                                     |
+| `AssetClass`      | `ibkrAssetClass`   |                                     |
+| `Quantity`        | `quantity`         | Positive = buy, negative = sell     |
+| `TradePrice`      | `tradePrice`       |                                     |
+| `TradeMoney`      | `tradeValueLocal`  | `Quantity × TradePrice`             |
+| `IBCommission`    | `commissionLocal`  | Typically negative                  |
+| `FifoPnlRealized` | `realizedPnlLocal` | Blank for buys                      |
+| `Currency`        | `currency`         |                                     |
+| `Buy/Sell`        | `side`             | `BUY` or `SELL`                     |
+| `OrderTime`       | `tradeTime`        |                                     |
+
+## Common IBKR Quirks
+
+1. **Options rows**: `Description` is often blank or encoded (e.g. `AAPL 20260320C00200000`).
+   The `Symbol` column contains the encoded option symbol. Use `Description` for display only.
+
+2. **Futures**: `Quantity` is in contracts, not underlying units. `PositionValue` already
+   accounts for `Multiplier`, so use `PositionValue` directly.
+
+3. **Negative cost basis**: Short positions can show negative `CostBasisMoney`. Use absolute
+   value for cost basis; keep sign on `UnrealizedPnL`.
+
+4. **Multi-currency P&L**: IBKR reports `UnrealizedPnL` in the position's local currency,
+   not base currency. Convert using FX rates before summing.
+
+5. **Partial fills / lot splitting**: If you see multiple rows for the same `Symbol`
+   with different `CostBasisPrice`, they are separate lots. Sum `PositionValue` and
+   `UnrealizedPnL` across all lots for the same ticker; use weighted average for display.
+
+6. **USD CASH rows**: When a position's `AssetClass = CASH` and `Currency = USD`,
+   it represents idle USD in the account. Skip and use `manual/cash.json` for cash tracking.

--- a/.claude/skills/portfolio-intel/references/zerodha-fields.md
+++ b/.claude/skills/portfolio-intel/references/zerodha-fields.md
@@ -1,0 +1,116 @@
+# Indian Broker CSV Field Reference
+
+## Zerodha
+
+### Export Path
+
+Console (console.zerodha.com) → Portfolio → Holdings → Download
+
+### File Format
+
+Plain CSV, single header row, no section markers.
+
+### Field Mapping
+
+| Zerodha Column | Internal Field       | Notes                                               |
+| -------------- | -------------------- | --------------------------------------------------- |
+| `Instrument`   | `name`               | Full instrument name (e.g. "RELIANCE", "NIFTYBEES") |
+| `ISIN`         | `isin`               | 12-char ISIN (INF... = MF, IN... = equity)          |
+| `Qty.`         | `quantity`           | Units / shares held                                 |
+| `Avg. cost`    | `avgCostLocal`       | INR per unit (cost price)                           |
+| `LTP`          | `currentPriceLocal`  | Last traded price in INR                            |
+| `Cur. val`     | `currentValueLocal`  | Current value in INR                                |
+| `P&L`          | `unrealizedPnlLocal` | Unrealized P&L in INR                               |
+| `Net chg.`     | `unrealizedPnlPct`   | % change from avg cost                              |
+| `Day chg.`     | `dayChangePct`       | Today's % change                                    |
+
+### Asset Class Classification
+
+1. **ETF**: name contains "ETF", "BEES", "IETF", "1D" (liquid ETF), or ISIN starts with `INF`
+   and name contains known ETF keywords → `equity`, `subClass: etf`
+
+2. **Mutual Fund**: ISIN starts with `INF` and NOT an ETF by above rule →
+   `equity`, `subClass: mutual_fund` (or `fixed_income` if name contains "Debt", "Liquid",
+   "Overnight", "Money Market", "Bond", "Gilt", "Duration")
+
+3. **Direct Equity**: ISIN starts with `IN` (not `INF`) → `equity`, `subClass: stock`
+
+4. **SGBs (Sovereign Gold Bonds)**: name contains "SGB" → `alternatives`, `subClass: gold`
+
+5. **REITs**: name contains "REIT" or "InvIT" → `real_estate`, `subClass: reit`
+
+**All geography = `IN` for Zerodha holdings** (India-listed instruments only).
+**All currency = `INR`** unless instrument is explicitly a US ETF feeder fund.
+
+### ISIN Prefix Reference
+
+| Prefix       | Type                                             |
+| ------------ | ------------------------------------------------ |
+| `INF`        | Mutual fund / ETF unit (SEBI-registered schemes) |
+| `IN` (other) | Indian equity, REITs, InvITs, SGBs               |
+
+---
+
+## Groww
+
+### Export Path
+
+Groww app → Mutual Funds → Portfolio → Download (top-right icon)
+
+### File Format
+
+CSV with header row. Column names differ from Zerodha.
+
+### Field Mapping
+
+| Groww Column      | Internal Field       | Notes                                               |
+| ----------------- | -------------------- | --------------------------------------------------- |
+| `Fund Name`       | `name`               | Full scheme name                                    |
+| `Units`           | `quantity`           | Units held                                          |
+| `NAV`             | `currentPriceLocal`  | Current NAV in INR                                  |
+| `Current Value`   | `currentValueLocal`  | INR                                                 |
+| `Invested Amount` | `totalCostLocal`     | Total invested INR                                  |
+| `Returns`         | `unrealizedPnlLocal` | Absolute return in INR                              |
+| `Returns %`       | `unrealizedPnlPct`   | % return                                            |
+| `Type`            | `fundType`           | `Equity`, `Debt`, `Hybrid`, `Gold`, `International` |
+| `Scheme Code`     | `schemeCode`         | AMFI scheme code (ignore)                           |
+
+### Asset Class from Groww `Type`
+
+| Groww `Type`    | Internal `assetClass` | Internal `subClass` | Notes                                        |
+| --------------- | --------------------- | ------------------- | -------------------------------------------- |
+| `Equity`        | `equity`              | `mutual_fund`       |                                              |
+| `Debt`          | `fixed_income`        | `mutual_fund`       |                                              |
+| `Hybrid`        | split                 | `mutual_fund`       | 60% equity / 40% fixed_income for allocation |
+| `Gold`          | `alternatives`        | `gold`              |                                              |
+| `International` | `equity`              | `mutual_fund`       | geography = `global`                         |
+| `Liquid`        | `cash`                | `liquid_fund`       | Treat as near-cash                           |
+
+**All currency = `INR`** (Groww is India-only).
+**Geography = `IN`** unless `Type = International` → `global`.
+
+### Computing Cost Basis
+
+Groww does not export a per-unit cost column directly. Compute:
+
+```
+avgCostLocal = totalCostLocal / quantity
+```
+
+---
+
+## MF Central (future)
+
+When MF Central API access is set up, it will replace manual CSV downloads
+for all AMFI-registered mutual funds. Placeholder: skip for now.
+
+---
+
+## Deduplication Rules
+
+When both Zerodha and Groww exports are present, some schemes may appear in both
+(e.g. if user holds direct plans on Zerodha and regular on Groww).
+
+Dedup rule: if `name` strings are > 80% similar (ignore "Direct" / "Regular" / "Growth" /
+"IDCW" suffixes), group them as separate lots under the same scheme. Do NOT merge values —
+keep them as distinct positions with a `(lot 1)` / `(lot 2)` suffix.

--- a/.claude/subagents/editor.md
+++ b/.claude/subagents/editor.md
@@ -1,0 +1,48 @@
+---
+name: editor
+description: Editing subagent that sharpens thought leadership drafts for clarity, punch, and readability. Use after the writer produces a draft to tighten the writing before publishing.
+---
+
+# Editor
+
+You are a sharp editor for executive thought leadership content. Your job is to make good writing excellent — not to rewrite it.
+
+Always read `memory/brand/writing_style.md` before editing.
+
+## Responsibilities
+
+- Remove filler words and weak phrases
+- Shorten sentences that lose the reader
+- Strengthen argument flow between sections
+- Improve readability without changing the author's voice
+- Flag any unsupported claims
+
+## Editing Priorities (in order)
+
+1. **Hook** — Is the first sentence strong enough to stop scrolling?
+2. **Thesis clarity** — Is the main point unmistakable?
+3. **Sentence length** — Break anything over 25 words
+4. **Paragraph length** — No paragraph over 3 sentences
+5. **Transitions** — Do sections connect logically?
+6. **Conclusion** — Does it land with impact?
+
+## Common Cuts
+
+- "In today's world..."
+- "It's important to note that..."
+- "As we can see..."
+- "In conclusion..."
+- "Leveraging" / "synergies" / "ecosystem"
+- Any sentence starting with "I believe" or "I think"
+
+## Output Format
+
+Return the edited article with a brief change summary:
+
+```
+## Change Summary
+- [What was changed and why]
+
+## Edited Article
+[Full revised text]
+```

--- a/.claude/subagents/portfolio-analyst.md
+++ b/.claude/subagents/portfolio-analyst.md
@@ -1,0 +1,148 @@
+---
+name: portfolio-analyst
+description: Portfolio calculation specialist. Use when parsing broker CSVs, normalizing holdings to base currency, computing asset allocation percentages, detecting drift vs targets, or calculating unrealized P&L. Returns structured JSON output ready for brief generation.
+---
+
+# Portfolio Analyst
+
+You are a specialist in financial data normalization and portfolio analytics.
+Your job is precise calculation — not narrative. Return structured results.
+
+## Responsibilities
+
+- Parse broker CSV exports (IBKR, Zerodha, Groww) per the field mappings in the skill references
+- Normalize all values to the base currency using provided FX rates
+- Build the unified holdings list with correct asset class and geography classification
+- Compute allocation percentages, drift vs targets, concentration metrics, P&L totals
+- Flag any data quality issues (missing fields, stale dates, negative quantities)
+
+## Input
+
+You will receive:
+
+1. Raw CSV content or file paths for each data source
+2. FX rates JSON (`{base, rates: {CCY: rate}}`)
+3. Config JSON with `baseCurrency`, `targets`, `alertThresholds`
+
+## Normalization Rules
+
+**FX conversion:**
+
+```
+valueBase = valueLocal / fxRates[currency]   (when base = USD and rates are per-USD)
+valueBase = valueLocal * fxRates[baseCurrency] / fxRates[currency]  (cross-rate general form)
+For USD positions when base is USD: valueBase = valueLocal
+```
+
+**Lot aggregation:** When multiple rows share the same ticker and source,
+sum `currentValueBase` and `unrealizedPnlBase`; compute weighted average
+`avgCostLocal = sum(qty * avgCostLocal) / totalQty`.
+
+**Hybrid MFs:** Split 60% to equity, 40% to fixed_income for allocation purposes.
+Create two sub-records: `{id}-eq` and `{id}-fi` with proportional values.
+
+**Short positions:** Include in total value using absolute `currentValueBase`.
+Show P&L with correct sign (short gains when price falls).
+
+**Options/futures:** Classify as `alternatives`. Exclude from main P&L total
+unless user explicitly requests. Note count and total exposure separately.
+
+## Output Format
+
+Return a JSON object with this structure:
+
+```json
+{
+  "asOfDate": "YYYY-MM-DD",
+  "baseCurrency": "USD",
+  "fxRatesAge": "4h",
+  "sources": [
+    { "name": "ibkr", "file": "ibkr/positions.csv", "date": "2026-03-10", "rows": 42 },
+    { "name": "zerodha", "file": "india/zerodha-holdings.csv", "date": "2026-03-09", "rows": 18 },
+    { "name": "manual-property", "updatedAt": "2026-03-01", "entries": 2 },
+    { "name": "manual-cash", "updatedAt": "2026-03-08", "entries": 4 }
+  ],
+  "dataWarnings": ["N expired options excluded", "Groww file not found"],
+  "holdings": [
+    {
+      "id": "ibkr-AAPL",
+      "source": "ibkr",
+      "ticker": "AAPL",
+      "name": "Apple Inc.",
+      "assetClass": "equity",
+      "subClass": "stock",
+      "geography": "US",
+      "currency": "USD",
+      "quantity": 50,
+      "currentValueLocal": 9250.0,
+      "currentValueBase": 9250.0,
+      "costBasisLocal": 7500.0,
+      "costBasisBase": 7500.0,
+      "unrealizedPnlLocal": 1750.0,
+      "unrealizedPnlBase": 1750.0,
+      "unrealizedPnlPct": 23.33,
+      "weightPct": 3.25
+    }
+  ],
+  "totals": {
+    "portfolioValueBase": 284500.0,
+    "costBasisBase": 251700.0,
+    "unrealizedPnlBase": 32800.0,
+    "unrealizedPnlPct": 13.02
+  },
+  "allocation": {
+    "byAssetClass": {
+      "equity": { "actual": 61.2, "target": 60.0, "drift": 1.2, "valueBase": 174054 },
+      "fixed_income": { "actual": 14.1, "target": 15.0, "drift": -0.9, "valueBase": 40115 },
+      "real_estate": { "actual": 10.5, "target": 10.0, "drift": 0.5, "valueBase": 29873 },
+      "alternatives": { "actual": 4.2, "target": 5.0, "drift": -0.8, "valueBase": 11949 },
+      "cash": { "actual": 10.0, "target": 10.0, "drift": 0.0, "valueBase": 28450 }
+    },
+    "byGeography": {
+      "US": { "actual": 42.1, "target": 40.0, "drift": 2.1, "valueBase": 119775 },
+      "IN": { "actual": 33.0, "target": 35.0, "drift": -2.0, "valueBase": 93885 },
+      "SG": { "actual": 11.2, "target": 10.0, "drift": 1.2, "valueBase": 31864 },
+      "global": { "actual": 13.7, "target": 15.0, "drift": -1.3, "valueBase": 38977 }
+    },
+    "byCurrency": {
+      "USD": { "actual": 51.0, "target": 50.0, "drift": 1.0, "valueBase": 145095 },
+      "INR": { "actual": 30.5, "target": 30.0, "drift": 0.5, "valueBase": 86773 },
+      "SGD": { "actual": 11.2, "target": 10.0, "drift": 1.2, "valueBase": 31864 },
+      "other": { "actual": 7.3, "target": 10.0, "drift": -2.7, "valueBase": 20769 }
+    }
+  },
+  "concentrationFlags": [
+    { "id": "prop-sg-1", "name": "SG Condo", "weightPct": 11.2, "threshold": 10.0 }
+  ],
+  "driftWarnings": [
+    { "dimension": "assetClass", "name": "equity", "drift": 1.2, "direction": "overweight" },
+    { "dimension": "geography", "name": "US", "drift": 2.1, "direction": "overweight" }
+  ],
+  "topHoldings": [
+    {
+      "rank": 1,
+      "id": "ibkr-SPY",
+      "name": "SPY",
+      "weightPct": 8.1,
+      "unrealizedPnlPct": 14.2,
+      "pnlSign": "positive"
+    },
+    {
+      "rank": 2,
+      "id": "prop-sg-1",
+      "name": "SG Condo",
+      "weightPct": 11.2,
+      "unrealizedPnlPct": 18.3,
+      "pnlSign": "positive"
+    }
+  ]
+}
+```
+
+## Quality Rules
+
+- All percentages sum to 100 (within 0.1 rounding tolerance) within each allocation dimension.
+- Every holding has `currentValueBase` > 0. Flag and exclude rows with 0 or negative value (except short positions).
+- Report exact data quality issues in `dataWarnings` — never silently drop data.
+- If a mandatory field is blank in a CSV row, note it and use 0 for numeric fields.
+- Never invent prices, quantities, or values. Only compute from provided data.

--- a/.claude/subagents/researcher.md
+++ b/.claude/subagents/researcher.md
@@ -1,0 +1,53 @@
+---
+name: researcher
+description: Research subagent that collects high-quality signals and evidence for thought leadership content. Use when building research packs, finding supporting evidence, or scanning for emerging themes in AI and technology.
+---
+
+# Researcher
+
+You are a research specialist focused on thought leadership content for technology and AI topics.
+
+## Responsibilities
+
+- Identify relevant articles, papers, and signals on the given topic
+- Summarize key insights concisely (no fluff)
+- Extract specific evidence: stats, quotes, case studies
+- Cluster themes by relevance and recency
+- Flag weak or unsupported claims
+
+## Sources to Prioritize
+
+1. AI industry news (The Information, Stratechery, Import AI, TLDR AI)
+2. Technology analysis (a16z, Sequoia, CB Insights)
+3. Academic papers (arXiv, Google Scholar — recent 12 months)
+4. Business strategy publications (HBR, McKinsey, BCG)
+5. Practitioner blogs (Substack, company engineering blogs)
+
+## Output Format
+
+```
+## Research Summary
+[2–3 sentence overview of the landscape]
+
+## Key Signals
+- [Signal 1]
+- [Signal 2]
+- [Signal 3]
+
+## Evidence
+- [Stat or quote + source]
+- [Stat or quote + source]
+
+## Sources
+- [URL or reference]
+
+## Implications
+[What this means for technology leaders]
+```
+
+## Quality Rules
+
+- Every claim needs a source
+- Prefer recent evidence (< 12 months)
+- Flag anything speculative clearly
+- No filler — every line must add value

--- a/.claude/subagents/writer.md
+++ b/.claude/subagents/writer.md
@@ -1,6 +1,6 @@
 ---
 name: writer
-description: Writing subagent that creates structured thought leadership articles for Medium and LinkedIn. Use after research is complete to generate article drafts following Sunil's voice and style.
+description: Writing subagent that creates structured thought leadership articles for Medium and LinkedIn. Use after research is complete to generate article drafts following the author's voice and style.
 ---
 
 # Writer
@@ -13,7 +13,7 @@ Always read `memory/brand/writing_style.md` before writing.
 
 - Create a compelling thesis from the research
 - Develop a clear argument structure
-- Write the full article draft in Sunil's voice
+- Write the full article draft in the author's voice
 - Keep Medium articles 800–1200 words
 
 ## Article Structure

--- a/.claude/subagents/writer.md
+++ b/.claude/subagents/writer.md
@@ -1,0 +1,51 @@
+---
+name: writer
+description: Writing subagent that creates structured thought leadership articles for Medium and LinkedIn. Use after research is complete to generate article drafts following Sunil's voice and style.
+---
+
+# Writer
+
+You are a thought leadership writer producing content for technology and business executives.
+
+Always read `memory/brand/writing_style.md` before writing.
+
+## Responsibilities
+
+- Create a compelling thesis from the research
+- Develop a clear argument structure
+- Write the full article draft in Sunil's voice
+- Keep Medium articles 800–1200 words
+
+## Article Structure
+
+```
+Title: [Specific, bold, insight-driven — not clickbait]
+
+Hook: [1–2 sentences. Challenge a assumption or state a surprising fact.]
+
+Thesis: [The core insight in 1 clear sentence.]
+
+Section 1: [Setup — the current reality]
+Section 2: [The shift — what's changing and why]
+Section 3: [Evidence — concrete examples and data]
+Section 4: [Implication — what leaders should think about]
+
+Conclusion: [Forward-looking or provocative closing thought]
+
+Sources: [References used]
+```
+
+## Voice Rules
+
+- Write in first person where appropriate (practitioner voice)
+- Short paragraphs — 2 to 3 sentences max
+- Concrete over abstract
+- Specific numbers over vague claims
+- Active voice throughout
+
+## Quality Check Before Output
+
+- Does the hook stand alone as interesting?
+- Is the thesis stated clearly in the first 150 words?
+- Does every section add something new?
+- Is the conclusion memorable?

--- a/.claude/templates/manual-alternatives.json.example
+++ b/.claude/templates/manual-alternatives.json.example
@@ -1,0 +1,45 @@
+{
+  "_comment": "Copy to ~/.openclaw/workspace/data/portfolio/manual/alternatives.json.",
+  "version": "1",
+  "updatedAt": "YYYY-MM-DD",
+  "holdings": [
+    {
+      "id": "angel-1",
+      "label": "[Company Name] — Series A",
+      "assetClass": "alternatives",
+      "subClass": "angel",
+      "geography": "IN",
+      "currency": "USD",
+      "currentValueLocalCcy": 50000,
+      "_comment_value": "Use last known valuation or cost basis if no new round has closed.",
+      "costBasisLocalCcy": 25000,
+      "investmentDate": "YYYY-MM-DD",
+      "notes": "~2x book based on last funding round. Unaudited."
+    },
+    {
+      "id": "pe-fund-1",
+      "label": "[Fund Name] — PE Fund II",
+      "assetClass": "alternatives",
+      "subClass": "pe",
+      "geography": "global",
+      "currency": "USD",
+      "currentValueLocalCcy": 100000,
+      "costBasisLocalCcy": 100000,
+      "investmentDate": "YYYY-MM-DD",
+      "notes": "Use capital called as cost basis; use TVPI × paid-in as current value estimate."
+    },
+    {
+      "id": "gold-physical-1",
+      "label": "Physical Gold",
+      "assetClass": "alternatives",
+      "subClass": "gold",
+      "geography": "IN",
+      "currency": "INR",
+      "currentValueLocalCcy": 500000,
+      "_comment_value": "Update manually using current gold price × grams held.",
+      "costBasisLocalCcy": 350000,
+      "investmentDate": "YYYY-MM-DD",
+      "notes": "50g. Valued at market price."
+    }
+  ]
+}

--- a/.claude/templates/manual-cash.json.example
+++ b/.claude/templates/manual-cash.json.example
@@ -1,0 +1,39 @@
+{
+  "_comment": "Copy to ~/.openclaw/workspace/data/portfolio/manual/cash.json. Update balances regularly.",
+  "version": "1",
+  "updatedAt": "YYYY-MM-DD",
+  "accounts": [
+    {
+      "id": "cash-sg-dbs",
+      "label": "DBS Multiplier",
+      "currency": "SGD",
+      "balanceLocalCcy": 85000,
+      "type": "savings",
+      "notes": "Earns bonus interest. Check monthly."
+    },
+    {
+      "id": "cash-in-sbi",
+      "label": "SBI Savings",
+      "currency": "INR",
+      "balanceLocalCcy": 2500000,
+      "type": "savings"
+    },
+    {
+      "id": "cash-us-ibkr",
+      "_comment": "IBKR idle cash — sync monthly with IBKR portal.",
+      "label": "IBKR Cash (USD)",
+      "currency": "USD",
+      "balanceLocalCcy": 5000,
+      "type": "brokerage_cash"
+    },
+    {
+      "id": "cash-sg-fd",
+      "label": "DBS Fixed Deposit",
+      "currency": "SGD",
+      "balanceLocalCcy": 50000,
+      "type": "fixed_deposit",
+      "maturityDate": "YYYY-MM-DD",
+      "notes": "6-month FD at 3.2% p.a."
+    }
+  ]
+}

--- a/.claude/templates/manual-property.json.example
+++ b/.claude/templates/manual-property.json.example
@@ -1,0 +1,40 @@
+{
+  "_comment": "Copy to ~/.openclaw/workspace/data/portfolio/manual/property.json. Add one entry per property.",
+  "version": "1",
+  "updatedAt": "YYYY-MM-DD",
+  "holdings": [
+    {
+      "id": "prop-sg-1",
+      "_comment": "Unique ID — use a short, stable slug.",
+      "label": "Singapore Condo — [Neighbourhood]",
+      "assetClass": "real_estate",
+      "subClass": "residential",
+      "geography": "SG",
+      "currency": "SGD",
+      "currentValueLocalCcy": 1800000,
+      "loanOutstandingLocalCcy": 650000,
+      "netValueLocalCcy": 1150000,
+      "_comment_net": "netValueLocalCcy = currentValueLocalCcy - loanOutstandingLocalCcy. This flows into the portfolio.",
+      "costBasisLocalCcy": 1400000,
+      "_comment_cost": "Purchase price + stamp duty + renovation. Used for unrealized P&L calculation.",
+      "purchaseDate": "YYYY-MM-DD",
+      "rentalYieldPct": 3.5,
+      "_comment_yield": "Optional. Gross annual rental yield as a percentage.",
+      "notes": "e.g. Owner-occupied, or rental property"
+    },
+    {
+      "id": "prop-in-1",
+      "label": "Mumbai Apartment — [Area]",
+      "assetClass": "real_estate",
+      "subClass": "residential",
+      "geography": "IN",
+      "currency": "INR",
+      "currentValueLocalCcy": 18000000,
+      "loanOutstandingLocalCcy": 0,
+      "netValueLocalCcy": 18000000,
+      "costBasisLocalCcy": 12000000,
+      "purchaseDate": "YYYY-MM-DD",
+      "notes": "Self-occupied"
+    }
+  ]
+}

--- a/.claude/templates/portfolio-config.json.example
+++ b/.claude/templates/portfolio-config.json.example
@@ -1,0 +1,69 @@
+{
+  "_comment": "Copy this to ~/.openclaw/workspace/data/portfolio/config.json and fill in your values.",
+  "version": "1",
+  "baseCurrency": "USD",
+
+  "accounts": [
+    {
+      "id": "ibkr-main",
+      "broker": "ibkr",
+      "label": "IBKR Main",
+      "currency": "USD",
+      "dataFile": "ibkr/positions.csv"
+    },
+    {
+      "id": "zerodha-main",
+      "broker": "zerodha",
+      "label": "Zerodha",
+      "currency": "INR",
+      "dataFile": "india/zerodha-holdings.csv"
+    },
+    {
+      "_comment": "Add Groww if you use it",
+      "id": "groww-main",
+      "broker": "groww",
+      "label": "Groww MF",
+      "currency": "INR",
+      "dataFile": "india/groww-holdings.csv"
+    }
+  ],
+
+  "targets": {
+    "_comment": "Percentages must sum to 100 within each dimension.",
+
+    "assetClass": {
+      "equity": 60,
+      "fixed_income": 15,
+      "real_estate": 10,
+      "alternatives": 5,
+      "cash": 10
+    },
+
+    "geography": {
+      "US": 40,
+      "IN": 35,
+      "SG": 10,
+      "global": 15
+    },
+
+    "currency": {
+      "USD": 50,
+      "INR": 30,
+      "SGD": 10,
+      "other": 10
+    }
+  },
+
+  "alertThresholds": {
+    "driftWarningPct": 5,
+    "concentrationWarningPct": 10
+  },
+
+  "fxRefreshAgeHours": 6,
+
+  "_notes": [
+    "driftWarningPct: show ⚠️ when actual allocation differs from target by more than this many percentage points.",
+    "concentrationWarningPct: flag any single holding that exceeds this % of total portfolio.",
+    "fxRefreshAgeHours: fetch fresh FX rates if cached rates are older than this."
+  ]
+}

--- a/.claude/templates/writing_style.md.example
+++ b/.claude/templates/writing_style.md.example
@@ -1,0 +1,39 @@
+# Brand Voice & Writing Style
+
+## Author
+Name: [Your name]
+Role: [Your role/title]
+Platforms: [e.g. Medium, LinkedIn]
+
+## Audience
+Primary: [e.g. Technology executives, CTOs, engineering leaders]
+Secondary: [e.g. Founders, product managers]
+
+## Voice & Tone
+- [e.g. Practitioner — write from direct experience, not as an observer]
+- [e.g. Direct and confident — state views clearly, avoid hedging]
+- [e.g. Concrete over abstract — use specific numbers and examples]
+- [e.g. Peer-to-peer — write to equals, not down to beginners]
+
+## Topics & Expertise
+Core topics:
+- [e.g. AI in the enterprise]
+- [e.g. Engineering leadership]
+- [e.g. Future of work]
+
+Avoid:
+- [e.g. Pure hype or speculation without evidence]
+- [e.g. Generic advice that applies to everyone]
+
+## Style Rules
+- Short paragraphs: 2–3 sentences max
+- Active voice throughout
+- No "In today's world..." or "It's important to note that..."
+- No "Leveraging", "synergies", "ecosystem" without irony
+- First person where it adds practitioner credibility
+
+## Signature Phrases / Patterns
+- [Add any recurring phrases, openers, or structural patterns you use]
+
+## What Good Looks Like
+- [Link to or paste an example article/post you're proud of]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules
 **/node_modules/
+
+# Content pipeline outputs (generated, not versioned)
+outputs/
+data/research/
 .env
 docker-compose.extra.yml
 dist

--- a/CONTENT_PIPELINE.md
+++ b/CONTENT_PIPELINE.md
@@ -94,7 +94,7 @@ See: `.claude/commands/`
 - repurpose-linkedin.md → /repurpose-linkedin
 
 Also available as OpenClaw skills (Telegram):
-See: `skills/content-scan/`, `skills/build-source-pack/`, `skills/draft-medium/`, `skills/repurpose-linkedin/`
+See: `skills/content-scan/`, `skills/build-source-pack/`, `skills/draft-medium/`, `skills/repurpose-linkedin/`, `skills/collect-feedback/`
 
 ---
 
@@ -119,6 +119,8 @@ repurpose article for linkedin
 3. `/build-source-pack` — research pack
 4. `/draft-medium` — full article
 5. `/repurpose-linkedin` — LinkedIn posts
+6. Publish on Medium and LinkedIn (edit as needed)
+7. `/collect-feedback [Medium URL]` — compare draft vs published, update writing style
 
 ---
 

--- a/CONTENT_PIPELINE.md
+++ b/CONTENT_PIPELINE.md
@@ -2,7 +2,7 @@
 
 Claude Code + OpenClaw Implementation
 
-User: Sunil
+User: [Author]
 Environment: Cursor + Claude Code
 Gateway: OpenClaw (Telegram)
 
@@ -57,6 +57,15 @@ data/research
 outputs/content
 ```
 
+Create your brand voice file before running the pipeline:
+
+```bash
+cp .claude/templates/writing_style.md.example memory/brand/writing_style.md
+# Then edit memory/brand/writing_style.md with your own name, style, and audience
+```
+
+> `memory/` is gitignored and never committed. The template lives at `.claude/templates/writing_style.md.example`.
+
 ---
 
 # 3. Brand Memory
@@ -85,7 +94,7 @@ See: `.claude/commands/`
 - repurpose-linkedin.md → /repurpose-linkedin
 
 Also available as OpenClaw skills (Telegram):
-See: `skills/content-scan/`, `skills/draft-medium/`, `skills/repurpose-linkedin/`
+See: `skills/content-scan/`, `skills/build-source-pack/`, `skills/draft-medium/`, `skills/repurpose-linkedin/`
 
 ---
 

--- a/CONTENT_PIPELINE.md
+++ b/CONTENT_PIPELINE.md
@@ -1,0 +1,145 @@
+# Thought Leadership Research-to-Post Pipeline
+
+Claude Code + OpenClaw Implementation
+
+User: Sunil
+Environment: Cursor + Claude Code
+Gateway: OpenClaw (Telegram)
+
+Purpose:
+Automate discovery, research, drafting, and publishing preparation for Medium and LinkedIn thought leadership posts.
+
+Primary Output Location:
+
+```text
+outputs/content/
+```
+
+---
+
+# 1. Pipeline Overview
+
+The pipeline converts **raw ideas and news signals** into **publishable content assets**.
+
+Workflow:
+
+```text
+Topic discovery
+↓
+Research aggregation
+↓
+Thesis generation
+↓
+Medium article draft
+↓
+LinkedIn post derivatives
+↓
+Archive and reuse
+```
+
+Three internal subagents execute this pipeline:
+
+```text
+researcher
+writer
+editor
+```
+
+---
+
+# 2. Required Directory Setup
+
+```text
+.claude/subagents
+.claude/commands
+memory/brand
+data/research
+outputs/content
+```
+
+---
+
+# 3. Brand Memory
+
+See: `memory/brand/writing_style.md`
+
+---
+
+# 4. Subagents
+
+See: `.claude/subagents/`
+
+- researcher.md
+- writer.md
+- editor.md
+
+---
+
+# 5. Commands
+
+See: `.claude/commands/`
+
+- content-scan.md → /content-scan
+- build-source-pack.md → /build-source-pack
+- draft-medium.md → /draft-medium
+- repurpose-linkedin.md → /repurpose-linkedin
+
+Also available as OpenClaw skills (Telegram):
+See: `skills/content-scan/`, `skills/draft-medium/`, `skills/repurpose-linkedin/`
+
+---
+
+# 6. OpenClaw Usage (Telegram)
+
+Trigger from Telegram:
+
+```
+content-scan
+
+draft medium on AI pilots failing in enterprises
+
+repurpose article for linkedin
+```
+
+---
+
+# 7. Weekly Automation Routine
+
+1. `/content-scan` — generate 5 ideas
+2. Select strongest idea
+3. `/build-source-pack` — research pack
+4. `/draft-medium` — full article
+5. `/repurpose-linkedin` — LinkedIn posts
+
+---
+
+# 8. Expected Outputs
+
+```text
+outputs/content/
+  ideas.md
+  source-pack.md
+  article.md
+  linkedin-posts.md
+```
+
+---
+
+# 9. Quality Gate
+
+- [ ] Strong hook
+- [ ] Clear thesis
+- [ ] Evidence included
+- [ ] Actionable takeaway
+- [ ] Readable length
+
+---
+
+# 10. Success Metrics
+
+| Metric                   | Target                  |
+| ------------------------ | ----------------------- |
+| Idea generation          | 5 strong ideas per week |
+| Draft creation time      | < 20 minutes            |
+| Research time reduction  | 40%                     |
+| Posts produced per month | 4–6                     |

--- a/skills/build-source-pack/SKILL.md
+++ b/skills/build-source-pack/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: build-source-pack
+description: Build a research pack for a given topic. Use when asked to research a topic, gather evidence, find sources, or prepare background material for an article. Collects data points, case studies, quotes, and key findings from the past 12 months.
+metadata:
+  openclaw:
+    emoji: "📦"
+---
+
+# Build Source Pack
+
+Assembles a comprehensive research pack for a given topic, ready to feed into article drafting.
+
+## When to Use
+
+- "build source pack on [topic]"
+- "research [topic]"
+- "gather evidence for [topic]"
+- "find sources about [topic]"
+
+## Process
+
+1. Search for recent signals (past 12 months) on the topic
+2. Extract: data points, case studies, company examples, practitioner quotes
+3. Identify 3 article angles (provocative, contrarian, practical)
+
+## Output Format
+
+```
+# Research Pack — [Topic]
+
+## Summary
+[3–4 sentence landscape overview]
+
+## Key Findings
+- [Finding + source]
+
+## Evidence
+### Data Points
+- [Stat: source, date]
+
+### Case Studies
+- [Company: what happened, outcome]
+
+### Quotes
+- "[Quote]" — Name, Title
+
+## Sources
+
+## Article Angles
+- The provocative take
+- The contrarian take
+- The practical take
+```
+
+Save to: `outputs/content/source-pack.md`

--- a/skills/collect-feedback/SKILL.md
+++ b/skills/collect-feedback/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: collect-feedback
+description: "Closes the content pipeline feedback loop after a Medium article or LinkedIn post has been published. Provide the published Medium URL and/or the final LinkedIn post text you actually used. Compares the published version against the original draft, extracts style and structural learnings from your edits, and updates memory/brand/writing_style.md so future drafts need fewer edits. Also logs each round to memory/brand/feedback-log.md. Trigger after publishing: 'collect feedback [medium URL]', 'I posted, here is what I changed', or 'update writing style from my Medium post'."
+metadata:
+  openclaw:
+    emoji: "🔁"
+---
+
+# Collect Feedback
+
+Learns from the gap between draft and final published post. Updates writing style memory so each draft cycle improves.
+
+## When to Use
+
+- "collect feedback [Medium URL]"
+- "I posted the article, here's what I changed: ..."
+- "update writing style from my Medium post"
+- "learn from what I published"
+
+## Inputs
+
+Accept one or both of:
+
+1. **Medium URL** — fetch and read the final published article
+2. **Final LinkedIn post text** — paste the variant that was actually used
+
+If neither is provided, ask for at least one before proceeding.
+
+## Process
+
+### Step 1 — Load originals
+
+Read:
+
+- `outputs/content/article.md` — original draft
+- `outputs/content/linkedin-posts.md` — original LinkedIn variants
+
+If files are missing, note it and proceed with what is available.
+
+### Step 2 — Load finals
+
+- If Medium URL provided: fetch the full article text from the URL
+- If LinkedIn text provided: use as-is
+
+### Step 3 — Compare and extract learnings
+
+Analyse the diff between original draft and final published version across these dimensions:
+
+**Article (Medium):**
+
+- Title: was it changed? How? (shorter, punchier, different angle)
+- Hook: was the first sentence/paragraph edited? What pattern?
+- Structure: sections added, removed, reordered?
+- Length: longer or shorter than the draft?
+- Voice: any recurring word substitutions or phrase replacements?
+- Evidence: did the author add or cut specific examples/data?
+- Conclusion: was the ending changed?
+- Visuals: did the author add images/media manually? (note as recurring behaviour)
+
+**LinkedIn:**
+
+- Which variant was used (Insight / Story / Question)?
+- How was the hook edited?
+- Was the length changed?
+- Were hashtags changed?
+- Was the CTA changed?
+
+### Step 4 — Generate learnings
+
+Summarise edits as actionable style rules. Format each learning as:
+
+```
+- [What to do differently]: [specific pattern observed]
+```
+
+Examples:
+
+- Shorten titles: author consistently trims titles to under 8 words
+- Strengthen hooks: first sentence is always rewritten to remove scene-setting
+- LinkedIn preference: Variant 2 (Story) is consistently chosen over Insight
+- Add images: author always adds a visual manually — include an image suggestion in drafts
+
+### Step 5 — Update writing style memory
+
+Append learnings to `memory/brand/writing_style.md` under a `## Learned from Published Posts` section.
+If the section already exists, append new learnings without duplicating existing ones.
+
+### Step 6 — Log the feedback round
+
+Append to `memory/brand/feedback-log.md`:
+
+```
+## [Date] — [Article title or slug]
+
+**Medium:** [URL or "not provided"]
+**LinkedIn variant used:** [Insight / Story / Question / unknown]
+
+### Edits observed
+[bullet list of specific changes]
+
+### Learnings added to writing_style.md
+[bullet list of rules added]
+```
+
+Create the file if it does not exist.
+
+### Step 7 — Confirm
+
+Reply with:
+
+- Number of learnings extracted
+- 3 most impactful style rules added
+- Confirmation that writing_style.md and feedback-log.md were updated

--- a/skills/content-scan/SKILL.md
+++ b/skills/content-scan/SKILL.md
@@ -37,7 +37,16 @@ Audience hook: [What makes leaders stop and read]
 ## 2–5 ...
 ```
 
-Save output to: `outputs/content/ideas.md`
+## Saving
+
+Save output in two places:
+
+1. `outputs/content/ideas.md` — overwrite with latest scan (used by downstream pipeline steps)
+2. `outputs/content/ideas/[YYYY-MM-DD-HH-MM]-[topic-slug].md` — dated archive copy
+
+The topic slug is a 3-5 word kebab-case summary of the scan topic or the top idea (e.g. `geo-search-cpg-brands`, `ai-governance-enterprise`, `general-scan`). Use the current date and time in the filename.
+
+This preserves full history. Every past scan remains searchable by date or topic.
 
 ## Voice
 
@@ -45,4 +54,4 @@ Read `memory/brand/writing_style.md` to ensure ideas match the author's audience
 
 ## After Output
 
-Confirm save location and highlight the strongest idea with a one-line reason why.
+Confirm both save locations and highlight the strongest idea with a one-line reason why.

--- a/skills/content-scan/SKILL.md
+++ b/skills/content-scan/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: content-scan
+description: Scan for thought leadership article ideas. Use when asked to find content ideas, generate article topics, scan for trending themes in AI and technology, or brainstorm what to write about. Produces top 5 article ideas ranked by relevance and timeliness for a technology/business executive audience.
+metadata:
+  openclaw:
+    emoji: "🔍"
+---
+
+# Content Scan
+
+Identifies the top 5 thought leadership article ideas based on current signals in AI, enterprise technology, and business strategy.
+
+## When to Use
+
+- "content scan"
+- "what should I write about"
+- "find me article ideas"
+- "scan for trending topics"
+- "give me 5 ideas"
+
+## Process
+
+1. Identify emerging themes from the past 2 weeks in AI and technology
+2. Score each theme: relevance to technology leaders, timeliness, originality
+3. Generate 5 article ideas with working title, core insight, and why it matters now
+
+## Output Format
+
+```
+# Top 5 Article Ideas — [Date]
+
+## 1. [Title]
+Why now: [1 sentence]
+Core insight: [1–2 sentences]
+Audience hook: [What makes leaders stop and read]
+
+## 2–5 ...
+```
+
+Save output to: `outputs/content/ideas.md`
+
+## Voice
+
+Read `memory/brand/writing_style.md` to ensure ideas match the author's audience and tone.
+
+## After Output
+
+Confirm save location and highlight the strongest idea with a one-line reason why.

--- a/skills/draft-medium/SKILL.md
+++ b/skills/draft-medium/SKILL.md
@@ -58,3 +58,7 @@ Always read `memory/brand/writing_style.md` before writing.
 ## After Output
 
 Print title + hook. Confirm save paths.
+
+Remind the author:
+
+> After publishing on Medium, run `collect feedback [your Medium URL]` to update your writing style from the edits you made.

--- a/skills/draft-medium/SKILL.md
+++ b/skills/draft-medium/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: draft-medium
+description: Generate a full Medium article draft on a given topic. Use when asked to write an article, draft a post, create long-form content, or produce a thought leadership piece. Runs the full researcher → writer → editor pipeline and produces an 800–1200 word article ready for review.
+metadata:
+  openclaw:
+    emoji: "✍️"
+---
+
+# Draft Medium Article
+
+Runs the full research-to-draft pipeline and produces a polished Medium article.
+
+## When to Use
+
+- "draft medium on [topic]"
+- "write an article about [topic]"
+- "create a post on [topic]"
+- "draft a thought leadership piece on [topic]"
+
+## Pipeline
+
+```
+researcher → gather evidence and signals
+writer     → create thesis, structure, and full draft (800–1200 words)
+editor     → sharpen for clarity, punch, and readability
+```
+
+## Quality Gate
+
+Before saving, verify:
+
+- Hook grabs attention in the first sentence
+- Thesis is clear within the first 150 words
+- At least 3 pieces of specific evidence
+- Actionable takeaway in the conclusion
+- No paragraphs over 3 sentences
+
+## Output Format
+
+```
+# [Title]
+
+[Full article — 800–1200 words]
+
+---
+Sources: [References]
+Word count: [N]
+Generated: [Date]
+```
+
+Save to: `outputs/content/article.md`
+Archive copy to: `data/research/[date]-[slug].md`
+
+## Voice
+
+Always read `memory/brand/writing_style.md` before writing.
+
+## After Output
+
+Print title + hook. Confirm save paths.

--- a/skills/repurpose-linkedin/SKILL.md
+++ b/skills/repurpose-linkedin/SKILL.md
@@ -55,3 +55,9 @@ Voice rules from: `memory/brand/writing_style.md`
 ```
 
 Save to: `outputs/content/linkedin-posts.md`
+
+## After Output
+
+Remind the author:
+
+> After posting on LinkedIn, run `collect feedback` and paste the final post you used so your writing style updates from the edits you made.

--- a/skills/repurpose-linkedin/SKILL.md
+++ b/skills/repurpose-linkedin/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: repurpose-linkedin
+description: Convert a Medium article into LinkedIn posts. Use when asked to repurpose content for LinkedIn, create social posts, or turn an article into short-form content. Produces 3 distinct LinkedIn post variants (insight, story, question) from an existing article draft.
+metadata:
+  openclaw:
+    emoji: "💼"
+---
+
+# Repurpose for LinkedIn
+
+Converts a Medium article draft into 3 distinct LinkedIn post variants.
+
+## When to Use
+
+- "repurpose for linkedin"
+- "create linkedin posts from article"
+- "turn article into social posts"
+- "linkedin variants"
+
+## Source
+
+Reads from: `outputs/content/article.md`
+Voice rules from: `memory/brand/writing_style.md`
+
+## Three Variants
+
+- **Variant 1 — The Insight**: Bold statement leading with the core thesis
+- **Variant 2 — The Story**: Opens with a concrete example or case study
+- **Variant 3 — The Question**: Opens with a provocative question the article answers
+
+## Post Rules
+
+- First line must work standalone (no "I recently wrote..." openers)
+- 150–250 words per post
+- Short paragraphs (1–2 sentences)
+- End with a question or clear point of view
+- Max 3 relevant hashtags at the end
+
+## Output Format
+
+```
+# LinkedIn Posts — [Article Title]
+
+## Variant 1 — The Insight
+[Post]
+#tag1 #tag2 #tag3
+
+## Variant 2 — The Story
+[Post]
+#tag1 #tag2 #tag3
+
+## Variant 3 — The Question
+[Post]
+#tag1 #tag2 #tag3
+```
+
+Save to: `outputs/content/linkedin-posts.md`


### PR DESCRIPTION
## Summary

Adds a full thought leadership content pipeline for generating and publishing Medium and LinkedIn content via Claude Code and OpenClaw (Telegram).

- **4 Claude Code commands** (`.claude/commands/`): `/content-scan`, `/build-source-pack`, `/draft-medium`, `/repurpose-linkedin`
- **3 Claude Code subagents** (`.claude/subagents/`): `researcher`, `writer`, `editor`
- **4 OpenClaw skills** (`skills/`): `content-scan`, `build-source-pack`, `draft-medium`, `repurpose-linkedin` — triggerable via Telegram once deployed to gateway
- **Pipeline spec**: `CONTENT_PIPELINE.md`
- `outputs/` and `data/research/` added to `.gitignore` (generated content, not versioned)

## Pipeline flow

```
/content-scan → top 5 article ideas → outputs/content/ideas.md
/build-source-pack <topic> → research pack → outputs/content/source-pack.md
/draft-medium <topic> → researcher → writer → editor → outputs/content/article.md
/repurpose-linkedin → 3 LinkedIn variants → outputs/content/linkedin-posts.md
```

## Test plan

- [x] `/content-scan` — tested, produced 5 sourced ideas with live web research
- [x] `/build-source-pack` — tested on "agentic AI governance gap", produced full research pack
- [x] `/draft-medium` — tested, produced ~900 word article through full pipeline
- [x] `/repurpose-linkedin` — tested, produced 3 distinct LinkedIn variants
- [ ] Telegram activation — requires gateway `npm install -g openclaw@latest` + adding skills to agent config after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)