### PR TITLE
Auto-reply: normalize inbound metadata timestamps to UTC

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -214,7 +214,7 @@ describe("buildInboundUserContextPrefix", () => {
     } as TemplateContext);
 
     const conversationInfo = parseConversationInfoPayload(text);
-    expect(conversationInfo["timestamp"]).toEqual(expect.any(String));
+    expect(conversationInfo["timestamp"]).toBe("Sun 2026-02-15T13:35Z");
   });
 
   it("omits invalid timestamps instead of throwing", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -1,6 +1,6 @@
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveSenderLabel } from "../../channels/sender-label.js";
-import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
+import { formatUtcTimestamp } from "../../infra/format-time/format-datetime.js";
 import type { TemplateContext } from "../templating.js";
 
 function safeTrim(value: unknown): string | undefined {
@@ -19,12 +19,16 @@ function formatConversationTimestamp(value: unknown): string | undefined {
   if (Number.isNaN(date.getTime())) {
     return undefined;
   }
-  const formatted = formatZonedTimestamp(date);
+  // Keep conversation metadata timezone-stable across app/gateway deployments by
+  // normalizing to UTC instead of host-local timezone.
+  const formatted = formatUtcTimestamp(date);
   if (!formatted) {
     return undefined;
   }
   try {
-    const weekday = new Intl.DateTimeFormat("en-US", { weekday: "short" }).format(date);
+    const weekday = new Intl.DateTimeFormat("en-US", { timeZone: "UTC", weekday: "short" }).format(
+      date,
+    );
     return weekday ? `${weekday} ${formatted}` : formatted;
   } catch {
     return formatted;


### PR DESCRIPTION
## Problem

When app and gateway run in different timezones, inbound conversation metadata timestamps can be formatted using gateway local timezone, causing inconsistent/shifted time context in dispatch/reply tasks.

## Root Cause

`buildInboundUserContextPrefix` used local-zoned timestamp formatting in `inbound-meta`, which depends on host timezone.

## Fix

- Normalize conversation metadata timestamp rendering to UTC in:
  - `src/auto-reply/reply/inbound-meta.ts`
- Keep weekday calculation aligned to UTC.
- Add regression assertion in:
  - `src/auto-reply/reply/inbound-meta.test.ts`
  - Expect fixed UTC output (`Sun 2026-02-15T13:35Z`) for deterministic behavior.

## Validation

- `pnpm test src/auto-reply/reply/inbound-meta.test.ts`
  - 23 tests passed