### PR TITLE
docs(logging): define diagnostics as the telemetry surface

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -148,6 +148,37 @@ replace logs; they exist to feed metrics, traces, and other exporters.
 Diagnostics events are emitted in-process, but exporters only attach when
 diagnostics + the exporter plugin are enabled.
 
+### Telemetry surface ownership
+
+OpenClaw has separate surfaces for automation, runtime control, and telemetry:
+
+| If you want to...                                                                      | Use...                                  | Why                                                                |
+| -------------------------------------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------ |
+| Export metrics, traces, or machine-readable health signals                             | Diagnostic events                       | Observability should be append-only telemetry, not a behavior hook |
+| Rewrite prompts, block tools, cancel outbound messages, or add policy/middleware       | Typed plugin hooks via `api.on(...)`    | Runtime hooks can mutate or block behavior                         |
+| Trigger coarse operator automation such as file writes, notifications, or side effects | HOOK.md hooks / `api.registerHook(...)` | Internal hooks are for operator automation, not telemetry schemas  |
+
+Future OTEL work should extend `src/infra/diagnostic-events.ts`, then map those
+events in the `diagnostics-otel` plugin. Do not add telemetry-only proposals by
+growing the hook APIs.
+
+### What diagnostic events are for
+
+Diagnostic events are the observability contract between the gateway runtime and
+telemetry consumers such as the `diagnostics-otel` plugin.
+
+Diagnostic events should be:
+
+- append-only signals for exporters, dashboards, alerts, and troubleshooting
+- safe to ignore without affecting runtime behavior
+- stable enough that exporters can map them into metrics, traces, or logs
+
+Diagnostic events should not be used for:
+
+- blocking, vetoing, or rewriting runtime behavior
+- policy enforcement or middleware ordering
+- side-effect automation that must run for the system to behave correctly
+
 ### OpenTelemetry vs OTLP
 
 - **OpenTelemetry (OTel)**: the data model + SDKs for traces, metrics, and logs.
@@ -183,6 +214,28 @@ Queue + session:
 - `session.stuck`: session stuck warning + age.
 - `run.attempt`: run retry/attempt metadata.
 - `diagnostic.heartbeat`: aggregate counters (webhooks/queue/session).
+
+Tool safety:
+
+- `tool.loop`: repeated-tool-loop warning/block telemetry emitted by the runtime.
+
+### What is still missing
+
+The current event catalog is useful, but still coarse in a few places. New
+observability work should generally extend `src/infra/diagnostic-events.ts`
+instead of asking hooks to carry telemetry-only meaning.
+
+Priority gaps for future telemetry work:
+
+- Run lifecycle: explicit run start, run end, and run error boundaries.
+- Model lifecycle: request/response/error boundaries in addition to aggregate
+  `model.usage`.
+- Tool lifecycle: tool call start/end/error boundaries, plus first-class exporter
+  mapping for existing `tool.loop` events.
+- Outbound delivery lifecycle: delivery attempted/sent/failed boundaries across
+  channels, separate from message processing.
+- Attribute hygiene: clearer redaction and cardinality guidance for exporter-safe
+  fields.
 
 ### Enable diagnostics (no exporter)
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the logging/OTEL docs explain what gets exported, but they do not clearly state that diagnostics events are the telemetry contract and that telemetry-only work should not expand the hook APIs.
- Why it matters: without that boundary, OTEL proposals and observability asks keep getting mixed into runtime hook design instead of extending the existing diagnostic event bus.
- What changed: `docs/logging.md` now defines diagnostics events as the observability surface, adds a hook-vs-diagnostics decision table, documents the current event catalog more explicitly, and lists the main missing telemetry boundaries that should extend `src/infra/diagnostic-events.ts`.
- What did NOT change (scope boundary): no runtime telemetry implementation changed in this PR, and no new diagnostic events or OTEL exporter mappings were added.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] API / contracts
- [x] UI / DX

## Linked Issue/PR

- Related #21290
- Related #28166
- Related #36231
- Related #26081

## User-visible / Behavior Changes

- Docs now explicitly route telemetry/export work to diagnostics events instead of hooks.
- The logging page now calls out the current event catalog and the next missing telemetry boundaries.
- None of the runtime telemetry behavior changed.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): none

### Steps

1. Read the current logging docs against `src/infra/diagnostic-events.ts` and `extensions/diagnostics-otel/src/service.ts`.
2. Update the logging docs to separate telemetry from hooks and document the current event surface.
3. Run `pnpm check`.

### Expected

- Docs reflect diagnostics events as the telemetry surface and steer OTEL additions toward the diagnostic event bus.

### Actual

- `docs/logging.md` now makes that boundary explicit, and `pnpm check` passes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed `docs/logging.md` against `src/infra/diagnostic-events.ts` and `extensions/diagnostics-otel/src/service.ts`.
- Edge cases checked: verified the docs do not claim hook APIs drive OTEL export and note that `tool.loop` exists on the diagnostic bus even though it is not yet a first-class OTEL exporter mapping.
- What you did **not** verify: no runtime telemetry code changed, so there was no collector/backend exercise in this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `docs/logging.md`
- Known bad symptoms reviewers should watch for: docs implying new diagnostic events or exporter behavior that do not exist yet.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the docs could overstate current exporter coverage.
  - Mitigation: the text calls out current event coverage separately from missing future telemetry boundaries and notes the existing `tool.loop` exporter gap.
