### PR TITLE
fix(agents): reduce env base64 heuristic false positives

### DIFF
--- a/src/agents/sandbox/sanitize-env-vars.test.ts
+++ b/src/agents/sandbox/sanitize-env-vars.test.ts
@@ -42,6 +42,17 @@ describe("sanitizeEnvVars", () => {
     expect(result.warnings).toContain("SAFE_TEXT: Value looks like base64-encoded credential data");
   });
 
+  it("does not warn for long alphanumeric values that are not structurally base64", () => {
+    const longAlphaNum =
+      "a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V2w3X4y5Z6a7B8c9D0e1F2g3H4i5J6k7L8m9N0o1P2q3R4s5";
+    const result = sanitizeEnvVars({
+      SAFE_TEXT: longAlphaNum,
+    });
+
+    expect(result.allowed).toEqual({ SAFE_TEXT: longAlphaNum });
+    expect(result.warnings).toEqual([]);
+  });
+
   it("supports strict mode with explicit allowlist", () => {
     const result = sanitizeEnvVars(
       {

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -30,6 +30,18 @@ const ALLOWED_ENV_VAR_PATTERNS: ReadonlyArray<RegExp> = [
   /^NODE_ENV$/i,
 ];
 
+const BASE64_HEURISTIC = /^[A-Za-z0-9+/]+={0,2}$/;
+
+function looksLikeBase64CredentialData(value: string): boolean {
+  if (value.length < 80 || value.length % 4 !== 0) {
+    return false;
+  }
+  if (!BASE64_HEURISTIC.test(value)) {
+    return false;
+  }
+  return /[+/=]/.test(value);
+}
+
 export type EnvVarSanitizationResult = {
   allowed: Record<string, string>;
   blocked: string[];
@@ -49,7 +61,7 @@ export function validateEnvVarValue(value: string): string | undefined {
   if (value.length > 32768) {
     return "Value exceeds maximum length";
   }
-  if (/^[A-Za-z0-9+/=]{80,}$/.test(value)) {
+  if (looksLikeBase64CredentialData(value)) {
     return "Value looks like base64-encoded credential data";
   }
   return undefined;


### PR DESCRIPTION
## Summary
- tighten the env-value base64 heuristic to require actual base64 structure instead of any long alphanumeric string
- keep warning on padded/base64-shaped values while avoiding false positives for long plain alphanumeric payloads
- add a regression test covering the non-base64 long-value case

## Problem
Fixes #39680.

`validateEnvVarValue` warned on any 80+ character value matching `[A-Za-z0-9+/=]`, which caught long plain alphanumeric payloads that are not structurally base64.

## Root cause
The heuristic only checked character class + length, so long non-base64 strings with no padding or base64 punctuation still matched.

## What changed
- require the candidate value to be 4-byte aligned
- require it to match base64 shape with padding only at the end
- require at least one non-alphanumeric base64 signal (`+`, `/`, or `=`)

## Verification
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/vitest run src/agents/sandbox/sanitize-env-vars.test.ts`
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxfmt --check src/agents/sandbox/sanitize-env-vars.ts src/agents/sandbox/sanitize-env-vars.test.ts`
- `/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxlint src/agents/sandbox/sanitize-env-vars.ts src/agents/sandbox/sanitize-env-vars.test.ts`