### PR TITLE
fix(cron): preserve silent NO_REPLY completions

### DIFF
--- a/src/agents/pi-embedded-runner.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.e2e.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import "./test-helpers/fast-coding-tools.js";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { OpenClawConfig } from "../config/config.js";
 
 function createMockUsage(input: number, output: number) {
@@ -33,7 +34,12 @@ vi.mock("@mariozechner/pi-ai", async () => {
 
   const buildAssistantMessage = (model: { api: string; provider: string; id: string }) => ({
     role: "assistant" as const,
-    content: [{ type: "text" as const, text: "ok" }],
+    content: [
+      {
+        type: "text" as const,
+        text: model.id === "mock-silent" ? SILENT_REPLY_TOKEN : "ok",
+      },
+    ],
     stopReason: "stop" as const,
     api: model.api,
     provider: model.provider,
@@ -287,5 +293,29 @@ describe("runEmbeddedPiAgent", () => {
 
     expect(result.meta.error).toBeUndefined();
     expect(result.payloads?.length ?? 0).toBeGreaterThan(0);
+    expect(result.silentReply).toBeUndefined();
+  });
+
+  it("marks exact NO_REPLY completions as silent without emitting payloads", async () => {
+    const sessionFile = nextSessionFile();
+    const cfg = makeOpenAiConfig(["mock-silent"]);
+    const sessionKey = nextSessionKey();
+    const result = await runEmbeddedPiAgent({
+      sessionId: "session:test",
+      sessionKey,
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "silence please",
+      provider: "openai",
+      model: "mock-silent",
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("silent-turn"),
+      enqueue: immediateEnqueue,
+    });
+
+    expect(result.payloads).toBeUndefined();
+    expect(result.silentReply).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -209,7 +209,11 @@ function resolveSilentReply(params: {
   payloadCount: number;
   stopReason?: string;
 }): boolean {
-  if (params.payloadCount > 0 || params.stopReason === "error") {
+  if (
+    params.payloadCount > 0 ||
+    params.stopReason === "error" ||
+    params.stopReason === "max_tokens"
+  ) {
     return false;
   }
   for (let idx = params.assistantTexts.length - 1; idx >= 0; idx -= 1) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import {
   ensureContextEnginesInitialized,
   resolveContextEngine,
@@ -202,6 +203,24 @@ const toNormalizedUsage = (usage: UsageAccumulator) => {
     total: lastPromptTokens + usage.output || undefined,
   };
 };
+
+function resolveSilentReply(params: {
+  assistantTexts: string[];
+  payloadCount: number;
+  stopReason?: string;
+}): boolean {
+  if (params.payloadCount > 0 || params.stopReason === "error") {
+    return false;
+  }
+  for (let idx = params.assistantTexts.length - 1; idx >= 0; idx -= 1) {
+    const text = params.assistantTexts[idx];
+    if (!text?.trim()) {
+      continue;
+    }
+    return isSilentReplyText(text, SILENT_REPLY_TOKEN);
+  }
+  return false;
+}
 
 function resolveActiveErrorContext(params: {
   lastAssistant: { provider?: string; model?: string } | undefined;
@@ -1418,6 +1437,11 @@ export async function runEmbeddedPiAgent(
             inlineToolResultsAllowed: false,
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
           });
+          const silentReply = resolveSilentReply({
+            assistantTexts: attempt.assistantTexts,
+            payloadCount: payloads.length,
+            stopReason: lastAssistant?.stopReason,
+          });
 
           // Timeout aborts can leave the run without any assistant payloads.
           // Emit an explicit timeout error instead of silently completing, so
@@ -1464,6 +1488,7 @@ export async function runEmbeddedPiAgent(
           }
           return {
             payloads: payloads.length ? payloads : undefined,
+            silentReply: silentReply || undefined,
             meta: {
               durationMs: Date.now() - started,
               agentMeta,

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -63,6 +63,9 @@ export type EmbeddedPiRunResult = {
     isError?: boolean;
   }>;
   meta: EmbeddedPiRunMeta;
+  // True when the run intentionally completed with an exact NO_REPLY token and
+  // therefore produced no user-facing payloads.
+  silentReply?: boolean;
   // True if a messaging tool (telegram, whatsapp, discord, slack, sessions_send)
   // successfully sent a message. Used to suppress agent's confirmation text.
   didSendViaMessagingTool?: boolean;

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -1,5 +1,6 @@
 import "./run.overflow-compaction.mocks.shared.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 
 const runtimePluginMocks = vi.hoisted(() => ({
   ensureRuntimePluginsLoaded: vi.fn(),
@@ -126,5 +127,60 @@ describe("runEmbeddedPiAgent usage reporting", () => {
     // Check if total matches the last turn's total (200)
     // If the bug exists, it will likely be 350
     expect(usage?.total).toBe(200);
+  });
+
+  it("flags exact NO_REPLY completions as silent when payloads are suppressed", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce({
+      aborted: false,
+      promptError: null,
+      timedOut: false,
+      sessionIdUsed: "test-session",
+      assistantTexts: [SILENT_REPLY_TOKEN],
+      lastAssistant: {
+        content: [{ type: "text", text: SILENT_REPLY_TOKEN }],
+        stopReason: "stop",
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const result = await runEmbeddedPiAgent({
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      sessionFile: "/tmp/session.json",
+      workspaceDir: "/tmp/workspace",
+      prompt: "hello",
+      timeoutMs: 30000,
+      runId: "run-silent-reply",
+    });
+
+    expect(result.payloads).toBeUndefined();
+    expect(result.silentReply).toBe(true);
+  });
+
+  it("does not flag mixed assistant text as silent", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce({
+      aborted: false,
+      promptError: null,
+      timedOut: false,
+      sessionIdUsed: "test-session",
+      assistantTexts: [`done ${SILENT_REPLY_TOKEN}`],
+      lastAssistant: {
+        content: [{ type: "text", text: `done ${SILENT_REPLY_TOKEN}` }],
+        stopReason: "stop",
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const result = await runEmbeddedPiAgent({
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      sessionFile: "/tmp/session.json",
+      workspaceDir: "/tmp/workspace",
+      prompt: "hello",
+      timeoutMs: 30000,
+      runId: "run-mixed-reply",
+    });
+
+    expect(result.silentReply).toBeUndefined();
   });
 });

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -183,4 +183,31 @@ describe("runEmbeddedPiAgent usage reporting", () => {
 
     expect(result.silentReply).toBeUndefined();
   });
+
+  it("does not flag NO_REPLY as silent when the run stopped at max_tokens", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce({
+      aborted: false,
+      promptError: null,
+      timedOut: false,
+      sessionIdUsed: "test-session",
+      assistantTexts: [SILENT_REPLY_TOKEN],
+      lastAssistant: {
+        content: [{ type: "text", text: SILENT_REPLY_TOKEN }],
+        stopReason: "max_tokens",
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const result = await runEmbeddedPiAgent({
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      sessionFile: "/tmp/session.json",
+      workspaceDir: "/tmp/workspace",
+      prompt: "hello",
+      timeoutMs: 30000,
+      runId: "run-max-tokens-no-reply",
+    });
+
+    expect(result.silentReply).toBeUndefined();
+  });
 });

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 
 // --- Module mocks (must be hoisted before imports) ---
 
@@ -253,6 +254,20 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.delivered).toBe(true);
 
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats synthesized NO_REPLY as an intentional delivered completion", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: SILENT_REPLY_TOKEN });
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result?.status).toBe("ok");
+    expect(state.result?.delivered).toBe(true);
+    expect(state.delivered).toBe(false);
+    expect(state.deliveryAttempted).toBe(false);
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
   it("no delivery requested means deliveryAttempted stays false and no delivery is sent", async () => {

--- a/src/cron/isolated-agent/run.interim-retry.test.ts
+++ b/src/cron/isolated-agent/run.interim-retry.test.ts
@@ -80,6 +80,18 @@ describe("runCronIsolatedAgentTurn — interim ack retry", () => {
     await runTurnAndExpectOk(1, 1);
   });
 
+  it("does not retry when the first turn completed silently with NO_REPLY", async () => {
+    usePayloadTextExtraction();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: undefined,
+      silentReply: true,
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    mockFallbackPassthrough();
+    await runTurnAndExpectOk(1, 1);
+  });
+
   it("does not retry when descendants were spawned in this run even if they already settled", async () => {
     usePayloadTextExtraction();
     runEmbeddedPiAgentMock.mockResolvedValueOnce({

--- a/src/cron/isolated-agent/run.silent-delivery.test.ts
+++ b/src/cron/isolated-agent/run.silent-delivery.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { resolveSilentCronDeliveryText } from "./run.js";
+
+describe("resolveSilentCronDeliveryText", () => {
+  it("synthesizes NO_REPLY for silent cron completions without other delivery text", () => {
+    expect(resolveSilentCronDeliveryText({ silentReply: true })).toBe(SILENT_REPLY_TOKEN);
+  });
+
+  it("does not synthesize NO_REPLY when a messaging tool already sent elsewhere", () => {
+    expect(
+      resolveSilentCronDeliveryText({
+        silentReply: true,
+        didSendViaMessagingTool: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not override an existing synthesized reply", () => {
+    expect(
+      resolveSilentCronDeliveryText({
+        silentReply: true,
+        synthesizedText: "already have text",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -53,6 +53,10 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
   resolveDefaultAgentId: vi.fn().mockReturnValue("default"),
   resolveAgentSkillsFilter: resolveAgentSkillsFilterMock,
+  resolveSessionAgentId: vi.fn().mockReturnValue("default"),
+  resolveSessionAgentIds: vi
+    .fn()
+    .mockReturnValue({ defaultAgentId: "default", sessionAgentId: "default" }),
 }));
 
 vi.mock("../../agents/skills.js", () => ({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -36,6 +36,7 @@ import {
   normalizeVerboseLevel,
   supportsXHighThinking,
 } from "../../auto-reply/thinking.js";
+import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
@@ -658,6 +659,7 @@ export async function runCronIsolatedAgentTurn(params: {
       const shouldRetryInterimAck =
         !interimRunResult.meta?.error &&
         !interimRunResult.didSendViaMessagingTool &&
+        !interimRunResult.silentReply &&
         !interimPayloadHasStructuredContent &&
         !interimPayloads.some((payload) => payload?.isError === true) &&
         countActiveDescendantRuns(agentSessionKey) === 0 &&
@@ -765,6 +767,10 @@ export async function runCronIsolatedAgentTurn(params: {
       : synthesizedText
         ? [{ text: synthesizedText }]
         : [];
+  if (finalRunResult.silentReply && !synthesizedText) {
+    synthesizedText = SILENT_REPLY_TOKEN;
+    deliveryPayloads = [{ text: SILENT_REPLY_TOKEN }];
+  }
   const deliveryPayloadHasStructuredContent =
     Boolean(deliveryPayload?.mediaUrl) ||
     (deliveryPayload?.mediaUrls?.length ?? 0) > 0 ||

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -191,6 +191,17 @@ function appendCronDeliveryInstruction(params: {
   return `${params.commandBody}\n\nReturn your summary as plain text; it will be delivered automatically. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`.trim();
 }
 
+export function resolveSilentCronDeliveryText(params: {
+  silentReply?: boolean;
+  synthesizedText?: string;
+  didSendViaMessagingTool?: boolean;
+}): string | undefined {
+  if (!params.silentReply || params.synthesizedText || params.didSendViaMessagingTool) {
+    return undefined;
+  }
+  return SILENT_REPLY_TOKEN;
+}
+
 export async function runCronIsolatedAgentTurn(params: {
   cfg: OpenClawConfig;
   deps: CliDeps;
@@ -767,9 +778,14 @@ export async function runCronIsolatedAgentTurn(params: {
       : synthesizedText
         ? [{ text: synthesizedText }]
         : [];
-  if (finalRunResult.silentReply && !synthesizedText) {
-    synthesizedText = SILENT_REPLY_TOKEN;
-    deliveryPayloads = [{ text: SILENT_REPLY_TOKEN }];
+  const silentCronDeliveryText = resolveSilentCronDeliveryText({
+    silentReply: finalRunResult.silentReply,
+    synthesizedText,
+    didSendViaMessagingTool: finalRunResult.didSendViaMessagingTool,
+  });
+  if (silentCronDeliveryText) {
+    synthesizedText = silentCronDeliveryText;
+    deliveryPayloads = [{ text: silentCronDeliveryText }];
   }
   const deliveryPayloadHasStructuredContent =
     Boolean(deliveryPayload?.mediaUrl) ||


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: isolated cron jobs can treat an intentional `NO_REPLY` completion as an interim acknowledgement and inject a second "complete the task now" prompt.
- Why it matters: that creates duplicate work, transcript noise, and false `not-delivered` state for cron jobs that are supposed to end silently.
- What changed: `runEmbeddedPiAgent()` now returns a narrow `silentReply` signal for exact final `NO_REPLY` completions with no payloads, isolated cron skips the retry when that signal is present, and cron delivery reuses the existing `NO_REPLY` silent-success path so delivery state stays correct.
- What did NOT change (scope boundary): this does not change general empty-output handling, interim-ack heuristics for real acknowledgements, or any non-exact `NO_REPLY` text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41246
- Related #40075

## User-visible / Behavior Changes

- Isolated cron jobs that intentionally finish with exact `NO_REPLY` no longer get a forced follow-up prompt.
- Delivery-requested cron jobs now treat those silent completions as intentional success instead of surfacing `not-delivered`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.x
- Runtime/container: local pnpm workspace
- Model/provider: mocked embedded runner + cron isolated agent suites
- Integration/channel (if any): isolated cron / Telegram-shaped delivery paths in tests
- Relevant config (redacted): none

### Steps

1. Configure an isolated cron job whose successful path ends with exact `NO_REPLY`.
2. Run the job under `2026.3.8` logic.
3. Observe the cron runner inject `Your previous response was only an acknowledgement...` and continue the run.

### Expected

- Exact `NO_REPLY` should end the run silently with no forced retry and no false `not-delivered` state.

### Actual

- The silent completion is stripped out of payloads, then misread as interim / empty and retried.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/cron/isolated-agent/run.interim-retry.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/agents/pi-embedded-runner/usage-reporting.test.ts`
  - `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-runner.e2e.test.ts`
  - `pnpm build`
  - `pnpm test` (`873` files passed, `7101` tests passed, `2` skipped)
  - `git diff --check`
- Edge cases checked:
  - mixed assistant text containing `NO_REPLY` is not classified as silent
  - silent cron completions still count as intentional delivery success
  - descendant/interim retry heuristics still apply to real acknowledgement text
- What you did **not** verify:
  - `pnpm check` is still failing on untouched upstream formatting drift in `CONTRIBUTING.md` on current `main`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `5bd09eb70`
- Files/config to restore: `src/agents/pi-embedded-runner/run.ts`, `src/cron/isolated-agent/run.ts`
- Known bad symptoms reviewers should watch for: legitimate empty non-`NO_REPLY` cron completions being treated as delivered

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: over-classifying silent completions could hide real empty-output failures.
  - Mitigation: the new signal only sets on exact final `NO_REPLY` when payload generation already produced nothing.
- Risk: cron delivery state could drift from retry classification.
  - Mitigation: the cron path now reuses the existing `NO_REPLY` silent-delivery handling, and both sides have dedicated regression coverage.

AI-assisted: Yes. Session summary: issue triage on latest `origin/main`, tests-first implementation, audit pass for delivery-state and default-test-gate coverage, then submission.
