### PR TITLE
fix(gateway): run before_reset hooks for sessions.reset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,6 @@ Welcome to the lobster tank! 🦞
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
   - GitHub [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
-    
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
   - GitHub [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
@@ -73,7 +72,7 @@ Welcome to the lobster tank! 🦞
 
 - **Robin Waslander** - Security, PR triage, bug fixes
   - GitHub: [@hydro13](https://github.com/hydro13) · X: [@Robin_waslander](https://x.com/Robin_waslander)
- 
+
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!

--- a/src/auto-reply/reply/commands-core.test.ts
+++ b/src/auto-reply/reply/commands-core.test.ts
@@ -40,7 +40,7 @@ describe("emitResetCommandHooks", () => {
       workspaceDir: "/tmp/openclaw-workspace",
     });
 
-    await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
+    expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1);
     const [, ctx] = hookRunnerMocks.runBeforeReset.mock.calls[0] ?? [];
     return ctx;
   }

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -1,9 +1,7 @@
-import fs from "node:fs/promises";
 import { resetAcpSessionInPlace } from "../../acp/persistent-bindings.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
-import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { isAcpSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { isAcpSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
 import { handleAcpCommand } from "./commands-acp.js";
@@ -39,6 +37,7 @@ import type {
   CommandHandlerResult,
   HandleCommandsParams,
 } from "./commands-types.js";
+import { emitBeforeResetPluginHook } from "./reset-hooks.js";
 import { routeReply } from "./route-reply.js";
 
 let HANDLERS: CommandHandler[] | null = null;
@@ -91,47 +90,12 @@ export async function emitResetCommandHooks(params: {
     }
   }
 
-  // Fire before_reset plugin hook — extract memories before session history is lost
-  const hookRunner = getGlobalHookRunner();
-  if (hookRunner?.hasHooks("before_reset")) {
-    const prevEntry = params.previousSessionEntry;
-    const sessionFile = prevEntry?.sessionFile;
-    // Fire-and-forget: read old session messages and run hook
-    void (async () => {
-      try {
-        const messages: unknown[] = [];
-        if (sessionFile) {
-          const content = await fs.readFile(sessionFile, "utf-8");
-          for (const line of content.split("\n")) {
-            if (!line.trim()) {
-              continue;
-            }
-            try {
-              const entry = JSON.parse(line);
-              if (entry.type === "message" && entry.message) {
-                messages.push(entry.message);
-              }
-            } catch {
-              // skip malformed lines
-            }
-          }
-        } else {
-          logVerbose("before_reset: no session file available, firing hook with empty messages");
-        }
-        await hookRunner.runBeforeReset(
-          { sessionFile, messages, reason: params.action },
-          {
-            agentId: resolveAgentIdFromSessionKey(params.sessionKey),
-            sessionKey: params.sessionKey,
-            sessionId: prevEntry?.sessionId,
-            workspaceDir: params.workspaceDir,
-          },
-        );
-      } catch (err: unknown) {
-        logVerbose(`before_reset hook failed: ${String(err)}`);
-      }
-    })();
-  }
+  emitBeforeResetPluginHook({
+    sessionKey: params.sessionKey,
+    previousSessionEntry: params.previousSessionEntry,
+    workspaceDir: params.workspaceDir,
+    reason: params.action,
+  });
 }
 
 function applyAcpResetTailContext(ctx: HandleCommandsParams["ctx"], resetTail: string): void {

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -90,7 +90,7 @@ export async function emitResetCommandHooks(params: {
     }
   }
 
-  emitBeforeResetPluginHook({
+  await emitBeforeResetPluginHook({
     sessionKey: params.sessionKey,
     previousSessionEntry: params.previousSessionEntry,
     workspaceDir: params.workspaceDir,

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -55,6 +55,7 @@ export async function emitResetCommandHooks(params: {
   sessionKey?: string;
   sessionEntry?: HandleCommandsParams["sessionEntry"];
   previousSessionEntry?: HandleCommandsParams["previousSessionEntry"];
+  storePath?: HandleCommandsParams["storePath"];
   workspaceDir: string;
 }): Promise<void> {
   const hookEvent = createInternalHookEvent("command", params.action, params.sessionKey ?? "", {
@@ -95,6 +96,7 @@ export async function emitResetCommandHooks(params: {
     previousSessionEntry: params.previousSessionEntry,
     workspaceDir: params.workspaceDir,
     reason: params.action,
+    storePath: params.storePath,
   });
 }
 
@@ -211,6 +213,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
           sessionKey: boundAcpKey,
           sessionEntry: hookSessionEntry,
           previousSessionEntry: hookPreviousSessionEntry,
+          storePath: params.storePath,
           workspaceDir: params.workspaceDir,
         });
         if (resetTail) {
@@ -250,6 +253,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       sessionKey: params.sessionKey,
       sessionEntry: params.sessionEntry,
       previousSessionEntry: params.previousSessionEntry,
+      storePath: params.storePath,
       workspaceDir: params.workspaceDir,
     });
   }

--- a/src/auto-reply/reply/reset-hooks.test.ts
+++ b/src/auto-reply/reply/reset-hooks.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HookRunner } from "../../plugins/hooks.js";
+
+const hookRunnerMocks = vi.hoisted(() => ({
+  hasHooks: vi.fn<HookRunner["hasHooks"]>(),
+  runBeforeReset: vi.fn<HookRunner["runBeforeReset"]>(),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () =>
+    ({
+      hasHooks: hookRunnerMocks.hasHooks,
+      runBeforeReset: hookRunnerMocks.runBeforeReset,
+    }) as unknown as HookRunner,
+}));
+
+const { emitBeforeResetPluginHook } = await import("./reset-hooks.js");
+
+describe("emitBeforeResetPluginHook", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-before-reset-"));
+    storePath = path.join(tempDir, "sessions.json");
+    hookRunnerMocks.hasHooks.mockReset();
+    hookRunnerMocks.runBeforeReset.mockReset();
+    hookRunnerMocks.hasHooks.mockImplementation((hookName) => hookName === "before_reset");
+    hookRunnerMocks.runBeforeReset.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("re-resolves transcript paths within the session store directory", async () => {
+    const transcriptPath = path.join(tempDir, "sess-main.jsonl");
+    await fs.writeFile(
+      transcriptPath,
+      `${JSON.stringify({ type: "message", message: { role: "user", content: "hello" } })}\n`,
+      "utf-8",
+    );
+    const resolvedTranscriptPath = await fs.realpath(transcriptPath).catch(() => transcriptPath);
+
+    await emitBeforeResetPluginHook({
+      sessionKey: "agent:main:main",
+      previousSessionEntry: {
+        sessionId: "sess-main",
+        sessionFile: "../../etc/passwd",
+      },
+      workspaceDir: "/tmp/openclaw-workspace",
+      reason: "new",
+      storePath,
+    });
+
+    expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: resolvedTranscriptPath,
+        messages: [{ role: "user", content: "hello" }],
+        reason: "new",
+      }),
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "sess-main",
+      }),
+    );
+  });
+
+  it("caps extracted transcript messages to a bounded maximum", async () => {
+    const transcriptPath = path.join(tempDir, "sess-cap.jsonl");
+    const lines = Array.from({ length: 1_050 }, (_, index) =>
+      JSON.stringify({ type: "message", message: { role: "user", content: `m-${index}` } }),
+    ).join("\n");
+    await fs.writeFile(transcriptPath, `${lines}\n`, "utf-8");
+
+    await emitBeforeResetPluginHook({
+      sessionKey: "agent:main:main",
+      previousSessionEntry: {
+        sessionId: "sess-cap",
+        sessionFile: "sess-cap.jsonl",
+      },
+      workspaceDir: "/tmp/openclaw-workspace",
+      reason: "reset",
+      storePath,
+    });
+
+    const [event] = hookRunnerMocks.runBeforeReset.mock.calls[0] ?? [];
+    const messages = event?.messages;
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages).toHaveLength(1_000);
+    expect(messages?.[0]).toEqual({ role: "user", content: "m-0" });
+    expect(messages?.at(-1)).toEqual({ role: "user", content: "m-999" });
+  });
+});

