### PR TITLE
fix(reply): strip leading session recap scaffolding

### DIFF
--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { extractInboundSenderLabel, stripInboundMetadata } from "./strip-inbound-meta.js";
+import {
+  extractInboundSenderLabel,
+  stripInboundMetadata,
+  stripLeadingInboundMetadata,
+} from "./strip-inbound-meta.js";
 
 const CONV_BLOCK = `Conversation info (untrusted metadata):
 \`\`\`json
@@ -32,6 +36,15 @@ UNTRUSTED channel metadata (discord)
 Sender labels:
 example
 <<<END_EXTERNAL_UNTRUSTED_CONTENT id="deadbeefdeadbeef">>>`;
+
+const SESSION_RECAP_BLOCK = `<session-recap>
+<summary>Found 10 recent items across 3 categories</summary>
+<ledger-items count="2">
+  <item path="ledger/2026-03-09.md">
+    <title>ledger/2026-03-09.md</title>
+  </item>
+</ledger-items>
+</session-recap>`;
 
 describe("stripInboundMetadata", () => {
   it("fast-path: returns same string when no sentinels present", () => {
@@ -117,6 +130,38 @@ Real user content`;
 name: test
 Hello from user`;
     expect(stripInboundMetadata(input)).toBe(input);
+  });
+
+  it("strips a leading session recap block", () => {
+    const input = `${SESSION_RECAP_BLOCK}\n\nActual user message`;
+    expect(stripInboundMetadata(input)).toBe("Actual user message");
+  });
+
+  it("does not strip session recap text that appears mid-message", () => {
+    const input = `Hello world\n${SESSION_RECAP_BLOCK}\n\nFollow-up`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
+
+  it("does not strip a malformed leading session recap block without a closing tag", () => {
+    const input = `<session-recap>\n<summary>Found 10 recent items across 3 categories</summary>\n\nActual user message`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
+});
+
+describe("stripLeadingInboundMetadata", () => {
+  it("strips a leading session recap block", () => {
+    const input = `${SESSION_RECAP_BLOCK}\n\nActual user message`;
+    expect(stripLeadingInboundMetadata(input)).toBe("Actual user message");
+  });
+
+  it("does not strip session recap text that appears mid-message", () => {
+    const input = `Hello world\n${SESSION_RECAP_BLOCK}\n\nFollow-up`;
+    expect(stripLeadingInboundMetadata(input)).toBe(input);
+  });
+
+  it("does not strip a malformed leading session recap block without a closing tag", () => {
+    const input = `<session-recap>\n<summary>Found 10 recent items across 3 categories</summary>\n\nActual user message`;
+    expect(stripLeadingInboundMetadata(input)).toBe(input);
   });
 });
 

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -154,6 +154,12 @@ describe("stripLeadingInboundMetadata", () => {
     expect(stripLeadingInboundMetadata(input)).toBe("Actual user message");
   });
 
+  it("strips a single-line leading session recap block", () => {
+    const input =
+      "<session-recap><summary>Found 10 recent items across 3 categories</summary></session-recap>\n\nActual user message";
+    expect(stripLeadingInboundMetadata(input)).toBe("Actual user message");
+  });
+
   it("does not strip session recap text that appears mid-message", () => {
     const input = `Hello world\n${SESSION_RECAP_BLOCK}\n\nFollow-up`;
     expect(stripLeadingInboundMetadata(input)).toBe(input);

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -132,9 +132,9 @@ Hello from user`;
     expect(stripInboundMetadata(input)).toBe(input);
   });
 
-  it("strips a leading session recap block", () => {
+  it("preserves a leading session recap block", () => {
     const input = `${SESSION_RECAP_BLOCK}\n\nActual user message`;
-    expect(stripInboundMetadata(input)).toBe("Actual user message");
+    expect(stripInboundMetadata(input)).toBe(input);
   });
 
   it("does not strip session recap text that appears mid-message", () => {

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -33,6 +33,8 @@ const SENTINEL_FAST_RE = new RegExp(
     .join("|"),
 );
 const SESSION_RECAP_QUICK_RE = /<\s*session[-_]recap\b/i;
+const SESSION_RECAP_SINGLE_LINE_RE =
+  /^<\s*session[-_]recap\b[^<>]*>.*<\s*\/\s*session[-_]recap\s*>\s*$/i;
 const SESSION_RECAP_OPEN_LINE_RE = /^<\s*session[-_]recap\b[^<>]*>\s*$/i;
 const SESSION_RECAP_CLOSE_LINE_RE = /^<\s*\/\s*session[-_]recap\s*>\s*$/i;
 
@@ -115,7 +117,18 @@ function stripLeadingSessionRecapBlock(lines: string[]): { lines: string[]; stri
   while (index < lines.length && lines[index]?.trim() === "") {
     index += 1;
   }
-  if (index >= lines.length || !SESSION_RECAP_OPEN_LINE_RE.test(lines[index] ?? "")) {
+  if (index >= lines.length) {
+    return { lines, stripped: false };
+  }
+  const startLine = lines[index] ?? "";
+  if (SESSION_RECAP_SINGLE_LINE_RE.test(startLine)) {
+    let end = index + 1;
+    while (end < lines.length && lines[end]?.trim() === "") {
+      end += 1;
+    }
+    return { lines: lines.slice(end), stripped: true };
+  }
+  if (!SESSION_RECAP_OPEN_LINE_RE.test(startLine)) {
     return { lines, stripped: false };
   }
 

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -150,18 +150,11 @@ function stripLeadingSessionRecapBlock(lines: string[]): { lines: string[]; stri
  * (fast path — zero allocation).
  */
 export function stripInboundMetadata(text: string): string {
-  const hasSentinel = !!text && SENTINEL_FAST_RE.test(text);
-  const hasSessionRecap = !!text && SESSION_RECAP_QUICK_RE.test(text);
-  if (!text || (!hasSentinel && !hasSessionRecap)) {
+  if (!text || !SENTINEL_FAST_RE.test(text)) {
     return text;
   }
 
-  const recap = stripLeadingSessionRecapBlock(text.split("\n"));
-  if (!hasSentinel && !recap.stripped) {
-    return text;
-  }
-
-  const lines = recap.lines;
+  const lines = text.split("\n");
   const result: string[] = [];
   let inMetaBlock = false;
   let inFencedJson = false;

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -32,6 +32,9 @@ const SENTINEL_FAST_RE = new RegExp(
     .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
     .join("|"),
 );
+const SESSION_RECAP_QUICK_RE = /<\s*session[-_]recap\b/i;
+const SESSION_RECAP_OPEN_LINE_RE = /^<\s*session[-_]recap\b[^<>]*>\s*$/i;
+const SESSION_RECAP_CLOSE_LINE_RE = /^<\s*\/\s*session[-_]recap\s*>\s*$/i;
 
 function isInboundMetaSentinelLine(line: string): boolean {
   const trimmed = line.trim();
@@ -105,6 +108,32 @@ function stripTrailingUntrustedContextSuffix(lines: string[]): string[] {
   return lines;
 }
 
+// Session recap is injected as a standalone leading block and should never
+// consume literal recap tags that appear later in real user text.
+function stripLeadingSessionRecapBlock(lines: string[]): { lines: string[]; stripped: boolean } {
+  let index = 0;
+  while (index < lines.length && lines[index]?.trim() === "") {
+    index += 1;
+  }
+  if (index >= lines.length || !SESSION_RECAP_OPEN_LINE_RE.test(lines[index] ?? "")) {
+    return { lines, stripped: false };
+  }
+
+  let end = index + 1;
+  while (end < lines.length && !SESSION_RECAP_CLOSE_LINE_RE.test(lines[end] ?? "")) {
+    end += 1;
+  }
+  if (end >= lines.length) {
+    return { lines, stripped: false };
+  }
+
+  end += 1;
+  while (end < lines.length && lines[end]?.trim() === "") {
+    end += 1;
+  }
+  return { lines: lines.slice(end), stripped: true };
+}
+
 /**
  * Remove all injected inbound metadata prefix blocks from `text`.
  *
@@ -121,11 +150,18 @@ function stripTrailingUntrustedContextSuffix(lines: string[]): string[] {
  * (fast path — zero allocation).
  */
 export function stripInboundMetadata(text: string): string {
-  if (!text || !SENTINEL_FAST_RE.test(text)) {
+  const hasSentinel = !!text && SENTINEL_FAST_RE.test(text);
+  const hasSessionRecap = !!text && SESSION_RECAP_QUICK_RE.test(text);
+  if (!text || (!hasSentinel && !hasSessionRecap)) {
     return text;
   }
 
-  const lines = text.split("\n");
+  const recap = stripLeadingSessionRecapBlock(text.split("\n"));
+  if (!hasSentinel && !recap.stripped) {
+    return text;
+  }
+
+  const lines = recap.lines;
   const result: string[] = [];
   let inMetaBlock = false;
   let inFencedJson = false;
@@ -178,11 +214,18 @@ export function stripInboundMetadata(text: string): string {
 }
 
 export function stripLeadingInboundMetadata(text: string): string {
-  if (!text || !SENTINEL_FAST_RE.test(text)) {
+  const hasSentinel = !!text && SENTINEL_FAST_RE.test(text);
+  const hasSessionRecap = !!text && SESSION_RECAP_QUICK_RE.test(text);
+  if (!text || (!hasSentinel && !hasSessionRecap)) {
     return text;
   }
 
-  const lines = text.split("\n");
+  const recap = stripLeadingSessionRecapBlock(text.split("\n"));
+  if (!hasSentinel && !recap.stripped) {
+    return text;
+  }
+
+  const lines = recap.lines;
   let index = 0;
 
   while (index < lines.length && lines[index] === "") {

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "vitest";
 import { stripEnvelopeFromMessage } from "./chat-sanitize.js";
 
 describe("stripEnvelopeFromMessage", () => {
+  const SESSION_RECAP_BLOCK = `<session-recap>
+<summary>Found 10 recent items across 3 categories</summary>
+</session-recap>`;
+
   test("removes message_id hint lines from user messages", () => {
     const input = {
       role: "user",
@@ -48,6 +52,15 @@ describe("stripEnvelopeFromMessage", () => {
     };
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe("Assistant body");
+  });
+
+  test("does not strip leading session recap blocks from assistant messages", () => {
+    const input = {
+      role: "assistant",
+      content: `${SESSION_RECAP_BLOCK}\n\nAssistant body`,
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe(`${SESSION_RECAP_BLOCK}\n\nAssistant body`);
   });
 
   test("removes inbound un-bracketed conversation info blocks from user messages", () => {

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -177,6 +177,16 @@ example
     expect(text).toBe("Actual user message");
   });
 
+  it("strips a single-line leading session recap block for user messages", () => {
+    const text = extractTextFromMessage({
+      role: "user",
+      content:
+        "<session-recap><summary>Found 10 recent items across 3 categories</summary></session-recap>\n\nActual user message",
+    });
+
+    expect(text).toBe("Actual user message");
+  });
+
   it("preserves session recap text when it appears mid-message", () => {
     const content = `Hello world\n${SESSION_RECAP_BLOCK}\n\nFollow-up`;
     const text = extractTextFromMessage({

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -8,6 +8,10 @@ import {
 } from "./tui-formatters.js";
 
 describe("extractTextFromMessage", () => {
+  const SESSION_RECAP_BLOCK = `<session-recap>
+<summary>Found 10 recent items across 3 categories</summary>
+</session-recap>`;
+
   it("renders errorMessage when assistant content is empty", () => {
     const text = extractTextFromMessage({
       role: "assistant",
@@ -162,6 +166,25 @@ example
     });
 
     expect(text).toBe("Hello world");
+  });
+
+  it("strips a leading session recap block for user messages", () => {
+    const text = extractTextFromMessage({
+      role: "user",
+      content: `${SESSION_RECAP_BLOCK}\n\nActual user message`,
+    });
+
+    expect(text).toBe("Actual user message");
+  });
+
+  it("preserves session recap text when it appears mid-message", () => {
+    const content = `Hello world\n${SESSION_RECAP_BLOCK}\n\nFollow-up`;
+    const text = extractTextFromMessage({
+      role: "user",
+      content,
+    });
+
+    expect(text).toBe(content);
   });
 });
 

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -7,6 +7,10 @@ import {
 } from "./message-extract.ts";
 
 describe("extractTextCached", () => {
+  const SESSION_RECAP_BLOCK = `<session-recap>
+<summary>Found 10 recent items across 3 categories</summary>
+</session-recap>`;
+
   it("matches extractText output", () => {
     const message = {
       role: "assistant",
@@ -41,6 +45,16 @@ describe("extractTextCached", () => {
     };
     expect(extractText(message)).toBe("Final user answer");
     expect(extractTextCached(message)).toBe("Final user answer");
+  });
+
+  it("strips a leading session recap block from user messages", () => {
+    const message = {
+      role: "user",
+      content: `${SESSION_RECAP_BLOCK}\n\nVisible user text`,
+    };
+
+    expect(extractText(message)).toBe("Visible user text");
+    expect(extractTextCached(message)).toBe("Visible user text");
   });
 });
 

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -56,6 +56,17 @@ describe("extractTextCached", () => {
     expect(extractText(message)).toBe("Visible user text");
     expect(extractTextCached(message)).toBe("Visible user text");
   });
+
+  it("strips a single-line leading session recap block from user messages", () => {
+    const message = {
+      role: "user",
+      content:
+        "<session-recap><summary>Found 10 recent items across 3 categories</summary></session-recap>\n\nVisible user text",
+    };
+
+    expect(extractText(message)).toBe("Visible user text");
+    expect(extractTextCached(message)).toBe("Visible user text");
+  });
 });
 
 describe("extractThinkingCached", () => {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,4 +1,4 @@
-import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
+import { stripLeadingInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
 import { stripThinkingTags } from "../format.ts";
 
@@ -11,7 +11,7 @@ function processMessageText(text: string, role: string): string {
     return stripThinkingTags(text);
   }
   return shouldStripInboundMetadata
-    ? stripInboundMetadata(stripEnvelope(text))
+    ? stripLeadingInboundMetadata(stripEnvelope(text))
     : stripEnvelope(text);
 }
 

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -6,6 +6,10 @@ import {
 } from "./message-normalizer.ts";
 
 describe("message-normalizer", () => {
+  const SESSION_RECAP_BLOCK = `<session-recap>
+<summary>Found 10 recent items across 3 categories</summary>
+</session-recap>`;
+
   describe("normalizeMessage", () => {
     beforeEach(() => {
       vi.useFakeTimers();
@@ -120,6 +124,25 @@ describe("message-normalizer", () => {
       });
 
       expect(result.senderLabel).toBe("Iris");
+    });
+
+    it("strips a leading session recap block from user messages", () => {
+      const result = normalizeMessage({
+        role: "user",
+        content: `${SESSION_RECAP_BLOCK}\n\nVisible user text`,
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: "Visible user text" }]);
+    });
+
+    it("preserves session recap text when it appears mid-message", () => {
+      const content = `Visible prefix\n${SESSION_RECAP_BLOCK}\n\nVisible suffix`;
+      const result = normalizeMessage({
+        role: "user",
+        content,
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: content }]);
     });
   });
 

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -2,7 +2,7 @@
  * Message normalization utilities for chat rendering.
  */
 
-import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
+import { stripLeadingInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
 
 /**
@@ -57,7 +57,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   if (role === "user" || role === "User") {
     content = content.map((item) => {
       if (item.type === "text" && typeof item.text === "string") {
-        return { ...item, text: stripInboundMetadata(item.text) };
+        return { ...item, text: stripLeadingInboundMetadata(item.text) };
       }
       return item;
     });


### PR DESCRIPTION
## Summary

- Problem: leading `<session-recap>...</session-recap>` scaffolding leaked into visible user message rendering in the Control UI and TUI.
- Why it matters: recap blocks are internal context, so rendering them as plain text is a user-facing regression and obscures the real message body.
- What changed: taught the shared inbound metadata stripper to remove only leading standalone `session-recap` blocks and added regression coverage in the shared parser plus TUI and Control UI consumers.
- What did NOT change (scope boundary): no generic XML stripping, no assistant-message sanitization changes, and no mid-message literal recap removal.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40948
- Related #40948

## User-visible / Behavior Changes

Leading `<session-recap>` scaffolding is no longer shown in user-visible text rendering for the Control UI and TUI. Literal recap tags remain visible when they appear mid-message.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: Node 25.5.0, pnpm 10.23.0
- Model/provider: Any provider that stores recap-prefixed user messages
- Integration/channel (if any): Control UI and TUI
- Relevant config (redacted): N/A

### Steps

1. Render a user message whose stored text begins with a standalone `<session-recap>...</session-recap>` block.
2. Open that message in the Control UI or TUI.
3. Compare the visible text before and after the fix.

### Expected

- Only the real user-visible message body is shown.

### Actual

- Before this fix, the recap block rendered as plain text ahead of the real message body.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/auto-reply/reply/strip-inbound-meta.test.ts src/tui/tui-formatters.test.ts`
  - `pnpm exec vitest run --config vitest.config.ts src/ui/chat/message-normalizer.test.ts` (run in `ui/`)
  - `pnpm build`
  - `pnpm test`
  - `pnpm check`
  - `git diff --check`
- Edge cases checked:
  - leading recap block is stripped
  - mid-message literal recap tags are preserved
  - malformed leading recap blocks without a closing tag are preserved
- What you did **not** verify:
  - manual live reproduction in a running gateway session after the patch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `d0cb787bd`.
- Files/config to restore:
  - `src/auto-reply/reply/strip-inbound-meta.ts`
  - `src/auto-reply/reply/strip-inbound-meta.test.ts`
  - `src/tui/tui-formatters.test.ts`
  - `ui/src/ui/chat/message-normalizer.test.ts`
- Known bad symptoms reviewers should watch for:
  - legitimate leading standalone recap XML authored by a user being stripped unexpectedly

## Risks and Mitigations

- Risk: a user-authored message that starts with a standalone `session-recap` block could be treated like injected scaffolding.
  - Mitigation: stripping is limited to a leading standalone block with a matching closing tag; mid-message and malformed recap blocks are preserved.

## AI Assistance

- AI-assisted: Yes
- Prompt/session summary: triaged fresh unclaimed bug reports, selected `#40948` because it had no PR overlap and a localized root cause, wrote failing shared-parser and consumer regressions first, implemented the narrow shared-stripper change, then verified with targeted UI/TUI tests plus full `build`, `test`, and `check`.
