### PR TITLE
feat(routing): support peer.id wildcard for kind-level route matching

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -852,3 +852,185 @@ describe("binding evaluation cache scalability", () => {
     }
   });
 });
+
+describe("peer.id wildcard (binding.peer.kind)", () => {
+  test("peer.id '*' matches any direct chat", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "dm-agent",
+          match: { channel: "feishu", peer: { kind: "direct", id: "*" } },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "direct", id: "user-123" },
+    });
+    expect(route.agentId).toBe("dm-agent");
+    expect(route.matchedBy).toBe("binding.peer.kind");
+  });
+
+  test("peer.id '*' matches any group chat", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "group-agent",
+          match: { channel: "feishu", peer: { kind: "group", id: "*" } },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "group", id: "group-456" },
+    });
+    expect(route.agentId).toBe("group-agent");
+    expect(route.matchedBy).toBe("binding.peer.kind");
+  });
+
+  test("exact peer.id takes priority over wildcard", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "wildcard-agent",
+          match: { channel: "feishu", peer: { kind: "direct", id: "*" } },
+        },
+        {
+          agentId: "exact-agent",
+          match: { channel: "feishu", peer: { kind: "direct", id: "wood-id" } },
+        },
+      ],
+    };
+    const exactRoute = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "direct", id: "wood-id" },
+    });
+    expect(exactRoute.agentId).toBe("exact-agent");
+    expect(exactRoute.matchedBy).toBe("binding.peer");
+
+    const otherRoute = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "direct", id: "other-user" },
+    });
+    expect(otherRoute.agentId).toBe("wildcard-agent");
+    expect(otherRoute.matchedBy).toBe("binding.peer.kind");
+  });
+
+  test("wildcard peer.kind takes priority over binding.channel", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "channel-agent",
+          match: { channel: "feishu" },
+        },
+        {
+          agentId: "kind-agent",
+          match: { channel: "feishu", peer: { kind: "direct", id: "*" } },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "direct", id: "someone" },
+    });
+    expect(route.agentId).toBe("kind-agent");
+    expect(route.matchedBy).toBe("binding.peer.kind");
+  });
+
+  test("wildcard group binding matches runtime channel peer kind", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "group-agent",
+          match: { channel: "slack", peer: { kind: "group", id: "*" } },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: null,
+      peer: { kind: "channel", id: "C999" },
+    });
+    expect(route.agentId).toBe("group-agent");
+    expect(route.matchedBy).toBe("binding.peer.kind");
+  });
+
+  test("wildcard direct does not match group peer", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "dm-agent",
+          match: { channel: "feishu", peer: { kind: "direct", id: "*" } },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "group", id: "group-1" },
+    });
+    expect(route.agentId).toBe("main");
+    expect(route.matchedBy).toBe("default");
+  });
+
+  test("full scenario: wood DM + other DMs + all groups", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "dm" }, { id: "main" }, { id: "group" }],
+      },
+      bindings: [
+        {
+          agentId: "dm",
+          match: { channel: "feishu", peer: { kind: "direct", id: "wood-uid" } },
+        },
+        {
+          agentId: "main",
+          match: { channel: "feishu", peer: { kind: "direct", id: "*" } },
+        },
+        {
+          agentId: "group",
+          match: { channel: "feishu", peer: { kind: "group", id: "*" } },
+        },
+      ],
+    };
+
+    const woodRoute = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "direct", id: "wood-uid" },
+    });
+    expect(woodRoute.agentId).toBe("dm");
+    expect(woodRoute.matchedBy).toBe("binding.peer");
+
+    const otherDmRoute = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "direct", id: "someone-else" },
+    });
+    expect(otherDmRoute.agentId).toBe("main");
+    expect(otherDmRoute.matchedBy).toBe("binding.peer.kind");
+
+    const groupRoute = resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: null,
+      peer: { kind: "group", id: "any-group-id" },
+    });
+    expect(groupRoute.agentId).toBe("group");
+    expect(groupRoute.matchedBy).toBe("binding.peer.kind");
+  });
+});

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -50,6 +50,7 @@ export type ResolvedAgentRoute = {
   matchedBy:
     | "binding.peer"
     | "binding.peer.parent"
+    | "binding.peer.kind"
     | "binding.guild+roles"
     | "binding.guild"
     | "binding.team"
@@ -168,6 +169,7 @@ export function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): 
 type NormalizedPeerConstraint =
   | { state: "none" }
   | { state: "invalid" }
