### PR TITLE
fix: use updateSessionStore for heartbeat dedupe to prevent race

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -31,7 +31,6 @@ import {
   resolveAgentMainSessionKey,
   resolveSessionFilePath,
   resolveStorePath,
-  saveSessionStore,
   updateSessionStore,
 } from "../config/sessions.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
@@ -961,16 +960,16 @@ export async function runHeartbeatOnce(opts: {
 
     // Record last delivered heartbeat payload for dedupe.
     if (!shouldSkipMain && normalized.text.trim()) {
-      const store = loadSessionStore(storePath);
-      const current = store[sessionKey];
-      if (current) {
-        store[sessionKey] = {
-          ...current,
-          lastHeartbeatText: normalized.text,
-          lastHeartbeatSentAt: startedAt,
-        };
-        await saveSessionStore(storePath, store);
-      }
+      await updateSessionStore(storePath, (store) => {
+        const current = store[sessionKey];
+        if (current) {
+          store[sessionKey] = {
+            ...current,
+            lastHeartbeatText: normalized.text,
+            lastHeartbeatSentAt: startedAt,
+          };
+        }
+      });
     }
 
     emitHeartbeatEvent({


### PR DESCRIPTION
## Summary

The heartbeat dedupe write in `runHeartbeatOnce` (`src/infra/heartbeat-runner.ts:963`) uses a raw `loadSessionStore` / `saveSessionStore` pair without holding the session store lock. If an inbound message (or any other concurrent writer) modifies the store between the read and write, the heartbeat overwrites it with a stale snapshot, silently dropping the update.

This is a classic TOCTOU (time-of-check-time-of-use) race. The same file already uses `updateSessionStore` correctly at line 363 for `updatedAt` writes — this change applies the same pattern to the dedupe write.

## What changed

Replaced the manual `loadSessionStore` → mutate → `saveSessionStore` sequence with `updateSessionStore`, which re-reads inside the lock (as its own doc comment says: "Always re-read inside the lock to avoid clobbering concurrent writers"). Also removed the now-unused `saveSessionStore` import.

## Test plan

- [ ] Existing heartbeat tests still pass
- [ ] Verify heartbeat dedupe still works (send duplicate heartbeat content, confirm second is skipped)
- [ ] Under concurrent load, session store entries are no longer clobbered by heartbeat writes