### PR TITLE
fix: emit lifecycle events for ACP sessions to enable auto-announce (#40693)

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -38,6 +38,7 @@ const hoisted = vi.hoisted(() => {
   const loadSessionStoreMock = vi.fn();
   const resolveStorePathMock = vi.fn();
   const resolveSessionTranscriptFileMock = vi.fn();
+  const registerSubagentRunMock = vi.fn();
   const state = {
     cfg: createDefaultSpawnConfig(),
   };
@@ -55,6 +56,7 @@ const hoisted = vi.hoisted(() => {
     loadSessionStoreMock,
     resolveStorePathMock,
     resolveSessionTranscriptFileMock,
+    registerSubagentRunMock,
     state,
   };
 });
@@ -133,6 +135,11 @@ vi.mock("./acp-spawn-parent-stream.js", () => ({
     hoisted.startAcpSpawnParentStreamRelayMock(...args),
   resolveAcpSpawnStreamLogPath: (...args: unknown[]) =>
     hoisted.resolveAcpSpawnStreamLogPathMock(...args),
+}));
+
+vi.mock("./subagent-registry.js", () => ({
+  registerSubagentRun: (params: unknown) => hoisted.registerSubagentRunMock(params),
+  countActiveRunsForSession: () => 0,
 }));
 
 const { spawnAcpDirect } = await import("./acp-spawn.js");
@@ -315,6 +322,7 @@ describe("spawnAcpDirect", () => {
           },
         };
       });
+    hoisted.registerSubagentRunMock.mockReset();
   });
 
   it("spawns ACP session, binds a new thread, and dispatches initial task", async () => {
@@ -367,6 +375,15 @@ describe("spawnAcpDirect", () => {
         mode: "persistent",
       }),
     );
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        childSessionKey: result.childSessionKey,
+        requesterSessionKey: "agent:main:main",
+        cleanup: "keep",
+        spawnMode: "session",
+      }),
+    );
     const transcriptCalls = hoisted.resolveSessionTranscriptFileMock.mock.calls.map(
       (call: unknown[]) => call[0] as { threadId?: string },
     );
@@ -407,6 +424,13 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.channel).toBeUndefined();
     expect(agentCall?.params?.to).toBeUndefined();
     expect(agentCall?.params?.threadId).toBeUndefined();
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        cleanup: "keep",
+        spawnMode: "run",
+      }),
+    );
   });
 
   it("keeps ACP spawn running when session-file persistence fails", async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -41,7 +41,12 @@ import {
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
-import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
+import { registerSubagentRun } from "./subagent-registry.js";
+import {
+  resolveDisplaySessionKey,
+  resolveInternalSessionKey,
+  resolveMainSessionAlias,
+} from "./tools/sessions-resolution.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
 
@@ -514,6 +519,12 @@ export async function spawnAcpDirect(
     to: ctx.agentTo,
     threadId: ctx.agentThreadId,
   });
+  const { mainKey, alias } = resolveMainSessionAlias(cfg);
+  const requesterDisplayKey = resolveDisplaySessionKey({
+    key: requesterInternalKey,
+    alias,
+    mainKey,
+  });
   // For thread-bound ACP spawns, force bootstrap delivery to the new child thread.
   const boundThreadIdRaw = binding?.conversation.conversationId;
   const boundThreadId = boundThreadIdRaw ? String(boundThreadIdRaw).trim() || undefined : undefined;
@@ -581,6 +592,24 @@ export async function spawnAcpDirect(
       error: summarizeError(err),
       childSessionKey: sessionKey,
     };
+  }
+
+  try {
+    registerSubagentRun({
+      runId: childRunId,
+      childSessionKey: sessionKey,
+      requesterSessionKey: requesterInternalKey,
+      requesterOrigin,
+      requesterDisplayKey,
+      task: params.task,
+      cleanup: "keep",
+      label: params.label || undefined,
+      spawnMode,
+    });
+  } catch (err) {
+    log.warn(
+      `failed to register ACP subagent run ${childRunId} for ${sessionKey}: ${summarizeError(err)}`,
+    );
   }
 
   if (streamToParentRequested && parentSessionKey) {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -49,6 +49,12 @@ const bindingServiceMocks = vi.hoisted(() => ({
   listBySession: vi.fn<(sessionKey: string) => SessionBindingRecord[]>(() => []),
 }));
 
+const agentEventMocks = vi.hoisted(() => ({
+  emitAgentEvent: vi.fn(),
+  getLatestAgentRunIdForSession: vi.fn<(sessionKey: string) => string | undefined>(() => "run-1"),
+  getAgentRunContext: vi.fn(),
+}));
+
 vi.mock("../../acp/control-plane/manager.js", () => ({
   getAcpSessionManager: () => managerMocks,
 }));
@@ -83,6 +89,17 @@ vi.mock("../../infra/outbound/session-binding-service.js", () => ({
     listBySession: (sessionKey: string) => bindingServiceMocks.listBySession(sessionKey),
   }),
 }));
