### PR TITLE
feat(sessions): JSONL transcript archival with configurable retention

### DIFF
--- a/src/config/sessions/archival.test.ts
+++ b/src/config/sessions/archival.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { archiveSessionTranscript } from "./archival.js";
 
 function makeSessionLine(role: string, content: string, seq: number): string {
-  return JSON.stringify({ role, content, seq });
+  return JSON.stringify({ message: { role, content }, seq });
 }
 
 function buildSessionFile(turnCount: number): string {
@@ -58,7 +58,10 @@ describe("archiveSessionTranscript", () => {
 
     // Verify exactly keepLastTurns user turns are retained
     const entries = lines.slice(2).map((l) => JSON.parse(l) as Record<string, unknown>);
-    const keptUserTurns = entries.filter((e) => e.role === "user");
+    const keptUserTurns = entries.filter((e) => {
+      const msg = e.message as Record<string, unknown> | undefined;
+      return msg?.role === "user";
+    });
     expect(keptUserTurns).toHaveLength(5);
   });
 
@@ -69,7 +72,7 @@ describe("archiveSessionTranscript", () => {
 
     const result = await archiveSessionTranscript({ sessionFile, keepLastTurns: 5 });
     expect(result.archived).toBe(true);
-    expect(result.archiveMarkerSeq).toBeGreaterThan(0);
+    expect(result.archiveMarkerLineIndex).toBeGreaterThan(0);
   });
 
   it("handles missing file gracefully", async () => {

--- a/src/config/sessions/archival.test.ts
+++ b/src/config/sessions/archival.test.ts
@@ -69,7 +69,7 @@ describe("archiveSessionTranscript", () => {
 
   it("handles missing file gracefully", async () => {
     const result = await archiveSessionTranscript({
-      sessionFile: "/tmp/nonexistent-session.jsonl",
+      sessionFile: path.join(os.tmpdir(), `nonexistent-session-${Date.now()}.jsonl`),
       keepLastTurns: 5,
     });
     expect(result.archived).toBe(false);

--- a/src/config/sessions/archival.test.ts
+++ b/src/config/sessions/archival.test.ts
@@ -55,6 +55,11 @@ describe("archiveSessionTranscript", () => {
     expect(marker.type).toBe("archive_marker");
     expect(marker.totalArchived).toBe(result.linesRemoved);
     expect(typeof marker.archivedAt).toBe("string");
+
+    // Verify exactly keepLastTurns user turns are retained
+    const entries = lines.slice(2).map((l) => JSON.parse(l) as Record<string, unknown>);
+    const keptUserTurns = entries.filter((e) => e.role === "user");
+    expect(keptUserTurns).toHaveLength(5);
   });
 
   it("inserts correct archive marker format", async () => {

--- a/src/config/sessions/archival.test.ts
+++ b/src/config/sessions/archival.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { archiveSessionTranscript } from "./archival.js";
+
+function makeSessionLine(role: string, content: string, seq: number): string {
+  return JSON.stringify({ role, content, seq });
+}
+
+function buildSessionFile(turnCount: number): string {
+  const lines: string[] = [JSON.stringify({ type: "session_header", version: 1 })];
+  for (let i = 0; i < turnCount; i++) {
+    lines.push(makeSessionLine("user", `Turn ${i + 1} question`, i * 3 + 1));
+    lines.push(makeSessionLine("assistant", `Turn ${i + 1} answer`, i * 3 + 2));
+    lines.push(makeSessionLine("toolResult", `Turn ${i + 1} tool`, i * 3 + 3));
+  }
+  return lines.join("\n") + "\n";
+}
+
+describe("archiveSessionTranscript", () => {
+  let tmpDir: string;
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips when total turns <= keepLastTurns", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "archival-test-"));
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    await fs.writeFile(sessionFile, buildSessionFile(5));
+
+    const result = await archiveSessionTranscript({ sessionFile, keepLastTurns: 10 });
+    expect(result.archived).toBe(false);
+  });
+
+  it("archives old turns and keeps last N", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "archival-test-"));
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    await fs.writeFile(sessionFile, buildSessionFile(20));
+
+    const result = await archiveSessionTranscript({ sessionFile, keepLastTurns: 5 });
+    expect(result.archived).toBe(true);
+    expect(result.linesRemoved).toBeGreaterThan(0);
+    expect(result.linesKept).toBeGreaterThan(0);
+
+    // Verify file structure: header + archive_marker + remaining messages
+    const raw = await fs.readFile(sessionFile, "utf-8");
+    const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+    const header = JSON.parse(lines[0]);
+    expect(header.type).toBe("session_header");
+    const marker = JSON.parse(lines[1]);
+    expect(marker.type).toBe("archive_marker");
+    expect(marker.totalArchived).toBe(result.linesRemoved);
+    expect(typeof marker.archivedAt).toBe("string");
+  });
+
+  it("inserts correct archive marker format", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "archival-test-"));
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    await fs.writeFile(sessionFile, buildSessionFile(10));
+
+    const result = await archiveSessionTranscript({ sessionFile, keepLastTurns: 5 });
+    expect(result.archived).toBe(true);
+    expect(result.archiveMarkerSeq).toBeGreaterThan(0);
+  });
+
+  it("handles missing file gracefully", async () => {
+    const result = await archiveSessionTranscript({
+      sessionFile: "/tmp/nonexistent-session.jsonl",
+      keepLastTurns: 5,
+    });
+    expect(result.archived).toBe(false);
+  });
+
+  it("preserves file integrity with atomic write", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "archival-test-"));
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    await fs.writeFile(sessionFile, buildSessionFile(15));
+
+    await archiveSessionTranscript({ sessionFile, keepLastTurns: 5 });
+
+    // Verify file is valid JSONL
+    const raw = await fs.readFile(sessionFile, "utf-8");
+    const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+});

