### PR TITLE
fix(daemon): accept localized schtasks running states

### DIFF
--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -44,15 +44,28 @@ describe("scheduled task runtime derivation", () => {
     ).toEqual({ status: "running" });
   });
 
-  it("treats Running without numeric result as unknown", () => {
+  it("treats Running without numeric result as running", () => {
     expect(
       deriveScheduledTaskRuntimeStatus({
         status: "Running",
       }),
-    ).toEqual({
-      status: "unknown",
-      detail: "Task status is locale-dependent and no numeric Last Run Result was available.",
-    });
+    ).toEqual({ status: "running" });
+  });
+
+  it("treats German localized running status as running", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Wird ausgeführt",
+      }),
+    ).toEqual({ status: "running" });
+  });
+
+  it("treats mojibake running status as running", () => {
+    expect(
+      deriveScheduledTaskRuntimeStatus({
+        status: "Wird ausgef�hrt",
+      }),
+    ).toEqual({ status: "running" });
   });
 
   it("treats non-running result codes as stopped", () => {
@@ -102,10 +115,7 @@ describe("scheduled task runtime derivation", () => {
       deriveScheduledTaskRuntimeStatus({
         status: "Wird ausgeführt",
       }),
-    ).toEqual({
-      status: "unknown",
-      detail: "Task status is locale-dependent and no numeric Last Run Result was available.",
-    });
+    ).toEqual({ status: "running" });
   });
 });
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -156,27 +156,47 @@ function normalizeTaskResultCode(value?: string): string | null {
 }
 
 const RUNNING_RESULT_CODES = new Set(["0x41301"]);
-const UNKNOWN_STATUS_DETAIL =
-  "Task status is locale-dependent and no numeric Last Run Result was available.";
+
+function normalizeTaskStatus(value?: string): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/\p{M}+/gu, "")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+}
+
+function isRunningTaskStatus(value?: string): boolean {
+  const normalized = normalizeTaskStatus(value);
+  return normalized === "running" || normalized.startsWith("wird ausgef");
+}
 
 export function deriveScheduledTaskRuntimeStatus(parsed: ScheduledTaskInfo): {
   status: GatewayServiceRuntime["status"];
   detail?: string;
 } {
+  if (!parsed.status?.trim()) {
+    return { status: "unknown" };
+  }
+
   const normalizedResult = normalizeTaskResultCode(parsed.lastRunResult);
-  if (normalizedResult != null) {
-    if (RUNNING_RESULT_CODES.has(normalizedResult)) {
-      return { status: "running" };
-    }
+  if (normalizedResult && RUNNING_RESULT_CODES.has(normalizedResult)) {
+    return { status: "running" };
+  }
+
+  if (!isRunningTaskStatus(parsed.status)) {
+    return { status: "stopped" };
+  }
+
+  if (normalizedResult && !RUNNING_RESULT_CODES.has(normalizedResult)) {
     return {
       status: "stopped",
       detail: `Task Last Run Result=${parsed.lastRunResult}; treating as not running.`,
     };
   }
-  if (parsed.status?.trim()) {
-    return { status: "unknown", detail: UNKNOWN_STATUS_DETAIL };
-  }
-  return { status: "unknown" };
+
+  return { status: "running" };
 }
 
 function buildTaskScript({

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { createEventHandlers } from "./tui-event-handlers.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import { createEventHandlers } from "./tui-event-handlers.js";
 
 type MockFn = ReturnType<typeof vi.fn>;
 type HandlerChatLog = {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,7 +1,7 @@
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
-import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 
 type EventHandlerChatLog = {
   startTool: (toolCallId: string, toolName: string, args: unknown) => void;

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,5 +1,5 @@
-import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 


### PR DESCRIPTION
## Summary
- normalize Scheduled Task status text before deriving runtime state
- treat localized and mojibake variants of running states as running
- keep the existing stale-running safeguard based on `Last Run Result`

## Problem
`openclaw node status` only recognized the English `Running` schtasks state, so localized Windows hosts like German `Wird ausgeführt` were incorrectly reported as stopped.

## Verification
- pnpm exec vitest run src/daemon/schtasks.test.ts
- pnpm exec oxfmt --check src/daemon/schtasks.ts src/daemon/schtasks.test.ts
- pnpm exec oxlint src/daemon/schtasks.ts src/daemon/schtasks.test.ts

Fixes #39057