### PR TITLE
fix(browser): prevent AX refs from causing relay click timeouts

### DIFF
--- a/src/agents/tools/browser-tool.actions.ts
+++ b/src/agents/tools/browser-tool.actions.ts
@@ -112,10 +112,13 @@ export async function executeSnapshotAction(params: {
 }): Promise<AgentToolResult<unknown>> {
   const { input, baseUrl, profile, proxyRequest } = params;
   const snapshotDefaults = loadConfig().browser?.snapshotDefaults;
-  const format: "ai" | "aria" | undefined =
+  const requestedFormat: "ai" | "aria" | undefined =
     input.snapshotFormat === "ai" || input.snapshotFormat === "aria"
       ? input.snapshotFormat
       : undefined;
+  // Tool-driven browser automation expects actionable refs from AI snapshots by default.
+  // Falling back to server-selected format can yield AX-tree refs (axN) that are not clickable.
+  const format: "ai" | "aria" = requestedFormat ?? "ai";
   const mode: "efficient" | undefined =
     input.mode === "efficient"
       ? "efficient"
@@ -150,7 +153,7 @@ export async function executeSnapshotAction(params: {
         ? maxChars
         : undefined;
   const snapshotQuery = {
-    ...(format ? { format } : {}),
+    format,
     targetId,
     limit,
     ...(typeof resolvedMaxChars === "number" ? { maxChars: resolvedMaxChars } : {}),

--- a/src/agents/tools/browser-tool.test.ts
+++ b/src/agents/tools/browser-tool.test.ts
@@ -243,7 +243,7 @@ describe("browser tool snapshot maxChars", () => {
     );
   });
 
-  it("lets the server choose snapshot format when the user does not request one", async () => {
+  it("defaults to ai snapshot format when the user does not request one", async () => {
     const tool = createBrowserTool();
     await tool.execute?.("call-1", { action: "snapshot", profile: "chrome" });
 
@@ -256,8 +256,8 @@ describe("browser tool snapshot maxChars", () => {
     const opts = browserClientMocks.browserSnapshot.mock.calls.at(-1)?.[1] as
       | { format?: string; maxChars?: number }
       | undefined;
-    expect(opts?.format).toBeUndefined();
-    expect(Object.hasOwn(opts ?? {}, "maxChars")).toBe(false);
+    expect(opts?.format).toBe("ai");
+    expect(opts?.maxChars).toBe(DEFAULT_AI_SNAPSHOT_MAX_CHARS);
   });
 
   it("routes to node proxy when target=node", async () => {

--- a/src/browser/pw-session.test.ts
+++ b/src/browser/pw-session.test.ts
@@ -71,6 +71,13 @@ describe("pw-session refLocator", () => {
 
     expect(mocks.locator).toHaveBeenCalledWith("aria-ref=e1");
   });
+
+  it("fails fast for AX-tree refs from aria snapshots", () => {
+    const { page, mocks } = fakePage();
+
+    expect(() => refLocator(page, "ax70")).toThrow(/not actionable/i);
+    expect(mocks.locator).not.toHaveBeenCalled();
+  });
 });
 
 describe("pw-session role refs cache", () => {

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -564,6 +564,13 @@ export function refLocator(page: Page, ref: string) {
     return info.nth !== undefined ? locator.nth(info.nth) : locator;
   }
 
+  if (/^ax\d+$/i.test(normalized)) {
+    throw new Error(
+      `Unsupported ref "${normalized}". AX-tree refs (axN) are not actionable. ` +
+        `Run a new snapshot with format="ai" and use eN refs for click/type/act.`,
+    );
+  }
+
   return page.locator(`aria-ref=${normalized}`);
 }
 


### PR DESCRIPTION
## Summary
- Default agent `browser` tool snapshots to `format: "ai"` when `snapshotFormat` is not explicitly provided.
- Add fail-fast guard for `axN` refs in Playwright interaction path with an actionable error message.
- Update tests for the new default and AX ref guard behavior.

## Problem observed
In LINE/Telegram relay flows using `profile=my-chrome` (extension relay), the agent was repeatedly failing on Sora interactions with this sequence:
1. `act kind=press` called without `key` -> `key is required`
2. subsequent clicks targeted AX refs like `ax70`
3. Playwright waited on `locator('aria-ref=ax70')` and timed out repeatedly
4. user-facing result escalated to generic browser `timed out` guidance

This happens because AX-tree refs (`axN`) are not actionable in `click/type/act`, but they were being used in automation turns.

## Why this fix
- Using AI snapshots by default in the agent tool keeps refs actionable for follow-up interactions (`eN`).
- The new fail-fast guard avoids long timeout loops when `axN` refs are accidentally passed, and tells the agent exactly how to recover (take AI snapshot and use `eN`).

## Scope / compatibility
- No schema/config changes.
- Explicit `snapshotFormat: "aria"` still works for read-only inspection use cases.
- Existing automation gains safer defaults with minimal behavior change.

## Validation
- Updated unit tests:
  - `src/agents/tools/browser-tool.test.ts`
  - `src/browser/pw-session.test.ts`
- Local test execution is not available in this environment (`pnpm/corepack` missing), so CI is expected to validate full checks.
