### PR TITLE
fix(gateway): fail probe immediately on non-JSON ws messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,6 @@ Welcome to the lobster tank! 🦞
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
   - GitHub [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
-    
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
   - GitHub [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
@@ -73,7 +72,7 @@ Welcome to the lobster tank! 🦞
 
 - **Robin Waslander** - Security, PR triage, bug fixes
   - GitHub: [@hydro13](https://github.com/hydro13) · X: [@Robin_waslander](https://x.com/Robin_waslander)
- 
+
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -112,7 +112,8 @@ vi.mock("../logger.js", async (importOriginal) => {
   };
 });
 
-const { GatewayClient } = await import("./client.js");
+// Import after mocks to avoid circular dependency
+const { GatewayClient, GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON } = await import("./client.js");
 
 function getLatestWs(): MockWebSocket {
   const ws = wsInstances.at(-1);
@@ -608,7 +609,7 @@ describe("GatewayClient handleMessage parse errors", () => {
       }),
     );
     // Should close the connection with parse error code
-    expect(onClose).toHaveBeenCalledWith(1008, "parse error");
+    expect(onClose).toHaveBeenCalledWith(GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON);
     client.stop();
   });
 
@@ -634,7 +635,7 @@ describe("GatewayClient handleMessage parse errors", () => {
       ws.emitMessage("not valid json");
       
       // Verify close was called
-      expect(onClose).toHaveBeenCalledWith(1008, "parse error");
+      expect(onClose).toHaveBeenCalledWith(GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON);
       
       // The client should be marked as closed, preventing reconnection
       // We verify this by checking that no new WebSocket instances are created
@@ -681,7 +682,7 @@ describe("GatewayClient handleMessage parse errors", () => {
         message: expect.stringContaining("│ Config invalid"),
       }),
     );
-    expect(onClose).toHaveBeenCalledWith(1008, "parse error");
+    expect(onClose).toHaveBeenCalledWith(GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON);
     client.stop();
   });
 
@@ -709,7 +710,7 @@ describe("GatewayClient handleMessage parse errors", () => {
     // The pending request should be rejected with the parse error
     await expect(requestPromise).rejects.toThrow("Failed to parse JSON message from gateway");
     
-    expect(onClose).toHaveBeenCalledWith(1008, "parse error");
+    expect(onClose).toHaveBeenCalledWith(GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON);
     client.stop();
   });
 });

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -113,7 +113,8 @@ vi.mock("../logger.js", async (importOriginal) => {
 });
 
 // Import after mocks to avoid circular dependency
-const { GatewayClient, GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON } = await import("./client.js");
+const { GatewayClient, GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON } =
+  await import("./client.js");
 
 function getLatestWs(): MockWebSocket {
   const ws = wsInstances.at(-1);
@@ -551,9 +552,7 @@ describe("GatewayClient handleMessage parse errors", () => {
     expect(logDebugMock).toHaveBeenCalledWith(
       expect.stringContaining("gateway client parse error"),
     );
-    expect(logDebugMock).toHaveBeenCalledWith(
-      expect.stringContaining("not valid json"),
-    );
+    expect(logDebugMock).toHaveBeenCalledWith(expect.stringContaining("not valid json"));
     client.stop();
   });
 
@@ -572,9 +571,7 @@ describe("GatewayClient handleMessage parse errors", () => {
       expect.stringContaining("gateway client parse error"),
     );
     // Should be truncated to 300 chars + "..."
-    expect(logDebugMock).toHaveBeenCalledWith(
-      expect.stringContaining("xxx..."),
-    );
+    expect(logDebugMock).toHaveBeenCalledWith(expect.stringContaining("xxx..."));
     client.stop();
   });
 
@@ -593,7 +590,7 @@ describe("GatewayClient handleMessage parse errors", () => {
     // First, complete the handshake so we're in a state where messages are processed
     ws.emitOpen();
     emitConnectChallenge(ws);
-    
+
     // Now send invalid JSON
     ws.emitMessage("not valid json");
 
@@ -609,7 +606,10 @@ describe("GatewayClient handleMessage parse errors", () => {
       }),
     );
     // Should close the connection with parse error code
-    expect(onClose).toHaveBeenCalledWith(GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON);
+    expect(onClose).toHaveBeenCalledWith(
+      GATEWAY_PARSE_ERROR_CLOSE_CODE,
+      GATEWAY_PARSE_ERROR_CLOSE_REASON,
+    );
     client.stop();
   });
 
