### PR TITLE
fix(models): upgrade stale exact gpt-5.4 registry rows

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11562,7 +11562,7 @@
         "filename": "src/agents/pi-embedded-runner/model.ts",
         "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
         "is_verified": false,
-        "line_number": 279
+        "line_number": 302
       }
     ],
     "src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts": [
@@ -13013,5 +13013,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-09T08:37:13Z"
+  "generated_at": "2026-03-10T02:34:33Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,7 +205,7 @@
         "filename": "apps/macos/Sources/OpenClawProtocol/GatewayModels.swift",
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
-        "line_number": 1763
+        "line_number": 1859
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
@@ -266,7 +266,7 @@
         "filename": "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
-        "line_number": 1763
+        "line_number": 1859
       }
     ],
     "docs/.i18n/zh-CN.tm.jsonl": [
@@ -11659,7 +11659,7 @@
         "filename": "src/agents/tools/web-search.ts",
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
-        "line_number": 292
+        "line_number": 291
       }
     ],
     "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
@@ -13013,5 +13013,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T02:34:33Z"
+  "generated_at": "2026-03-10T03:11:06Z"
 }

--- a/src/agents/pi-embedded-error-observation.test.ts
+++ b/src/agents/pi-embedded-error-observation.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as loggingConfigModule from "../logging/config.js";
+import {
+  buildApiErrorObservationFields,
+  buildTextObservationFields,
+  sanitizeForConsole,
+} from "./pi-embedded-error-observation.js";
+
+const OBSERVATION_BEARER_TOKEN = "sk-redact-test-token";
+const OBSERVATION_COOKIE_VALUE = "session-cookie-token";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildApiErrorObservationFields", () => {
+  it("redacts request ids and exposes stable hashes instead of raw payloads", () => {
+    const observed = buildApiErrorObservationFields(
+      '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_overload"}',
+    );
+
+    expect(observed).toMatchObject({
+      rawErrorPreview: expect.stringContaining('"request_id":"sha256:'),
+      rawErrorHash: expect.stringMatching(/^sha256:/),
+      rawErrorFingerprint: expect.stringMatching(/^sha256:/),
+      providerErrorType: "overloaded_error",
+      providerErrorMessagePreview: "Overloaded",
+      requestIdHash: expect.stringMatching(/^sha256:/),
+    });
+    expect(observed.rawErrorPreview).not.toContain("req_overload");
+  });
+
+  it("forces token redaction for observation previews", () => {
+    const observed = buildApiErrorObservationFields(
+      `Authorization: Bearer ${OBSERVATION_BEARER_TOKEN}`,
+    );
+
+    expect(observed.rawErrorPreview).not.toContain(OBSERVATION_BEARER_TOKEN);
+    expect(observed.rawErrorPreview).toContain(OBSERVATION_BEARER_TOKEN.slice(0, 6));
+    expect(observed.rawErrorHash).toMatch(/^sha256:/);
+  });
+
+  it("redacts observation-only header and cookie formats", () => {
+    const observed = buildApiErrorObservationFields(
+      `x-api-key: ${OBSERVATION_BEARER_TOKEN} Cookie: session=${OBSERVATION_COOKIE_VALUE}`,
+    );
+
+    expect(observed.rawErrorPreview).not.toContain(OBSERVATION_COOKIE_VALUE);
+    expect(observed.rawErrorPreview).toContain("x-api-key: ***");
+    expect(observed.rawErrorPreview).toContain("Cookie: session=");
+  });
+
+  it("does not let cookie redaction consume unrelated fields on the same line", () => {
+    const observed = buildApiErrorObservationFields(
+      `Cookie: session=${OBSERVATION_COOKIE_VALUE} status=503 request_id=req_cookie`,
+    );
+
+    expect(observed.rawErrorPreview).toContain("Cookie: session=");
+    expect(observed.rawErrorPreview).toContain("status=503");
+    expect(observed.rawErrorPreview).toContain("request_id=sha256:");
+  });
+
+  it("builds sanitized generic text observation fields", () => {
+    const observed = buildTextObservationFields(
+      '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_prev"}',
+    );
+
+    expect(observed).toMatchObject({
+      textPreview: expect.stringContaining('"request_id":"sha256:'),
+      textHash: expect.stringMatching(/^sha256:/),
+      textFingerprint: expect.stringMatching(/^sha256:/),
+      providerErrorType: "overloaded_error",
+      providerErrorMessagePreview: "Overloaded",
+      requestIdHash: expect.stringMatching(/^sha256:/),
+    });
+    expect(observed.textPreview).not.toContain("req_prev");
+  });
+
+  it("redacts request ids in formatted plain-text errors", () => {
+    const observed = buildApiErrorObservationFields(
+      "LLM error overloaded_error: Overloaded (request_id: req_plaintext_123)",
+    );
+
+    expect(observed).toMatchObject({
+      rawErrorPreview: expect.stringContaining("request_id: sha256:"),
+      rawErrorFingerprint: expect.stringMatching(/^sha256:/),
+      requestIdHash: expect.stringMatching(/^sha256:/),
+    });
+    expect(observed.rawErrorPreview).not.toContain("req_plaintext_123");
+  });
+
+  it("keeps fingerprints stable across request ids for equivalent errors", () => {
+    const first = buildApiErrorObservationFields(
+      '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_001"}',
+    );
+    const second = buildApiErrorObservationFields(
+      '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_002"}',
+    );
+
+    expect(first.rawErrorFingerprint).toBe(second.rawErrorFingerprint);
+    expect(first.rawErrorHash).not.toBe(second.rawErrorHash);
+  });
+
+  it("truncates oversized raw and provider previews", () => {
+    const longMessage = "X".repeat(260);
+    const observed = buildApiErrorObservationFields(
+      `{"type":"error","error":{"type":"server_error","message":"${longMessage}"},"request_id":"req_long"}`,
+    );
+
+    expect(observed.rawErrorPreview).toBeDefined();
+    expect(observed.providerErrorMessagePreview).toBeDefined();
+    expect(observed.rawErrorPreview?.length).toBeLessThanOrEqual(401);
+    expect(observed.providerErrorMessagePreview?.length).toBeLessThanOrEqual(201);
+    expect(observed.providerErrorMessagePreview?.endsWith("…")).toBe(true);
+  });
+
+  it("caps oversized raw inputs before hashing and fingerprinting", () => {
+    const oversized = "X".repeat(70_000);
+    const bounded = "X".repeat(64_000);
+
+    expect(buildApiErrorObservationFields(oversized)).toMatchObject({
+      rawErrorHash: buildApiErrorObservationFields(bounded).rawErrorHash,
+      rawErrorFingerprint: buildApiErrorObservationFields(bounded).rawErrorFingerprint,
+    });
+  });
+
+  it("returns empty observation fields for empty input", () => {
+    expect(buildApiErrorObservationFields(undefined)).toEqual({});
+    expect(buildApiErrorObservationFields("")).toEqual({});
+    expect(buildApiErrorObservationFields("   ")).toEqual({});
+  });
+
+  it("re-reads configured redact patterns on each call", () => {
+    const readLoggingConfig = vi.spyOn(loggingConfigModule, "readLoggingConfig");
+    readLoggingConfig.mockReturnValueOnce(undefined);
+    readLoggingConfig.mockReturnValueOnce({
+      redactPatterns: [String.raw`\bcustom-secret-[A-Za-z0-9]+\b`],
+    });
+
+    const first = buildApiErrorObservationFields("custom-secret-abc123");
+    const second = buildApiErrorObservationFields("custom-secret-abc123");
+
+    expect(first.rawErrorPreview).toContain("custom-secret-abc123");
+    expect(second.rawErrorPreview).not.toContain("custom-secret-abc123");
+    expect(second.rawErrorPreview).toContain("custom");
+  });
+
+  it("fails closed when observation sanitization throws", () => {
+    vi.spyOn(loggingConfigModule, "readLoggingConfig").mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    expect(buildApiErrorObservationFields("request_id=req_123")).toEqual({});
+    expect(buildTextObservationFields("request_id=req_123")).toEqual({
+      textPreview: undefined,
+      textHash: undefined,
+      textFingerprint: undefined,
+      httpCode: undefined,
+      providerErrorType: undefined,
+      providerErrorMessagePreview: undefined,
+      requestIdHash: undefined,
+    });
+  });
+
+  it("ignores non-string configured redact patterns", () => {
+    vi.spyOn(loggingConfigModule, "readLoggingConfig").mockReturnValue({
+      redactPatterns: [
+        123 as never,
+        { bad: true } as never,
+        String.raw`\bcustom-secret-[A-Za-z0-9]+\b`,
+      ],
+    });
+
+    const observed = buildApiErrorObservationFields("custom-secret-abc123");
+
+    expect(observed.rawErrorPreview).not.toContain("custom-secret-abc123");
+    expect(observed.rawErrorPreview).toContain("custom");
+  });
+});
+
+describe("sanitizeForConsole", () => {
+  it("strips control characters from console-facing values", () => {
+    expect(sanitizeForConsole("run-1\nprovider\tmodel\rtest")).toBe("run-1 provider model test");
+  });
+});

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -6,12 +6,14 @@ vi.mock("../pi-model-discovery.js", () => ({
 }));
 
 import type { OpenClawConfig } from "../../config/config.js";
