### PR TITLE
fix(config): filter empty values in raw redaction

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12263,49 +12263,49 @@
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "8e22880b4e96bab354e1da6c91d2f58dabde3555",
         "is_verified": false,
-        "line_number": 397
+        "line_number": 417
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "8e22880b4e96bab354e1da6c91d2f58dabde3555",
         "is_verified": false,
-        "line_number": 397
+        "line_number": 417
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "a9c732e05044a08c760cce7f6d142cd0d35a19e5",
         "is_verified": false,
-        "line_number": 455
+        "line_number": 475
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "50843dd5651cfafbe7c5611c1eed195c63e6e3fd",
         "is_verified": false,
-        "line_number": 771
+        "line_number": 791
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "927e7cdedcb8f71af399a49fb90a381df8b8df28",
         "is_verified": false,
-        "line_number": 1007
+        "line_number": 1027
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "1996cc327bd39dad69cd8feb24250dafd51e7c08",
         "is_verified": false,
-        "line_number": 1013
+        "line_number": 1033
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "a5c0a65a4fa8874a486aa5072671927ceba82a90",
         "is_verified": false,
-        "line_number": 1037
+        "line_number": 1057
       }
     ],
     "src/config/schema.help.ts": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ Welcome to the lobster tank! 🦞
 
 - **Robin Waslander** - Security, PR triage, bug fixes
   - GitHub: [@hydro13](https://github.com/hydro13) · X: [@Robin_waslander](https://x.com/Robin_waslander)
+
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,6 @@ Welcome to the lobster tank! 🦞
 
 - **Robin Waslander** - Security, PR triage, bug fixes
   - GitHub: [@hydro13](https://github.com/hydro13) · X: [@Robin_waslander](https://x.com/Robin_waslander)
-
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!

--- a/src/config/redact-snapshot.raw.test.ts
+++ b/src/config/redact-snapshot.raw.test.ts
@@ -7,7 +7,7 @@ describe("replaceSensitiveValuesInRaw", () => {
       channels: {
         qzone: { cookie: "" },
         youtube: { oauthClientSecret: "" },
-        discourse: { apiKey: "top-secret-value" },
+        discourse: { apiKey: "top-secret-value" }, // pragma: allowlist secret
       },
     });
 

--- a/src/config/redact-snapshot.raw.test.ts
+++ b/src/config/redact-snapshot.raw.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { replaceSensitiveValuesInRaw } from "./redact-snapshot.raw.js";
+
+describe("replaceSensitiveValuesInRaw", () => {
+  it("ignores empty sensitive values so raw redaction does not explode", () => {
+    const raw = JSON.stringify({
+      channels: {
+        qzone: { cookie: "" },
+        youtube: { oauthClientSecret: "" },
+        discourse: { apiKey: "top-secret-value" },
+      },
+    });
+
+    const result = replaceSensitiveValuesInRaw({
+      raw,
+      sensitiveValues: ["", "", "top-secret-value"],
+      redactedSentinel: "__OPENCLAW_REDACTED__",
+    });
+
+    expect(result).toContain('"cookie":""');
+    expect(result).toContain('"oauthClientSecret":""');
+    expect(result).not.toContain("top-secret-value");
+    expect(result).toContain("__OPENCLAW_REDACTED__");
+    expect(result.length).toBeLessThan(raw.length * 3);
+  });
+
+  it("deduplicates repeated non-empty secrets before replaceAll", () => {
+    const raw = '{"a":"same-secret","b":"same-secret"}';
+    const result = replaceSensitiveValuesInRaw({
+      raw,
+      sensitiveValues: ["same-secret", "same-secret"],
+      redactedSentinel: "__OPENCLAW_REDACTED__",
+    });
+
+    expect(result).toBe('{"a":"__OPENCLAW_REDACTED__","b":"__OPENCLAW_REDACTED__"}');
+  });
+});

--- a/src/config/redact-snapshot.raw.ts
+++ b/src/config/redact-snapshot.raw.ts
@@ -6,7 +6,13 @@ export function replaceSensitiveValuesInRaw(params: {
   sensitiveValues: string[];
   redactedSentinel: string;
 }): string {
-  const values = [...params.sensitiveValues].toSorted((a, b) => b.length - a.length);
+  // Empty strings carry no redaction information, but String#replaceAll("", x)
+  // inserts the replacement between every character and can blow up the raw
+  // config payload into an invalid-length string. Deduplicate while filtering
+  // them out so repeated empty/duplicate secrets stay cheap and safe.
+  const values = [...new Set(params.sensitiveValues.filter((value) => value.length > 0))].toSorted(
+    (a, b) => b.length - a.length,
+  );
   let result = params.raw;
   for (const value of values) {
     result = result.replaceAll(value, params.redactedSentinel);

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -251,18 +251,19 @@ describe("redactConfigSnapshot", () => {
       channels: {
         qzone: { cookie: "" },
         youtube: { oauthClientSecret: "" },
-        discourse: { apiKey: "abcdef1234567890ghij" },
+        discourse: { apiKey: "abcdef1234567890ghij" }, // pragma: allowlist secret
       },
     };
     const snapshot = makeSnapshot(config, JSON5.stringify(config));
 
     const result = redactConfigSnapshot(snapshot, mainSchemaHints);
+    const redactedRaw = result.raw ?? "";
 
-    expect(result.raw).not.toContain("abcdef1234567890ghij");
-    expect(result.raw).toContain(REDACTED_SENTINEL);
-    expect(result.raw).toContain("cookie:''");
-    expect(result.raw).toContain("oauthClientSecret:''");
-    expect(result.raw.length).toBeLessThan((snapshot.raw?.length ?? 0) * 3);
+    expect(redactedRaw).not.toContain("abcdef1234567890ghij");
+    expect(redactedRaw).toContain(REDACTED_SENTINEL);
+    expect(redactedRaw).toContain("cookie:''");
+    expect(redactedRaw).toContain("oauthClientSecret:''");
+    expect(redactedRaw.length).toBeLessThan((snapshot.raw?.length ?? 0) * 3);
   });
 
   it("redacts secrets in raw field via text-based redaction", () => {

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -246,6 +246,25 @@ describe("redactConfigSnapshot", () => {
     expect(result.hash).toBe("abc123");
   });
 
+  it("keeps config.get redaction stable when sensitive fields are empty strings", () => {
+    const config = {
+      channels: {
+        qzone: { cookie: "" },
+        youtube: { oauthClientSecret: "" },
+        discourse: { apiKey: "abcdef1234567890ghij" },
+      },
+    };
+    const snapshot = makeSnapshot(config, JSON5.stringify(config));
+
+    const result = redactConfigSnapshot(snapshot, mainSchemaHints);
+
+    expect(result.raw).not.toContain("abcdef1234567890ghij");
+    expect(result.raw).toContain(REDACTED_SENTINEL);
+    expect(result.raw).toContain("cookie:''");
+    expect(result.raw).toContain("oauthClientSecret:''");
+    expect(result.raw.length).toBeLessThan((snapshot.raw?.length ?? 0) * 3);
+  });
+
   it("redacts secrets in raw field via text-based redaction", () => {
     const config = { token: "abcdef1234567890ghij" };
     const raw = '{ "token": "abcdef1234567890ghij" }';


### PR DESCRIPTION
## Summary

This fixes a `config.get` failure caused by empty sensitive config values during raw-text redaction.

When `collectSensitiveValues(...)` includes `""`, the raw redaction pass eventually does:

```ts
raw.replaceAll('', REDACTED_SENTINEL)
```

That inserts the sentinel between every character, inflates the raw config payload dramatically, and can throw `RangeError: Invalid string length`.

## User-visible impact

This is not limited to the Agents page.

In my local reproduction on macOS, the failure showed up as a broader Control UI configuration outage during a live migration/debugging session:

- the QQ / QZone plugin config UI could not load or save updated `wsUrl` values
- a Discourse multi-site configuration looked missing in the UI even though it existed on disk
- the dashboard showed `GatewayRequestError: RangeError: Invalid string length`
- `openclaw gateway call config.get --params '{}'` failed consistently until the patch was applied

So a single empty sensitive field can make unrelated configuration surfaces look broken because the shared `config.get` RPC never returns.

## Root cause

`replaceSensitiveValuesInRaw(...)` iterates every collected sensitive value and calls `replaceAll` on the raw JSON5 text.

Empty strings are not useful redaction tokens, but JavaScript treats `replaceAll('', value)` specially by inserting `value` between every character (and at both ends). With a non-trivial config file, that can exceed Node's max string length.

## Fix

- filter out empty sensitive values before the raw replacement loop
- deduplicate the remaining values so repeated secrets do not trigger redundant replacements
- keep the existing longest-first replacement order unchanged

## Tests

Added regression coverage for both layers:

- `src/config/redact-snapshot.raw.test.ts`
  - ignores empty sensitive values without exploding the raw payload
  - deduplicates repeated non-empty sensitive values
- `src/config/redact-snapshot.test.ts`
  - verifies the full `redactConfigSnapshot(...)` path stays stable with empty sensitive fields from realistic channel config paths (`channels.qzone.cookie`, `channels.youtube.oauthClientSecret`) while still redacting a real secret

## Verification

```bash
pnpm exec vitest run src/config/redact-snapshot.raw.test.ts src/config/redact-snapshot.test.ts
pnpm exec oxfmt --check src/config/redact-snapshot.raw.ts src/config/redact-snapshot.raw.test.ts src/config/redact-snapshot.test.ts
pnpm exec oxlint src/config/redact-snapshot.raw.ts src/config/redact-snapshot.raw.test.ts src/config/redact-snapshot.test.ts
```

## Related

- #40818
- #22902

Fixes #41247