@@ -630,27 +630,30 @@ describe("GatewayClient handleMessage parse errors", () => {
       const ws = getLatestWs();
       ws.emitOpen();
       emitConnectChallenge(ws);
-      
+
       // Trigger parse error
       ws.emitMessage("not valid json");
-      
+
       // Verify close was called
-      expect(onClose).toHaveBeenCalledWith(GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON);
-      
+      expect(onClose).toHaveBeenCalledWith(
+        GATEWAY_PARSE_ERROR_CLOSE_CODE,
+        GATEWAY_PARSE_ERROR_CLOSE_REASON,
+      );
+
       // The client should be marked as closed, preventing reconnection
       // We verify this by checking that no new WebSocket instances are created
       // after the parse error (scheduleReconnect would create a new one)
       const afterParseErrorWsCount = wsInstances.length;
-      
+
       // Wait a bit to see if reconnection would happen
       vi.advanceTimersByTime(2000);
-      
+
       const afterTimeoutWsCount = wsInstances.length;
-      
+
       // Should not have created new WebSocket instances
       expect(afterTimeoutWsCount).toBe(initialWsCount);
       expect(afterParseErrorWsCount).toBe(initialWsCount);
-      
+
       client.stop();
     } finally {
       vi.useRealTimers();
@@ -672,7 +675,7 @@ describe("GatewayClient handleMessage parse errors", () => {
     // First, complete the handshake
     ws.emitOpen();
     emitConnectChallenge(ws);
-    
+
     // Simulate the actual issue: box-drawing characters from doctor output
     const boxDrawingMessage = "│ Config invalid";
     ws.emitMessage(boxDrawingMessage);
@@ -682,7 +685,10 @@ describe("GatewayClient handleMessage parse errors", () => {
         message: expect.stringContaining("│ Config invalid"),
       }),
     );
-    expect(onClose).toHaveBeenCalledWith(GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON);
+    expect(onClose).toHaveBeenCalledWith(
+      GATEWAY_PARSE_ERROR_CLOSE_CODE,
+      GATEWAY_PARSE_ERROR_CLOSE_REASON,
+    );
     client.stop();
   });
 
@@ -700,17 +706,20 @@ describe("GatewayClient handleMessage parse errors", () => {
     const ws = getLatestWs();
     ws.emitOpen();
     emitConnectChallenge(ws);
-    
+
     // Make a request that will be pending
     const requestPromise = client.request("health");
-    
+
     // Trigger parse error before response
     ws.emitMessage("not valid json");
-    
+
     // The pending request should be rejected with the parse error
     await expect(requestPromise).rejects.toThrow("Failed to parse JSON message from gateway");
-    
-    expect(onClose).toHaveBeenCalledWith(GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON);
+
+    expect(onClose).toHaveBeenCalledWith(
+      GATEWAY_PARSE_ERROR_CLOSE_CODE,
+      GATEWAY_PARSE_ERROR_CLOSE_REASON,
+    );
     client.stop();
   });
 });

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -9,6 +9,7 @@ const loadDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const storeDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const clearDevicePairingMock = vi.hoisted(() => vi.fn());
 const logDebugMock = vi.hoisted(() => vi.fn());
+const logErrorMock = vi.hoisted(() => vi.fn());
 
 type WsEvent = "open" | "message" | "close" | "error";
 type WsEventHandlers = {
@@ -52,7 +53,10 @@ class MockWebSocket {
     }
   }
 