+
+vi.mock("../../infra/agent-events.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/agent-events.js")>();
+  return {
+    ...actual,
+    emitAgentEvent: (event: unknown) => agentEventMocks.emitAgentEvent(event),
+    getLatestAgentRunIdForSession: (sessionKey: string) =>
+      agentEventMocks.getLatestAgentRunIdForSession(sessionKey),
+    getAgentRunContext: (runId: string) => agentEventMocks.getAgentRunContext(runId),
+  };
+});
 
 const { tryDispatchAcpReply } = await import("./dispatch-acp.js");
 const sessionKey = "agent:codex-acp:session-1";
@@ -227,6 +244,11 @@ describe("tryDispatchAcpReply", () => {
     sessionMetaMocks.readAcpSessionEntry.mockReturnValue(null);
     bindingServiceMocks.listBySession.mockReset();
     bindingServiceMocks.listBySession.mockReturnValue([]);
+    agentEventMocks.emitAgentEvent.mockReset();
+    agentEventMocks.getLatestAgentRunIdForSession.mockReset();
+    agentEventMocks.getLatestAgentRunIdForSession.mockReturnValue("run-1");
+    agentEventMocks.getAgentRunContext.mockReset();
+    agentEventMocks.getAgentRunContext.mockReturnValue(undefined);
   });
 
   it("routes ACP block output to originating channel", async () => {
@@ -369,6 +391,53 @@ describe("tryDispatchAcpReply", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.stringContaining("ACP_DISPATCH_DISABLED"),
+      }),
+    );
+  });
+
+  it("emits lifecycle end event when ACP turn completes", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({ type: "done" });
+      },
+    );
+
+    await runDispatch({
+      bodyForAgent: "test",
+    });
+
+    expect(agentEventMocks.emitAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        stream: "lifecycle",
+        sessionKey,
+        data: expect.objectContaining({
+          phase: "end",
+          endedAt: expect.any(Number),
+        }),
+      }),
+    );
+  });
+
+  it("emits lifecycle error event when ACP turn fails", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockRejectedValue(new Error("runtime exploded"));
+
+    await runDispatch({
+      bodyForAgent: "test",
+    });
+
+    expect(agentEventMocks.emitAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        stream: "lifecycle",
+        sessionKey,
+        data: expect.objectContaining({
+          phase: "error",
+          endedAt: expect.any(Number),
+          error: expect.any(String),
+        }),
       }),
     );
   });

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -11,6 +11,11 @@ import { readAcpSessionEntry } from "../../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
+import {
+  emitAgentEvent,
+  getAgentRunContext,
+  getLatestAgentRunIdForSession,
+} from "../../infra/agent-events.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
@@ -103,6 +108,18 @@ function resolveAcpRequestId(ctx: FinalizedMsgContext): string {
     return String(id);
   }
   return generateSecureUuid();
