### PR TITLE
Fix: Deduplicate tool call IDs in normalizeToolCallIdsInMessage

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -333,10 +333,20 @@ function normalizeToolCallIdsInMessage(message: unknown): void {
     if (typeof typedBlock.id === "string") {
       const trimmedId = typedBlock.id.trim();
       if (trimmedId) {
-        if (typedBlock.id !== trimmedId) {
-          typedBlock.id = trimmedId;
+        // Check for duplicate IDs - if already used, generate a new unique ID
+        if (usedIds.has(trimmedId)) {
+          let dedupedId = "";
+          while (!dedupedId || usedIds.has(dedupedId)) {
+            dedupedId = `${trimmedId}_dedup_${fallbackIndex++}`;
+          }
+          typedBlock.id = dedupedId;
+          usedIds.add(dedupedId);
+        } else {
+          if (typedBlock.id !== trimmedId) {
+            typedBlock.id = trimmedId;
+          }
+          usedIds.add(trimmedId);
         }
-        usedIds.add(trimmedId);
         continue;
       }
     }


### PR DESCRIPTION
## Summary
- Fixed bug where duplicate tool call IDs (e.g., `edit:22`) were not being deduplicated
- Now checks if ID already exists in `usedIds` set before assigning
- If duplicate detected, generates unique ID by appending `_dedup_N` suffix
- Prevents HTTP 400 errors from OpenAI-compatible APIs that require unique `tool_call_id` values

## Problem
When multiple tool calls have the same ID (e.g., `edit:22`), OpenAI-compatible APIs return HTTP 400 Bad Request because they require every tool call ID within a single request to be unique.

The original `normalizeToolCallIdsInMessage` function only handled empty IDs (generating `call_auto_N`), but did not deduplicate identical IDs within a single assistant message.

## Solution
Modified the function to check if an ID already exists in the `usedIds` set before assigning it. If a duplicate is detected, a new unique ID is generated by appending `_dedup_N` suffix.

## Test Plan
- Manual testing with duplicate tool call IDs
- Verify no HTTP 400 errors from OpenAI-compatible APIs
- Ensure unique IDs are generated for all tool calls

Fixes #40897