### PR TITLE
fix: spawn detached recovery process before launchctl bootout

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -22,6 +22,7 @@ const state = vi.hoisted(() => ({
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
   fileModes: new Map<string, number>(),
+  spawnCalls: [] as Array<{ command: string; args: string[]; options: Record<string, unknown> }>,
 }));
 const defaultProgramArguments = ["node", "-e", "process.exit(0)"];
 
@@ -52,6 +53,17 @@ vi.mock("./exec-file.js", () => ({
     return { stdout: "", stderr: "", code: 0 };
   }),
 }));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn((command: string, args: string[], options: Record<string, unknown>) => {
+      state.spawnCalls.push({ command, args, options });
+      return { unref: vi.fn() };
+    }),
+  };
+});
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
@@ -113,6 +125,7 @@ beforeEach(() => {
   state.dirModes.clear();
   state.files.clear();
   state.fileModes.clear();
+  state.spawnCalls.length = 0;
   vi.clearAllMocks();
 });
 
@@ -302,6 +315,61 @@ describe("launchd install", () => {
     expect(state.dirModes.get("/Users/test/Library")).toBe(0o755);
     expect(state.dirModes.get("/Users/test/Library/LaunchAgents")).toBe(0o755);
     expect(state.fileModes.get(plistPath)).toBe(0o644);
+  });
+
+  it("spawns a detached recovery process only when inside the gateway (#41198)", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.printOutput = ["state = running", "pid = 5555"].join("\n");
+    const killSpy = vi.spyOn(process, "kill");
+    killSpy.mockImplementation(() => {
+      const err = new Error("no such process") as NodeJS.ErrnoException;
+      err.code = "ESRCH";
+      throw err;
+    });
+    const origMarker = process.env.OPENCLAW_SERVICE_MARKER;
+
+    try {
+      // Without OPENCLAW_SERVICE_MARKER: no detached child spawned
+      delete process.env.OPENCLAW_SERVICE_MARKER;
+      await restartLaunchAgent({ env, stdout: new PassThrough() });
+      expect(state.spawnCalls.length).toBe(0);
+
+      // Reset for second call
+      state.launchctlCalls.length = 0;
+
+      // With OPENCLAW_SERVICE_MARKER=openclaw: detached child spawned
+      process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+      await restartLaunchAgent({ env, stdout: new PassThrough() });
+
+      expect(state.spawnCalls.length).toBe(1);
+      const call = state.spawnCalls[0];
+      expect(call.command).toBe(process.execPath);
+      expect(call.args[0]).toBe("-e");
+      expect(call.options.detached).toBe(true);
+      expect(call.options.stdio).toBe("ignore");
+
+      // Verify the inline script references the correct domain/label/pid
+      const script = call.args[1];
+      expect(script).toContain("ai.openclaw.gateway");
+      expect(script).toContain("bootstrap");
+      expect(script).toContain("kickstart");
+      expect(script).toContain("5555"); // previousPid
+
+      // Verify bootout still happened
+      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+      const label = "ai.openclaw.gateway";
+      const bootoutIndex = state.launchctlCalls.findIndex(
+        (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
+      );
+      expect(bootoutIndex).toBeGreaterThanOrEqual(0);
+    } finally {
+      killSpy.mockRestore();
+      if (origMarker !== undefined) {
+        process.env.OPENCLAW_SERVICE_MARKER = origMarker;
+      } else {
+        delete process.env.OPENCLAW_SERVICE_MARKER;
+      }
+    }
   });
 
   it("restarts LaunchAgent with bootout-enable-bootstrap-kickstart order", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
@@ -468,6 +469,81 @@ export async function installLaunchAgent({
   return { plistPath };
 }
 
+/**
+ * Build an inline Node.js script that re-bootstraps the LaunchAgent after
+ * the current gateway process has exited.  The script is spawned as a fully
+ * detached process so it survives the `launchctl bootout` that kills the
+ * gateway (and any child processes in its tree).
+ *
+ * Flow: wait for previous PID to exit → enable → bootstrap → kickstart.
+ */
+function buildDetachedRecoveryScript(args: {
+  domain: string;
+  label: string;
+  plistPath: string;
+  previousPid: number | undefined;
+}): string {
+  // JSON-encode values so they are safely embedded in the inline script.
+  const d = JSON.stringify(args.domain);
+  const l = JSON.stringify(args.label);
+  const p = JSON.stringify(args.plistPath);
+  const pid = args.previousPid ?? 0;
+
+  return `
+"use strict";
+const { execFileSync } = require("child_process");
+
+const domain = ${d};
+const label = ${l};
+const plistPath = ${p};
+const prevPid = ${pid};
+
+function pidAlive(pid) {
+  if (pid <= 0) return false;
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+// Wait for the previous gateway process to exit (up to 30 s).
+const deadline = Date.now() + 30000;
+function poll() {
+  if (!pidAlive(prevPid)) {
+    recover();
+  } else if (Date.now() >= deadline) {
+    // Gateway still alive after 30 s — bootout likely failed; do not
+    // interfere.  The parent CLI will surface the error.
+    process.exit(0);
+  } else {
+    setTimeout(poll, 200);
+  }
+}
+
+function lctl(args) {
+  try {
+    execFileSync("launchctl", args, { timeout: 10000 });
+  } catch { /* best effort */ }
+}
+
+function recover() {
+  lctl(["enable", domain + "/" + label]);
+  lctl(["bootstrap", domain, plistPath]);
+  lctl(["kickstart", "-k", domain + "/" + label]);
+  process.exit(0);
+}
+
+if (prevPid > 0) { poll(); } else { recover(); }
+`.trim();
+}
+
+/**
+ * Detect whether the current process is a descendant of the gateway.
+ * The gateway sets OPENCLAW_SERVICE_MARKER in the launchd environment;
+ * agent exec children inherit it.  A standalone terminal session will
+ * not have this variable set.
+ */
+function isRunningInsideGateway(): boolean {
+  return process.env.OPENCLAW_SERVICE_MARKER === "openclaw";
+}
+
 export async function restartLaunchAgent({
   stdout,
   env,
@@ -482,6 +558,23 @@ export async function restartLaunchAgent({
     runtime.code === 0
       ? parseLaunchctlPrint(runtime.stdout || runtime.stderr || "").pid
       : undefined;
+
+  // When running inside the gateway process tree (e.g. agent exec),
+  // `launchctl bootout` will kill this process before it can run the
+  // bootstrap/kickstart steps.  Spawn a detached recovery process that
+  // survives the shutdown and re-registers the service.  (#41198)
+  //
+  // Only spawn when actually inside the gateway to avoid a double
+  // kickstart -k in the normal case (kickstart -k is not idempotent —
+  // it kills the running process).
+  if (isRunningInsideGateway()) {
+    const recoveryScript = buildDetachedRecoveryScript({ domain, label, plistPath, previousPid });
+    const child = spawn(process.execPath, ["-e", recoveryScript], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+  }
 
   const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
   if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {


### PR DESCRIPTION
## Summary

- Fixes gateway restart failure when invoked from within the gateway process tree (e.g. by an agent via exec tool)
- Spawns a detached Node.js child process before `launchctl bootout` to ensure `enable` → `bootstrap` → `kickstart` steps survive the gateway shutdown

Fixes #41198

## Problem

When `openclaw gateway restart` runs as a child of the gateway (agent exec → CLI → `restartLaunchAgent()`), `launchctl bootout` kills the entire process tree. The CLI never reaches the `bootstrap` + `kickstart` steps, leaving the launchd service fully unloaded. `KeepAlive: true` can't help because the service was `bootout`-ed (unregistered), not just killed.

## Solution

Before calling `launchctl bootout`, check `OPENCLAW_SERVICE_MARKER` to detect whether the CLI is running inside the gateway process tree. Only when inside the gateway, spawn a fully detached child process (`detached: true`, `stdio: 'ignore'`, `unref()`) that:

1. Waits for the previous gateway PID to exit (polls `process.kill(pid, 0)` every 200ms, 30s timeout)
2. Runs `launchctl enable gui/<uid>/<label>`
3. Runs `launchctl bootstrap gui/<uid> <plist>`
4. Runs `launchctl kickstart -k gui/<uid>/<label>`

When running from a normal terminal (no `OPENCLAW_SERVICE_MARKER`), the original sequential flow is preserved — no detached child, no double kickstart, errors still thrown as before.

## Changes

- `src/daemon/launchd.ts`: Added `isRunningInsideGateway()` detection and `buildDetachedRecoveryScript()` helper. Modified `restartLaunchAgent()` to conditionally spawn the detached recovery process before bootout.
- `src/daemon/launchd.test.ts`: Added test verifying the detached process is only spawned when `OPENCLAW_SERVICE_MARKER` is set, and not spawned in the normal case.

## Test plan

- [x] `npx vitest run src/daemon/launchd.test.ts` — 22/22 tests pass
- [x] `pnpm build` — builds successfully
- [x] `npx tsgo` — no type errors
- [ ] Manual: install patched build, have agent run `openclaw gateway restart`, verify gateway recovers