### PR TITLE
fix: unref drain poll timers to avoid blocking process exit

### DIFF
--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -317,7 +317,10 @@ export function waitForActiveTasks(timeoutMs: number): Promise<{ drained: boolea
         resolve({ drained: false });
         return;
       }
-      setTimeout(check, POLL_INTERVAL_MS);
+      const t = setTimeout(check, POLL_INTERVAL_MS);
+      if (typeof t === "object" && "unref" in t) {
+        t.unref();
+      }
     };
     check();
   });


### PR DESCRIPTION
## Summary

`waitForActiveTasks()` in `src/process/command-queue.ts` uses a recursive `setTimeout` chain (50ms interval) to poll for task completion during shutdown. These timers are not `unref()`'d, so they keep the Node.js event loop alive for up to the full timeout duration even after the process should have exited.

With a 10-second drain timeout, that's 200 unnecessary timer firings holding the process open.

## What changed

Added `.unref()` to the poll timer, using the same guard pattern already used in `channel-health-monitor.ts:191-193`:

```typescript
if (typeof t === "object" && "unref" in t) {
  t.unref();
}
```

## Test plan

- [ ] `waitForActiveTasks` still waits for active tasks to complete
- [ ] Process exits cleanly without being held by drain timers when all other work is done