### PR TITLE
feat(exec): add cloud execution provider (host="cloud")

### DIFF
--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -52,6 +52,8 @@ export interface ProcessSession {
   exited: boolean;
   truncated: boolean;
   backgrounded: boolean;
+  /** Optional kill handler for proxy sessions (e.g. cloud sandbox). */
+  onKill?: () => Promise<void>;
 }
 
 export interface FinishedSession {

--- a/src/agents/bash-tools.exec-host-cloud.test.ts
+++ b/src/agents/bash-tools.exec-host-cloud.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../infra/cloud-sandbox-registry.js", () => ({
+  resolveCloudSandboxProvider: vi.fn(),
+}));
+
+vi.mock("./bash-tools.exec-host-shared.js", () => ({
+  resolveExecHostApprovalContext: vi.fn().mockReturnValue({
+    approvals: {},
+    hostSecurity: "allowlist",
+    hostAsk: "on-miss",
+    askFallback: undefined,
+  }),
+}));
+
+vi.mock("./bash-tools.exec-runtime.js", () => ({
+  emitExecSystemEvent: vi.fn(),
+}));
+
+vi.mock("./bash-process-registry.js", () => ({
+  addSession: vi.fn(),
+  appendOutput: vi.fn(),
+  createSessionSlug: vi.fn().mockReturnValue("slug-fallback-1"),
+  markBackgrounded: vi.fn(),
+  markExited: vi.fn(),
+}));
+
+import type { CloudSandboxProvider } from "../infra/cloud-sandbox-provider.js";
+import { addSession, markBackgrounded } from "./bash-process-registry.js";
+import { executeCloudHostCommand } from "./bash-tools.exec-host-cloud.js";
+
+function getTextContent(result: { content: Array<{ type: string; text?: string }> }): string {
+  const item = result.content[0];
+  if (item.type === "text" && typeof item.text === "string") {
+    return item.text;
+  }
+  throw new Error(`Expected text content, got ${item.type}`);
+}
+
+function createMockProvider(overrides?: Partial<CloudSandboxProvider>): CloudSandboxProvider {
+  return {
+    id: "test-cloud",
+    exec: vi.fn<CloudSandboxProvider["exec"]>().mockResolvedValue({
+      exitCode: 0,
+      stdout: "hello world",
+      stderr: "",
+      timedOut: false,
+    }),
+    execBackground: vi.fn<CloudSandboxProvider["execBackground"]>().mockResolvedValue({
+      sessionId: "bg-session-1",
+      initialOutput: "starting...",
+    }),
+    readSessionLog: vi.fn().mockResolvedValue({ done: true, output: "", exitCode: 0 }),
+    killSession: vi.fn(),
+    ensureReady: vi.fn<CloudSandboxProvider["ensureReady"]>().mockResolvedValue(undefined),
+    dispose: vi.fn(),
+    isReady: () => true,
+    ...overrides,
+  };
+}
+
+const baseParams = {
+  command: "echo hello",
+  workdir: "/tmp",
+  env: {},
+  defaultTimeoutSec: 120,
+  security: "allowlist" as const,
+  ask: "on-miss" as const,
+  warnings: [],
+};
+
+describe("executeCloudHostCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when no provider is available", async () => {
+    await expect(executeCloudHostCommand({ ...baseParams, provider: null })).rejects.toThrow(
+      "exec host=cloud requires a cloud sandbox plugin",
+    );
+  });
+
+  it("calls ensureReady before exec", async () => {
+    const ensureReadyMock = vi
+      .fn<CloudSandboxProvider["ensureReady"]>()
+      .mockResolvedValue(undefined);
+    const execMock = vi.fn<CloudSandboxProvider["exec"]>().mockResolvedValue({
+      exitCode: 0,
+      stdout: "hello world",
+      stderr: "",
+      timedOut: false,
+    });
+    const provider = createMockProvider({ ensureReady: ensureReadyMock, exec: execMock });
+    await executeCloudHostCommand({ ...baseParams, provider });
+    expect(ensureReadyMock).toHaveBeenCalledOnce();
+    expect(execMock).toHaveBeenCalledOnce();
+    const execCall = execMock.mock.calls[0][0];
+    expect(execCall.command).toBe("echo hello");
+    expect(execCall.cwd).toBe("/tmp");
+  });
+
+  it("returns formatted result for successful sync exec", async () => {
+    const provider = createMockProvider();
+    const result = await executeCloudHostCommand({ ...baseParams, provider });
+    expect(getTextContent(result)).toBe("hello world");
+    expect(result.details).toMatchObject({
+      status: "completed",
+      exitCode: 0,
+    });
+  });
+
+  it("returns failed status for non-zero exit code", async () => {
+    const provider = createMockProvider({
+      exec: vi.fn<CloudSandboxProvider["exec"]>().mockResolvedValue({
+        exitCode: 1,
+        stdout: "",
+        stderr: "command not found",
+        timedOut: false,
+      }),
+    });
+    const result = await executeCloudHostCommand({ ...baseParams, provider });
+    expect(getTextContent(result)).toBe("[stderr]\ncommand not found");
+    expect(result.details).toMatchObject({
+      status: "failed",
+      exitCode: 1,
+    });
+  });
+
+  it("includes timeout indicator when command times out", async () => {
+    const provider = createMockProvider({
+      exec: vi.fn<CloudSandboxProvider["exec"]>().mockResolvedValue({
+        exitCode: 137,
+        stdout: "partial",
+        stderr: "",
+        timedOut: true,
+      }),
+    });
+    const result = await executeCloudHostCommand({
+      ...baseParams,
+      provider,
+      timeoutSec: 30,
+    });
+    expect(getTextContent(result)).toContain("[timed out after 30000ms]");
+    expect(result.details).toMatchObject({
+      status: "failed",
+    });
+  });
+
+  it("passes timeout to provider", async () => {
+    const execMock = vi.fn<CloudSandboxProvider["exec"]>().mockResolvedValue({
+      exitCode: 0,
+      stdout: "hello world",
+      stderr: "",
+      timedOut: false,
+    });
+    const provider = createMockProvider({ exec: execMock });
+    await executeCloudHostCommand({
+      ...baseParams,
+      provider,
+      timeoutSec: 60,
+    });
+    const execCall = execMock.mock.calls[0][0];
+    expect(execCall.timeoutMs).toBe(60_000);
+  });
+
+  it("uses defaultTimeoutSec when no explicit timeout", async () => {
+    const execMock = vi.fn<CloudSandboxProvider["exec"]>().mockResolvedValue({
+      exitCode: 0,
+      stdout: "hello world",
+      stderr: "",
+      timedOut: false,
+    });
+    const provider = createMockProvider({ exec: execMock });
+    await executeCloudHostCommand({
+      ...baseParams,
+      provider,
+      defaultTimeoutSec: 90,
+    });
+    const execCall = execMock.mock.calls[0][0];
+    expect(execCall.timeoutMs).toBe(90_000);
+  });
+
+  it("handles background execution", async () => {
+    const execMock = vi.fn<CloudSandboxProvider["exec"]>().mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+    });
+    const execBackgroundMock = vi.fn<CloudSandboxProvider["execBackground"]>().mockResolvedValue({
+      sessionId: "bg-session-1",
+      initialOutput: "starting...",
+    });
+    const provider = createMockProvider({
+      exec: execMock,
+      execBackground: execBackgroundMock,
+    });
+    const result = await executeCloudHostCommand({
+      ...baseParams,
+      provider,
+      backgroundMs: 0,
+    });
+    expect(execBackgroundMock).toHaveBeenCalledOnce();
+    expect(execMock).not.toHaveBeenCalled();
+    expect(getTextContent(result)).toContain("cloud sandbox");
+    expect(getTextContent(result)).toContain("bg-session-1");
+    expect(result.details).toMatchObject({
+      status: "running",
+      sessionId: "bg-session-1",
+    });
+    // Verify proxy session is registered in the process registry
+    expect(addSession).toHaveBeenCalledOnce();
+    expect(markBackgrounded).toHaveBeenCalledOnce();
+  });
+
+  it("includes initial output in background result", async () => {
+    const provider = createMockProvider();
+    const result = await executeCloudHostCommand({
+      ...baseParams,
+      provider,
+      backgroundMs: 0,
+    });
+    expect(getTextContent(result)).toContain("starting...");
+  });
+
+  it("wraps provider exec errors with provider id", async () => {
+    const provider = createMockProvider({
+      exec: vi.fn().mockRejectedValue(new Error("network timeout")),
+    });
+    await expect(executeCloudHostCommand({ ...baseParams, provider })).rejects.toThrow(
+      "Cloud sandbox exec failed (provider=test-cloud): network timeout",
+    );
+  });
+
+  it("returns (no output) when stdout and stderr are empty", async () => {
+    const provider = createMockProvider({
+      exec: vi.fn<CloudSandboxProvider["exec"]>().mockResolvedValue({
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+      }),
+    });
+    const result = await executeCloudHostCommand({ ...baseParams, provider });
+    expect(getTextContent(result)).toBe("(no output)");
+  });
+
+  it("prepends warnings to output", async () => {
+    const provider = createMockProvider();
+    const result = await executeCloudHostCommand({
+      ...baseParams,
+      provider,
+      warnings: ["Warning: pathPrepend ignored"],
+    });
+    expect(getTextContent(result)).toContain("Warning: pathPrepend ignored");
+    expect(getTextContent(result)).toContain("hello world");
+  });
+
+  it("sets onKill on proxy session that delegates to provider.killSession", async () => {
+    const killSessionMock = vi
+      .fn<CloudSandboxProvider["killSession"]>()
+      .mockResolvedValue(undefined);
+    const provider = createMockProvider({ killSession: killSessionMock });
+    await executeCloudHostCommand({
+      ...baseParams,
+      provider,
+      backgroundMs: 0,
+    });
+    // Extract the proxy session passed to addSession
+    const addSessionMock = vi.mocked(addSession);
+    expect(addSessionMock).toHaveBeenCalledOnce();
+    const proxySession = addSessionMock.mock.calls[0][0];
+    expect(proxySession.onKill).toBeTypeOf("function");
+    // Invoke onKill and verify it delegates to provider.killSession
+    await proxySession.onKill!();
+    expect(killSessionMock).toHaveBeenCalledWith("bg-session-1");
+  });
+});

