### PR TITLE
security: add config/ to .gitignore to prevent credential leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 **/node_modules/
 .env
 docker-compose.extra.yml
+config/
 dist
 pnpm-lock.yaml
 bun.lock


### PR DESCRIPTION
The config/ directory contains runtime-generated files that may include sensitive credentials (API keys, tokens, session data). This change prevents accidental exposure if users commit these files.

Similar to .env files, config/ should be local-only.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `config/` directory contains runtime-generated files with sensitive credentials (API keys, AWS tokens, session data) but was not ignored by git
- Why it matters: Developers can accidentally commit these files, exposing credentials in git history even after deletion
- What changed: Added single line `config/` to `.gitignore`
- What did NOT change (scope boundary): No code changes, no config structure changes, no migration needed, existing git history untouched

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

None - discovered during security audit

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write `None`.

None. This is transparent to users and only affects git tracking behavior.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

This prevents accidental git commits of sensitive configuration files. The config/ directory is created at runtime and can contain:
- API keys (Anthropic, Google, Brave Search)
- AWS Bedrock credentials
- Telegram bot tokens
- Session data

Without this ignore rule, git add . or IDE auto-staging can commit these files, exposing secrets in repository history.

## Repro + Verification

### Environment

- OS: Windows 11 Pro 10.0.26200
- Runtime/container: Node.js with Bun, Docker
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A (this prevents config from being tracked)

### Steps

1. Start with clean git state: git status
2. Simulate runtime config generation: mkdir -p config/agents/main/agent && echo '{"models": {"google": {"apiKey": "AIzaSyTest123Secret"}}}' > config/agents/main/agent/models.json
3. Check git status BEFORE this change (Expected: Untracked files: config/)
4. Apply .gitignore change: add "config/" line to .gitignore
5. Check git status AFTER this change (Expected: nothing to commit, config/ now ignored)
6. Verify force-add behavior with git add -f config/

### Expected

After adding config/ to .gitignore, the entire config/ directory should be ignored by git, preventing accidental commits.

### Actual

Verified: config/ directory is completely ignored after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Example scenario: Without this change, runtime-generated files like config/agents/main/agent/models.json containing API keys could be accidentally committed. Even if deleted in a subsequent commit, credentials remain in git history. This .gitignore addition prevents such exposure.

Verification results:
- Tested locally with simulated runtime config files
- Verified this effectively prevents credential exposure scenarios
- Confirmed existing .gitignore patterns don't cover config/ directory

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Created test config files with mock credentials
  - Verified git status ignores them after adding config/ rule
  - Tested with nested subdirectories (config/agents/main/agent/)
  - Confirmed no impact on existing tracked files
  - Verified .gitignore syntax is correct

- Edge cases checked:
  - Nested directories under config/ are all ignored
  - No conflict with other .gitignore patterns
  - Works on Windows file system

- What you did not verify:
  - Behavior on macOS/Linux (should be identical for gitignore rules)
  - Integration with specific git GUI clients

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

N/A - No bot review conversations yet

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

This only affects future git operations. Existing repositories will simply start ignoring config/ on next git status. No action required from users.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  ```bash
  # Remove the line from .gitignore
  sed -i '/^config\/$/d' .gitignore
  # Or manually delete the "config/" line
  ```

- Files/config to restore: None - this is pure git ignore rule

- Known bad symptoms reviewers should watch for: None expected. Worst case: config/ files become visible to git again (original behavior)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Developers may assume ALL config files are now ignored and stop being cautious
  - Mitigation: README documentation already instructs manual config creation. This change aligns with documented best practices.

- Risk: Existing repositories with tracked config/ files won't auto-untrack them
  - Mitigation: This is expected git behavior. Users must manually git rm --cached config/ if they have existing tracked files. This PR only prevents future tracking.
