### PR TITLE
fix(embedding): add encoding_format parameter to OpenAI-compatible requests

### DIFF
--- a/src/memory-host-sdk/host/embeddings-remote-provider.ts
+++ b/src/memory-host-sdk/host/embeddings-remote-provider.ts
@@ -32,7 +32,7 @@ export function createRemoteEmbeddingProvider(params: {
       headers: client.headers,
       ssrfPolicy: client.ssrfPolicy,
       fetchImpl: client.fetchImpl,
-      body: { model: client.model, input },
+      body: { model: client.model, input, encoding_format: "float" },
       errorPrefix: params.errorPrefix,
     });
   };


### PR DESCRIPTION
  ## Summary
  - Add `encoding_format: "float"` parameter to embedding API requests
  - Fixes compatibility with OpenAI-compatible services that require this parameter (e.g., internal llmproxy services)

  ## Context
  Some OpenAI-compatible API services (like internal llmproxy proxies) require the `encoding_format` parameter to be explicitly specified. OpenAI's official API supports this parameter with `"float"` as the default value.

  Without this parameter, these services return:
  Error: 'encoding_format' only support with [float, base64]

  ## Changes
  - `src/memory/embeddings-remote-provider.ts`: Add `encoding_format: "float"` to request body

  ## Test plan
  - [x] Type check passes
  - [x] Lint passes
  - [x] All embedding tests pass (39 tests)

  Co-Authored-By: Claude <noreply@anthropic.com>