### PR TITLE
fix(config): preserve $include directives when writing config

### DIFF
--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -344,3 +344,62 @@ export function resolveConfigIncludes(
 ): unknown {
   return new IncludeProcessor(configPath, resolver).process(obj);
 }
+
+// ============================================================================
+// Restore $include directives on write
+// ============================================================================
+
+/**
+ * Recursively restore $include directives from original parsed config
+ * to the resolved config that we're about to write back.
+ * This preserves the modular config structure.
+ */
+export function restoreIncludes(
+  resolved: unknown,
+  original: unknown,
+): unknown {
+  if (typeof resolved !== "object" || resolved === null) {
+    return resolved;
+  }
+  if (typeof original !== "object" || original === null) {
+    return resolved;
+  }
+
+  const resolvedObj = resolved as Record<string, unknown>;
+  const originalObj = original as Record<string, unknown>;
+
+  // If original has $include at this level, prefer it over resolved value
+  if (INCLUDE_KEY in originalObj && !(INCLUDE_KEY in resolvedObj)) {
+    const result = { ...resolvedObj };
+    result[INCLUDE_KEY] = originalObj[INCLUDE_KEY];
+    return result;
+  }
+
+  // Recursively restore $include in nested objects
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(resolvedObj)) {
+    const resVal = resolvedObj[key];
+    const orgVal = originalObj[key];
+
+    if (
+      typeof resVal === "object" &&
+      resVal !== null &&
+      typeof orgVal === "object" &&
+      orgVal !== null &&
+      !Array.isArray(resVal) &&
+      !Array.isArray(orgVal)
+    ) {
+      result[key] = restoreIncludes(resVal, orgVal);
+    } else {
+      result[key] = resVal;
+    }
+  }
+
+  for (const key of Object.keys(originalObj)) {
+    if (!(key in result)) {
+      result[key] = originalObj[key];
+    }
+  }
+
+  return result;
+}

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -40,6 +40,7 @@ import {
   ConfigIncludeError,
   readConfigIncludeFileWithGuards,
   resolveConfigIncludes,
+  restoreIncludes,
 } from "./includes.js";
 import { findLegacyConfigIssues } from "./legacy.js";
 import { applyMergePatch } from "./merge-patch.js";
@@ -1131,6 +1132,16 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
     } catch {
       // If reading the current file fails, write cfg as-is (no env restoration)
+    }
+
+    // Restore $include directives from the original parsed config.
+    // This preserves the modular config structure when writing back.
+    if (snapshot.valid && snapshot.exists && snapshot.parsed) {
+      try {
+        cfgToWrite = restoreIncludes(cfgToWrite, snapshot.parsed) as OpenClawConfig;
+      } catch {
+        // If restore fails, write cfg as-is
+      }
     }
 
     const dir = path.dirname(configPath);


### PR DESCRIPTION
## Summary

Fix `plugins install` to preserve `$include` directives instead of flattening the entire config into a monolithic file.

## Problem

When running `openclaw plugins install`, the command rewrites `openclaw.json` with all `$include` directives resolved and inlined. This:
1. Destroys the modular config structure users have set up
2. Leaves orphaned `config/*.json5` files
3. **Security issue**: Secrets from separate files get inlined into the main config

## Solution

1. Add `restoreIncludes()` function in `src/config/includes.ts` to track and restore `$include` directives
2. Call `restoreIncludes` in `writeConfigFile` after env var restoration
3. Preserve original `$include` references from the parsed config

## Changes

- `src/config/includes.ts`: Add `restoreIncludes()` function (+61 lines)
- `src/config/io.ts`: Import and call `restoreIncludes` (+9 lines)

## Testing

1. Set up modular config with `$include` directives
2. Run `plugins install` for a new plugin
3. Verify `$include` structure is preserved
4. Verify new plugin is correctly added

Fixes #41050