### PR TITLE
fix: hotfix batch -- config schema, ACP sessions, duplicate tool IDs, redaction crash, usage streaming

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12214,98 +12214,98 @@
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "7f413afd37447cd321d79286be0f58d7a9875d9b",
         "is_verified": false,
-        "line_number": 78
+        "line_number": 79
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "abb1aabcd0e49019c2873944a40671a80ccd64c7",
         "is_verified": false,
-        "line_number": 84
+        "line_number": 85
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "83a9937c6de261ffda22304834f30fe6c8f97926",
         "is_verified": false,
-        "line_number": 88
+        "line_number": 89
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "c21afa950dee2a70f3e0f6ffdfbc87f8edb90262",
         "is_verified": false,
-        "line_number": 91
+        "line_number": 92
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 96
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 96
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "87ac76dfc9cba93bead43c191e31bd099a97cc11",
         "is_verified": false,
-        "line_number": 227
+        "line_number": 228
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "8e22880b4e96bab354e1da6c91d2f58dabde3555",
         "is_verified": false,
-        "line_number": 397
+        "line_number": 398
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "8e22880b4e96bab354e1da6c91d2f58dabde3555",
         "is_verified": false,
-        "line_number": 397
+        "line_number": 398
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "a9c732e05044a08c760cce7f6d142cd0d35a19e5",
         "is_verified": false,
-        "line_number": 455
+        "line_number": 456
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "50843dd5651cfafbe7c5611c1eed195c63e6e3fd",
         "is_verified": false,
-        "line_number": 771
+        "line_number": 772
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "927e7cdedcb8f71af399a49fb90a381df8b8df28",
         "is_verified": false,
-        "line_number": 1007
+        "line_number": 1008
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "1996cc327bd39dad69cd8feb24250dafd51e7c08",
         "is_verified": false,
-        "line_number": 1013
+        "line_number": 1014
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "a5c0a65a4fa8874a486aa5072671927ceba82a90",
         "is_verified": false,