--- a/src/config/sessions/archival.ts
+++ b/src/config/sessions/archival.ts
@@ -34,8 +34,11 @@ export async function archiveSessionTranscript(params: ArchivalParams): Promise<
   let raw: string;
   try {
     raw = await fs.readFile(sessionFile, "utf-8");
-  } catch {
-    return noArchival;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return noArchival;
+    }
+    throw err;
   }
 
   const lines = raw.split("\n").filter((line) => line.trim().length > 0);

--- a/src/config/sessions/archival.ts
+++ b/src/config/sessions/archival.ts
@@ -3,15 +3,13 @@ import fs from "node:fs/promises";
 export type ArchivalParams = {
   sessionFile: string;
   keepLastTurns: number;
-  /** If true, verify entries are synced before archiving. No-op without DB entry sync. */
-  verifyEntrySynced?: boolean;
 };
 
 export type ArchivalResult = {
   archived: boolean;
   linesRemoved: number;
   linesKept: number;
-  archiveMarkerSeq: number;
+  archiveMarkerLineIndex: number;
 };
 
 /**
@@ -28,7 +26,7 @@ export async function archiveSessionTranscript(params: ArchivalParams): Promise<
     archived: false,
     linesRemoved: 0,
     linesKept: 0,
-    archiveMarkerSeq: 0,
+    archiveMarkerLineIndex: 0,
   };
 
   let raw: string;
@@ -51,7 +49,8 @@ export async function archiveSessionTranscript(params: ArchivalParams): Promise<
   for (let i = 1; i < lines.length; i++) {
     try {
       const parsed = JSON.parse(lines[i]);
-      if (parsed && typeof parsed === "object" && parsed.role === "user") {
+      const msg = parsed?.message;
+      if (msg && typeof msg === "object" && (msg as Record<string, unknown>).role === "user") {
         turnStartIndices.push(i);
       }
     } catch {
@@ -72,21 +71,34 @@ export async function archiveSessionTranscript(params: ArchivalParams): Promise<
 
   const header = lines[0];
   const keptLines = lines.slice(cutLineIndex);
-  const removedCount = cutLineIndex - 1; // exclude header from count
+
+  // Count removed entries, excluding any prior archive markers
+  let removedCount = 0;
+  for (let i = 1; i < cutLineIndex; i++) {
+    try {
+      const p = JSON.parse(lines[i]);
+      if (p && typeof p === "object" && (p as Record<string, unknown>).type !== "archive_marker") {
+        removedCount++;
+      }
+    } catch {
+      removedCount++; // count malformed lines as removed entries
+    }
+  }
 
   const archiveMarker = JSON.stringify({
     type: "archive_marker",
-    archivedBeforeSeq: cutLineIndex,
+    archivedBeforeLineIndex: cutLineIndex,
     archivedAt: new Date().toISOString(),
     totalArchived: removedCount,
   });
 
   const newContent = [header, archiveMarker, ...keptLines].join("\n") + "\n";
 
-  // Atomic write: temp file + rename
+  // Atomic write: temp file + rename (preserve original permissions)
+  const stat = await fs.stat(sessionFile);
   const tmpFile = `${sessionFile}.archival-${Date.now()}.tmp`;
   try {
-    await fs.writeFile(tmpFile, newContent, "utf-8");
+    await fs.writeFile(tmpFile, newContent, { encoding: "utf-8", mode: stat.mode });
     await fs.rename(tmpFile, sessionFile);
   } catch (err) {
     // Clean up temp file on failure
@@ -102,6 +114,6 @@ export async function archiveSessionTranscript(params: ArchivalParams): Promise<
     archived: true,
     linesRemoved: removedCount,
     linesKept: keptLines.length,
-    archiveMarkerSeq: cutLineIndex,
+    archiveMarkerLineIndex: cutLineIndex,
   };
 }

--- a/src/config/sessions/archival.ts
+++ b/src/config/sessions/archival.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs/promises";
+
+export type ArchivalParams = {
+  sessionFile: string;
+  keepLastTurns: number;
+  /** If true, verify entries are synced before archiving. No-op without DB entry sync. */
+  verifyEntrySynced?: boolean;
+};
+
+export type ArchivalResult = {
+  archived: boolean;
+  linesRemoved: number;
+  linesKept: number;
+  archiveMarkerSeq: number;
+};
+
+/**
+ * Archive old turns from a JSONL session file, keeping only the last N turns.
+ *
+ * A "turn" starts at each user message. The function preserves the session
+ * header (line 0) and inserts an archive marker after archival.
+ *
+ * File replacement is atomic (write to temp file, then rename).
+ */
+export async function archiveSessionTranscript(params: ArchivalParams): Promise<ArchivalResult> {
+  const { sessionFile, keepLastTurns } = params;
+  const noArchival: ArchivalResult = {
+    archived: false,
+    linesRemoved: 0,
+    linesKept: 0,
+    archiveMarkerSeq: 0,
+  };
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(sessionFile, "utf-8");
+  } catch {
+    return noArchival;
+  }
+
+  const lines = raw.split("\n").filter((line) => line.trim().length > 0);
+  if (lines.length < 2) {
+    return noArchival;
+  }
+
+  // Count turns — a turn starts at each user message
+  const turnStartIndices: number[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    try {
+      const parsed = JSON.parse(lines[i]);
+      if (parsed && typeof parsed === "object" && parsed.role === "user") {
+        turnStartIndices.push(i);
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  if (turnStartIndices.length <= keepLastTurns) {
+    return noArchival;
+  }
+
+  // Find the cut point: keep last N turns
+  const cutTurnIndex = turnStartIndices.length - keepLastTurns;
+  const cutLineIndex = turnStartIndices[cutTurnIndex];
+  if (cutLineIndex === undefined || cutLineIndex <= 0) {
+    return noArchival;
+  }
+
+  const header = lines[0];
+  const keptLines = lines.slice(cutLineIndex);
+  const removedCount = cutLineIndex - 1; // exclude header from count
+
+  const archiveMarker = JSON.stringify({
+    type: "archive_marker",
+    archivedBeforeSeq: cutLineIndex,
+    archivedAt: new Date().toISOString(),
+    totalArchived: removedCount,
+  });
+
+  const newContent = [header, archiveMarker, ...keptLines].join("\n") + "\n";
+
+  // Atomic write: temp file + rename
+  const tmpFile = `${sessionFile}.archival-${Date.now()}.tmp`;
+  try {
+    await fs.writeFile(tmpFile, newContent, "utf-8");
+    await fs.rename(tmpFile, sessionFile);
+  } catch (err) {
+    // Clean up temp file on failure
+    try {
+      await fs.unlink(tmpFile);
+    } catch {
+      // ignore cleanup failure
+    }
+    throw err;
+  }
+
+  return {
+    archived: true,
+    linesRemoved: removedCount,
+    linesKept: keptLines.length,
+    archiveMarkerSeq: cutLineIndex,
+  };
+}

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -140,6 +140,13 @@ export const SessionSchema = z
         }
       })
       .optional(),
