### PR TITLE
fix(models): strip redundant same-provider model prefixes

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -223,6 +223,63 @@ describe("resolveModel", () => {
     expect(result.model?.id).toBe("missing-model");
   });
 
+  it("strips a redundant same-provider prefix before resolving inline openai-compatible models", () => {
+    const cfg = {
+      models: {
+        providers: {
+          google: {
+            baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("gemini-2.5-pro"),
+                api: "openai-completions",
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("google", "google/gemini-2.5-pro", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "google",
+      id: "gemini-2.5-pro",
+      api: "openai-completions",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+    });
+  });
+
+  it("preserves cross-provider model ids for pass-through providers", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("anthropic/claude-sonnet-4-6"),
+                api: "openai-completions",
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("openrouter", "anthropic/claude-sonnet-4-6", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openrouter",
+      id: "anthropic/claude-sonnet-4-6",
+      api: "openai-completions",
+    });
+  });
+
   it("includes provider headers in provider fallback model", () => {
     const cfg = {
       models: {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -7,7 +7,11 @@ import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { isSecretRefHeaderValueMarker } from "../model-auth-markers.js";
 import { resolveForwardCompatModel } from "../model-forward-compat.js";
-import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
+import {
+  findNormalizedProviderValue,
+  normalizeProviderId,
+  parseModelRef,
+} from "../model-selection.js";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 import { normalizeResolvedProviderModel } from "./model.provider-normalization.js";
 
@@ -250,13 +254,25 @@ export function resolveModel(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
-  const model = resolveModelWithRegistry({ provider, modelId, modelRegistry, cfg });
+  const normalizedModelId = (() => {
+    const parsed = parseModelRef(modelId, provider);
+    if (!parsed) {
+      return modelId;
+    }
+    return parsed.provider === normalizeProviderId(provider) ? parsed.model : modelId;
+  })();
+  const model = resolveModelWithRegistry({
+    provider,
+    modelId: normalizedModelId,
+    modelRegistry,
+    cfg,
+  });
   if (model) {
     return { model, authStorage, modelRegistry };
   }
 
   return {
-    error: buildUnknownModelError(provider, modelId),
+    error: buildUnknownModelError(provider, normalizedModelId),
     authStorage,
     modelRegistry,
   };


### PR DESCRIPTION
## Summary
- strip redundant same-provider prefixes before `resolveModel(...)` matches configured or inline models
- keep cross-provider pass-through ids intact for providers like OpenRouter
- add regression coverage for both cases

## Why
Some call paths can reach `resolveModel(...)` with `provider=google` and `modelId=google/gemini-2.5-pro`. That misses the configured `gemini-2.5-pro` entry and falls through to a fallback model whose id still includes the redundant prefix, which Google's OpenAI-compatible endpoint rejects. Normalizing only same-provider prefixes fixes that path without breaking pass-through refs like `anthropic/claude-sonnet-4-6` on `openrouter`.

## Testing
- `corepack pnpm exec vitest run src/agents/pi-embedded-runner/model.test.ts`
- `corepack pnpm exec oxlint --type-aware src/agents/pi-embedded-runner/model.ts src/agents/pi-embedded-runner/model.test.ts`

AI-assisted: prepared with Codex and validated with the targeted tests above.

Fixes #41249
