### PR TITLE
Retry LanceDB initialization after failures

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -218,6 +218,109 @@ describe("memory plugin e2e", () => {
     }
   });
 
+  test("retries LanceDB initialization after a failed dynamic import", async () => {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const countRows = vi.fn(async () => 0);
+    const add = vi.fn(async () => undefined);
+    const del = vi.fn(async () => undefined);
+    const connect = vi.fn(async () => ({
+      tableNames: vi.fn(async () => ["memories"]),
+      openTable: vi.fn(async () => ({
+        vectorSearch,
+        countRows,
+        add,
+        delete: del,
+      })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+
+    try {
+      const {
+        default: memoryPlugin,
+        __setLanceDBImporterForTests,
+      } = await import("./index.js");
+      let failImport = true;
+      __setLanceDBImporterForTests(async () => {
+        if (failImport) {
+          throw new Error("Cannot find module '@lancedb/lancedb'");
+        }
+        return { connect } as typeof import("@lancedb/lancedb");
+      });
+
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const warn = vi.fn();
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+          },
+          dbPath,
+          autoCapture: false,
+          autoRecall: true,
+        },
+        runtime: {},
+        logger: {
+          info: vi.fn(),
+          warn,
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+        registerTool: (tool: any, opts: any) => {
+          registeredTools.push({ tool, opts });
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+        registerCli: vi.fn(),
+        // oxlint-disable-next-line typescript/no-explicit-any
+        registerService: vi.fn(),
+        // oxlint-disable-next-line typescript/no-explicit-any
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+      const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+
+      await expect(recallTool.execute("test-call-first", { query: "hello retry" })).rejects.toThrow(
+        "failed to load LanceDB",
+      );
+
+      failImport = false;
+
+      await expect(
+        recallTool.execute("test-call-second", { query: "hello retry" }),
+      ).resolves.toMatchObject({
+        details: { count: 0 },
+      });
+
+      expect(connect).toHaveBeenCalledTimes(1);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      const mod = await import("./index.js");
+      mod.__setLanceDBImporterForTests(null);
+      vi.doUnmock("openai");
+      vi.resetModules();
+    }
+  });
+
   test("shouldCapture applies real capture rules", async () => {
     const { shouldCapture } = await import("./index.js");
 

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -24,17 +24,28 @@ import {
 // ============================================================================
 
 let lancedbImportPromise: Promise<typeof import("@lancedb/lancedb")> | null = null;
+let importLanceDBModule: () => Promise<typeof import("@lancedb/lancedb")> = () =>
+  import("@lancedb/lancedb");
+
 const loadLanceDB = async (): Promise<typeof import("@lancedb/lancedb")> => {
   if (!lancedbImportPromise) {
-    lancedbImportPromise = import("@lancedb/lancedb");
+    lancedbImportPromise = importLanceDBModule();
   }
   try {
     return await lancedbImportPromise;
   } catch (err) {
+    lancedbImportPromise = null;
     // Common on macOS today: upstream package may not ship darwin native bindings.
     throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`, { cause: err });
   }
 };
+
+export function __setLanceDBImporterForTests(
+  importer: (() => Promise<typeof import("@lancedb/lancedb")>) | null,
+): void {
+  importLanceDBModule = importer ?? (() => import("@lancedb/lancedb"));
+  lancedbImportPromise = null;
+}
 
 type MemoryEntry = {
   id: string;
@@ -75,7 +86,12 @@ class MemoryDB {
     }
 
     this.initPromise = this.doInitialize();
-    return this.initPromise;
+    try {
+      await this.initPromise;
+    } catch (err) {
+      this.initPromise = null;
+      throw err;
+    }
   }
 
   private async doInitialize(): Promise<void> {

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -30,10 +30,9 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("console.log(1)");
   });
 
-  it("flattens remote markdown images into alt text", () => {
+  it("renders remote markdown images", () => {
     const html = toSanitizedMarkdownHtml("![Alt text](https://example.com/image.png)");
-    expect(html).not.toContain("<img");
-    expect(html).toContain("Alt text");
+    expect(html).toContain('<img src="https://example.com/image.png" alt="Alt text">');
   });
 
   it("preserves base64 data URI images (#15437)", () => {
@@ -42,7 +41,7 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("data:image/png;base64,");
   });
 
-  it("flattens non-data markdown image urls", () => {
+  it("flattens unsafe markdown image urls", () => {
     const html = toSanitizedMarkdownHtml("![X](javascript:alert(1))");
     expect(html).not.toContain("<img");
     expect(html).not.toContain("javascript:");
@@ -51,8 +50,7 @@ describe("toSanitizedMarkdownHtml", () => {
 
   it("uses a plain fallback label for unlabeled markdown images", () => {
     const html = toSanitizedMarkdownHtml("![](https://example.com/image.png)");
-    expect(html).not.toContain("<img");
-    expect(html).toContain("image");
+    expect(html).toContain('<img src="https://example.com/image.png" alt="image">');
   });
 
   it("renders GFM markdown tables (#20410)", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -1,6 +1,7 @@
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 import { truncateText } from "./format.ts";
+import { resolveSafeExternalUrl } from "./open-external-url.ts";
 
 const allowedTags = [
   "a",
@@ -43,7 +44,6 @@ const MARKDOWN_CHAR_LIMIT = 140_000;
 const MARKDOWN_PARSE_LIMIT = 40_000;
 const MARKDOWN_CACHE_LIMIT = 200;
 const MARKDOWN_CACHE_MAX_CHARS = 50_000;
-const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
 const markdownCache = new Map<string, string>();
 
 function getCachedMarkdown(key: string): string | null {
@@ -141,15 +141,20 @@ htmlEscapeRenderer.html = ({ text }: { text: string }) => escapeHtml(text);
 htmlEscapeRenderer.image = (token: { href?: string | null; text?: string | null }) => {
   const label = normalizeMarkdownImageLabel(token.text);
   const href = token.href?.trim() ?? "";
-  if (!INLINE_DATA_IMAGE_RE.test(href)) {
+  const safeHref = resolveSafeExternalUrl(href, getMarkdownBaseHref(), { allowDataImage: true });
+  if (!safeHref) {
     return escapeHtml(label);
   }
-  return `<img src="${escapeHtml(href)}" alt="${escapeHtml(label)}">`;
+  return `<img src="${escapeHtml(safeHref)}" alt="${escapeHtml(label)}">`;
 };
 
 function normalizeMarkdownImageLabel(text?: string | null): string {
   const trimmed = text?.trim();
   return trimmed ? trimmed : "image";
+}
+
+function getMarkdownBaseHref(): string {
+  return globalThis.location?.href ?? "https://openclaw.ai/";
 }
 
 function escapeHtml(value: string): string {


### PR DESCRIPTION
## Summary
- clear the cached LanceDB import promise when the dynamic import fails so the next recall can retry
- clear the MemoryDB initialization promise when startup fails so a later successful load can recover without restarting the gateway
- add a regression test that forces the first import to fail and the next call to succeed in the same process

## Testing
- corepack pnpm vitest run extensions/memory-lancedb/index.test.ts
- corepack pnpm exec oxlint --type-aware extensions/memory-lancedb/index.ts extensions/memory-lancedb/index.test.ts

Closes #41377