### PR TITLE
fix(plugins): preserve modular config includes on cli writes

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -64,6 +64,7 @@ cat ~/.openclaw/openclaw.json
 - Skills status summary (eligible/missing/blocked).
 - Config normalization for legacy values.
 - OpenCode Zen provider override warnings (`models.providers.opencode`).
+- Codex OAuth shadowing warnings (`models.providers.openai-codex`).
 - Legacy on-disk state migration (sessions/agent dir/WhatsApp auth).
 - State integrity and permissions checks (sessions, transcripts, state dir).
 - Config file permission checks (chmod 600) when running locally.
@@ -139,6 +140,14 @@ If you’ve added `models.providers.opencode` (or `opencode-zen`) manually, it
 overrides the built-in OpenCode Zen catalog from `@mariozechner/pi-ai`. That can
 force every model onto a single API or zero out costs. Doctor warns so you can
 remove the override and restore per-model API routing + costs.
+
+### 2c) Codex OAuth provider overrides
+
+If you previously added `models.providers.openai-codex` manually, that legacy
+override can shadow the built-in Codex OAuth provider path that newer releases
+use automatically. Doctor warns when it sees that override alongside Codex OAuth
+so you can remove the stale config and get the built-in routing/fallback behavior
+back.
 
 ### 3) Legacy state migrations (disk layout)
 