+import { discoverModels } from "../pi-model-discovery.js";
 import { buildInlineProviderModels, resolveModel } from "./model.js";
 import {
   buildOpenAICodexForwardCompatExpectation,
   makeModel,
   mockDiscoveredModel,
   mockOpenAICodexTemplateModel,
+  OPENAI_CODEX_TEMPLATE_MODEL,
   resetMockDiscoverModels,
 } from "./model.test-harness.js";
 
@@ -478,6 +480,43 @@ describe("resolveModel", () => {
 
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
+  });
+
+  it("upgrades stale exact openai-codex gpt-5.4 registry metadata via forward-compat", () => {
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider !== "openai-codex") {
+          return null;
+        }
+        if (modelId === "gpt-5.4") {
+          return {
+            ...OPENAI_CODEX_TEMPLATE_MODEL,
+            id: "gpt-5.4",
+            name: "GPT-5.4",
+            contextWindow: 272000,
+          };
+        }
+        if (modelId === "gpt-5.3-codex") {
+          return {
+            ...OPENAI_CODEX_TEMPLATE_MODEL,
+            id: "gpt-5.3-codex",
+            name: "GPT-5.3 Codex",
+          };
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      name: "GPT-5.4",
+      contextWindow: 1_050_000,
+      maxTokens: 128000,
+    });
   });
 
   it("applies provider overrides to openai gpt-5.4 forward-compat models", () => {

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -519,6 +519,36 @@ describe("resolveModel", () => {
     });
   });
 
