### PR TITLE
fix(ui): auto-load usage data when navigating to usage tab

### DIFF
--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -26,6 +26,7 @@ import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { loadSkills } from "./controllers/skills.ts";
+import { loadUsage, type UsageState } from "./controllers/usage.ts";
 import {
   inferBasePathFromPathname,
   normalizeBasePath,
@@ -192,6 +193,9 @@ export async function refreshActiveTab(host: SettingsHost) {
   }
   if (host.tab === "sessions") {
     await loadSessions(host as unknown as OpenClawApp);
+  }
+  if (host.tab === "usage") {
+    await loadUsage(host as unknown as UsageState);
   }
   if (host.tab === "cron") {
     await loadCron(host);


### PR DESCRIPTION
## Summary

- Problem: `refreshActiveTab()` in `app-settings.ts` handles all 12 tabs but omits `"usage"`, so navigating to `/usage` or reconnecting WebSocket while on the usage tab never triggers `loadUsage()`.
- Why it matters: Users see an empty "Select a date range and click Refresh to load usage" prompt on first visit instead of auto-loaded data — inconsistent with every other tab.
- What changed: Added `"usage"` branch to `refreshActiveTab()` that calls `loadUsage()`.
- What did NOT change (scope boundary): No changes to usage data fetching logic, rendering, date handling, or other tabs.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- N/A (discovered via code reading)

## User-visible / Behavior Changes

Usage tab now auto-loads data when first navigated to or when WebSocket reconnects, consistent with all other tabs.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any (browser UI)
- Runtime/container: any
- Model/provider: N/A
- Integration/channel: N/A

### Steps

1. Open the Control UI
2. Navigate to `/usage` tab

### Expected

- Usage data loads automatically (same as sessions, channels, cron, etc.)

### Actual

- Empty page showing "Select a date range and click Refresh to load usage."

## Evidence

- [x] Trace/log snippets

`refreshActiveTab()` at `ui/src/ui/app-settings.ts:184` has `if` branches for: overview, channels, instances, sessions, cron, skills, agents, nodes, chat, config, debug, logs — but no branch for `usage`. The `"usage"` tab is defined in `navigation.ts:20` and routed via `TAB_PATHS`/`TAB_GROUPS`, but `refreshActiveTab` never calls `loadUsage()` for it.

## Human Verification (required)

- Verified scenarios: `pnpm build` passes (no type errors), `pnpm check` passes (lint/format clean), pre-commit hooks pass.
- Edge cases checked: `loadUsage()` already guards against `!client || !state.connected` and `state.usageLoading`, so double-calls from reconnect are safe.
- What I did **not** verify: full `pnpm test` suite (running in background; change is a 3-line addition with no new logic).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit.
- Files/config to restore: `ui/src/ui/app-settings.ts`
- Known bad symptoms reviewers should watch for: None expected; `loadUsage` is already used by the Refresh button in the same UI.

## Risks and Mitigations

None — the fix adds a missing branch that calls an existing, well-guarded function.

---

🤖 AI-assisted (Claude Opus 4.6). Bug discovered via code reading, fix verified with build + lint.