-        "line_number": 1037
+        "line_number": 1038
       }
     ],
     "src/config/schema.help.ts": [

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -262,13 +262,25 @@ describe("normalizeModelCompat", () => {
     expect(supportsDeveloperRole(normalized)).toBe(false);
   });
 
-  it("overrides explicit supportsUsageInStreaming true on non-native endpoints", () => {
+  it("respects explicit supportsUsageInStreaming true on non-native endpoints", () => {
     const model = {
       ...baseModel(),
       provider: "custom-cpa",
       baseUrl: "https://proxy.example.com/v1",
       compat: { supportsUsageInStreaming: true },
     };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+  });
+
+  it("defaults supportsUsageInStreaming to false when not explicitly set", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom-cpa",
+      baseUrl: "https://proxy.example.com/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
     const normalized = normalizeModelCompat(model);
     expect(supportsUsageInStreaming(normalized)).toBe(false);
   });

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -55,17 +55,24 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   // The `developer` role and stream usage chunks are OpenAI-native behaviors.
   // Many OpenAI-compatible backends reject `developer` and/or emit usage-only
   // chunks that break strict parsers expecting choices[0]. For non-native
-  // openai-completions endpoints, force both compat flags off.
+  // openai-completions endpoints, default both compat flags to off but respect
+  // explicit user overrides from config.
   const compat = model.compat ?? undefined;
   // When baseUrl is empty the pi-ai library defaults to api.openai.com, so
   // leave compat unchanged and let default native behavior apply.
-  // Note: explicit true values are intentionally overridden for non-native
-  // endpoints for safety.
   const needsForce = baseUrl ? !isOpenAINativeEndpoint(baseUrl) : false;
   if (!needsForce) {
     return model;
   }
-  if (compat?.supportsDeveloperRole === false && compat?.supportsUsageInStreaming === false) {
+
+  // Honour explicit user opt-in: if the user has set supportsUsageInStreaming
+  // to true in their model config, keep it enabled.  This lets proxies that
+  // correctly implement usage streaming (e.g. LiteLLM) report token counts.
+  const keepUsage = compat?.supportsUsageInStreaming === true;
+  if (
+    compat?.supportsDeveloperRole === false &&
+    (compat?.supportsUsageInStreaming === false || keepUsage)
+  ) {
     return model;
   }
 
@@ -73,7 +80,7 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   return {
     ...model,
     compat: compat
-      ? { ...compat, supportsDeveloperRole: false, supportsUsageInStreaming: false }
+      ? { ...compat, supportsDeveloperRole: false, supportsUsageInStreaming: keepUsage }
       : { supportsDeveloperRole: false, supportsUsageInStreaming: false },
   } as typeof model;
 }

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage, UserMessage, Usage } from "@mariozechner/pi-ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as helpers from "./pi-embedded-helpers.js";
 import {
+  expectOpenAIResponsesStrictSanitizeCall,
   expectGoogleModelApiFullSanitizeCall,
   loadSanitizeSessionHistoryWithCleanMocks,
   makeMockSessionManager,
@@ -230,6 +231,20 @@ describe("sanitizeSessionHistory", () => {
       "session:history",
       expect.objectContaining({ sanitizeMode: "images-only", sanitizeToolCallIds: false }),
     );
+  });
+
+  it("sanitizes tool call ids for OpenAI-compatible responses providers", async () => {
+    setNonGoogleModelApi();
+
+    await sanitizeSessionHistory({
+      messages: mockMessages,
+      modelApi: "openai-responses",
+      provider: "custom",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expectOpenAIResponsesStrictSanitizeCall(helpers.sanitizeSessionMessagesImages, mockMessages);
   });
 
   it("sanitizes tool call ids for openai-completions", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -428,6 +428,26 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(finalToolCall.name).toBe("read");
     expect(finalToolCall.id).toBe("call_42");
   });
+
+  it("reassigns duplicate tool call ids within a message to unique fallbacks", async () => {
+    const finalToolCallA = { type: "toolCall", name: " read ", id: "  edit:22  " };
+    const finalToolCallB = { type: "toolCall", name: " write ", id: "edit:22" };
+    const finalMessage = { role: "assistant", content: [finalToolCallA, finalToolCallB] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    await stream.result();
+
+    expect(finalToolCallA.name).toBe("read");
+    expect(finalToolCallB.name).toBe("write");
+    expect(finalToolCallA.id).toBe("edit:22");
+    expect(finalToolCallB.id).toBe("call_auto_1");
+  });
 });
 
 describe("isOllamaCompatProvider", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -322,6 +322,7 @@ function normalizeToolCallIdsInMessage(message: unknown): void {
   }
 
   let fallbackIndex = 1;
+  const assignedIds = new Set<string>();
   for (const block of content) {
     if (!block || typeof block !== "object") {
       continue;
@@ -333,20 +334,23 @@ function normalizeToolCallIdsInMessage(message: unknown): void {
     if (typeof typedBlock.id === "string") {
       const trimmedId = typedBlock.id.trim();
       if (trimmedId) {
-        if (typedBlock.id !== trimmedId) {
-          typedBlock.id = trimmedId;
+        if (!assignedIds.has(trimmedId)) {
+          if (typedBlock.id !== trimmedId) {
+            typedBlock.id = trimmedId;
+          }
+          assignedIds.add(trimmedId);
+          continue;
         }
-        usedIds.add(trimmedId);
-        continue;
       }
     }
 
     let fallbackId = "";
-    while (!fallbackId || usedIds.has(fallbackId)) {
+    while (!fallbackId || usedIds.has(fallbackId) || assignedIds.has(fallbackId)) {
       fallbackId = `call_auto_${fallbackIndex++}`;
     }
     typedBlock.id = fallbackId;
     usedIds.add(fallbackId);
+    assignedIds.add(fallbackId);
   }
 }
 

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -29,6 +29,29 @@ const buildDuplicateIdCollisionInput = () =>
     },
   ]);
 
+const buildRepeatedRawIdInput = () =>
+  castAgentMessages([
+    {
+      role: "assistant",
+      content: [
+        { type: "toolCall", id: "edit:22", name: "edit", arguments: {} },
+        { type: "toolCall", id: "edit:22", name: "edit", arguments: {} },
+      ],
+    },
+    {
+      role: "toolResult",
+      toolCallId: "edit:22",
+      toolName: "edit",
+      content: [{ type: "text", text: "one" }],
+    },
+    {
+      role: "toolResult",
+      toolCallId: "edit:22",
+      toolName: "edit",
+      content: [{ type: "text", text: "two" }],
+    },
+  ]);
+
 function expectCollisionIdsRemainDistinct(
   out: AgentMessage[],
   mode: "strict" | "strict9",
@@ -111,6 +134,14 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       expectCollisionIdsRemainDistinct(out, "strict");
     });
 
+    it("assigns distinct IDs when identical raw tool call ids repeat", () => {
+      const input = buildRepeatedRawIdInput();
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input);
+      expect(out).not.toBe(input);
+      expectCollisionIdsRemainDistinct(out, "strict");
+    });
+
     it("caps tool call IDs at 40 chars while preserving uniqueness", () => {
       const longA = `call_${"a".repeat(60)}`;
       const longB = `call_${"a".repeat(59)}b`;
@@ -181,6 +212,16 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       expect(aId).not.toMatch(/[_-]/);
       expect(bId).not.toMatch(/[_-]/);
     });
