### PR TITLE
browser/extension: release idle relay connection for cross-profile handoff

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -250,6 +250,11 @@ function onRelayClosed(reason) {
     }
   }
 
+  if (tabs.size === 0) {
+    cancelReconnect()
+    return
+  }
+
   scheduleReconnect()
 }
 
@@ -288,6 +293,26 @@ function cancelReconnect() {
     reconnectTimer = null
   }
   reconnectAttempt = 0
+}
+
+function releaseRelayIfIdle(reason = 'idle') {
+  if (tabs.size > 0) return
+
+  cancelReconnect()
+  relayConnectRequestId = null
+
+  const ws = relayWs
+  if (!ws) return
+
+  if (ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
+    return
+  }
+
+  try {
+    ws.close(1000, `idle:${reason}`)
+  } catch {
+    // ignore
+  }
 }
 
 // Re-announce all attached tabs to the relay after reconnect.
@@ -359,6 +384,7 @@ async function reannounceAttachedTabs() {
   }
 
   await persistState()
+  releaseRelayIfIdle('reannounce')
 }
 
 function sendToRelay(payload) {
@@ -602,6 +628,7 @@ async function detachTab(tabId, reason) {
   })
 
   await persistState()
+  releaseRelayIfIdle('detached')
 }
 
 async function connectOrToggleForActiveTab() {
@@ -898,6 +925,7 @@ chrome.tabs.onRemoved.addListener((tabId) => void whenReady(() => {
     }
   }
   void persistState()
+  releaseRelayIfIdle('tab-removed')
 }))
 
 chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => void whenReady(() => {

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -282,6 +282,10 @@ function scheduleReconnect() {
       if (!isRetryableReconnectError(err)) {
         return
       }
+      if (tabs.size === 0) {
+        cancelReconnect()
+        return
+      }
       scheduleReconnect()
     }
   }, delay)

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -47,6 +47,10 @@ const reattachPending = new Set()
 let reconnectAttempt = 0
 let reconnectTimer = null
 
+function hasLiveAttachmentDemand() {
+  return tabs.size > 0 || reattachPending.size > 0
+}
+
 const TAB_VALIDATION_ATTEMPTS = 2
 const TAB_VALIDATION_RETRY_DELAY_MS = 1000
 
@@ -250,7 +254,7 @@ function onRelayClosed(reason) {
     }
   }
 
-  if (tabs.size === 0) {
+  if (!hasLiveAttachmentDemand()) {
     cancelReconnect()
     return
   }
@@ -282,7 +286,7 @@ function scheduleReconnect() {
       if (!isRetryableReconnectError(err)) {
         return
       }
-      if (tabs.size === 0) {
+      if (!hasLiveAttachmentDemand()) {
         cancelReconnect()
         return
       }
@@ -300,7 +304,7 @@ function cancelReconnect() {
 }
 
 function releaseRelayIfIdle(reason = 'idle') {
-  if (tabs.size > 0) return
+  if (hasLiveAttachmentDemand()) return
 
   cancelReconnect()
   relayConnectRequestId = null


### PR DESCRIPTION
## Summary
- Release the extension relay websocket when no attached tabs remain.
- Skip reconnect scheduling when there are zero tracked tabs.
- Trigger idle release after detach, tab removal, and reannounce cleanup.
- Add a race-condition guard in reconnect catch path to avoid scheduling retries when `tabs.size === 0`.

## Why
If relay is not released while idle, Profile A can keep occupying the single extension websocket slot even after users toggle off/close tabs.
Then Profile B cannot take over and shows error badge `!` with `Extension already connected` behavior.

Also, during an in-flight reconnect callback, tabs may drop to zero after `reconnectTimer = null`; without an extra guard, retry scheduling can still occur even though the extension is idle.

## Scope
- `assets/chrome-extension/background.js` only
- No server config/schema changes
- Backward compatible while tabs are attached
