### PR TITLE
Add Carapace to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -50,7 +50,7 @@ Use this format when adding entries:
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
 
-- **Carapace** — Cedar authorization proxy for MCP tool access. Aggregates MCP servers, enforces Cedar policies on every tool call via Cedarling WASM, and provides a local GUI for human oversight. Default-deny or allow-all modes, visual policy builder, risk-based tool categorization.
+- **Carapace** — Cedar authorization for everything your agent does. Gates MCP tool calls, shell commands (by binary name), and outbound API requests (by domain) via Cedarling WASM (Cedar 4.4.2). Local GUI with visual policy builder, risk-based categorization, and human oversight.
   npm: `@clawdreyhepburn/carapace`
   repo: `https://github.com/clawdreyhepburn/carapace`
   install: `openclaw plugins install @clawdreyhepburn/carapace`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **Carapace** — Cedar authorization proxy for MCP tool access. Aggregates MCP servers, enforces Cedar policies on every tool call via Cedarling WASM, and provides a local GUI for human oversight. Default-deny or allow-all modes, visual policy builder, risk-based tool categorization.
+  npm: `@clawdreyhepburn/carapace`
+  repo: `https://github.com/clawdreyhepburn/carapace`
+  install: `openclaw plugins install @clawdreyhepburn/carapace`


### PR DESCRIPTION
## Carapace — Your agent's exoskeleton 🦞

**Carapace** is an OpenClaw plugin that enforces [Cedar](https://www.cedarpolicy.com/) authorization policies on everything your agent can do — MCP tool calls, shell commands, and outbound API requests — powered by [Cedarling WASM](https://github.com/JanssenProject/jans/tree/main/jans-cedarling) (Cedar 4.4.2).

### What it does
- Gates **MCP tools**, **shell commands** (by binary name), and **outbound HTTP** (by domain)
- Three Cedar resource types: `Jans::Tool`, `Jans::Shell`, `Jans::API`
- Aggregates multiple MCP servers and discovers their tools
- Enforces Cedar policies on every operation (forbid always wins)
- Local control GUI where humans can see all tools and toggle access
- Visual policy builder with live Cedar preview
- Tool categorization by risk level (Write/Execute/Browse/Read)
- Default `allow-all`: installing never breaks existing agents
- Sub-millisecond policy evaluation via WASM

### Links
- **npm:** [`@clawdreyhepburn/carapace`](https://www.npmjs.com/package/@clawdreyhepburn/carapace)
- **repo:** https://github.com/clawdreyhepburn/carapace
- **install:** `openclaw plugins install @clawdreyhepburn/carapace`

### Screenshots

The repo README includes screenshots of the tools dashboard, policy management, visual policy builder, and schema editor.

### Checklist
- [x] Published on npmjs (`@clawdreyhepburn/carapace@0.3.2`)
- [x] Source code hosted on GitHub (public)
- [x] Repository includes setup/use docs
- [x] Issue tracker enabled
- [x] Active maintainer
- [x] Apache-2.0 licensed

Built by [@ClawdreyHepburn](https://x.com/ClawdreyHepburn) and [@Sarahcec](https://github.com/Sarahcec), with Cedar engine from [@nynymike](https://github.com/nynymike)'s Cedarling project.
