### PR TITLE
feat(media): add AssemblyAI audio transcription provider

### DIFF
--- a/src/media-understanding/providers/assemblyai/audio.test.ts
+++ b/src/media-understanding/providers/assemblyai/audio.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import { withFetchPreconnect } from "../../../test-utils/fetch-mock.js";
+import { installPinnedHostnameTestHooks } from "../audio.test-helpers.js";
+import {
+  DEFAULT_ASSEMBLYAI_BASE_URL,
+  DEFAULT_ASSEMBLYAI_MODEL,
+  transcribeAssemblyAIAudio,
+} from "./audio.js";
+
+installPinnedHostnameTestHooks();
+
+/**
+ * AssemblyAI uses a 3-step async flow: upload → create transcript job → poll until done.
+ * The mock fetchFn must route all three request types.
+ */
+function createAssemblyAIFetchMock(opts: {
+  transcriptText: string;
+  transcriptId?: string;
+  pollSteps?: number; // how many "processing" responses before "completed"
+}) {
+  const { transcriptText, transcriptId = "test-id-123", pollSteps = 0 } = opts;
+  let pollCount = 0;
+  let seenRequests: Array<{ url: string; method: string; auth: string | null }> = [];
+
+  const fetchFn = withFetchPreconnect(
+    async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = (init?.method ?? "GET").toUpperCase();
+      const auth = new Headers(init?.headers).get("authorization");
+      seenRequests.push({ url, method, auth });
+
+      // Step 1: upload
+      if (url.endsWith("/upload") && method === "POST") {
+        return new Response(
+          JSON.stringify({ upload_url: "https://cdn.assemblyai.com/upload/test" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      // Step 2: create transcript
+      if (url.endsWith("/transcript") && method === "POST") {
+        return new Response(JSON.stringify({ id: transcriptId }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      // Step 3: poll
+      if (url.includes(`/transcript/${transcriptId}`) && method === "GET") {
+        if (pollCount < pollSteps) {
+          pollCount++;
+          return new Response(JSON.stringify({ id: transcriptId, status: "processing" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({ id: transcriptId, status: "completed", text: transcriptText }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    },
+  );
+
+  return { fetchFn, getRequests: () => seenRequests };
+}
+
+describe("transcribeAssemblyAIAudio", () => {
+  it("returns transcript text on success", async () => {
+    const { fetchFn } = createAssemblyAIFetchMock({ transcriptText: "hello world" });
+
+    const result = await transcribeAssemblyAIAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.mp3",
+      apiKey: "test-key",
+      timeoutMs: 30_000,
+      fetchFn,
+    });
+
+    expect(result.text).toBe("hello world");
+    expect(result.model).toBe(DEFAULT_ASSEMBLYAI_MODEL);
+  });
+
+  it("sets default base URL correctly", () => {
+    expect(DEFAULT_ASSEMBLYAI_BASE_URL).toBe("https://api.assemblyai.com/v2");
+  });
+
+  it("uses api key as authorization header", async () => {
+    const { fetchFn, getRequests } = createAssemblyAIFetchMock({ transcriptText: "hi" });
+
+    await transcribeAssemblyAIAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.mp3",
+      apiKey: "my-secret-key",
+      timeoutMs: 30_000,
+      fetchFn,
+    });
+
+    const requests = getRequests();
+    for (const req of requests) {
+      expect(req.auth).toBe("my-secret-key");
+    }
+  });
+
+  it("respects authorization header override", async () => {
+    const { fetchFn, getRequests } = createAssemblyAIFetchMock({ transcriptText: "ok" });
+
+    await transcribeAssemblyAIAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.mp3",
+      apiKey: "ignored-key",
+      headers: { authorization: "Bearer override" },
+      timeoutMs: 30_000,
+      fetchFn,
+    });
+
+    const requests = getRequests();
+    for (const req of requests) {
+      expect(req.auth).toBe("Bearer override");
+    }
+  });
+
+  it("sends language_code when language is provided", async () => {
+    let capturedBody: unknown;
+    const fetchFn = withFetchPreconnect(
+      async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.endsWith("/upload")) {
+          return new Response(
+            JSON.stringify({ upload_url: "https://cdn.assemblyai.com/upload/x" }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        if (url.endsWith("/transcript") && (init?.method ?? "").toUpperCase() === "POST") {
+          capturedBody = JSON.parse(init?.body as string);
+          return new Response(JSON.stringify({ id: "lang-id" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({ id: "lang-id", status: "completed", text: "olá mundo" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      },
+    );
+
+    const result = await transcribeAssemblyAIAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.mp3",
+      apiKey: "key",
+      language: "pt",
+      timeoutMs: 30_000,
+      fetchFn,
+    });
+
+    expect(result.text).toBe("olá mundo");
+    expect((capturedBody as Record<string, unknown>).language_code).toBe("pt");
+  });
+
+  it("handles polling through processing state", async () => {
+    const { fetchFn } = createAssemblyAIFetchMock({
+      transcriptText: "eventually done",
+      pollSteps: 2,
+    });
+
+    const result = await transcribeAssemblyAIAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.mp3",
+      apiKey: "key",
+      timeoutMs: 30_000,
+      fetchFn,
+    });
+
+    expect(result.text).toBe("eventually done");
+  });
+
+  it("throws on transcript error status", async () => {
+    const fetchFn = withFetchPreconnect(
+      async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.endsWith("/upload")) {
+          return new Response(
+            JSON.stringify({ upload_url: "https://cdn.assemblyai.com/upload/e" }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        if (url.endsWith("/transcript")) {
+          return new Response(JSON.stringify({ id: "err-id" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({ id: "err-id", status: "error", error: "audio too short" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      },
+    );
+
+    await expect(
+      transcribeAssemblyAIAudio({
+        buffer: Buffer.from("audio"),
+        fileName: "voice.mp3",
+        apiKey: "key",
+        timeoutMs: 30_000,
+        fetchFn,
+      }),
+    ).rejects.toThrow("AssemblyAI transcript error: audio too short");
+  });
+});

--- a/src/media-understanding/providers/assemblyai/audio.test.ts
+++ b/src/media-understanding/providers/assemblyai/audio.test.ts
@@ -78,7 +78,7 @@ describe("transcribeAssemblyAIAudio", () => {
     const result = await transcribeAssemblyAIAudio({
       buffer: Buffer.from("audio"),
       fileName: "voice.mp3",
-      apiKey: "test-key",
+      apiKey: "test-key", // pragma: allowlist secret
       timeoutMs: 30_000,
       fetchFn,
     });
@@ -97,7 +97,7 @@ describe("transcribeAssemblyAIAudio", () => {
     await transcribeAssemblyAIAudio({
       buffer: Buffer.from("audio"),
       fileName: "voice.mp3",
-      apiKey: "my-secret-key",
+      apiKey: "my-secret-key", // pragma: allowlist secret
       timeoutMs: 30_000,
       fetchFn,
     });
@@ -114,7 +114,7 @@ describe("transcribeAssemblyAIAudio", () => {
     await transcribeAssemblyAIAudio({
       buffer: Buffer.from("audio"),
       fileName: "voice.mp3",
-      apiKey: "ignored-key",
+      apiKey: "ignored-key", // pragma: allowlist secret
       headers: { authorization: "Bearer override" },
       timeoutMs: 30_000,
       fetchFn,
@@ -158,7 +158,7 @@ describe("transcribeAssemblyAIAudio", () => {
     const result = await transcribeAssemblyAIAudio({
       buffer: Buffer.from("audio"),
       fileName: "voice.mp3",
-      apiKey: "key",
+      apiKey: "key", // pragma: allowlist secret
       language: "pt",
       timeoutMs: 30_000,
       fetchFn,
@@ -177,7 +177,7 @@ describe("transcribeAssemblyAIAudio", () => {
     const result = await transcribeAssemblyAIAudio({
       buffer: Buffer.from("audio"),
       fileName: "voice.mp3",
-      apiKey: "key",
+      apiKey: "key", // pragma: allowlist secret
       timeoutMs: 30_000,
       fetchFn,
     });
@@ -216,7 +216,7 @@ describe("transcribeAssemblyAIAudio", () => {
       transcribeAssemblyAIAudio({
         buffer: Buffer.from("audio"),
         fileName: "voice.mp3",
-        apiKey: "key",
+        apiKey: "key", // pragma: allowlist secret
         timeoutMs: 30_000,
         fetchFn,
       }),

--- a/src/media-understanding/providers/assemblyai/audio.ts
+++ b/src/media-understanding/providers/assemblyai/audio.ts
@@ -1,0 +1,124 @@
+import type { AudioTranscriptionRequest, AudioTranscriptionResult } from "../../types.js";
+import {
+  assertOkOrThrowHttpError,
+  fetchWithTimeoutGuarded,
+  normalizeBaseUrl,
+  postTranscriptionRequest,
+  requireTranscriptionText,
+} from "../shared.js";
+
+export const DEFAULT_ASSEMBLYAI_BASE_URL = "https://api.assemblyai.com/v2";
+export const DEFAULT_ASSEMBLYAI_MODEL = "best";
+
+const POLL_INTERVAL_MS = 2_000;
+const MAX_POLL_ATTEMPTS = 120; // 4 min max with 2s intervals
+
+type UploadResponse = {
+  upload_url?: string;
+};
+
+type TranscriptResponse = {
+  id?: string;
+  status?: "queued" | "processing" | "completed" | "error";
+  text?: string;
+  error?: string;
+};
+
+export async function transcribeAssemblyAIAudio(
+  params: AudioTranscriptionRequest,
+): Promise<AudioTranscriptionResult> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const baseUrl = normalizeBaseUrl(params.baseUrl, DEFAULT_ASSEMBLYAI_BASE_URL);
+  const allowPrivate = Boolean(params.baseUrl?.trim());
+  const model = params.model?.trim() || DEFAULT_ASSEMBLYAI_MODEL;
+
+  const authHeaders = new Headers(params.headers);
+  if (!authHeaders.has("authorization")) {
+    authHeaders.set("authorization", params.apiKey);
+  }
+
+  // Step 1: Upload audio binary
+  const uploadHeaders = new Headers(authHeaders);
+  uploadHeaders.set("content-type", "application/octet-stream");
+  const { response: uploadRes, release: releaseUpload } = await postTranscriptionRequest({
+    url: `${baseUrl}/upload`,
+    headers: uploadHeaders,
+    body: new Uint8Array(params.buffer),
+    timeoutMs: params.timeoutMs,
+    fetchFn,
+    allowPrivateNetwork: allowPrivate,
+  });
+  let uploadData: UploadResponse;
+  try {
+    await assertOkOrThrowHttpError(uploadRes, "AssemblyAI upload");
+    uploadData = (await uploadRes.json()) as UploadResponse;
+  } finally {
+    await releaseUpload();
+  }
+  if (!uploadData.upload_url) {
+    throw new Error("AssemblyAI upload: missing upload_url in response");
+  }
+
+  // Step 2: Create transcript job
+  const transcriptBody: Record<string, unknown> = { audio_url: uploadData.upload_url };
+  if (params.language?.trim()) {
+    transcriptBody.language_code = params.language.trim();
+  }
+  if (model !== "best") {
+    transcriptBody.speech_model = model;
+  }
+  const createHeaders = new Headers(authHeaders);
+  createHeaders.set("content-type", "application/json");
+  const { response: createRes, release: releaseCreate } = await fetchWithTimeoutGuarded(
+    `${baseUrl}/transcript`,
+    { method: "POST", headers: createHeaders, body: JSON.stringify(transcriptBody) },
+    params.timeoutMs,
+    fetchFn,
+    allowPrivate ? { ssrfPolicy: { allowPrivateNetwork: true } } : undefined,
+  );
+  let createData: TranscriptResponse;
+  try {
+    await assertOkOrThrowHttpError(createRes, "AssemblyAI create transcript");
+    createData = (await createRes.json()) as TranscriptResponse;
+  } finally {
+    await releaseCreate();
+  }
+  if (!createData.id) {
+    throw new Error("AssemblyAI create transcript: missing id in response");
+  }
+
+  // Step 3: Poll until completed or error
+  const deadline = Date.now() + params.timeoutMs;
+  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+    if (Date.now() >= deadline) {
+      throw new Error(`AssemblyAI transcript timed out after ${params.timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+
+    const remainingMs = Math.max(10_000, deadline - Date.now());
+    const { response: pollRes, release: releasePoll } = await fetchWithTimeoutGuarded(
+      `${baseUrl}/transcript/${createData.id}`,
+      { method: "GET", headers: authHeaders },
+      remainingMs,
+      fetchFn,
+      allowPrivate ? { ssrfPolicy: { allowPrivateNetwork: true } } : undefined,
+    );
+    let pollData: TranscriptResponse;
+    try {
+      await assertOkOrThrowHttpError(pollRes, "AssemblyAI poll transcript");
+      pollData = (await pollRes.json()) as TranscriptResponse;
+    } finally {
+      await releasePoll();
+    }
+
+    if (pollData.status === "error") {
+      throw new Error(`AssemblyAI transcript error: ${pollData.error ?? "unknown"}`);
+    }
+    if (pollData.status === "completed") {
+      const text = requireTranscriptionText(pollData.text, "AssemblyAI returned empty transcript");
+      return { text, model };
+    }
+  }
+
+  throw new Error("AssemblyAI transcript: max poll attempts exceeded");
+}

--- a/src/media-understanding/providers/assemblyai/audio.ts
+++ b/src/media-understanding/providers/assemblyai/audio.ts
@@ -95,7 +95,7 @@ export async function transcribeAssemblyAIAudio(
     }
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
 
-    const remainingMs = Math.max(10_000, deadline - Date.now());
+    const remainingMs = Math.min(10_000, Math.max(1_000, deadline - Date.now()));
     const { response: pollRes, release: releasePoll } = await fetchWithTimeoutGuarded(
       `${baseUrl}/transcript/${createData.id}`,
       { method: "GET", headers: authHeaders },

--- a/src/media-understanding/providers/assemblyai/index.ts
+++ b/src/media-understanding/providers/assemblyai/index.ts
@@ -1,0 +1,8 @@
+import type { MediaUnderstandingProvider } from "../../types.js";
+import { transcribeAssemblyAIAudio } from "./audio.js";
+
+export const assemblyaiProvider: MediaUnderstandingProvider = {
+  id: "assemblyai",
+  capabilities: ["audio"],
+  transcribeAudio: transcribeAssemblyAIAudio,
+};

--- a/src/media-understanding/providers/index.ts
+++ b/src/media-understanding/providers/index.ts
@@ -1,6 +1,7 @@
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import type { MediaUnderstandingProvider } from "../types.js";
 import { anthropicProvider } from "./anthropic/index.js";
+import { assemblyaiProvider } from "./assemblyai/index.js";
 import { deepgramProvider } from "./deepgram/index.js";
 import { googleProvider } from "./google/index.js";
 import { groqProvider } from "./groq/index.js";
@@ -21,6 +22,7 @@ const PROVIDERS: MediaUnderstandingProvider[] = [
   mistralProvider,
   zaiProvider,
   deepgramProvider,
+  assemblyaiProvider,
 ];
 
 export function normalizeMediaProviderId(id: string): string {


### PR DESCRIPTION
## Summary

Adds [AssemblyAI](https://www.assemblyai.com/) as a media understanding provider for audio transcription.

AssemblyAI uses an async 3-step polling flow rather than a single-shot request, which is different from most providers:

1. **Upload** — POST binary audio to `/v2/upload`, receive an `upload_url`
2. **Create job** — POST to `/v2/transcript` with the upload URL, receive a job `id`
3. **Poll** — GET `/v2/transcript/:id` every 2s until `status === "completed"` or `"error"`

## Files changed

| File | Change |
|------|--------|
| `src/media-understanding/providers/assemblyai/index.ts` | Provider registration |
| `src/media-understanding/providers/assemblyai/audio.ts` | Transcription implementation |
| `src/media-understanding/providers/assemblyai/audio.test.ts` | Unit tests (7 tests) |
| `src/media-understanding/providers/index.ts` | Register `assemblyaiProvider` in registry |

## Implementation notes

- Follows existing provider conventions: uses `fetchWithTimeoutGuarded`, `assertOkOrThrowHttpError`, `requireTranscriptionText` from `shared.ts`
- SSRF-guarded on all three HTTP calls (upload, create, poll)
- Supports `language`, `model`, `baseUrl` (for proxies/testing), and `headers` overrides
- Default model: `"best"` (AssemblyAI's highest accuracy option)
- Max poll window: 4 minutes (120 × 2s intervals), bounded by `params.timeoutMs`
- `release()` called after each response body is consumed

## Testing

```
✓ returns transcript text on success
✓ sets default base URL correctly
✓ uses api key as authorization header
✓ respects authorization header override
✓ sends language_code when language is provided
✓ handles polling through processing state
✓ throws on transcript error status

7 tests passed
```

## Config example

```json
{
  "tools": {
    "media": {
      "audio": {
        "enabled": true,
        "models": [{ "provider": "assemblyai", "model": "best" }],
        "language": "en"
      }
    }
  }
}
```