### PR TITLE
chore(skills): include escaped-path details in warning

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -190,12 +190,15 @@ function warnEscapedSkillPath(params: {
   candidatePath: string;
   candidateRealPath: string;
 }) {
-  skillsLogger.warn("Skipping skill path that resolves outside its configured root.", {
-    source: params.source,
-    rootDir: params.rootDir,
-    path: params.candidatePath,
-    realPath: params.candidateRealPath,
-  });
+  skillsLogger.warn(
+    `Skipping skill path that resolves outside its configured root (source=${params.source} rootDir=${params.rootDir} path=${params.candidatePath} realPath=${params.candidateRealPath}).`,
+    {
+      source: params.source,
+      rootDir: params.rootDir,
+      path: params.candidatePath,
+      realPath: params.candidateRealPath,
+    },
+  );
 }
 
 function resolveContainedSkillPath(params: {


### PR DESCRIPTION
## What\nWhen OpenClaw skips a skill path because it resolves outside its configured root, the current warning message does not include enough context to diagnose the root cause. In practice this can happen with common setups (e.g., Python virtualenv symlinks inside a skill folder) and is hard to debug without the skipped path details.\n\nThis PR keeps the existing security behavior (still skips the escaped path) but augments the warning message to include:\n- source\n- rootDir\n- candidate path\n- resolved realPath\n\n## Why\nImproves operator debuggability without changing the safety policy.