### PR TITLE
plugins: skip reinstall when update target is unchanged

### DIFF
--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -203,6 +203,70 @@ describe("updateNpmInstalledPlugins", () => {
       },
     ]);
   });
+
+  it("keeps integrity drift callbacks on the real update step only", async () => {
+    await fs.mkdir("/tmp/opik-openclaw", { recursive: true });
+    await fs.writeFile(
+      "/tmp/opik-openclaw/package.json",
+      JSON.stringify({ name: "@opik/opik-openclaw", version: "0.2.5" }),
+      "utf-8",
+    );
+
+    installPluginFromNpmSpecMock
+      .mockResolvedValueOnce({
+        ok: true,
+        pluginId: "opik-openclaw",
+        targetDir: "/tmp/opik-openclaw",
+        version: "0.2.6",
+        extensions: ["index.ts"],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        pluginId: "opik-openclaw",
+        targetDir: "/tmp/opik-openclaw",
+        version: "0.2.6",
+        extensions: ["index.ts"],
+      });
+
+    const onIntegrityDrift = vi.fn(async () => true);
+    const { updateNpmInstalledPlugins } = await import("./update.js");
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          installs: {
+            "opik-openclaw": {
+              source: "npm",
+              spec: "@opik/opik-openclaw@0.2.5",
+              integrity: "sha512-old",
+              installPath: "/tmp/opik-openclaw",
+            },
+          },
+        },
+      },
+      pluginIds: ["opik-openclaw"],
+      onIntegrityDrift,
+    });
+
+    expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(2);
+    expect(installPluginFromNpmSpecMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        dryRun: true,
+        expectedIntegrity: undefined,
+        onIntegrityDrift: undefined,
+      }),
+    );
+    expect(installPluginFromNpmSpecMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        expectedIntegrity: "sha512-old",
+        onIntegrityDrift: expect.any(Function),
+      }),
+    );
+    expect(onIntegrityDrift).not.toHaveBeenCalled();
+    expect(result.changed).toBe(true);
+    expect(result.outcomes[0]?.status).toBe("updated");
+  });
 });
 
 describe("syncPluginsForUpdateChannel", () => {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const installPluginFromNpmSpecMock = vi.fn();
@@ -16,9 +17,10 @@ vi.mock("./bundled-sources.js", () => ({
 }));
 
 describe("updateNpmInstalledPlugins", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     installPluginFromNpmSpecMock.mockReset();
     resolveBundledPluginSourcesMock.mockReset();
+    await fs.rm("/tmp/opik-openclaw", { recursive: true, force: true });
   });
 
   it("skips integrity drift checks for unpinned npm specs during dry-run updates", async () => {
@@ -153,6 +155,51 @@ describe("updateNpmInstalledPlugins", () => {
         pluginId: "bad",
         status: "error",
         message: "Failed to check bad: unsupported npm spec: github:evil/evil",
+      },
+    ]);
+  });
+
+  it("skips reinstalling plugins that are already up to date", async () => {
+    await fs.mkdir("/tmp/opik-openclaw", { recursive: true });
+    await fs.writeFile(
+      "/tmp/opik-openclaw/package.json",
+      JSON.stringify({ name: "@opik/opik-openclaw", version: "0.2.6" }),
+      "utf-8",
+    );
+
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: true,
+      pluginId: "opik-openclaw",
+      targetDir: "/tmp/opik-openclaw",
+      version: "0.2.6",
+      extensions: ["index.ts"],
+    });
+
+    const { updateNpmInstalledPlugins } = await import("./update.js");
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          installs: {
+            "opik-openclaw": {
+              source: "npm",
+              spec: "@opik/opik-openclaw",
+              installPath: "/tmp/opik-openclaw",
+            },
+          },
+        },
+      },
+      pluginIds: ["opik-openclaw"],
+    });
+
+    expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
+    expect(result.changed).toBe(false);
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "opik-openclaw",
+        status: "unchanged",
+        currentVersion: "0.2.6",
+        nextVersion: "0.2.6",
+        message: "opik-openclaw already at 0.2.6.",
       },
     ]);
   });

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -267,13 +267,20 @@ export async function updateNpmInstalledPlugins(params: {
         mode: "update",
         dryRun: true,
         expectedPluginId: pluginId,
-        expectedIntegrity: expectedIntegrityForUpdate(record.spec, record.integrity),
-        onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
-          pluginId,
-          dryRun: true,
-          logger,
-          onIntegrityDrift: params.onIntegrityDrift,
-        }),
+        // For real updates, the probe is only used to discover the target version.
+        // Keep integrity-drift handling for the actual install step to avoid duplicate
+        // prompts/warnings/callback side effects.
+        expectedIntegrity: params.dryRun
+          ? expectedIntegrityForUpdate(record.spec, record.integrity)
+          : undefined,
+        onIntegrityDrift: params.dryRun
+          ? createPluginUpdateIntegrityDriftHandler({
+              pluginId,
+              dryRun: true,
+              logger,
+              onIntegrityDrift: params.onIntegrityDrift,
+            })
+          : undefined,
         logger,
       });
     } catch (err) {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -260,64 +260,67 @@ export async function updateNpmInstalledPlugins(params: {
     }
     const currentVersion = await readInstalledPackageVersion(installPath);
 
-    if (params.dryRun) {
-      let probe: Awaited<ReturnType<typeof installPluginFromNpmSpec>>;
-      try {
-        probe = await installPluginFromNpmSpec({
-          spec: record.spec,
-          mode: "update",
+    let probe: Awaited<ReturnType<typeof installPluginFromNpmSpec>>;
+    try {
+      probe = await installPluginFromNpmSpec({
+        spec: record.spec,
+        mode: "update",
+        dryRun: true,
+        expectedPluginId: pluginId,
+        expectedIntegrity: expectedIntegrityForUpdate(record.spec, record.integrity),
+        onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
+          pluginId,
           dryRun: true,
-          expectedPluginId: pluginId,
-          expectedIntegrity: expectedIntegrityForUpdate(record.spec, record.integrity),
-          onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
-            pluginId,
-            dryRun: true,
-            logger,
-            onIntegrityDrift: params.onIntegrityDrift,
-          }),
           logger,
-        });
-      } catch (err) {
-        outcomes.push({
+          onIntegrityDrift: params.onIntegrityDrift,
+        }),
+        logger,
+      });
+    } catch (err) {
+      outcomes.push({
+        pluginId,
+        status: "error",
+        message: `Failed to check ${pluginId}: ${String(err)}`,
+      });
+      continue;
+    }
+    if (!probe.ok) {
+      outcomes.push({
+        pluginId,
+        status: "error",
+        message: formatNpmInstallFailure({
           pluginId,
-          status: "error",
-          message: `Failed to check ${pluginId}: ${String(err)}`,
-        });
-        continue;
-      }
-      if (!probe.ok) {
-        outcomes.push({
-          pluginId,
-          status: "error",
-          message: formatNpmInstallFailure({
-            pluginId,
-            spec: record.spec,
-            phase: "check",
-            result: probe,
-          }),
-        });
-        continue;
-      }
+          spec: record.spec,
+          phase: "check",
+          result: probe,
+        }),
+      });
+      continue;
+    }
 