+  | { state: "wildcard"; kind: ChatType }
   | { state: "valid"; kind: ChatType; id: string };
 
 type NormalizedBindingMatch = {
@@ -213,6 +215,7 @@ const MAX_RESOLVED_ROUTE_CACHE_KEYS = 4000;
 
 type EvaluatedBindingsIndex = {
   byPeer: Map<string, EvaluatedBinding[]>;
+  byPeerKind: Map<string, EvaluatedBinding[]>;
   byGuildWithRoles: Map<string, EvaluatedBinding[]>;
   byGuild: Map<string, EvaluatedBinding[]>;
   byTeam: Map<string, EvaluatedBinding[]>;
@@ -366,8 +369,41 @@ function collectPeerIndexedBindings(
   return out;
 }
 
+function peerKindLookupKeys(kind: ChatType): string[] {
+  if (kind === "group" || kind === "channel") {
+    return ["group", "channel"];
+  }
+  return [kind];
+}
+
+function collectPeerKindBindings(
+  index: EvaluatedBindingsIndex,
+  peer: RoutePeer | null,
+): EvaluatedBinding[] {
+  if (!peer) {
+    return [];
+  }
+  const out: EvaluatedBinding[] = [];
+  const seen = new Set<EvaluatedBinding>();
+  for (const key of peerKindLookupKeys(peer.kind)) {
+    const matches = index.byPeerKind.get(key);
+    if (!matches) {
+      continue;
+    }
+    for (const match of matches) {
+      if (seen.has(match)) {
+        continue;
+      }
+      seen.add(match);
+      out.push(match);
+    }
+  }
+  return out;
+}
+
 function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBindingsIndex {
   const byPeer = new Map<string, EvaluatedBinding[]>();
+  const byPeerKind = new Map<string, EvaluatedBinding[]>();
   const byGuildWithRoles = new Map<string, EvaluatedBinding[]>();
   const byGuild = new Map<string, EvaluatedBinding[]>();
   const byTeam = new Map<string, EvaluatedBinding[]>();
@@ -375,6 +411,12 @@ function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBin
   const byChannel: EvaluatedBinding[] = [];
 
   for (const binding of bindings) {
+    if (binding.match.peer.state === "wildcard") {
+      for (const key of peerKindLookupKeys(binding.match.peer.kind)) {
+        pushToIndexMap(byPeerKind, key, binding);
+      }
+      continue;
+    }
     if (binding.match.peer.state === "valid") {
       for (const key of peerLookupKeys(binding.match.peer.kind, binding.match.peer.id)) {
         pushToIndexMap(byPeer, key, binding);
@@ -402,6 +444,7 @@ function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBin
 
   return {
     byPeer,
+    byPeerKind,
     byGuildWithRoles,
     byGuild,
     byTeam,
@@ -480,6 +523,9 @@ function normalizePeerConstraint(
   const id = normalizeId(peer.id);
   if (!kind || !id) {
     return { state: "invalid" };
+  }
+  if (id === "*") {
+    return { state: "wildcard", kind };
   }
   return { state: "valid", kind, id };
 }
@@ -584,6 +630,11 @@ function peerKindMatches(bindingKind: ChatType, scopeKind: ChatType): boolean {
 function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope): boolean {
   if (match.peer.state === "invalid") {
     return false;
+  }
+  if (match.peer.state === "wildcard") {
+    if (!scope.peer || !peerKindMatches(match.peer.kind, scope.peer.kind)) {
+      return false;
+    }
   }
   if (match.peer.state === "valid") {
     if (
@@ -700,6 +751,9 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     if (value.state === "invalid") {
       return "invalid";
     }
+    if (value.state === "wildcard") {
+      return `${value.kind}:*`;
+    }
     return `${value.kind}:${value.id}`;
   };
 
@@ -740,6 +794,13 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       scopePeer: parentPeer && parentPeer.id ? parentPeer : null,
       candidates: collectPeerIndexedBindings(bindingsIndex, parentPeer),
       predicate: (candidate) => candidate.match.peer.state === "valid",
+    },
+    {
+      matchedBy: "binding.peer.kind",
+      enabled: Boolean(peer),
+      scopePeer: peer,
+      candidates: collectPeerKindBindings(bindingsIndex, peer),
+      predicate: (candidate) => candidate.match.peer.state === "wildcard",
     },
     {
       matchedBy: "binding.guild+roles",


### PR DESCRIPTION
## Summary

- Add `peer.id: "*"` wildcard support in route bindings to match **any peer of a given kind** (direct, group, channel)
- Introduce a new `binding.peer.kind` routing tier between `binding.peer.parent` and `binding.guild+roles`
- Preserve existing `group ↔ channel` interchangeability for wildcard bindings

## Motivation

Currently there is no way to write a single binding that routes "all direct messages" or "all group chats" to a specific agent. Users must either:
1. Omit `peer` entirely (which matches everything regardless of kind), or
2. Enumerate every individual peer ID

This makes it impossible to configure a common pattern like:
- **Specific user DM** → agent A (exact peer ID)
- **All other DMs** → agent B (kind-level)
- **All group chats** → agent C (kind-level)

With this change, `peer.id: "*"` acts as a kind-level wildcard:

```jsonc
"bindings": [
  { "agentId": "dm",    "match": { "channel": "feishu", "peer": { "kind": "direct", "id": "ou_specific_user" } } },
  { "agentId": "main",  "match": { "channel": "feishu", "peer": { "kind": "direct", "id": "*" } } },
  { "agentId": "group", "match": { "channel": "feishu", "peer": { "kind": "group",  "id": "*" } } }
]
```

## Implementation

**Files changed:** `src/routing/resolve-route.ts`, `src/routing/resolve-route.test.ts`

Key changes in `resolve-route.ts`:
- `NormalizedPeerConstraint` — new `{ state: "wildcard"; kind: ChatType }` variant
- `normalizePeerConstraint()` — returns wildcard state when `id === "*"`
- `EvaluatedBindingsIndex` — new `byPeerKind` map indexed by `ChatType`
- `buildEvaluatedBindingsIndex()` — routes wildcard bindings to `byPeerKind` (with group↔channel aliasing)
- `matchesBindingScope()` — wildcard state checks kind match only, skips id comparison
- New `binding.peer.kind` tier in the priority chain
- `matchedBy` union extended with `"binding.peer.kind"`

**Priority order:**
```
binding.peer > binding.peer.parent > binding.peer.kind (NEW) > binding.guild+roles > binding.guild > binding.team > binding.account > binding.channel > default
```

## Test plan

All 48 tests pass (41 existing + 7 new):

```
 ✓ src/routing/resolve-route.test.ts (48 tests) 60ms

 Test Files  1 passed (1)
       Tests  48 passed (48)
    Start at  01:33:46
    Duration  735ms
```

New test cases:
- [x] `peer.id: "*"` with `kind: "direct"` matches any direct chat
- [x] `peer.id: "*"` with `kind: "group"` matches any group chat
- [x] Exact `peer.id` takes priority over wildcard
- [x] Wildcard `peer.kind` takes priority over `binding.channel`
- [x] Wildcard `kind: "group"` matches runtime `kind: "channel"` (interchangeability)
- [x] Wildcard `kind: "direct"` does **not** match group peer
- [x] Full scenario: specific user DM + all other DMs + all groups → 3 different agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)