### PR TITLE
fix: separate filter state for Agents Skills panel and Skills tab

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -586,7 +586,7 @@ export function renderApp(state: AppViewState) {
                 toolsCatalogLoading: state.toolsCatalogLoading,
                 toolsCatalogError: state.toolsCatalogError,
                 toolsCatalogResult: state.toolsCatalogResult,
-                skillsFilter: state.skillsFilter,
+                skillsFilter: state.agentSkillsFilter,
                 onRefresh: async () => {
                   await loadAgents(state);
                   const nextSelected =
@@ -715,7 +715,7 @@ export function renderApp(state: AppViewState) {
                 onConfigSave: () => saveAgentsConfig(state),
                 onChannelsRefresh: () => loadChannels(state, false),
                 onCronRefresh: () => state.loadCron(),
-                onSkillsFilterChange: (next) => (state.skillsFilter = next),
+                onSkillsFilterChange: (next) => (state.agentSkillsFilter = next),
                 onSkillsRefresh: () => {
                   if (resolvedAgentId) {
                     void loadAgentSkills(state, resolvedAgentId);

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -147,6 +147,7 @@ export type AppViewState = {
   agentSkillsError: string | null;
   agentSkillsReport: SkillStatusReport | null;
   agentSkillsAgentId: string | null;
+  agentSkillsFilter: string;
   sessionsLoading: boolean;
   sessionsResult: SessionsListResult | null;
   sessionsError: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -348,6 +348,7 @@ export class OpenClawApp extends LitElement {
   @state() skillsReport: SkillStatusReport | null = null;
   @state() skillsError: string | null = null;
   @state() skillsFilter = "";
+  @state() agentSkillsFilter = "";
   @state() skillEdits: Record<string, string> = {};
   @state() skillsBusyKey: string | null = null;
   @state() skillMessages: Record<string, SkillMessage> = {};


### PR DESCRIPTION
Fixes #41605

## Problem
The Skills tab and Agents→Skills panel were sharing the same `skillsFilter` state. When users filtered skills in the Agents view and then switched to the Skills tab, the filter persisted, causing "No skills found" to appear even though skills existed.

This explains why:
- **Normal mode**: Filter state persisted across views
- **Incognito mode**: No state persistence, so it worked fine
- **Mobile**: Different UI behavior

## Solution
Introduced separate `agentSkillsFilter` state for the Agents view, keeping `skillsFilter` isolated to the Skills tab.

## Changes
- Added `agentSkillsFilter` state in `app.ts`
- Updated Agents view to use `agentSkillsFilter` in `app-render.ts`
- Added type definition in `app-view-state.ts`

## Testing
- Switch between Agents→Skills panel and Skills tab
- Filter in one view should not affect the other
- Each view maintains its own filter state independently