--- a/src/auto-reply/reply/reset-hooks.ts
+++ b/src/auto-reply/reply/reset-hooks.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs/promises";
+import { logVerbose } from "../../globals.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+
+type BeforeResetSessionEntry = {
+  sessionId?: string;
+  sessionFile?: string;
+} | null;
+
+export function emitBeforeResetPluginHook(params: {
+  sessionKey?: string;
+  previousSessionEntry?: BeforeResetSessionEntry;
+  workspaceDir: string;
+  reason: string;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("before_reset")) {
+    return;
+  }
+
+  const prevEntry = params.previousSessionEntry;
+  const sessionFile = prevEntry?.sessionFile;
+
+  // Fire-and-forget: read old session messages and run hook before reset mutates the store.
+  void (async () => {
+    try {
+      const messages: unknown[] = [];
+      if (sessionFile) {
+        const content = await fs.readFile(sessionFile, "utf-8");
+        for (const line of content.split("\n")) {
+          if (!line.trim()) {
+            continue;
+          }
+          try {
+            const entry = JSON.parse(line);
+            if (entry.type === "message" && entry.message) {
+              messages.push(entry.message);
+            }
+          } catch {
+            // Skip malformed transcript lines.
+          }
+        }
+      } else {
+        logVerbose("before_reset: no session file available, firing hook with empty messages");
+      }
+      await hookRunner.runBeforeReset(
+        { sessionFile, messages, reason: params.reason },
+        {
+          agentId: resolveAgentIdFromSessionKey(params.sessionKey),
+          sessionKey: params.sessionKey,
+          sessionId: prevEntry?.sessionId,
+          workspaceDir: params.workspaceDir,
+        },
+      );
+    } catch (err: unknown) {
+      logVerbose(`before_reset hook failed: ${String(err)}`);
+    }
+  })();
+}

