### PR TITLE
fix(plugins): clear discovery cache before install validation

### DIFF
--- a/src/cli/plugins-cli.install-cache.test.ts
+++ b/src/cli/plugins-cli.install-cache.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs";
+import path from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { runRegisteredCli } from "../test-utils/command-runner.js";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const existsSync = vi.fn();
+  return {
+    ...actual,
+    existsSync,
+    default: {
+      ...actual,
+      existsSync,
+    },
+  };
+});
+
+const loadConfig = vi.fn();
+const writeConfigFile = vi.fn();
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => loadConfig(),
+  writeConfigFile: (...args: unknown[]) => writeConfigFile(...args),
+}));
+
+const installPluginFromPath = vi.fn();
+const installPluginFromNpmSpec = vi.fn();
+vi.mock("../plugins/install.js", () => ({
+  installPluginFromPath: (...args: unknown[]) => installPluginFromPath(...args),
+  installPluginFromNpmSpec: (...args: unknown[]) => installPluginFromNpmSpec(...args),
+}));
+
+const clearPluginDiscoveryCache = vi.fn();
+vi.mock("../plugins/discovery.js", () => ({
+  clearPluginDiscoveryCache: () => clearPluginDiscoveryCache(),
+}));
+
+const clearPluginManifestRegistryCache = vi.fn();
+vi.mock("../plugins/manifest-registry.js", () => ({
+  clearPluginManifestRegistryCache: () => clearPluginManifestRegistryCache(),
+}));
+
+const buildPluginStatusReport = vi.fn();
+vi.mock("../plugins/status.js", () => ({
+  buildPluginStatusReport: (...args: unknown[]) => buildPluginStatusReport(...args),
+}));
+
+const applyExclusiveSlotSelection = vi.fn();
+vi.mock("../plugins/slots.js", () => ({
+  applyExclusiveSlotSelection: (...args: unknown[]) => applyExclusiveSlotSelection(...args),
+}));
+
+const findBundledPluginSource = vi.fn();
+vi.mock("../plugins/bundled-sources.js", () => ({
+  findBundledPluginSource: (...args: unknown[]) => findBundledPluginSource(...args),
+}));
+
+const resolvePinnedNpmInstallRecordForCli = vi.fn();
+vi.mock("./npm-resolution.js", () => ({
+  resolvePinnedNpmInstallRecordForCli: (...args: unknown[]) =>
+    resolvePinnedNpmInstallRecordForCli(...args),
+}));
+
+const defaultRuntime = {
+  error: vi.fn(),
+  exit: vi.fn(),
+  log: vi.fn(),
+};
+vi.mock("../runtime.js", () => ({
+  defaultRuntime,
+}));
+
+describe("plugins cli install cache invalidation", () => {
+  let registerPluginsCli: (typeof import("./plugins-cli.js"))["registerPluginsCli"];
+
+  beforeAll(async () => {
+    ({ registerPluginsCli } = await import("./plugins-cli.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadConfig.mockReturnValue({
+      plugins: {
+        allow: ["telegram"],
+      },
+    });
+    buildPluginStatusReport.mockReturnValue({
+      diagnostics: [],
+      plugins: [{ id: "repro-openclaw-plugin", kind: undefined }],
+      workspaceDir: "/tmp/workspace",
+    });
+    applyExclusiveSlotSelection.mockImplementation(({ config }: { config: unknown }) => ({
+      config,
+      warnings: [],
+    }));
+    findBundledPluginSource.mockReturnValue(undefined);
+    resolvePinnedNpmInstallRecordForCli.mockReturnValue({
+      installPath: "/tmp/state/extensions/repro-openclaw-plugin",
+      source: "npm",
+      spec: "repro-openclaw-plugin",
+      version: "1.0.0",
+    });
+    writeConfigFile.mockImplementation(async () => {
+      if (clearPluginDiscoveryCache.mock.calls.length === 0) {
+        throw new Error(
+          "Config validation failed: plugins.allow: plugin not found: repro-openclaw-plugin",
+        );
+      }
+    });
+  });
+
+  it("clears discovery cache before writing config for local plugin installs", async () => {
+    const pluginPath = path.resolve("/tmp/repro-openclaw-plugin");
+    vi.mocked(fs.existsSync).mockImplementation(
+      (candidate) => path.resolve(String(candidate)) === pluginPath,
+    );
+    installPluginFromPath.mockResolvedValue({
+      ok: true,
+      pluginId: "repro-openclaw-plugin",
+      targetDir: "/tmp/state/extensions/repro-openclaw-plugin",
+      version: "1.0.0",
+    });
+
+    await runRegisteredCli({
+      register: registerPluginsCli,
+      argv: ["plugins", "install", pluginPath],
+    });
+
+    expect(clearPluginManifestRegistryCache).toHaveBeenCalledTimes(1);
+    expect(clearPluginDiscoveryCache).toHaveBeenCalledTimes(1);
+    expect(clearPluginDiscoveryCache.mock.invocationCallOrder[0]).toBeLessThan(
+      writeConfigFile.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: expect.objectContaining({
+          allow: expect.arrayContaining(["telegram", "repro-openclaw-plugin"]),
+          entries: expect.objectContaining({
+            "repro-openclaw-plugin": expect.objectContaining({ enabled: true }),
+          }),
+          installs: expect.objectContaining({
+            "repro-openclaw-plugin": expect.objectContaining({
+              installPath: "/tmp/state/extensions/repro-openclaw-plugin",
+              source: "path",
+              sourcePath: pluginPath,
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("clears discovery cache before writing config for npm plugin installs", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: true,
+      npmResolution: {
+        integrity: "sha512-demo",
+        resolvedName: "repro-openclaw-plugin",
+        resolvedSpec: "repro-openclaw-plugin@1.0.0",
+        resolvedVersion: "1.0.0",
+        shasum: "deadbeef",
+      },
+      pluginId: "repro-openclaw-plugin",
+      targetDir: "/tmp/state/extensions/repro-openclaw-plugin",
+      version: "1.0.0",
+    });
+
+    await runRegisteredCli({
+      register: registerPluginsCli,
+      argv: ["plugins", "install", "repro-openclaw-plugin"],
+    });
+
+    expect(clearPluginManifestRegistryCache).toHaveBeenCalledTimes(1);
+    expect(clearPluginDiscoveryCache).toHaveBeenCalledTimes(1);
+    expect(clearPluginDiscoveryCache.mock.invocationCallOrder[0]).toBeLessThan(
+      writeConfigFile.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: expect.objectContaining({
+          allow: expect.arrayContaining(["telegram", "repro-openclaw-plugin"]),
+          entries: expect.objectContaining({
+            "repro-openclaw-plugin": expect.objectContaining({ enabled: true }),
+          }),
+          installs: expect.objectContaining({
+            "repro-openclaw-plugin": expect.objectContaining({
+              installPath: "/tmp/state/extensions/repro-openclaw-plugin",
+              source: "npm",
+              spec: "repro-openclaw-plugin",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -7,6 +7,7 @@ import { loadConfig, writeConfigFile } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { type BundledPluginSource, findBundledPluginSource } from "../plugins/bundled-sources.js";
+import { clearPluginDiscoveryCache } from "../plugins/discovery.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
 import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
 import { recordPluginInstall } from "../plugins/installs.js";
@@ -260,6 +261,7 @@ async function runPluginInstallCommand(params: {
     // Plugin CLI registrars may have warmed the manifest registry cache before install;
     // force a rescan so config validation sees the freshly installed plugin.
     clearPluginManifestRegistryCache();
+    clearPluginDiscoveryCache();
 
     let next = enablePluginInConfig(cfg, result.pluginId).config;
     const source: "archive" | "path" = resolveArchiveKind(resolved) ? "archive" : "path";
@@ -339,6 +341,7 @@ async function runPluginInstallCommand(params: {
   }
   // Ensure config validation sees newly installed plugin(s) even if the cache was warmed at startup.
   clearPluginManifestRegistryCache();
+  clearPluginDiscoveryCache();
 
   let next = enablePluginInConfig(cfg, result.pluginId).config;
   const installRecord = resolvePinnedNpmInstallRecordForCli(

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1,9 +1,15 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { clearPluginDiscoveryCache } from "../plugins/discovery.js";
 import { clearPluginManifestRegistryCache } from "../plugins/manifest-registry.js";
-import { validateConfigObjectWithPlugins } from "./config.js";
+import { validateConfigObjectWithPlugins } from "./validation.js";
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: vi.fn(),
+  getOAuthProviders: vi.fn(() => []),
+}));
 
 async function writePluginFixture(params: {
   dir: string;
@@ -39,6 +45,7 @@ describe("config plugin validation", () => {
   let bluebubblesPluginDir = "";
   let voiceCallSchemaPluginDir = "";
   const envSnapshot = {
+    OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS: process.env.OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS,
     OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
     OPENCLAW_PLUGIN_MANIFEST_CACHE_MS: process.env.OPENCLAW_PLUGIN_MANIFEST_CACHE_MS,
   };
@@ -103,7 +110,9 @@ describe("config plugin validation", () => {
       schema: voiceCallManifest.configSchema,
     });
     process.env.OPENCLAW_STATE_DIR = path.join(suiteHome, ".openclaw");
+    process.env.OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS = "10000";
     process.env.OPENCLAW_PLUGIN_MANIFEST_CACHE_MS = "10000";
+    clearPluginDiscoveryCache();
     clearPluginManifestRegistryCache();
     // Warm the plugin manifest cache once so path-based validations can reuse
     // parsed manifests across test cases.
@@ -117,7 +126,14 @@ describe("config plugin validation", () => {
 
   afterAll(async () => {
     await fs.rm(fixtureRoot, { recursive: true, force: true });
+    clearPluginDiscoveryCache();
     clearPluginManifestRegistryCache();
+    if (envSnapshot.OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS === undefined) {
+      delete process.env.OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS;
+    } else {
+      process.env.OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS =
+        envSnapshot.OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS;
+    }
     if (envSnapshot.OPENCLAW_STATE_DIR === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
     } else {
@@ -205,6 +221,72 @@ describe("config plugin validation", () => {
         ]),
       );
     }
+  });
+
+  it("requires clearing discovery cache before a newly installed local plugin can satisfy plugins.allow", async () => {
+    const installedPluginDir = path.join(
+      process.env.OPENCLAW_STATE_DIR ?? "",
+      "extensions",
+      "repro-openclaw-plugin",
+    );
+    await fs.rm(installedPluginDir, { force: true, recursive: true });
+    clearPluginDiscoveryCache();
+    clearPluginManifestRegistryCache();
+
+    const baseConfig = {
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        allow: ["telegram"],
+      },
+    };
+    const warmed = validateInSuite(baseConfig);
+    expect(warmed.ok).toBe(true);
+
+    await writePluginFixture({
+      dir: installedPluginDir,
+      id: "repro-openclaw-plugin",
+      schema: { type: "object", additionalProperties: false, properties: {} },
+    });
+    await fs.writeFile(
+      path.join(installedPluginDir, "package.json"),
+      JSON.stringify({
+        name: "repro-openclaw-plugin",
+        version: "1.0.0",
+        openclaw: {
+          extensions: ["./index.js"],
+        },
+      }),
+      "utf-8",
+    );
+    clearPluginManifestRegistryCache();
+
+    const nextConfig = {
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        allow: ["telegram", "repro-openclaw-plugin"],
+        entries: {
+          "repro-openclaw-plugin": { enabled: true },
+        },
+      },
+    };
+
+    const stale = validateInSuite(nextConfig);
+    expect(stale.ok).toBe(false);
+    if (!stale.ok) {
+      expect(stale.issues).toContainEqual({
+        path: "plugins.allow",
+        message: "plugin not found: repro-openclaw-plugin",
+      });
+    }
+
+    clearPluginDiscoveryCache();
+    clearPluginManifestRegistryCache();
+    const refreshed = validateInSuite(nextConfig);
+    expect(refreshed.ok).toBe(true);
+
+    await fs.rm(installedPluginDir, { force: true, recursive: true });
+    clearPluginDiscoveryCache();
+    clearPluginManifestRegistryCache();
   });
 
   it("surfaces plugin config diagnostics", async () => {


### PR DESCRIPTION
## Summary

- Problem: `plugins install <local-path>` can fail with `plugins.allow: plugin not found: <id>` when `plugins.allow` already exists, even though the plugin files were copied into the profile `extensions/` directory.
- Why it matters: the install aborts after mutating disk state, so users end up with copied plugin files but no matching config update.
- What changed: `plugins install` now clears both plugin manifest and plugin discovery caches before validating/writing config for copied installs, and regression tests cover the stale-cache validation path plus the CLI install flow.
- What did NOT change (scope boundary): no changes to plugin discovery rules, allowlist semantics, linked local path installs, or uninstall/update behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41229
- Related #27766

## User-visible / Behavior Changes

- `openclaw plugins install <local-path>` no longer fails on config validation just because `plugins.allow` already contains other valid plugin ids.
- npm installs through the same CLI path also refresh plugin discovery before config validation.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3 (local verification), issue report reproduces on Windows
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): plugin install CLI
- Relevant config (redacted): `plugins.allow: ["telegram"]`

### Steps

1. Prewarm plugin discovery with a config that already has `plugins.allow` set.
2. Copy/install a local plugin into the profile `extensions/` directory.
3. Enable it in config and validate/write immediately.

### Expected

- The newly installed plugin is discoverable during config validation, so `plugins.allow` passes and install completes.

### Actual

- Without clearing plugin discovery cache, validation can still see the pre-install registry snapshot and fail with `plugins.allow: plugin not found: <id>`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted verification I ran locally:

- `pnpm exec vitest run src/config/config.plugin-validation.test.ts src/cli/plugins-cli.install-cache.test.ts src/commands/onboarding/plugin-install.test.ts src/plugins/install.test.ts`
- `git diff --check`

Repo-wide commands requested in `CONTRIBUTING.md` are currently red on latest upstream `main` for unrelated untouched files:

- `pnpm build` fails in `src/agents/*` / `src/commands/openai-codex-oauth.ts` due existing type/module errors around `@mariozechner/pi-ai/oauth` and stream callback signatures.
- `pnpm check` fails on upstream formatting drift in `CONTRIBUTING.md`.
- `pnpm test` fails on the same untouched OAuth import issue plus unrelated `src/slack/monitor/slash.test.ts` regressions.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: local plugin install with existing allowlist, npm plugin install path clearing the same caches, stale validation reproducer for a newly installed plugin under the profile `extensions/` directory.
- Edge cases checked: install still writes the expected `plugins.entries`/`plugins.installs` config fields; cache refresh happens before `writeConfigFile`; no changes to `--link` path semantics.
- What you did **not** verify: real Windows CLI execution; end-to-end GitHub Actions green run, because latest upstream `main` is already red in unrelated areas listed above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove the added discovery-cache clears in `src/cli/plugins-cli.ts`.
- Files/config to restore: `src/cli/plugins-cli.ts`
- Known bad symptoms reviewers should watch for: none expected beyond the original install validation failure returning.

## Risks and Mitigations

- Risk: clearing discovery cache could cause an extra plugin directory rescan on install.
  - Mitigation: the cache clear is scoped to successful install paths immediately before config validation/write, not general plugin loading.

AI-assisted: yes
Testing degree: targeted + adjacent tests run locally; repo-wide gates checked and currently blocked by unrelated upstream failures.
Prompt/session summary: investigated fresh issue #41229 on latest `origin/main`, reproduced the stale discovery-cache validation path in tests, added CLI regression coverage, and fixed the install flow by clearing discovery cache alongside manifest cache before config validation.