+
+    it("assigns distinct strict IDs when identical raw tool call ids repeat", () => {
+      const input = buildRepeatedRawIdInput();
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input, "strict");
+      expect(out).not.toBe(input);
+      const { aId, bId } = expectCollisionIdsRemainDistinct(out, "strict");
+      expect(aId).not.toMatch(/[_-]/);
+      expect(bId).not.toMatch(/[_-]/);
+    });
   });
 
   describe("strict9 mode (Mistral tool call IDs)", () => {
@@ -224,6 +265,16 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
           content: [{ type: "text", text: "two" }],
         },
       ]);
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input, "strict9");
+      expect(out).not.toBe(input);
+      const { aId, bId } = expectCollisionIdsRemainDistinct(out, "strict9");
+      expect(aId.length).toBe(9);
+      expect(bId.length).toBe(9);
+    });
+
+    it("assigns distinct strict9 IDs when identical raw tool call ids repeat", () => {
+      const input = buildRepeatedRawIdInput();
 
       const out = sanitizeToolCallIdsForCloudCodeAssist(input, "strict9");
       expect(out).not.toBe(input);

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -144,9 +144,57 @@ function makeUniqueToolId(params: { id: string; used: Set<string>; mode: ToolCal
   return `${candidate.slice(0, MAX_LEN - ts.length)}${ts}`;
 }
 
+function createOccurrenceAwareResolver(mode: ToolCallIdMode): {
+  resolveAssistantId: (id: string) => string;
+  resolveToolResultId: (id: string) => string;
+} {
+  const used = new Set<string>();
+  const assistantOccurrences = new Map<string, number>();
+  const orphanToolResultOccurrences = new Map<string, number>();
+  const pendingByRawId = new Map<string, string[]>();
+
+  const allocate = (seed: string): string => {
+    const next = makeUniqueToolId({ id: seed, used, mode });
+    used.add(next);
+    return next;
+  };
+
+  const resolveAssistantId = (id: string): string => {
+    const occurrence = (assistantOccurrences.get(id) ?? 0) + 1;
+    assistantOccurrences.set(id, occurrence);
+    const next = allocate(occurrence === 1 ? id : `${id}:${occurrence}`);
+    const pending = pendingByRawId.get(id);
+    if (pending) {
+      pending.push(next);
+    } else {
+      pendingByRawId.set(id, [next]);
+    }
+    return next;
+  };
+
+  const resolveToolResultId = (id: string): string => {
+    const pending = pendingByRawId.get(id);
+    if (pending && pending.length > 0) {
+      const next = pending.shift() ?? "";
+      if (pending.length === 0) {
+        pendingByRawId.delete(id);
+      }
+      if (next) {
+        return next;
+      }
+    }
+
+    const occurrence = (orphanToolResultOccurrences.get(id) ?? 0) + 1;
+    orphanToolResultOccurrences.set(id, occurrence);
+    return allocate(`${id}:tool_result:${occurrence}`);
+  };
+
+  return { resolveAssistantId, resolveToolResultId };
+}
+
 function rewriteAssistantToolCallIds(params: {
   message: Extract<AgentMessage, { role: "assistant" }>;
-  resolve: (id: string) => string;
+  resolveId: (id: string) => string;
 }): Extract<AgentMessage, { role: "assistant" }> {
   const content = params.message.content;
   if (!Array.isArray(content)) {
@@ -168,7 +216,7 @@ function rewriteAssistantToolCallIds(params: {
     ) {
       return block;
     }
-    const nextId = params.resolve(id);
+    const nextId = params.resolveId(id);
     if (nextId === id) {
       return block;
     }
@@ -184,7 +232,7 @@ function rewriteAssistantToolCallIds(params: {
 
 function rewriteToolResultIds(params: {
   message: Extract<AgentMessage, { role: "toolResult" }>;
-  resolve: (id: string) => string;
+  resolveId: (id: string) => string;
 }): Extract<AgentMessage, { role: "toolResult" }> {
   const toolCallId =
     typeof params.message.toolCallId === "string" && params.message.toolCallId
@@ -193,8 +241,8 @@ function rewriteToolResultIds(params: {
   const toolUseId = (params.message as { toolUseId?: unknown }).toolUseId;
   const toolUseIdStr = typeof toolUseId === "string" && toolUseId ? toolUseId : undefined;
 
-  const nextToolCallId = toolCallId ? params.resolve(toolCallId) : undefined;
-  const nextToolUseId = toolUseIdStr ? params.resolve(toolUseIdStr) : undefined;
+  const nextToolCallId = toolCallId ? params.resolveId(toolCallId) : undefined;
+  const nextToolUseId = toolUseIdStr ? params.resolveId(toolUseIdStr) : undefined;
 
   if (nextToolCallId === toolCallId && nextToolUseId === toolUseIdStr) {
     return params.message;
@@ -219,21 +267,11 @@ export function sanitizeToolCallIdsForCloudCodeAssist(
 ): AgentMessage[] {
   // Strict mode: only [a-zA-Z0-9]
   // Strict9 mode: only [a-zA-Z0-9], length 9 (Mistral tool call requirement)
-  // Sanitization can introduce collisions (e.g. `a|b` and `a:b` -> `ab`).
-  // Fix by applying a stable, transcript-wide mapping and de-duping via suffix.
-  const map = new Map<string, string>();
-  const used = new Set<string>();
-
-  const resolve = (id: string) => {
-    const existing = map.get(id);
-    if (existing) {
-      return existing;
-    }
-    const next = makeUniqueToolId({ id, used, mode });
-    map.set(id, next);
-    used.add(next);
-    return next;
-  };
+  // Sanitization can introduce collisions, and some providers also reject raw
+  // duplicate tool-call IDs. Track assistant occurrences in-order so repeated
+  // raw IDs receive distinct rewritten IDs, while matching tool results consume
+  // the same rewritten IDs in encounter order.
+  const { resolveAssistantId, resolveToolResultId } = createOccurrenceAwareResolver(mode);
 
   let changed = false;
   const out = messages.map((msg) => {
@@ -244,7 +282,7 @@ export function sanitizeToolCallIdsForCloudCodeAssist(
     if (role === "assistant") {
       const next = rewriteAssistantToolCallIds({
         message: msg as Extract<AgentMessage, { role: "assistant" }>,
-        resolve,
+        resolveId: resolveAssistantId,
       });
       if (next !== msg) {
         changed = true;
@@ -254,7 +292,7 @@ export function sanitizeToolCallIdsForCloudCodeAssist(
     if (role === "toolResult") {
       const next = rewriteToolResultIds({
         message: msg as Extract<AgentMessage, { role: "toolResult" }>,
-        resolve,
+        resolveId: resolveToolResultId,
       });
       if (next !== msg) {
         changed = true;

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -78,7 +78,10 @@ export function resolveTranscriptPolicy(params: {
       provider,
       modelId,
     });
-  const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+  const requiresOpenAiCompatibleToolIdSanitization =
+    params.modelApi === "openai-completions" ||
+    (!isOpenAi &&
+      (params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses"));
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -325,6 +325,30 @@ describe("model compat config schema", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts requiresOpenAiAnthropicToolPayload compat field", () => {
+    const res = validateConfigObject({
+      models: {
+        providers: {
+          "kimi-coding": {
+            baseUrl: "https://api.kimi.example/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "k2p5",
+                name: "Kimi K2.5",
+                compat: {
+                  requiresOpenAiAnthropicToolPayload: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });
 
 describe("config paths", () => {

--- a/src/config/redact-snapshot.raw.ts
+++ b/src/config/redact-snapshot.raw.ts
@@ -6,7 +6,12 @@ export function replaceSensitiveValuesInRaw(params: {
   sensitiveValues: string[];
   redactedSentinel: string;
 }): string {
-  const values = [...params.sensitiveValues].toSorted((a, b) => b.length - a.length);
+  // Filter out empty strings before sorting: replaceAll("", sentinel) inserts
+  // the sentinel between every character, which can balloon the string to
+  // hundreds of megabytes and throw a RangeError: Invalid string length.
+  const values = [...params.sensitiveValues]
+    .filter((v) => v.length > 0)
+    .toSorted((a, b) => b.length - a.length);
   let result = params.raw;
   for (const value of values) {
     result = result.replaceAll(value, params.redactedSentinel);

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -5,6 +5,7 @@ import {
   redactConfigSnapshot,
   restoreRedactedValues as restoreRedactedValues_orig,
 } from "./redact-snapshot.js";
+import { replaceSensitiveValuesInRaw } from "./redact-snapshot.raw.js";
 import { __test__ } from "./schema.hints.js";
 import type { ConfigUiHints } from "./schema.js";
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
@@ -1093,6 +1094,37 @@ describe("restoreRedactedValues", () => {
     const result = restoreRedactedValues(incoming, original, hints) as typeof incoming;
     expect(result.channels.slack.accounts[0].botToken).toBe("original-token-first-account");
     expect(result.channels.slack.accounts[1].botToken).toBe("user-provided-new-token-value");
+  });
+});
+
+describe("replaceSensitiveValuesInRaw", () => {
+  it("does not throw RangeError when sensitiveValues contains an empty string", () => {
+    // Regression for #40818: config.get crashed with RangeError: Invalid string
+    // length when a sensitive field (e.g. talk.apiKey) was set to "". The empty
+    // string caused replaceAll("", sentinel) to insert the sentinel between every
+    // character of the raw config, ballooning a ~1KB string into hundreds of MB.
+    const raw = '{"talk":{"apiKey":""}}';
+    expect(() =>
+      replaceSensitiveValuesInRaw({
+        raw,
+        sensitiveValues: ["", ""],
+        redactedSentinel: REDACTED_SENTINEL,
+      }),
+    ).not.toThrow();
+    // Empty strings must be skipped — no mutation of the raw text.
+    const result = replaceSensitiveValuesInRaw({
+      raw,
+      sensitiveValues: ["", "real-secret"],
+      redactedSentinel: REDACTED_SENTINEL,
+    });
+    expect(result).not.toContain("real-secret");
+    expect(result).toBe(raw.replaceAll("real-secret", REDACTED_SENTINEL));
+  });
+
+  it("redactConfigSnapshot does not throw when a sensitive field is an empty string", () => {
+    const config = { talk: { apiKey: "" } };
+    const snapshot = makeSnapshot(config);
+    expect(() => redactConfigSnapshot(snapshot, mainSchemaHints)).not.toThrow();
   });
 });
 

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -198,6 +198,7 @@ export const ModelCompatSchema = z
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),
     requiresMistralToolIds: z.boolean().optional(),
+    requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
   })
   .strict()
   .optional();

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -19,6 +19,7 @@ import {
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
+  isAcpSessionKey,
   isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
@@ -97,8 +98,8 @@ export async function applySessionsPatchToStore(params: {
       if (!trimmed) {
         return invalid("invalid spawnedBy: empty");
       }
-      if (!isSubagentSessionKey(storeKey)) {
-        return invalid("spawnedBy is only supported for subagent:* sessions");
+      if (!isSubagentSessionKey(storeKey) && !isAcpSessionKey(storeKey)) {
+        return invalid("spawnedBy is only supported for subagent:* or acp sessions");
       }
       if (existing?.spawnedBy && existing.spawnedBy !== trimmed) {
         return invalid("spawnedBy cannot be changed once set");
@@ -114,8 +115,8 @@ export async function applySessionsPatchToStore(params: {
         return invalid("spawnDepth cannot be cleared once set");
       }
     } else if (raw !== undefined) {
-      if (!isSubagentSessionKey(storeKey)) {
-        return invalid("spawnDepth is only supported for subagent:* sessions");
+      if (!isSubagentSessionKey(storeKey) && !isAcpSessionKey(storeKey)) {
+        return invalid("spawnDepth is only supported for subagent:* or acp sessions");
       }
       const numeric = Number(raw);
       if (!Number.isInteger(numeric) || numeric < 0) {


### PR DESCRIPTION
## Summary

Cherry-picks five high-priority community hotfixes onto main in the recommended merge order. Each fix unblocks a distinct user-facing issue:

| # | PR | Fix | Unblocks |
|---|-----|-----|----------|
| 1 | #40973 | Add missing `requiresOpenAiAnthropicToolPayload` to `ModelCompatSchema` | Users who cannot configure Kimi Coding provider (CLI crashes on save) |
| 2 | #40981 | Allow `spawnedBy` / `spawnDepth` on ACP session keys | ACP users whose session spawning was rejected |
| 3 | #40996 | Deduplicate repeated tool call IDs + enable sanitization for non-native `openai-responses` / `openai-codex-responses` | OpenAI-compatible API users hitting HTTP 400 from duplicate IDs |
| 4 | #40891 | Filter empty strings from `replaceSensitiveValuesInRaw` | Dashboard users hitting `RangeError: Invalid string length` on `config.get` |
| 5 | #40947 | Honour explicit `supportsUsageInStreaming: true` on non-native endpoints | Proxy users (e.g. LiteLLM) whose token usage display showed 0 |

## PR selection rationale (where duplicates existed)

- **ACP session spawn**: Chose #40981 over #40995 -- both fix the same issue but #40981 uses the existing `isAcpSessionKey()` utility directly, resulting in a smaller and cleaner diff (5+/4- vs 32+/4-).
- **config.get RangeError**: Chose #40891 over #40887 -- #40891 updates `.secrets.baseline` (so the `secrets` CI check passes) and includes both a direct unit test and a full `redactConfigSnapshot` integration test.

## Pre-existing test note

The `"sanitizes tool call ids with strict9 for Mistral models"` test in `pi-embedded-runner.sanitize-session-history.test.ts` was already failing on `main` before any of these cherry-picks. It is NOT caused by any PR in this batch. The test expects `strict9` mode for `openrouter` + `mistralai/devstral-2512:free`, but `openrouter`'s provider capabilities don't include Mistral model hints for tool call ID mode.

## Verification

- `pnpm build` -- pass
- `pnpm check` -- pass
- All 185 targeted tests across the 6 affected test files pass:
  - `src/config/config-misc.test.ts` (33 tests)
  - `src/gateway/sessions-patch.test.ts` (20 tests)
  - `src/agents/tool-call-id.test.ts` (11 tests)
  - `src/agents/pi-embedded-runner/run/attempt.test.ts` (46 tests)
  - `src/config/redact-snapshot.test.ts` (42 tests)
  - `src/agents/model-compat.test.ts` (33 tests)

## Linked issues

Closes #40911, closes #40984, closes #40897, closes #40818

## Change type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Config

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes (empty-string filtering in redaction -- safe, no secrets exposed)
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

🤖 Generated with [Claude Code](https://claude.com/claude-code)