### PR TITLE
fix(slack): process thread_broadcast messages instead of dropping them

### DIFF
--- a/extensions/slack/src/monitor/events/message-subtype-handlers.ts
+++ b/extensions/slack/src/monitor/events/message-subtype-handlers.ts
@@ -10,6 +10,8 @@ type SupportedSubtype = "message_changed" | "message_deleted" | "thread_broadcas
 export type SlackMessageSubtypeHandler = {
   subtype: SupportedSubtype;
   eventKind: SupportedSubtype;
+  /** When true, the message is forwarded to handleSlackMessage after authorization. */
+  processAsMessage?: boolean;
   describe: (channelLabel: string) => string;
   contextKey: (event: SlackMessageEvent) => string;
   resolveSenderId: (event: SlackMessageEvent) => string | undefined;
@@ -62,6 +64,7 @@ const deletedHandler: SlackMessageSubtypeHandler = {
 const threadBroadcastHandler: SlackMessageSubtypeHandler = {
   subtype: "thread_broadcast",
   eventKind: "thread_broadcast",
+  processAsMessage: true,
   describe: (channelLabel) => `Slack thread reply broadcast in ${channelLabel}.`,
   contextKey: (event) => {
     const thread = event as SlackThreadBroadcastEvent;

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -222,6 +222,21 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
+  it("routes authorized thread_broadcast messages to the message handler", async () => {
+    messageQueueMock.mockClear();
+    messageAllowMock.mockReset().mockResolvedValue([]);
+    const { handler, handleSlackMessage } = createMessageHandlers({ dmPolicy: "open" });
+    expect(handler).toBeTruthy();
+
+    await handler!({
+      event: makeThreadBroadcastEvent() as unknown as Record<string, unknown>,
+      body: {},
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledTimes(1);
+    expect(messageQueueMock).not.toHaveBeenCalled();
+  });
+
   it("applies subtype system-event handling for channel messages", async () => {
     // message_changed events from channels arrive via the generic "message"
     // handler with channel_type:"channel" — not a separate event type.

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -34,10 +34,14 @@ export function registerSlackMessageEvents(params: {
         if (!ingressContext) {
           return;
         }
-        enqueueSystemEvent(subtypeHandler.describe(ingressContext.channelLabel), {
-          sessionKey: ingressContext.sessionKey,
-          contextKey: subtypeHandler.contextKey(message),
-        });
+        if (subtypeHandler.processAsMessage) {
+          await handleSlackMessage(message, { source: "message" });
+        } else {
+          enqueueSystemEvent(subtypeHandler.describe(ingressContext.channelLabel), {
+            sessionKey: ingressContext.sessionKey,
+            contextKey: subtypeHandler.contextKey(message),
+          });
+        }
         return;
       }
 

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -146,4 +146,43 @@ describe("createSlackMessageHandler", () => {
 
     expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
   });
+
+  it("accepts thread_broadcast messages as processable content", async () => {
+    const { handler, trackEvent } = createHandlerWithTracker();
+
+    await handler(
+      {
+        type: "message",
+        subtype: "thread_broadcast",
+        channel: "C1",
+        user: "U1",
+        ts: "123.456",
+        thread_ts: "123.400",
+        text: "broadcast reply",
+      } as never,
+      { source: "message" },
+    );
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(resolveThreadTsMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops unknown subtypes from the message stream", async () => {
+    const { handler, trackEvent } = createHandlerWithTracker();
+
+    await handler(
+      {
+        type: "message",
+        subtype: "channel_join",
+        channel: "C1",
+        user: "U1",
+        ts: "123.456",
+      } as never,
+      { source: "message" },
+    );
+
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -214,7 +214,8 @@ export function createSlackMessageHandler(params: {
       opts.source === "message" &&
       message.subtype &&
       message.subtype !== "file_share" &&
-      message.subtype !== "bot_message"
+      message.subtype !== "bot_message" &&
+      message.subtype !== "thread_broadcast"
     ) {
       return;
     }


### PR DESCRIPTION
## Summary

- **Problem:** Slack `thread_broadcast` messages ("Also send to channel" thread replies) are silently dropped — the bot never responds.
- **Why it matters:** Slack sends `thread_broadcast` *instead of* a regular message event, so these replies are invisible to the bot.
- **What changed:** Two independent gates were blocking these messages: the subtype handler in `messages.ts` only logged a system event, and the subtype filter in `message-handler.ts` dropped anything that wasn't `file_share`/`bot_message`. Both now allow `thread_broadcast` through.
- **What did NOT change:** `message_changed`/`message_deleted` remain system-event-only. Sender authorization is preserved.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #4351

## User-visible / Behavior Changes

Thread replies sent with Slack's "Also send to channel" now receive a bot response.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Slack's [`thread_broadcast`](https://docs.slack.dev/reference/events/message/thread_broadcast) subtype is sent *instead of* a regular message event when a user checks "Also send to channel" on a thread reply. The event carries `text`, `ts`, `thread_ts` at the top level — fully compatible with `SlackMessageEvent`. Two independent code paths were both dropping it: the subtype handler (system-event-only) and the message handler's subtype allowlist.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
