### PR TITLE
fix(daemon): include OrbStack and Docker Desktop in macOS LaunchAgent PATH

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -118,6 +118,10 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/Users/testuser/.local/share/pnpm"); // pnpm XDG fallback
     expect(result).toContain("/Users/testuser/.bun/bin");
 
+    // Should include container runtime paths (Docker Desktop, OrbStack)
+    expect(result).toContain("/Users/testuser/.docker/bin");
+    expect(result).toContain("/Users/testuser/.orbstack/bin");
+
     // Should also include macOS system directories
     expect(result).toContain("/opt/homebrew/bin");
     expect(result).toContain("/usr/local/bin");

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -149,6 +149,10 @@ export function resolveDarwinUserBinDirs(
   dirs.push(`${home}/Library/pnpm`); // pnpm default
   dirs.push(`${home}/.local/share/pnpm`); // pnpm XDG fallback
 
+  // Container runtimes (Docker Desktop, OrbStack)
+  dirs.push(`${home}/.docker/bin`); // Docker Desktop
+  dirs.push(`${home}/.orbstack/bin`); // OrbStack
+
   return dirs;
 }
 


### PR DESCRIPTION
## Summary
- Add `~/.docker/bin` (Docker Desktop) and `~/.orbstack/bin` (OrbStack) to `resolveDarwinUserBinDirs()` so the macOS LaunchAgent PATH includes container runtime binaries
- Without this, sandbox agent spawns fail with "docker command not found" even when Docker/OrbStack is installed

Fixes #41263

## Test plan
- [x] All 48 existing service-env tests pass
- [x] New assertions verify Docker Desktop and OrbStack paths are included in macOS PATH
- [ ] On macOS with OrbStack: `openclaw gateway install` then verify `docker` resolves in the LaunchAgent environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)