### PR TITLE
fix(agents): populate messagingToolSentMediaUrls for tool-result media deduplication

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -251,4 +251,32 @@ describe("handleToolExecutionEnd media emission", () => {
       mediaUrls: ["/tmp/canvas-output.png"],
     });
   });
+
+  it("tracks tool result media URLs in messagingToolSentMediaUrls for deduplication", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await emitPngMediaToolResult(ctx);
+
+    // Media URL should be tracked for final-reply deduplication
+    expect(ctx.state.messagingToolSentMediaUrls).toContain("/tmp/screenshot.png");
+  });
+
+  it("tracks remote tool result media URLs for untrusted tools", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await emitUntrustedToolMediaResult(ctx, "https://example.com/file.png");
+
+    expect(ctx.state.messagingToolSentMediaUrls).toContain("https://example.com/file.png");
+  });
+
+  it("does NOT track media when tool result is an error", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await emitPngMediaToolResult(ctx, { isError: true });
+
+    expect(ctx.state.messagingToolSentMediaUrls).toHaveLength(0);
+  });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -170,6 +170,10 @@ function emitToolResultOutput(params: {
   if (mediaPaths.length === 0) {
     return;
   }
+  // Track media URLs for deduplication against the agent's final reply.
+  if (mediaPaths.length > 0) {
+    ctx.state.messagingToolSentMediaUrls.push(...mediaPaths);
+  }
   try {
     void ctx.params.onToolResult({ mediaUrls: mediaPaths });
   } catch {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -338,6 +338,13 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!cleanedText && filteredMediaUrls.length === 0) {
       return;
     }
+    // Track media URLs sent via tool results so that the final reply deduplication
+    // can strip duplicates. Without this, images produced by tools like exec (e.g.
+    // nano-banana-pro) are sent once here and again in the agent's MEDIA: reply.
+    if (filteredMediaUrls.length > 0) {
+      messagingToolSentMediaUrls.push(...filteredMediaUrls);
+      trimMessagingToolSent();
+    }
     try {
       void params.onToolResult({
         text: cleanedText,


### PR DESCRIPTION
## Summary

- **Bug**: `messagingToolSentMediaUrls` is initialized in the embedded subscribe state but never populated when tools emit media results. This causes images produced by tools (e.g. screenshot, canvas) to be sent twice — once via the tool result callback and again in the agent's final `MEDIA:` reply.
- **Fix**: Push media URLs into `messagingToolSentMediaUrls` in both `emitToolResultOutput` (trusted tool media paths) and the streaming tool-result handler (untrusted tool media URLs), so the final-reply deduplication logic can filter them out.
- **Tests**: Adds 3 test cases covering trusted media tracking, untrusted remote URL tracking, and error-result exclusion.