### PR TITLE
fix(gateway): limit chokidar watch depth to avoid fd exhaustion

### DIFF
--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -1,6 +1,6 @@
+import chokidar, { type FSWatcher } from "chokidar";
 import os from "node:os";
 import path from "node:path";
-import chokidar, { type FSWatcher } from "chokidar";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { CONFIG_DIR, resolveUserPath } from "../../utils.js";
@@ -168,6 +168,7 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
 
   const watcher = chokidar.watch(watchTargets, {
     ignoreInitial: true,
+    depth: 2,
     awaitWriteFinish: {
       stabilityThreshold: debounceMs,
       pollInterval: 100,

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -1,9 +1,11 @@
+import type { DatabaseSync } from "node:sqlite";
+import chokidar, { FSWatcher } from "chokidar";
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { DatabaseSync } from "node:sqlite";
-import chokidar, { FSWatcher } from "chokidar";
+import type { SessionFileEntry } from "./session-files.js";
+import type { MemorySource, MemorySyncProgressUpdate } from "./types.js";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import { ResolvedMemorySearchConfig } from "../agents/memory-search.js";
 import { type OpenClawConfig } from "../config/config.js";
@@ -35,7 +37,6 @@ import {
 } from "./internal.js";
 import { type MemoryFileEntry } from "./internal.js";
 import { ensureMemoryIndexSchema } from "./memory-schema.js";
-import type { SessionFileEntry } from "./session-files.js";
 import {
   buildSessionEntry,
   listSessionFilesForAgent,
@@ -43,7 +44,6 @@ import {
 } from "./session-files.js";
 import { loadSqliteVecExtension } from "./sqlite-vec.js";
 import { requireNodeSqlite } from "./sqlite.js";
-import type { MemorySource, MemorySyncProgressUpdate } from "./types.js";
 
 type MemoryIndexMeta = {
   model: string;
@@ -392,8 +392,11 @@ export abstract class MemoryManagerSyncOps {
         // Skip missing/unreadable additional paths.
       }
     }
+    // Limit depth to avoid FSEventWrap explosion (fd exhaustion) on macOS when memory/ or
+    // extraPaths contain large trees; see #41606.
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
+      depth: 2,
       ignored: (watchPath) => shouldIgnoreMemoryWatchPath(String(watchPath)),
       awaitWriteFinish: {
         stabilityThreshold: this.settings.sync.watchDebounceMs,

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -393,7 +393,8 @@ export abstract class MemoryManagerSyncOps {
       }
     }
     // Limit depth to avoid FSEventWrap explosion (fd exhaustion) on macOS when memory/ or
-    // extraPaths contain large trees; see #41606.
+    // extraPaths contain large trees; see #41606. Files deeper than 2 levels do not emit
+    // watch events and rely on full sync (interval, new session, or manual) for updates.
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
       depth: 2,


### PR DESCRIPTION
Fixes #41606

- **Problem:** Chokidar watchers (memory + skills) recurse into huge dirs (e.g. `memory/` with node_modules), creating 9k+ FSEventWrap handles and exhausting FDs → `spawn EBADF` in embedded gateway.
- **Fix:** Add `depth: 2` to both watchers to limit recursion.