--- a/src/agents/bash-tools.exec-host-cloud.ts
+++ b/src/agents/bash-tools.exec-host-cloud.ts
@@ -1,0 +1,303 @@
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { CloudSandboxProvider } from "../infra/cloud-sandbox-provider.js";
+import { resolveCloudSandboxProvider } from "../infra/cloud-sandbox-registry.js";
+import type { ExecAsk, ExecSecurity } from "../infra/exec-approvals.js";
+import {
+  addSession,
+  appendOutput,
+  createSessionSlug,
+  markBackgrounded,
+  markExited,
+} from "./bash-process-registry.js";
+import type { ProcessSession } from "./bash-process-registry.js";
+import { resolveExecHostApprovalContext } from "./bash-tools.exec-host-shared.js";
+import { emitExecSystemEvent } from "./bash-tools.exec-runtime.js";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+
+export type ExecuteCloudHostCommandParams = {
+  command: string;
+  workdir: string;
+  env: Record<string, string>;
+  timeoutSec?: number;
+  defaultTimeoutSec: number;
+  /** Effective timeout in ms for background polling watchdog. `null` = no timeout. */
+  backgroundTimeoutMs?: number | null;
+  backgroundMs?: number;
+  yieldMs?: number;
+  scopeKey?: string;
+  sessionKey?: string;
+  agentId?: string;
+  security: ExecSecurity;
+  ask: ExecAsk;
+  warnings: string[];
+  notifyOnExit?: boolean;
+  notifyOnExitEmptySuccess?: boolean;
+  maxOutputChars?: number;
+  pendingMaxOutputChars?: number;
+  /** Injected provider for testability; defaults to resolveCloudSandboxProvider(). */
+  provider?: CloudSandboxProvider | null;
+};
+
+export async function executeCloudHostCommand(
+  params: ExecuteCloudHostCommandParams,
+): Promise<AgentToolResult<ExecToolDetails>> {
+  // 1. Resolve provider
+  const provider = params.provider ?? resolveCloudSandboxProvider();
+  if (!provider) {
+    throw new Error(
+      [
+        "exec host=cloud requires a cloud sandbox plugin (none registered).",
+        "Install a cloud sandbox plugin (e.g. satellite-openclaw-plugin) and ensure it registers a cloud-sandbox service.",
+      ].join("\n"),
+    );
+  }
+
+  // 2. Security / approval (reuse the shared approval context).
+  // resolveExecHostApprovalContext merges agent-level overrides (minSecurity / maxAsk)
+  // and throws on security=deny. Cloud sandboxes provide process-level isolation,
+  // so allowlist/approval enforcement is intentionally not applied here — the
+  // sandbox itself is the security boundary. The hostSecurity/hostAsk values are
+  // preserved for future use if cloud hosts need finer-grained approval.
+  // oxlint-disable-next-line no-unused-vars -- intentionally captured; see comment above
+  const { hostSecurity, hostAsk } = resolveExecHostApprovalContext({
+    agentId: params.agentId,
+    security: params.security,
+    ask: params.ask,
+    host: "cloud",
+  });
+
+  // 3. Ensure sandbox is ready
+  await provider.ensureReady();
+
+  const warningText = params.warnings.length ? `${params.warnings.join("\n")}\n\n` : "";
+  const timeoutMs = (params.timeoutSec ?? params.defaultTimeoutSec) * 1000;
+  const maxOutput = params.maxOutputChars ?? 200_000;
+  const pendingMaxOutput = params.pendingMaxOutputChars ?? 30_000;
+
+  // 4. Background execution
+  if (params.backgroundMs !== undefined || params.yieldMs !== undefined) {
+    const cloudSession = await provider.execBackground({
+      command: params.command,
+      cwd: params.workdir,
+      env: params.env,
+    });
+
+    // Register a proxy session in the process registry so the `process` tool
+    // can poll/kill it via getSession(). The session delegates read/kill to
+    // the cloud provider's readSessionLog/killSession methods.
+    const cloudSessionId = cloudSession.sessionId || createSessionSlug();
+    const proxySession: ProcessSession = {
+      id: cloudSessionId,
+      command: params.command,
+      scopeKey: params.scopeKey,
+      sessionKey: params.sessionKey,
+      notifyOnExit: params.notifyOnExit ?? false,
+      notifyOnExitEmptySuccess: params.notifyOnExitEmptySuccess ?? false,
+      exitNotified: false,
+      startedAt: Date.now(),
+      cwd: params.workdir,
+      maxOutputChars: maxOutput,
+      pendingMaxOutputChars: pendingMaxOutput,
+      totalOutputChars: 0,
+      pendingStdout: [],
+      pendingStderr: [],
+      pendingStdoutChars: 0,
+      pendingStderrChars: 0,
+      aggregated: "",
+      tail: "",
+      exited: false,
+      truncated: false,
+      backgrounded: true,
+      onKill: async () => {
+        await provider.killSession(cloudSessionId);
+      },
+    };
+    // Seed initial output through the normal accounting path so that
+    // maxOutputChars trimming and counter bookkeeping stay consistent.
+    const initialOutput = cloudSession.initialOutput ?? "";
+    if (initialOutput) {
+      appendOutput(proxySession, "stdout", initialOutput);
+    }
+    addSession(proxySession);
+    markBackgrounded(proxySession);
+
+    // Kick off a polling loop to keep the proxy session updated.
+    // This runs detached (fire-and-forget) so we don't block the response.
+    // backgroundTimeoutMs=null preserves the no-timeout semantics for
+    // background/yielded runs without an explicit timeout (matching non-cloud hosts).
+    const bgTimeoutMs = params.backgroundTimeoutMs ?? timeoutMs;
+    void pollCloudSession(
+      provider,
+      cloudSessionId,
+      proxySession,
+      initialOutput.length,
+      bgTimeoutMs,
+    );
+
+    emitExecSystemEvent(`Exec backgrounded (cloud, session=${cloudSessionId}): ${params.command}`, {
+      sessionKey: params.sessionKey,
+    });
+
+    const parts = [
+      `${warningText}Command running in background (cloud sandbox).`,
+      `Session: ${cloudSessionId}`,
+    ];
+    if (initialOutput) {
+      parts.push(`Initial output:\n${initialOutput}`);
+    }
+
+    return {
+      content: [{ type: "text", text: parts.join("\n") }],
+      details: {
+        status: "running",
+        sessionId: cloudSessionId,
+        startedAt: Date.now(),
+        cwd: params.workdir,
+      } satisfies ExecToolDetails,
+    };
+  }
+
+  // 5. Synchronous execution
+  const startedAt = Date.now();
+  let result;
+  try {
+    result = await provider.exec({
+      command: params.command,
+      cwd: params.workdir,
+      env: params.env,
+      timeoutMs,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Cloud sandbox exec failed (provider=${provider.id}): ${message}`, {
+      cause: err,
+    });
+  }
+  const durationMs = Date.now() - startedAt;
+
+  // 6. Emit system event
+  emitExecSystemEvent(
+    `Exec finished (cloud, exit=${result.exitCode}${result.timedOut ? " timed-out" : ""}): ${params.command}`,
+    { sessionKey: params.sessionKey },
+  );
+
+  // 7. Format result (matches existing exec output format)
+  const outputParts: string[] = [];
+  if (warningText) {
+    outputParts.push(warningText.trimEnd());
+  }
+  if (result.stdout) {
+    outputParts.push(result.stdout);
+  }
+  if (result.stderr) {
+    outputParts.push(`[stderr]\n${result.stderr}`);
+  }
+  if (result.timedOut) {
+    outputParts.push(`[timed out after ${timeoutMs}ms]`);
+  }
+
+  const output = outputParts.join("\n") || "(no output)";
+  const success = result.exitCode === 0 && !result.timedOut;
+
+  return {
+    content: [{ type: "text", text: output }],
+    details: {
+      status: success ? "completed" : "failed",
+      exitCode: result.exitCode,
+      durationMs,
+      aggregated: [result.stdout, result.stderr].filter(Boolean).join("\n"),
+      cwd: params.workdir,
+    } satisfies ExecToolDetails,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Background session polling
+// ---------------------------------------------------------------------------
+
+const POLL_INTERVAL_MS = 2_000;
+const MAX_POLL_FAILURES = 5;
+
+/**
+ * Poll the cloud provider for background session output and update the
+ * local proxy session in bash-process-registry. Runs detached (fire-and-forget).
+ */
+async function pollCloudSession(
+  provider: CloudSandboxProvider,
+  cloudSessionId: string,
+  proxySession: ProcessSession,
+  initialOutputLength: number,
+  timeoutMs: number | null,
+): Promise<void> {
+  let consecutiveFailures = 0;
+  // Track how many bytes we've already appended so we only forward the
+  // incremental portion — readSessionLog() returns *accumulated* output.
+  // Start from initialOutputLength because the proxy session is pre-seeded
+  // with initialOutput; without this the first poll would re-append it.
+  let appendedLength = initialOutputLength;
+  const deadline = timeoutMs !== null ? Date.now() + timeoutMs : null;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    if (proxySession.exited) {
+      return;
+    }
+
+    // Poll the provider *before* enforcing the timeout so that a command
+    // finishing between poll ticks is observed as done rather than force-killed.
+    try {
+      const log = await provider.readSessionLog(cloudSessionId);
+      if (log.output && log.output.length > appendedLength) {
+        const incremental = log.output.slice(appendedLength);
+        appendOutput(proxySession, "stdout", incremental);
+        appendedLength = log.output.length;
+      }
+      if (log.done) {
+        // Providers may omit exitCode for successful completions; treat
+        // null/undefined as success (exitCode 0).
+        const exitCode = log.exitCode ?? null;
+        const status = exitCode === null || exitCode === 0 ? "completed" : "failed";
+        markExited(proxySession, exitCode, null, status);
+        return;
+      }
+      consecutiveFailures = 0;
+    } catch {
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= MAX_POLL_FAILURES) {
+        // Best-effort kill so the remote job doesn't keep running (and billing).
+        // Only finalize the session if kill succeeds; otherwise keep it alive
+        // so the user can retry via `process kill`.
+        let killed = false;
+        try {
+          await provider.killSession(cloudSessionId);
+          killed = true;
+        } catch {
+          // kill failed — leave session active for manual retry
+        }
+        if (killed) {
+          markExited(proxySession, null, null, "failed");
+        }
+        return;
+      }
+    }
+
+    // Watchdog: kill the remote session if it exceeds the configured timeout.
+    // Only finalize the session if kill succeeds; otherwise keep it alive
+    // so the user can retry via `process kill`.
+    // When deadline is null, background timeout is bypassed (no-timeout semantics).
+    if (deadline !== null && Date.now() > deadline) {
+      let killed = false;
+      try {
+        await provider.killSession(cloudSessionId);
+        killed = true;
+      } catch {
+        // kill failed — leave session active for manual retry
+      }
+      if (killed) {
+        appendOutput(proxySession, "stderr", `[timed out after ${timeoutMs}ms]`);
+        markExited(proxySession, null, null, "failed");
+      }
+      return;
+    }
+  }
+}

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -126,7 +126,7 @@ export function resolveExecHostApprovalContext(params: {
   agentId?: string;
   security: ExecSecurity;
   ask: ExecAsk;
-  host: "gateway" | "node";
+  host: "gateway" | "node" | "cloud";
 }): ExecHostApprovalContext {
   const approvals = resolveExecApprovals(params.agentId, {
     security: params.security,

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -10,7 +10,11 @@ vi.mock("../infra/system-events.js", () => ({
 
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { emitExecSystemEvent } from "./bash-tools.exec-runtime.js";
+import {
+  emitExecSystemEvent,
+  normalizeExecHost,
+  renderExecHostLabel,
+} from "./bash-tools.exec-runtime.js";
 
 const requestHeartbeatNowMock = vi.mocked(requestHeartbeatNow);
 const enqueueSystemEventMock = vi.mocked(enqueueSystemEvent);
@@ -60,5 +64,42 @@ describe("emitExecSystemEvent", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("normalizeExecHost", () => {
+  it("parses cloud host", () => {
+    expect(normalizeExecHost("cloud")).toBe("cloud");
+  });
+
+  it("parses cloud host case-insensitively", () => {
+    expect(normalizeExecHost("Cloud")).toBe("cloud");
+    expect(normalizeExecHost("CLOUD")).toBe("cloud");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeExecHost("  cloud  ")).toBe("cloud");
+  });
+
+  it("returns null for unknown hosts", () => {
+    expect(normalizeExecHost("docker")).toBeNull();
+  });
+
+  it("parses existing hosts", () => {
+    expect(normalizeExecHost("sandbox")).toBe("sandbox");
+    expect(normalizeExecHost("gateway")).toBe("gateway");
+    expect(normalizeExecHost("node")).toBe("node");
+  });
+});
+
+describe("renderExecHostLabel", () => {
+  it("returns cloud for cloud host", () => {
+    expect(renderExecHostLabel("cloud")).toBe("cloud");
+  });
+
+  it("returns correct labels for other hosts", () => {
+    expect(renderExecHostLabel("sandbox")).toBe("sandbox");
+    expect(renderExecHostLabel("gateway")).toBe("gateway");
+    expect(renderExecHostLabel("node")).toBe("node");
   });
 });

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -162,7 +162,13 @@ export type ExecProcessHandle = {
 };
 
 export function renderExecHostLabel(host: ExecHost) {
-  return host === "sandbox" ? "sandbox" : host === "gateway" ? "gateway" : "node";
+  return host === "sandbox"
+    ? "sandbox"
+    : host === "gateway"
+      ? "gateway"
+      : host === "cloud"
+        ? "cloud"
+        : "node";
 }
 
 export function normalizeNotifyOutput(value: string) {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -10,6 +10,7 @@ import {
 import { logInfo } from "../logger.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { markBackgrounded } from "./bash-process-registry.js";
+import { executeCloudHostCommand } from "./bash-tools.exec-host-cloud.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
 import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
 import {
@@ -342,7 +343,7 @@ export function createExecTool(
         throw new Error(
           [
             "exec host=sandbox is configured, but sandbox runtime is unavailable for this session.",
-            'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or set tools.exec.host to "gateway"/"node".',
+            'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or set tools.exec.host to "gateway"/"node"/"cloud".',
           ].join("\n"),
         );
       }
@@ -390,13 +391,42 @@ export function createExecTool(
       }
 
       // `tools.exec.pathPrepend` is only meaningful when exec runs locally (gateway) or in the sandbox.
-      // Node hosts intentionally ignore request-scoped PATH overrides, so don't pretend this applies.
-      if (host === "node" && defaultPathPrepend.length > 0) {
+      // Node/cloud hosts intentionally ignore request-scoped PATH overrides, so don't pretend this applies.
+      if ((host === "node" || host === "cloud") && defaultPathPrepend.length > 0) {
         warnings.push(
-          "Warning: tools.exec.pathPrepend is ignored for host=node. Configure PATH on the node host/service instead.",
+          `Warning: tools.exec.pathPrepend is ignored for host=${host}. Configure PATH on the ${host} host/service instead.`,
         );
       } else {
         applyPathPrepend(env, defaultPathPrepend);
+      }
+
+      if (host === "cloud") {
+        const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;
+        const bgTimeoutBypass =
+          allowBackground && explicitTimeoutSec === null && (backgroundRequested || yieldRequested);
+        const bgTimeoutMs = bgTimeoutBypass
+          ? null
+          : (explicitTimeoutSec ?? defaultTimeoutSec) * 1000;
+        return executeCloudHostCommand({
+          command: params.command,
+          workdir,
+          env,
+          timeoutSec: params.timeout,
+          defaultTimeoutSec,
+          backgroundTimeoutMs: bgTimeoutMs,
+          backgroundMs: allowBackground && backgroundRequested ? 0 : undefined,
+          yieldMs: allowBackground && !backgroundRequested ? (yieldWindow ?? undefined) : undefined,
+          scopeKey: defaults?.scopeKey,
+          sessionKey: defaults?.sessionKey,
+          agentId,
+          security,
+          ask,
+          warnings,
+          notifyOnExit,
+          notifyOnExitEmptySuccess,
+          maxOutputChars: maxOutput,
+          pendingMaxOutputChars: pendingMaxOutput,
+        });
       }
 
       if (host === "node") {

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -546,13 +546,30 @@ export function createProcessTool(
           }
           const canceled = cancelManagedSession(scopedSession.id);
           if (!canceled) {
-            const terminated = terminateSessionFallback(scopedSession);
-            if (!terminated) {
-              return failText(
-                `Unable to terminate session ${params.sessionId}: no active supervisor run or process id.`,
-              );
+            // Try the session's custom kill handler (e.g. cloud sandbox provider).
+            if (scopedSession.onKill) {
+              let killError: string | undefined;
+              try {
+                await scopedSession.onKill();
+              } catch (err) {
+                killError = err instanceof Error ? err.message : String(err);
+              }
+              markExited(scopedSession, null, "SIGKILL", killError ? "failed" : "killed");
+              if (killError) {
+                resetPollRetrySuggestion(params.sessionId);
+                return failText(
+                  `Kill request for session ${params.sessionId} failed: ${killError}`,
+                );
+              }
+            } else {
+              const terminated = terminateSessionFallback(scopedSession);
+              if (!terminated) {
+                return failText(
+                  `Unable to terminate session ${params.sessionId}: no active supervisor run or process id.`,
+                );
+              }
+              markExited(scopedSession, null, "SIGKILL", "failed");
             }
-            markExited(scopedSession, null, "SIGKILL", "failed");
           }
           resetPollRetrySuggestion(params.sessionId);
           return {

--- a/src/auto-reply/reply/exec/directive.ts
+++ b/src/auto-reply/reply/exec/directive.ts
@@ -21,7 +21,12 @@ type ExecDirectiveParse = {
 
 function normalizeExecHost(value?: string): ExecHost | undefined {
   const normalized = value?.trim().toLowerCase();
-  if (normalized === "sandbox" || normalized === "gateway" || normalized === "node") {
+  if (
+    normalized === "sandbox" ||
+    normalized === "gateway" ||
+    normalized === "node" ||
+    normalized === "cloud"
+  ) {
     return normalized;
   }
   return undefined;

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -227,7 +227,7 @@ export type GroupToolPolicyBySenderConfig = Record<string, GroupToolPolicyConfig
 
 export type ExecToolConfig = {
   /** Exec host routing (default: sandbox). */
-  host?: "sandbox" | "gateway" | "node";
+  host?: "sandbox" | "gateway" | "node" | "cloud";
   /** Exec security mode (default: deny). */
   security?: "deny" | "allowlist" | "full";
   /** Exec ask mode (default: on-miss). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -401,7 +401,7 @@ const ToolExecSafeBinProfileSchema = z
   .strict();
 
 const ToolExecBaseShape = {
-  host: z.enum(["sandbox", "gateway", "node"]).optional(),
+  host: z.enum(["sandbox", "gateway", "node", "cloud"]).optional(),
   security: z.enum(["deny", "allowlist", "full"]).optional(),
   ask: z.enum(["off", "on-miss", "always"]).optional(),
   node: z.string().optional(),

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -39,9 +39,14 @@ function invalid(message: string): { ok: false; error: ErrorShape } {
   return { ok: false, error: errorShape(ErrorCodes.INVALID_REQUEST, message) };
 }
 
-function normalizeExecHost(raw: string): "sandbox" | "gateway" | "node" | undefined {
+function normalizeExecHost(raw: string): "sandbox" | "gateway" | "node" | "cloud" | undefined {
   const normalized = raw.trim().toLowerCase();
-  if (normalized === "sandbox" || normalized === "gateway" || normalized === "node") {
+  if (
+    normalized === "sandbox" ||
+    normalized === "gateway" ||
+    normalized === "node" ||
+    normalized === "cloud"
+  ) {
     return normalized;
   }
   return undefined;
@@ -235,7 +240,7 @@ export async function applySessionsPatchToStore(params: {
     } else if (raw !== undefined) {
       const normalized = normalizeExecHost(String(raw));
       if (!normalized) {
-        return invalid('invalid execHost (use "sandbox"|"gateway"|"node")');
+        return invalid('invalid execHost (use "sandbox"|"gateway"|"node"|"cloud")');
       }
       next.execHost = normalized;
     }

--- a/src/infra/cloud-sandbox-provider.ts
+++ b/src/infra/cloud-sandbox-provider.ts
@@ -1,0 +1,134 @@
+/**
+ * A cloud-hosted execution environment that plugins provide.
+ *
+ * The interface mirrors the semantics of the existing exec/browser runtime paths:
+ *   - exec: spawn a command, capture stdout/stderr/exitCode
+ *   - browser: expose a CDP endpoint for BrowserBridge
+ *
+ * Lifecycle:
+ *   Plugin registers the provider via registerService("cloud-sandbox:<id>", { ... }).
+ *   Core calls ensureReady() lazily on first exec/browser invocation.
+ *   Core calls dispose() on gateway_stop or session end.
+ */
+
+// ---------------------------------------------------------------------------
+// Provider interface
+// ---------------------------------------------------------------------------
+
+export interface CloudSandboxProvider {
+  /** Unique provider id (e.g. "ags", "e2b", "modal"). */
+  readonly id: string;
+
+  // ===========================================================================
+  // Exec
+  // ===========================================================================
+
+  /**
+   * Run a command synchronously. Return when the command exits or times out.
+   *
+   * Semantics must match the contract of `runExecProcess()`:
+   *   - command is a shell command string (will be passed to `/bin/sh -lc`)
+   *   - stdout and stderr are captured and returned as strings
+   *   - timedOut is true if the command was killed by the timeout
+   */
+  exec(params: CloudExecParams): Promise<CloudExecResult>;
+
+  /**
+   * Run a command in the background. Return immediately with a session handle.
+   * The caller may later call readSessionLog() or killSession().
+   */
+  execBackground(params: CloudExecBackgroundParams): Promise<CloudExecSession>;
+
+  /**
+   * Read accumulated output from a background session.
+   */
+  readSessionLog(sessionId: string): Promise<CloudExecSessionLog>;
+
+  /**
+   * Kill a background session.
+   */
+  killSession(sessionId: string): Promise<void>;
+
+  // ===========================================================================
+  // Browser (optional — provider may not support browser)
+  // ===========================================================================
+
+  /**
+   * Return a CDP WebSocket URL for the cloud browser.
+   *
+   * BrowserBridge will call `playwright.chromium.connectOverCDP(url)`.
+   * Returns null if the provider does not support browser.
+   *
+   * The URL must be directly connectable from the gateway host.
+   * If the provider requires tunneling or authentication, it must handle
+   * that internally and return a ready-to-use URL.
+   */
+  getBrowserCdpUrl?(): Promise<string | null>;
+
+  /**
+   * Return a VNC/noVNC observation URL (optional, for user observation).
+   */
+  getBrowserVncUrl?(): Promise<string | null>;
+
+  // ===========================================================================
+  // Lifecycle
+  // ===========================================================================
+
+  /**
+   * Lazily initialize the cloud sandbox (create VM, start services, etc.).
+   * Core guarantees this is called before any exec/browser call.
+   * Must be idempotent.
+   */
+  ensureReady(): Promise<void>;
+
+  /**
+   * Clean up resources (destroy VM, close connections).
+   * Called on gateway_stop or when the session ends.
+   */
+  dispose(): Promise<void>;
+
+  /**
+   * Health check. Returns true if the sandbox is alive and accepting commands.
+   */
+  isReady(): boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Parameter / result types
+// ---------------------------------------------------------------------------
+
+export type CloudExecParams = {
+  /** Shell command string (will be passed to /bin/sh -lc). */
+  command: string;
+  /** Working directory inside the sandbox. */
+  cwd?: string;
+  /** Environment variables to set. */
+  env?: Record<string, string>;
+  /** Timeout in milliseconds. */
+  timeoutMs?: number;
+};
+
+export type CloudExecResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+};
+
+export type CloudExecBackgroundParams = {
+  command: string;
+  cwd?: string;
+  env?: Record<string, string>;
+};
+
+export type CloudExecSession = {
+  sessionId: string;
+  /** Initial output captured during the first ~100ms of startup (optional). */
+  initialOutput?: string;
+};
+
+export type CloudExecSessionLog = {
+  output: string;
+  done: boolean;
+  exitCode?: number;
+};

--- a/src/infra/cloud-sandbox-registry.test.ts
+++ b/src/infra/cloud-sandbox-registry.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../plugins/runtime.js", () => ({
+  requireActivePluginRegistry: vi.fn(),
+}));
+
+import type { PluginRegistry } from "../plugins/registry.js";
+import { requireActivePluginRegistry } from "../plugins/runtime.js";
+import type { CloudSandboxProvider } from "./cloud-sandbox-provider.js";
+import { resolveCloudSandboxProvider } from "./cloud-sandbox-registry.js";
+
+const requireRegistryMock = vi.mocked(requireActivePluginRegistry);
+
+function createMockProvider(id: string): CloudSandboxProvider {
+  return {
+    id,
+    exec: vi.fn(),
+    execBackground: vi.fn(),
+    readSessionLog: vi.fn(),
+    killSession: vi.fn(),
+    ensureReady: vi.fn(),
+    dispose: vi.fn(),
+    isReady: () => true,
+  };
+}
+
+function mockRegistry(
+  services: Array<{ pluginId: string; service: { id: string; provider?: CloudSandboxProvider } }>,
+): void {
+  requireRegistryMock.mockReturnValue({
+    services: services.map((s) => ({
+      pluginId: s.pluginId,
+      service: {
+        id: s.service.id,
+        provider: s.service.provider,
+        start: vi.fn(),
+      },
+      source: "test",
+    })),
+  } as unknown as PluginRegistry);
+}
+
+describe("resolveCloudSandboxProvider", () => {
+  beforeEach(() => {
+    requireRegistryMock.mockReset();
+  });
+
+  it("returns null when no cloud-sandbox services are registered", () => {
+    mockRegistry([]);
+    expect(resolveCloudSandboxProvider()).toBeNull();
+  });
+
+  it("returns null when services exist but none match cloud-sandbox prefix", () => {
+    mockRegistry([{ pluginId: "some-plugin", service: { id: "other-service" } }]);
+    expect(resolveCloudSandboxProvider()).toBeNull();
+  });
+
+  it("returns provider from first matching cloud-sandbox service", () => {
+    const provider = createMockProvider("ags");
+    mockRegistry([{ pluginId: "satellite", service: { id: "cloud-sandbox:ags", provider } }]);
+    expect(resolveCloudSandboxProvider()).toBe(provider);
+  });
+
+  it("filters by providerId when specified", () => {
+    const agsProvider = createMockProvider("ags");
+    const e2bProvider = createMockProvider("e2b");
+    mockRegistry([
+      { pluginId: "satellite", service: { id: "cloud-sandbox:ags", provider: agsProvider } },
+      { pluginId: "e2b-plugin", service: { id: "cloud-sandbox:e2b", provider: e2bProvider } },
+    ]);
+    expect(resolveCloudSandboxProvider("e2b")).toBe(e2bProvider);
+  });
+
+  it("returns null when providerId does not match any service", () => {
+    const provider = createMockProvider("ags");
+    mockRegistry([{ pluginId: "satellite", service: { id: "cloud-sandbox:ags", provider } }]);
+    expect(resolveCloudSandboxProvider("modal")).toBeNull();
+  });
+
+  it("returns null when service matches prefix but has no provider property", () => {
+    mockRegistry([{ pluginId: "broken", service: { id: "cloud-sandbox:broken" } }]);
+    expect(resolveCloudSandboxProvider()).toBeNull();
+  });
+
+  it("skips providerless services and returns first valid provider", () => {
+    const validProvider = createMockProvider("e2b");
+    mockRegistry([
+      { pluginId: "broken", service: { id: "cloud-sandbox:broken" } },
+      { pluginId: "e2b-plugin", service: { id: "cloud-sandbox:e2b", provider: validProvider } },
+    ]);
+    expect(resolveCloudSandboxProvider()).toBe(validProvider);
+  });
+});

--- a/src/infra/cloud-sandbox-registry.ts
+++ b/src/infra/cloud-sandbox-registry.ts
@@ -1,0 +1,46 @@
+import { requireActivePluginRegistry } from "../plugins/runtime.js";
+import type { OpenClawPluginService } from "../plugins/types.js";
+import type { CloudSandboxProvider } from "./cloud-sandbox-provider.js";
+
+const CLOUD_SANDBOX_SERVICE_PREFIX = "cloud-sandbox:";
+
+/**
+ * Extended service record that carries the CloudSandboxProvider instance.
+ *
+ * Plugin registers a service with:
+ *   id = "cloud-sandbox:<provider-id>"
+ *   provider = <CloudSandboxProvider instance>
+ */
+export type CloudSandboxServiceRecord = OpenClawPluginService & {
+  provider: CloudSandboxProvider;
+};
+
+/**
+ * Resolve a CloudSandboxProvider from the plugin service registry.
+ *
+ * Convention: the plugin registers a service with
+ *   id = "cloud-sandbox:<provider-id>"
+ * and attaches a `provider` property to the service object.
+ *
+ * @param providerId - Optional provider id to filter by (e.g. "ags", "e2b").
+ *   When omitted, returns the first registered cloud-sandbox provider.
+ * @returns The resolved provider, or null if none is registered.
+ */
+export function resolveCloudSandboxProvider(providerId?: string): CloudSandboxProvider | null {
+  const registry = requireActivePluginRegistry();
+  const prefix = providerId
+    ? `${CLOUD_SANDBOX_SERVICE_PREFIX}${providerId}`
+    : CLOUD_SANDBOX_SERVICE_PREFIX;
+
+  const matches = registry.services.filter((s) =>
+    providerId ? s.service.id === prefix : s.service.id.startsWith(prefix),
+  );
+
+  for (const entry of matches) {
+    const record = entry.service as CloudSandboxServiceRecord;
+    if (record.provider) {
+      return record.provider;
+    }
+  }
+  return null;
+}

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -7,13 +7,18 @@ import { requestJsonlSocket } from "./jsonl-socket.js";
 export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
 
-export type ExecHost = "sandbox" | "gateway" | "node";
+export type ExecHost = "sandbox" | "gateway" | "node" | "cloud";
 export type ExecSecurity = "deny" | "allowlist" | "full";
 export type ExecAsk = "off" | "on-miss" | "always";
 
 export function normalizeExecHost(value?: string | null): ExecHost | null {
   const normalized = value?.trim().toLowerCase();
-  if (normalized === "sandbox" || normalized === "gateway" || normalized === "node") {
+  if (
+    normalized === "sandbox" ||
+    normalized === "gateway" ||
+    normalized === "node" ||
+    normalized === "cloud"
+  ) {
     return normalized;
   }
   return null;


### PR DESCRIPTION
## Summary

Add `"cloud"` as a new `ExecHost` variant for `exec` and `browser` tools, enabling transparent command routing to cloud sandbox runtimes provided by plugins (Firecracker MicroVMs, E2B, Modal, etc.) without requiring a local Docker container.

**CloudSandboxProvider interface:**
- Plugin-implemented contract: `exec`, `execBackground`, `readSessionLog`, `killSession`
- Optional browser support: `getBrowserCdpUrl()` / `getBrowserVncUrl()` for CDP-based browser automation
- Lifecycle: `ensureReady()` (lazy init), `dispose()` (cleanup), `isReady()` (health check)
- Provider registration via existing plugin service registry (`registerService("cloud-sandbox:<id>", ...)`)

**Cloud sandbox registry:**
- `resolveCloudSandboxProvider(providerId?)` — looks up the plugin service registry for registered cloud-sandbox services
- Returns the first matching provider, or filters by explicit `providerId`

**Cloud exec handler:**
- Follows the same pattern as `bash-tools.exec-host-node.ts`
- Synchronous exec: `provider.exec()` → formatted stdout/stderr/exitCode result
- Background exec: `provider.execBackground()` → session handle with initial output
- Reuses shared approval context (`resolveExecHostApprovalContext`)
- Emits system events via `emitExecSystemEvent` for heartbeat coordination
- Infrastructure errors are wrapped with provider id for debuggability

**Exec routing integration:**
- `host="cloud"` branch inserted in `bash-tools.exec.ts` before the `host="node"` path
- Security defaults to `"allowlist"` (same as `host="gateway"`) via existing logic — no special-casing needed

**Browser tool cloud target:**
- `target="cloud"` resolves `CloudSandboxProvider.getBrowserCdpUrl()` and passes CDP URL to `BrowserBridge`
- Explicit-only (no auto-resolution to cloud in this PR)

**Type/schema extensions (6 files):**
- `ExecHost` type, config type, zod schema, normalizers, and error messages all updated to include `"cloud"`

**Also includes:**
- 28 new tests across 3 files (12 cloud exec handler, 6 cloud registry, 10 exec-runtime with cloud variants)
- `pathPrepend` warning extended to cover `host="cloud"` (not supported on cloud hosts)

## Design decisions

- **Security default:** Three independent models (GLM5, Kimi K2.5, Qwen3.5) reviewed the RFC and unanimously recommended `host="cloud"` should NOT default to `security="full"`. The implementation follows this — cloud inherits `"allowlist"` through the existing default at `bash-tools.exec.ts:321`.
- **Provider via DI:** `executeCloudHostCommand` accepts a `provider` parameter for testability, defaulting to `resolveCloudSandboxProvider()`.
- **No browser auto-resolution:** Cloud browser requires explicit `target="cloud"`. Auto-detection deferred to follow-up.
- **Doctor command:** Cloud provider health check in `openclaw doctor` deferred to follow-up PR.

## Changes

- `src/infra/exec-approvals.ts` — add `"cloud"` to `ExecHost` union
- `src/config/types.tools.ts` — add `"cloud"` to config host type
- `src/config/zod-schema.agent-runtime.ts` — add `"cloud"` to zod enum
- `src/agents/bash-tools.exec-runtime.ts` — update `normalizeExecHost()` and `renderExecHostLabel()`
- `src/gateway/sessions-patch.ts` — update local normalizer + error message
- `src/auto-reply/reply/exec/directive.ts` — update local normalizer
- `src/infra/cloud-sandbox-provider.ts` — **new**: `CloudSandboxProvider` interface + param/result types
- `src/infra/cloud-sandbox-registry.ts` — **new**: plugin registry lookup for cloud providers
- `src/agents/bash-tools.exec-host-shared.ts` — expand host param to include `"cloud"`
- `src/agents/bash-tools.exec-host-cloud.ts` — **new**: cloud exec handler (sync + background)
- `src/agents/bash-tools.exec.ts` — add cloud routing branch + pathPrepend warning
- `src/agents/tools/browser-tool.schema.ts` — add `"cloud"` to `BROWSER_TARGETS`
- `src/agents/tools/browser-tool.ts` — add cloud CDP target resolution
- `src/infra/cloud-sandbox-registry.test.ts` — **new**: 6 tests
- `src/agents/bash-tools.exec-host-cloud.test.ts` — **new**: 12 tests
- `src/agents/bash-tools.exec-runtime.test.ts` — add cloud normalizer + label tests

## Example config

```yaml
tools:
  exec:
    host: cloud
```

When no cloud sandbox plugin is installed, this produces a clear error:
```
exec host=cloud requires a cloud sandbox plugin (none registered).
Install a cloud sandbox plugin (e.g. satellite-openclaw-plugin) and ensure it registers a cloud-sandbox service.
```

## Test plan

- [x] `tsc --noEmit` — 0 type errors
- [x] `pnpm lint` (oxlint --type-aware) — 0 warnings, 0 errors on 4728 files
- [x] `pnpm format` (oxfmt) — clean
- [x] `pnpm test -- --run src/infra/cloud-sandbox-registry.test.ts src/agents/bash-tools.exec-host-cloud.test.ts src/agents/bash-tools.exec-runtime.test.ts` — 28/28 pass
- [x] `pnpm test` — full suite passes (sole pre-existing failure in `bootstrap-extra-files/handler.test.ts`, unrelated)
- [x] Manual: configure `tools.exec.host: "cloud"` without a plugin → verify error message
- [x] Manual: install a cloud sandbox plugin → verify commands route to cloud provider
