### PR TITLE
fix(anthropic): recover from empty session error stubs

### DIFF
--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -360,6 +360,26 @@ describe("mergeConsecutiveUserTurns", () => {
 });
 
 describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
+  it("strips dangling toolCall blocks in pi-agent-core transcripts", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "tool-1", name: "test", arguments: {} },
+          { type: "text", text: "I'll check that" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([{ type: "text", text: "I'll check that" }]);
+  });
+
   it("should strip tool_use blocks without matching tool_result", () => {
     // Simulates: user asks -> assistant has tool_use -> user responds without tool_result
     // This happens after compaction trims history

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -1,12 +1,16 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 type AnthropicContentBlock = {
-  type: "text" | "toolUse" | "toolResult";
+  type: "text" | "toolCall" | "toolUse" | "toolResult";
   text?: string;
   id?: string;
   name?: string;
   toolUseId?: string;
 };
+
+function isAnthropicToolUseBlock(block: AnthropicContentBlock): boolean {
+  return block.type === "toolCall" || block.type === "toolUse";
+}
 
 /**
  * Strips dangling tool_use blocks from assistant messages when the immediately
@@ -59,16 +63,18 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       }
     }
 
-    // Filter out tool_use blocks that don't have matching tool_result
+    // Filter out assistant tool call blocks that don't have matching tool_result.
+    // pi-agent-core stores them as "toolCall" internally, but older sanitized
+    // transcripts may still contain "toolUse".
     const originalContent = Array.isArray(assistantMsg.content) ? assistantMsg.content : [];
     const filteredContent = originalContent.filter((block) => {
       if (!block) {
         return false;
       }
-      if (block.type !== "toolUse") {
+      if (!isAnthropicToolUseBlock(block)) {
         return true;
       }
-      // Keep tool_use if its id is in the valid set
+      // Keep tool blocks whose ids are present in the next user tool_result turn.
       return validToolUseIds.has(block.id || "");
     });
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -565,6 +565,71 @@ describe("sanitizeSessionHistory", () => {
     expect(result[1]?.role).toBe("assistant");
   });
 
+  it("drops empty assistant error stubs from Anthropic session history", async () => {
+    setNonGoogleModelApi();
+
+    const messages: AgentMessage[] = [
+      makeUserMessage("hello"),
+      makeAssistantMessage(
+        [
+          {
+            type: "thinking",
+            thinking: "reasoning",
+            thinkingSignature: "sig",
+          },
+          { type: "text", text: "ok" },
+        ],
+        { stopReason: "stop" },
+      ),
+      makeUserMessage("retry after failure"),
+      makeAssistantMessage([{ type: "text", text: "" }], {
+        stopReason: "error",
+      }),
+      makeUserMessage("continue"),
+    ];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      sessionManager: makeMockSessionManager(),
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result.map((message) => message.role)).toEqual(["user", "assistant", "user", "user"]);
+    expect(
+      result.some((message) => message.role === "assistant" && message.stopReason === "error"),
+    ).toBe(false);
+  });
+
+  it("keeps non-empty assistant error messages in session history", async () => {
+    setNonGoogleModelApi();
+
+    const messages: AgentMessage[] = [
+      makeUserMessage("hello"),
+      makeAssistantMessage([{ type: "text", text: "partial streamed response" }], {
+        stopReason: "error",
+      }),
+      makeUserMessage("continue"),
+    ];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      sessionManager: makeMockSessionManager(),
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+    expect(result[1]?.role).toBe("assistant");
+    expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
+      { type: "text", text: "partial streamed response" },
+    ]);
+  });
+
   it("synthesizes missing tool results for openai-responses after repair", async () => {
     const messages: AgentMessage[] = [
       makeAssistantMessage([{ type: "toolCall", id: "call_1", name: "read", arguments: {} }], {

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -655,6 +655,31 @@ describe("sanitizeSessionHistory", () => {
     expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).stopReason).toBe("error");
   });
 
+  it("does not drop empty assistant error stubs for strict OpenAI-compatible histories", async () => {
+    setNonGoogleModelApi();
+
+    const messages: AgentMessage[] = [
+      makeUserMessage("hello"),
+      makeAssistantMessage([{ type: "text", text: "" }], {
+        stopReason: "error",
+      }),
+      makeUserMessage("continue"),
+    ];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "vllm",
+      modelId: "gemma-3-27b",
+      sessionManager: makeMockSessionManager(),
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+    expect(result[1]?.role).toBe("assistant");
+    expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).stopReason).toBe("error");
+  });
+
   it("synthesizes missing tool results for openai-responses after repair", async () => {
     const messages: AgentMessage[] = [
       makeAssistantMessage([{ type: "toolCall", id: "call_1", name: "read", arguments: {} }], {

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -630,6 +630,31 @@ describe("sanitizeSessionHistory", () => {
     ]);
   });
 
+  it("does not drop empty assistant error stubs for non-Anthropic histories", async () => {
+    setNonGoogleModelApi();
+
+    const messages: AgentMessage[] = [
+      makeUserMessage("hello"),
+      makeAssistantMessage([{ type: "text", text: "" }], {
+        stopReason: "error",
+      }),
+      makeUserMessage("continue"),
+    ];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      modelId: "gpt-5.2",
+      sessionManager: makeMockSessionManager(),
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+    expect(result[1]?.role).toBe("assistant");
+    expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).stopReason).toBe("error");
+  });
+
   it("synthesizes missing tool results for openai-responses after repair", async () => {
     const messages: AgentMessage[] = [
       makeAssistantMessage([{ type: "toolCall", id: "call_1", name: "read", arguments: {} }], {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -13,6 +13,7 @@ import {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
   isCompactionFailureError,
+  isEmptyAssistantMessageContent,
   isGoogleModelApi,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
@@ -552,7 +553,18 @@ export async function sanitizeSessionHistory(params: {
   const droppedThinking = policy.dropThinkingBlocks
     ? dropThinkingBlocks(sanitizedImages)
     : sanitizedImages;
-  const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
+  // pi-agent-core persists a synthetic empty assistant error message when a
+  // request fails before yielding usable content. Anthropic drops empty
+  // assistant turns during payload conversion, which can turn
+  // user -> assistant(error) -> user into consecutive user turns.
+  const withoutEmptyAssistantErrors = droppedThinking.filter((msg) => {
+    if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
+      return true;
+    }
+    const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+    return assistant.stopReason !== "error" || !isEmptyAssistantMessageContent(assistant);
+  });
+  const sanitizedToolCalls = sanitizeToolCallInputs(withoutEmptyAssistantErrors, {
     allowedToolNames: params.allowedToolNames,
   });
   const repairedTools = policy.repairToolUseResultPairing

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -553,19 +553,22 @@ export async function sanitizeSessionHistory(params: {
   const droppedThinking = policy.dropThinkingBlocks
     ? dropThinkingBlocks(sanitizedImages)
     : sanitizedImages;
+  const dropsEmptyAssistantTurnsOnConversion =
+    params.modelApi === "anthropic-messages" || params.modelApi === "bedrock-converse-stream";
   // pi-agent-core persists a synthetic empty assistant error message when a
   // request fails before yielding usable content. Anthropic drops empty
   // assistant turns during payload conversion, which can turn
   // user -> assistant(error) -> user into consecutive user turns.
-  const withoutEmptyAssistantErrors = policy.validateAnthropicTurns
-    ? droppedThinking.filter((msg) => {
-        if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
-          return true;
-        }
-        const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
-        return assistant.stopReason !== "error" || !isEmptyAssistantMessageContent(assistant);
-      })
-    : droppedThinking;
+  const withoutEmptyAssistantErrors =
+    policy.validateAnthropicTurns && dropsEmptyAssistantTurnsOnConversion
+      ? droppedThinking.filter((msg) => {
+          if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
+            return true;
+          }
+          const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+          return assistant.stopReason !== "error" || !isEmptyAssistantMessageContent(assistant);
+        })
+      : droppedThinking;
   const sanitizedToolCalls = sanitizeToolCallInputs(withoutEmptyAssistantErrors, {
     allowedToolNames: params.allowedToolNames,
   });

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -557,13 +557,15 @@ export async function sanitizeSessionHistory(params: {
   // request fails before yielding usable content. Anthropic drops empty
   // assistant turns during payload conversion, which can turn
   // user -> assistant(error) -> user into consecutive user turns.
-  const withoutEmptyAssistantErrors = droppedThinking.filter((msg) => {
-    if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
-      return true;
-    }
-    const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
-    return assistant.stopReason !== "error" || !isEmptyAssistantMessageContent(assistant);
-  });
+  const withoutEmptyAssistantErrors = policy.validateAnthropicTurns
+    ? droppedThinking.filter((msg) => {
+        if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
+          return true;
+        }
+        const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+        return assistant.stopReason !== "error" || !isEmptyAssistantMessageContent(assistant);
+      })
+    : droppedThinking;
   const sanitizedToolCalls = sanitizeToolCallInputs(withoutEmptyAssistantErrors, {
     allowedToolNames: params.allowedToolNames,
   });


### PR DESCRIPTION
## Summary

- strip dangling Anthropic tool blocks for both internal `toolCall` and legacy `toolUse` transcripts
- drop only empty assistant `stopReason: "error"` stubs from Anthropic session history before provider conversion
- add focused regressions for the `toolCall` path and for empty-vs-non-empty assistant error messages

## Why

`#41578` is directionally right about two failure modes in Anthropic history recovery, but its implementation is looser than it needs to be:

- `validateAnthropicTurns()` should understand the current pi-agent-core internal block type (`toolCall`), while staying compatible with older `toolUse`-shaped transcripts
- session history should not drop every assistant error turn, because partial streamed failures can still contain meaningful content

This version keeps the useful part of the fix while avoiding the over-broad `stopReason === "error"` filter.

## Details

- `src/agents/pi-embedded-helpers/turns.ts`
  - treat both `toolCall` and `toolUse` as assistant tool blocks when stripping dangling Anthropic tool calls
- `src/agents/pi-embedded-runner/google.ts`
  - remove only assistant error stubs whose content is effectively empty
  - keep non-empty assistant error messages intact so partial streamed output is not discarded
- tests
  - add a direct `toolCall` regression for `validateAnthropicTurns`
  - add Anthropic session-history regressions covering empty error stubs vs non-empty error messages

## Verification

- `pnpm exec vitest run src/agents/pi-embedded-helpers.validate-turns.test.ts -t 'toolCall'`
- `pnpm exec vitest run src/agents/pi-embedded-runner.sanitize-session-history.test.ts -t 'assistant error'`
- `pnpm exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm exec oxlint --type-aware src/agents/pi-embedded-helpers/turns.ts src/agents/pi-embedded-runner/google.ts src/agents/pi-embedded-helpers.validate-turns.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- `pnpm format:check`

Closes #41571.
