### PR TITLE
fix(ui): surface update.run failures in control ui

### DIFF
--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -371,4 +371,40 @@ describe("runUpdate", () => {
       sessionKey: "agent:main:whatsapp:dm:+15555550123",
     });
   });
+
+  it("surfaces update.run payload failures", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      result: {
+        status: "error",
+        reason: "permission denied",
+      },
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+
+    await runUpdate(state);
+
+    expect(state.lastError).toBe("Update failed: permission denied");
+    expect(state.updateRunning).toBe(false);
+  });
+
+  it("surfaces skipped update results", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      result: {
+        status: "skipped",
+        reason: "package manager unsupported",
+      },
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+
+    await runUpdate(state);
+
+    expect(state.lastError).toBe("Update skipped: package manager unsupported");
+    expect(state.updateRunning).toBe(false);
+  });
 });

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -184,9 +184,27 @@ export async function runUpdate(state: ConfigState) {
   state.updateRunning = true;
   state.lastError = null;
   try {
-    await state.client.request("update.run", {
+    const res = await state.client.request<{
+      ok?: boolean;
+      result?: { status?: "ok" | "error" | "skipped"; reason?: string | null };
+    }>("update.run", {
       sessionKey: state.applySessionKey,
     });
+    const status = res?.result?.status;
+    if (res?.ok === false || status === "error" || status === "skipped") {
+      const reason =
+        typeof res?.result?.reason === "string" && res.result.reason.trim()
+          ? res.result.reason.trim()
+          : null;
+      state.lastError =
+        status === "skipped"
+          ? reason
+            ? `Update skipped: ${reason}`
+            : "Update skipped."
+          : reason
+            ? `Update failed: ${reason}`
+            : "Update failed.";
+    }
   } catch (err) {
     state.lastError = String(err);
   } finally {


### PR DESCRIPTION
## Summary

Fixes the Control UI "Update now" button appearing non-functional when `update.run` returns a business-level failure payload.

`GatewayBrowserClient.request(...)` only rejects transport-level RPC failures. `update.run` currently responds with `respond(true, ...)` even when the update runner reports `status: "error"` or `status: "skipped"`, so the UI treated those cases as success and showed no feedback.

This change makes the Control UI inspect the `update.run` payload and surface:

- `Update failed: <reason>` for runner errors
- `Update skipped: <reason>` for unsupported/no-op update paths

## Testing

- `corepack pnpm --dir ui exec vitest run src/ui/controllers/config.test.ts`
- `corepack pnpm exec oxlint --type-aware ui/src/ui/controllers/config.ts ui/src/ui/controllers/config.test.ts`

## AI disclosure

This PR was prepared with AI assistance. I verified the targeted UI controller tests and type-aware lint locally.

Fixes #41369
