### PR TITLE
fix(ui): preserve gateway token when editing websocket url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI: preserve manually entered Gateway Access tokens while editing URL formatting within the same normalized gateway endpoint, but clear them when the endpoint scope changes. Fixes #41545; carries forward #41546 and #42001. Thanks @wsyjh8 and @llagy0020.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Cron/Telegram: preserve explicit `:topic:` delivery targets over stale session-derived thread IDs when isolated cron announces to Telegram forum topics. Carries forward #59069; refs #49704 and #43808. Thanks @roytong9.
 - Build/runtime: write the runtime-postbuild stamp after `pnpm build` writes the build stamp, so the next CLI invocation does not re-sync runtime artifacts after a successful build. Fixes #73151. Thanks @bittoby.

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -583,12 +583,47 @@ describe("control UI routing", () => {
       'input[placeholder="ws://100.x.y.z:18789"]',
     );
     expect(gatewayUrlInput).not.toBeNull();
+
     gatewayUrlInput!.value = "wss://other-gateway.example/openclaw";
     gatewayUrlInput!.dispatchEvent(new Event("input", { bubbles: true }));
     await refreshed.updateComplete;
 
     expect(refreshed.settings.gatewayUrl).toBe("wss://other-gateway.example/openclaw");
     expect(refreshed.settings.token).toBe("");
+  });
+
+  it("preserves a typed token while editing the gateway URL within the same endpoint scope", async () => {
+    const app = mountApp("/ui/overview");
+    await app.updateComplete;
+
+    const tokenInput = app.querySelector<HTMLInputElement>(
+      'input[placeholder="OPENCLAW_GATEWAY_TOKEN"]',
+    );
+    expect(tokenInput).not.toBeNull();
+
+    tokenInput!.value = "typed-token";
+    tokenInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    await app.updateComplete;
+
+    const gatewayUrlInput = app.querySelector<HTMLInputElement>(
+      'input[placeholder="ws://100.x.y.z:18789"]',
+    );
+    expect(gatewayUrlInput).not.toBeNull();
+
+    gatewayUrlInput!.value = `${app.settings.gatewayUrl}/`;
+    gatewayUrlInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    await app.updateComplete;
+
+    gatewayUrlInput!.value = `  ${app.settings.gatewayUrl}  `;
+    gatewayUrlInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    await app.updateComplete;
+
+    const nextTokenInput = app.querySelector<HTMLInputElement>(
+      'input[placeholder="OPENCLAW_GATEWAY_TOKEN"]',
+    );
+
+    expect(app.settings.token).toBe("typed-token");
+    expect(nextTokenInput?.value).toBe("typed-token");
   });
 
   it("keeps a hash token pending until the gateway URL change is confirmed", async () => {

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -592,7 +592,7 @@ describe("control UI routing", () => {
     expect(refreshed.settings.token).toBe("");
   });
 
-  it("preserves a typed token while editing the gateway URL within the same endpoint scope", async () => {
+  it("preserves a typed token while editing within the same gateway scope", async () => {
     const app = mountApp("/ui/overview");
     await app.updateComplete;
 
@@ -624,6 +624,13 @@ describe("control UI routing", () => {
 
     expect(app.settings.token).toBe("typed-token");
     expect(nextTokenInput?.value).toBe("typed-token");
+
+    gatewayUrlInput!.value = "wss://other-gateway.example/openclaw";
+    gatewayUrlInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    await app.updateComplete;
+
+    expect(app.settings.gatewayUrl).toBe("wss://other-gateway.example/openclaw");
+    expect(app.settings.token).toBe("");
   });
 
   it("keeps a hash token pending until the gateway URL change is confirmed", async () => {

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -103,7 +103,7 @@ function getSessionStorage(): Storage | null {
   return getSafeSessionStorage();
 }
 
-function normalizeGatewayTokenScope(gatewayUrl: string): string {
+export function normalizeGatewayTokenScope(gatewayUrl: string): string {
   const trimmed = normalizeOptionalString(gatewayUrl) ?? "";
   if (!trimmed) {
     return "default";

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -268,7 +268,6 @@ export function renderOverview(props: OverviewProps) {
                 props.onSettingsChange({
                   ...props.settings,
                   gatewayUrl: v,
-                  token: v.trim() === props.settings.gatewayUrl.trim() ? props.settings.token : "",
                 });
               }}
               placeholder="ws://100.x.y.z:18789"

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -5,7 +5,7 @@ import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../external-link.ts"
 import { formatRelativeTimestamp, formatDurationHuman } from "../format.ts";
 import type { GatewayHelloOk } from "../gateway.ts";
 import { icons } from "../icons.ts";
-import type { UiSettings } from "../storage.ts";
+import { normalizeGatewayTokenScope, type UiSettings } from "../storage.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import type {
   AttentionItem,
@@ -265,9 +265,15 @@ export function renderOverview(props: OverviewProps) {
               .value=${props.settings.gatewayUrl}
               @input=${(e: Event) => {
                 const v = (e.target as HTMLInputElement).value;
+                const token =
+                  normalizeGatewayTokenScope(v) ===
+                  normalizeGatewayTokenScope(props.settings.gatewayUrl)
+                    ? props.settings.token
+                    : "";
                 props.onSettingsChange({
                   ...props.settings,
                   gatewayUrl: v,
+                  token,
                 });
               }}
               placeholder="ws://100.x.y.z:18789"


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Editing the WebSocket URL in Overview → Gateway Access cleared the Gateway Token field immediately.
- Why it matters: This caused Connect to fail unless the user noticed the token was cleared and re-entered it manually.
- What changed: Removed the incorrect token reset from the WebSocket URL input handler so editing the URL preserves the existing token.
- What did NOT change (scope boundary): No backend, gateway, auth flow, storage schema, or network behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41545
- Related #

## User-visible / Behavior Changes

- Editing the WebSocket URL no longer clears the Gateway Token field in Overview → Gateway Access.
- Users can now update the WebSocket URL without needing to re-enter the token before clicking Connect.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime/container: Source checkout, frontend started locally via `pnpm ui:dev`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Overview → Gateway Access form with WebSocket URL and Gateway Token

### Steps

1. Open the dashboard UI and go to Overview.
2. Enter a value into Gateway Token.
3. Edit the WebSocket URL field.
4. Observe whether the token remains unchanged.
5. Click Connect.

### Expected

- Editing WebSocket URL should not clear Gateway Token.
- Connect should continue using the preserved token.

### Actual

- Before this fix, editing WebSocket URL immediately cleared Gateway Token.
- After this fix, the token remains unchanged and Connect works with the preserved token.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Entered Gateway Token first, then edited WebSocket URL: token remained unchanged.
  - Entered WebSocket URL first, then entered Gateway Token, then edited WebSocket URL again: token remained unchanged.
  - After entering a correct token, Connect succeeded without needing to re-enter the token.
- Edge cases checked:
  - Verified the issue reproduced on the latest upstream/main before the fix.
  - Verified the token was previously cleared on input, even before focus left the URL field.
- What you did **not** verify:
  - Did not add or verify automated tests for this UI path.
  - Did not verify behavior across multiple browsers or production builds beyond local manual verification.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR or restore the previous version of `ui/src/ui/views/overview.ts`.
- Files/config to restore: `ui/src/ui/views/overview.ts`
- Known bad symptoms reviewers should watch for:
  - Gateway Token still gets cleared when WebSocket URL is edited.
  - Connect fails because token is unexpectedly missing after editing the URL.

## Risks and Mitigations

- Risk: Low. The change is limited to a single UI input handler in Overview.
- Mitigation: The fix preserves the existing settings object and removes only the incorrect token-clearing behavior. Manual verification confirmed that token preservation now works in both input orders and that Connect still succeeds with the preserved token.