### PR TITLE
fix: treat plugins.installs as no-op in reload watcher to prevent restart loop

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -90,6 +90,7 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
   { prefix: "talk", kind: "none" },
   { prefix: "skills", kind: "none" },
   { prefix: "secrets", kind: "none" },
+  { prefix: "plugins.installs", kind: "none" },
   { prefix: "plugins", kind: "restart" },
   { prefix: "ui", kind: "none" },
   { prefix: "gateway", kind: "restart" },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -192,6 +192,22 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toContain("diagnostics.stuckSessionWarnMs");
   });
 
+  it("treats plugins.installs metadata as no-op (avoids restart loop for npm-installed plugins)", () => {
+    const plan = buildGatewayReloadPlan([
+      "plugins.installs.botschat.resolvedAt",
+      "plugins.installs.botschat.installedAt",
+    ]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("plugins.installs.botschat.resolvedAt");
+    expect(plan.noopPaths).toContain("plugins.installs.botschat.installedAt");
+  });
+
+  it("still restarts for other plugins config changes", () => {
+    const plan = buildGatewayReloadPlan(["plugins.entries.foo.enabled"]);
+    expect(plan.restartGateway).toBe(true);
+    expect(plan.restartReasons).toContain("plugins.entries.foo.enabled");
+  });
+
   it("defaults unknown paths to restart", () => {
     const plan = buildGatewayReloadPlan(["unknownField"]);
     expect(plan.restartGateway).toBe(true);


### PR DESCRIPTION
## Summary

- Add `plugins.installs` as `kind: "none"` in `BASE_RELOAD_RULES_TAIL` (before the `plugins → restart` catch-all) so that plugin install metadata timestamp changes are ignored by the reload watcher
- Add two test cases: one verifying `plugins.installs.*` is treated as no-op, another confirming other `plugins.*` paths (e.g. `plugins.entries`) still trigger restart as expected

Fixes #41001

## Problem

The plugin loader writes `resolvedAt` / `installedAt` timestamps to `openclaw.json` for npm-installed plugins on every gateway startup. The reload watcher diffs the config, sees these changed paths under `plugins.installs.*`, and matches them against the catch-all `{ prefix: "plugins", kind: "restart" }` rule. This triggers SIGTERM → gateway restarts → plugin loader writes timestamps again → infinite loop.

On macOS with launchd (KeepAlive=true), the rapid crash loop eventually causes the service to be unloaded entirely, leaving the gateway dead.

```
[reload] config change detected; evaluating reload
  (meta.lastTouchedAt, plugins.installs.botschat.resolvedAt, plugins.installs.botschat.installedAt)
[reload] config change requires gateway restart
[gateway] signal SIGTERM received
... launchd restarts → loop repeats ...
```

## Fix

One-line rule addition in `BASE_RELOAD_RULES_TAIL`:

```typescript
{ prefix: "plugins.installs", kind: "none" },  // ← new
{ prefix: "plugins", kind: "restart" },         // ← existing catch-all
```

Since `matchRule()` uses first-match-wins and `plugins.installs` is more specific than `plugins`, install metadata changes are now classified as no-op while other plugin config changes (`plugins.entries`, `plugins.slots`, `plugins.load`) still correctly trigger a restart.

## Test plan

- [ ] `plugins.installs.*.resolvedAt` / `installedAt` changes → no restart (new test)
- [ ] `plugins.entries.*` changes → still triggers restart (new test)
- [ ] Existing reload tests continue to pass
- [ ] Manual verification: gateway with npm-installed plugin no longer enters restart loop