### PR TITLE
fix(control-ui): preserve token when editing WebSocket URL

### DIFF
--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -198,7 +198,7 @@ describe("control UI routing", () => {
     expect(window.location.hash).toBe("");
   });
 
-  it("clears the current token when the gateway URL changes", async () => {
+  it("keeps the current token when the gateway URL changes", async () => {
     const app = mountApp("/ui/overview#token=abc123");
     await app.updateComplete;
 
@@ -211,7 +211,35 @@ describe("control UI routing", () => {
     await app.updateComplete;
 
     expect(app.settings.gatewayUrl).toBe("wss://other-gateway.example/openclaw");
-    expect(app.settings.token).toBe("");
+    expect(app.settings.token).toBe("abc123");
+  });
+
+  it("preserves a typed token while editing the gateway URL from overview", async () => {
+    const app = mountApp("/ui/overview");
+    await app.updateComplete;
+
+    const tokenInput = app.querySelector<HTMLInputElement>(
+      'input[placeholder="OPENCLAW_GATEWAY_TOKEN"]',
+    );
+    expect(tokenInput).not.toBeNull();
+    tokenInput!.value = "typed-token";
+    tokenInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    await app.updateComplete;
+
+    const gatewayUrlInput = app.querySelector<HTMLInputElement>(
+      'input[placeholder="ws://100.x.y.z:18789"]',
+    );
+    expect(gatewayUrlInput).not.toBeNull();
+    gatewayUrlInput!.value = "wss://other-gateway.example/openclaw";
+    gatewayUrlInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    await app.updateComplete;
+
+    const nextTokenInput = app.querySelector<HTMLInputElement>(
+      'input[placeholder="OPENCLAW_GATEWAY_TOKEN"]',
+    );
+    expect(app.settings.gatewayUrl).toBe("wss://other-gateway.example/openclaw");
+    expect(app.settings.token).toBe("typed-token");
+    expect(nextTokenInput?.value).toBe("typed-token");
   });
 
   it("keeps a hash token pending until the gateway URL change is confirmed", async () => {

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -208,7 +208,6 @@ export function renderOverview(props: OverviewProps) {
                 props.onSettingsChange({
                   ...props.settings,
                   gatewayUrl: v,
-                  token: v.trim() === props.settings.gatewayUrl.trim() ? props.settings.token : "",
                 });
               }}
               placeholder="ws://100.x.y.z:18789"


### PR DESCRIPTION
## Summary
- preserve the current gateway token when the Overview WebSocket URL field changes
- stop the Overview URL input from blanking the in-memory token on every edit
- add browser regression coverage for both existing-token and typed-token flows

## Testing
- corepack pnpm --dir ui exec vitest run src/ui/navigation.browser.test.ts
- corepack pnpm exec oxlint --type-aware ui/src/ui/views/overview.ts ui/src/ui/navigation.browser.test.ts

## Notes
- behavior-only Control UI fix; no meaningful visual delta to screenshot
- AI-assisted with Codex; targeted tests passed and I understand the change

Fixes #41545