### PR TITLE
fix(net): preserve proxy-aware undici dispatcher for codex runs

### DIFF
--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -57,6 +57,7 @@ vi.mock("node:net", () => ({
   getDefaultAutoSelectFamily,
 }));
 
+import { PROXY_ENV_KEYS } from "./proxy-env.js";
 import {
   DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
   ensureGlobalUndiciStreamTimeouts,
@@ -66,6 +67,10 @@ import {
 describe("ensureGlobalUndiciStreamTimeouts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    for (const key of PROXY_ENV_KEYS) {
+      vi.stubEnv(key, "");
+    }
     resetGlobalUndiciStreamTimeoutsForTests();
     setCurrentDispatcher(new Agent());
     getDefaultAutoSelectFamily.mockReturnValue(undefined);

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   Agent,
@@ -71,6 +71,10 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     getDefaultAutoSelectFamily.mockReturnValue(undefined);
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("replaces default Agent dispatcher with extended stream timeouts", () => {
     getDefaultAutoSelectFamily.mockReturnValue(true);
 
@@ -100,6 +104,23 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
     expect(next.options?.connect).toEqual({
       autoSelectFamily: false,
+      autoSelectFamilyAttemptTimeout: 300,
+    });
+  });
+
+  it("upgrades Agent dispatcher to EnvHttpProxyAgent when proxy env is configured", () => {
+    getDefaultAutoSelectFamily.mockReturnValue(true);
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+
+    ensureGlobalUndiciStreamTimeouts();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(EnvHttpProxyAgent);
+    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.connect).toEqual({
+      autoSelectFamily: true,
       autoSelectFamilyAttemptTimeout: 300,
     });
   });

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -1,5 +1,6 @@
 import * as net from "node:net";
 import { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { hasProxyEnvConfigured } from "./proxy-env.js";
 
 export const DEFAULT_UNDICI_STREAM_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -59,6 +60,13 @@ function resolveDispatcherKey(params: {
   return `${params.kind}:${params.timeoutMs}:${autoSelectToken}`;
 }
 
+function resolveEffectiveDispatcherKind(kind: DispatcherKind): DispatcherKind {
+  if (kind === "agent" && hasProxyEnvConfigured()) {
+    return "env-proxy";
+  }
+  return kind;
+}
+
 export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }): void {
   const timeoutMsRaw = opts?.timeoutMs ?? DEFAULT_UNDICI_STREAM_TIMEOUT_MS;
   const timeoutMs = Math.max(1, Math.floor(timeoutMsRaw));
@@ -77,16 +85,17 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
   if (kind === "unsupported") {
     return;
   }
+  const effectiveKind = resolveEffectiveDispatcherKind(kind);
 
   const autoSelectFamily = resolveAutoSelectFamily();
-  const nextKey = resolveDispatcherKey({ kind, timeoutMs, autoSelectFamily });
+  const nextKey = resolveDispatcherKey({ kind: effectiveKind, timeoutMs, autoSelectFamily });
   if (lastAppliedDispatcherKey === nextKey) {
     return;
   }
 
   const connect = resolveConnectOptions(autoSelectFamily);
   try {
-    if (kind === "env-proxy") {
+    if (effectiveKind === "env-proxy") {
       const proxyOptions = {
         bodyTimeout: timeoutMs,
         headersTimeout: timeoutMs,


### PR DESCRIPTION
## Summary
- preserve a proxy-aware global undici dispatcher when standard proxy env vars are configured
- keep `ensureGlobalUndiciStreamTimeouts` from downgrading `openai-codex` runs back to a direct `Agent`
- add regression coverage for `HTTP(S)_PROXY` environments that start from the default undici `Agent`

## Why
OpenClaw agent runs call `ensureGlobalUndiciStreamTimeouts()` before embedded model execution. In proxy-required environments, the default undici global dispatcher is usually a plain `Agent`, so the helper rebuilt another plain `Agent` and dropped proxy routing entirely.

That breaks `openai-codex` requests after upgrades unless users manually force `NODE_USE_ENV_PROXY=1` in the gateway service environment. `deepseek` can still work because it goes through a different provider path.

## Repro
1. Configure `HTTP_PROXY` / `HTTPS_PROXY` so OpenAI traffic must go through a proxy.
2. Set the model to `openai-codex/gpt-5.3-codex`.
3. Run an embedded agent request.
4. Observe `LLM request timed out` with zero provider usage, while non-codex providers may still succeed.

## Fix
When the current global dispatcher is the default undici `Agent`, but standard proxy env vars are present, treat the effective dispatcher kind as `env-proxy` and rebuild it as an `EnvHttpProxyAgent` with the same stream timeout / `autoSelectFamily` settings.

## Testing
- [x] AI-assisted
- [x] Fully tested locally for this change
- `pnpm build`
- `pnpm check`
- `vitest run --config vitest.unit.config.ts src/infra/net/undici-global-dispatcher.test.ts`
- Started `pnpm test`; manually stopped after 216 passing test files / 3861 passing tests with no failures seen, because the full suite is very large
