### PR TITLE
fix(openai-completions): flatten assistant tool history content

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -13,6 +13,7 @@ import {
   shouldInjectOllamaCompatNumCtx,
   decodeHtmlEntitiesInObject,
   wrapOllamaCompatNumCtx,
+  wrapOpenAICompletionsToolHistoryPayload,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.js";
 
@@ -584,6 +585,64 @@ describe("shouldInjectOllamaCompatNumCtx", () => {
         providerId: "ollama",
       }),
     ).toBe(false);
+  });
+});
+
+describe("wrapOpenAICompletionsToolHistoryPayload", () => {
+  it("rewrites assistant tool-call history content arrays to strings", () => {
+    let payloadSeen: Record<string, unknown> | undefined;
+    const baseFn = vi.fn((_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "I'll run the command..." }],
+            tool_calls: [{ id: "call_1", type: "function" }],
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "plain reply" }],
+          },
+        ],
+      };
+      options?.onPayload?.(payload, _model);
+      payloadSeen = payload;
+      return {} as never;
+    });
+    const downstream = vi.fn();
+
+    const wrapped = wrapOpenAICompletionsToolHistoryPayload(baseFn as never);
+    void wrapped({} as never, {} as never, { onPayload: downstream } as never);
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    const messages = payloadSeen?.messages as Array<Record<string, unknown>>;
+    expect(messages[0]?.content).toBe("I'll run the command...");
+    expect(messages[1]?.content).toEqual([{ type: "text", text: "plain reply" }]);
+    expect(downstream).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves unsupported assistant content shapes", () => {
+    let payloadSeen: Record<string, unknown> | undefined;
+    const baseFn = vi.fn((_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "input_text", text: "unsupported" }],
+            tool_calls: [{ id: "call_1", type: "function" }],
+          },
+        ],
+      };
+      options?.onPayload?.(payload, _model);
+      payloadSeen = payload;
+      return {} as never;
+    });
+
+    const wrapped = wrapOpenAICompletionsToolHistoryPayload(baseFn as never);
+    void wrapped({} as never, {} as never);
+
+    const messages = (payloadSeen?.messages ?? []) as Array<Record<string, unknown>>;
+    expect(messages[0]?.content).toEqual([{ type: "input_text", text: "unsupported" }]);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -242,6 +242,73 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
     });
 }
 
+type OpenAICompatAssistantPayloadMessage = {
+  role?: unknown;
+  content?: unknown;
+  tool_calls?: unknown;
+};
+
+function normalizeOpenAICompletionsAssistantToolHistoryPayload(payload: unknown): void {
+  if (!payload || typeof payload !== "object") {
+    return;
+  }
+  const messages = (payload as { messages?: unknown }).messages;
+  if (!Array.isArray(messages)) {
+    return;
+  }
+
+  for (const entry of messages) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const message = entry as OpenAICompatAssistantPayloadMessage;
+    if (
+      message.role !== "assistant" ||
+      !Array.isArray(message.tool_calls) ||
+      message.tool_calls.length === 0 ||
+      !Array.isArray(message.content)
+    ) {
+      continue;
+    }
+
+    const textParts: string[] = [];
+    let unsupportedContent = false;
+    for (const part of message.content) {
+      if (!part || typeof part !== "object") {
+        unsupportedContent = true;
+        break;
+      }
+      const record = part as { type?: unknown; text?: unknown };
+      if (record.type !== "text" || typeof record.text !== "string") {
+        unsupportedContent = true;
+        break;
+      }
+      textParts.push(record.text);
+    }
+
+    if (unsupportedContent) {
+      continue;
+    }
+
+    message.content =
+      joinPresentTextSegments(textParts, {
+        separator: "",
+      }) ?? null;
+  }
+}
+
+export function wrapOpenAICompletionsToolHistoryPayload(baseFn: StreamFn | undefined): StreamFn {
+  const streamFn = baseFn ?? streamSimple;
+  return (model, context, options) =>
+    streamFn(model, context, {
+      ...options,
+      onPayload: (payload: unknown, payloadModel) => {
+        normalizeOpenAICompletionsAssistantToolHistoryPayload(payload);
+        return options?.onPayload?.(payload, payloadModel);
+      },
+    });
+}
+
 function normalizeToolCallNameForDispatch(rawName: string, allowedToolNames?: Set<string>): string {
   const trimmed = rawName.trim();
   if (!trimmed) {
@@ -1272,6 +1339,12 @@ export async function runEmbeddedAttempt(
           ),
         );
         activeSession.agent.streamFn = wrapOllamaCompatNumCtx(activeSession.agent.streamFn, numCtx);
+      }
+
+      if (params.model.api === "openai-completions") {
+        activeSession.agent.streamFn = wrapOpenAICompletionsToolHistoryPayload(
+          activeSession.agent.streamFn,
+        );
       }
 
       applyExtraParamsToAgent(


### PR DESCRIPTION
## Summary
- rewrite raw `openai-completions` payloads so assistant history entries with `tool_calls` send string content instead of text-part arrays
- keep the fix local to OpenClaw by applying it in the `onPayload` wrapper before the request leaves the process
- add regression tests to cover the payload rewrite and downstream `onPayload` chaining

## Testing
- `corepack pnpm exec vitest run src/agents/pi-embedded-runner/run/attempt.test.ts`
- `corepack pnpm exec oxlint --type-aware src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.test.ts`

## AI disclosure
- This PR was prepared with AI assistance. I reviewed the changes locally and ran the targeted test and lint commands above.

Fixes #41438