### PR TITLE
fix(acpx): prefer OAuth session auth and block OpenAI key env leakage in chatgpt mode

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -260,9 +260,9 @@ describe("buildChildEnv", () => {
     const originalOpenAiApiKeys = process.env.OPENAI_API_KEYS;
     const originalAzureOpenAiApiKey = process.env.AZURE_OPENAI_API_KEY;
     try {
-      process.env.OPENAI_API_KEY = "openai-key-fixture-primary";
-      process.env.OPENAI_API_KEYS = "openai-key-fixture-a,openai-key-fixture-b";
-      process.env.AZURE_OPENAI_API_KEY = "azure-openai-key-fixture";
+      process.env.OPENAI_API_KEY = "openai-fixture-primary";
+      process.env.OPENAI_API_KEYS = "openai-fixture-a,openai-fixture-b";
+      process.env.AZURE_OPENAI_API_KEY = "azure-openai-fixture";
 
       const childEnv = buildChildEnv({
         ACPX_AUTH_CHATGPT: "oauth-session",
@@ -295,11 +295,11 @@ describe("buildChildEnv", () => {
   it("preserves OpenAI API key env when ACPX OAuth auth is not requested", () => {
     const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
     try {
-      process.env.OPENAI_API_KEY = "openai-key-fixture-primary";
+      process.env.OPENAI_API_KEY = "openai-fixture-primary";
 
       const childEnv = buildChildEnv();
 
-      expect(childEnv.OPENAI_API_KEY).toBe("openai-key-fixture-primary");
+      expect(childEnv.OPENAI_API_KEY).toBe("openai-fixture-primary");
       expect(childEnv.OPENCLAW_SHELL).toBe("acp");
     } finally {
       if (originalOpenAiApiKey === undefined) {

--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createWindowsCmdShimFixture } from "../../../shared/windows-cmd-shim-test-fixtures.js";
 import {
+  buildChildEnv,
   resolveSpawnCommand,
   spawnAndCollect,
   type SpawnCommandCache,
@@ -250,6 +251,63 @@ describe("waitForExit", () => {
     expect(exit.code).toBe(0);
     expect(exit.signal).toBeNull();
     expect(exit.error).toBeNull();
+  });
+});
+
+describe("buildChildEnv", () => {
+  it("drops OpenAI API key env when ACPX OAuth auth is requested", () => {
+    const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+    const originalOpenAiApiKeys = process.env.OPENAI_API_KEYS;
+    const originalAzureOpenAiApiKey = process.env.AZURE_OPENAI_API_KEY;
+    try {
+      process.env.OPENAI_API_KEY = "sk-test-primary";
+      process.env.OPENAI_API_KEYS = "sk-test-a,sk-test-b";
+      process.env.AZURE_OPENAI_API_KEY = "azure-test";
+
+      const childEnv = buildChildEnv({
+        ACPX_AUTH_CHATGPT: "oauth-session",
+      });
+
+      expect(childEnv.ACPX_AUTH_CHATGPT).toBe("oauth-session");
+      expect(childEnv.OPENCLAW_SHELL).toBe("acp");
+      expect(childEnv.OPENAI_API_KEY).toBeUndefined();
+      expect(childEnv.OPENAI_API_KEYS).toBeUndefined();
+      expect(childEnv.AZURE_OPENAI_API_KEY).toBeUndefined();
+    } finally {
+      if (originalOpenAiApiKey === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+      }
+      if (originalOpenAiApiKeys === undefined) {
+        delete process.env.OPENAI_API_KEYS;
+      } else {
+        process.env.OPENAI_API_KEYS = originalOpenAiApiKeys;
+      }
+      if (originalAzureOpenAiApiKey === undefined) {
+        delete process.env.AZURE_OPENAI_API_KEY;
+      } else {
+        process.env.AZURE_OPENAI_API_KEY = originalAzureOpenAiApiKey;
+      }
+    }
+  });
+
+  it("preserves OpenAI API key env when ACPX OAuth auth is not requested", () => {
+    const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+    try {
+      process.env.OPENAI_API_KEY = "sk-test-primary";
+
+      const childEnv = buildChildEnv();
+
+      expect(childEnv.OPENAI_API_KEY).toBe("sk-test-primary");
+      expect(childEnv.OPENCLAW_SHELL).toBe("acp");
+    } finally {
+      if (originalOpenAiApiKey === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+      }
+    }
   });
 });
 

--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -260,9 +260,9 @@ describe("buildChildEnv", () => {
     const originalOpenAiApiKeys = process.env.OPENAI_API_KEYS;
     const originalAzureOpenAiApiKey = process.env.AZURE_OPENAI_API_KEY;
     try {
-      process.env.OPENAI_API_KEY = "sk-test-primary";
-      process.env.OPENAI_API_KEYS = "sk-test-a,sk-test-b";
-      process.env.AZURE_OPENAI_API_KEY = "azure-test";
+      process.env.OPENAI_API_KEY = "openai-key-fixture-primary";
+      process.env.OPENAI_API_KEYS = "openai-key-fixture-a,openai-key-fixture-b";
+      process.env.AZURE_OPENAI_API_KEY = "azure-openai-key-fixture";
 
       const childEnv = buildChildEnv({
         ACPX_AUTH_CHATGPT: "oauth-session",
@@ -295,11 +295,11 @@ describe("buildChildEnv", () => {
   it("preserves OpenAI API key env when ACPX OAuth auth is not requested", () => {
     const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
     try {
-      process.env.OPENAI_API_KEY = "sk-test-primary";
+      process.env.OPENAI_API_KEY = "openai-key-fixture-primary";
 
       const childEnv = buildChildEnv();
 
-      expect(childEnv.OPENAI_API_KEY).toBe("sk-test-primary");
+      expect(childEnv.OPENAI_API_KEY).toBe("openai-key-fixture-primary");
       expect(childEnv.OPENCLAW_SHELL).toBe("acp");
     } finally {
       if (originalOpenAiApiKey === undefined) {

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -39,9 +39,12 @@ const ACPX_BLOCKED_OPENAI_ENV_KEYS = [
   "AZURE_OPENAI_API_KEY",
 ] as const;
 
-function buildChildEnv(extraEnv?: Record<string, string>): NodeJS.ProcessEnv {
+function buildChildEnv(
+  extraEnv?: Record<string, string>,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
   const childEnv: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...baseEnv,
     OPENCLAW_SHELL: "acp",
     ...(extraEnv ?? {}),
   };
@@ -176,7 +179,7 @@ export function spawnWithResolvedCommand(
 
   return spawn(resolved.command, resolved.args, {
     cwd: params.cwd,
-    env: buildChildEnv(inheritedEnv),
+    env: buildChildEnv(undefined, inheritedEnv),
     stdio: ["pipe", "pipe", "pipe"],
     shell: resolved.shell,
     windowsHide: resolved.windowsHide,

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -32,6 +32,31 @@ type SpawnRuntime = {
   execPath: string;
 };
 
+const ACPX_OAUTH_ENV_KEYS = ["ACPX_AUTH_CHATGPT"] as const;
+const ACPX_BLOCKED_OPENAI_ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "OPENAI_API_KEYS",
+  "AZURE_OPENAI_API_KEY",
+] as const;
+
+function buildChildEnv(extraEnv?: Record<string, string>): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENCLAW_SHELL: "acp",
+    ...(extraEnv ?? {}),
+  };
+  const oauthRequested = ACPX_OAUTH_ENV_KEYS.some((key) => {
+    const value = childEnv[key];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+  if (oauthRequested) {
+    for (const key of ACPX_BLOCKED_OPENAI_ENV_KEYS) {
+      delete childEnv[key];
+    }
+  }
+  return childEnv;
+}
+
 export type SpawnCommandCache = {
   key?: string;
   candidate?: WindowsSpawnProgramCandidate;
@@ -145,14 +170,20 @@ export function spawnWithResolvedCommand(
   );
   childEnv.OPENCLAW_SHELL = "acp";
 
+  const inheritedEnv = Object.fromEntries(
+    Object.entries(childEnv).filter(([, value]) => typeof value === "string"),
+  ) as Record<string, string>;
+
   return spawn(resolved.command, resolved.args, {
     cwd: params.cwd,
-    env: childEnv,
+    env: buildChildEnv(inheritedEnv),
     stdio: ["pipe", "pipe", "pipe"],
     shell: resolved.shell,
     windowsHide: resolved.windowsHide,
   });
 }
+
+export { buildChildEnv };
 
 export async function waitForExit(child: ChildProcessWithoutNullStreams): Promise<SpawnExit> {
   // Handle callers that start waiting after the child has already exited.


### PR DESCRIPTION
## Summary

- Problem: ACPX child runtime inherited `OPENAI_API_KEY`-style env vars even when ChatGPT OAuth selector (`ACPX_AUTH_CHATGPT`) was set.
- Why it matters: key leakage can trigger wrong auth path/fallback behavior in OAuth-selected runs.
- What changed:
  - Added `buildChildEnv()` guard in ACPX process runtime to scrub:
    - `OPENAI_API_KEY`
    - `OPENAI_API_KEYS`
    - `AZURE_OPENAI_API_KEY`
    only when `ACPX_AUTH_CHATGPT` is present.
  - Kept non-OAuth behavior unchanged.
  - Added regression tests for scrub vs preserve behavior.
- Scope boundary:
  - No non-ACPX runtime changes.
  - No network/protocol changes.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Auth / tokens
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

- ACPX OAuth-selected runs now avoid inherited OpenAI API key env leakage.
- No behavior change when OAuth selector is not set.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation:
  - Risk: environments previously relying on implicit key fallback in OAuth-selected mode may observe auth behavior change.
  - Mitigation: change is narrowly gated to `ACPX_AUTH_CHATGPT`; covered by tests.

## Repro + Verification

### Steps

1. Set `OPENAI_API_KEY` (and/or `OPENAI_API_KEYS`, `AZURE_OPENAI_API_KEY`) in parent env.
2. Build child env with `ACPX_AUTH_CHATGPT=oauth-session`.
3. Verify key env vars are absent in child env.
4. Build child env without OAuth selector.
5. Verify key env vars remain present.

### Evidence

- Targeted tests run and passing:
  - `pnpm -s vitest extensions/acpx/src/runtime-internals/process.test.ts`

## Human Verification

- Verified scenarios:
  - Key env vars removed when OAuth selector set.
  - Key env vars preserved when OAuth selector absent.
- Not verified:
  - Full repository suite in this PR prep pass.

---

### AI assistance

AI-assisted PR.
Testing level: lightly tested (targeted ACPX runtime-internals tests run locally and passing).
