### PR TITLE
feat(cards): add shared adaptive card rendering for all channels

### DIFF
--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -31,6 +31,13 @@ export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
 // ---------------------------------------------------------------------------
 
 const AC_CARD_RE = /<!--adaptive-card-->([\s\S]*?)<!--\/adaptive-card-->/;
+const AC_MARKERS_RE =
+  /<!--adaptive-card-->[\s\S]*?<!--\/adaptive-card-->|<!--adaptive-card-data-->[\s\S]*?<!--\/adaptive-card-data-->/g;
+
+/** Strip all adaptive card markers, returning only the fallback text. */
+function stripCardMarkers(text: string): string {
+  return text.replace(AC_MARKERS_RE, "").trim();
+}
 
 interface AcParsed {
   card: { type: "AdaptiveCard"; body: unknown[]; actions?: unknown[] };
@@ -135,7 +142,9 @@ function buildActionRow(actions: unknown[]): unknown | null {
     const label = acStr(action.title);
     if (!label) continue;
     if (action.type === "Action.OpenUrl") {
-      buttons.push({ type: 2, style: 5, label, url: acStr(action.url) });
+      const url = acStr(action.url);
+      if (!url) continue; // skip: Discord rejects link buttons with an empty URL
+      buttons.push({ type: 2, style: 5, label, url });
     } else if (action.type === "Action.Submit") {
       const customId = typeof action.id === "string" ? action.id : `ac_submit_${buttons.length}`;
       buttons.push({ type: 2, style: 1, label, custom_id: customId });
@@ -307,22 +316,26 @@ export const discordOutbound: ChannelOutboundAdapter = {
       const parsed = parseAdaptiveCardMarkers(text);
       if (parsed) {
         const rendered = renderDiscordCard(parsed);
-        const send =
-          resolveOutboundSendDep<typeof sendMessageDiscord>(deps, "discord") ?? sendMessageDiscord;
-        const target = resolveDiscordOutboundTarget({ to, threadId });
-        return await send(target, rendered.fallback, {
-          verbose: false,
-          replyTo: replyToId ?? undefined,
-          accountId: accountId ?? undefined,
-          silent: silent ?? undefined,
-          cfg,
-          embeds: rendered.embeds as NonNullable<
-            Parameters<typeof sendMessageDiscord>[2]
-          >["embeds"],
-          components: rendered.components as NonNullable<
-            Parameters<typeof sendMessageDiscord>[2]
-          >["components"],
-        });
+        if (rendered.embeds.length > 0) {
+          const send =
+            resolveOutboundSendDep<typeof sendMessageDiscord>(deps, "discord") ?? sendMessageDiscord;
+          const target = resolveDiscordOutboundTarget({ to, threadId });
+          return await send(target, rendered.fallback, {
+            verbose: false,
+            replyTo: replyToId ?? undefined,
+            accountId: accountId ?? undefined,
+            silent: silent ?? undefined,
+            cfg,
+            embeds: rendered.embeds as NonNullable<
+              Parameters<typeof sendMessageDiscord>[2]
+            >["embeds"],
+            components: rendered.components as NonNullable<
+              Parameters<typeof sendMessageDiscord>[2]
+            >["components"],
+          });
+        }
+        // Card markers present but rendering failed; strip markers to avoid leaking raw JSON
+        text = parsed.fallbackText || stripCardMarkers(text);
       }
 
       if (!silent) {

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -24,6 +24,144 @@ import { buildDiscordInteractiveComponents } from "./shared-interactive.js";
 
 export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
 
+// ---------------------------------------------------------------------------
+// Adaptive Card rendering: inline card extraction + Discord embed conversion.
+// Mirrors src/cards/parse.ts + src/cards/strategies/discord.ts but kept inline
+// to avoid cross-workspace imports (extensions cannot import from src/ directly).
+// ---------------------------------------------------------------------------
+
+const AC_CARD_RE = /<!--adaptive-card-->([\s\S]*?)<!--\/adaptive-card-->/;
+
+interface AcParsed {
+  card: { type: "AdaptiveCard"; body: unknown[]; actions?: unknown[] };
+  fallbackText: string;
+}
+
+function parseAdaptiveCardMarkers(text: string): AcParsed | null {
+  const m = AC_CARD_RE.exec(text);
+  if (!m) {
+    return null;
+  }
+  try {
+    const card = JSON.parse(m[1].trim());
+    if (card?.type !== "AdaptiveCard") {
+      return null;
+    }
+    const fallbackText = text.slice(0, m.index).trim();
+    return { card, fallbackText };
+  } catch {
+    return null;
+  }
+}
+
+type AcElement = Record<string, unknown>;
+
+function acStr(val: unknown, fallback = ""): string {
+  if (typeof val === "string") return val;
+  if (val == null) return fallback;
+  return JSON.stringify(val);
+}
+
+interface DiscordEmbed {
+  title?: string;
+  description?: string;
+  fields?: Array<{ name: string; value: string; inline?: boolean }>;
+  image?: { url: string };
+}
+
+function buildEmbedFromBody(body: unknown[]): DiscordEmbed {
+  const embed: DiscordEmbed = {};
+  const descParts: string[] = [];
+  for (const raw of body) {
+    const el = raw as AcElement;
+    switch (el.type) {
+      case "TextBlock": {
+        const text = acStr(el.text);
+        const weight = el.weight as string | undefined;
+        if (weight === "Bolder" && !embed.title) {
+          embed.title = text;
+        } else {
+          descParts.push(weight === "Bolder" ? `**${text}**` : text);
+        }
+        break;
+      }
+      case "FactSet": {
+        const facts = el.facts as Array<{ title?: string; value?: string }> | undefined;
+        if (facts?.length) {
+          embed.fields ??= [];
+          for (const f of facts) {
+            embed.fields.push({ name: f.title ?? "", value: f.value ?? "", inline: true });
+          }
+        }
+        break;
+      }
+      case "Image": {
+        const url = acStr(el.url);
+        if (url) embed.image = { url };
+        break;
+      }
+      case "ColumnSet": {
+        const columns = el.columns as Array<{ items?: AcElement[] }> | undefined;
+        if (columns?.length) {
+          const sub = buildEmbedFromBody(columns.flatMap((col) => col.items ?? []));
+          if (sub.title && !embed.title) embed.title = sub.title;
+          if (sub.description) descParts.push(sub.description);
+          if (sub.fields?.length) { embed.fields ??= []; embed.fields.push(...sub.fields); }
+          if (sub.image && !embed.image) embed.image = sub.image;
+        }
+        break;
+      }
+      case "Container": {
+        const items = el.items as AcElement[] | undefined;
+        if (items?.length) {
+          const sub = buildEmbedFromBody(items);
+          if (sub.title && !embed.title) embed.title = sub.title;
+          if (sub.description) descParts.push(sub.description);
+          if (sub.fields?.length) { embed.fields ??= []; embed.fields.push(...sub.fields); }
+          if (sub.image && !embed.image) embed.image = sub.image;
+        }
+        break;
+      }
+    }
+  }
+  if (descParts.length > 0) embed.description = descParts.join("\n");
+  return embed;
+}
+
+function buildActionRow(actions: unknown[]): unknown | null {
+  const buttons: Array<{ type: 2; style: number; label: string; url?: string; custom_id?: string }> = [];
+  for (const raw of actions) {
+    const action = raw as AcElement;
+    const label = acStr(action.title);
+    if (!label) continue;
+    if (action.type === "Action.OpenUrl") {
+      buttons.push({ type: 2, style: 5, label, url: acStr(action.url) });
+    } else if (action.type === "Action.Submit") {
+      const customId = typeof action.id === "string" ? action.id : `ac_submit_${buttons.length}`;
+      buttons.push({ type: 2, style: 1, label, custom_id: customId });
+    }
+  }
+  return buttons.length > 0 ? { type: 1, components: buttons } : null;
+}
+
+function renderDiscordCard(parsed: AcParsed): {
+  embeds: DiscordEmbed[];
+  components: unknown[] | undefined;
+  fallback: string;
+} {
+  const embed = buildEmbedFromBody(parsed.card.body);
+  const components: unknown[] = [];
+  if (parsed.card.actions?.length) {
+    const row = buildActionRow(parsed.card.actions);
+    if (row) components.push(row);
+  }
+  return {
+    embeds: [embed],
+    components: components.length > 0 ? components : undefined,
+    fallback: parsed.fallbackText,
+  };
+}
+
 function resolveDiscordOutboundTarget(params: {
   to: string;
   threadId?: string | number | null;
@@ -165,6 +303,28 @@ export const discordOutbound: ChannelOutboundAdapter = {
   ...createAttachedChannelResultAdapter({
     channel: "discord",
     sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity, silent }) => {
+      // Adaptive card rendering: convert card markers to Discord embeds + components
+      const parsed = parseAdaptiveCardMarkers(text);
+      if (parsed) {
+        const rendered = renderDiscordCard(parsed);
+        const send =
+          resolveOutboundSendDep<typeof sendMessageDiscord>(deps, "discord") ?? sendMessageDiscord;
+        const target = resolveDiscordOutboundTarget({ to, threadId });
+        return await send(target, rendered.fallback, {
+          verbose: false,
+          replyTo: replyToId ?? undefined,
+          accountId: accountId ?? undefined,
+          silent: silent ?? undefined,
+          cfg,
+          embeds: rendered.embeds as NonNullable<
+            Parameters<typeof sendMessageDiscord>[2]
+          >["embeds"],
+          components: rendered.components as NonNullable<
+            Parameters<typeof sendMessageDiscord>[2]
+          >["components"],
+        });
+      }
+
       if (!silent) {
         const webhookResult = await maybeSendDiscordWebhookText({
           cfg,

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -131,7 +131,22 @@ function buildEmbedFromBody(body: unknown[]): DiscordEmbed {
       }
     }
   }
-  if (descParts.length > 0) embed.description = descParts.join("\n");
+  if (descParts.length > 0) {
+    const desc = descParts.join("\n");
+    // Discord limits embed description to 4096 chars
+    embed.description = desc.length > 4096 ? desc.slice(0, 4093) + "..." : desc;
+  }
+  // Discord limits: title 256 chars, 25 fields max, field name/value 1024 chars
+  if (embed.title && embed.title.length > 256) {
+    embed.title = embed.title.slice(0, 253) + "...";
+  }
+  if (embed.fields) {
+    embed.fields = embed.fields.slice(0, 25).map((f) => ({
+      name: f.name.length > 1024 ? f.name.slice(0, 1021) + "..." : f.name || "\u200B",
+      value: f.value.length > 1024 ? f.value.slice(0, 1021) + "..." : f.value || "\u200B",
+      inline: f.inline,
+    }));
+  }
   return embed;
 }
 
@@ -315,8 +330,13 @@ export const discordOutbound: ChannelOutboundAdapter = {
       // Adaptive card rendering: convert card markers to Discord embeds + components
       const parsed = parseAdaptiveCardMarkers(text);
       if (parsed) {
-        const rendered = renderDiscordCard(parsed);
-        if (rendered.embeds.length > 0) {
+        let rendered: ReturnType<typeof renderDiscordCard> | null = null;
+        try {
+          rendered = renderDiscordCard(parsed);
+        } catch {
+          // strategy error -- fall through to fallback text
+        }
+        if (rendered && rendered.embeds.length > 0) {
           const send =
             resolveOutboundSendDep<typeof sendMessageDiscord>(deps, "discord") ?? sendMessageDiscord;
           const target = resolveDiscordOutboundTarget({ to, threadId });

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -3,7 +3,30 @@ import { createAttachedChannelResultAdapter } from "openclaw/plugin-sdk/channel-
 import type { ChannelOutboundAdapter } from "../runtime-api.js";
 import { createMSTeamsPollStoreFs } from "./polls.js";
 import { getMSTeamsRuntime } from "./runtime.js";
-import { sendMessageMSTeams, sendPollMSTeams } from "./send.js";
+import { sendAdaptiveCardMSTeams, sendMessageMSTeams, sendPollMSTeams } from "./send.js";
+
+/**
+ * Extract an Adaptive Card from marker comments embedded in reply text.
+ * Mirrors the regex in src/cards/parse.ts but kept inline to avoid
+ * a cross-workspace import (extensions cannot import from src/ directly).
+ */
+const AC_CARD_RE = /<!--adaptive-card-->([\s\S]*?)<!--\/adaptive-card-->/;
+
+function extractAdaptiveCard(text: string): Record<string, unknown> | null {
+  const m = AC_CARD_RE.exec(text);
+  if (!m) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(m[1].trim());
+    if (parsed?.type === "AdaptiveCard") {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // malformed JSON
+  }
+  return null;
+}
 
 export const msteamsOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
@@ -14,6 +37,12 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
   ...createAttachedChannelResultAdapter({
     channel: "msteams",
     sendText: async ({ cfg, to, text, deps }) => {
+      // Native adaptive card pass-through: Teams supports AC directly
+      const card = extractAdaptiveCard(text);
+      if (card) {
+        return await sendAdaptiveCardMSTeams({ cfg, to, card });
+      }
+
       type SendFn = (
         to: string,
         text: string,

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -11,6 +11,8 @@ import { sendAdaptiveCardMSTeams, sendMessageMSTeams, sendPollMSTeams } from "./
  * a cross-workspace import (extensions cannot import from src/ directly).
  */
 const AC_CARD_RE = /<!--adaptive-card-->([\s\S]*?)<!--\/adaptive-card-->/;
+const AC_MARKERS_RE =
+  /<!--adaptive-card-->[\s\S]*?<!--\/adaptive-card-->|<!--adaptive-card-data-->[\s\S]*?<!--\/adaptive-card-data-->/g;
 
 function extractAdaptiveCard(text: string): Record<string, unknown> | null {
   const m = AC_CARD_RE.exec(text);
@@ -28,6 +30,11 @@ function extractAdaptiveCard(text: string): Record<string, unknown> | null {
   return null;
 }
 
+/** Strip all adaptive card markers, returning only the fallback text. */
+function stripCardMarkers(text: string): string {
+  return text.replace(AC_MARKERS_RE, "").trim();
+}
+
 export const msteamsOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: (text, limit) => getMSTeamsRuntime().channel.text.chunkMarkdownText(text, limit),
@@ -38,9 +45,14 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
     channel: "msteams",
     sendText: async ({ cfg, to, text, deps }) => {
       // Native adaptive card pass-through: Teams supports AC directly
-      const card = extractAdaptiveCard(text);
+      const hasMarkers = AC_CARD_RE.test(text);
+      const card = hasMarkers ? extractAdaptiveCard(text) : null;
       if (card) {
         return await sendAdaptiveCardMSTeams({ cfg, to, card });
+      }
+      // Strip markers to avoid leaking raw JSON if card extraction failed
+      if (hasMarkers) {
+        text = stripCardMarkers(text);
       }
 
       type SendFn = (

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -21,6 +21,136 @@ import { sendMessageSlack, type SlackSendIdentity } from "./send.js";
 
 const SLACK_MAX_BLOCKS = 50;
 
+// ---------------------------------------------------------------------------
+// Adaptive Card rendering: inline card extraction + Slack Block Kit conversion.
+// Mirrors src/cards/parse.ts + src/cards/strategies/slack.ts but kept inline
+// to avoid cross-workspace imports (extensions cannot import from src/ directly).
+// ---------------------------------------------------------------------------
+
+const AC_CARD_RE = /<!--adaptive-card-->([\s\S]*?)<!--\/adaptive-card-->/;
+
+interface AcParsed {
+  card: { type: "AdaptiveCard"; body: unknown[]; actions?: unknown[] };
+  fallbackText: string;
+}
+
+function parseAdaptiveCardMarkers(text: string): AcParsed | null {
+  const m = AC_CARD_RE.exec(text);
+  if (!m) {
+    return null;
+  }
+  try {
+    const card = JSON.parse(m[1].trim());
+    if (card?.type !== "AdaptiveCard") {
+      return null;
+    }
+    const fallbackText = text.slice(0, m.index).trim();
+    return { card, fallbackText };
+  } catch {
+    return null;
+  }
+}
+
+type AcElement = Record<string, unknown>;
+
+function acStr(val: unknown, fallback = ""): string {
+  if (typeof val === "string") return val;
+  if (val == null) return fallback;
+  return JSON.stringify(val);
+}
+
+function renderAcTextBlock(el: AcElement): unknown {
+  const text = acStr(el.text);
+  const weight = el.weight as string | undefined;
+  const formatted = weight === "Bolder" ? `*${text}*` : text;
+  return { type: "section", text: { type: "mrkdwn", text: formatted } };
+}
+
+function renderAcFactSet(el: AcElement): unknown | null {
+  const facts = el.facts as Array<{ title?: string; value?: string }> | undefined;
+  if (!facts?.length) return null;
+  return {
+    type: "section",
+    fields: facts.map((f) => ({ type: "mrkdwn", text: `*${f.title ?? ""}*\n${f.value ?? ""}` })),
+  };
+}
+
+function renderAcImage(el: AcElement): unknown | null {
+  const url = acStr(el.url);
+  const alt = acStr(el.altText) || acStr(el.alt) || "image";
+  if (!url) return null;
+  return { type: "image", image_url: url, alt_text: alt };
+}
+
+function renderAcElement(el: AcElement): unknown[] {
+  switch (el.type) {
+    case "TextBlock":
+      return [renderAcTextBlock(el)];
+    case "FactSet": {
+      const block = renderAcFactSet(el);
+      return block ? [block] : [];
+    }
+    case "Image": {
+      const block = renderAcImage(el);
+      return block ? [block] : [];
+    }
+    case "ColumnSet": {
+      const columns = el.columns as Array<{ items?: AcElement[] }> | undefined;
+      if (!columns?.length) return [];
+      return columns.flatMap((col) => (col.items ?? []).flatMap(renderAcElement));
+    }
+    case "Container": {
+      const items = el.items as AcElement[] | undefined;
+      return (items ?? []).flatMap(renderAcElement);
+    }
+    default:
+      return [];
+  }
+}
+
+function renderAcActions(actions: unknown[]): unknown[] {
+  type SlackButton = {
+    type: "button";
+    text: { type: "plain_text"; text: string };
+    url?: string;
+    action_id?: string;
+    value?: string;
+  };
+  const buttons: SlackButton[] = [];
+  for (const raw of actions) {
+    const action = raw as AcElement;
+    const label = acStr(action.title);
+    if (!label) continue;
+    if (action.type === "Action.OpenUrl") {
+      buttons.push({ type: "button", text: { type: "plain_text", text: label }, url: acStr(action.url) });
+    } else if (action.type === "Action.Submit") {
+      const actionId = typeof action.id === "string" ? action.id : `ac_submit_${buttons.length}`;
+      buttons.push({
+        type: "button",
+        text: { type: "plain_text", text: label },
+        action_id: actionId,
+        value: action.data != null ? JSON.stringify(action.data) : undefined,
+      });
+    }
+  }
+  return buttons.length > 0 ? [{ type: "actions", elements: buttons }] : [];
+}
+
+function renderSlackCard(parsed: AcParsed): { blocks: unknown[]; fallback: string } {
+  const blocks: unknown[] = [];
+  for (const el of parsed.card.body) {
+    const rendered = renderAcElement(el as AcElement);
+    if (rendered.length > 0) {
+      if (blocks.length > 0) blocks.push({ type: "divider" });
+      blocks.push(...rendered);
+    }
+  }
+  if (parsed.card.actions?.length) {
+    blocks.push(...renderAcActions(parsed.card.actions));
+  }
+  return { blocks, fallback: parsed.fallbackText };
+}
+
 function resolveRenderedInteractiveBlocks(
   interactive?: InteractiveReply,
 ): SlackBlock[] | undefined {
@@ -205,8 +335,27 @@ export const slackOutbound: ChannelOutboundAdapter = {
   },
   ...createAttachedChannelResultAdapter({
     channel: "slack",
-    sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity }) =>
-      await sendSlackOutboundMessage({
+    sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity }) => {
+      // Adaptive card rendering: convert card markers to Slack Block Kit
+      const acParsed = parseAdaptiveCardMarkers(text);
+      if (acParsed) {
+        const rendered = renderSlackCard(acParsed);
+        if (rendered.blocks.length > 0) {
+          const send =
+            resolveOutboundSendDep<typeof sendMessageSlack>(deps, "slack") ?? sendMessageSlack;
+          const threadTs = replyToId ?? (threadId != null ? String(threadId) : undefined);
+          const slackIdentity = resolveSlackSendIdentity(identity);
+          return await send(to, rendered.fallback, {
+            cfg,
+            threadTs,
+            accountId: accountId ?? undefined,
+            blocks: rendered.blocks as NonNullable<Parameters<typeof sendMessageSlack>[2]>["blocks"],
+            ...(slackIdentity ? { identity: slackIdentity } : {}),
+          });
+        }
+      }
+
+      return await sendSlackOutboundMessage({
         cfg,
         to,
         text,
@@ -215,7 +364,8 @@ export const slackOutbound: ChannelOutboundAdapter = {
         replyToId,
         threadId,
         identity,
-      }),
+      });
+    },
     sendMedia: async ({
       cfg,
       to,

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -28,6 +28,13 @@ const SLACK_MAX_BLOCKS = 50;
 // ---------------------------------------------------------------------------
 
 const AC_CARD_RE = /<!--adaptive-card-->([\s\S]*?)<!--\/adaptive-card-->/;
+const AC_MARKERS_RE =
+  /<!--adaptive-card-->[\s\S]*?<!--\/adaptive-card-->|<!--adaptive-card-data-->[\s\S]*?<!--\/adaptive-card-data-->/g;
+
+/** Strip all adaptive card markers, returning only the fallback text. */
+function stripCardMarkers(text: string): string {
+  return text.replace(AC_MARKERS_RE, "").trim();
+}
 
 interface AcParsed {
   card: { type: "AdaptiveCard"; body: unknown[]; actions?: unknown[] };
@@ -66,13 +73,16 @@ function renderAcTextBlock(el: AcElement): unknown {
   return { type: "section", text: { type: "mrkdwn", text: formatted } };
 }
 
-function renderAcFactSet(el: AcElement): unknown | null {
+function renderAcFactSet(el: AcElement): unknown[] {
   const facts = el.facts as Array<{ title?: string; value?: string }> | undefined;
-  if (!facts?.length) return null;
-  return {
-    type: "section",
-    fields: facts.map((f) => ({ type: "mrkdwn", text: `*${f.title ?? ""}*\n${f.value ?? ""}` })),
-  };
+  if (!facts?.length) return [];
+  const fields = facts.map((f) => ({ type: "mrkdwn", text: `*${f.title ?? ""}*\n${f.value ?? ""}` }));
+  // Slack limits section blocks to 10 fields; split into chunks if needed
+  const blocks: unknown[] = [];
+  for (let i = 0; i < fields.length; i += 10) {
+    blocks.push({ type: "section", fields: fields.slice(i, i + 10) });
+  }
+  return blocks;
 }
 
 function renderAcImage(el: AcElement): unknown | null {
@@ -86,10 +96,8 @@ function renderAcElement(el: AcElement): unknown[] {
   switch (el.type) {
     case "TextBlock":
       return [renderAcTextBlock(el)];
-    case "FactSet": {
-      const block = renderAcFactSet(el);
-      return block ? [block] : [];
-    }
+    case "FactSet":
+      return renderAcFactSet(el);
     case "Image": {
       const block = renderAcImage(el);
       return block ? [block] : [];
@@ -122,7 +130,9 @@ function renderAcActions(actions: unknown[]): unknown[] {
     const label = acStr(action.title);
     if (!label) continue;
     if (action.type === "Action.OpenUrl") {
-      buttons.push({ type: "button", text: { type: "plain_text", text: label }, url: acStr(action.url) });
+      const url = acStr(action.url);
+      if (!url) continue; // skip: Slack rejects link buttons with an empty URL
+      buttons.push({ type: "button", text: { type: "plain_text", text: label }, url });
     } else if (action.type === "Action.Submit") {
       const actionId = typeof action.id === "string" ? action.id : `ac_submit_${buttons.length}`;
       buttons.push({
@@ -353,6 +363,9 @@ export const slackOutbound: ChannelOutboundAdapter = {
             ...(slackIdentity ? { identity: slackIdentity } : {}),
           });
         }
+        // Card markers present but no blocks rendered (unsupported elements).
+        // Use fallback text to avoid leaking raw markers to the user.
+        text = acParsed.fallbackText || stripCardMarkers(text);
       }
 
       return await sendSlackOutboundMessage({

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -66,11 +66,16 @@ function acStr(val: unknown, fallback = ""): string {
   return JSON.stringify(val);
 }
 
+/** Slack limits section text to 3000 chars. */
+function truncateMrkdwn(text: string, limit = 3000): string {
+  return text.length > limit ? text.slice(0, limit - 3) + "..." : text;
+}
+
 function renderAcTextBlock(el: AcElement): unknown {
   const text = acStr(el.text);
   const weight = el.weight as string | undefined;
   const formatted = weight === "Bolder" ? `*${text}*` : text;
-  return { type: "section", text: { type: "mrkdwn", text: formatted } };
+  return { type: "section", text: { type: "mrkdwn", text: truncateMrkdwn(formatted) } };
 }
 
 function renderAcFactSet(el: AcElement): unknown[] {
@@ -349,8 +354,13 @@ export const slackOutbound: ChannelOutboundAdapter = {
       // Adaptive card rendering: convert card markers to Slack Block Kit
       const acParsed = parseAdaptiveCardMarkers(text);
       if (acParsed) {
-        const rendered = renderSlackCard(acParsed);
-        if (rendered.blocks.length > 0) {
+        let rendered: ReturnType<typeof renderSlackCard> | null = null;
+        try {
+          rendered = renderSlackCard(acParsed);
+        } catch {
+          // strategy error -- fall through to fallback text
+        }
+        if (rendered && rendered.blocks.length > 0) {
           const send =
             resolveOutboundSendDep<typeof sendMessageSlack>(deps, "slack") ?? sendMessageSlack;
           const threadTs = replyToId ?? (threadId != null ? String(threadId) : undefined);

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -25,6 +25,13 @@ export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
 // ---------------------------------------------------------------------------
 
 const AC_CARD_RE = /<!--adaptive-card-->([\s\S]*?)<!--\/adaptive-card-->/;
+const AC_MARKERS_RE =
+  /<!--adaptive-card-->[\s\S]*?<!--\/adaptive-card-->|<!--adaptive-card-data-->[\s\S]*?<!--\/adaptive-card-data-->/g;
+
+/** Strip all adaptive card markers, returning only the fallback text. */
+function stripCardMarkers(text: string): string {
+  return text.replace(AC_MARKERS_RE, "").trim();
+}
 
 interface AcParsed {
   card: { type: "AdaptiveCard"; body: unknown[]; actions?: unknown[] };
@@ -110,10 +117,19 @@ function renderTgActions(actions: unknown[]): InlineButton[][] {
     const label = acStr(action.title);
     if (!label) continue;
     if (action.type === "Action.OpenUrl") {
-      buttons.push({ text: label, url: acStr(action.url) });
+      const url = acStr(action.url);
+      if (!url) continue; // skip: Telegram rejects inline buttons with an empty URL
+      buttons.push({ text: label, url });
     } else if (action.type === "Action.Submit") {
-      const data = action.data != null ? JSON.stringify(action.data) : label;
-      buttons.push({ text: label, callback_data: data.slice(0, 64) });
+      // Encode action data as callback_data (Telegram limit: 64 bytes)
+      const raw = action.data != null ? JSON.stringify(action.data) : label;
+      // Truncate by UTF-8 byte length, not character count
+      const encoder = new TextEncoder();
+      let truncated = raw;
+      while (encoder.encode(truncated).byteLength > 64) {
+        truncated = truncated.slice(0, -1);
+      }
+      buttons.push({ text: label, callback_data: truncated });
     }
   }
   return buttons.length > 0 ? buttons.map((b) => [b]) : [];
@@ -237,13 +253,17 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       const acParsed = parseAdaptiveCardMarkers(text);
       if (acParsed) {
         const rendered = renderTelegramCard(acParsed);
-        const buttons: TelegramInlineButtons | undefined = rendered.replyMarkup
-          ? (rendered.replyMarkup.inline_keyboard as unknown as TelegramInlineButtons)
-          : undefined;
-        return await send(to, rendered.text, {
-          ...baseOpts,
-          buttons,
-        });
+        if (rendered.text) {
+          const buttons: TelegramInlineButtons | undefined = rendered.replyMarkup
+            ? (rendered.replyMarkup.inline_keyboard as unknown as TelegramInlineButtons)
+            : undefined;
+          return await send(to, rendered.text, {
+            ...baseOpts,
+            buttons,
+          });
+        }
+        // Card markers present but rendering failed; strip markers to avoid leaking raw JSON
+        text = acParsed.fallbackText || stripCardMarkers(text);
       }
 
       return await send(to, text, {

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -18,6 +18,122 @@ import { sendMessageTelegram } from "./send.js";
 
 export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
 
+// ---------------------------------------------------------------------------
+// Adaptive Card rendering: inline card extraction + Telegram HTML conversion.
+// Mirrors src/cards/parse.ts + src/cards/strategies/telegram.ts but kept inline
+// to avoid cross-workspace imports (extensions cannot import from src/ directly).
+// ---------------------------------------------------------------------------
+
+const AC_CARD_RE = /<!--adaptive-card-->([\s\S]*?)<!--\/adaptive-card-->/;
+
+interface AcParsed {
+  card: { type: "AdaptiveCard"; body: unknown[]; actions?: unknown[] };
+  fallbackText: string;
+}
+
+function parseAdaptiveCardMarkers(text: string): AcParsed | null {
+  const m = AC_CARD_RE.exec(text);
+  if (!m) {
+    return null;
+  }
+  try {
+    const card = JSON.parse(m[1].trim());
+    if (card?.type !== "AdaptiveCard") {
+      return null;
+    }
+    const fallbackText = text.slice(0, m.index).trim();
+    return { card, fallbackText };
+  } catch {
+    return null;
+  }
+}
+
+type AcElement = Record<string, unknown>;
+
+function acStr(val: unknown, fallback = ""): string {
+  if (typeof val === "string") return val;
+  if (val == null) return fallback;
+  return JSON.stringify(val);
+}
+
+function acEscapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function renderTgTextBlock(el: AcElement): string {
+  const escaped = acEscapeHtml(acStr(el.text));
+  const weight = el.weight as string | undefined;
+  const isSubtle = el.isSubtle === true;
+  let line = escaped;
+  if (weight === "Bolder") line = `<b>${line}</b>`;
+  if (isSubtle) line = `<i>${line}</i>`;
+  return line;
+}
+
+function renderTgFactSet(el: AcElement): string {
+  const facts = el.facts as Array<{ title?: string; value?: string }> | undefined;
+  if (!facts?.length) return "";
+  return facts
+    .map((f) => `<b>${acEscapeHtml(f.title ?? "")}</b>: ${acEscapeHtml(f.value ?? "")}`)
+    .join("\n");
+}
+
+function renderTgElement(el: AcElement): string {
+  switch (el.type) {
+    case "TextBlock":
+      return renderTgTextBlock(el);
+    case "FactSet":
+      return renderTgFactSet(el);
+    case "ColumnSet": {
+      const columns = el.columns as Array<{ items?: AcElement[] }> | undefined;
+      if (!columns?.length) return "";
+      return columns
+        .flatMap((col) => (col.items ?? []).map(renderTgElement))
+        .filter(Boolean)
+        .join("\n");
+    }
+    case "Container": {
+      const items = el.items as AcElement[] | undefined;
+      return (items ?? []).map(renderTgElement).filter(Boolean).join("\n");
+    }
+    default:
+      return "";
+  }
+}
+
+type InlineButton = { text: string; url?: string; callback_data?: string };
+
+function renderTgActions(actions: unknown[]): InlineButton[][] {
+  const buttons: InlineButton[] = [];
+  for (const raw of actions) {
+    const action = raw as AcElement;
+    const label = acStr(action.title);
+    if (!label) continue;
+    if (action.type === "Action.OpenUrl") {
+      buttons.push({ text: label, url: acStr(action.url) });
+    } else if (action.type === "Action.Submit") {
+      const data = action.data != null ? JSON.stringify(action.data) : label;
+      buttons.push({ text: label, callback_data: data.slice(0, 64) });
+    }
+  }
+  return buttons.length > 0 ? buttons.map((b) => [b]) : [];
+}
+
+function renderTelegramCard(parsed: AcParsed): {
+  text: string;
+  replyMarkup?: { inline_keyboard: InlineButton[][] };
+} {
+  const lines: string[] = [];
+  for (const el of parsed.card.body) {
+    const rendered = renderTgElement(el as AcElement);
+    if (rendered) lines.push(rendered);
+  }
+  const text = lines.join("\n\n") || acEscapeHtml(parsed.fallbackText);
+  const keyboard = parsed.card.actions?.length ? renderTgActions(parsed.card.actions) : [];
+  if (keyboard.length === 0) return { text };
+  return { text, replyMarkup: { inline_keyboard: keyboard } };
+}
+
 type TelegramSendFn = typeof sendMessageTelegram;
 type TelegramSendOpts = Parameters<TelegramSendFn>[2];
 
@@ -116,6 +232,20 @@ export const telegramOutbound: ChannelOutboundAdapter = {
         replyToId,
         threadId,
       });
+
+      // Adaptive card rendering: convert card markers to Telegram HTML + inline keyboard
+      const acParsed = parseAdaptiveCardMarkers(text);
+      if (acParsed) {
+        const rendered = renderTelegramCard(acParsed);
+        const buttons: TelegramInlineButtons | undefined = rendered.replyMarkup
+          ? (rendered.replyMarkup.inline_keyboard as unknown as TelegramInlineButtons)
+          : undefined;
+        return await send(to, rendered.text, {
+          ...baseOpts,
+          buttons,
+        });
+      }
+
       return await send(to, text, {
         ...baseOpts,
       });

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -252,8 +252,13 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       // Adaptive card rendering: convert card markers to Telegram HTML + inline keyboard
       const acParsed = parseAdaptiveCardMarkers(text);
       if (acParsed) {
-        const rendered = renderTelegramCard(acParsed);
-        if (rendered.text) {
+        let rendered: ReturnType<typeof renderTelegramCard> | null = null;
+        try {
+          rendered = renderTelegramCard(acParsed);
+        } catch {
+          // strategy error -- fall through to fallback text
+        }
+        if (rendered?.text) {
           const buttons: TelegramInlineButtons | undefined = rendered.replyMarkup
             ? (rendered.replyMarkup.inline_keyboard as unknown as TelegramInlineButtons)
             : undefined;

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -1,0 +1,7 @@
+export { parseAdaptiveCardMarkers, stripCardMarkers } from "./parse.js";
+export type { ParsedAdaptiveCard } from "./parse.js";
+export type { CardRenderResult, CardRenderStrategy } from "./types.js";
+export { discordStrategy } from "./strategies/discord.js";
+export { nativeStrategy } from "./strategies/native.js";
+export { slackStrategy } from "./strategies/slack.js";
+export { telegramStrategy } from "./strategies/telegram.js";

--- a/src/cards/parse.test.ts
+++ b/src/cards/parse.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { parseAdaptiveCardMarkers, stripCardMarkers } from "./parse.js";
+
+const SAMPLE_CARD = JSON.stringify({
+  type: "AdaptiveCard",
+  version: "1.5",
+  body: [{ type: "TextBlock", text: "Hello", weight: "Bolder" }],
+  actions: [{ type: "Action.OpenUrl", title: "Open", url: "https://example.com" }],
+});
+
+const SAMPLE_DATA = JSON.stringify({ key: "val" });
+
+function buildMarkedText(opts?: { card?: string; data?: string; fallback?: string }): string {
+  const fallback = opts?.fallback ?? "Fallback text here";
+  const card = opts?.card ?? SAMPLE_CARD;
+  let text = `${fallback}\n\n<!--adaptive-card-->${card}<!--/adaptive-card-->`;
+  if (opts?.data !== undefined) {
+    text += `\n<!--adaptive-card-data-->${opts.data}<!--/adaptive-card-data-->`;
+  }
+  return text;
+}
+
+describe("parseAdaptiveCardMarkers", () => {
+  it("returns null for plain text without markers", () => {
+    expect(parseAdaptiveCardMarkers("just some text")).toBeNull();
+  });
+
+  it("parses card JSON and fallback text", () => {
+    const text = buildMarkedText();
+    const result = parseAdaptiveCardMarkers(text);
+    expect(result).not.toBeNull();
+    expect(result!.card.type).toBe("AdaptiveCard");
+    expect(result!.card.version).toBe("1.5");
+    expect(result!.card.body).toHaveLength(1);
+    expect(result!.card.actions).toHaveLength(1);
+    expect(result!.fallbackText).toBe("Fallback text here");
+    expect(result!.templateData).toBeUndefined();
+  });
+
+  it("parses template data when present", () => {
+    const text = buildMarkedText({ data: SAMPLE_DATA });
+    const result = parseAdaptiveCardMarkers(text);
+    expect(result).not.toBeNull();
+    expect(result!.templateData).toEqual({ key: "val" });
+  });
+
+  it("returns null for malformed card JSON", () => {
+    const text = buildMarkedText({ card: "not valid json" });
+    expect(parseAdaptiveCardMarkers(text)).toBeNull();
+  });
+
+  it("returns null when card type is not AdaptiveCard", () => {
+    const text = buildMarkedText({
+      card: JSON.stringify({ type: "Other", version: "1.0", body: [] }),
+    });
+    expect(parseAdaptiveCardMarkers(text)).toBeNull();
+  });
+
+  it("handles empty fallback text", () => {
+    const text = `<!--adaptive-card-->${SAMPLE_CARD}<!--/adaptive-card-->`;
+    const result = parseAdaptiveCardMarkers(text);
+    expect(result).not.toBeNull();
+    expect(result!.fallbackText).toBe("");
+  });
+
+  it("ignores malformed template data but still parses the card", () => {
+    const text = buildMarkedText({ data: "{broken" });
+    const result = parseAdaptiveCardMarkers(text);
+    expect(result).not.toBeNull();
+    expect(result!.card.type).toBe("AdaptiveCard");
+    expect(result!.templateData).toBeUndefined();
+  });
+});
+
+describe("stripCardMarkers", () => {
+  it("strips all markers and returns fallback text", () => {
+    const text = buildMarkedText({ data: SAMPLE_DATA });
+    expect(stripCardMarkers(text)).toBe("Fallback text here");
+  });
+
+  it("returns original text when no markers present", () => {
+    expect(stripCardMarkers("hello world")).toBe("hello world");
+  });
+
+  it("strips card marker without data marker", () => {
+    const text = buildMarkedText();
+    expect(stripCardMarkers(text)).toBe("Fallback text here");
+  });
+});

--- a/src/cards/parse.test.ts
+++ b/src/cards/parse.test.ts
@@ -70,6 +70,52 @@ describe("parseAdaptiveCardMarkers", () => {
     expect(result!.card.type).toBe("AdaptiveCard");
     expect(result!.templateData).toBeUndefined();
   });
+
+  it("extracts cardId and previewUrl from meta marker", () => {
+    const meta = JSON.stringify({
+      cardId: "abc-123",
+      previewUrl: "https://img.example.com/preview.png",
+    });
+    const text = buildMarkedText() + `\n<!--adaptive-card-meta-->${meta}<!--/adaptive-card-meta-->`;
+    const result = parseAdaptiveCardMarkers(text);
+    expect(result).not.toBeNull();
+    expect(result!.cardId).toBe("abc-123");
+    expect(result!.previewUrl).toBe("https://img.example.com/preview.png");
+  });
+
+  it("extracts cardId and previewUrl from card top-level $cardId/$previewUrl", () => {
+    const card = JSON.stringify({
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: [{ type: "TextBlock", text: "Hi" }],
+      $cardId: "top-level-id",
+      $previewUrl: "https://img.example.com/top.png",
+    });
+    const text = buildMarkedText({ card });
+    const result = parseAdaptiveCardMarkers(text);
+    expect(result).not.toBeNull();
+    expect(result!.cardId).toBe("top-level-id");
+    expect(result!.previewUrl).toBe("https://img.example.com/top.png");
+    // Should be stripped from the card object
+    expect((result!.card as Record<string, unknown>).$cardId).toBeUndefined();
+    expect((result!.card as Record<string, unknown>).$previewUrl).toBeUndefined();
+  });
+
+  it("prefers meta marker over card top-level for cardId/previewUrl", () => {
+    const card = JSON.stringify({
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: [],
+      $cardId: "from-card",
+      $previewUrl: "https://card.example.com",
+    });
+    const meta = JSON.stringify({ cardId: "from-meta", previewUrl: "https://meta.example.com" });
+    const text = `Fallback\n\n<!--adaptive-card-->${card}<!--/adaptive-card-->\n<!--adaptive-card-meta-->${meta}<!--/adaptive-card-meta-->`;
+    const result = parseAdaptiveCardMarkers(text);
+    expect(result).not.toBeNull();
+    expect(result!.cardId).toBe("from-meta");
+    expect(result!.previewUrl).toBe("https://meta.example.com");
+  });
 });
 
 describe("stripCardMarkers", () => {
@@ -84,6 +130,12 @@ describe("stripCardMarkers", () => {
 
   it("strips card marker without data marker", () => {
     const text = buildMarkedText();
+    expect(stripCardMarkers(text)).toBe("Fallback text here");
+  });
+
+  it("strips meta markers too", () => {
+    const meta = JSON.stringify({ cardId: "abc" });
+    const text = buildMarkedText() + `\n<!--adaptive-card-meta-->${meta}<!--/adaptive-card-meta-->`;
     expect(stripCardMarkers(text)).toBe("Fallback text here");
   });
 });

--- a/src/cards/parse.ts
+++ b/src/cards/parse.ts
@@ -1,0 +1,66 @@
+/**
+ * Parse adaptive card markers embedded in reply text.
+ *
+ * The adaptive-cards extension embeds card JSON between HTML comment markers:
+ *   <!--adaptive-card-->{ ... }<!--/adaptive-card-->
+ *   <!--adaptive-card-data-->{ ... }<!--/adaptive-card-data-->
+ *
+ * Everything before the first marker is treated as fallback plain text.
+ */
+
+export interface ParsedAdaptiveCard {
+  card: {
+    type: "AdaptiveCard";
+    version: string;
+    body: unknown[];
+    actions?: unknown[];
+  };
+  fallbackText: string;
+  templateData?: unknown;
+}
+
+const CARD_RE = /<!--adaptive-card-->([\s\S]*?)<!--\/adaptive-card-->/;
+const DATA_RE = /<!--adaptive-card-data-->([\s\S]*?)<!--\/adaptive-card-data-->/;
+const MARKERS_RE =
+  /<!--adaptive-card-->[\s\S]*?<!--\/adaptive-card-->|<!--adaptive-card-data-->[\s\S]*?<!--\/adaptive-card-data-->/g;
+
+/**
+ * Attempt to parse adaptive card markers from message text.
+ * Returns null when no card markers are present.
+ */
+export function parseAdaptiveCardMarkers(text: string): ParsedAdaptiveCard | null {
+  const cardMatch = CARD_RE.exec(text);
+  if (!cardMatch) {
+    return null;
+  }
+
+  let card: ParsedAdaptiveCard["card"];
+  try {
+    card = JSON.parse(cardMatch[1].trim());
+  } catch {
+    return null;
+  }
+
+  if (card?.type !== "AdaptiveCard") {
+    return null;
+  }
+
+  const fallbackText = text.slice(0, cardMatch.index).trim();
+
+  const dataMatch = DATA_RE.exec(text);
+  let templateData: unknown;
+  if (dataMatch) {
+    try {
+      templateData = JSON.parse(dataMatch[1].trim());
+    } catch {
+      // ignore malformed template data
+    }
+  }
+
+  return { card, fallbackText, templateData };
+}
+
+/** Strip all adaptive card markers, returning only the fallback text. */
+export function stripCardMarkers(text: string): string {
+  return text.replace(MARKERS_RE, "").trim();
+}

--- a/src/cards/parse.ts
+++ b/src/cards/parse.ts
@@ -17,12 +17,17 @@ export interface ParsedAdaptiveCard {
   };
   fallbackText: string;
   templateData?: unknown;
+  /** Stable card identifier extracted from the tool result metadata or card top-level $cardId. */
+  cardId?: string;
+  /** Preview image URL extracted from the tool result metadata or card top-level $previewUrl. */
+  previewUrl?: string;
 }
 
 const CARD_RE = /<!--adaptive-card-->([\s\S]*?)<!--\/adaptive-card-->/;
 const DATA_RE = /<!--adaptive-card-data-->([\s\S]*?)<!--\/adaptive-card-data-->/;
+const META_RE = /<!--adaptive-card-meta-->([\s\S]*?)<!--\/adaptive-card-meta-->/;
 const MARKERS_RE =
-  /<!--adaptive-card-->[\s\S]*?<!--\/adaptive-card-->|<!--adaptive-card-data-->[\s\S]*?<!--\/adaptive-card-data-->/g;
+  /<!--adaptive-card-->[\s\S]*?<!--\/adaptive-card-->|<!--adaptive-card-data-->[\s\S]*?<!--\/adaptive-card-data-->|<!--adaptive-card-meta-->[\s\S]*?<!--\/adaptive-card-meta-->/g;
 
 /**
  * Attempt to parse adaptive card markers from message text.
@@ -57,7 +62,43 @@ export function parseAdaptiveCardMarkers(text: string): ParsedAdaptiveCard | nul
     }
   }
 
-  return { card, fallbackText, templateData };
+  // Extract cardId/previewUrl from meta marker or card top-level properties
+  let cardId: string | undefined;
+  let previewUrl: string | undefined;
+
+  const metaMatch = META_RE.exec(text);
+  if (metaMatch) {
+    try {
+      const meta = JSON.parse(metaMatch[1].trim()) as Record<string, unknown>;
+      if (typeof meta.cardId === "string") {
+        cardId = meta.cardId;
+      }
+      if (typeof meta.previewUrl === "string") {
+        previewUrl = meta.previewUrl;
+      }
+    } catch {
+      // ignore malformed meta
+    }
+  }
+
+  // Fall back to card top-level $cardId / $previewUrl (and strip them from the card)
+  const cardAny = card as Record<string, unknown>;
+  if (!cardId && typeof cardAny.$cardId === "string") {
+    cardId = cardAny.$cardId;
+  }
+  if (!previewUrl && typeof cardAny.$previewUrl === "string") {
+    previewUrl = cardAny.$previewUrl;
+  }
+  delete cardAny.$cardId;
+  delete cardAny.$previewUrl;
+
+  return {
+    card,
+    fallbackText,
+    templateData,
+    ...(cardId ? { cardId } : {}),
+    ...(previewUrl ? { previewUrl } : {}),
+  };
 }
 
 /** Strip all adaptive card markers, returning only the fallback text. */

--- a/src/cards/strategies/discord.ts
+++ b/src/cards/strategies/discord.ts
@@ -120,7 +120,21 @@ function buildEmbedFromBody(body: unknown[]): DiscordEmbed {
   }
 
   if (descParts.length > 0) {
-    embed.description = descParts.join("\n");
+    const desc = descParts.join("\n");
+    // Discord limits embed description to 4096 chars
+    embed.description = desc.length > 4096 ? desc.slice(0, 4093) + "..." : desc;
+  }
+
+  // Discord limits: title 256 chars, 25 fields max, field name/value 1024 chars
+  if (embed.title && embed.title.length > 256) {
+    embed.title = embed.title.slice(0, 253) + "...";
+  }
+  if (embed.fields) {
+    embed.fields = embed.fields.slice(0, 25).map((f) => ({
+      name: f.name.length > 1024 ? f.name.slice(0, 1021) + "..." : f.name || "\u200B",
+      value: f.value.length > 1024 ? f.value.slice(0, 1021) + "..." : f.value || "\u200B",
+      inline: f.inline,
+    }));
   }
 
   return embed;

--- a/src/cards/strategies/discord.ts
+++ b/src/cards/strategies/discord.ts
@@ -1,0 +1,184 @@
+/**
+ * Discord rendering strategy for Adaptive Cards.
+ *
+ * Converts AC elements to Discord embeds + button components.
+ */
+
+import type { ParsedAdaptiveCard } from "../parse.js";
+import type { CardRenderResult, CardRenderStrategy } from "../types.js";
+
+type AcElement = Record<string, unknown>;
+
+/** Safely coerce an unknown AC property to string. */
+function str(val: unknown, fallback = ""): string {
+  if (typeof val === "string") {
+    return val;
+  }
+  if (val == null) {
+    return fallback;
+  }
+  return JSON.stringify(val);
+}
+
+interface DiscordEmbed {
+  title?: string;
+  description?: string;
+  fields?: Array<{ name: string; value: string; inline?: boolean }>;
+  image?: { url: string };
+}
+
+interface DiscordButton {
+  type: 2; // Button component type
+  style: number;
+  label: string;
+  url?: string;
+  custom_id?: string;
+}
+
+function buildEmbedFromBody(body: unknown[]): DiscordEmbed {
+  const embed: DiscordEmbed = {};
+  const descParts: string[] = [];
+
+  for (const raw of body) {
+    const el = raw as AcElement;
+    switch (el.type) {
+      case "TextBlock": {
+        const text = str(el.text);
+        const weight = el.weight as string | undefined;
+        // First Bolder TextBlock becomes the embed title
+        if (weight === "Bolder" && !embed.title) {
+          embed.title = text;
+        } else {
+          descParts.push(weight === "Bolder" ? `**${text}**` : text);
+        }
+        break;
+      }
+      case "FactSet": {
+        const facts = el.facts as Array<{ title?: string; value?: string }> | undefined;
+        if (facts?.length) {
+          embed.fields ??= [];
+          for (const f of facts) {
+            embed.fields.push({
+              name: f.title ?? "",
+              value: f.value ?? "",
+              inline: true,
+            });
+          }
+        }
+        break;
+      }
+      case "Image": {
+        const url = str(el.url);
+        if (url) {
+          embed.image = { url };
+        }
+        break;
+      }
+      case "ColumnSet": {
+        const columns = el.columns as Array<{ items?: AcElement[] }> | undefined;
+        if (columns?.length) {
+          const nested = columns.flatMap((col) => col.items ?? []);
+          const sub = buildEmbedFromBody(nested);
+          if (sub.title && !embed.title) {
+            embed.title = sub.title;
+          }
+          if (sub.description) {
+            descParts.push(sub.description);
+          }
+          if (sub.fields?.length) {
+            embed.fields ??= [];
+            embed.fields.push(...sub.fields);
+          }
+          if (sub.image && !embed.image) {
+            embed.image = sub.image;
+          }
+        }
+        break;
+      }
+      case "Container": {
+        const items = el.items as AcElement[] | undefined;
+        if (items?.length) {
+          const sub = buildEmbedFromBody(items);
+          if (sub.title && !embed.title) {
+            embed.title = sub.title;
+          }
+          if (sub.description) {
+            descParts.push(sub.description);
+          }
+          if (sub.fields?.length) {
+            embed.fields ??= [];
+            embed.fields.push(...sub.fields);
+          }
+          if (sub.image && !embed.image) {
+            embed.image = sub.image;
+          }
+        }
+        break;
+      }
+      // skip unknown element types
+    }
+  }
+
+  if (descParts.length > 0) {
+    embed.description = descParts.join("\n");
+  }
+
+  return embed;
+}
+
+function buildActionRow(actions: unknown[]): unknown {
+  const buttons: DiscordButton[] = [];
+  for (const raw of actions) {
+    const action = raw as AcElement;
+    const label = str(action.title);
+    if (!label) {
+      continue;
+    }
+    if (action.type === "Action.OpenUrl") {
+      // Style 5 = Link
+      buttons.push({
+        type: 2,
+        style: 5,
+        label,
+        url: str(action.url),
+      });
+    } else if (action.type === "Action.Submit") {
+      // Style 1 = Primary
+      const customId = typeof action.id === "string" ? action.id : `ac_submit_${buttons.length}`;
+      buttons.push({
+        type: 2,
+        style: 1,
+        label,
+        custom_id: customId,
+      });
+    }
+  }
+  if (buttons.length === 0) {
+    return null;
+  }
+  // Action row component (type 1)
+  return { type: 1, components: buttons };
+}
+
+export const discordStrategy: CardRenderStrategy = {
+  name: "discord",
+  render(parsed: ParsedAdaptiveCard): CardRenderResult {
+    const embed = buildEmbedFromBody(parsed.card.body);
+    const embeds = [embed];
+
+    const components: unknown[] = [];
+    if (parsed.card.actions?.length) {
+      const actionRow = buildActionRow(parsed.card.actions);
+      if (actionRow) {
+        components.push(actionRow);
+      }
+    }
+
+    return {
+      type: "discord",
+      embeds,
+      components: components.length > 0 ? components : undefined,
+      fallback: parsed.fallbackText,
+    };
+  },
+};

--- a/src/cards/strategies/discord.ts
+++ b/src/cards/strategies/discord.ts
@@ -115,6 +115,33 @@ function buildEmbedFromBody(body: unknown[]): DiscordEmbed {
         }
         break;
       }
+      case "Icon":
+        // Discord has no icon equivalent; skip gracefully
+        break;
+      case "List": {
+        const listTitle = str(el.title);
+        const listItems = el.items as Array<{ title?: string; subtitle?: string }> | undefined;
+        const bullets: string[] = [];
+        if (listItems?.length) {
+          for (const item of listItems) {
+            const itemTitle = item.title ?? "";
+            const itemSub = item.subtitle ? ` - ${item.subtitle}` : "";
+            bullets.push(`\u2022 ${itemTitle}${itemSub}`);
+          }
+        }
+        if (listTitle || bullets.length > 0) {
+          embed.fields ??= [];
+          embed.fields.push({
+            name: listTitle || "\u200B",
+            value: bullets.join("\n") || "\u200B",
+            inline: false,
+          });
+        }
+        break;
+      }
+      case "ActionSet":
+        // ActionSet actions are collected separately in the render pass
+        break;
       // skip unknown element types
     }
   }
@@ -184,9 +211,18 @@ export const discordStrategy: CardRenderStrategy = {
     const embed = buildEmbedFromBody(parsed.card.body);
     const embeds = [embed];
 
+    // Collect actions from both top-level and inline ActionSet elements
+    const allActions = [...(parsed.card.actions ?? [])];
+    for (const el of parsed.card.body) {
+      const elem = el as AcElement;
+      if (elem.type === "ActionSet" && Array.isArray(elem.actions)) {
+        allActions.push(...(elem.actions as unknown[]));
+      }
+    }
+
     const components: unknown[] = [];
-    if (parsed.card.actions?.length) {
-      const actionRow = buildActionRow(parsed.card.actions);
+    if (allActions.length > 0) {
+      const actionRow = buildActionRow(allActions);
       if (actionRow) {
         components.push(actionRow);
       }

--- a/src/cards/strategies/discord.ts
+++ b/src/cards/strategies/discord.ts
@@ -136,11 +136,15 @@ function buildActionRow(actions: unknown[]): unknown {
     }
     if (action.type === "Action.OpenUrl") {
       // Style 5 = Link
+      const url = str(action.url);
+      if (!url) {
+        continue; // skip: Discord rejects link buttons with an empty URL
+      }
       buttons.push({
         type: 2,
         style: 5,
         label,
-        url: str(action.url),
+        url,
       });
     } else if (action.type === "Action.Submit") {
       // Style 1 = Primary

--- a/src/cards/strategies/native.ts
+++ b/src/cards/strategies/native.ts
@@ -1,0 +1,21 @@
+/**
+ * Native pass-through strategy for channels that support Adaptive Cards directly
+ * (e.g. Microsoft Teams, Webex).
+ *
+ * Returns the card JSON as an attachment with the standard AC content type.
+ */
+
+import type { ParsedAdaptiveCard } from "../parse.js";
+import type { CardRenderResult, CardRenderStrategy } from "../types.js";
+
+export const nativeStrategy: CardRenderStrategy = {
+  name: "native",
+  render(parsed: ParsedAdaptiveCard): CardRenderResult {
+    return {
+      type: "attachment",
+      contentType: "application/vnd.microsoft.card.adaptive",
+      content: parsed.card,
+      fallback: parsed.fallbackText,
+    };
+  },
+};

--- a/src/cards/strategies/slack.ts
+++ b/src/cards/strategies/slack.ts
@@ -86,6 +86,40 @@ function renderElement(el: AcElement): unknown[] {
       const items = el.items as AcElement[] | undefined;
       return (items ?? []).flatMap(renderElement);
     }
+    case "Icon":
+      // Slack Block Kit has no icon equivalent; skip gracefully
+      return [];
+    case "List": {
+      const title = str(el.title);
+      const items = el.items as Array<{ title?: string; subtitle?: string }> | undefined;
+      const parts: string[] = [];
+      if (title) {
+        parts.push(`*${title}*`);
+      }
+      if (items?.length) {
+        for (const item of items) {
+          const itemTitle = item.title ?? "";
+          const itemSub = item.subtitle ? ` - ${item.subtitle}` : "";
+          parts.push(`\u2022 ${itemTitle}${itemSub}`);
+        }
+      }
+      if (parts.length === 0) {
+        return [];
+      }
+      return [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: truncateMrkdwn(parts.join("\n")) },
+        },
+      ];
+    }
+    case "ActionSet": {
+      const actions = el.actions as unknown[] | undefined;
+      if (!actions?.length) {
+        return [];
+      }
+      return renderActions(actions);
+    }
     default:
       return [];
   }

--- a/src/cards/strategies/slack.ts
+++ b/src/cards/strategies/slack.ts
@@ -20,13 +20,18 @@ function str(val: unknown, fallback = ""): string {
   return JSON.stringify(val);
 }
 
+/** Slack limits section text to 3000 chars. */
+function truncateMrkdwn(text: string, limit = 3000): string {
+  return text.length > limit ? text.slice(0, limit - 3) + "..." : text;
+}
+
 function renderTextBlock(el: AcElement): unknown {
   const text = str(el.text);
   const weight = el.weight as string | undefined;
   const formatted = weight === "Bolder" ? `*${text}*` : text;
   return {
     type: "section",
-    text: { type: "mrkdwn", text: formatted },
+    text: { type: "mrkdwn", text: truncateMrkdwn(formatted) },
   };
 }
 

--- a/src/cards/strategies/slack.ts
+++ b/src/cards/strategies/slack.ts
@@ -30,18 +30,21 @@ function renderTextBlock(el: AcElement): unknown {
   };
 }
 
-function renderFactSet(el: AcElement): unknown {
+function renderFactSet(el: AcElement): unknown[] {
   const facts = el.facts as Array<{ title?: string; value?: string }> | undefined;
   if (!facts?.length) {
-    return null;
+    return [];
   }
-  return {
-    type: "section",
-    fields: facts.map((f) => ({
-      type: "mrkdwn",
-      text: `*${f.title ?? ""}*\n${f.value ?? ""}`,
-    })),
-  };
+  const fields = facts.map((f) => ({
+    type: "mrkdwn",
+    text: `*${f.title ?? ""}*\n${f.value ?? ""}`,
+  }));
+  // Slack limits section blocks to 10 fields; split into chunks if needed
+  const blocks: unknown[] = [];
+  for (let i = 0; i < fields.length; i += 10) {
+    blocks.push({ type: "section", fields: fields.slice(i, i + 10) });
+  }
+  return blocks;
 }
 
 function renderImage(el: AcElement): unknown {
@@ -61,10 +64,8 @@ function renderElement(el: AcElement): unknown[] {
   switch (el.type) {
     case "TextBlock":
       return [renderTextBlock(el)];
-    case "FactSet": {
-      const block = renderFactSet(el);
-      return block ? [block] : [];
-    }
+    case "FactSet":
+      return renderFactSet(el);
     case "Image": {
       const block = renderImage(el);
       return block ? [block] : [];
@@ -102,10 +103,14 @@ function renderActions(actions: unknown[]): unknown[] {
       continue;
     }
     if (action.type === "Action.OpenUrl") {
+      const url = str(action.url);
+      if (!url) {
+        continue; // skip: Slack rejects link buttons with an empty URL
+      }
       buttons.push({
         type: "button",
         text: { type: "plain_text", text: label },
-        url: str(action.url),
+        url,
       });
     } else if (action.type === "Action.Submit") {
       const actionId = typeof action.id === "string" ? action.id : `ac_submit_${buttons.length}`;

--- a/src/cards/strategies/slack.ts
+++ b/src/cards/strategies/slack.ts
@@ -1,0 +1,152 @@
+/**
+ * Slack Block Kit rendering strategy for Adaptive Cards.
+ *
+ * Converts AC elements to Slack blocks (section, image, actions, divider).
+ */
+
+import type { ParsedAdaptiveCard } from "../parse.js";
+import type { CardRenderResult, CardRenderStrategy } from "../types.js";
+
+type AcElement = Record<string, unknown>;
+
+/** Safely coerce an unknown AC property to string. */
+function str(val: unknown, fallback = ""): string {
+  if (typeof val === "string") {
+    return val;
+  }
+  if (val == null) {
+    return fallback;
+  }
+  return JSON.stringify(val);
+}
+
+function renderTextBlock(el: AcElement): unknown {
+  const text = str(el.text);
+  const weight = el.weight as string | undefined;
+  const formatted = weight === "Bolder" ? `*${text}*` : text;
+  return {
+    type: "section",
+    text: { type: "mrkdwn", text: formatted },
+  };
+}
+
+function renderFactSet(el: AcElement): unknown {
+  const facts = el.facts as Array<{ title?: string; value?: string }> | undefined;
+  if (!facts?.length) {
+    return null;
+  }
+  return {
+    type: "section",
+    fields: facts.map((f) => ({
+      type: "mrkdwn",
+      text: `*${f.title ?? ""}*\n${f.value ?? ""}`,
+    })),
+  };
+}
+
+function renderImage(el: AcElement): unknown {
+  const url = str(el.url);
+  const alt = str(el.altText) || str(el.alt) || "image";
+  if (!url) {
+    return null;
+  }
+  return {
+    type: "image",
+    image_url: url,
+    alt_text: alt,
+  };
+}
+
+function renderElement(el: AcElement): unknown[] {
+  switch (el.type) {
+    case "TextBlock":
+      return [renderTextBlock(el)];
+    case "FactSet": {
+      const block = renderFactSet(el);
+      return block ? [block] : [];
+    }
+    case "Image": {
+      const block = renderImage(el);
+      return block ? [block] : [];
+    }
+    case "ColumnSet": {
+      const columns = el.columns as Array<{ items?: AcElement[] }> | undefined;
+      if (!columns?.length) {
+        return [];
+      }
+      return columns.flatMap((col) => (col.items ?? []).flatMap(renderElement));
+    }
+    case "Container": {
+      const items = el.items as AcElement[] | undefined;
+      return (items ?? []).flatMap(renderElement);
+    }
+    default:
+      return [];
+  }
+}
+
+type SlackButton = {
+  type: "button";
+  text: { type: "plain_text"; text: string };
+  url?: string;
+  action_id?: string;
+  value?: string;
+};
+
+function renderActions(actions: unknown[]): unknown[] {
+  const buttons: SlackButton[] = [];
+  for (const raw of actions) {
+    const action = raw as AcElement;
+    const label = str(action.title);
+    if (!label) {
+      continue;
+    }
+    if (action.type === "Action.OpenUrl") {
+      buttons.push({
+        type: "button",
+        text: { type: "plain_text", text: label },
+        url: str(action.url),
+      });
+    } else if (action.type === "Action.Submit") {
+      const actionId = typeof action.id === "string" ? action.id : `ac_submit_${buttons.length}`;
+      buttons.push({
+        type: "button",
+        text: { type: "plain_text", text: label },
+        action_id: actionId,
+        value: action.data != null ? JSON.stringify(action.data) : undefined,
+      });
+    }
+  }
+  if (buttons.length === 0) {
+    return [];
+  }
+  return [{ type: "actions", elements: buttons }];
+}
+
+export const slackStrategy: CardRenderStrategy = {
+  name: "slack",
+  render(parsed: ParsedAdaptiveCard): CardRenderResult {
+    const blocks: unknown[] = [];
+
+    for (const el of parsed.card.body) {
+      const rendered = renderElement(el as AcElement);
+      if (rendered.length > 0) {
+        // Add a divider between groups when we already have blocks
+        if (blocks.length > 0) {
+          blocks.push({ type: "divider" });
+        }
+        blocks.push(...rendered);
+      }
+    }
+
+    if (parsed.card.actions?.length) {
+      blocks.push(...renderActions(parsed.card.actions));
+    }
+
+    return {
+      type: "slack",
+      blocks,
+      fallback: parsed.fallbackText,
+    };
+  },
+};

--- a/src/cards/strategies/strategies.test.ts
+++ b/src/cards/strategies/strategies.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import type { ParsedAdaptiveCard } from "../parse.js";
+import { discordStrategy } from "./discord.js";
+import { nativeStrategy } from "./native.js";
+import { slackStrategy } from "./slack.js";
+import { telegramStrategy } from "./telegram.js";
+
+function makeParsed(overrides?: Partial<ParsedAdaptiveCard>): ParsedAdaptiveCard {
+  return {
+    card: {
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: [
+        { type: "TextBlock", text: "Status", weight: "Bolder" },
+        {
+          type: "FactSet",
+          facts: [
+            { title: "Deploy", value: "Done" },
+            { title: "Tests", value: "Pending" },
+          ],
+        },
+      ],
+      actions: [
+        { type: "Action.OpenUrl", title: "View", url: "https://example.com" },
+        { type: "Action.Submit", title: "Approve", data: { ok: true } },
+      ],
+    },
+    fallbackText: "Status: Deploy (Done), Tests (Pending)",
+    ...overrides,
+  };
+}
+
+// ── Telegram ──
+
+describe("telegramStrategy", () => {
+  it("renders TextBlock + FactSet as HTML with inline keyboard", () => {
+    const result = telegramStrategy.render(makeParsed());
+    expect(result.type).toBe("telegram");
+    if (result.type !== "telegram") {
+      return;
+    }
+    expect(result.text).toContain("<b>Status</b>");
+    expect(result.text).toContain("<b>Deploy</b>: Done");
+    expect(result.replyMarkup).toBeDefined();
+    expect(result.replyMarkup!.inline_keyboard).toHaveLength(2);
+    expect(result.replyMarkup!.inline_keyboard[0][0].url).toBe("https://example.com");
+    expect(result.replyMarkup!.inline_keyboard[1][0].callback_data).toBeDefined();
+  });
+
+  it("skips Action.OpenUrl with empty URL", () => {
+    const parsed = makeParsed();
+    parsed.card.actions = [{ type: "Action.OpenUrl", title: "Bad", url: "" }];
+    const result = telegramStrategy.render(parsed);
+    if (result.type !== "telegram") {
+      return;
+    }
+    expect(result.replyMarkup).toBeUndefined();
+  });
+
+  it("truncates callback_data by byte length", () => {
+    const parsed = makeParsed();
+    // Create data that exceeds 64 bytes with multi-byte chars
+    parsed.card.actions = [{ type: "Action.Submit", title: "Go", data: { msg: "A".repeat(80) } }];
+    const result = telegramStrategy.render(parsed);
+    if (result.type !== "telegram") {
+      return;
+    }
+    const cbData = result.replyMarkup!.inline_keyboard[0][0].callback_data!;
+    const byteLen = new TextEncoder().encode(cbData).byteLength;
+    expect(byteLen).toBeLessThanOrEqual(64);
+  });
+
+  it("falls back to fallbackText when body is empty", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [];
+    const result = telegramStrategy.render(parsed);
+    if (result.type !== "telegram") {
+      return;
+    }
+    expect(result.text).toContain("Status: Deploy");
+  });
+});
+
+// ── Slack ──
+
+describe("slackStrategy", () => {
+  it("renders TextBlock as mrkdwn section and FactSet as fields", () => {
+    const result = slackStrategy.render(makeParsed());
+    expect(result.type).toBe("slack");
+    if (result.type !== "slack") {
+      return;
+    }
+    expect(result.blocks.length).toBeGreaterThan(0);
+    const section = result.blocks[0] as { type: string; text: { text: string } };
+    expect(section.type).toBe("section");
+    expect(section.text.text).toContain("*Status*");
+    // Should have action buttons
+    const actions = result.blocks.find((b: unknown) => (b as { type: string }).type === "actions");
+    expect(actions).toBeDefined();
+  });
+
+  it("skips Action.OpenUrl with empty URL", () => {
+    const parsed = makeParsed();
+    parsed.card.actions = [{ type: "Action.OpenUrl", title: "Bad", url: "" }];
+    const result = slackStrategy.render(parsed);
+    if (result.type !== "slack") {
+      return;
+    }
+    const actions = result.blocks.find((b: unknown) => (b as { type: string }).type === "actions");
+    expect(actions).toBeUndefined();
+  });
+
+  it("splits FactSet with >10 facts into multiple sections", () => {
+    const facts = Array.from({ length: 15 }, (_, i) => ({
+      title: `Key${i}`,
+      value: `Val${i}`,
+    }));
+    const parsed = makeParsed();
+    parsed.card.body = [{ type: "FactSet", facts }];
+    parsed.card.actions = [];
+    const result = slackStrategy.render(parsed);
+    if (result.type !== "slack") {
+      return;
+    }
+    const sections = result.blocks.filter(
+      (b: unknown) =>
+        (b as { type: string; fields?: unknown }).type === "section" &&
+        (b as { fields?: unknown[] }).fields,
+    );
+    expect(sections.length).toBe(2); // 10 + 5
+  });
+});
+
+// ── Discord ──
+
+describe("discordStrategy", () => {
+  it("renders TextBlock as embed title and FactSet as fields", () => {
+    const result = discordStrategy.render(makeParsed());
+    expect(result.type).toBe("discord");
+    if (result.type !== "discord") {
+      return;
+    }
+    expect(result.embeds).toHaveLength(1);
+    const embed = result.embeds[0] as { title?: string; fields?: unknown[] };
+    expect(embed.title).toBe("Status");
+    expect(embed.fields).toHaveLength(2);
+    expect(result.components).toBeDefined();
+  });
+
+  it("skips Action.OpenUrl with empty URL", () => {
+    const parsed = makeParsed();
+    parsed.card.actions = [{ type: "Action.OpenUrl", title: "Bad", url: "" }];
+    const result = discordStrategy.render(parsed);
+    if (result.type !== "discord") {
+      return;
+    }
+    expect(result.components).toBeUndefined();
+  });
+
+  it("truncates title to 256 chars", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [{ type: "TextBlock", text: "A".repeat(300), weight: "Bolder" }];
+    parsed.card.actions = [];
+    const result = discordStrategy.render(parsed);
+    if (result.type !== "discord") {
+      return;
+    }
+    const embed = result.embeds[0] as { title?: string };
+    expect(embed.title!.length).toBeLessThanOrEqual(256);
+  });
+
+  it("caps fields at 25", () => {
+    const facts = Array.from({ length: 30 }, (_, i) => ({
+      title: `Key${i}`,
+      value: `Val${i}`,
+    }));
+    const parsed = makeParsed();
+    parsed.card.body = [{ type: "FactSet", facts }];
+    parsed.card.actions = [];
+    const result = discordStrategy.render(parsed);
+    if (result.type !== "discord") {
+      return;
+    }
+    const embed = result.embeds[0] as { fields?: unknown[] };
+    expect(embed.fields!.length).toBeLessThanOrEqual(25);
+  });
+});
+
+// ── Native ──
+
+describe("nativeStrategy", () => {
+  it("returns card as attachment with correct contentType", () => {
+    const result = nativeStrategy.render(makeParsed());
+    expect(result.type).toBe("attachment");
+    if (result.type !== "attachment") {
+      return;
+    }
+    expect(result.contentType).toBe("application/vnd.microsoft.card.adaptive");
+    expect(result.content).toEqual(makeParsed().card);
+    expect(result.fallback).toBe("Status: Deploy (Done), Tests (Pending)");
+  });
+});

--- a/src/cards/strategies/strategies.test.ts
+++ b/src/cards/strategies/strategies.test.ts
@@ -79,6 +79,55 @@ describe("telegramStrategy", () => {
     }
     expect(result.text).toContain("Status: Deploy");
   });
+
+  it("renders Icon as emoji + name", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [{ type: "Icon", name: "settings" }];
+    parsed.card.actions = [];
+    const result = telegramStrategy.render(parsed);
+    if (result.type !== "telegram") {
+      return;
+    }
+    expect(result.text).toContain("\u{1F535} settings");
+  });
+
+  it("renders List as bulleted items with title", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [
+      {
+        type: "List",
+        title: "Tasks",
+        items: [{ title: "Build", subtitle: "in progress" }, { title: "Deploy" }],
+      },
+    ];
+    parsed.card.actions = [];
+    const result = telegramStrategy.render(parsed);
+    if (result.type !== "telegram") {
+      return;
+    }
+    expect(result.text).toContain("<b>Tasks</b>");
+    expect(result.text).toContain("\u2022 Build - in progress");
+    expect(result.text).toContain("\u2022 Deploy");
+  });
+
+  it("collects ActionSet actions into inline keyboard", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [
+      { type: "TextBlock", text: "Hello" },
+      {
+        type: "ActionSet",
+        actions: [{ type: "Action.OpenUrl", title: "Link", url: "https://example.com/inline" }],
+      },
+    ];
+    parsed.card.actions = [];
+    const result = telegramStrategy.render(parsed);
+    if (result.type !== "telegram") {
+      return;
+    }
+    expect(result.replyMarkup).toBeDefined();
+    expect(result.replyMarkup!.inline_keyboard).toHaveLength(1);
+    expect(result.replyMarkup!.inline_keyboard[0][0].url).toBe("https://example.com/inline");
+  });
 });
 
 // ── Slack ──
@@ -128,6 +177,58 @@ describe("slackStrategy", () => {
         (b as { fields?: unknown[] }).fields,
     );
     expect(sections.length).toBe(2); // 10 + 5
+  });
+
+  it("skips Icon gracefully", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [{ type: "Icon", name: "settings" }];
+    parsed.card.actions = [];
+    const result = slackStrategy.render(parsed);
+    if (result.type !== "slack") {
+      return;
+    }
+    expect(result.blocks).toHaveLength(0);
+  });
+
+  it("renders List as mrkdwn section with bullets", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [
+      {
+        type: "List",
+        title: "Tasks",
+        items: [{ title: "Build", subtitle: "done" }, { title: "Test" }],
+      },
+    ];
+    parsed.card.actions = [];
+    const result = slackStrategy.render(parsed);
+    if (result.type !== "slack") {
+      return;
+    }
+    const section = result.blocks[0] as { type: string; text: { text: string } };
+    expect(section.type).toBe("section");
+    expect(section.text.text).toContain("*Tasks*");
+    expect(section.text.text).toContain("\u2022 Build - done");
+    expect(section.text.text).toContain("\u2022 Test");
+  });
+
+  it("renders ActionSet as actions block", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [
+      { type: "TextBlock", text: "Info" },
+      {
+        type: "ActionSet",
+        actions: [{ type: "Action.OpenUrl", title: "Go", url: "https://example.com/go" }],
+      },
+    ];
+    parsed.card.actions = [];
+    const result = slackStrategy.render(parsed);
+    if (result.type !== "slack") {
+      return;
+    }
+    const actionsBlock = result.blocks.find(
+      (b: unknown) => (b as { type: string }).type === "actions",
+    );
+    expect(actionsBlock).toBeDefined();
   });
 });
 
@@ -183,6 +284,68 @@ describe("discordStrategy", () => {
     }
     const embed = result.embeds[0] as { fields?: unknown[] };
     expect(embed.fields!.length).toBeLessThanOrEqual(25);
+  });
+
+  it("skips Icon gracefully", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [{ type: "Icon", name: "alert" }];
+    parsed.card.actions = [];
+    const result = discordStrategy.render(parsed);
+    if (result.type !== "discord") {
+      return;
+    }
+    const embed = result.embeds[0] as { title?: string; description?: string };
+    // Icon should not produce a title or description
+    expect(embed.title).toBeUndefined();
+    expect(embed.description).toBeUndefined();
+  });
+
+  it("renders List as embed field with bulleted items", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [
+      {
+        type: "List",
+        title: "Deployments",
+        items: [
+          { title: "staging", subtitle: "live" },
+          { title: "production", subtitle: "pending" },
+        ],
+      },
+    ];
+    parsed.card.actions = [];
+    const result = discordStrategy.render(parsed);
+    if (result.type !== "discord") {
+      return;
+    }
+    const embed = result.embeds[0] as { fields?: Array<{ name: string; value: string }> };
+    expect(embed.fields).toHaveLength(1);
+    expect(embed.fields![0].name).toBe("Deployments");
+    expect(embed.fields![0].value).toContain("\u2022 staging - live");
+    expect(embed.fields![0].value).toContain("\u2022 production - pending");
+  });
+
+  it("collects ActionSet actions into button components", () => {
+    const parsed = makeParsed();
+    parsed.card.body = [
+      { type: "TextBlock", text: "Info", weight: "Bolder" },
+      {
+        type: "ActionSet",
+        actions: [{ type: "Action.OpenUrl", title: "Visit", url: "https://example.com/visit" }],
+      },
+    ];
+    parsed.card.actions = [];
+    const result = discordStrategy.render(parsed);
+    if (result.type !== "discord") {
+      return;
+    }
+    expect(result.components).toBeDefined();
+    const row = result.components![0] as {
+      type: number;
+      components: Array<{ label: string; url?: string }>;
+    };
+    expect(row.type).toBe(1);
+    expect(row.components[0].label).toBe("Visit");
+    expect(row.components[0].url).toBe("https://example.com/visit");
   });
 });
 

--- a/src/cards/strategies/telegram.ts
+++ b/src/cards/strategies/telegram.ts
@@ -86,11 +86,21 @@ function renderActions(actions: unknown[]): InlineButton[][] {
       continue;
     }
     if (action.type === "Action.OpenUrl") {
-      buttons.push({ text: label, url: str(action.url) });
+      const url = str(action.url);
+      if (!url) {
+        continue; // skip: Telegram rejects inline buttons with an empty URL
+      }
+      buttons.push({ text: label, url });
     } else if (action.type === "Action.Submit") {
       // Encode action data as callback_data (Telegram limit: 64 bytes)
-      const data = action.data != null ? JSON.stringify(action.data) : label;
-      buttons.push({ text: label, callback_data: data.slice(0, 64) });
+      const raw = action.data != null ? JSON.stringify(action.data) : label;
+      // Truncate by UTF-8 byte length, not character count
+      const encoder = new TextEncoder();
+      let truncated = raw;
+      while (encoder.encode(truncated).byteLength > 64) {
+        truncated = truncated.slice(0, -1);
+      }
+      buttons.push({ text: label, callback_data: truncated });
     }
   }
   if (buttons.length === 0) {

--- a/src/cards/strategies/telegram.ts
+++ b/src/cards/strategies/telegram.ts
@@ -70,6 +70,32 @@ function renderElement(el: AcElement): string {
       const items = el.items as AcElement[] | undefined;
       return (items ?? []).map(renderElement).filter(Boolean).join("\n");
     }
+    case "Icon": {
+      // Render icon as emoji/name text representation; graceful fallback
+      const name = str(el.name);
+      return name ? `\u{1F535} ${escapeHtml(name)}` : "";
+    }
+    case "List": {
+      const title = str(el.title);
+      const items = el.items as Array<{ title?: string; subtitle?: string }> | undefined;
+      const parts: string[] = [];
+      if (title) {
+        parts.push(`<b>${escapeHtml(title)}</b>`);
+      }
+      if (items?.length) {
+        for (const item of items) {
+          const itemTitle = item.title ?? "";
+          const itemSub = item.subtitle ? ` - ${item.subtitle}` : "";
+          parts.push(`\u2022 ${escapeHtml(itemTitle + itemSub)}`);
+        }
+      }
+      return parts.join("\n");
+    }
+    case "ActionSet": {
+      // Inline ActionSet actions are collected by the top-level render pass;
+      // render nothing in body text (buttons added to keyboard below)
+      return "";
+    }
     default:
       return "";
   }
@@ -123,7 +149,16 @@ export const telegramStrategy: CardRenderStrategy = {
 
     const text = lines.join("\n\n") || escapeHtml(parsed.fallbackText);
 
-    const keyboard = parsed.card.actions?.length ? renderActions(parsed.card.actions) : [];
+    // Collect actions from both top-level and inline ActionSet elements
+    const allActions = [...(parsed.card.actions ?? [])];
+    for (const el of parsed.card.body) {
+      const elem = el as AcElement;
+      if (elem.type === "ActionSet" && Array.isArray(elem.actions)) {
+        allActions.push(...(elem.actions as unknown[]));
+      }
+    }
+
+    const keyboard = allActions.length > 0 ? renderActions(allActions) : [];
 
     if (keyboard.length === 0) {
       return { type: "telegram", text };

--- a/src/cards/strategies/telegram.ts
+++ b/src/cards/strategies/telegram.ts
@@ -1,0 +1,128 @@
+/**
+ * Telegram rendering strategy for Adaptive Cards.
+ *
+ * Converts AC elements to Telegram HTML text + inline keyboard buttons.
+ */
+
+import type { ParsedAdaptiveCard } from "../parse.js";
+import type { CardRenderResult, CardRenderStrategy } from "../types.js";
+
+type AcElement = Record<string, unknown>;
+
+/** Safely coerce an unknown AC property to string. */
+function str(val: unknown, fallback = ""): string {
+  if (typeof val === "string") {
+    return val;
+  }
+  if (val == null) {
+    return fallback;
+  }
+  return JSON.stringify(val);
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function renderTextBlock(el: AcElement): string {
+  const escaped = escapeHtml(str(el.text));
+  const weight = el.weight as string | undefined;
+  const isSubtle = el.isSubtle === true;
+
+  let line = escaped;
+  if (weight === "Bolder") {
+    line = `<b>${line}</b>`;
+  }
+  if (isSubtle) {
+    line = `<i>${line}</i>`;
+  }
+  return line;
+}
+
+function renderFactSet(el: AcElement): string {
+  const facts = el.facts as Array<{ title?: string; value?: string }> | undefined;
+  if (!facts?.length) {
+    return "";
+  }
+  return facts
+    .map((f) => `<b>${escapeHtml(f.title ?? "")}</b>: ${escapeHtml(f.value ?? "")}`)
+    .join("\n");
+}
+
+function renderElement(el: AcElement): string {
+  switch (el.type) {
+    case "TextBlock":
+      return renderTextBlock(el);
+    case "FactSet":
+      return renderFactSet(el);
+    case "ColumnSet": {
+      // Flatten columns into sequential elements
+      const columns = el.columns as Array<{ items?: AcElement[] }> | undefined;
+      if (!columns?.length) {
+        return "";
+      }
+      return columns
+        .flatMap((col) => (col.items ?? []).map(renderElement))
+        .filter(Boolean)
+        .join("\n");
+    }
+    case "Container": {
+      const items = el.items as AcElement[] | undefined;
+      return (items ?? []).map(renderElement).filter(Boolean).join("\n");
+    }
+    default:
+      return "";
+  }
+}
+
+type InlineButton = { text: string; url?: string; callback_data?: string };
+
+function renderActions(actions: unknown[]): InlineButton[][] {
+  const buttons: InlineButton[] = [];
+  for (const raw of actions) {
+    const action = raw as AcElement;
+    const label = str(action.title);
+    if (!label) {
+      continue;
+    }
+    if (action.type === "Action.OpenUrl") {
+      buttons.push({ text: label, url: str(action.url) });
+    } else if (action.type === "Action.Submit") {
+      // Encode action data as callback_data (Telegram limit: 64 bytes)
+      const data = action.data != null ? JSON.stringify(action.data) : label;
+      buttons.push({ text: label, callback_data: data.slice(0, 64) });
+    }
+  }
+  if (buttons.length === 0) {
+    return [];
+  }
+  // One button per row
+  return buttons.map((b) => [b]);
+}
+
+export const telegramStrategy: CardRenderStrategy = {
+  name: "telegram",
+  render(parsed: ParsedAdaptiveCard): CardRenderResult {
+    const lines: string[] = [];
+    for (const el of parsed.card.body) {
+      const rendered = renderElement(el as AcElement);
+      if (rendered) {
+        lines.push(rendered);
+      }
+    }
+
+    const text = lines.join("\n\n") || escapeHtml(parsed.fallbackText);
+
+    const keyboard = parsed.card.actions?.length ? renderActions(parsed.card.actions) : [];
+
+    if (keyboard.length === 0) {
+      return { type: "telegram", text };
+    }
+
+    return {
+      type: "telegram",
+      text,
+      replyMarkup: { inline_keyboard: keyboard },
+    };
+  },
+};

--- a/src/cards/types.ts
+++ b/src/cards/types.ts
@@ -1,0 +1,29 @@
+import type { ParsedAdaptiveCard } from "./parse.js";
+
+export type CardRenderResult =
+  | { type: "text"; text: string }
+  | {
+      type: "telegram";
+      text: string;
+      replyMarkup?: {
+        inline_keyboard: Array<Array<{ text: string; url?: string; callback_data?: string }>>;
+      };
+    }
+  | { type: "slack"; blocks: unknown[]; fallback: string }
+  | {
+      type: "discord";
+      embeds: unknown[];
+      components?: unknown[];
+      fallback: string;
+    }
+  | {
+      type: "attachment";
+      contentType: string;
+      content: unknown;
+      fallback: string;
+    };
+
+export interface CardRenderStrategy {
+  name: string;
+  render(parsed: ParsedAdaptiveCard): CardRenderResult;
+}


### PR DESCRIPTION
## Summary

Adds a shared card rendering layer that enables **any channel** to consume Adaptive Cards natively. Works with any plugin that emits `<!--adaptive-card-->` markers in tool result text, including the standalone [`@vikrantsingh01/openclaw-adaptive-cards`](https://github.com/VikrantSingh01/openclaw-adaptive-cards) plugin (v4.0.0).

- **Shared parser**: Extracts card JSON, fallback text, and template data from `<!--adaptive-card-->` markers embedded in tool result text
- **Per-channel strategies**: Telegram (HTML + inline keyboards), Slack (Block Kit), Discord (embeds + button components), Teams/Webex (native AC attachment pass-through)
- **Outbound adapter wiring**: Each channel's outbound adapter detects markers and renders natively before sending — no gateway or hook system changes needed
- **Unit tests** covering parser + all strategy edge cases

**Note:** After rebase on main, the outbound adapters now live in `extensions/*/src/outbound-adapter.ts` (previously `src/channels/plugins/outbound/`). Card rendering logic has been applied to the new extension locations with inline parsing (no cross-workspace imports).

### Channel Rendering Matrix

| Channel | Strategy | AC Elements Supported | Actions |
|---|---|---|---|
| **Teams / Webex** | Native pass-through | All (AC v1.6) | All native |
| **Slack** | Block Kit translation | TextBlock, FactSet, Image, ColumnSet, Container | OpenUrl (button), Submit (action button) |
| **Telegram** | HTML + inline keyboard | TextBlock, FactSet, ColumnSet, Container | OpenUrl (URL button), Submit (callback button) |
| **Discord** | Embeds + components | TextBlock, FactSet, Image, ColumnSet, Container | OpenUrl (link button), Submit (primary button) |
| **Other channels** | Fallback text only | N/A — markers stripped, plain text shown | N/A |

### Architecture

```
Tool result text (with <!--adaptive-card--> markers)
     |
     v
Channel outbound adapter
     |
     +-- parseAdaptiveCardMarkers(text)
     |       -> { card, fallbackText, templateData } | null
     |
     +-- If card found -> try { render(parsed) } catch -> fallback
     |       -> channel-native format (blocks/embeds/keyboard/attachment)
     |
     +-- If no card -> send text as normal
```

Each strategy is a pure function (ParsedAdaptiveCard -> CardRenderResult) with no side effects, making them trivially testable and independently deployable.

### Production Guardrails

- Empty URL guard: `Action.OpenUrl` with missing URL skipped in all strategies (prevents Discord/Slack/Telegram 400 errors)
- Telegram: `callback_data` truncated by UTF-8 byte length (64B limit), not character count
- Slack: FactSets split into chunks of 10 fields per section block; mrkdwn text capped at 3,000 chars
- Discord: embed title 256 chars, description 4,096 chars, 25 fields max, field name/value 1,024 chars
- All adapters: render wrapped in try/catch — strategy errors fall through to fallback text
- All adapters: markers stripped from text when rendering fails or produces empty output (no raw JSON leak)

### Ecosystem Context

| Package | Version | Role |
|---------|---------|------|
| [adaptive-cards-mcp](https://github.com/AiCodingBattle/adaptive-cards-mcp) | v2.3.0 | Shared core — v1.6 schema validation, 7 host profiles, WCAG a11y scoring, 21 patterns, 924 tests |
| [openclaw-adaptive-cards](https://github.com/VikrantSingh01/openclaw-adaptive-cards) | v4.0.0 | Plugin — `adaptive_card` tool, MCP bridge, marker transport, prompt guidance, action routing |
| **This PR** | — | Channel-side rendering — parse markers, render natively per channel |

### Related PRs

- #41908 — Concept documentation
- #41735 — Community plugins listing
- #42350 — iOS native rendering
- #42307 — Web UI rendering
- #42304 — Android native rendering

## Test Plan

- [x] `pnpm check` passes (lint + format)
- [x] Parser tests pass
- [x] Strategy tests pass
- [x] Existing outbound adapter tests pass
- [ ] Telegram: `/acard test` renders as HTML with inline keyboard
- [ ] Slack: `/acard test` renders as Block Kit with button
- [ ] Discord: `/acard test` renders as embed with button component
- [ ] Teams: `/acard test` renders as native Adaptive Card