-      const nextVersion = probe.version ?? "unknown";
-      const currentLabel = currentVersion ?? "unknown";
-      if (currentVersion && probe.version && currentVersion === probe.version) {
-        outcomes.push({
-          pluginId,
-          status: "unchanged",
-          currentVersion: currentVersion ?? undefined,
-          nextVersion: probe.version ?? undefined,
-          message: `${pluginId} is up to date (${currentLabel}).`,
-        });
-      } else {
-        outcomes.push({
-          pluginId,
-          status: "updated",
-          currentVersion: currentVersion ?? undefined,
-          nextVersion: probe.version ?? undefined,
-          message: `Would update ${pluginId}: ${currentLabel} -> ${nextVersion}.`,
-        });
-      }
+    const probedVersion = probe.version ?? "unknown";
+    const currentLabel = currentVersion ?? "unknown";
+    if (currentVersion && probe.version && currentVersion === probe.version) {
+      outcomes.push({
+        pluginId,
+        status: "unchanged",
+        currentVersion: currentVersion ?? undefined,
+        nextVersion: probe.version ?? undefined,
+        message: params.dryRun
+          ? `${pluginId} is up to date (${currentLabel}).`
+          : `${pluginId} already at ${currentLabel}.`,
+      });
+      continue;
+    }
+
+    if (params.dryRun) {
+      outcomes.push({
+        pluginId,
+        status: "updated",
+        currentVersion: currentVersion ?? undefined,
+        nextVersion: probe.version ?? undefined,
+        message: `Would update ${pluginId}: ${currentLabel} -> ${probedVersion}.`,
+      });
       continue;
     }
 
@@ -369,7 +372,6 @@ export async function updateNpmInstalledPlugins(params: {
     });
     changed = true;
 
-    const currentLabel = currentVersion ?? "unknown";
     const nextLabel = nextVersion ?? "unknown";
     if (currentVersion && nextVersion && currentVersion === nextVersion) {
       outcomes.push({


### PR DESCRIPTION
## Summary
- probe npm-installed plugins with a dry-run update before doing any real install work
- skip download/reinstall entirely when the installed version already matches the latest version
- add a regression test covering the unchanged-version path

Fixes #40912