### PR TITLE
fix(health-monitor): avoid telegram stale-socket restarts for scoped channel ids

### DIFF
--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -143,6 +143,28 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 
+  it("skips stale-socket detection for scoped telegram channel ids (e.g. telegram:default)", () => {
+    // Regression: channelId may include an account suffix; a strict equality check
+    // against "telegram" would miss "telegram:default" and trigger false stale-socket restarts.
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: null,
+      },
+      {
+        channelId: "telegram:default",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
   it("skips stale-socket detection for channels in webhook mode", () => {
     const evaluation = evaluateChannelHealth(
       {

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -110,8 +110,10 @@ export function evaluateChannelHealth(
   // explicitly operating in webhook mode. In these cases, there is no persistent
   // outgoing socket that can go half-dead, so the lack of incoming events
   // does not necessarily indicate a connection failure.
+  // NOTE: channelId may be scoped with an account suffix (e.g. "telegram:default"),
+  // so we match by prefix rather than exact equality.
   if (
-    policy.channelId !== "telegram" &&
+    !policy.channelId.startsWith("telegram") &&
     snapshot.mode !== "webhook" &&
     snapshot.connected === true &&
     snapshot.lastEventAt != null

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -113,7 +113,8 @@ export function evaluateChannelHealth(
   // NOTE: channelId may be scoped with an account suffix (e.g. "telegram:default"),
   // so we match by prefix rather than exact equality.
   if (
-    !policy.channelId.startsWith("telegram") &&
+    policy.channelId !== "telegram" &&
+    !policy.channelId.startsWith("telegram:") &&
     snapshot.mode !== "webhook" &&
     snapshot.connected === true &&
     snapshot.lastEventAt != null


### PR DESCRIPTION
## Root cause
The health policy intentionally skips stale-socket detection for Telegram long-polling channels, but it checked `policy.channelId !== "telegram"`.

In production the channel id is scoped with an account suffix (e.g. `telegram:default`), so the skip did not apply and the health monitor restarted Telegram every ~30 minutes on quiet chats.

## Fix
Treat Telegram channel ids as a prefix match: `policy.channelId.startsWith("telegram")`.

## Tests
- Added regression test for `telegram:default` in `src/gateway/channel-health-policy.test.ts`.

## Tests run
`pnpm test src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts`
}