### PR TITLE
fix: remove abort listener in health monitor stop() to prevent closure leak

### DIFF
--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -181,6 +181,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
       clearInterval(timer);
       timer = null;
     }
+    abortSignal?.removeEventListener("abort", stop);
   }
 
   if (abortSignal?.aborted) {


### PR DESCRIPTION
## Summary

`startChannelHealthMonitor` registers an abort signal listener (`{ once: true }`) that calls `stop()`. However, when `stop()` is called directly — during config reload (`createGatewayReloadHandlers`) or gateway shutdown — the listener is never removed.

The `stop` closure captures the entire monitor scope: `channelManager`, `restartRecords` Map, `timer`, logging references, and timing config. These stay alive until the `AbortSignal` is GC'd, which may be much later if the signal is a top-level process controller.

## What changed

Added `abortSignal?.removeEventListener("abort", stop)` inside `stop()`. The listener was registered with `{ once: true }`, so if abort fires first it auto-removes — but if `stop()` is called before abort, this line ensures cleanup. Both orderings are now safe.

## Test plan

- [ ] Health monitor still stops correctly on abort signal
- [ ] Health monitor still stops correctly on direct `stop()` call
- [ ] After stop(), the monitor closure is eligible for GC even if the abort signal lives on