### PR TITLE
Cron: fix manual isolated run deadlock

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1,7 +1,13 @@
 import fs from "node:fs/promises";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
-import { clearCommandLane, setCommandLaneConcurrency } from "../process/command-queue.js";
+import {
+  clearCommandLane,
+  enqueueCommandInLane,
+  markGatewayDraining,
+  resetAllLanes,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import * as schedule from "./schedule.js";
 import {
@@ -38,6 +44,12 @@ const FAST_TIMEOUT_SECONDS = 0.0025;
 
 describe("Cron issue regressions", () => {
   const { makeStorePath } = setupCronIssueRegressionFixtures();
+
+  afterEach(() => {
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
+    resetAllLanes();
+  });
 
   it("covers schedule updates and payload patching", async () => {
     const store = makeStorePath();
@@ -1495,7 +1507,9 @@ describe("Cron issue regressions", () => {
   it("queues manual cron.run requests behind the cron execution lane", async () => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
     setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronDispatch, 1);
 
     const store = makeStorePath();
     const dueAt = Date.parse("2026-02-06T10:05:02.000Z");
@@ -1566,12 +1580,15 @@ describe("Cron issue regressions", () => {
     });
 
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
   });
 
   it("logs unexpected queued manual run background failures once", async () => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
     setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronDispatch, 1);
 
     const dueAt = Date.parse("2026-02-06T10:05:03.000Z");
     const job = createDueIsolatedJob({ id: "queued-failure", nowMs: dueAt, nextRunAtMs: dueAt });
@@ -1594,6 +1611,363 @@ describe("Cron issue regressions", () => {
     );
 
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
+  });
+
+  it("does not reserve isolated manual runs when cron admission enqueue is rejected", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronDispatch, 1);
+
+    const store = makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:03.500Z");
+    const job = createDueIsolatedJob({
+      id: "queued-isolated-drain-reject",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    await fs.writeFile(store.storePath, JSON.stringify({ version: 1, jobs: [job] }), "utf-8");
+
+    const dispatchLaneStarted = createDeferred<void>();
+    const releaseDispatchLane = createDeferred<void>();
+    void enqueueCommandInLane(CommandLane.CronDispatch, async () => {
+      dispatchLaneStarted.resolve();
+      await releaseDispatchLane.promise;
+    });
+    await dispatchLaneStarted.promise;
+
+    const log = createNoopLogger();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log,
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+
+    const result = await enqueueRun(state, job.id, "force");
+    expect(result).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+
+    markGatewayDraining();
+    releaseDispatchLane.resolve();
+
+    await vi.waitFor(() => {
+      const storedJob = state.store?.jobs.find((entry) => entry.id === job.id);
+      expect(storedJob?.state.runningAtMs).toBeUndefined();
+      expect(storedJob?.state.lastStatus).toBe("error");
+      expect(storedJob?.state.lastError).toContain("gateway draining");
+    });
+    await vi.waitFor(() => expect(log.error).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not reserve main-target manual runs when cron enqueue is rejected", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronDispatch, 1);
+
+    const store = makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:03.750Z");
+    const job: CronJob = {
+      id: "queued-main-drain-reject",
+      name: "queued main drain reject",
+      enabled: true,
+      createdAtMs: dueAt,
+      updatedAtMs: dueAt,
+      schedule: { kind: "at", at: new Date(dueAt).toISOString() },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "main" },
+      delivery: { mode: "none" },
+      state: { nextRunAtMs: dueAt },
+    };
+    await fs.writeFile(store.storePath, JSON.stringify({ version: 1, jobs: [job] }), "utf-8");
+
+    const dispatchLaneStarted = createDeferred<void>();
+    const releaseDispatchLane = createDeferred<void>();
+    void enqueueCommandInLane(CommandLane.CronDispatch, async () => {
+      dispatchLaneStarted.resolve();
+      await releaseDispatchLane.promise;
+    });
+    await dispatchLaneStarted.promise;
+
+    const log = createNoopLogger();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log,
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+
+    const result = await enqueueRun(state, job.id, "force");
+    expect(result).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+
+    markGatewayDraining();
+    releaseDispatchLane.resolve();
+
+    await vi.waitFor(() => {
+      const storedJob = state.store?.jobs.find((entry) => entry.id === job.id);
+      expect(storedJob?.state.runningAtMs).toBeUndefined();
+      expect(storedJob?.state.lastStatus).toBe("error");
+      expect(storedJob?.state.lastError).toContain("gateway draining");
+    });
+    await vi.waitFor(() => expect(log.error).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not clobber active run state when manual enqueue rejection races with an in-flight run", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronDispatch, 1);
+
+    const store = makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:03.900Z");
+    const job: CronJob = {
+      id: "queued-race-active-run-preserved",
+      name: "queued race active run preserved",
+      enabled: true,
+      createdAtMs: dueAt,
+      updatedAtMs: dueAt,
+      schedule: { kind: "at", at: new Date(dueAt).toISOString() },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "main" },
+      delivery: { mode: "none" },
+      state: { nextRunAtMs: dueAt },
+    };
+    await fs.writeFile(store.storePath, JSON.stringify({ version: 1, jobs: [job] }), "utf-8");
+
+    const dispatchLaneStarted = createDeferred<void>();
+    const releaseDispatchLane = createDeferred<void>();
+    void enqueueCommandInLane(CommandLane.CronDispatch, async () => {
+      dispatchLaneStarted.resolve();
+      await releaseDispatchLane.promise;
+    });
+    await dispatchLaneStarted.promise;
+
+    const log = createNoopLogger();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log,
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+
+    const result = await enqueueRun(state, job.id, "force");
+    expect(result).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+
+    const activeRunStartedAt = dueAt + 123;
+    const storedBeforeReject = state.store?.jobs.find((entry) => entry.id === job.id);
+    expect(storedBeforeReject).toBeTruthy();
+    if (!storedBeforeReject) {
+      throw new Error("job should exist before dispatch release");
+    }
+    storedBeforeReject.state.runningAtMs = activeRunStartedAt;
+    storedBeforeReject.state.lastStatus = undefined;
+    storedBeforeReject.state.lastError = undefined;
+
+    markGatewayDraining();
+    releaseDispatchLane.resolve();
+
+    await vi.waitFor(() => expect(log.error).toHaveBeenCalledTimes(1));
+    const storedAfterReject = state.store?.jobs.find((entry) => entry.id === job.id);
+    expect(storedAfterReject?.state.runningAtMs).toBe(activeRunStartedAt);
+    expect(storedAfterReject?.state.lastStatus).toBeUndefined();
+    expect(storedAfterReject?.state.lastError).toBeUndefined();
+  });
+
+  it("does not deadlock manual isolated runs when the isolated executor re-enters the cron lane", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronDispatch, 1);
+
+    const store = makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:04.000Z");
+    const job = createDueIsolatedJob({
+      id: "manual-lane-deadlock",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    await fs.writeFile(store.storePath, JSON.stringify({ version: 1, jobs: [job] }), "utf-8");
+
+    const nestedCronLaneStarted = createDeferred<void>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: createNoopLogger(),
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(
+        async ({ lane }: { lane?: string }) =>
+          await enqueueCommandInLane(lane ?? CommandLane.Cron, async () => {
+            nestedCronLaneStarted.resolve();
+            return { status: "ok" as const, summary: "done" };
+          }),
+      ),
+    });
+
+    const result = await enqueueRun(state, job.id, "force");
+    expect(result).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+
+    await nestedCronLaneStarted.promise;
+    await vi.waitFor(() => {
+      const storedJob = state.store?.jobs.find((entry) => entry.id === job.id);
+      expect(storedJob?.state.lastStatus).toBe("ok");
+      expect(typeof storedJob?.state.lastRunAtMs).toBe("number");
+      expect(storedJob?.state.runningAtMs).toBeUndefined();
+    });
+
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
+  });
+
+  it("starts manual isolated timeoutSeconds after cron lane admission", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronDispatch, 1);
+
+    const store = makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:05.000Z");
+    const job = createDueIsolatedJob({
+      id: "manual-timeout-after-admission",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    if (job.payload.kind === "agentTurn") {
+      job.payload.timeoutSeconds = 0.03;
+    }
+    await fs.writeFile(store.storePath, JSON.stringify({ version: 1, jobs: [job] }), "utf-8");
+
+    const blockingCronLaneStarted = createDeferred<void>();
+    const releaseBlockingCronLane = createDeferred<void>();
+    void enqueueCommandInLane(CommandLane.Cron, async () => {
+      blockingCronLaneStarted.resolve();
+      await releaseBlockingCronLane.promise;
+    });
+    await blockingCronLaneStarted.promise;
+
+    const isolatedStarted = createDeferred<void>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: createNoopLogger(),
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(
+        async ({ abortSignal, lane }: { abortSignal?: AbortSignal; lane?: string }) =>
+          await enqueueCommandInLane(lane ?? CommandLane.Cron, async () => {
+            isolatedStarted.resolve();
+            if (abortSignal?.aborted) {
+              return {
+                status: "error" as const,
+                error:
+                  typeof abortSignal.reason === "string"
+                    ? abortSignal.reason
+                    : "cron: job execution timed out",
+              };
+            }
+            return { status: "ok" as const, summary: "done" };
+          }),
+      ),
+    });
+
+    const result = await enqueueRun(state, job.id, "force");
+    expect(result).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+
+    setTimeout(() => {
+      releaseBlockingCronLane.resolve();
+    }, 40);
+
+    await isolatedStarted.promise;
+    await vi.waitFor(() => {
+      const storedJob = state.store?.jobs.find((entry) => entry.id === job.id);
+      expect(storedJob?.state.lastStatus).toBe("ok");
+      expect(storedJob?.state.lastError).toBeUndefined();
+    });
+  });
+
+  it("keeps manual main-target runs behind the cron execution limiter", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(CommandLane.CronDispatch);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+    setCommandLaneConcurrency(CommandLane.CronDispatch, 1);
+
+    const store = makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:06.000Z");
+    const job: CronJob = {
+      id: "manual-main-lane-gate",
+      name: "manual main lane gate",
+      enabled: true,
+      createdAtMs: dueAt,
+      updatedAtMs: dueAt,
+      schedule: { kind: "at", at: new Date(dueAt).toISOString() },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "main-target-work" },
+      delivery: { mode: "none" },
+      state: { nextRunAtMs: dueAt },
+    };
+    await fs.writeFile(store.storePath, JSON.stringify({ version: 1, jobs: [job] }), "utf-8");
+
+    const blockingCronLaneStarted = createDeferred<void>();
+    const releaseBlockingCronLane = createDeferred<void>();
+    void enqueueCommandInLane(CommandLane.Cron, async () => {
+      blockingCronLaneStarted.resolve();
+      await releaseBlockingCronLane.promise;
+    });
+    await blockingCronLaneStarted.promise;
+
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: createNoopLogger(),
+      nowMs: () => dueAt,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn().mockResolvedValue({ status: "ok", summary: "ok" }),
+    });
+
+    const result = await enqueueRun(state, job.id, "force");
+    expect(result).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(requestHeartbeatNow).not.toHaveBeenCalled();
+
+    releaseBlockingCronLane.resolve();
+    await vi.waitFor(() => {
+      expect(enqueueSystemEvent).toHaveBeenCalledWith("main-target-work", {
+        agentId: undefined,
+        sessionKey: undefined,
+        contextKey: `cron:${job.id}`,
+      });
+      expect(requestHeartbeatNow).toHaveBeenCalledWith({
+        reason: `cron:${job.id}`,
+        agentId: undefined,
+        sessionKey: undefined,
+      });
+    });
   });
 
   // Regression: isolated cron runs must not abort at 1/3 of configured timeoutSeconds.

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -1,4 +1,8 @@
-import { enqueueCommandInLane } from "../../process/command-queue.js";
+import {
+  CommandLaneClearedError,
+  enqueueCommandInLane,
+  GatewayDrainingError,
+} from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
 import { normalizeCronCreateDeliveryInput } from "./initial-delivery.js";
