### PR TITLE
fix: avoid config redaction RangeError on empty sensitive values

### DIFF
--- a/src/config/redact-snapshot.raw.test.ts
+++ b/src/config/redact-snapshot.raw.test.ts
@@ -67,13 +67,19 @@ describe("replaceSensitiveValuesInRaw", () => {
   });
 
   it("handles non-string raw input gracefully", () => {
-    const result = replaceSensitiveValuesInRaw({
+    const nullResult = replaceSensitiveValuesInRaw({
       raw: null as unknown as string,
       sensitiveValues: ["test"],
       redactedSentinel: "***",
     });
-    // String(null) returns "null", but our defensive code returns empty string
-    expect(result).toBe("");
+    const objectResult = replaceSensitiveValuesInRaw({
+      raw: { secret: "test" } as unknown as string,
+      sensitiveValues: ["test"],
+      redactedSentinel: "***",
+    });
+
+    expect(nullResult).toBe("");
+    expect(objectResult).toBe("");
   });
 
   it("handles unicode strings", () => {

--- a/src/config/redact-snapshot.raw.test.ts
+++ b/src/config/redact-snapshot.raw.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { replaceSensitiveValuesInRaw } from "./redact-snapshot.raw.js";
+
+describe("replaceSensitiveValuesInRaw", () => {
+  it("redacts sensitive values from raw string", () => {
+    const result = replaceSensitiveValuesInRaw({
+      raw: '{"apiKey": "secret123", "name": "test"}',
+      sensitiveValues: ["secret123"],
+      redactedSentinel: "__REDACTED__",
+    });
+    expect(result).toBe('{"apiKey": "__REDACTED__", "name": "test"}');
+  });
+
+  it("handles multiple sensitive values (longest first)", () => {
+    const result = replaceSensitiveValuesInRaw({
+      raw: '{"key1": "abc", "key2": "abcdef"}',
+      sensitiveValues: ["abc", "abcdef"],
+      redactedSentinel: "***",
+    });
+    expect(result).toBe('{"key1": "***", "key2": "***"}');
+  });
+
+  // Regression test for #41247
+  it("handles empty strings without throwing RangeError", () => {
+    expect(() =>
+      replaceSensitiveValuesInRaw({
+        raw: '{"key": "value"}',
+        sensitiveValues: ["", "value"],
+        redactedSentinel: "__REDACTED__",
+      }),
+    ).not.toThrow();
+
+    const result = replaceSensitiveValuesInRaw({
+      raw: '{"key": "value"}',
+      sensitiveValues: ["", "value"],
+      redactedSentinel: "__REDACTED__",
+    });
+    expect(result).toBe('{"key": "__REDACTED__"}');
+  });
+
+  it("handles null and undefined values", () => {
+    const result = replaceSensitiveValuesInRaw({
+      raw: '{"key": "secret"}',
+      sensitiveValues: [null, undefined, "secret"] as unknown as string[],
+      redactedSentinel: "***",
+    });
+    expect(result).toBe('{"key": "***"}');
+  });
+
+  it("returns raw unchanged when no valid sensitive values", () => {
+    const raw = '{"key": "value"}';
+    const result = replaceSensitiveValuesInRaw({
+      raw,
+      sensitiveValues: ["", null, undefined] as unknown as string[],
+      redactedSentinel: "__REDACTED__",
+    });
+    expect(result).toBe(raw);
+  });
+
+  it("uses default sentinel when provided sentinel is empty", () => {
+    const result = replaceSensitiveValuesInRaw({
+      raw: '{"key": "secret"}',
+      sensitiveValues: ["secret"],
+      redactedSentinel: "",
+    });
+    expect(result).toBe('{"key": "__REDACTED__"}');
+  });
+
+  it("handles non-string raw input gracefully", () => {
+    const result = replaceSensitiveValuesInRaw({
+      raw: null as unknown as string,
+      sensitiveValues: ["test"],
+      redactedSentinel: "***",
+    });
+    // String(null) returns "null", but our defensive code returns empty string
+    expect(result).toBe("");
+  });
+
+  it("handles unicode strings", () => {
+    const result = replaceSensitiveValuesInRaw({
+      raw: '{"key": "🔑secret🔑"}',
+      sensitiveValues: ["🔑secret🔑"],
+      redactedSentinel: "***",
+    });
+    expect(result).toBe('{"key": "***"}');
+  });
+});

--- a/src/config/redact-snapshot.raw.ts
+++ b/src/config/redact-snapshot.raw.ts
@@ -5,9 +5,8 @@ import JSON5 from "json5";
  * Redacts sensitive values from a raw config string.
  * Filters out empty/null/undefined values to prevent RangeError (#41247).
  *
- * Note: When `params.raw` is not a string (e.g., null, number), it is
- * converted to a string via `String(params.raw ?? "")` and returned
- * without redaction. This is a silent fallback for invalid input.
+ * Note: When `params.raw` is not a string, this returns an empty string
+ * defensively instead of returning a stringified unredacted value.
  */
 export function replaceSensitiveValuesInRaw(params: {
   raw: string;
@@ -16,7 +15,7 @@ export function replaceSensitiveValuesInRaw(params: {
 }): string {
   // Defensive: validate input types
   if (typeof params.raw !== "string") {
-    return String(params.raw ?? "");
+    return "";
   }
 
   // Defensive: normalize and filter sensitive values

--- a/src/config/redact-snapshot.raw.ts
+++ b/src/config/redact-snapshot.raw.ts
@@ -6,7 +6,10 @@ export function replaceSensitiveValuesInRaw(params: {
   sensitiveValues: string[];
   redactedSentinel: string;
 }): string {
-  const values = [...params.sensitiveValues].toSorted((a, b) => b.length - a.length);
+  // FIX #41247: Filter out empty strings to prevent RangeError
+  const values = [...params.sensitiveValues]
+    .filter((v) => v && v.length > 0)
+    .toSorted((a, b) => b.length - a.length);
   let result = params.raw;
   for (const value of values) {
     result = result.replaceAll(value, params.redactedSentinel);

--- a/src/config/redact-snapshot.raw.ts
+++ b/src/config/redact-snapshot.raw.ts
@@ -1,18 +1,44 @@
 import { isDeepStrictEqual } from "node:util";
 import JSON5 from "json5";
 
+/**
+ * Redacts sensitive values from a raw config string.
+ * Filters out empty/null/undefined values to prevent RangeError (#41247).
+ *
+ * Note: When `params.raw` is not a string (e.g., null, number), it is
+ * converted to a string via `String(params.raw ?? "")` and returned
+ * without redaction. This is a silent fallback for invalid input.
+ */
 export function replaceSensitiveValuesInRaw(params: {
   raw: string;
   sensitiveValues: string[];
   redactedSentinel: string;
 }): string {
-  // FIX #41247: Filter out empty strings to prevent RangeError
+  // Defensive: validate input types
+  if (typeof params.raw !== "string") {
+    return String(params.raw ?? "");
+  }
+
+  // Defensive: normalize and filter sensitive values
+  // Empty strings cause RangeError in String.replaceAll (#41247)
   const values = [...params.sensitiveValues]
-    .filter((v) => v && v.length > 0)
+    .filter((v): v is string => typeof v === "string" && v.length > 0)
     .toSorted((a, b) => b.length - a.length);
+
+  // Early return if no valid values to redact
+  if (values.length === 0) {
+    return params.raw;
+  }
+
+  // Defensive: ensure sentinel is valid
+  const sentinel =
+    typeof params.redactedSentinel === "string" && params.redactedSentinel.length > 0
+      ? params.redactedSentinel
+      : "__REDACTED__";
+
   let result = params.raw;
   for (const value of values) {
-    result = result.replaceAll(value, params.redactedSentinel);
+    result = result.replaceAll(value, sentinel);
   }
   return result;
 }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -292,10 +292,7 @@ export function buildGatewayCronService(params: {
         abortSignal,
         agentId,
         sessionKey: `cron:${job.id}`,
-        // FIX #41266: Use subagent lane to avoid deadlock with cron lane
-        // The outer enqueueRun already holds CommandLane.Cron; using "cron"
-        // here would cause deadlock since cron lane has concurrency=1.
-        lane: "subagent",
+        lane: "cron",
       });
     },
     sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) => {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -292,7 +292,10 @@ export function buildGatewayCronService(params: {
         abortSignal,
         agentId,
         sessionKey: `cron:${job.id}`,
-        lane: "cron",
+        // FIX #41266: Use subagent lane to avoid deadlock with cron lane
+        // The outer enqueueRun already holds CommandLane.Cron; using "cron"
+        // here would cause deadlock since cron lane has concurrency=1.
+        lane: "subagent",
       });
     },
     sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) => {


### PR DESCRIPTION
## Summary

- Problem: `config.get` can fail with `RangeError: Invalid string length` when raw config redaction sees an empty sensitive value.
- Why it matters: that breaks Control UI screens that depend on the redacted config snapshot.
- What changed: empty, null, and undefined sensitive values are filtered before raw-text replacement; the helper now returns an empty string for non-string raw input; focused regression tests were added.
- What did NOT change (scope boundary): this PR does not change cron behavior, delivery behavior, or config schema.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41247
- Related #40818
- Related #22902

## User-visible / Behavior Changes

- `config.get` no longer fails when a sensitive config field is present but empty.
- Control UI pages that depend on the redacted config snapshot can load normally again in this failure mode.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: this changes only local redaction behavior. Empty sensitive values are skipped before replacement, and non-string raw input now returns an empty string instead of a stringified unredacted value.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node.js dev environment
- Model/provider: not applicable
- Integration/channel (if any): not applicable
- Relevant config (redacted): config containing empty sensitive string values

### Steps

1. Put an empty string in a sensitive config field.
2. Call `config.get` or load a Control UI screen that depends on the redacted config snapshot.
3. Observe the before/after behavior.

### Expected

- `config.get` returns successfully.
- Redaction does not fail on empty sensitive values.

### Actual

- Before this change, raw config redaction could reach `replaceAll("")` and fail with `RangeError: Invalid string length`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm vitest run src/config/redact-snapshot.raw.test.ts src/config/redact-snapshot.test.ts`
- Edge cases checked: empty strings, null/undefined sensitive values, empty sentinel, non-string raw input, overlapping values
- What you did **not** verify: full end-to-end Control UI reproduction in this branch after the focused helper fix

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or the helper changes in `src/config/redact-snapshot.raw.ts`
- Files/config to restore: `src/config/redact-snapshot.raw.ts`, `src/config/redact-snapshot.raw.test.ts`
- Known bad symptoms reviewers should watch for: unexpected empty output from the helper when non-string raw input is passed

## Risks and Mitigations

- Risk: non-string raw input now returns `""` instead of a stringified value
  - Mitigation: this is a safer fallback because it avoids returning potentially unredacted content, and the behavior is covered by tests
