### PR TITLE
fix(discord): preserve content-type in media uploads and skip WebP optimization

### DIFF
--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -1774,7 +1774,10 @@ async function deliverDiscordInteractionReply(params: {
   const text = payload.text ?? "";
 
   let hasReplied = false;
-  const sendMessage = async (content: string, files?: { name: string; data: Buffer }[]) => {
+  const sendMessage = async (
+    content: string,
+    files?: { name: string; data: Buffer; contentType?: string }[],
+  ) => {
     const payload =
       files && files.length > 0
         ? {
@@ -1784,7 +1787,14 @@ async function deliverDiscordInteractionReply(params: {
                 return { name: file.name, data: file.data };
               }
               const arrayBuffer = Uint8Array.from(file.data).buffer;
-              return { name: file.name, data: new Blob([arrayBuffer]) };
+              // Preserve the original content-type so Discord receives the correct MIME type.
+              return {
+                name: file.name,
+                data: new Blob(
+                  [arrayBuffer],
+                  file.contentType ? { type: file.contentType } : undefined,
+                ),
+              };
             }),
           }
         : { content };
@@ -1808,6 +1818,7 @@ async function deliverDiscordInteractionReply(params: {
         return {
           name: loaded.fileName ?? "upload",
           data: loaded.buffer,
+          contentType: loaded.contentType,
         };
       }),
     );

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -103,7 +103,7 @@ export async function sendDiscordComponentMessage(
         `Component file block expects attachment "${expectedAttachmentName}", but the uploaded file is "${fileName}". Update components.blocks[].file or provide a matching filename.`,
       );
     }
-    const fileData = toDiscordFileBlob(media.buffer);
+    const fileData = toDiscordFileBlob(media.buffer, media.contentType);
     files = [{ data: fileData, name: fileName }];
   } else if (expectedAttachmentName) {
     throw new Error(

--- a/extensions/discord/src/send.shared.test.ts
+++ b/extensions/discord/src/send.shared.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { toDiscordFileBlob } from "./send.shared.js";
+
+describe("toDiscordFileBlob", () => {
+  it("returns the same Blob when input is already a Blob", () => {
+    const blob = new Blob(["hello"], { type: "image/png" });
+    const result = toDiscordFileBlob(blob);
+    expect(result).toBe(blob);
+    expect(result.type).toBe("image/png");
+  });
+
+  it("converts Uint8Array to Blob with content-type preserved", () => {
+    const data = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const result = toDiscordFileBlob(data, "image/png");
+    expect(result).toBeInstanceOf(Blob);
+    expect(result.type).toBe("image/png");
+    expect(result.size).toBe(4);
+  });
+
+  it("converts Uint8Array to Blob without content-type when omitted", () => {
+    const data = new Uint8Array([0x00, 0x01]);
+    const result = toDiscordFileBlob(data);
+    expect(result).toBeInstanceOf(Blob);
+    expect(result.type).toBe("");
+    expect(result.size).toBe(2);
+  });
+
+  it("preserves WebP content-type", () => {
+    const data = new Uint8Array([0x52, 0x49, 0x46, 0x46]); // RIFF header
+    const result = toDiscordFileBlob(data, "image/webp");
+    expect(result.type).toBe("image/webp");
+  });
+
+  it("preserves GIF content-type", () => {
+    const data = new Uint8Array([0x47, 0x49, 0x46]); // GIF header
+    const result = toDiscordFileBlob(data, "image/gif");
+    expect(result.type).toBe("image/gif");
+  });
+});

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -348,13 +348,14 @@ export function stripUndefinedFields<T extends object>(value: T): T {
   return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T;
 }
 
-export function toDiscordFileBlob(data: Blob | Uint8Array): Blob {
+export function toDiscordFileBlob(data: Blob | Uint8Array, contentType?: string): Blob {
   if (data instanceof Blob) {
     return data;
   }
   const arrayBuffer = new ArrayBuffer(data.byteLength);
   new Uint8Array(arrayBuffer).set(data);
-  return new Blob([arrayBuffer]);
+  // Preserve the original content-type so Discord receives the correct MIME type.
+  return new Blob([arrayBuffer], contentType ? { type: contentType } : undefined);
 }
 
 async function sendDiscordText(
@@ -436,7 +437,7 @@ async function sendDiscordMedia(
   const caption = chunks[0] ?? "";
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
   const flags = silent ? SUPPRESS_NOTIFICATIONS_FLAG : undefined;
-  const fileData = toDiscordFileBlob(media.buffer);
+  const fileData = toDiscordFileBlob(media.buffer, media.contentType);
   const captionComponents = resolveDiscordSendComponents({
     components,
     text: caption,

--- a/extensions/whatsapp/src/media.test.ts
+++ b/extensions/whatsapp/src/media.test.ts
@@ -345,6 +345,63 @@ describe("web media loading", () => {
     expect(result.contentType).toBe("image/jpeg");
     expect(result.buffer.length).toBeLessThanOrEqual(fallbackPngCap);
   });
+
+  it("preserves WebP from URL without JPEG conversion", async () => {
+    // Minimal valid WebP (1x1 lossy) generated via sharp.
+    const webpBuffer = await sharp({
+      create: { width: 1, height: 1, channels: 3, background: "#ff0000" },
+    })
+      .webp()
+      .toBuffer();
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+      ok: true,
+      body: true,
+      arrayBuffer: async () =>
+        webpBuffer.buffer.slice(
+          webpBuffer.byteOffset,
+          webpBuffer.byteOffset + webpBuffer.byteLength,
+        ),
+      headers: { get: () => "image/webp" },
+      status: 200,
+    } as unknown as Response);
+
+    const result = await loadWebMedia("https://example.com/sticker.webp", 1024 * 1024);
+
+    expect(result.kind).toBe("image");
+    expect(result.contentType).toBe("image/webp");
+    // WebP magic: starts with "RIFF"
+    expect(result.buffer.slice(0, 4).toString()).toBe("RIFF");
+
+    fetchMock.mockRestore();
+  });
+
+  it("preserves WebP from local file without optimization", async () => {
+    const webpBuffer = await sharp({
+      create: { width: 10, height: 10, channels: 3, background: "#0000ff" },
+    })
+      .webp()
+      .toBuffer();
+    const webpFile = await writeTempFile(webpBuffer, ".webp");
+
+    const result = await loadWebMedia(webpFile, 1024 * 1024);
+
+    expect(result.kind).toBe("image");
+    expect(result.contentType).toBe("image/webp");
+    // Buffer should be unchanged (no optimization applied).
+    expect(result.buffer.length).toBe(webpBuffer.length);
+  });
+
+  it("throws descriptive error when WebP exceeds size cap", async () => {
+    const webpBuffer = await sharp({
+      create: { width: 10, height: 10, channels: 3, background: "#0000ff" },
+    })
+      .webp()
+      .toBuffer();
+    const webpFile = await writeTempFile(webpBuffer, ".webp");
+
+    await expect(loadWebMedia(webpFile, { maxBytes: 1 })).rejects.toThrow(/WebP exceeds/i);
+  });
 });
 
 describe("Discord voice message input hardening", () => {

--- a/extensions/whatsapp/src/media.ts
+++ b/extensions/whatsapp/src/media.ts
@@ -292,9 +292,13 @@ async function loadWebMediaInternal(
     const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind ?? "document");
     if (params.kind === "image") {
       const isGif = params.contentType === "image/gif";
-      if (isGif || !optimizeImages) {
+      // Skip optimization for GIF and WebP to preserve animation frames and format fidelity.
+      const isWebp = params.contentType === "image/webp";
+      if (isGif || isWebp || !optimizeImages) {
         if (params.buffer.length > cap) {
-          throw new Error(formatCapLimit(isGif ? "GIF" : "Media", cap, params.buffer.length));
+          throw new Error(
+            formatCapLimit(isGif ? "GIF" : isWebp ? "WebP" : "Media", cap, params.buffer.length),
+          );
         }
         return {
           buffer: params.buffer,


### PR DESCRIPTION
## Summary

- Problem: `toDiscordFileBlob()` creates `new Blob([arrayBuffer])` without a `type` parameter, so Discord receives all media uploads as `application/octet-stream`. Additionally, WebP images (including animated WebP) are passed through `optimizeImageToJpeg()`, converting them to JPEG and destroying animation frames and format fidelity.
- Why it matters: Discord cannot properly render media when content-type is missing, and animated WebP stickers/images lose their animation.
- What changed: (1) `toDiscordFileBlob()` now accepts an optional `contentType` parameter and passes it to the Blob constructor. All call sites (`send.shared.ts`, `send.components.ts`) now thread through `media.contentType`. (2) The same pattern in `native-command.ts` now also preserves content-type. (3) `image/webp` is now skipped alongside `image/gif` in the image optimization path in `media.ts`.
- What did NOT change (scope boundary): No changes to optimization logic for other image formats. GIF handling unchanged. No changes to the media fetch/download pipeline.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #41256

## User-visible / Behavior Changes

- Discord media uploads now carry the correct MIME content-type instead of `application/octet-stream`.
- Animated WebP images are no longer converted to static JPEG; they retain their original format and animation frames.
- WebP images that exceed the size cap now show "WebP exceeds ..." in the error message instead of the generic "Media exceeds ...".

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Integration/channel (if any): Discord

### Steps

1. Send an animated WebP image through Discord channel
2. Observe the uploaded file retains `.webp` format and animation
3. Send a PNG/JPEG through Discord and verify correct content-type header

### Expected

- Media uploads have correct content-type
- WebP images (including animated) are not converted to JPEG

### Actual

- Before fix: all uploads had `application/octet-stream`; WebP was converted to static JPEG

## Evidence

- [x] Failing test/log before + passing after
  - New test `src/discord/send.shared.test.ts`: verifies `toDiscordFileBlob` preserves content-type for PNG, WebP, GIF, and omits type when not provided
  - New tests in `src/web/media.test.ts`: verifies WebP is preserved from both URL and local file, GIF is preserved, and WebP over cap shows descriptive error

## Human Verification (required)

- Verified scenarios: all new and existing tests pass (32 tests across 2 files)
- Edge cases checked: Blob with no content-type (backwards compatible), WebP exceeding size cap error message
- What you did **not** verify: live Discord upload (no bot token in test env)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `src/discord/send.shared.ts`, `src/discord/send.components.ts`, `src/discord/monitor/native-command.ts`, `src/web/media.ts`
- Known bad symptoms reviewers should watch for: media upload failures on Discord

## Risks and Mitigations

- Risk: Some Discord API consumers may not expect a typed Blob where they previously received an untyped one.
  - Mitigation: Discord's API accepts typed Blobs; this aligns with the intended behavior. The `type` parameter is optional and falls back to empty string when omitted.