### PR TITLE
fix(exec): preserve multiline async approval output

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -12,7 +12,7 @@ import {
 import { detectCommandObfuscation } from "../infra/exec-obfuscation-detect.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
 import { logInfo } from "../logger.js";
-import { markBackgrounded, tail } from "./bash-process-registry.js";
+import { markBackgrounded } from "./bash-process-registry.js";
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
@@ -25,10 +25,8 @@ import {
   resolveExecHostApprovalContext,
 } from "./bash-tools.exec-host-shared.js";
 import {
-  DEFAULT_NOTIFY_TAIL_CHARS,
   createApprovalSlug,
   emitExecSystemEvent,
-  normalizeNotifyOutput,
   runExecProcess,
 } from "./bash-tools.exec-runtime.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
@@ -63,6 +61,23 @@ export type ProcessGatewayAllowlistResult = {
   execCommandOverride?: string;
   pendingResult?: AgentToolResult<ExecToolDetails>;
 };
+
+function buildGatewayApprovalCompletionSummary(params: {
+  approvalId: string;
+  sessionId: string;
+  exitLabel: string;
+  output: string;
+  truncated: boolean;
+}) {
+  const truncationSuffix = params.truncated ? ", output truncated to capture cap" : "";
+  const header =
+    `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ` +
+    `${params.exitLabel}${truncationSuffix})`;
+  if (!params.output) {
+    return header;
+  }
+  return `${header}\n${params.output}`;
+}
 
 export async function processGatewayAllowlist(
   params: ProcessGatewayAllowlistParams,
@@ -288,13 +303,14 @@ export async function processGatewayAllowlist(
       if (runningTimer) {
         clearTimeout(runningTimer);
       }
-      const output = normalizeNotifyOutput(
-        tail(outcome.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
-      );
       const exitLabel = outcome.timedOut ? "timeout" : `code ${outcome.exitCode ?? "?"}`;
-      const summary = output
-        ? `Exec finished (gateway id=${approvalId}, session=${run.session.id}, ${exitLabel})\n${output}`
-        : `Exec finished (gateway id=${approvalId}, session=${run.session.id}, ${exitLabel})`;
+      const summary = buildGatewayApprovalCompletionSummary({
+        approvalId,
+        sessionId: run.session.id,
+        exitLabel,
+        output: outcome.aggregated,
+        truncated: run.session.truncated,
+      });
       emitExecSystemEvent(summary, { sessionKey: params.notifySessionKey, contextKey });
     })();
 

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -304,12 +304,13 @@ export async function processGatewayAllowlist(
         clearTimeout(runningTimer);
       }
       const exitLabel = outcome.timedOut ? "timeout" : `code ${outcome.exitCode ?? "?"}`;
+      const outputTruncatedToCap = run.session.totalOutputChars > run.session.aggregated.length;
       const summary = buildGatewayApprovalCompletionSummary({
         approvalId,
         sessionId: run.session.id,
         exitLabel,
         output: outcome.aggregated,
-        truncated: run.session.truncated,
+        truncated: outputTruncatedToCap,
       });
       emitExecSystemEvent(summary, { sessionKey: params.notifySessionKey, contextKey });
     })();

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -27,6 +27,10 @@ vi.mock("../infra/exec-obfuscation-detect.js", () => ({
 let callGatewayTool: typeof import("./tools/gateway.js").callGatewayTool;
 let createExecTool: typeof import("./bash-tools.exec.js").createExecTool;
 let detectCommandObfuscation: typeof import("../infra/exec-obfuscation-detect.js").detectCommandObfuscation;
+let peekSystemEvents: typeof import("../infra/system-events.js").peekSystemEvents;
+let resetSystemEventsForTest: typeof import("../infra/system-events.js").resetSystemEventsForTest;
+let DEFAULT_MAX_OUTPUT: number;
+const TEST_SESSION_KEY = "discord:dm:exec-approval-output";
 
 function buildPreparedSystemRunPayload(rawInvokeParams: unknown) {
   const invoke = (rawInvokeParams ?? {}) as {
@@ -42,6 +46,37 @@ function buildPreparedSystemRunPayload(rawInvokeParams: unknown) {
   return buildSystemRunPreparePayload(params);
 }
 
+function buildMultilineOutput(lineCount: number, lineWidth: number) {
+  return (
+    Array.from({ length: lineCount }, (_, index) => {
+      const suffix = String(index).padStart(2, "0");
+      return `line-${suffix}:${"x".repeat(lineWidth)}`;
+    }).join("\n") + "\n"
+  );
+}
+
+function buildNodeStdoutCommand(output: string) {
+  const script = `process.stdout.write(${JSON.stringify(output)});`;
+  return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
+}
+
+function tail(text: string, maxChars: number) {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return text.slice(text.length - maxChars);
+}
+
+async function waitForExecFinishedEvent(sessionKey: string) {
+  await expect
+    .poll(() => peekSystemEvents(sessionKey).find((event) => event.startsWith("Exec finished")), {
+      timeout: 10_000,
+      interval: 20,
+    })
+    .toBeTruthy();
+  return peekSystemEvents(sessionKey).find((event) => event.startsWith("Exec finished")) ?? "";
+}
+
 describe("exec approvals", () => {
   let previousHome: string | undefined;
   let previousUserProfile: string | undefined;
@@ -50,6 +85,8 @@ describe("exec approvals", () => {
     ({ callGatewayTool } = await import("./tools/gateway.js"));
     ({ createExecTool } = await import("./bash-tools.exec.js"));
     ({ detectCommandObfuscation } = await import("../infra/exec-obfuscation-detect.js"));
+    ({ peekSystemEvents, resetSystemEventsForTest } = await import("../infra/system-events.js"));
+    ({ DEFAULT_MAX_OUTPUT } = await import("./bash-tools.exec-runtime.js"));
   });
 
   beforeEach(async () => {
@@ -59,9 +96,11 @@ describe("exec approvals", () => {
     process.env.HOME = tempDir;
     // Windows uses USERPROFILE for os.homedir()
     process.env.USERPROFILE = tempDir;
+    resetSystemEventsForTest();
   });
 
   afterEach(() => {
+    resetSystemEventsForTest();
     vi.resetAllMocks();
     if (previousHome === undefined) {
       delete process.env.HOME;
@@ -290,6 +329,74 @@ describe("exec approvals", () => {
     await approvalSeen;
     expect(calls).toContain("exec.approval.request");
     expect(calls).toContain("exec.approval.waitDecision");
+  });
+
+  it("preserves full multiline output for async gateway approvals", async () => {
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "exec.approval.request") {
+        return { status: "accepted", id: (params as { id?: string })?.id };
+      }
+      if (method === "exec.approval.waitDecision") {
+        return { decision: "allow-once" };
+      }
+      return { ok: true };
+    });
+
+    const output = buildMultilineOutput(8, 64);
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "always",
+      security: "full",
+      approvalRunningNoticeMs: 0,
+      sessionKey: TEST_SESSION_KEY,
+    });
+
+    const result = await tool.execute("call-gateway-output", {
+      command: buildNodeStdoutCommand(output),
+    });
+
+    expect(result.details.status).toBe("approval-pending");
+
+    const event = await waitForExecFinishedEvent(TEST_SESSION_KEY);
+    const body = event.slice(event.indexOf("\n") + 1);
+
+    expect(body).toBe(output.trimEnd());
+    expect(body.startsWith("line-00:")).toBe(true);
+    expect(body).toContain("\nline-01:");
+    expect(body.length).toBeGreaterThan(400);
+  });
+
+  it("marks captured output as truncated when approval delivery hits the exec cap", async () => {
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "exec.approval.request") {
+        return { status: "accepted", id: (params as { id?: string })?.id };
+      }
+      if (method === "exec.approval.waitDecision") {
+        return { decision: "allow-once" };
+      }
+      return { ok: true };
+    });
+
+    const output = buildMultilineOutput(3000, 64);
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "always",
+      security: "full",
+      approvalRunningNoticeMs: 0,
+      sessionKey: TEST_SESSION_KEY,
+    });
+
+    const result = await tool.execute("call-gateway-output-truncated", {
+      command: buildNodeStdoutCommand(output),
+    });
+
+    expect(result.details.status).toBe("approval-pending");
+
+    const event = await waitForExecFinishedEvent(TEST_SESSION_KEY);
+    const body = event.slice(event.indexOf("\n") + 1);
+
+    expect(event).toContain("output truncated to capture cap");
+    expect(body).toBe(tail(output, DEFAULT_MAX_OUTPUT).trimEnd());
   });
 
   it("waits for approval registration before returning approval-pending", async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: async gateway exec approvals reuse the compact background-notify formatter, so the `System:` event sent back after approval keeps only the last 400 characters and collapses all whitespace.
- Why it matters: agents receive incomplete command results with no truncation signal, which can lead to wrong follow-up decisions on multi-line outputs like `crontab -l`.
- What changed: the approval-completion path now emits the full captured exec output with newlines preserved, and it adds an explicit `output truncated to capture cap` note when the existing exec capture limit is hit.
- What did NOT change (scope boundary): this PR does not change the normal background `notifyOnExit` summary behavior or the existing max-output capture limit.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41152

## User-visible / Behavior Changes

When a gateway exec command is approved asynchronously, the completion `System:` event now preserves the captured multi-line output instead of flattening it to a 400-character tail. If the existing exec capture cap is hit, the completion header explicitly says `output truncated to capture cap`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout via `pnpm` / Node
- Model/provider: n/a
- Integration/channel (if any): async gateway exec approvals / system-event delivery
- Relevant config (redacted): `tools.exec.host: gateway` with async exec approval flow enabled

### Steps

1. Run a gateway exec command through the async approval flow that prints more than 400 characters across multiple lines.
2. Approve the request and inspect the resulting `System:` event delivered back to the session.
3. Repeat with output large enough to exceed the existing exec capture cap.

### Expected

- Multi-line output is delivered intact with newlines preserved.
- If the exec capture cap is hit, the event makes that truncation explicit.

### Actual

- Before this PR, the event body was reduced to the last 400 characters and all whitespace was flattened.
- After this PR, approval completion uses the full captured output and flags real capture-cap truncation.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: gateway approval completion preserves an 8-line output end to end; gateway approval completion adds a truncation note when output exceeds the existing exec capture cap.
- Edge cases checked: empty-output completions still fall back to the header-only summary; the generic background `notifyOnExit` path remains unchanged and its existing test file still passes.
- What you did **not** verify: I did not run a live Discord approval round-trip against a real external channel outside the automated regression coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore the old approval-completion formatter.
- Files/config to restore: `src/agents/bash-tools.exec-host-gateway.ts` and the added regressions in `src/agents/bash-tools.exec.approval-id.test.ts`.
- Known bad symptoms reviewers should watch for: approval-completion events still dropping the front of long output, or generic background exec notifications unexpectedly switching to full multi-line bodies.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: full captured approval output can now be much larger than the previous 400-character summary.
  - Mitigation: this path already had an exec capture cap, the PR does not raise that cap, and the event now explicitly marks when that existing cap truncates the result.

## AI Assistance

- AI-assisted: Yes (Codex)
- Testing degree: Fully tested
- Prompt/session summary: triaged fresh unclaimed exec issues, confirmed #41152 still reproduced on current `main`, wrote failing approval-path regressions first, patched only the gateway approval-completion formatter, then audited the scope boundary against the normal background notify path and reran the full verification suite.
- Understanding confirmation: I understand this fix is intentionally limited to async gateway approval result delivery and should not change the compact formatting used for ordinary background `notifyOnExit` summaries.

## Verification Commands

- `pnpm exec vitest run src/agents/bash-tools.exec.approval-id.test.ts src/agents/bash-tools.test.ts`
- `git diff --check`
- `pnpm check`
- `pnpm build`
- `pnpm test`
