### PR TITLE
cron: avoid manual cron.run self-deadlock

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
-import { clearCommandLane, setCommandLaneConcurrency } from "../process/command-queue.js";
+import {
+  clearCommandLane,
+  enqueueCommandInLane,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import * as schedule from "./schedule.js";
 import {
@@ -1566,6 +1570,54 @@ describe("Cron issue regressions", () => {
     });
 
     clearCommandLane(CommandLane.Cron);
+  });
+
+  it("manual isolated cron.run does not deadlock when isolated execution reuses the cron lane", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.Nested);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.Nested, 1);
+
+    const store = makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:02.500Z");
+    const job = createIsolatedRegressionJob({
+      id: "manual-cron-lane-deadlock",
+      name: "manual cron lane deadlock",
+      scheduledAt: dueAt,
+      schedule: { kind: "at", at: new Date(dueAt).toISOString() },
+      payload: { kind: "agentTurn", message: "manual deadlock", timeoutSeconds: 0.05 },
+      state: { nextRunAtMs: dueAt },
+    });
+    await writeCronJobs(store.storePath, [job]);
+
+    const innerTaskStarted = createDeferred<void>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: createNoopLogger(),
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        return enqueueCommandInLane(CommandLane.Cron, async () => {
+          innerTaskStarted.resolve();
+          return { status: "ok" as const, summary: "inner cron lane run" };
+        });
+      }),
+    });
+
+    const ack = await enqueueRun(state, job.id, "force");
+    expect(ack).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+
+    await innerTaskStarted.promise;
+    await vi.waitFor(() => {
+      const jobs = state.store?.jobs ?? [];
+      expect(jobs.find((entry) => entry.id === job.id)?.state.lastStatus).toBe("ok");
+    });
+
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.Nested);
   });
 
   it("logs unexpected queued manual run background failures once", async () => {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -531,8 +531,12 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
   }
 
   const runId = `manual:${id}:${state.deps.nowMs()}:${nextManualRunId++}`;
+  // Manual cron.run requests can execute isolated jobs that enqueue their own
+  // work on the dedicated cron lane. Queue the outer background task on the
+  // nested lane so manual runs do not self-block behind their own inner cron
+  // execution.
   void enqueueCommandInLane(
-    CommandLane.Cron,
+    CommandLane.Nested,
     async () => {
       const result = await run(state, id, mode);
       if (result.ok && "ran" in result && !result.ran) {


### PR DESCRIPTION
## Summary
- move the outer `cron.run` background enqueue off the shared cron lane
- add a regression covering isolated manual runs that re-enqueue onto the cron lane

## Problem
Manual `cron.run` for isolated jobs can self-block when the outer background task is queued on `CommandLane.Cron` and the isolated execution path also needs `CommandLane.Cron` internally.

In practice this can manifest as manual runs sitting for nearly their full timeout budget with `queueAhead=0`, then timing out before the isolated work really begins.

## Root cause
`enqueueRun()` queued the manual background task on `CommandLane.Cron`, and isolated cron execution can itself enqueue onto the cron lane. With cron lane concurrency at 1, the outer task holds the lane while waiting for inner cron-lane work that can never start.

## Fix
Queue the outer manual-run background task on `CommandLane.Nested` instead. That keeps manual `cron.run` serialized and out of the main lane, but avoids self-deadlocking the inner cron-lane work used by isolated runs.

## Validation
- added regression: `manual isolated cron.run does not deadlock when isolated execution reuses the cron lane`
- passed targeted regression
- passed full `src/cron/service.issue-regressions.test.ts`

### Commands
```bash
pnpm exec vitest run --config vitest.unit.config.ts src/cron/service.issue-regressions.test.ts -t "manual isolated cron.run does not deadlock when isolated execution reuses the cron lane"
pnpm exec vitest run --config vitest.unit.config.ts src/cron/service.issue-regressions.test.ts
```