+}
+
+function resolveAcpLifecycleRunId(sessionKey: string, requestId: string): string | undefined {
+  const bySession = getLatestAgentRunIdForSession(sessionKey);
+  if (bySession) {
+    return bySession;
+  }
+  const requestContext = getAgentRunContext(requestId);
+  if (requestContext?.sessionKey === sessionKey) {
+    return requestId;
+  }
+  return undefined;
 }
 
 function hasBoundConversationForSession(params: {
@@ -226,6 +243,8 @@ export async function tryDispatchAcpReply(params: {
   });
 
   const acpDispatchStartedAt = Date.now();
+  const requestId = resolveAcpRequestId(params.ctx);
+  const lifecycleRunId = resolveAcpLifecycleRunId(sessionKey, requestId);
   try {
     const dispatchPolicyError = resolveAcpDispatchPolicyError(params.cfg);
     if (dispatchPolicyError) {
@@ -252,9 +271,20 @@ export async function tryDispatchAcpReply(params: {
       sessionKey,
       text: promptText,
       mode: "prompt",
-      requestId: resolveAcpRequestId(params.ctx),
+      requestId,
       onEvent: async (event) => await projector.onEvent(event),
     });
+    if (lifecycleRunId) {
+      emitAgentEvent({
+        runId: lifecycleRunId,
+        stream: "lifecycle",
+        sessionKey,
+        data: {
+          phase: "end",
+          endedAt: Date.now(),
+        },
+      });
+    }
 
     await projector.flush(true);
     const ttsMode = resolveTtsConfig(params.cfg).mode ?? "final";
@@ -319,6 +349,18 @@ export async function tryDispatchAcpReply(params: {
       fallbackCode: "ACP_TURN_FAILED",
       fallbackMessage: "ACP turn failed before completion.",
     });
+    if (lifecycleRunId) {
+      emitAgentEvent({
+        runId: lifecycleRunId,
+        stream: "lifecycle",
+        sessionKey,
+        data: {
+          phase: "error",
+          endedAt: Date.now(),
+          error: acpError.message,
+        },
+      });
+    }
     const delivered = await delivery.deliver("final", {
       text: formatAcpRuntimeErrorText(acpError),
       isError: true,

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -23,18 +23,60 @@ export type AgentRunContext = {
 const seqByRun = new Map<string, number>();
 const listeners = new Set<(evt: AgentEventPayload) => void>();
 const runContextById = new Map<string, AgentRunContext>();
+const runIdsBySessionKey = new Map<string, Set<string>>();
+
+function normalizeSessionKey(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function addRunIdToSession(sessionKey: string, runId: string) {
+  const existing = runIdsBySessionKey.get(sessionKey);
+  if (!existing) {
+    runIdsBySessionKey.set(sessionKey, new Set([runId]));
+    return;
+  }
+  // Re-add to keep insertion order stable for latest-run lookup.
+  if (existing.delete(runId)) {
+    existing.add(runId);
+    return;
+  }
+  existing.add(runId);
+}
+
+function removeRunIdFromSession(sessionKey: string, runId: string) {
+  const existing = runIdsBySessionKey.get(sessionKey);
+  if (!existing) {
+    return;
+  }
+  existing.delete(runId);
+  if (existing.size === 0) {
+    runIdsBySessionKey.delete(sessionKey);
+  }
+}
 
 export function registerAgentRunContext(runId: string, context: AgentRunContext) {
   if (!runId) {
     return;
   }
+  const nextSessionKey = normalizeSessionKey(context.sessionKey);
   const existing = runContextById.get(runId);
   if (!existing) {
     runContextById.set(runId, { ...context });
+    if (nextSessionKey) {
+      addRunIdToSession(nextSessionKey, runId);
+    }
     return;
   }
-  if (context.sessionKey && existing.sessionKey !== context.sessionKey) {
-    existing.sessionKey = context.sessionKey;
+  const previousSessionKey = normalizeSessionKey(existing.sessionKey);
+  if (nextSessionKey && existing.sessionKey !== nextSessionKey) {
+    if (previousSessionKey) {
+      removeRunIdFromSession(previousSessionKey, runId);
+    }
+    existing.sessionKey = nextSessionKey;
+    addRunIdToSession(nextSessionKey, runId);
+  } else if (nextSessionKey) {
+    addRunIdToSession(nextSessionKey, runId);
   }
   if (context.verboseLevel && existing.verboseLevel !== context.verboseLevel) {
     existing.verboseLevel = context.verboseLevel;
@@ -52,11 +94,28 @@ export function getAgentRunContext(runId: string) {
 }
 
 export function clearAgentRunContext(runId: string) {
+  const existing = runContextById.get(runId);
+  if (existing?.sessionKey) {
+    removeRunIdFromSession(existing.sessionKey, runId);
+  }
   runContextById.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {
   runContextById.clear();
+  runIdsBySessionKey.clear();
+}
+
+export function getLatestAgentRunIdForSession(sessionKey: string): string | undefined {
+  const normalized = normalizeSessionKey(sessionKey);
+  if (!normalized) {
+    return undefined;
+  }
+  const runIds = runIdsBySessionKey.get(normalized);
+  if (!runIds || runIds.size === 0) {
+    return undefined;
+  }
+  return Array.from(runIds).at(-1);
 }
 
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {


### PR DESCRIPTION
## Summary

ACP sessions spawned via `sessions_spawn(runtime='acp')` never trigger the auto-announce flow to the parent session. This PR fixes that.

## Root Cause

The announce system depends on `lifecycle` events with `phase: 'end'`:

1. Standard subagent runs emit lifecycle events via `handleAgentEnd()` → `emitAgentEvent({ stream: 'lifecycle', phase: 'end' })`
2. The subagent registry listener picks up that event → calls `completeSubagentRun()` → triggers announce to parent

**ACP sessions had two gaps:**
- `acp-spawn.ts` never called `registerSubagentRun()`, so the registry had no entry
- `dispatch-acp.ts` never emitted lifecycle events after `acpManager.runTurn()` completed

## Changes

### `src/agents/acp-spawn.ts`
- Call `registerSubagentRun()` after successful gateway dispatch, matching the pattern in `subagent-spawn.ts`

### `src/auto-reply/reply/dispatch-acp.ts`
- Emit `lifecycle` events (`phase: 'end'` on success, `phase: 'error'` on failure) after ACP turn completion
- Add `resolveAcpLifecycleRunId()` to look up the registered runId from session context

### `src/infra/agent-events.ts`
- Add `sessionKey→runId` reverse index (`runIdsBySessionKey`) so `dispatch-acp.ts` can resolve the correct runId without threading it through the entire dispatch pipeline
- Export `getLatestAgentRunIdForSession()` for the reverse lookup

### Tests
- `dispatch-acp.test.ts`: Added tests for lifecycle end/error event emission
- `acp-spawn.test.ts`: Added assertions for `registerSubagentRun()` calls

## Testing

- All modified-file tests pass (23/23)
- `pnpm build` passes
- Format check passes on all modified files

Fixes #40693

AI-assisted (Codex + manual review/fixes). Fully tested.