### PR TITLE
fix(cli): request nodes run approval only after denial

### DIFF
--- a/src/cli/nodes-cli.coverage.test.ts
+++ b/src/cli/nodes-cli.coverage.test.ts
@@ -15,7 +15,10 @@ type NodeInvokeCall = {
 };
 
 let lastNodeInvokeCall: NodeInvokeCall | null = null;
+let nodeInvokeCalls: NodeInvokeCall[] = [];
 let lastApprovalRequestCall: { params?: Record<string, unknown> } | null = null;
+let denyNextSystemRunForApproval = false;
+let nextSystemRunErrorMessage: string | null = null;
 let localExecApprovalsFile: ExecApprovalsFile = { version: 1, agents: {} };
 let nodeExecApprovalsFile: ExecApprovalsFile = {
   version: 1,
@@ -44,6 +47,7 @@ const callGateway = vi.fn(async (opts: NodeInvokeCall) => {
   }
   if (opts.method === "node.invoke") {
     lastNodeInvokeCall = opts;
+    nodeInvokeCalls.push(opts);
     const command = opts.params?.command;
     if (command === "system.run.prepare") {
       const params = (opts.params?.params ?? {}) as {
@@ -53,6 +57,15 @@ const callGateway = vi.fn(async (opts: NodeInvokeCall) => {
         agentId?: unknown;
       };
       return buildSystemRunPreparePayload(params);
+    }
+    if (command === "system.run" && nextSystemRunErrorMessage) {
+      const message = nextSystemRunErrorMessage;
+      nextSystemRunErrorMessage = null;
+      throw new Error(message);
+    }
+    if (command === "system.run" && denyNextSystemRunForApproval) {
+      denyNextSystemRunForApproval = false;
+      throw new Error("SYSTEM_RUN_DENIED: approval required");
     }
     return {
       payload: {
@@ -81,7 +94,7 @@ const callGateway = vi.fn(async (opts: NodeInvokeCall) => {
 
 const randomIdempotencyKey = vi.fn(() => "rk_test");
 
-const { defaultRuntime, resetRuntimeCapture } = createCliRuntimeCapture();
+const { defaultRuntime, resetRuntimeCapture, runtimeErrors } = createCliRuntimeCapture();
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGateway(opts as NodeInvokeCall),
@@ -137,7 +150,10 @@ describe("nodes-cli coverage", () => {
     callGateway.mockClear();
     randomIdempotencyKey.mockClear();
     lastNodeInvokeCall = null;
+    nodeInvokeCalls = [];
     lastApprovalRequestCall = null;
+    denyNextSystemRunForApproval = false;
+    nextSystemRunErrorMessage = null;
     localExecApprovalsFile = { version: 1, agents: {} };
     nodeExecApprovalsFile = {
       version: 1,
@@ -150,7 +166,7 @@ describe("nodes-cli coverage", () => {
     };
   });
 
-  it("invokes system.run with parsed params", async () => {
+  it("invokes system.run with parsed params without pre-asking on ask=on-miss", async () => {
     const invoke = await runNodesCommand([
       "nodes",
       "run",
@@ -180,20 +196,10 @@ describe("nodes-cli coverage", () => {
       timeoutMs: 1200,
       needsScreenRecording: true,
       agentId: "main",
-      approved: true,
-      approvalDecision: "allow-once",
-      runId: expect.any(String),
+      approved: false,
     });
     expect(invoke?.params?.timeoutMs).toBe(5000);
-    const approval = getApprovalRequestCall();
-    expect(approval?.params?.["commandArgv"]).toEqual(["echo", "hi"]);
-    expect(approval?.params?.["systemRunPlan"]).toEqual({
-      argv: ["echo", "hi"],
-      cwd: "/tmp",
-      rawCommand: null,
-      agentId: "main",
-      sessionKey: null,
-    });
+    expect(getApprovalRequestCall()).toBeNull();
   });
 
   it("invokes system.run with raw command", async () => {
@@ -215,19 +221,87 @@ describe("nodes-cli coverage", () => {
       command: ["/bin/sh", "-lc", "echo hi"],
       rawCommand: "echo hi",
       agentId: "main",
+      approved: false,
+    });
+    expect(getApprovalRequestCall()).toBeNull();
+  });
+
+  it("requests approval on-miss only after node reports approval required", async () => {
+    denyNextSystemRunForApproval = true;
+
+    const invoke = await runNodesCommand(["nodes", "run", "--node", "mac-1", "echo", "hi"]);
+
+    expect(invoke).toBeTruthy();
+    expect(invoke?.params?.command).toBe("system.run");
+
+    const systemRunCalls = nodeInvokeCalls.filter((call) => call.params?.command === "system.run");
+    expect(systemRunCalls).toHaveLength(2);
+    expect(systemRunCalls[0]?.params?.params).toMatchObject({
+      command: ["echo", "hi"],
+      approved: false,
+    });
+    expect(systemRunCalls[1]?.params?.params).toMatchObject({
+      command: ["echo", "hi"],
       approved: true,
       approvalDecision: "allow-once",
       runId: expect.any(String),
     });
+
     const approval = getApprovalRequestCall();
-    expect(approval?.params?.["commandArgv"]).toEqual(["/bin/sh", "-lc", "echo hi"]);
+    expect(approval?.params?.["commandArgv"]).toEqual(["echo", "hi"]);
     expect(approval?.params?.["systemRunPlan"]).toEqual({
-      argv: ["/bin/sh", "-lc", "echo hi"],
+      argv: ["echo", "hi"],
       cwd: null,
-      rawCommand: "echo hi",
+      rawCommand: null,
       agentId: "main",
       sessionKey: null,
     });
+  });
+
+  it("pre-prompts when ask=always before the first system.run", async () => {
+    nodeExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        security: "allowlist",
+        ask: "always",
+        askFallback: "deny",
+      },
+      agents: {},
+    };
+
+    const invoke = await runNodesCommand(["nodes", "run", "--node", "mac-1", "echo", "hi"]);
+
+    expect(invoke).toBeTruthy();
+    expect(invoke?.params?.command).toBe("system.run");
+    expect(nodeInvokeCalls.filter((call) => call.params?.command === "system.run")).toHaveLength(1);
+
+    const approval = getApprovalRequestCall();
+    expect(approval?.params?.["commandArgv"]).toEqual(["echo", "hi"]);
+    expect(approval?.params?.["systemRunPlan"]).toEqual({
+      argv: ["echo", "hi"],
+      cwd: null,
+      rawCommand: null,
+      agentId: "main",
+      sessionKey: null,
+    });
+    expect(invoke?.params?.params).toMatchObject({
+      command: ["echo", "hi"],
+      approved: true,
+      approvalDecision: "allow-once",
+      runId: expect.any(String),
+    });
+  });
+
+  it("does not request approval for non-approval denials", async () => {
+    nextSystemRunErrorMessage = "SYSTEM_RUN_DENIED: allowlist miss";
+
+    await expect(
+      runNodesCommand(["nodes", "run", "--node", "mac-1", "echo", "hi"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(nodeInvokeCalls.filter((call) => call.params?.command === "system.run")).toHaveLength(1);
+    expect(getApprovalRequestCall()).toBeNull();
+    expect(runtimeErrors.join("\n")).toContain("SYSTEM_RUN_DENIED: allowlist miss");
   });
 
   it("inherits ask=off from local exec approvals when tools.exec.ask is unset", async () => {

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -399,31 +399,70 @@ export function registerNodesInvokeCommands(nodes: Command) {
           if (approvals.hostSecurity === "deny") {
             throw new Error("exec denied: host=node security=deny");
           }
-          const approvalResult = await maybeRequestNodesRunApproval({
-            opts,
-            nodeId,
-            agentId,
-            preparedCmdText: preparedContext.prepared.cmdText,
-            approvalPlan,
-            hostSecurity: approvals.hostSecurity,
-            hostAsk: approvals.hostAsk,
-            askFallback: approvals.askFallback,
-          });
-          const invokeParams = buildSystemRunInvokeParams({
-            nodeId,
-            approvalPlan,
-            nodeEnv: preparedContext.nodeEnv,
-            timeoutMs: preparedContext.timeoutMs,
-            invokeTimeout: preparedContext.invokeTimeout,
-            approvedByAsk: approvalResult.approvedByAsk,
-            approvalDecision: approvalResult.approvalDecision,
-            approvalId: approvalResult.approvalId,
-            idempotencyKey: opts.idempotencyKey,
-            fallbackAgentId: agentId,
-            needsScreenRecording: opts.needsScreenRecording === true,
-          });
+          let approvalResult: Awaited<ReturnType<typeof maybeRequestNodesRunApproval>> = {
+            approvedByAsk: false,
+            approvalDecision: null,
+            approvalId: null,
+          };
+          let promptedForApproval = false;
+          if (approvals.hostAsk === "always") {
+            approvalResult = await maybeRequestNodesRunApproval({
+              opts,
+              nodeId,
+              agentId,
+              preparedCmdText: preparedContext.prepared.cmdText,
+              approvalPlan,
+              hostSecurity: approvals.hostSecurity,
+              hostAsk: approvals.hostAsk,
+              askFallback: approvals.askFallback,
+            });
+            promptedForApproval = true;
+          }
 
-          const result = await callGatewayCli("node.invoke", opts, invokeParams);
+          const invokeSystemRun = async () => {
+            const invokeParams = buildSystemRunInvokeParams({
+              nodeId,
+              approvalPlan,
+              nodeEnv: preparedContext.nodeEnv,
+              timeoutMs: preparedContext.timeoutMs,
+              invokeTimeout: preparedContext.invokeTimeout,
+              approvedByAsk: approvalResult.approvedByAsk,
+              approvalDecision: approvalResult.approvalDecision,
+              approvalId: approvalResult.approvalId,
+              idempotencyKey: opts.idempotencyKey,
+              fallbackAgentId: agentId,
+              needsScreenRecording: opts.needsScreenRecording === true,
+            });
+            return await callGatewayCli("node.invoke", opts, invokeParams);
+          };
+
+          let result: unknown;
+          try {
+            result = await invokeSystemRun();
+          } catch (firstErr) {
+            const msg = firstErr instanceof Error ? firstErr.message : String(firstErr);
+            const shouldPromptOnMiss =
+              !promptedForApproval &&
+              approvals.hostAsk !== "off" &&
+              msg.includes("SYSTEM_RUN_DENIED: approval required");
+            if (!shouldPromptOnMiss) {
+              throw firstErr;
+            }
+
+            approvalResult = await maybeRequestNodesRunApproval({
+              opts,
+              nodeId,
+              agentId,
+              preparedCmdText: preparedContext.prepared.cmdText,
+              approvalPlan,
+              hostSecurity: approvals.hostSecurity,
+              hostAsk: approvals.hostAsk,
+              askFallback: approvals.askFallback,
+            });
+            promptedForApproval = true;
+            result = await invokeSystemRun();
+          }
+
           if (opts.json) {
             defaultRuntime.log(JSON.stringify(result, null, 2));
             return;


### PR DESCRIPTION
## Summary

- Problem: `openclaw nodes run` requested approval up front for `ask=on-miss`, before the first `system.run` attempt.
- Why it matters: already-allowlisted node commands still triggered repeated approval prompts instead of running directly.
- What changed: `nodes run` now tries `node.invoke(system.run)` first and only requests approval after `SYSTEM_RUN_DENIED: approval required`.
- What did NOT change (scope boundary): `ask=always` still pre-prompts, and non-approval denials still surface without opening an approval request.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #19862

## User-visible / Behavior Changes

`openclaw nodes run` no longer opens approval prompts for already-allowlisted commands just because `ask=on-miss` is configured.

Approval is now only requested after the node actually returns `SYSTEM_RUN_DENIED: approval required`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Docker gateway + macOS node
- Model/provider: N/A
- Integration/channel (if any): CLI `nodes run`
- Relevant config (redacted): node exec approvals in `allowlist` mode with `ask=on-miss`

### Steps

1. Allowlist a node command for the active agent.
2. Run `openclaw nodes run --node <node> -- <allowlisted command>`.
3. Observe whether an approval request is created before the first node invoke.

### Expected

- `ask=on-miss` should only prompt when the node actually denies with `SYSTEM_RUN_DENIED: approval required`.

### Actual

- Before this fix, the CLI requested approval up front for `ask=on-miss`, so even already-allowlisted commands still opened approval prompts.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: already-allowlisted direct argv node commands no longer pre-prompt under `ask=on-miss`; approval-required denial still triggers approval + retry; `ask=always` still pre-prompts; non-approval denials do not open approval requests; targeted Vitest coverage passes; rebuilt the patched gateway image and verified the live fix against a macOS node with `things` allowlisted; `pnpm check` and `pnpm test` pass locally.
- Edge cases checked: raw-command path still stays on the same CLI approval flow; unrelated invoke errors still propagate without retry.
- What you did **not** verify: Windows node behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the `nodes run` flow change in `src/cli/nodes-cli/register.invoke.ts`
- Files/config to restore: `src/cli/nodes-cli/register.invoke.ts`, `src/cli/nodes-cli.coverage.test.ts`
- Known bad symptoms reviewers should watch for: missing prompt for `ask=always`; approval-required denials not retrying after approval; approval prompts appearing for non-approval denials such as allowlist misses.

## Risks and Mitigations

- Risk: `ask=always` behavior could accidentally regress into try-first behavior.
  - Mitigation: the explicit pre-approval branch for `hostAsk === "always"` is preserved and now covered by regression tests.
- Risk: the retry path could become too broad and prompt on non-approval failures.
  - Mitigation: retry remains gated on `SYSTEM_RUN_DENIED: approval required`, and there is regression coverage for allowlist-miss behavior.

## AI Assistance

AI-assisted with Codex.
Locally tested with targeted Vitest coverage, full `pnpm check`, full `pnpm test`, and a live Docker gateway + macOS node repro.
I understand what the code does.