--- a/src/auto-reply/reply/reset-hooks.ts
+++ b/src/auto-reply/reply/reset-hooks.ts
@@ -8,12 +8,12 @@ type BeforeResetSessionEntry = {
   sessionFile?: string;
 } | null;
 
-export function emitBeforeResetPluginHook(params: {
+export async function emitBeforeResetPluginHook(params: {
   sessionKey?: string;
   previousSessionEntry?: BeforeResetSessionEntry;
   workspaceDir: string;
   reason: string;
-}): void {
+}): Promise<void> {
   const hookRunner = getGlobalHookRunner();
   if (!hookRunner?.hasHooks("before_reset")) {
     return;
@@ -22,39 +22,36 @@ export function emitBeforeResetPluginHook(params: {
   const prevEntry = params.previousSessionEntry;
   const sessionFile = prevEntry?.sessionFile;
 
-  // Fire-and-forget: read old session messages and run hook before reset mutates the store.
-  void (async () => {
-    try {
-      const messages: unknown[] = [];
-      if (sessionFile) {
-        const content = await fs.readFile(sessionFile, "utf-8");
-        for (const line of content.split("\n")) {
-          if (!line.trim()) {
-            continue;
-          }
-          try {
-            const entry = JSON.parse(line);
-            if (entry.type === "message" && entry.message) {
-              messages.push(entry.message);
-            }
-          } catch {
-            // Skip malformed transcript lines.
-          }
+  try {
+    const messages: unknown[] = [];
+    if (sessionFile) {
+      const content = await fs.readFile(sessionFile, "utf-8");
+      for (const line of content.split("\n")) {
+        if (!line.trim()) {
+          continue;
         }
-      } else {
-        logVerbose("before_reset: no session file available, firing hook with empty messages");
+        try {
+          const entry = JSON.parse(line);
+          if (entry.type === "message" && entry.message) {
+            messages.push(entry.message);
+          }
+        } catch {
+          // Skip malformed transcript lines.
+        }
       }
-      await hookRunner.runBeforeReset(
-        { sessionFile, messages, reason: params.reason },
-        {
-          agentId: resolveAgentIdFromSessionKey(params.sessionKey),
-          sessionKey: params.sessionKey,
-          sessionId: prevEntry?.sessionId,
-          workspaceDir: params.workspaceDir,
-        },
-      );
-    } catch (err: unknown) {
-      logVerbose(`before_reset hook failed: ${String(err)}`);
+    } else {
+      logVerbose("before_reset: no session file available, firing hook with empty messages");
     }
-  })();
+    await hookRunner.runBeforeReset(
+      { sessionFile, messages, reason: params.reason },
+      {
+        agentId: resolveAgentIdFromSessionKey(params.sessionKey),
+        sessionKey: params.sessionKey,
+        sessionId: prevEntry?.sessionId,
+        workspaceDir: params.workspaceDir,
+      },
+    );
+  } catch (err: unknown) {
+    logVerbose(`before_reset hook failed: ${String(err)}`);
+  }
 }

--- a/src/auto-reply/reply/reset-hooks.ts
+++ b/src/auto-reply/reply/reset-hooks.ts
@@ -1,4 +1,7 @@
+import { createReadStream } from "node:fs";
 import fs from "node:fs/promises";
+import readline from "node:readline";
+import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
@@ -8,11 +11,68 @@ type BeforeResetSessionEntry = {
   sessionFile?: string;
 } | null;
 
+const MAX_BEFORE_RESET_TRANSCRIPT_BYTES = 2 * 1024 * 1024;
+const MAX_BEFORE_RESET_TRANSCRIPT_LINES = 10_000;
+const MAX_BEFORE_RESET_MESSAGES = 1_000;
+
+async function readBoundedBeforeResetMessages(sessionFile: string): Promise<unknown[]> {
+  const stat = await fs.stat(sessionFile);
+  if (stat.size > MAX_BEFORE_RESET_TRANSCRIPT_BYTES) {
+    logVerbose(
+      `before_reset: transcript exceeds ${MAX_BEFORE_RESET_TRANSCRIPT_BYTES} bytes; skipping message extraction`,
+    );
+    return [];
+  }
+
+  const messages: unknown[] = [];
+  let lineCount = 0;
+  let bytesRead = 0;
+  let truncated = false;
+  const stream = createReadStream(sessionFile, { encoding: "utf-8" });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  try {
+    for await (const line of rl) {
+      lineCount += 1;
+      bytesRead += Buffer.byteLength(line, "utf-8") + 1;
+      if (
+        lineCount > MAX_BEFORE_RESET_TRANSCRIPT_LINES ||
+        bytesRead > MAX_BEFORE_RESET_TRANSCRIPT_BYTES ||
+        messages.length >= MAX_BEFORE_RESET_MESSAGES
+      ) {
+        truncated = true;
+        break;
+      }
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type === "message" && entry.message) {
+          messages.push(entry.message);
+        }
+      } catch {
+        // Skip malformed transcript lines.
+      }
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+
+  if (truncated) {
+    logVerbose("before_reset: transcript parsing truncated to bounded limits");
+  }
+
+  return messages;
+}
+
 export async function emitBeforeResetPluginHook(params: {
   sessionKey?: string;
   previousSessionEntry?: BeforeResetSessionEntry;
   workspaceDir: string;
   reason: string;
+  storePath?: string;
 }): Promise<void> {
   const hookRunner = getGlobalHookRunner();
   if (!hookRunner?.hasHooks("before_reset")) {
@@ -20,34 +80,34 @@ export async function emitBeforeResetPluginHook(params: {
   }
 
   const prevEntry = params.previousSessionEntry;
-  const sessionFile = prevEntry?.sessionFile;
+  const sessionId = prevEntry?.sessionId;
+  const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+  const pathOpts = resolveSessionFilePathOptions({
+    agentId,
+    storePath: params.storePath,
+  });
+  let sessionFile: string | undefined;
 
   try {
-    const messages: unknown[] = [];
-    if (sessionFile) {
-      const content = await fs.readFile(sessionFile, "utf-8");
-      for (const line of content.split("\n")) {
-        if (!line.trim()) {
-          continue;
-        }
-        try {
-          const entry = JSON.parse(line);
-          if (entry.type === "message" && entry.message) {
-            messages.push(entry.message);
-          }
-        } catch {
-          // Skip malformed transcript lines.
-        }
+    let messages: unknown[] = [];
+    if (sessionId) {
+      sessionFile = resolveSessionFilePath(sessionId, prevEntry ?? undefined, pathOpts);
+      try {
+        messages = await readBoundedBeforeResetMessages(sessionFile);
+      } catch (err: unknown) {
+        logVerbose(`before_reset: failed reading transcript messages: ${String(err)}`);
       }
+    } else if (prevEntry?.sessionFile) {
+      logVerbose("before_reset: session file present without session id; skipping transcript read");
     } else {
       logVerbose("before_reset: no session file available, firing hook with empty messages");
     }
     await hookRunner.runBeforeReset(
       { sessionFile, messages, reason: params.reason },
       {
-        agentId: resolveAgentIdFromSessionKey(params.sessionKey),
+        agentId,
         sessionKey: params.sessionKey,
-        sessionId: prevEntry?.sessionId,
+        sessionId,
         workspaceDir: params.workspaceDir,
       },
     );

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -490,12 +490,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
     );
     await triggerInternalHook(hookEvent);
-    emitBeforeResetPluginHook({
-      sessionKey: target.canonicalKey ?? key,
-      previousSessionEntry: entry,
-      workspaceDir: resolveAgentWorkspaceDir(cfg, target.agentId),
-      reason: commandReason,
-    });
     const mutationCleanupError = await cleanupSessionBeforeMutation({
       cfg,
       key,
@@ -509,6 +503,12 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       respond(false, undefined, mutationCleanupError);
       return;
     }
+    await emitBeforeResetPluginHook({
+      sessionKey: target.canonicalKey ?? key,
+      previousSessionEntry: entry,
+      workspaceDir: resolveAgentWorkspaceDir(cfg, target.agentId),
+      reason: commandReason,
+    });
     let oldSessionId: string | undefined;
     let oldSessionFile: string | undefined;
     const next = await updateSessionStore(storePath, (store) => {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../../agents/bootstrap-cache.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue.js";
+import { emitBeforeResetPluginHook } from "../../auto-reply/reply/reset-hooks.js";
 import { closeTrackedBrowserTabsForSessions } from "../../browser/session-tab-registry.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -489,6 +490,12 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
     );
     await triggerInternalHook(hookEvent);
+    emitBeforeResetPluginHook({
+      sessionKey: target.canonicalKey ?? key,
+      previousSessionEntry: entry,
+      workspaceDir: resolveAgentWorkspaceDir(cfg, target.agentId),
+      reason: commandReason,
+    });
     const mutationCleanupError = await cleanupSessionBeforeMutation({
       cfg,
       key,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -508,6 +508,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       previousSessionEntry: entry,
       workspaceDir: resolveAgentWorkspaceDir(cfg, target.agentId),
       reason: commandReason,
+      storePath,
     });
     let oldSessionId: string | undefined;
     let oldSessionFile: string | undefined;

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1235,6 +1235,7 @@ describe("gateway server sessions", () => {
 
     embeddedRunMock.activeIds.add("sess-main");
     embeddedRunMock.waitResults.set("sess-main", false);
+    subagentLifecycleHookState.hasBeforeResetHook = true;
 
     const { ws } = await openClient();
 
@@ -1251,6 +1252,7 @@ describe("gateway server sessions", () => {
     );
     expect(waitCallCountAtSnapshotClear).toEqual([1]);
     expect(browserSessionTabMocks.closeTrackedBrowserTabsForSessions).not.toHaveBeenCalled();
+    expect(beforeResetHookMocks.runBeforeReset).not.toHaveBeenCalled();
 
     const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -37,6 +37,11 @@ const subagentLifecycleHookMocks = vi.hoisted(() => ({
 
 const subagentLifecycleHookState = vi.hoisted(() => ({
   hasSubagentEndedHook: true,
+  hasBeforeResetHook: false,
+}));
+
+const beforeResetHookMocks = vi.hoisted(() => ({
+  runBeforeReset: vi.fn(async () => {}),
 }));
 
 const threadBindingMocks = vi.hoisted(() => ({
@@ -96,8 +101,10 @@ vi.mock("../plugins/hook-runner-global.js", async (importOriginal) => {
     ...actual,
     getGlobalHookRunner: vi.fn(() => ({
       hasHooks: (hookName: string) =>
-        hookName === "subagent_ended" && subagentLifecycleHookState.hasSubagentEndedHook,
+        (hookName === "subagent_ended" && subagentLifecycleHookState.hasSubagentEndedHook) ||
+        (hookName === "before_reset" && subagentLifecycleHookState.hasBeforeResetHook),
       runSubagentEnded: subagentLifecycleHookMocks.runSubagentEnded,
+      runBeforeReset: beforeResetHookMocks.runBeforeReset,
     })),
   };
 });
@@ -220,6 +227,8 @@ describe("gateway server sessions", () => {
     sessionHookMocks.triggerInternalHook.mockClear();
     subagentLifecycleHookMocks.runSubagentEnded.mockClear();
     subagentLifecycleHookState.hasSubagentEndedHook = true;
+    subagentLifecycleHookState.hasBeforeResetHook = false;
+    beforeResetHookMocks.runBeforeReset.mockClear();
     threadBindingMocks.unbindThreadBindingsBySessionKey.mockClear();
     acpRuntimeMocks.cancel.mockClear();
     acpRuntimeMocks.close.mockClear();
@@ -1176,6 +1185,44 @@ describe("gateway server sessions", () => {
       },
     });
     expect(event.context?.previousSessionEntry).toMatchObject({ sessionId: "sess-main" });
+    ws.close();
+  });
+
+  test("sessions.reset runs before_reset plugin hooks with gateway session context", async () => {
+    const { dir } = await createSessionStoreDir();
+    await writeSingleLineSession(dir, "sess-main", "hello");
+
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          sessionFile: path.join(dir, "sess-main.jsonl"),
+          updatedAt: Date.now(),
+        },
+      },
+    });
+    subagentLifecycleHookState.hasBeforeResetHook = true;
+
+    const { ws } = await openClient();
+    const reset = await rpcReq<{ ok: true; key: string }>(ws, "sessions.reset", {
+      key: "main",
+      reason: "new",
+    });
+    expect(reset.ok).toBe(true);
+
+    await vi.waitFor(() => expect(beforeResetHookMocks.runBeforeReset).toHaveBeenCalledTimes(1));
+    expect(beforeResetHookMocks.runBeforeReset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: path.join(dir, "sess-main.jsonl"),
+        reason: "new",
+      }),
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "sess-main",
+      }),
+    );
+
     ws.close();
   });
 

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1191,6 +1191,9 @@ describe("gateway server sessions", () => {
   test("sessions.reset runs before_reset plugin hooks with gateway session context", async () => {
     const { dir } = await createSessionStoreDir();
     await writeSingleLineSession(dir, "sess-main", "hello");
+    const resolvedTranscriptPath = await fs
+      .realpath(path.join(dir, "sess-main.jsonl"))
+      .catch(() => path.join(dir, "sess-main.jsonl"));
 
     await writeSessionStore({
       entries: {
@@ -1213,7 +1216,7 @@ describe("gateway server sessions", () => {
     await vi.waitFor(() => expect(beforeResetHookMocks.runBeforeReset).toHaveBeenCalledTimes(1));
     expect(beforeResetHookMocks.runBeforeReset).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionFile: path.join(dir, "sess-main.jsonl"),
+        sessionFile: resolvedTranscriptPath,
         reason: "new",
       }),
       expect.objectContaining({

--- a/src/telegram/bot-native-commands.test.ts
+++ b/src/telegram/bot-native-commands.test.ts
@@ -270,4 +270,58 @@ describe("registerTelegramNativeCommands", () => {
     );
     expect(sendMessage).not.toHaveBeenCalledWith(123, "Command not found.");
   });
+
+  it("uses the DM thread session key for plugin command internal sent hooks", async () => {
+    const commandHandlers = new Map<string, (ctx: unknown) => Promise<void>>();
+
+    pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
+      {
+        name: "plug",
+        description: "Plugin command",
+      },
+    ] as never);
+    pluginCommandMocks.matchPluginCommand.mockReturnValue({
+      command: { key: "plug", requireAuth: false },
+      args: undefined,
+    } as never);
+
+    registerTelegramNativeCommands({
+      ...buildParams({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+          },
+        },
+      }),
+      bot: {
+        api: {
+          setMyCommands: vi.fn().mockResolvedValue(undefined),
+          sendMessage: vi.fn().mockResolvedValue(undefined),
+        },
+        command: vi.fn((name: string, cb: (ctx: unknown) => Promise<void>) => {
+          commandHandlers.set(name, cb);
+        }),
+      } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+    });
+
+    const handler = commandHandlers.get("plug");
+    expect(handler).toBeTruthy();
+
+    await handler?.({
+      match: "",
+      message: {
+        message_id: 42,
+        date: Math.floor(Date.now() / 1000),
+        chat: { id: 12345, type: "private" },
+        from: { id: 12345, username: "alice" },
+        message_thread_id: 99,
+      },
+    });
+
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKeyForInternalHooks: "agent:main:main:thread:12345:99",
+      }),
+    );
+  });
 });

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -540,6 +540,20 @@ export const registerTelegramNativeCommands = ({
     chunkMode: params.chunkMode,
     linkPreview: telegramCfg.linkPreview,
   });
+  const resolveDmThreadSessionKey = (params: {
+    baseSessionKey: string;
+    chatId: string | number;
+    threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
+  }): string => {
+    const dmThreadId = params.threadSpec.scope === "dm" ? params.threadSpec.id : undefined;
+    if (dmThreadId == null) {
+      return params.baseSessionKey;
+    }
+    return resolveThreadSessionKeys({
+      baseSessionKey: params.baseSessionKey,
+      threadId: `${params.chatId}:${dmThreadId}`,
+    }).sessionKey;
+  };
 
   if (commandsToRegister.length > 0 || pluginCatalog.commands.length > 0) {
     if (typeof (bot as unknown as { command?: unknown }).command !== "function") {
@@ -647,17 +661,11 @@ export const registerTelegramNativeCommands = ({
             });
             return;
           }
-          const baseSessionKey = route.sessionKey;
-          // DMs: use raw messageThreadId for thread sessions (not resolvedThreadId which is for forums)
-          const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
-          const threadKeys =
-            dmThreadId != null
-              ? resolveThreadSessionKeys({
-                  baseSessionKey,
-                  threadId: `${chatId}:${dmThreadId}`,
-                })
-              : null;
-          const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
+          const sessionKey = resolveDmThreadSessionKey({
+            baseSessionKey: route.sessionKey,
+            chatId,
+            threadSpec,
+          });
           const { skillFilter, groupSystemPrompt } = resolveTelegramGroupPromptSettings({
             groupConfig,
             topicConfig,
@@ -833,10 +841,15 @@ export const registerTelegramNativeCommands = ({
             return;
           }
           const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
+          const sessionKeyForInternalHooks = resolveDmThreadSessionKey({
+            baseSessionKey: route.sessionKey,
+            chatId,
+            threadSpec,
+          });
           const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
             chatId,
             accountId: route.accountId,
-            sessionKeyForInternalHooks: route.sessionKey,
+            sessionKeyForInternalHooks,
             mirrorIsGroup: isGroup,
             mirrorGroupId: isGroup ? String(chatId) : undefined,
             mediaLocalRoots,


### PR DESCRIPTION
## Summary

- Problem: chat-command resets already fired the typed plugin `before_reset` lifecycle, but gateway `sessions.reset` only emitted the legacy internal command hook.
- Why it matters: plugins observing reset/new events saw different behavior depending on whether a reset came from `/new` or from the gateway API.
- What changed: extracted the shared `before_reset` plugin dispatch into `src/auto-reply/reply/reset-hooks.ts`, reused it from `commands-core`, and invoked it from `sessions.reset` with the resolved gateway session workspace/context.
- What did NOT change (scope boundary): this does not unify the broader reset lifecycle or change internal command hook semantics beyond adding the missing plugin parity.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #30853

## User-visible / Behavior Changes

Gateway `sessions.reset` now fires the typed plugin `before_reset` hook with the same pre-reset session context as the chat-command reset path.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway sessions API
- Relevant config (redacted): none

### Steps

1. Seed a session with an existing transcript and enable a plugin `before_reset` hook.
2. Reset the session through `sessions.reset`.
3. Verify the plugin hook receives the prior session context before the session entry is replaced.

### Expected

- Gateway `sessions.reset` emits the same `before_reset` plugin lifecycle as the command reset path.

### Actual

- Verified with focused command reset and gateway sessions tests plus full `pnpm check`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: command reset still emits `before_reset`; gateway `sessions.reset` now emits it with session/workspace context; gateway reset suite remains green.
- Edge cases checked: `reason: new` is preserved; shared helper still handles missing session files by emitting an empty message list.
- What you did **not** verify: live plugin execution against a real gateway deployment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/auto-reply/reply/commands-core.ts`, `src/auto-reply/reply/reset-hooks.ts`, `src/gateway/server-methods/sessions.ts`, `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`.
- Known bad symptoms reviewers should watch for: gateway resets missing `before_reset` callbacks or firing them with the wrong session/workspace context.

## Risks and Mitigations

- Risk: the shared helper could drift between gateway and command callers if future reset behavior diverges.
  - Mitigation: both entrypoints now call the same helper, and tests cover both command and gateway reset paths.
