### PR TITLE
fix: allow spawnedBy and spawnDepth on ACP sessions

### DIFF
--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -19,6 +19,7 @@ import {
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
+  isAcpSessionKey,
   isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
@@ -97,8 +98,8 @@ export async function applySessionsPatchToStore(params: {
       if (!trimmed) {
         return invalid("invalid spawnedBy: empty");
       }
-      if (!isSubagentSessionKey(storeKey)) {
-        return invalid("spawnedBy is only supported for subagent:* sessions");
+      if (!isSubagentSessionKey(storeKey) && !isAcpSessionKey(storeKey)) {
+        return invalid("spawnedBy is only supported for subagent:* or acp sessions");
       }
       if (existing?.spawnedBy && existing.spawnedBy !== trimmed) {
         return invalid("spawnedBy cannot be changed once set");
@@ -114,8 +115,8 @@ export async function applySessionsPatchToStore(params: {
         return invalid("spawnDepth cannot be cleared once set");
       }
     } else if (raw !== undefined) {
-      if (!isSubagentSessionKey(storeKey)) {
-        return invalid("spawnDepth is only supported for subagent:* sessions");
+      if (!isSubagentSessionKey(storeKey) && !isAcpSessionKey(storeKey)) {
+        return invalid("spawnDepth is only supported for subagent:* or acp sessions");
       }
       const numeric = Number(raw);
       if (!Number.isInteger(numeric) || numeric < 0) {


### PR DESCRIPTION
## Problem

Fixes #40984

ACP session spawning via `sessions_spawn` (with `runtime: "acp"`) was failing with:

```
spawnedBy is only supported for subagent:* sessions
```

The `sessions-patch.ts` validation only checked for `subagent:*` session keys when setting `spawnedBy` and `spawnDepth`. ACP sessions use `agent:*:acp:*` key patterns (e.g. `agent:claude:acp:<uuid>`), which failed this check.

## Fix

Extend the validation in `applySessionsPatchToStore` to also accept session keys containing `:acp:`, so ACP sessions can properly track their parent session lineage.

## Changes

- `src/gateway/sessions-patch.ts`: Added `|| storeKey.includes(":acp:")` check alongside `isSubagentSessionKey()` for both `spawnedBy` and `spawnDepth` validation.

## Testing

- `pnpm build` ✅
- `pnpm check` ✅
- `vitest run src/gateway/sessions-patch.test.ts` — **20 tests pass** ✅
- Confirmed ACP thread spawning works after this fix (Claude Code and Codex via `sessions_spawn` with `runtime: "acp"`)
- Previously spawning was consistently rejected with the validation error

## AI Disclosure

- [x] AI-assisted (OpenClaw agent + Claude Opus 4)
- [x] Fully tested locally
- [x] I understand what the code does