### PR TITLE
fix(discord): Discord WebSocket disconnects every 10-35 minutes conti…

### DIFF
--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -32,7 +32,9 @@ export async function runDiscordGatewayLifecycle(params: {
   const HELLO_TIMEOUT_MS = 30000;
   const HELLO_CONNECTED_POLL_MS = 250;
   const MAX_CONSECUTIVE_HELLO_STALLS = 3;
-  const RECONNECT_STALL_TIMEOUT_MS = 5 * 60_000;
+  // Discord gateways may take longer than 5 minutes to recover from network issues or server-side problems
+  // Timeout was updated to 10 minutes after an issue was mentioned.
+  const RECONNECT_STALL_TIMEOUT_MS = 10 * 60_000;
   const gateway = params.client.getPlugin<GatewayPlugin>("gateway");
   if (gateway) {
     registerGateway(params.accountId, gateway);


### PR DESCRIPTION
…nuously

The gateway reconnect stall timeout was increased because 5 minutes is insufficient for the watchdog, Discord gateway may take longer than 5 minutes to recover.

Fixes #41339

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: **RECONNECT_STALL_TIMEOUT_MS** was 5 minutes, it didn't let Discord gateway recover, Discord's gateway may take longer than 5 minutes to recover from network issues or server-side problems.
- Why it matters: It fixes the WebSocket disconnecting bugs which may cause problems in the API.
- What changed: Updated **RECONNECT_STALL_TIMEOUT_MS** to **10 minutes** so it gives the gateway more time to recover before checking with the watchdog.
- What did NOT change (scope boundary): Watchdog logic remains unchanged.

## Change Type (select all)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [X] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41339 
- Related #41372 

## User-visible / Behavior Changes

Watchdog may take more time to check gateway, user could be affected by this.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Evidence

Attach at least one:

- [X] Trace/log snippets
