### PR TITLE
discord: share component registry across module instances

### DIFF
--- a/src/discord/components-registry.ts
+++ b/src/discord/components-registry.ts
@@ -1,9 +1,33 @@
 import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
 
 const DEFAULT_COMPONENT_TTL_MS = 30 * 60 * 1000;
+const DISCORD_COMPONENT_REGISTRY_STATE_KEY = "__openclawDiscordComponentRegistryState";
 
-const componentEntries = new Map<string, DiscordComponentEntry>();
-const modalEntries = new Map<string, DiscordModalEntry>();
+type DiscordComponentRegistryState = {
+  componentEntries: Map<string, DiscordComponentEntry>;
+  modalEntries: Map<string, DiscordModalEntry>;
+};
+
+function createDiscordComponentRegistryState(): DiscordComponentRegistryState {
+  return {
+    componentEntries: new Map<string, DiscordComponentEntry>(),
+    modalEntries: new Map<string, DiscordModalEntry>(),
+  };
+}
+
+function resolveDiscordComponentRegistryState(): DiscordComponentRegistryState {
+  const runtimeGlobal = globalThis as typeof globalThis & {
+    [DISCORD_COMPONENT_REGISTRY_STATE_KEY]?: DiscordComponentRegistryState;
+  };
+  if (!runtimeGlobal[DISCORD_COMPONENT_REGISTRY_STATE_KEY]) {
+    runtimeGlobal[DISCORD_COMPONENT_REGISTRY_STATE_KEY] = createDiscordComponentRegistryState();
+  }
+  return runtimeGlobal[DISCORD_COMPONENT_REGISTRY_STATE_KEY];
+}
+
+const DISCORD_COMPONENT_REGISTRY_STATE = resolveDiscordComponentRegistryState();
+const componentEntries = DISCORD_COMPONENT_REGISTRY_STATE.componentEntries;
+const modalEntries = DISCORD_COMPONENT_REGISTRY_STATE.modalEntries;
 
 function isExpired(entry: { expiresAt?: number }, now: number) {
   return typeof entry.expiresAt === "number" && entry.expiresAt <= now;

--- a/src/discord/components.test.ts
+++ b/src/discord/components.test.ts
@@ -1,5 +1,5 @@
 import { MessageFlags } from "discord-api-types/v10";
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, beforeEach, vi } from "vitest";
 import {
   clearDiscordComponentEntries,
   registerDiscordComponentEntries,
@@ -94,5 +94,25 @@ describe("discord component registry", () => {
     const consumed = resolveDiscordComponentEntry({ id: "btn_1" });
     expect(consumed?.id).toBe("btn_1");
     expect(resolveDiscordComponentEntry({ id: "btn_1" })).toBeNull();
+  });
+
+  it("shares the component registry across fresh module instances", async () => {
+    registerDiscordComponentEntries({
+      entries: [{ id: "btn_global", kind: "button", label: "Confirm" }],
+      modals: [{ id: "mdl_global", title: "Details", fields: [] }],
+      ttlMs: 1000,
+    });
+
+    vi.resetModules();
+    const freshRegistry = await import("./components-registry.js");
+
+    expect(
+      freshRegistry.resolveDiscordComponentEntry({ id: "btn_global", consume: false })?.id,
+    ).toBe("btn_global");
+    expect(freshRegistry.resolveDiscordModalEntry({ id: "mdl_global", consume: false })?.id).toBe(
+      "mdl_global",
+    );
+
+    freshRegistry.clearDiscordComponentEntries();
   });
 });


### PR DESCRIPTION
## Summary
- store Discord component/modal registry state on `globalThis` so separate module instances share the same entries
- keep the existing TTL/consume behavior intact
- add a regression test that resets modules and verifies a fresh import can still resolve previously registered entries

Fixes #40923