-  close(_code?: number, _reason?: string): void {}
+  close(code?: number, reason?: string): void {
+    // Actually trigger close handlers to simulate real WebSocket behavior
+    this.emitClose(code ?? 1000, reason ?? "");
+  }
 
   send(data: string): void {
     this.sent.push(data);
@@ -104,6 +108,7 @@ vi.mock("../logger.js", async (importOriginal) => {
   return {
     ...actual,
     logDebug: (...args: unknown[]) => logDebugMock(...args),
+    logError: (...args: unknown[]) => logErrorMock(...args),
   };
 });
 
@@ -253,6 +258,7 @@ describe("GatewayClient close handling", () => {
     clearDevicePairingMock.mockClear();
     clearDevicePairingMock.mockResolvedValue(true);
     logDebugMock.mockClear();
+    logErrorMock.mockClear();
   });
 
   it("clears stale token on device token mismatch close", () => {
@@ -456,6 +462,254 @@ describe("GatewayClient connect auth payload", () => {
       token: "explicit-device-token",
       deviceToken: "explicit-device-token",
     });
+    client.stop();
+  });
+});
+
+describe("GatewayClient handleMessage parse errors", () => {
+  beforeEach(() => {
+    wsInstances.length = 0;
+    logDebugMock.mockClear();
+    logErrorMock.mockClear();
+  });
+
+  function emitConnectChallenge(ws: MockWebSocket, nonce = "nonce-1") {
+    ws.emitMessage(
+      JSON.stringify({
+        type: "event",
+        event: "connect.challenge",
+        payload: { nonce },
+      }),
+    );
+  }
+
+  it("handles valid JSON event frames normally", () => {
+    const onEvent = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onEvent,
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitMessage(
+      JSON.stringify({
+        type: "event",
+        event: "tick",
+        payload: {},
+      }),
+    );
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "tick",
+      }),
+    );
+    expect(logDebugMock).not.toHaveBeenCalled();
+    client.stop();
+  });
+
+  it("handles valid JSON response frames normally", () => {
+    const onClose = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onClose,
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+
+    // Simulate a successful response
+    ws.emitMessage(
+      JSON.stringify({
+        type: "res",
+        id: "test-id",
+        ok: true,
+        payload: { result: "success" },
+      }),
+    );
+
+    expect(logDebugMock).not.toHaveBeenCalled();
+    // Should not close on valid response
+    expect(onClose).not.toHaveBeenCalled();
+    client.stop();
+  });
+
+  it("logs parse errors for non-JSON messages in non-PROBE mode", () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      mode: "backend", // Not PROBE mode
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitMessage("not valid json");
+
+    expect(logDebugMock).toHaveBeenCalledWith(
+      expect.stringContaining("gateway client parse error"),
+    );
+    expect(logDebugMock).toHaveBeenCalledWith(
+      expect.stringContaining("not valid json"),
+    );
+    client.stop();
+  });
+
+  it("handles truncated long messages in parse error logs", () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      mode: "backend",
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    const longMessage = "x".repeat(500);
+    ws.emitMessage(longMessage);
+
+    expect(logDebugMock).toHaveBeenCalledWith(
+      expect.stringContaining("gateway client parse error"),
+    );
+    // Should be truncated to 300 chars + "..."
+    expect(logDebugMock).toHaveBeenCalledWith(
+      expect.stringContaining("xxx..."),
+    );
+    client.stop();
+  });
+
+  it("triggers immediate failure in PROBE mode on parse failure", () => {
+    const onConnectError = vi.fn();
+    const onClose = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      mode: "probe", // PROBE mode
+      onConnectError,
+      onClose,
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    // First, complete the handshake so we're in a state where messages are processed
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+    
+    // Now send invalid JSON
+    ws.emitMessage("not valid json");
+
+    // Should trigger onConnectError with descriptive message
+    expect(onConnectError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Failed to parse JSON message from gateway"),
+      }),
+    );
+    expect(onConnectError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("not valid json"),
+      }),
+    );
+    // Should close the connection with parse error code
+    expect(onClose).toHaveBeenCalledWith(1008, "parse error");
+    client.stop();
+  });
+
+  it("prevents reconnection after parse error in PROBE mode", () => {
+    vi.useFakeTimers();
+    try {
+      const onConnectError = vi.fn();
+      const onClose = vi.fn();
+      const client = new GatewayClient({
+        url: "ws://127.0.0.1:18789",
+        mode: "probe",
+        onConnectError,
+        onClose,
+      });
+
+      client.start();
+      const initialWsCount = wsInstances.length;
+      const ws = getLatestWs();
+      ws.emitOpen();
+      emitConnectChallenge(ws);
+      
+      // Trigger parse error
+      ws.emitMessage("not valid json");
+      
+      // Verify close was called
+      expect(onClose).toHaveBeenCalledWith(1008, "parse error");
+      
+      // The client should be marked as closed, preventing reconnection
+      // We verify this by checking that no new WebSocket instances are created
+      // after the parse error (scheduleReconnect would create a new one)
+      const afterParseErrorWsCount = wsInstances.length;
+      
+      // Wait a bit to see if reconnection would happen
+      vi.advanceTimersByTime(2000);
+      
+      const afterTimeoutWsCount = wsInstances.length;
+      
+      // Should not have created new WebSocket instances
+      expect(afterTimeoutWsCount).toBe(initialWsCount);
+      expect(afterParseErrorWsCount).toBe(initialWsCount);
+      
+      client.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("includes box-drawing characters in error message for debugging", () => {
+    const onConnectError = vi.fn();
+    const onClose = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      mode: "probe",
+      onConnectError,
+      onClose,
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    // First, complete the handshake
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+    
+    // Simulate the actual issue: box-drawing characters from doctor output
+    const boxDrawingMessage = "│ Config invalid";
+    ws.emitMessage(boxDrawingMessage);
+
+    expect(onConnectError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("│ Config invalid"),
+      }),
+    );
+    expect(onClose).toHaveBeenCalledWith(1008, "parse error");
+    client.stop();
+  });
+
+  it("flushes pending requests with parse error in PROBE mode", async () => {
+    const onConnectError = vi.fn();
+    const onClose = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      mode: "probe",
+      onConnectError,
+      onClose,
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+    
+    // Make a request that will be pending
+    const requestPromise = client.request("health");
+    
+    // Trigger parse error before response
+    ws.emitMessage("not valid json");
+    
+    // The pending request should be rejected with the parse error
+    await expect(requestPromise).rejects.toThrow("Failed to parse JSON message from gateway");
+    
+    expect(onClose).toHaveBeenCalledWith(1008, "parse error");
     client.stop();
   });
 });

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -83,6 +83,10 @@ export function describeGatewayCloseCode(code: number): string | undefined {
   return GATEWAY_CLOSE_CODE_HINTS[code];
 }
 
