### PR TITLE
fix: prefer sessionKey over label in sessions_send instead of rejecting both

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -63,14 +63,10 @@ export function createSessionsSendTool(opts?: {
       const sessionKeyParam = readStringParam(params, "sessionKey");
       const labelParam = readStringParam(params, "label")?.trim() || undefined;
       const labelAgentIdParam = readStringParam(params, "agentId")?.trim() || undefined;
-      if (sessionKeyParam && labelParam) {
-        return jsonResult({
-          runId: crypto.randomUUID(),
-          status: "error",
-          error: "Provide either sessionKey or label (not both).",
-        });
-      }
 
+      // When both sessionKey and label are provided, prefer sessionKey.
+      // LLMs frequently supply both optional params; rejecting that just
+      // causes unnecessary tool-call failures.
       let sessionKey = sessionKeyParam;
       if (!sessionKey && labelParam) {
         const requesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);


### PR DESCRIPTION
## Summary

Fixes #41199 (sessions_send portion).

When an LLM calls `sessions_send` with both `sessionKey` and `label` parameters, the tool currently returns an error: *"Provide either sessionKey or label (not both)."* This breaks agent-to-agent communication because LLMs consistently fill both optional parameters — confirmed across GPT, Kimi, and DeepSeek models.

## What changed

Instead of rejecting the call, prefer `sessionKey` when both are provided. The existing fallback logic at line 74 (`if (!sessionKey && labelParam)`) already handles the label-only path correctly, so when `sessionKey` is present, `labelParam` is naturally ignored.

This is the least invasive fix — strictly more permissive, no behavior change for single-param calls.

## Note on Issue 2 (message tool poll params)

Issue #41199 also describes a similar problem with the `message` tool rejecting `action: "send"` when poll parameters are present. That fix involves a different trade-off (silently ignoring poll params vs auto-switching action) and is better addressed in a separate PR after discussion.

## Test plan

- [ ] `sessions_send` with only `sessionKey` → works as before
- [ ] `sessions_send` with only `label` → works as before
- [ ] `sessions_send` with both `sessionKey` and `label` → uses `sessionKey`, no error
- [ ] Agent-to-agent communication works across multiple models