### PR TITLE
fix(discord): break resume loop on consecutive 1005 close failures

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -411,6 +411,99 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("clears resume state after consecutive resume failures (rapid 1005 close loop)", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const { emitter, gateway } = createGatewayHarness({
+        state: {
+          sessionId: "session-stale",
+          resumeGatewayUrl: "wss://resume.discord.gg",
+          sequence: 789,
+        },
+        sequence: 789,
+      });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+      // Simulate the 1005 resume loop: open→close(1005) five times rapidly
+      // without isConnected ever becoming true.
+      waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+        for (let i = 0; i < 5; i++) {
+          emitter.emit("debug", "WebSocket connection opened");
+          // Close immediately with 1005 — no READY/RESUMED received
+          emitter.emit("debug", "WebSocket connection closed with code 1005");
+        }
+      });
+
+      const { lifecycleParams, runtimeLog } = createLifecycleHarness({ gateway });
+      await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+      // Resume state should have been cleared after 5 consecutive failures
+      expect(gateway.state).toBeDefined();
+      expect(gateway.state?.sessionId).toBeNull();
+      expect(gateway.state?.resumeGatewayUrl).toBeNull();
+      expect(gateway.state?.sequence).toBeNull();
+      expect(gateway.sequence).toBeNull();
+
+      // Should have logged the force-fresh-identify message
+      expect(runtimeLog).toHaveBeenCalledWith(
+        expect.stringContaining("consecutive resume failures"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets resume failure counter when connection becomes connected", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const { emitter, gateway } = createGatewayHarness({
+        state: {
+          sessionId: "session-ok",
+          resumeGatewayUrl: "wss://resume.discord.gg",
+          sequence: 100,
+        },
+        sequence: 100,
+      });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+      // 3 failures, then a successful connection, then 3 more failures.
+      // The counter should reset after success, so we never hit the threshold of 5.
+      waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+        // 3 failed resume attempts
+        for (let i = 0; i < 3; i++) {
+          emitter.emit("debug", "WebSocket connection opened");
+          emitter.emit("debug", "WebSocket connection closed with code 1005");
+        }
+
+        // Successful connection
+        gateway.isConnected = true;
+        emitter.emit("debug", "WebSocket connection opened");
+        await vi.advanceTimersByTimeAsync(500); // let connected poll fire
+
+        // Drop and 3 more failures
+        emitter.emit("debug", "WebSocket connection closed with code 1006");
+        gateway.isConnected = false;
+        for (let i = 0; i < 3; i++) {
+          emitter.emit("debug", "WebSocket connection opened");
+          emitter.emit("debug", "WebSocket connection closed with code 1005");
+        }
+      });
+
+      const { lifecycleParams, runtimeLog } = createLifecycleHarness({ gateway });
+      await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+      // Session state should NOT have been cleared — never hit 5 consecutive
+      expect(gateway.state?.sessionId).toBe("session-ok");
+      expect(runtimeLog).not.toHaveBeenCalledWith(
+        expect.stringContaining("consecutive resume failures"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not push connected: true when abortSignal is already aborted", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     const emitter = new EventEmitter();

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -32,6 +32,7 @@ export async function runDiscordGatewayLifecycle(params: {
   const HELLO_TIMEOUT_MS = 30000;
   const HELLO_CONNECTED_POLL_MS = 250;
   const MAX_CONSECUTIVE_HELLO_STALLS = 3;
+  const MAX_CONSECUTIVE_RESUME_FAILURES = 5;
   const RECONNECT_STALL_TIMEOUT_MS = 5 * 60_000;
   const gateway = params.client.getPlugin<GatewayPlugin>("gateway");
   if (gateway) {
@@ -111,6 +112,7 @@ export async function runDiscordGatewayLifecycle(params: {
   let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let helloConnectedPollId: ReturnType<typeof setInterval> | undefined;
   let consecutiveHelloStalls = 0;
+  let consecutiveResumeFailures = 0;
   const clearHelloWatch = () => {
     if (helloTimeoutId) {
       clearTimeout(helloTimeoutId);
@@ -123,6 +125,9 @@ export async function runDiscordGatewayLifecycle(params: {
   };
   const resetHelloStallCounter = () => {
     consecutiveHelloStalls = 0;
+  };
+  const resetResumeFailureCounter = () => {
+    consecutiveResumeFailures = 0;
   };
   const parseGatewayCloseCode = (message: string): number | undefined => {
     const match = /code\s+(\d{3,5})/i.exec(message);
@@ -160,6 +165,25 @@ export async function runDiscordGatewayLifecycle(params: {
       // false during reconnect handling after this debug line is emitted.
       if (gateway?.isConnected) {
         resetHelloStallCounter();
+        resetResumeFailureCounter();
+      } else {
+        // Connection closed without ever becoming connected (no READY/RESUMED).
+        // This happens when resume attempts fail — Discord closes with 1005
+        // because the session is stale.  Track consecutive failures and force
+        // a fresh IDENTIFY after the threshold so we don't loop forever.
+        // This runs synchronously before Carbon's handleClose, so clearing
+        // the resume state here causes Carbon's canResume() to return false
+        // on the next reconnection attempt.
+        consecutiveResumeFailures += 1;
+        if (consecutiveResumeFailures >= MAX_CONSECUTIVE_RESUME_FAILURES) {
+          params.runtime.log?.(
+            danger(
+              `discord: ${consecutiveResumeFailures} consecutive resume failures; clearing session to force fresh identify`,
+            ),
+          );
+          clearResumeState();
+          resetResumeFailureCounter();
+        }
       }
       reconnectStallWatchdog.arm(at);
       pushStatus({
@@ -191,6 +215,7 @@ export async function runDiscordGatewayLifecycle(params: {
       }
       sawConnected = true;
       resetHelloStallCounter();
+      resetResumeFailureCounter();
       const connectedAt = Date.now();
       reconnectStallWatchdog.disarm();
       pushStatus({
@@ -210,6 +235,7 @@ export async function runDiscordGatewayLifecycle(params: {
       }
       if (sawConnected || gateway?.isConnected) {
         resetHelloStallCounter();
+        resetResumeFailureCounter();
       } else {
         consecutiveHelloStalls += 1;
         const forceFreshIdentify = consecutiveHelloStalls >= MAX_CONSECUTIVE_HELLO_STALLS;


### PR DESCRIPTION
## Problem

When a Discord WebSocket session goes stale after a network drop (code 1006), subsequent resume attempts fail immediately with code 1005. This creates an infinite reconnect loop because:

1. **Carbon's `reconnectAttempts` counter resets on every WS open** — even when the connection is immediately closed with 1005 before READY/RESUMED. The `maxAttempts` limit is never reached.
2. **The stale session state (`sessionId`, `sequence`) is never cleared for 1005/1006** — only Discord-specific close codes (4007, 4009) trigger session reset in Carbon. Standard WebSocket codes pass through, keeping `canResume()` returning true forever.
3. **The existing HELLO-stall detector does not catch this** — connections close in milliseconds, well before the 30-second HELLO timeout fires.

In production, this manifests as a rapid open→1005→open→1005 cycle that continues until an external watchdog kills the process (~5 minutes / ~15+ iterations in our case).

### Log excerpt from the issue
```
02:25:22 gateway: WebSocket connection closed with code 1006
02:25:22 gateway: Attempting resume with backoff: 1000ms after code 1006
02:25:34 gateway: WebSocket connection closed with code 1005
02:26:01 gateway: WebSocket connection closed with code 1005
02:26:25 gateway: WebSocket connection closed with code 1005
... (repeats ~15 times over 5 minutes until external watchdog restarts)
```

## Fix

Adds a `consecutiveResumeFailures` counter in `provider.lifecycle.ts` (OpenClaw's layer) that tracks close events where `isConnected` was never true — meaning READY/RESUMED was never received.

After **5 consecutive failures**, the resume state is cleared **synchronously** before Carbon's `handleClose` runs (the debug event fires before the close handler in `setupWebSocket`), causing `canResume()` to return false and triggering a fresh IDENTIFY on the next reconnect attempt.

The counter resets whenever a connection successfully reaches the connected state, so transient failures that recover don't accumulate.

This follows the same pattern as the existing `consecutiveHelloStalls` detector but targets the different failure mode where connections close too fast for the HELLO timeout to fire.

### Changes

- `src/discord/monitor/provider.lifecycle.ts` — 26 lines added (counter, threshold, clear logic)
- `src/discord/monitor/provider.lifecycle.test.ts` — 93 lines added (2 test cases)

## Testing

- [x] All 13 lifecycle tests pass (11 existing + 2 new)
- [x] All related gateway tests pass (gateway-logging, monitor.gateway, gateway-error-guard)
- [x] Tested locally — confirmed the fix would have broken the loop observed in production logs

## AI Disclosure

This PR was AI-assisted (OpenClaw agent + Claude) with human direction and review.