+// Shared constants for parse error handling between client.ts and probe.ts
+export const GATEWAY_PARSE_ERROR_CLOSE_CODE = 1008;
+export const GATEWAY_PARSE_ERROR_CLOSE_REASON = "parse error" as const;
+
 export class GatewayClient {
   private ws: WebSocket | null = null;
   private opts: GatewayClientOptions;
@@ -430,7 +434,7 @@ export class GatewayClient {
         this.flushPendingErrors(parseError);
         // Notify and close the connection
         this.opts.onConnectError?.(parseError);
-        this.ws?.close(1008, "parse error");
+        this.ws?.close(GATEWAY_PARSE_ERROR_CLOSE_CODE, GATEWAY_PARSE_ERROR_CLOSE_REASON);
         return;
       }
       logDebug(`gateway client parse error: ${String(err)}; raw (truncated): ${truncatedRaw}`);

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -406,7 +406,34 @@ export class GatewayClient {
         }
       }
     } catch (err) {
-      logDebug(`gateway client parse error: ${String(err)}`);
+      // Truncate raw message for safe logging (avoid excessive length in case of large payloads)
+      const truncatedRaw = raw.length > 300 ? raw.slice(0, 300) + "..." : raw;
+      const parseError = new Error(
+        `Failed to parse JSON message from gateway: ${String(err)}; raw (truncated): ${truncatedRaw}`,
+      );
+      // In PROBE mode, treat parse failures as fatal protocol errors to ensure explicit failure
+      // instead of silently continuing and causing ambiguous probe results.
+      if (this.opts.mode === GATEWAY_CLIENT_MODES.PROBE) {
+        // Mark as closed to prevent any reconnection attempts
+        this.closed = true;
+        // Clear reconnect timer if pending
+        if (this.connectTimer) {
+          clearTimeout(this.connectTimer);
+          this.connectTimer = null;
+        }
+        // Clear tick watcher
+        if (this.tickTimer) {
+          clearInterval(this.tickTimer);
+          this.tickTimer = null;
+        }
+        // Flush any pending requests with the parse error
+        this.flushPendingErrors(parseError);
+        // Notify and close the connection
+        this.opts.onConnectError?.(parseError);
+        this.ws?.close(1008, "parse error");
+        return;
+      }
+      logDebug(`gateway client parse error: ${String(err)}; raw (truncated): ${truncatedRaw}`);
     }
   }
 

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -12,7 +12,9 @@ class MockGatewayClient {
   constructor(opts: Record<string, unknown>) {
     this.opts = opts;
     gatewayClientState.options = opts;
-    gatewayClientState.triggerOnClose = opts.onClose as ((code: number, reason: string) => void) | null;
+    gatewayClientState.triggerOnClose = opts.onClose as
+      | ((code: number, reason: string) => void)
+      | null;
     gatewayClientState.triggerOnConnectError = opts.onConnectError as ((err: Error) => void) | null;
   }
 
@@ -71,7 +73,7 @@ describe("probeGateway", () => {
 
   it("fails immediately on parse error close instead of waiting for timeout", async () => {
     const startedAt = Date.now();
-    
+
     // Start the probe
     const probePromise = probeGateway({
       url: "ws://127.0.0.1:18789",
@@ -83,15 +85,17 @@ describe("probeGateway", () => {
     // 1. First, onConnectError with parse error
     setTimeout(() => {
       gatewayClientState.triggerOnConnectError?.(
-        new Error("Failed to parse JSON message from gateway: SyntaxError; raw (truncated): not-json")
+        new Error(
+          "Failed to parse JSON message from gateway: SyntaxError; raw (truncated): not-json",
+        ),
       );
     }, 10);
-    
+
     // 2. Then, onClose with parse error close
     setTimeout(() => {
       gatewayClientState.triggerOnClose?.(
         GATEWAY_PARSE_ERROR_CLOSE_CODE,
-        GATEWAY_PARSE_ERROR_CLOSE_REASON
+        GATEWAY_PARSE_ERROR_CLOSE_REASON,
       );
     }, 50);
 
@@ -101,7 +105,7 @@ describe("probeGateway", () => {
     // Should fail explicitly with parse error message
     expect(result.ok).toBe(false);
     expect(result.error).toContain("Failed to parse JSON message from gateway");
-    
+
     // Should fail quickly, not wait for the 5000ms timeout
     expect(elapsed).toBeLessThan(1000);
   });
@@ -120,7 +124,9 @@ describe("probeGateway", () => {
     // 1. First, onConnectError with parse error
     setTimeout(() => {
       gatewayClientState.triggerOnConnectError?.(
-        new Error("Failed to parse JSON message from gateway: SyntaxError; raw (truncated): not-json")
+        new Error(
+          "Failed to parse JSON message from gateway: SyntaxError; raw (truncated): not-json",
+        ),
       );
     }, 10);
 

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const gatewayClientState = vi.hoisted(() => ({
   options: null as Record<string, unknown> | null,
   triggerOnClose: null as ((code: number, reason: string) => void) | null,
+  triggerOnConnectError: null as ((err: Error) => void) | null,
 }));
 
 class MockGatewayClient {
@@ -12,6 +13,7 @@ class MockGatewayClient {
     this.opts = opts;
     gatewayClientState.options = opts;
     gatewayClientState.triggerOnClose = opts.onClose as ((code: number, reason: string) => void) | null;
+    gatewayClientState.triggerOnConnectError = opts.onConnectError as ((err: Error) => void) | null;
   }
 
   start(): void {
@@ -31,14 +33,21 @@ class MockGatewayClient {
 
 vi.mock("./client.js", () => ({
   GatewayClient: MockGatewayClient,
+  GATEWAY_PARSE_ERROR_CLOSE_CODE: 1008,
+  GATEWAY_PARSE_ERROR_CLOSE_REASON: "parse error",
 }));
 
 const { probeGateway } = await import("./probe.js");
+
+// Use constants from the mock (same values as client.ts exports)
+const GATEWAY_PARSE_ERROR_CLOSE_CODE = 1008;
+const GATEWAY_PARSE_ERROR_CLOSE_REASON = "parse error";
 
 describe("probeGateway", () => {
   beforeEach(() => {
     gatewayClientState.options = null;
     gatewayClientState.triggerOnClose = null;
+    gatewayClientState.triggerOnConnectError = null;
   });
 
   it("connects with operator.read scope", async () => {
@@ -70,19 +79,28 @@ describe("probeGateway", () => {
       timeoutMs: 5000, // Long timeout to prove we don't wait
     });
 
-    // Simulate a parse error close from the gateway after a short delay
-    // This simulates what happens when gateway sends non-JSON content
+    // Simulate the real production order:
+    // 1. First, onConnectError with parse error
     setTimeout(() => {
-      gatewayClientState.triggerOnClose?.(1008, "parse error");
+      gatewayClientState.triggerOnConnectError?.(
+        new Error("Failed to parse JSON message from gateway: SyntaxError; raw (truncated): not-json")
+      );
+    }, 10);
+    
+    // 2. Then, onClose with parse error close
+    setTimeout(() => {
+      gatewayClientState.triggerOnClose?.(
+        GATEWAY_PARSE_ERROR_CLOSE_CODE,
+        GATEWAY_PARSE_ERROR_CLOSE_REASON
+      );
     }, 50);
 
     const result = await probePromise;
     const elapsed = Date.now() - startedAt;
 
-    // Should fail explicitly
+    // Should fail explicitly with parse error message
     expect(result.ok).toBe(false);
-    expect(result.error).toContain("gateway protocol error");
-    expect(result.error).toContain("parse error");
+    expect(result.error).toContain("Failed to parse JSON message from gateway");
     
     // Should fail quickly, not wait for the 5000ms timeout
     expect(elapsed).toBeLessThan(1000);

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -105,4 +105,39 @@ describe("probeGateway", () => {
     // Should fail quickly, not wait for the 5000ms timeout
     expect(elapsed).toBeLessThan(1000);
   });
+
+  it("fails immediately on any close after parse error, even with code 1006", async () => {
+    const startedAt = Date.now();
+
+    // Start the probe
+    const probePromise = probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 5000, // Long timeout to prove we don't wait
+    });
+
+    // Simulate the real production order:
+    // 1. First, onConnectError with parse error
+    setTimeout(() => {
+      gatewayClientState.triggerOnConnectError?.(
+        new Error("Failed to parse JSON message from gateway: SyntaxError; raw (truncated): not-json")
+      );
+    }, 10);
+
+    // 2. Then, onClose with abnormal close (1006) and empty reason
+    // This tests that sawParseError triggers fast-fail regardless of close code
+    setTimeout(() => {
+      gatewayClientState.triggerOnClose?.(1006, "");
+    }, 50);
+
+    const result = await probePromise;
+    const elapsed = Date.now() - startedAt;
+
+    // Should fail explicitly with parse error message
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Failed to parse JSON message from gateway");
+
+    // Should fail quickly, not wait for the 5000ms timeout
+    expect(elapsed).toBeLessThan(1000);
+  });
 });

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const gatewayClientState = vi.hoisted(() => ({
   options: null as Record<string, unknown> | null,
+  triggerOnClose: null as ((code: number, reason: string) => void) | null,
 }));
 
 class MockGatewayClient {
@@ -10,17 +11,12 @@ class MockGatewayClient {
   constructor(opts: Record<string, unknown>) {
     this.opts = opts;
     gatewayClientState.options = opts;
+    gatewayClientState.triggerOnClose = opts.onClose as ((code: number, reason: string) => void) | null;
   }
 
   start(): void {
-    void Promise.resolve()
-      .then(async () => {
-        const onHelloOk = this.opts.onHelloOk;
-        if (typeof onHelloOk === "function") {
-          await onHelloOk();
-        }
-      })
-      .catch(() => {});
+    // Don't auto-trigger onHelloOk - let tests control the flow
+    // This allows testing of failure paths like parse errors
   }
 
   stop(): void {}
@@ -40,7 +36,20 @@ vi.mock("./client.js", () => ({
 const { probeGateway } = await import("./probe.js");
 
 describe("probeGateway", () => {
+  beforeEach(() => {
+    gatewayClientState.options = null;
+    gatewayClientState.triggerOnClose = null;
+  });
+
   it("connects with operator.read scope", async () => {
+    // Manually trigger onHelloOk to simulate successful connection
+    setTimeout(() => {
+      const onHelloOk = gatewayClientState.options?.onHelloOk as (() => Promise<void>) | undefined;
+      if (onHelloOk) {
+        onHelloOk();
+      }
+    }, 10);
+
     const result = await probeGateway({
       url: "ws://127.0.0.1:18789",
       auth: { token: "secret" },
@@ -49,5 +58,33 @@ describe("probeGateway", () => {
 
     expect(gatewayClientState.options?.scopes).toEqual(["operator.read"]);
     expect(result.ok).toBe(true);
+  });
+
+  it("fails immediately on parse error close instead of waiting for timeout", async () => {
+    const startedAt = Date.now();
+    
+    // Start the probe
+    const probePromise = probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 5000, // Long timeout to prove we don't wait
+    });
+
+    // Simulate a parse error close from the gateway after a short delay
+    // This simulates what happens when gateway sends non-JSON content
+    setTimeout(() => {
+      gatewayClientState.triggerOnClose?.(1008, "parse error");
+    }, 50);
+
+    const result = await probePromise;
+    const elapsed = Date.now() - startedAt;
+
+    // Should fail explicitly
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("gateway protocol error");
+    expect(result.error).toContain("parse error");
+    
+    // Should fail quickly, not wait for the 5000ms timeout
+    expect(elapsed).toBeLessThan(1000);
   });
 });

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -57,7 +57,7 @@ describe("probeGateway", () => {
     setTimeout(() => {
       const onHelloOk = gatewayClientState.options?.onHelloOk as (() => Promise<void>) | undefined;
       if (onHelloOk) {
-        onHelloOk();
+        void onHelloOk();
       }
     }, 10);
 

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -81,8 +81,7 @@ export async function probeGateway(opts: {
         // Otherwise, we still check for the explicit parse error close.
         if (
           sawParseError ||
-          (code === GATEWAY_PARSE_ERROR_CLOSE_CODE &&
-            reason === GATEWAY_PARSE_ERROR_CLOSE_REASON)
+          (code === GATEWAY_PARSE_ERROR_CLOSE_CODE && reason === GATEWAY_PARSE_ERROR_CLOSE_REASON)
         ) {
           settle({
             ok: false,

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -74,13 +74,15 @@ export async function probeGateway(opts: {
       },
       onClose: (code, reason) => {
         close = { code, reason };
-        // In PROBE mode, a close with code 1008 and reason "parse error" (or after seeing
-        // a parse-error connectError) is a fatal protocol error that should immediately
-        // fail the probe, not wait for timeout.
-        // This handles the case where the gateway sends non-JSON content.
+        // In PROBE mode, if we've already seen a parse error via onConnectError,
+        // any subsequent close should immediately fail the probe, regardless of
+        // the close code or reason. This handles cases where the connection closes
+        // with code 1006 (abnormal closure) or empty reason after the parse error.
+        // Otherwise, we still check for the explicit parse error close.
         if (
-          code === GATEWAY_PARSE_ERROR_CLOSE_CODE &&
-          (reason === GATEWAY_PARSE_ERROR_CLOSE_REASON || sawParseError)
+          sawParseError ||
+          (code === GATEWAY_PARSE_ERROR_CLOSE_CODE &&
+            reason === GATEWAY_PARSE_ERROR_CLOSE_REASON)
         ) {
           settle({
             ok: false,

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -2,7 +2,11 @@ import { randomUUID } from "node:crypto";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { SystemPresence } from "../infra/system-presence.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
-import { GatewayClient } from "./client.js";
+import {
+  GATEWAY_PARSE_ERROR_CLOSE_CODE,
+  GATEWAY_PARSE_ERROR_CLOSE_REASON,
+  GatewayClient,
+} from "./client.js";
 import { READ_SCOPE } from "./method-scopes.js";
 
 export type GatewayProbeAuth = {
@@ -38,6 +42,7 @@ export async function probeGateway(opts: {
   let connectLatencyMs: number | null = null;
   let connectError: string | null = null;
   let close: GatewayProbeClose | null = null;
+  let sawParseError = false;
 
   return await new Promise<GatewayProbeResult>((resolve) => {
     let settled = false;
@@ -62,13 +67,21 @@ export async function probeGateway(opts: {
       instanceId,
       onConnectError: (err) => {
         connectError = formatErrorMessage(err);
+        // Track if we've seen a parse error to enable fast-fail on close
+        if (err.message.includes("Failed to parse JSON message from gateway")) {
+          sawParseError = true;
+        }
       },
       onClose: (code, reason) => {
         close = { code, reason };
-        // In PROBE mode, a close with code 1008 and reason "parse error" is a fatal
-        // protocol error that should immediately fail the probe, not wait for timeout.
+        // In PROBE mode, a close with code 1008 and reason "parse error" (or after seeing
+        // a parse-error connectError) is a fatal protocol error that should immediately
+        // fail the probe, not wait for timeout.
         // This handles the case where the gateway sends non-JSON content.
-        if (code === 1008 && reason === "parse error") {
+        if (
+          code === GATEWAY_PARSE_ERROR_CLOSE_CODE &&
+          (reason === GATEWAY_PARSE_ERROR_CLOSE_REASON || sawParseError)
+        ) {
           settle({
             ok: false,
             connectLatencyMs,

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -65,6 +65,21 @@ export async function probeGateway(opts: {
       },
       onClose: (code, reason) => {
         close = { code, reason };
+        // In PROBE mode, a close with code 1008 and reason "parse error" is a fatal
+        // protocol error that should immediately fail the probe, not wait for timeout.
+        // This handles the case where the gateway sends non-JSON content.
+        if (code === 1008 && reason === "parse error") {
+          settle({
+            ok: false,
+            connectLatencyMs,
+            error: connectError ?? `gateway protocol error: ${reason}`,
+            close,
+            health: null,
+            status: null,
+            presence: null,
+            configSnapshot: null,
+          });
+        }
       },
       onHelloOk: async () => {
         connectLatencyMs = Date.now() - startedAt;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw gateway status` could receive a non-JSON WebSocket frame during probe, causing JSON parsing to fail and leaving the probe in an ambiguous failure state.
- Why it matters: instead of failing explicitly, the probe could wait for timeout or fail unclearly, making diagnosis harder and masking protocol-level issues.
- What changed: in PROBE mode, the gateway client now treats non-JSON WS frames as fatal protocol errors, stops reconnect attempts, closes the connection with a parse-error close reason, and allows `probeGateway()` to fail immediately instead of waiting for timeout.
- What did NOT change (scope boundary): this PR does not change gateway server handlers, response payloads, `config.get` / `status` / `health` behavior, or the WS protocol shape for valid JSON messages.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40326
- Related #

## User-visible / Behavior Changes

- `openclaw gateway status` now fails explicitly when probe receives a non-JSON WebSocket message, instead of timing out ambiguously.
- Error handling in probe mode is more diagnosable because parse failures now include truncated raw message context.
- Probe-mode clients no longer attempt to reconnect after this parse-failure path.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: local Node.js / pnpm dev environment
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket probe path
- Relevant config (redacted): local default/dev config

### Steps

1. Start from a gateway probe path where the client receives a non-JSON WebSocket frame.
2. Run `openclaw gateway status` (or exercise the equivalent probe path in tests).
3. Observe probe behavior before and after the fix.

### Expected

- Probe should fail explicitly and quickly when a non-JSON WS frame is received in PROBE mode.
- Probe should not continue reconnecting after this parse failure.
- Valid JSON WS frames should continue to work as before.

### Actual

- Before this change, parse failure was only logged/debugged in the client, and the probe could continue into an ambiguous timeout/failure path.
- After this change, the probe fails immediately on a parse-error close in PROBE mode, with no reconnect loop.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reviewed the full probe path from `gateway status` → `probeGateway()` → `GatewayClient`.
  - Ran targeted gateway tests covering client parse-error handling and probe failure behavior.
  - Confirmed valid JSON event/response frame handling still passes existing and added tests.
- Edge cases checked:
  - Non-JSON frame in PROBE mode triggers explicit failure.
  - The parse-failure path does not continue reconnecting.
  - Pending requests are flushed/rejected on fatal parse failure.
  - Long raw messages are truncated in diagnostics.
- What you did **not** verify:
  - I did not verify the ultimate upstream source of the non-JSON frame on a live gateway instance.
  - I did not change or validate any gateway server handler output semantics in this PR.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / revert the changes in `src/gateway/client.ts` and `src/gateway/probe.ts`
- Files/config to restore:
  - `src/gateway/client.ts`
  - `src/gateway/probe.ts`
  - related test files, if doing a full revert
- Known bad symptoms reviewers should watch for:
  - Probe unexpectedly failing on valid JSON frames
  - Probe no longer reconnecting in cases where it previously should
  - Pending request handling regressing after connection close

## Risks and Mitigations

- Risk: treating parse failure as fatal in PROBE mode could surface failures earlier than before.
  - Mitigation: scope is limited to PROBE mode only; normal JSON-message handling is unchanged and covered by tests.
- Risk: close-reason matching (`1008`, `"parse error"`) is somewhat specific.
  - Mitigation: this keeps the change minimal and localized, and regression tests cover the intended failure path.
- Risk: diagnostic raw payload logging could become noisy for large frames.
  - Mitigation: raw content is truncated before inclusion in the error/debug message.