### PR TITLE
Accept legacy anthropic tool payload compat config overrides

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -133,6 +133,40 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts legacy anthropic tool payload compat overrides", () => {
+    const res = validateConfigObject({
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            apiKey: "env:OPENROUTER_API_KEY",
+            models: [
+              {
+                id: "openrouter/test-model",
+                name: "OpenRouter Test Model",
+                reasoning: true,
+                input: ["text"],
+                cost: {
+                  input: 0,
+                  output: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                },
+                contextWindow: 200000,
+                maxTokens: 64000,
+                compat: {
+                  requiresOpenAiAnthropicToolPayload: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects non-positive pdf limits", () => {
     const res = validateConfigObject({
       agents: {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -198,6 +198,7 @@ export const ModelCompatSchema = z
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),
     requiresMistralToolIds: z.boolean().optional(),
+    requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
Fixes #40911

## Summary

The config schema already supports `requiresOpenAiAnthropicToolPayload` at the type/runtime level, but `ModelCompatSchema` was still missing the field.

That caused config writes to fail when newer provider presets wrote the compat flag back into `openclaw.json`, even though the rest of the stack already understood it.

## Changes

- add `requiresOpenAiAnthropicToolPayload` to `ModelCompatSchema`
- add a config regression test covering legacy compat overrides

## Verification

```bash
pnpm exec vitest run src/config/config.schema-regressions.test.ts
```
