### PR TITLE
fix(heartbeat): honor explicit target session keys

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -568,6 +568,81 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("uses the explicit telegram heartbeat target session when no session override is set", async () => {
+    const tmpDir = await createCaseDir("hb-explicit-telegram-session");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "telegram", to: "-100123" },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const mainSessionKey = resolveMainSessionKey(cfg);
+      const agentId = resolveAgentIdFromSessionKey(mainSessionKey);
+      const telegramSessionKey = buildAgentPeerSessionKey({
+        agentId,
+        channel: "telegram",
+        peerKind: "group",
+        peerId: "-100123",
+      });
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [mainSessionKey]: {
+            sessionId: "sid-main",
+            updatedAt: Date.now(),
+          },
+          [telegramSessionKey]: {
+            sessionId: "sid-telegram",
+            updatedAt: Date.now() + 1_000,
+            lastChannel: "telegram",
+            lastTo: "-100123",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: "Final alert" }]);
+      const sendTelegram = vi.fn<NonNullable<HeartbeatDeps["sendTelegram"]>>().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-100123",
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: {
+          ...createHeartbeatDeps(
+            vi
+              .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+              .mockResolvedValue({ messageId: "w1", toJid: "jid" }),
+          ),
+          sendTelegram,
+        },
+      });
+
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith("-100123", "Final alert", expect.any(Object));
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          SessionKey: telegramSessionKey,
+          OriginatingChannel: "telegram",
+          OriginatingTo: "-100123",
+          Provider: "heartbeat",
+        }),
+        expect.objectContaining({ isHeartbeat: true, suppressToolErrorWarnings: false }),
+        cfg,
+      );
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
   it("uses per-agent heartbeat overrides and session keys", async () => {
     const tmpDir = await createCaseDir("hb-agent-overrides");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -60,6 +60,7 @@ import {
 } from "./heartbeat-wake.js";
 import type { OutboundSendDeps } from "./outbound/deliver.js";
 import { deliverOutboundPayloads } from "./outbound/deliver.js";
+import { resolveOutboundSessionRoute } from "./outbound/outbound-session.js";
 import { buildOutboundSessionContext } from "./outbound/session-context.js";
 import {
   resolveHeartbeatDeliveryTarget,
@@ -250,7 +251,7 @@ function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatC
   );
 }
 
-function resolveHeartbeatSession(
+async function resolveHeartbeatSession(
   cfg: OpenClawConfig,
   agentId?: string,
   heartbeat?: HeartbeatConfig,
@@ -299,6 +300,33 @@ function resolveHeartbeatSession(
 
   const trimmed = heartbeat?.session?.trim() ?? "";
   if (!trimmed) {
+    const target = heartbeat?.target?.trim().toLowerCase() ?? "";
+    const explicitTo = heartbeat?.to?.trim() ?? "";
+    if (target && target !== "none" && target !== "last" && explicitTo) {
+      const delivery = resolveHeartbeatDeliveryTarget({
+        cfg,
+        entry: mainEntry,
+        heartbeat,
+      });
+      if (delivery.channel !== "none" && delivery.to) {
+        const route = await resolveOutboundSessionRoute({
+          cfg,
+          channel: delivery.channel,
+          agentId: resolvedAgentId,
+          accountId: delivery.accountId,
+          target: delivery.to,
+          threadId: delivery.threadId,
+        });
+        if (route) {
+          return {
+            sessionKey: route.sessionKey,
+            storePath,
+            store,
+            entry: store[route.sessionKey],
+          };
+        }
+      }
+    }
     return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
   }
 
@@ -508,7 +536,8 @@ async function resolveHeartbeatPreflight(params: {
     params.heartbeat,
     params.forcedSessionKey,
   );
-  const pendingEventEntries = peekSystemEventEntries(session.sessionKey);
+  const resolvedSession = await session;
+  const pendingEventEntries = peekSystemEventEntries(resolvedSession.sessionKey);
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
     event.contextKey?.startsWith("cron:"),
   );
@@ -521,7 +550,7 @@ async function resolveHeartbeatPreflight(params: {
     hasTaggedCronEvents;
   const basePreflight = {
     ...reasonFlags,
-    session,
+    session: resolvedSession,
     pendingEventEntries,
     hasTaggedCronEvents,
     shouldInspectPendingEvents,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -506,7 +506,7 @@ type HeartbeatReasonFlags = {
 type HeartbeatSkipReason = "empty-heartbeat-file";
 
 type HeartbeatPreflight = HeartbeatReasonFlags & {
-  session: ReturnType<typeof resolveHeartbeatSession>;
+  session: Awaited<ReturnType<typeof resolveHeartbeatSession>>;
   pendingEventEntries: ReturnType<typeof peekSystemEventEntries>;
   hasTaggedCronEvents: boolean;
   shouldInspectPendingEvents: boolean;


### PR DESCRIPTION
## Summary
- route heartbeat runs onto the explicit delivery session when `heartbeat.target` and `heartbeat.to` are both set
- keep existing `main` fallback for `target: last` and other cases that still depend on session metadata
- add a regression test covering explicit Telegram heartbeat delivery

## Problem
Fixes #39674.

`runHeartbeatOnce` changed delivery to the explicit heartbeat target, but it still kept the run bound to the agent main session unless `heartbeat.session` was also configured.

## Root cause
`resolveHeartbeatSession` only considered the main session, a forced `sessionKey`, or `heartbeat.session`. It never derived a session from an explicit heartbeat delivery target.

## What changed
- when `heartbeat.target` and `heartbeat.to` are explicit, derive the session key through outbound session routing
- keep the previous fallback behavior when the heartbeat target still relies on session history (for example `target: last`)
- cover the explicit Telegram target case with a regression test

## Verification
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/vitest run src/infra/heartbeat-runner.returns-default-unset.test.ts`
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxfmt --check src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxlint src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`