--- a/src/cli/plugins-cli.install-config-write.test.ts
+++ b/src/cli/plugins-cli.install-config-write.test.ts
@@ -1,0 +1,107 @@
+import { Command } from "commander";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { runRegisteredCli } from "../test-utils/command-runner.js";
+
+const loadConfigMock = vi.fn(() => ({}));
+const installPluginFromNpmSpecMock = vi.fn();
+const persistPluginConfigWriteMock = vi.fn(async (_cfg: Record<string, unknown>) => {});
+const clearPluginManifestRegistryCacheMock = vi.fn();
+const buildPluginStatusReportMock = vi.fn(() => ({
+  workspaceDir: "/tmp/workspace",
+  diagnostics: [],
+  plugins: [{ id: "demo", kind: "integration" }],
+}));
+const applyExclusiveSlotSelectionMock = vi.fn(
+  ({ config }: { config: Record<string, unknown> }) => ({
+    config,
+    warnings: [],
+  }),
+);
+const runtimeLogMock = vi.fn();
+const runtimeErrorMock = vi.fn();
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => loadConfigMock(),
+}));
+
+vi.mock("../plugins/install.js", () => ({
+  installPluginFromNpmSpec: (...args: unknown[]) => installPluginFromNpmSpecMock(...args),
+  installPluginFromPath: vi.fn(),
+}));
+
+vi.mock("../plugins/config-write.js", () => ({
+  persistPluginConfigWrite: (cfg: Record<string, unknown>) => persistPluginConfigWriteMock(cfg),
+}));
+
+vi.mock("../plugins/manifest-registry.js", () => ({
+  clearPluginManifestRegistryCache: () => clearPluginManifestRegistryCacheMock(),
+}));
+
+vi.mock("../plugins/status.js", () => ({
+  buildPluginStatusReport: () => buildPluginStatusReportMock(),
+}));
+
+vi.mock("../plugins/slots.js", () => ({
+  applyExclusiveSlotSelection: (params: { config: Record<string, unknown> }) =>
+    applyExclusiveSlotSelectionMock(params),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    log: (...args: unknown[]) => runtimeLogMock(...args),
+    error: (...args: unknown[]) => runtimeErrorMock(...args),
+  },
+}));
+
+describe("plugins cli install config writes", () => {
+  let registerPluginsCli: (typeof import("./plugins-cli.js"))["registerPluginsCli"];
+
+  beforeAll(async () => {
+    ({ registerPluginsCli } = await import("./plugins-cli.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: true,
+      pluginId: "demo",
+      targetDir: "/tmp/extensions/demo",
+      version: "1.2.3",
+      extensions: ["./dist/index.js"],
+      npmResolution: {
+        name: "@openclaw/demo",
+        version: "1.2.3",
+        resolvedSpec: "@openclaw/demo@1.2.3",
+        integrity: "sha512-demo",
+        shasum: "deadbeef",
+        resolvedAt: "2026-03-09T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("routes plugin install writes through the include-preserving plugin config writer", async () => {
+    await runRegisteredCli({
+      register: (program: Command) => registerPluginsCli(program),
+      argv: ["plugins", "install", "@openclaw/demo"],
+    });
+
+    expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
+    expect(clearPluginManifestRegistryCacheMock).toHaveBeenCalledTimes(1);
+    expect(persistPluginConfigWriteMock).toHaveBeenCalledTimes(1);
+    expect(persistPluginConfigWriteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: expect.objectContaining({
+          entries: expect.objectContaining({
+            demo: expect.objectContaining({ enabled: true }),
+          }),
+          installs: expect.objectContaining({
+            demo: expect.objectContaining({
+              source: "npm",
+              installPath: "/tmp/extensions/demo",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -3,10 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import type { Command } from "commander";
 import type { OpenClawConfig } from "../config/config.js";
-import { loadConfig, writeConfigFile } from "../config/config.js";
+import { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { type BundledPluginSource, findBundledPluginSource } from "../plugins/bundled-sources.js";
+import { persistPluginConfigWrite } from "../plugins/config-write.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
 import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
 import { recordPluginInstall } from "../plugins/installs.js";
@@ -189,7 +190,7 @@ async function installBundledPluginSource(params: {
   });
   const slotResult = applySlotSelectionForPlugin(next, params.bundledSource.pluginId);
   next = slotResult.config;
-  await writeConfigFile(next);
+  await persistPluginConfigWrite(next);
   logSlotWarnings(slotResult.warnings);
   defaultRuntime.log(theme.warn(params.warning));
   defaultRuntime.log(`Installed plugin: ${params.bundledSource.pluginId}`);
@@ -242,7 +243,7 @@ async function runPluginInstallCommand(params: {
       });
       const slotResult = applySlotSelectionForPlugin(next, probe.pluginId);
       next = slotResult.config;
-      await writeConfigFile(next);
+      await persistPluginConfigWrite(next);
       logSlotWarnings(slotResult.warnings);
       defaultRuntime.log(`Linked plugin path: ${shortenHomePath(resolved)}`);
       defaultRuntime.log(`Restart the gateway to load plugins.`);
@@ -272,7 +273,7 @@ async function runPluginInstallCommand(params: {
     });
     const slotResult = applySlotSelectionForPlugin(next, result.pluginId);
     next = slotResult.config;
-    await writeConfigFile(next);
+    await persistPluginConfigWrite(next);
     logSlotWarnings(slotResult.warnings);
     defaultRuntime.log(`Installed plugin: ${result.pluginId}`);
     defaultRuntime.log(`Restart the gateway to load plugins.`);
@@ -356,7 +357,7 @@ async function runPluginInstallCommand(params: {
   });
   const slotResult = applySlotSelectionForPlugin(next, result.pluginId);
   next = slotResult.config;
-  await writeConfigFile(next);
+  await persistPluginConfigWrite(next);
   logSlotWarnings(slotResult.warnings);
   defaultRuntime.log(`Installed plugin: ${result.pluginId}`);
   defaultRuntime.log(`Restart the gateway to load plugins.`);
@@ -557,7 +558,7 @@ export function registerPluginsCli(program: Command) {
       let next: OpenClawConfig = enableResult.config;
       const slotResult = applySlotSelectionForPlugin(next, id);
       next = slotResult.config;
-      await writeConfigFile(next);
+      await persistPluginConfigWrite(next);
       logSlotWarnings(slotResult.warnings);
       if (enableResult.enabled) {
         defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
@@ -577,7 +578,7 @@ export function registerPluginsCli(program: Command) {
     .action(async (id: string) => {
       const cfg = loadConfig();
       const next = setPluginEnabledInConfig(cfg, id, false);
-      await writeConfigFile(next);
+      await persistPluginConfigWrite(next);
       defaultRuntime.log(`Disabled plugin "${id}". Restart the gateway to apply.`);
     });
 
@@ -688,7 +689,7 @@ export function registerPluginsCli(program: Command) {
         defaultRuntime.log(theme.warn(warning));
       }
 
-      await writeConfigFile(result.config);
+      await persistPluginConfigWrite(result.config);
 
       const removed: string[] = [];
       if (result.actions.entry) {
@@ -783,7 +784,7 @@ export function registerPluginsCli(program: Command) {
       }
 
       if (!opts.dryRun && result.changed) {
-        await writeConfigFile(result.config);
+        await persistPluginConfigWrite(result.config);
         defaultRuntime.log("Restart the gateway to load plugins.");
       }
     });

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -18,6 +18,9 @@ import type { OpenClawConfig } from "../config/config.js";
 import { note } from "../terminal/note.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
+const CODEX_PROVIDER_ID = "openai-codex";
+const CODEX_OAUTH_WARNING_TITLE = "Codex OAuth";
+
 export async function maybeRepairAnthropicOAuthProfileId(
   cfg: OpenClawConfig,
   prompter: DoctorPrompter,
@@ -198,6 +201,55 @@ export async function maybeRemoveDeprecatedCliAuthProfiles(
     );
   }
   return pruned.next;
+}
+
+function hasConfiguredCodexOAuthProfile(cfg: OpenClawConfig): boolean {
+  return Object.values(cfg.auth?.profiles ?? {}).some(
+    (profile) => profile.provider === CODEX_PROVIDER_ID && profile.mode === "oauth",
+  );
+}
+
+function hasStoredCodexOAuthProfile(): boolean {
+  const store = ensureAuthProfileStore(undefined, { allowKeychainPrompt: false });
+  return Object.values(store.profiles).some(
+    (profile) => profile.provider === CODEX_PROVIDER_ID && profile.type === "oauth",
+  );
+}
+
+function buildCodexProviderOverrideWarning(providerOverride: unknown): string {
+  const lines = [
+    `- models.providers.${CODEX_PROVIDER_ID} is set while Codex OAuth is configured.`,
+    "- This legacy manual override can shadow the built-in Codex OAuth provider.",
+  ];
+  if (
+    providerOverride &&
+    typeof providerOverride === "object" &&
+    !Array.isArray(providerOverride)
+  ) {
+    const record = providerOverride as Record<string, unknown>;
+    if (typeof record.api === "string") {
+      lines.push(`- models.providers.${CODEX_PROVIDER_ID}.api=${record.api}`);
+    }
+    if (typeof record.baseUrl === "string") {
+      lines.push(`- models.providers.${CODEX_PROVIDER_ID}.baseUrl=${record.baseUrl}`);
+    }
+  }
+  lines.push(
+    `- Remove models.providers.${CODEX_PROVIDER_ID} to restore the built-in Codex OAuth provider path after recent fixes.`,
+  );
+  lines.push("- If this override is intentional, you can ignore this warning.");
+  return lines.join("\n");
+}
+
+export function noteLegacyCodexProviderOverride(cfg: OpenClawConfig): void {
+  const providerOverride = cfg.models?.providers?.[CODEX_PROVIDER_ID];
+  if (!providerOverride) {
+    return;
+  }
+  if (!hasConfiguredCodexOAuthProfile(cfg) && !hasStoredCodexOAuthProfile()) {
+    return;
+  }
+  note(buildCodexProviderOverrideWarning(providerOverride), CODEX_OAUTH_WARNING_TITLE);
 }
 
 type AuthIssue = {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -27,6 +27,7 @@ import {
   maybeRemoveDeprecatedCliAuthProfiles,
   maybeRepairAnthropicOAuthProfileId,
   noteAuthProfileHealth,
+  noteLegacyCodexProviderOverride,
 } from "./doctor-auth.js";
 import { noteBootstrapFileSize } from "./doctor-bootstrap-size.js";
 import { doctorShellCompletion } from "./doctor-completion.js";
@@ -138,6 +139,7 @@ export async function doctorCommand(
     prompter,
     allowKeychainPrompt: options.nonInteractive !== true && Boolean(process.stdin.isTTY),
   });
+  noteLegacyCodexProviderOverride(cfg);
   const gatewayDetails = buildGatewayConnectionDetails({ config: cfg });
   if (gatewayDetails.remoteFallbackNote) {
     note(gatewayDetails.remoteFallbackNote, "Gateway");

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -2,7 +2,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { createDoctorRuntime, mockDoctorConfigSnapshot, note } from "./doctor.e2e-harness.js";
+import {
+  createDoctorRuntime,
+  ensureAuthProfileStore,
+  mockDoctorConfigSnapshot,
+  note,
+} from "./doctor.e2e-harness.js";
 import "./doctor.fast-path-mocks.js";
 
 vi.doUnmock("./doctor-state-integrity.js");
@@ -56,6 +61,81 @@ describe("doctor command", () => {
         title === "OpenCode Zen" && String(message).includes("models.providers.opencode"),
     );
     expect(warned).toBe(true);
+  });
+
+  it("warns when a legacy openai-codex provider override shadows Codex OAuth", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        models: {
+          providers: {
+            "openai-codex": {
+              api: "openai-responses",
+              baseUrl: "https://api.openai.com/v1",
+            },
+          },
+        },
+        auth: {
+          profiles: {
+            "openai-codex:user@example.com": {
+              provider: "openai-codex",
+              mode: "oauth",
+              email: "user@example.com",
+            },
+          },
+        },
+      },
+    });
+    ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        "openai-codex:user@example.com": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+          email: "user@example.com",
+        },
+      },
+    });
+
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    const warned = note.mock.calls.some(
+      ([message, title]) =>
+        title === "Codex OAuth" && String(message).includes("models.providers.openai-codex"),
+    );
+    expect(warned).toBe(true);
+  });
+
+  it("does not warn about an openai-codex provider override without Codex OAuth", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        models: {
+          providers: {
+            "openai-codex": {
+              api: "openai-responses",
+              baseUrl: "https://api.openai.com/v1",
+            },
+          },
+        },
+      },
+    });
+    ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+    });
+
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    const warned = note.mock.calls.some(([, title]) => title === "Codex OAuth");
+    expect(warned).toBe(false);
   });
 
   it("skips gateway auth warning when OPENCLAW_GATEWAY_TOKEN is set", async () => {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -63,7 +63,7 @@ describe("doctor command", () => {
     expect(warned).toBe(true);
   });
 
-  it("warns when a legacy openai-codex provider override shadows Codex OAuth", async () => {
+  it("warns when a legacy openai-codex provider override shadows configured Codex OAuth", async () => {
     mockDoctorConfigSnapshot({
       config: {
         models: {
@@ -80,6 +80,36 @@ describe("doctor command", () => {
               provider: "openai-codex",
               mode: "oauth",
               email: "user@example.com",
+            },
+          },
+        },
+      },
+    });
+    ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+    });
+
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    const warned = note.mock.calls.some(
+      ([message, title]) =>
+        title === "Codex OAuth" && String(message).includes("models.providers.openai-codex"),
+    );
+    expect(warned).toBe(true);
+  });
+
+  it("warns when a legacy openai-codex provider override shadows stored Codex OAuth", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        models: {
+          providers: {
+            "openai-codex": {
+              api: "openai-responses",
+              baseUrl: "https://api.openai.com/v1",
             },
           },
         },

--- a/src/plugins/config-write.test.ts
+++ b/src/plugins/config-write.test.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readConfigFileSnapshotForWrite } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { persistPluginConfigWrite } from "./config-write.js";
+
+async function makeTempModularConfig(params?: { pluginsRaw?: string }): Promise<{
+  rootDir: string;
+  configPath: string;
+  pluginsPath: string;
+}> {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-config-write-"));
+  const configDir = path.join(rootDir, "config");
+  await fs.mkdir(configDir, { recursive: true });
+  const configPath = path.join(rootDir, "openclaw.json");
+  const pluginsPath = path.join(configDir, "plugins.json5");
+  await fs.writeFile(
+    path.join(configDir, "env.json5"),
+    JSON.stringify({ OPENAI_API_KEY: "${OPENAI_API_KEY}" }, null, 2),
+    "utf-8",
+  );
+  await fs.writeFile(
+    configPath,
+    `{
+  env: { $include: "./config/env.json5" },
+  plugins: { $include: "./config/plugins.json5" }
+}
+`,
+    "utf-8",
+  );
+  await fs.writeFile(
+    pluginsPath,
+    params?.pluginsRaw ??
+      `{}
+`,
+    "utf-8",
+  );
+  return { rootDir, configPath, pluginsPath };
+}
+
+async function readJsonFile(filePath: string): Promise<unknown> {
+  const raw = await fs.readFile(filePath, "utf-8");
+  return JSON.parse(raw);
+}
+
+async function withConfigPath<T>(configPath: string, run: () => Promise<T>): Promise<T> {
+  return await withEnvAsync(
+    {
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_DISABLE_CONFIG_CACHE: "1",
+      OPENAI_API_KEY: "sk-test",
+    },
+    run,
+  );
+}
+
+describe("persistPluginConfigWrite", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("preserves root $include directives and writes plugin changes into the included file", async () => {
+    const paths = await makeTempModularConfig();
+    tempRoots.push(paths.rootDir);
+    const nextConfig: OpenClawConfig = {
+      plugins: {
+        entries: {
+          telegram: { enabled: true },
+        },
+      },
+    };
+
+    await withConfigPath(paths.configPath, async () => {
+      const current = (await readConfigFileSnapshotForWrite()).snapshot.config;
+      await persistPluginConfigWrite({
+        ...current,
+        ...nextConfig,
+      });
+    });
+
+    const rootRaw = await fs.readFile(paths.configPath, "utf-8");
+    expect(rootRaw).toContain('$include: "./config/plugins.json5"');
+    expect(rootRaw).toContain('$include: "./config/env.json5"');
+    expect(rootRaw).not.toContain('"telegram"');
+
+    await expect(readJsonFile(paths.pluginsPath)).resolves.toEqual(nextConfig.plugins);
+  });
+
+  it("fails validation before mutating either config file", async () => {
+    const paths = await makeTempModularConfig();
+    tempRoots.push(paths.rootDir);
+    const beforeRoot = await fs.readFile(paths.configPath, "utf-8");
+    const beforePlugins = await fs.readFile(paths.pluginsPath, "utf-8");
+
+    await withConfigPath(paths.configPath, async () => {
+      const current = (await readConfigFileSnapshotForWrite()).snapshot.config;
+      await expect(
+        persistPluginConfigWrite({
+          ...current,
+          plugins: {
+            enabled: "yes" as unknown as boolean,
+          },
+        }),
+      ).rejects.toThrow(/plugins/i);
+    });
+
+    await expect(fs.readFile(paths.configPath, "utf-8")).resolves.toBe(beforeRoot);
+    await expect(fs.readFile(paths.pluginsPath, "utf-8")).resolves.toBe(beforePlugins);
+  });
+
+  it("preserves the plugins include while updating other changed root keys", async () => {
+    const paths = await makeTempModularConfig();
+    tempRoots.push(paths.rootDir);
+
+    await withConfigPath(paths.configPath, async () => {
+      const current = (await readConfigFileSnapshotForWrite()).snapshot.config;
+      await persistPluginConfigWrite({
+        ...current,
+        gateway: {
+          port: 19001,
+        },
+        plugins: {
+          entries: {
+            telegram: { enabled: true },
+          },
+        },
+      });
+    });
+
+    const rootRaw = await fs.readFile(paths.configPath, "utf-8");
+    expect(rootRaw).toContain('"$include": "./config/plugins.json5"');
+    expect(rootRaw).toContain('"$include": "./config/env.json5"');
+    expect(rootRaw).toContain('"gateway"');
+    expect(rootRaw).not.toContain('"telegram"');
+    await expect(readJsonFile(paths.pluginsPath)).resolves.toEqual({
+      entries: {
+        telegram: { enabled: true },
+      },
+    });
+  });
+});

--- a/src/plugins/config-write.test.ts
+++ b/src/plugins/config-write.test.ts
@@ -7,7 +7,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { persistPluginConfigWrite } from "./config-write.js";
 
-async function makeTempModularConfig(params?: { pluginsRaw?: string }): Promise<{
+async function makeTempModularConfig(params?: { rootRaw?: string; pluginsRaw?: string }): Promise<{
   rootDir: string;
   configPath: string;
   pluginsPath: string;
@@ -22,15 +22,14 @@ async function makeTempModularConfig(params?: { pluginsRaw?: string }): Promise<
     JSON.stringify({ OPENAI_API_KEY: "${OPENAI_API_KEY}" }, null, 2),
     "utf-8",
   );
-  await fs.writeFile(
-    configPath,
+  const rootRaw =
+    params?.rootRaw ??
     `{
   env: { $include: "./config/env.json5" },
   plugins: { $include: "./config/plugins.json5" }
 }
-`,
-    "utf-8",
-  );
+`;
+  await fs.writeFile(configPath, rootRaw, "utf-8");
   await fs.writeFile(
     pluginsPath,
     params?.pluginsRaw ??
@@ -52,6 +51,7 @@ async function withConfigPath<T>(configPath: string, run: () => Promise<T>): Pro
       OPENCLAW_CONFIG_PATH: configPath,
       OPENCLAW_DISABLE_CONFIG_CACHE: "1",
       OPENAI_API_KEY: "sk-test",
+      OPENCLAW_GATEWAY_TOKEN: "gateway-token-live",
     },
     run,
   );
@@ -144,5 +144,81 @@ describe("persistPluginConfigWrite", () => {
         telegram: { enabled: true },
       },
     });
+  });
+
+  it("preserves plugin include env placeholders when plugin writes keep the same secret", async () => {
+    const paths = await makeTempModularConfig({
+      pluginsRaw: `{
+  entries: {
+    demo: {
+      enabled: false,
+      config: {
+        apiKey: "\${OPENAI_API_KEY}"
+      }
+    }
+  }
+}
+`,
+    });
+    tempRoots.push(paths.rootDir);
+
+    await withConfigPath(paths.configPath, async () => {
+      const current = (await readConfigFileSnapshotForWrite()).snapshot.config;
+      await persistPluginConfigWrite({
+        ...current,
+        plugins: {
+          ...current.plugins,
+          entries: {
+            ...current.plugins?.entries,
+            demo: {
+              ...current.plugins?.entries?.demo,
+              enabled: true,
+            },
+          },
+        },
+      });
+    });
+
+    const pluginsRaw = await fs.readFile(paths.pluginsPath, "utf-8");
+    expect(pluginsRaw).toContain("${OPENAI_API_KEY}");
+    expect(pluginsRaw).not.toContain("sk-test");
+  });
+
+  it("preserves root env placeholders when plugin writes update another field in the same subtree", async () => {
+    const paths = await makeTempModularConfig({
+      rootRaw: `{
+  env: { $include: "./config/env.json5" },
+  gateway: {
+    auth: {
+      token: "\${OPENCLAW_GATEWAY_TOKEN}"
+    },
+    port: 18080
+  },
+  plugins: { $include: "./config/plugins.json5" }
+}
+`,
+    });
+    tempRoots.push(paths.rootDir);
+
+    await withConfigPath(paths.configPath, async () => {
+      const current = (await readConfigFileSnapshotForWrite()).snapshot.config;
+      await persistPluginConfigWrite({
+        ...current,
+        gateway: {
+          ...current.gateway,
+          port: 19001,
+        },
+        plugins: {
+          entries: {
+            telegram: { enabled: true },
+          },
+        },
+      });
+    });
+
+    const rootRaw = await fs.readFile(paths.configPath, "utf-8");
+    expect(rootRaw).toContain("${OPENCLAW_GATEWAY_TOKEN}");
+    expect(rootRaw).not.toContain("gateway-token-live");
+    expect(rootRaw).toContain('"port": 19001');
   });
 });

--- a/src/plugins/config-write.test.ts
+++ b/src/plugins/config-write.test.ts
@@ -50,7 +50,7 @@ async function withConfigPath<T>(configPath: string, run: () => Promise<T>): Pro
     {
       OPENCLAW_CONFIG_PATH: configPath,
       OPENCLAW_DISABLE_CONFIG_CACHE: "1",
-      OPENAI_API_KEY: "sk-test",
+      OPENAI_API_KEY: "sk-test", // pragma: allowlist secret
       OPENCLAW_GATEWAY_TOKEN: "gateway-token-live",
     },
     run,

--- a/src/plugins/config-write.ts
+++ b/src/plugins/config-write.ts
@@ -9,6 +9,7 @@ import {
   validateConfigObjectRawWithPlugins,
   writeConfigFile,
 } from "../config/config.js";
+import { restoreEnvVarRefs } from "../config/env-preserve.js";
 import { INCLUDE_KEY } from "../config/includes.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { writeTextAtomic } from "../infra/json-files.js";
@@ -69,11 +70,26 @@ async function ensureIncludedPluginsFileIsReadable(filePath: string): Promise<vo
   }
 }
 
+async function restoreConfigFragmentEnvRefs(
+  filePath: string,
+  value: unknown,
+  envSnapshot?: Record<string, string | undefined>,
+): Promise<unknown> {
+  const raw = await fs.readFile(filePath, "utf-8");
+  const parsed = parseConfigJson5(raw);
+  if (!parsed.ok) {
+    return value;
+  }
+  return restoreEnvVarRefs(value, parsed.parsed, envSnapshot ?? process.env);
+}
+
 async function writePluginsIncludeFile(
   filePath: string,
   plugins: OpenClawConfig["plugins"] | undefined,
+  envSnapshot?: Record<string, string | undefined>,
 ): Promise<void> {
-  await writeConfigFragment(filePath, plugins ?? {});
+  const nextValue = await restoreConfigFragmentEnvRefs(filePath, plugins ?? {}, envSnapshot);
+  await writeConfigFragment(filePath, nextValue);
 }
 
 function buildUpdatedRootSource(
@@ -127,9 +143,18 @@ export async function persistPluginConfigWrite(nextConfig: OpenClawConfig): Prom
     return;
   }
   await ensureIncludedPluginsFileIsReadable(includePath);
-  await writePluginsIncludeFile(includePath, validatedConfig.plugins);
+  await writePluginsIncludeFile(
+    includePath,
+    validatedConfig.plugins,
+    writeOptions.envSnapshotForRestore,
+  );
   if (nextRootSource) {
-    await writeConfigFragment(snapshot.path, nextRootSource);
+    const nextRootValue = await restoreConfigFragmentEnvRefs(
+      snapshot.path,
+      nextRootSource,
+      writeOptions.envSnapshotForRestore,
+    );
+    await writeConfigFragment(snapshot.path, nextRootValue);
   }
   clearConfigCache();
 }

--- a/src/plugins/config-write.ts
+++ b/src/plugins/config-write.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { maintainConfigBackups } from "../config/backup-rotation.js";
+import {
+  clearConfigCache,
+  parseConfigJson5,
+  readConfigFileSnapshotForWrite,
+  validateConfigObjectRawWithPlugins,
+  writeConfigFile,
+} from "../config/config.js";
+import { INCLUDE_KEY } from "../config/includes.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { writeTextAtomic } from "../infra/json-files.js";
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolvePluginsIncludePath(configPath: string, parsedRoot: unknown): string | null {
+  if (!isPlainRecord(parsedRoot) || !("plugins" in parsedRoot)) {
+    return null;
+  }
+  const pluginsNode = parsedRoot.plugins;
+  if (!isPlainRecord(pluginsNode) || Object.keys(pluginsNode).length !== 1) {
+    return null;
+  }
+  const includePath = pluginsNode[INCLUDE_KEY];
+  if (typeof includePath !== "string" || includePath.length === 0) {
+    return null;
+  }
+  return path.isAbsolute(includePath)
+    ? includePath
+    : path.resolve(path.dirname(configPath), includePath);
+}
+
+function resolveChangedRootKeys(current: OpenClawConfig, next: OpenClawConfig): string[] {
+  const keys = new Set([...Object.keys(current), ...Object.keys(next)]);
+  const changed: string[] = [];
+  for (const key of keys) {
+    if (key === "plugins") {
+      continue;
+    }
+    if (
+      !isDeepStrictEqual(current[key as keyof OpenClawConfig], next[key as keyof OpenClawConfig])
+    ) {
+      changed.push(key);
+    }
+  }
+  return changed;
+}
+
+function validateConfigForPluginWrite(nextConfig: OpenClawConfig): OpenClawConfig {
+  const validated = validateConfigObjectRawWithPlugins(nextConfig);
+  if (validated.ok) {
+    return validated.config;
+  }
+  const issue = validated.issues[0];
+  const pathLabel = issue?.path ? issue.path : "<root>";
+  const issueMessage = issue?.message ?? "invalid";
+  throw new Error(`Config validation failed: ${pathLabel}: ${issueMessage}`);
+}
+
+async function ensureIncludedPluginsFileIsReadable(filePath: string): Promise<void> {
+  const raw = await fs.readFile(filePath, "utf-8");
+  const parsed = parseConfigJson5(raw);
+  if (!parsed.ok || !isPlainRecord(parsed.parsed)) {
+    throw new Error(`Invalid plugins include file: ${filePath}`);
+  }
+}
+
+async function writePluginsIncludeFile(
+  filePath: string,
+  plugins: OpenClawConfig["plugins"] | undefined,
+): Promise<void> {
+  await writeConfigFragment(filePath, plugins ?? {});
+}
+
+function buildUpdatedRootSource(
+  parsedRoot: unknown,
+  nextConfig: OpenClawConfig,
+  changedKeys: string[],
+): Record<string, unknown> | null {
+  if (!isPlainRecord(parsedRoot)) {
+    return null;
+  }
+  const nextRoot = structuredClone(parsedRoot);
+  for (const key of changedKeys) {
+    const nextValue = nextConfig[key as keyof OpenClawConfig];
+    if (nextValue === undefined) {
+      delete nextRoot[key];
+      continue;
+    }
+    nextRoot[key] = structuredClone(nextValue);
+  }
+  return nextRoot;
+}
+
+async function writeConfigFragment(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  await fs.access(filePath).then(
+    async () => await maintainConfigBackups(filePath, fs),
+    async () => undefined,
+  );
+  await writeTextAtomic(filePath, JSON.stringify(value, null, 2), {
+    mode: 0o600,
+    ensureDirMode: 0o700,
+    appendTrailingNewline: true,
+  });
+}
+
+export async function persistPluginConfigWrite(nextConfig: OpenClawConfig): Promise<void> {
+  const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+  const includePath = resolvePluginsIncludePath(snapshot.path, snapshot.parsed);
+  if (!snapshot.valid || !includePath) {
+    await writeConfigFile(nextConfig, writeOptions);
+    return;
+  }
+  const validatedConfig = validateConfigForPluginWrite(nextConfig);
+  const changedRootKeys = resolveChangedRootKeys(snapshot.config, validatedConfig);
+  const nextRootSource =
+    changedRootKeys.length > 0
+      ? buildUpdatedRootSource(snapshot.parsed, validatedConfig, changedRootKeys)
+      : null;
+  if (changedRootKeys.length > 0 && !nextRootSource) {
+    await writeConfigFile(validatedConfig, writeOptions);
+    return;
+  }
+  await ensureIncludedPluginsFileIsReadable(includePath);
+  await writePluginsIncludeFile(includePath, validatedConfig.plugins);
+  if (nextRootSource) {
+    await writeConfigFragment(snapshot.path, nextRootSource);
+  }
+  clearConfigCache();
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw plugins install` rewrites modular `openclaw.json` files with `$include` directives fully resolved and inlined, orphaning the split `config/*.json5` files.
- Why it matters: this silently destroys modular config structure and can inline secrets from isolated include files back into `openclaw.json`.
- What changed: added a plugin-specific config writer that preserves a pure root `plugins: { "$include": ... }` layout by updating the included plugins file directly, while keeping other untouched root includes intact; all plugin CLI write paths now route through that helper.
- What did NOT change (scope boundary): this PR does not add a generic include-aware serializer for arbitrary config sections or complex non-root plugin include shapes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41050

## User-visible / Behavior Changes

`openclaw plugins install` on a modular config with `plugins: { "$include": "./config/plugins.json5" }` now preserves the include structure instead of flattening the entire config into `openclaw.json`. Related plugin CLI writes (`update`, `uninstall`, enable/disable paths) also route through the same include-preserving helper when that root shape is present.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout via `pnpm` / Node
- Model/provider: n/a
- Integration/channel (if any): plugins CLI
- Relevant config (redacted): root `openclaw.json` with `plugins: { "$include": "./config/plugins.json5" }` and other sections split into `config/*.json5`

### Steps

1. Create a modular `openclaw.json` that uses `$include` for `plugins` and other sections.
2. Run `openclaw plugins install @mem0/openclaw-mem0`.
3. Inspect `openclaw.json` and `config/plugins.json5` after the install.

### Expected

- `openclaw.json` keeps its `$include` directives.
- The plugin change is written into `config/plugins.json5`.

### Actual

- Before this PR, the full resolved config was written back into `openclaw.json` and all `$include` directives were lost.
- After this PR, the plugins include is preserved and plugin changes land in the included file.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: helper-level regression for preserving a modular plugins include, validation-failure no-write behavior, and preserving the plugins include while also updating another changed root key; CLI regression proving `plugins install` uses the include-preserving writer.
- Edge cases checked: invalid plugin config is rejected without mutating either file; plugin writes that also touch another root key still preserve the plugins include and keep other untouched includes intact.
- What you did **not** verify: I did not run a live `plugins install` against a real npm package on a hand-authored modular config outside the automated regression coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or switch the plugin CLI call sites back to `writeConfigFile(...)`.
- Files/config to restore: `src/cli/plugins-cli.ts`, `src/plugins/config-write.ts`, and the added regression tests.
- Known bad symptoms reviewers should watch for: plugin CLI writes still flattening modular configs, or plugin/root mixed updates failing to keep the plugins include in place.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: modular configs where a plugin command also changes another top-level root section now write both the included plugins file and the root config file.
  - Mitigation: the helper is limited to a safe pure-root `plugins.$include` shape, each file write is atomic and backed up, and regressions cover both plugin-only writes and mixed root-key updates.

## AI Assistance

- AI-assisted: Yes (Codex)
- Testing degree: Fully tested
- Prompt/session summary: triaged fresh unclaimed plugin/config issues, selected #41050 as the strongest current merge candidate, wrote failing regressions first for helper and CLI behavior, implemented a plugin-scoped include-preserving writer, then audited and expanded the fix to cover mixed root-key updates without flattening untouched includes.
- Understanding confirmation: I understand this change is intentionally scoped to plugin CLI writes and pure root `plugins.$include` layouts; it is not a generic config serializer rewrite.

## Verification Commands

- `pnpm exec vitest run src/config/io.write-config.test.ts src/plugins/update.test.ts src/plugins/uninstall.test.ts src/plugins/config-write.test.ts src/cli/plugins-cli.install-config-write.test.ts`
- `git diff --check`
- `pnpm check`
- `pnpm build`
- `pnpm test`