+  it("does not downgrade exact openai-codex gpt-5.3-codex registry metadata", () => {
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider !== "openai-codex") {
+          return null;
+        }
+        if (modelId === "gpt-5.3-codex") {
+          return {
+            ...OPENAI_CODEX_TEMPLATE_MODEL,
+            id: "gpt-5.3-codex",
+            name: "GPT-5.3 Codex",
+            contextWindow: 272000,
+          };
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+      name: "GPT-5.3 Codex",
+      contextWindow: 272000,
+      maxTokens: 128000,
+    });
+  });
+
   it("applies provider overrides to openai gpt-5.4 forward-compat models", () => {
     mockDiscoveredModel({
       provider: "openai",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -146,13 +146,27 @@ export function resolveModelWithRegistry(params: {
 }): Model<Api> | undefined {
   const { provider, modelId, modelRegistry, cfg } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
+  const forwardCompat = resolveForwardCompatModel(provider, modelId, modelRegistry);
   const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
 
   if (model) {
+    const effectiveModel =
+      forwardCompat === undefined
+        ? model
+        : ({
+            ...model,
+            api: forwardCompat.api ?? model.api,
+            baseUrl: forwardCompat.baseUrl ?? model.baseUrl,
+            reasoning: forwardCompat.reasoning ?? model.reasoning,
+            input: forwardCompat.input ?? model.input,
+            contextWindow: forwardCompat.contextWindow ?? model.contextWindow,
+            maxTokens: forwardCompat.maxTokens ?? model.maxTokens,
+            compat: forwardCompat.compat ?? model.compat,
+          } as Model<Api>);
     return normalizeResolvedModel({
       provider,
       model: applyConfiguredProviderOverrides({
-        discoveredModel: model,
+        discoveredModel: effectiveModel,
         providerConfig,
         modelId,
       }),
@@ -171,7 +185,6 @@ export function resolveModelWithRegistry(params: {
 
   // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.
   // Otherwise, configured providers can default to a generic API and break specific transports.
-  const forwardCompat = resolveForwardCompatModel(provider, modelId, modelRegistry);
   if (forwardCompat) {
     return normalizeResolvedModel({
       provider,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -138,6 +138,15 @@ export function buildInlineProviderModels(
   });
 }
 
+function shouldUpgradeExactRegistryRowWithForwardCompat(
+  provider: string,
+  modelId: string,
+): boolean {
+  return (
+    normalizeProviderId(provider) === "openai-codex" && modelId.trim().toLowerCase() === "gpt-5.4"
+  );
+}
+
 export function resolveModelWithRegistry(params: {
   provider: string;
   modelId: string;
@@ -151,7 +160,8 @@ export function resolveModelWithRegistry(params: {
 
   if (model) {
     const effectiveModel =
-      forwardCompat === undefined
+      forwardCompat === undefined ||
+      !shouldUpgradeExactRegistryRowWithForwardCompat(provider, modelId)
         ? model
         : ({
             ...model,


### PR DESCRIPTION
## Summary
- upgrade exact `openai-codex/gpt-5.4` registry rows with forward-compat metadata before returning them from `resolveModelWithRegistry()`
- keep friendly registry names like `GPT-5.4` while overriding stale ctx/max token metadata
- add a regression test for the `models list` symptom reported in #41318

## Why
`openclaw models list` can still show `openai-codex/gpt-5.4` at ~266k ctx when the underlying registry already contains an exact `gpt-5.4` row with stale metadata. In that case `resolveModelWithRegistry()` returned the discovered row immediately and never let the forward-compat upgrade patch apply.

Runtime agent execution was already able to use the larger context via the forward-compat path, but listing could stay stuck on the stale registry value.

## Testing
- `corepack pnpm vitest run src/agents/pi-embedded-runner/model.test.ts --testNamePattern "openai-codex fallback|stale exact openai-codex gpt-5.4|provider overrides to openai gpt-5.4"`
- `corepack pnpm vitest run src/commands/models/list.list-command.forward-compat.test.ts`

Closes #41318.