@@ -358,7 +362,7 @@ type PreparedManualRun =
 
 type ManualRunDisposition =
   | Extract<PreparedManualRun, { ran: false }>
-  | { ok: true; runnable: true };
+  | { ok: true; runnable: true; sessionTarget: CronJob["sessionTarget"] };
 
 type ManualRunPreflightResult =
   | { ok: false }
@@ -409,7 +413,7 @@ async function inspectManualRunDisposition(
   if ("reason" in result) {
     return result;
   }
-  return { ok: true, runnable: true } as const;
+  return { ok: true, runnable: true, sessionTarget: result.job.sessionTarget } as const;
 }
 
 async function prepareManualRun(
@@ -452,21 +456,14 @@ async function prepareManualRun(
   });
 }
 
-async function finishPreparedManualRun(
+async function finalizePreparedManualRun(
   state: CronServiceState,
   prepared: Extract<PreparedManualRun, { ran: true }>,
-  mode?: "due" | "force",
+  mode: "due" | "force" | undefined,
+  coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>,
 ): Promise<void> {
-  const executionJob = prepared.executionJob;
   const startedAt = prepared.startedAt;
   const jobId = prepared.jobId;
-
-  let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
-  try {
-    coreResult = await executeJobCoreWithTimeout(state, executionJob);
-  } catch (err) {
-    coreResult = { status: "error", error: String(err) };
-  }
   const endedAt = state.deps.nowMs();
 
   await locked(state, async () => {
@@ -539,6 +536,141 @@ async function finishPreparedManualRun(
   });
 }
 
+async function finishPreparedManualRun(
+  state: CronServiceState,
+  prepared: Extract<PreparedManualRun, { ran: true }>,
+  mode?: "due" | "force",
+  opts?: { isolatedExecutionLane?: string },
+): Promise<void> {
+  const executionJob = prepared.executionJob;
+
+  let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
+  try {
+    coreResult = await executeJobCoreWithTimeout(state, executionJob, {
+      isolatedLane:
+        executionJob.sessionTarget === "isolated" ? opts?.isolatedExecutionLane : undefined,
+    });
+  } catch (err) {
+    coreResult = { status: "error", error: String(err) };
+  }
+  await finalizePreparedManualRun(state, prepared, mode, coreResult);
+}
+
+function createQueuedManualRunLaneOpts(state: CronServiceState, id: string, runId: string) {
+  return {
+    warnAfterMs: 5_000,
+    onWait: (waitMs: number, queuedAhead: number) => {
+      state.deps.log.warn(
+        { jobId: id, runId, waitMs, queuedAhead },
+        "cron: queued manual run waiting for an execution slot",
+      );
+    },
+  } as const;
+}
+
+function isAdmissionError(err: unknown): boolean {
+  return err instanceof GatewayDrainingError || err instanceof CommandLaneClearedError;
+}
+
+function parseStartedAtFromRunId(runId: string): number | undefined {
+  const parts = runId.split(":");
+  if (parts.length >= 3) {
+    const ts = Number.parseInt(parts[parts.length - 2] ?? "", 10);
+    return Number.isNaN(ts) ? undefined : ts;
+  }
+  return undefined;
+}
+
+async function surfaceManualRunEnqueueFailure(
+  state: CronServiceState,
+  id: string,
+  runId: string,
+  err: unknown,
+): Promise<void> {
+  const endedAt = state.deps.nowMs();
+  const startedAt = parseStartedAtFromRunId(runId) ?? endedAt;
+  const errMessage =
+    err instanceof GatewayDrainingError ? "gateway draining; manual run not executed" : String(err);
+
+  await locked(state, async () => {
+    await ensureLoaded(state, { skipRecompute: true });
+    const job = state.store?.jobs.find((entry) => entry.id === id);
+    if (!job) {
+      return;
+    }
+    if (typeof job.state.runningAtMs === "number") {
+      // A different execution (for example scheduler-driven) may have started
+      // while this manual enqueue was waiting. Do not clobber active run state.
+      return;
+    }
+
+    job.state.runningAtMs = undefined;
+    job.state.lastRunStatus = "error";
+    job.state.lastStatus = "error";
+    job.state.lastError = errMessage;
+    job.state.lastErrorReason = undefined;
+    job.state.lastDeliveryStatus = "not-delivered";
+    job.state.lastDeliveryError = errMessage;
+    job.updatedAtMs = endedAt;
+
+    emit(state, {
+      jobId: job.id,
+      action: "finished",
+      status: "error",
+      error: errMessage,
+      runAtMs: startedAt,
+      durationMs: 0,
+      nextRunAtMs: job.state.nextRunAtMs,
+      deliveryStatus: job.state.lastDeliveryStatus,
+      deliveryError: job.state.lastDeliveryError,
+    });
+
+    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+    await persist(state);
+    armTimer(state);
+  });
+}
+function queueManualRunExecution(
+  state: CronServiceState,
+  id: string,
+  runId: string,
+  mode: "due" | "force" | undefined,
+  opts?: { isolatedExecutionLane?: string },
+): void {
+  const laneOpts = createQueuedManualRunLaneOpts(state, id, runId);
+  void enqueueCommandInLane(
+    CommandLane.Cron,
+    async () => {
+      const prepared = await prepareManualRun(state, id, mode);
+      if (!prepared.ok || !prepared.ran) {
+        if (prepared.ok && "ran" in prepared && !prepared.ran) {
+          state.deps.log.info(
+            { jobId: id, runId, reason: prepared.reason },
+            "cron: queued manual run skipped before execution",
+          );
+        }
+        return prepared;
+      }
+      await finishPreparedManualRun(state, prepared, mode, opts);
+      return { ok: true, ran: true } as const;
+    },
+    laneOpts,
+  ).catch((err) => {
+    state.deps.log.error(
+      { jobId: id, runId, err: String(err) },
+      "cron: queued manual run background execution failed",
+    );
+    if (isAdmissionError(err)) {
+      void surfaceManualRunEnqueueFailure(state, id, runId, err).catch((surfErr) => {
+        state.deps.log.error(
+          { jobId: id, runId, surfErr: String(surfErr) },
+          "cron: failed to surface manual run enqueue failure",
+        );
+      });
+    }
+  });
+}
+
 export async function run(state: CronServiceState, id: string, mode?: "due" | "force") {
   const prepared = await prepareManualRun(state, id, mode);
   if (!prepared.ok || !prepared.ran) {
@@ -555,32 +687,38 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
   }
 
   const runId = `manual:${id}:${state.deps.nowMs()}:${nextManualRunId++}`;
+  const manualDispatchLane = CommandLane.CronDispatch;
+  const dispatchLaneOpts = createQueuedManualRunLaneOpts(state, id, runId);
   void enqueueCommandInLane(
-    CommandLane.Cron,
+    manualDispatchLane,
     async () => {
-      const result = await run(state, id, mode);
-      if (result.ok && "ran" in result && !result.ran) {
-        state.deps.log.info(
-          { jobId: id, runId, reason: result.reason },
-          "cron: queued manual run skipped before execution",
-        );
+      if (disposition.sessionTarget === "isolated") {
+        // Hold the cron execution slot for the whole isolated run so CLI-based
+        // providers cannot overlap other cron work, but route the embedded
+        // agent's internal global queue through cron-dispatch to avoid the
+        // original self-deadlock when it re-enters a lane during execution.
+        queueManualRunExecution(state, id, runId, mode, {
+          isolatedExecutionLane: CommandLane.CronDispatch,
+        });
+        return { ok: true, enqueued: true, runId } as const;
       }
-      return result;
+      queueManualRunExecution(state, id, runId, mode);
+      return { ok: true, enqueued: true, runId } as const;
     },
-    {
-      warnAfterMs: 5_000,
-      onWait: (waitMs, queuedAhead) => {
-        state.deps.log.warn(
-          { jobId: id, runId, waitMs, queuedAhead },
-          "cron: queued manual run waiting for an execution slot",
-        );
-      },
-    },
+    dispatchLaneOpts,
   ).catch((err) => {
     state.deps.log.error(
       { jobId: id, runId, err: String(err) },
       "cron: queued manual run background execution failed",
     );
+    if (isAdmissionError(err)) {
+      void surfaceManualRunEnqueueFailure(state, id, runId, err).catch((surfErr) => {
+        state.deps.log.error(
+          { jobId: id, runId, surfErr: String(surfErr) },
+          "cron: failed to surface manual run enqueue failure",
+        );
+      });
+    }
   });
   return { ok: true, enqueued: true, runId } as const;
 }

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -84,6 +84,7 @@ export type CronServiceDeps = {
     job: CronJob;
     message: string;
     abortSignal?: AbortSignal;
+    lane?: string;
   }) => Promise<
     {
       summary?: string;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -65,17 +65,18 @@ type StartupCatchupPlan = {
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
+  opts?: { isolatedLane?: string },
 ): Promise<Awaited<ReturnType<typeof executeJobCore>>> {
   const jobTimeoutMs = resolveCronJobTimeoutMs(job);
   if (typeof jobTimeoutMs !== "number") {
-    return await executeJobCore(state, job);
+    return await executeJobCore(state, job, undefined, opts);
   }
 
   const runAbortController = new AbortController();
   let timeoutId: NodeJS.Timeout | undefined;
   try {
     return await Promise.race([
-      executeJobCore(state, job, runAbortController.signal),
+      executeJobCore(state, job, runAbortController.signal, opts),
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {
           runAbortController.abort(timeoutErrorMessage());
@@ -1006,6 +1007,7 @@ export async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
   abortSignal?: AbortSignal,
+  opts?: { isolatedLane?: string },
 ): Promise<
   CronRunOutcome & CronRunTelemetry & { delivered?: boolean; deliveryAttempted?: boolean }
 > {
@@ -1134,6 +1136,7 @@ export async function executeJobCore(
     job,
     message: job.payload.message,
     abortSignal,
+    lane: opts?.isolatedLane,
   });
 
   if (abortSignal?.aborted) {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -282,7 +282,7 @@ export function buildGatewayCronService(params: {
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },
-    runIsolatedAgentJob: async ({ job, message, abortSignal }) => {
+    runIsolatedAgentJob: async ({ job, message, abortSignal, lane }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       return await runCronIsolatedAgentTurn({
         cfg: runtimeConfig,
@@ -292,7 +292,7 @@ export function buildGatewayCronService(params: {
         abortSignal,
         agentId,
         sessionKey: `cron:${job.id}`,
-        lane: "cron",
+        lane: lane ?? "cron",
       });
     },
     sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) => {

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -5,6 +5,7 @@ import { CommandLane } from "../process/lanes.js";
 
 export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) {
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
+  setCommandLaneConcurrency(CommandLane.CronDispatch, cfg.cron?.maxConcurrentRuns ?? 1);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
 }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -136,6 +136,7 @@ export function createGatewayReloadHandlers(params: {
     }
 
     setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
+    setCommandLaneConcurrency(CommandLane.CronDispatch, nextConfig.cron?.maxConcurrentRuns ?? 1);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
 

--- a/src/process/lanes.ts
+++ b/src/process/lanes.ts
@@ -1,6 +1,7 @@
 export const enum CommandLane {
   Main = "main",
   Cron = "cron",
+  CronDispatch = "cron-dispatch",
   Subagent = "subagent",
   Nested = "nested",
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- **Problem:** Manual cron job triggers from both the API/tooling and the dashboard `Run` button returned `ok: true` / `enqueued: true`, but isolated cron sessions were never spawned, so the job silently never executed.
- **Why it matters:** This breaks the operator escape hatch for cron jobs. Scheduled runs still work, but any manual retry, backfill, or on-demand execution path becomes a no-op even though the caller sees a success response.
- **What changed:**
  - Identified that manual `cron.run` dispatch was enqueuing onto the same global `cron` lane later re-entered by isolated cron agent turns, which created a self-deadlock.
  - Added a dedicated `cron-dispatch` lane for manual background dispatch while keeping actual cron job execution on the existing `cron` lane.
  - Wired the new lane into startup and reload concurrency configuration so it respects the same cron concurrency cap.
  - Added regression coverage in `src/cron/service.issue-regressions.test.ts` to prove manual isolated runs no longer deadlock when the isolated executor re-enters the `cron` lane.
- **What did NOT change (scope boundary):** Scheduled cron execution logic is unchanged. Cron job payload semantics, isolated session behavior, and the dashboard/API contract are unchanged aside from manual triggers now actually executing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41507

## User-visible / Behavior Changes

Users manually running cron jobs from the dashboard or the `cron.run` API/tool path will now get a real isolated execution instead of a silent enqueue-without-execution no-op.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22.x+
- Model/provider: N/A
- Integration/channel (if any): Gateway cron API + dashboard/manual trigger path
- Relevant config (redacted): Cron job with `sessionTarget: "isolated"` and `payload.kind: "agentTurn"`

### Steps

1. Create or use an existing cron job that successfully runs on schedule.
2. Trigger it manually through the dashboard `Run` button or `cron run --jobId <id> --runMode force`.
3. Inspect cron run history and session spawning.

### Expected

- Manual trigger enqueues background work, spawns the isolated cron session, and records run history.

### Actual

- Prior to this PR, the API returned success but the work was deadlocked on the shared `cron` lane, so no isolated session spawned and no run history was recorded.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

*(Note: Added a regression test that simulates the isolated executor re-entering the `cron` lane and confirms the manual run completes instead of stalling.)*

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:** Ran `pnpm exec vitest run --config vitest.config.ts src/cron/service.issue-regressions.test.ts` and `pnpm exec vitest run --config vitest.config.ts src/gateway/server.cron.test.ts` after the fix.
- **Edge cases checked:** Verified that the manual dispatch path uses a separate lane while isolated cron execution can still enqueue work onto the existing `cron` lane without deadlocking.
- **What you did not verify:** Did not manually click the dashboard `Run` button or exercise a live cron job on a running gateway instance.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this specific PR commit.
- Known bad symptoms reviewers should watch for: Cron manual triggers start but unexpectedly ignore the configured cron concurrency cap, which would suggest the new dispatch lane is no longer sharing the expected concurrency setting.

## Risks and Mitigations

- Risk: Adding a second lane for manual dispatch could drift from the configured cron concurrency if its limit is not kept in sync.
  - Mitigation: The new `cron-dispatch` lane is explicitly initialized and reloaded with `cfg.cron?.maxConcurrentRuns ?? 1`, and regression coverage exercises the deadlock case directly.
