### PR TITLE
fix(telegram): surface error when getFile() fails instead of misleading placeholder

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -53,6 +53,7 @@ import {
   buildTelegramParentPeer,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
+  resolveTelegramMediaPlaceholder,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { resolveTelegramConversationRoute } from "./conversation-route.js";
@@ -1013,6 +1014,27 @@ export const registerTelegramHandlers = ({
     if (msg.sticker && !media && !hasText) {
       logVerbose("telegram: skipping sticker-only message (unsupported sticker type)");
       return;
+    }
+
+    // When resolveMedia returns null for a message that contains media fields
+    // (e.g. video, photo), the getFile() call failed silently.  Warn the user
+    // so they know the media was not attached instead of silently proceeding
+    // with a misleading placeholder-only body.
+    if (!media && !msg.sticker && resolveTelegramMediaPlaceholder(msg)) {
+      logger.warn({ chatId }, "telegram: media resolution returned null; notifying user");
+      await withTelegramApiErrorLogging({
+        operation: "sendMessage",
+        runtime,
+        fn: () =>
+          bot.api.sendMessage(
+            chatId,
+            "⚠️ Failed to download media. The file may exceed Telegram's 20 MB download limit. Please try again or send a smaller file.",
+            {
+              reply_to_message_id: msg.message_id,
+            },
+          ),
+      }).catch(() => {});
+      // Still proceed so any accompanying text caption reaches the agent.
     }
 
     const allMedia = media

--- a/src/telegram/bot-message-context.body.ts
+++ b/src/telegram/bot-message-context.body.ts
@@ -137,7 +137,11 @@ export async function resolveTelegramInboundBody(params: {
   const commandAuthorized = commandGate.commandAuthorized;
   const historyKey = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : undefined;
 
-  let placeholder = resolveTelegramMediaPlaceholder(msg) ?? "";
+  // Only emit a media placeholder when media was actually resolved.
+  // When allMedia is empty (e.g. getFile() failed silently), emitting a
+  // placeholder like <media:video> is misleading — it makes it look like
+  // the agent received the media when it did not.
+  let placeholder = allMedia.length > 0 ? (resolveTelegramMediaPlaceholder(msg) ?? "") : "";
   const cachedStickerDescription = allMedia[0]?.stickerMetadata?.cachedDescription;
   const stickerSupportsVision = msg.sticker
     ? await resolveStickerVisionSupport({ cfg, agentId: routeAgentId })


### PR DESCRIPTION
## Summary

When Telegram's `getFile()` fails (e.g. file exceeds the 20 MB Bot API limit), `resolveMedia()` returns `null` but the inbound message body still contained a `<media:video>` placeholder with no actual attachment. This made it appear as if the agent received the media when it did not, and no user-visible error was shown.

**Two changes:**

- **`bot-handlers.ts`**: Send a user-visible warning (`⚠️ Failed to download media…`) when media resolution returns `null` for a message that contains media fields (video, photo, audio, document). The message still proceeds so any accompanying text caption reaches the agent.
- **`bot-message-context.body.ts`**: Suppress the media type placeholder (e.g. `<media:video>`) when `allMedia` is empty, so the agent body does not contain misleading tags suggesting media was attached.

Fixes #40991

## Test plan

- [x] Existing `delivery.resolve-media-retry.test.ts` tests pass (18/18)
- [x] `pnpm build` succeeds
- [x] `pnpm check` succeeds
- [ ] Verify with a Telegram video >20 MB: user should see the warning message and the agent body should not contain a bare `<media:video>` placeholder
- [ ] Verify normal video (<20 MB) still attaches correctly with placeholder