### PR TITLE
fix(ui): allow cronjob edit form to scroll independently on narrow screens

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -926,6 +926,8 @@
   .cron-workspace-form {
     position: static;
     order: -1;
+    max-height: 80vh;
+    overflow-y: auto;
   }
 
   .cron-form-grid {


### PR DESCRIPTION
## Summary

  - **Problem:** On screens ≤1100px, the cronjob edit form loses its scroll containment when switching to `position: static`, causing the entire
  page to scroll instead of the form panel.
  - **Why it matters:** Users must scroll the entire page to the bottom before the edit form begins scrolling, making cronjob editing frustrating on
   narrow screens or tablets.
  - **What changed:** Added `max-height: 80vh` and `overflow-y: auto` to `.cron-workspace-form` in the `≤1100px` media query, restoring independent
  scroll behavior consistent with the desktop layout.
  - **What did NOT change:** Desktop layout (>1100px) is untouched. No JS or logic changes.

  ## Change Type

  - [x] Bug fix

  ## Scope

  - [x] UI / DX

  ## User-visible / Behavior Changes

  On narrow screens (≤1100px), the cronjob edit form now scrolls independently within its own panel instead of requiring the entire page to scroll
  first.

  ## Screenshots

<img width="2396" height="1194" alt="image" src="https://github.com/user-attachments/assets/8207e4e1-2c44-466a-bc51-b3f0f661559a" />

  ## Repro + Verification

  1. Open OpenClaw web UI → Cronjobs page
  2. Resize browser to ≤1100px (or use DevTools responsive mode)
  3. Click **Edit** on any cronjob
  4. Try scrolling within the edit form

  **Before:** Mouse wheel scrolls the entire page; form only scrolls after page hits bottom.
  **After:** Form panel scrolls independently.

  ## Security Impact

  None. CSS-only change, no new permissions, network calls, secrets, or data access.

  ## Compatibility

  - Backward compatible: Yes
  - Config/env changes: No
  - Migration needed: No

  ## AI Disclosure 🤖

  - AI-assisted: Yes (Claude Code)
  - I understand what the code does: The fix adds scroll containment (`max-height` + `overflow-y: auto`) to the form container in the responsive
  breakpoint, matching the behavior already present in the desktop sticky layout.

  ## Risks

  - `80vh` could feel constrained on very short viewports — can be tuned if needed.
  - `overflow-y: auto` only activates when content overflows, so no unnecessary scrollbar on short forms.
