### PR TITLE
fix(daemon): fall back to launchctl proxy env on macOS

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveGatewayStateDir } from "./paths.js";
 import {
   buildMinimalServicePath,
@@ -9,6 +9,22 @@ import {
   getMinimalServicePathParts,
   getMinimalServicePathPartsFromEnv,
 } from "./service-env.js";
+
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: execFileSyncMock,
+  };
+});
+
+beforeEach(() => {
+  execFileSyncMock.mockReset();
+});
 
 describe("getMinimalServicePathParts - Linux user directories", () => {
   it("includes user bin directories when HOME is set on Linux", () => {
@@ -330,6 +346,60 @@ describe("buildServiceEnvironment", () => {
     expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
     expect(env.http_proxy).toBe("http://proxy.local:7890");
     expect(env.all_proxy).toBe("socks5://proxy.local:1080");
+  });
+
+  it("falls back to launchctl proxy variables on darwin when shell env is empty", () => {
+    execFileSyncMock.mockImplementation((_command, args: string[]) => {
+      const key = args[1];
+      if (key === "HTTP_PROXY" || key === "HTTPS_PROXY" || key === "ALL_PROXY") {
+        return "http://127.0.0.1:6152\n";
+      }
+      return "\n";
+    });
+
+    const env = buildServiceEnvironment({
+      env: { HOME: "/Users/tester" },
+      port: 18789,
+      platform: "darwin",
+    });
+
+    expect(env.HTTP_PROXY).toBe("http://127.0.0.1:6152");
+    expect(env.HTTPS_PROXY).toBe("http://127.0.0.1:6152");
+    expect(env.ALL_PROXY).toBe("http://127.0.0.1:6152");
+    expect(env.NO_PROXY).toBeUndefined();
+  });
+
+  it("prefers explicit proxy env values over launchctl fallbacks", () => {
+    execFileSyncMock.mockImplementation(() => "http://127.0.0.1:9999\n");
+
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/Users/tester",
+        HTTP_PROXY: "http://127.0.0.1:6152",
+        HTTPS_PROXY: "http://127.0.0.1:6152",
+        ALL_PROXY: "http://127.0.0.1:6152",
+      },
+      port: 18789,
+      platform: "darwin",
+    });
+
+    expect(env.HTTP_PROXY).toBe("http://127.0.0.1:6152");
+    expect(env.HTTPS_PROXY).toBe("http://127.0.0.1:6152");
+    expect(env.ALL_PROXY).toBe("http://127.0.0.1:6152");
+  });
+
+  it("does not query launchctl outside darwin", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/tester" },
+      port: 18789,
+      platform: "linux",
+    });
+
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(env.HTTP_PROXY).toBeUndefined();
+    expect(env.HTTPS_PROXY).toBeUndefined();
+    expect(env.ALL_PROXY).toBeUndefined();
+    expect(env.NO_PROXY).toBeUndefined();
   });
 });
 

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { VERSION } from "../version.js";
@@ -47,8 +48,34 @@ const SERVICE_PROXY_ENV_KEYS = [
   "all_proxy",
 ] as const;
 
+const SERVICE_PROXY_LAUNCHCTL_KEYS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "ALL_PROXY",
+] as const;
+
+function readLaunchctlEnvironmentValue(
+  key: (typeof SERVICE_PROXY_LAUNCHCTL_KEYS)[number],
+  platform: NodeJS.Platform,
+): string | undefined {
+  if (platform !== "darwin") {
+    return undefined;
+  }
+  try {
+    const value = execFileSync("/bin/launchctl", ["getenv", key], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function readServiceProxyEnvironment(
   env: Record<string, string | undefined>,
+  platform: NodeJS.Platform = process.platform,
 ): Record<string, string | undefined> {
   const out: Record<string, string | undefined> = {};
   for (const key of SERVICE_PROXY_ENV_KEYS) {
@@ -61,6 +88,16 @@ function readServiceProxyEnvironment(
       continue;
     }
     out[key] = trimmed;
+  }
+  for (const key of SERVICE_PROXY_LAUNCHCTL_KEYS) {
+    if (out[key]) {
+      continue;
+    }
+    const value = readLaunchctlEnvironmentValue(key, platform);
+    if (!value) {
+      continue;
+    }
+    out[key] = value;
   }
   return out;
 }
@@ -317,7 +354,7 @@ function resolveSharedServiceEnvironmentFields(
   const configPath = env.OPENCLAW_CONFIG_PATH;
   // Keep a usable temp directory for supervised services even when the host env omits TMPDIR.
   const tmpDir = env.TMPDIR?.trim() || os.tmpdir();
-  const proxyEnv = readServiceProxyEnvironment(env);
+  const proxyEnv = readServiceProxyEnvironment(env, platform);
   // On macOS, launchd services don't inherit the shell environment, so Node's undici/fetch
   // cannot locate the system CA bundle. Default to /etc/ssl/cert.pem so TLS verification
   // works correctly when running as a LaunchAgent without extra user configuration.


### PR DESCRIPTION
## Summary

Fix macOS LaunchAgent installs when proxy settings exist in `launchctl` but are missing from the invoking shell environment.

Before this change, `openclaw gateway install/start` only copied proxy variables from the current process env. On macOS, that can produce a LaunchAgent without `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY`, even though the user has working proxy settings in `launchctl`. The result is that foreground `openclaw gateway` may work, while service-managed gateway startup fails on outbound network calls.

This change adds a darwin-only fallback to `/bin/launchctl getenv` for:
- `HTTP_PROXY`
- `HTTPS_PROXY`
- `NO_PROXY`
- `ALL_PROXY`

Explicit env vars still win over the fallback.

## Repro

1. On macOS, configure proxy through launchd / system proxy path so `launchctl getenv HTTP_PROXY` is set.
2. Run `openclaw gateway install` or `openclaw gateway start` from a shell where proxy vars are unset.
3. Observe that the generated LaunchAgent lacks proxy env and service-mode outbound requests fail.
4. Foreground `openclaw gateway` may still behave differently depending on the environment it inherits.

## Fix

- Add darwin-only launchctl fallback in service env generation.
- Keep existing env precedence.
- Add unit coverage for:
  - darwin fallback
  - explicit env precedence
  - non-darwin no-op

## Testing

- `pnpm exec vitest run --config vitest.unit.config.ts src/daemon/service-env.test.ts`

## AI Assistance

AI-assisted with Codex.