+    archival: z
+      .object({
+        enabled: z.boolean().optional(),
+        keepLastTurns: z.number().int().min(5).max(100).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- Add `archiveSessionTranscript()` function that trims old turns from JSONL session files, keeping the last N user turns
- Uses atomic file replacement (write to temp + rename) to prevent data corruption
- Inserts an `archive_marker` entry with metadata about removed entries for auditability
- Configurable via `session.archival` in config:
  ```yaml
  session:
    archival:
      enabled: true
      keepLastTurns: 15  # range: 5–100
  ```

## Motivation

Long-running sessions accumulate large JSONL transcript files that grow unbounded. This is especially problematic for always-on agents with frequent heartbeats or automated interactions. Archival provides a simple, safe way to trim old turns while preserving the most recent conversation context.

The function is designed to be called from plugin hooks (e.g. `agent_end`) so extensions can control when archival happens based on their own criteria (e.g. after DB sync, after a certain number of turns, etc.).

## Design decisions

- **Turn-based retention** (not line-based): a "turn" starts at each user message, so multi-message assistant responses and tool results stay grouped with their turn
- **Atomic writes**: temp file + rename prevents partial writes on crash
- **Archive marker**: inserted after the session header so downstream tools can detect that archival occurred and know how many entries were removed
- **Fire-and-forget safe**: returns a result object rather than throwing on non-critical errors (e.g. missing file)
- **No dependency on DB or external services**: operates purely on the JSONL file

## Test plan

- [x] 5 unit tests covering: skip when under threshold, archive and verify structure, marker format, missing file handling, atomic write integrity
- [x] Retention count assertion verifying exactly `keepLastTurns` user turns are kept
- [x] Tests use OS temp directories for isolation