### PR TITLE
Bootstrap unloaded launchd gateway on restart

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 
 const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockSpawnSync = vi.hoisted(() => vi.fn());
+const launchAgentPlistExists = vi.hoisted(() => vi.fn());
+const repairLaunchAgentBootstrap = vi.hoisted(() => vi.fn());
 
 type RestartHealthSnapshot = {
   healthy: boolean;
@@ -85,6 +87,12 @@ vi.mock("../../daemon/service.js", () => ({
   resolveGatewayService: () => service,
 }));
 
+vi.mock("../../daemon/launchd.js", () => ({
+  launchAgentPlistExists: (env: Record<string, string | undefined>) => launchAgentPlistExists(env),
+  repairLaunchAgentBootstrap: (args: { env?: Record<string, string | undefined> }) =>
+    repairLaunchAgentBootstrap(args),
+}));
+
 vi.mock("./restart-health.js", () => ({
   DEFAULT_RESTART_HEALTH_ATTEMPTS: 120,
   DEFAULT_RESTART_HEALTH_DELAY_MS: 500,
@@ -127,6 +135,8 @@ describe("runDaemonRestart health checks", () => {
     loadConfig.mockReset();
     mockReadFileSync.mockReset();
     mockSpawnSync.mockReset();
+    launchAgentPlistExists.mockReset();
+    repairLaunchAgentBootstrap.mockReset();
 
     service.readCommand.mockResolvedValue({
       programArguments: ["openclaw", "gateway", "--port", "18789"],
@@ -157,6 +167,8 @@ describe("runDaemonRestart health checks", () => {
       configSnapshot: { commands: { restart: true } },
     });
     isRestartEnabled.mockReturnValue(true);
+    launchAgentPlistExists.mockResolvedValue(false);
+    repairLaunchAgentBootstrap.mockResolvedValue({ ok: true });
     mockReadFileSync.mockImplementation((path: string) => {
       const match = path.match(/\/proc\/(\d+)\/cmdline$/);
       if (!match) {
@@ -278,6 +290,35 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("re-bootstraps an installed LaunchAgent when restart finds it not loaded", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    launchAgentPlistExists.mockResolvedValue(true);
+    repairLaunchAgentBootstrap.mockResolvedValue({ ok: true });
+    runServiceRestart.mockImplementation(
+      async (params: RestartParams & { onNotLoaded?: () => Promise<unknown> }) => {
+        await params.onNotLoaded?.();
+        await params.postRestartCheck?.({
+          json: Boolean(params.opts?.json),
+          stdout: process.stdout,
+          warnings: [],
+          fail: (message: string) => {
+            throw new Error(message);
+          },
+        });
+        return true;
+      },
+    );
+
+    await runDaemonRestart({ json: true });
+
+    expect(launchAgentPlistExists).toHaveBeenCalledTimes(1);
+    expect(repairLaunchAgentBootstrap).toHaveBeenCalledWith({ env: process.env });
+    expect(waitForGatewayHealthyListener).toHaveBeenCalledTimes(1);
+    expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
+    expect(service.restart).not.toHaveBeenCalled();
+    expect(findGatewayPidsOnPortSync).not.toHaveBeenCalled();
   });
 
   it("fails unmanaged restart when multiple gateway listeners are present", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fsSync from "node:fs";
 import { isRestartEnabled } from "../../config/commands.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
+import { launchAgentPlistExists, repairLaunchAgentBootstrap } from "../../daemon/launchd.js";
 import { parseCmdScriptCommandLine } from "../../daemon/cmd-argv.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { probeGateway } from "../../gateway/probe.js";
@@ -180,6 +181,29 @@ async function restartGatewayWithoutServiceManager(port: number) {
   };
 }
 
+async function restartGatewayLaunchAgentIfInstalled() {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+  const serviceEnv = process.env as Record<string, string | undefined>;
+  const plistExists = await launchAgentPlistExists(serviceEnv);
+  if (!plistExists) {
+    return null;
+  }
+  const repaired = await repairLaunchAgentBootstrap({ env: serviceEnv });
+  if (!repaired.ok) {
+    throw new Error(
+      repaired.detail
+        ? `launchd bootstrap repair failed: ${repaired.detail}`
+        : "launchd bootstrap repair failed",
+    );
+  }
+  return {
+    result: "restarted" as const,
+    message: "Gateway LaunchAgent was installed but not loaded; re-bootstrapped launchd service.",
+  };
+}
+
 export async function runDaemonUninstall(opts: DaemonLifecycleOptions = {}) {
   return await runServiceUninstall({
     serviceNoun: "Gateway",
@@ -234,7 +258,9 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     opts,
     checkTokenDrift: true,
     onNotLoaded: async () => {
-      const handled = await restartGatewayWithoutServiceManager(restartPort);
+      const handled =
+        (await restartGatewayLaunchAgentIfInstalled()) ??
+        (await restartGatewayWithoutServiceManager(restartPort));
       if (handled) {
         restartedWithoutServiceManager = true;
       }

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -30,10 +30,9 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("console.log(1)");
   });
 
-  it("flattens remote markdown images into alt text", () => {
+  it("renders remote markdown images", () => {
     const html = toSanitizedMarkdownHtml("![Alt text](https://example.com/image.png)");
-    expect(html).not.toContain("<img");
-    expect(html).toContain("Alt text");
+    expect(html).toContain('<img src="https://example.com/image.png" alt="Alt text">');
   });
 
   it("preserves base64 data URI images (#15437)", () => {
@@ -42,7 +41,7 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("data:image/png;base64,");
   });
 
-  it("flattens non-data markdown image urls", () => {
+  it("flattens unsafe markdown image urls", () => {
     const html = toSanitizedMarkdownHtml("![X](javascript:alert(1))");
     expect(html).not.toContain("<img");
     expect(html).not.toContain("javascript:");
@@ -51,8 +50,7 @@ describe("toSanitizedMarkdownHtml", () => {
 
   it("uses a plain fallback label for unlabeled markdown images", () => {
     const html = toSanitizedMarkdownHtml("![](https://example.com/image.png)");
-    expect(html).not.toContain("<img");
-    expect(html).toContain("image");
+    expect(html).toContain('<img src="https://example.com/image.png" alt="image">');
   });
 
   it("renders GFM markdown tables (#20410)", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -1,6 +1,7 @@
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 import { truncateText } from "./format.ts";
+import { resolveSafeExternalUrl } from "./open-external-url.ts";
 
 const allowedTags = [
   "a",
@@ -43,7 +44,6 @@ const MARKDOWN_CHAR_LIMIT = 140_000;
 const MARKDOWN_PARSE_LIMIT = 40_000;
 const MARKDOWN_CACHE_LIMIT = 200;
 const MARKDOWN_CACHE_MAX_CHARS = 50_000;
-const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
 const markdownCache = new Map<string, string>();
 
 function getCachedMarkdown(key: string): string | null {
@@ -141,15 +141,20 @@ htmlEscapeRenderer.html = ({ text }: { text: string }) => escapeHtml(text);
 htmlEscapeRenderer.image = (token: { href?: string | null; text?: string | null }) => {
   const label = normalizeMarkdownImageLabel(token.text);
   const href = token.href?.trim() ?? "";
-  if (!INLINE_DATA_IMAGE_RE.test(href)) {
+  const safeHref = resolveSafeExternalUrl(href, getMarkdownBaseHref(), { allowDataImage: true });
+  if (!safeHref) {
     return escapeHtml(label);
   }
-  return `<img src="${escapeHtml(href)}" alt="${escapeHtml(label)}">`;
+  return `<img src="${escapeHtml(safeHref)}" alt="${escapeHtml(label)}">`;
 };
 
 function normalizeMarkdownImageLabel(text?: string | null): string {
   const trimmed = text?.trim();
   return trimmed ? trimmed : "image";
+}
+
+function getMarkdownBaseHref(): string {
+  return globalThis.location?.href ?? "https://openclaw.ai/";
 }
 
 function escapeHtml(value: string): string {


### PR DESCRIPTION
## Summary
- when openclaw gateway restart finds the macOS LaunchAgent not loaded, re-bootstrap the installed plist instead of immediately returning 
ot-loaded
- keep the existing unmanaged-process fallback for cases where no LaunchAgent plist exists
- add a daemon lifecycle regression test for the booted-out LaunchAgent path

## Testing
- corepack pnpm vitest run src/cli/daemon-cli/lifecycle.test.ts
- corepack pnpm exec oxlint --type-aware src/cli/daemon-cli/lifecycle.ts src/cli/daemon-cli/lifecycle.test.ts

Closes #41353