### PR TITLE
feat(plugins): pluggable session store adapter via plugin API

### DIFF
--- a/extensions/diffs/index.test.ts
+++ b/extensions/diffs/index.test.ts
@@ -31,6 +31,7 @@ describe("diffs plugin registration", () => {
       registerProvider() {},
       registerCommand() {},
       registerContextEngine() {},
+      registerSessionStoreAdapter() {},
       resolvePath(input: string) {
         return input;
       },
@@ -107,6 +108,7 @@ describe("diffs plugin registration", () => {
       registerProvider() {},
       registerCommand() {},
       registerContextEngine() {},
+      registerSessionStoreAdapter() {},
       resolvePath(input: string) {
         return input;
       },

--- a/extensions/diffs/src/tool.test.ts
+++ b/extensions/diffs/src/tool.test.ts
@@ -415,6 +415,7 @@ function createApi(): OpenClawPluginApi {
     registerProvider() {},
     registerCommand() {},
     registerContextEngine() {},
+    registerSessionStoreAdapter() {},
     resolvePath(input: string) {
       return input;
     },

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -47,10 +47,11 @@ function fakeApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi 
     registerHttpRoute() {},
     registerCommand() {},
     registerContextEngine() {},
+    registerSessionStoreAdapter() {},
     on() {},
     resolvePath: (p) => p,
     ...overrides,
-  };
+  } as OpenClawPluginApi;
 }
 
 function fakeCtx(overrides: Partial<OpenClawPluginToolContext> = {}): OpenClawPluginToolContext {

--- a/extensions/phone-control/index.test.ts
+++ b/extensions/phone-control/index.test.ts
@@ -41,6 +41,7 @@ function createApi(params: {
     registerProvider() {},
     registerContextEngine() {},
     registerCommand: params.registerCommand,
+    registerSessionStoreAdapter() {},
     resolvePath(input: string) {
       return input;
     },

--- a/src/config/sessions/adapter.ts
+++ b/src/config/sessions/adapter.ts
@@ -1,0 +1,23 @@
+import type { SessionEntry } from "./types.js";
+
+/**
+ * Abstract interface for session store persistence.
+ *
+ * Implementations handle the physical storage of session entries.
+ * The default implementation uses the local filesystem; an "external"
+ * adapter can delegate to a remote store (e.g. database or API).
+ */
+export type SessionStoreAdapter = {
+  /** Load a single session entry by key. Returns undefined if not found. */
+  load(sessionKey: string): SessionEntry | undefined;
+  /** Persist a single session entry. */
+  save(sessionKey: string, entry: SessionEntry): Promise<void>;
+  /** List all known session keys. */
+  list(): string[];
+  /** Remove a session entry by key. */
+  delete(sessionKey: string): Promise<void>;
+  /** Efficient bulk read. If provided, used instead of iterating list()+load(). */
+  toRecord?(): Record<string, SessionEntry>;
+  /** Pre-populate adapter cache on activation. */
+  warmCache?(): Promise<void>;
+};

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -16,6 +16,7 @@ import {
   type DeliveryContext,
 } from "../../utils/delivery-context.js";
 import { getFileStatSnapshot, isCacheEnabled, resolveCacheTtlMs } from "../cache-utils.js";
+import type { SessionStoreAdapter } from "./adapter.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
 import {
@@ -44,6 +45,29 @@ import {
 } from "./types.js";
 
 const log = createSubsystemLogger("sessions/store");
+
+// ============================================================================
+// Plugin Session Store Adapter
+// ============================================================================
+
+let pluginAdapterConfig: {
+  adapter: SessionStoreAdapter;
+  storePath: string;
+} | null = null;
+
+export async function activatePluginSessionStoreAdapter(params: {
+  adapter: SessionStoreAdapter;
+  storePath: string;
+}): Promise<void> {
+  pluginAdapterConfig = { adapter: params.adapter, storePath: params.storePath };
+  if (params.adapter.warmCache) {
+    await params.adapter.warmCache();
+  }
+}
+
+export function clearPluginSessionStoreAdapter(): void {
+  pluginAdapterConfig = null;
+}
 
 // ============================================================================
 // Session Store Cache with TTL Support
@@ -196,6 +220,21 @@ export function loadSessionStore(
   storePath: string,
   opts: LoadSessionStoreOptions = {},
 ): Record<string, SessionEntry> {
+  if (pluginAdapterConfig && storePath === pluginAdapterConfig.storePath) {
+    const adapter = pluginAdapterConfig.adapter;
+    if (adapter.toRecord) {
+      return structuredClone(adapter.toRecord());
+    }
+    const store: Record<string, SessionEntry> = {};
+    for (const key of adapter.list()) {
+      const entry = adapter.load(key);
+      if (entry) {
+        store[key] = entry;
+      }
+    }
+    return structuredClone(store);
+  }
+
   // Check cache first if enabled
   if (!opts.skipCache && isSessionStoreCacheEnabled()) {
     const currentFileStat = getFileStatSnapshot(storePath);
@@ -505,6 +544,12 @@ async function saveSessionStoreUnlocked(
     }
 
     throw err;
+  }
+
+  if (pluginAdapterConfig && storePath === pluginAdapterConfig.storePath) {
+    const adapter = pluginAdapterConfig.adapter;
+    const saves = Object.entries(store).map(([key, entry]) => adapter.save(key, entry));
+    await Promise.allSettled(saves);
   }
 }
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -59,10 +59,10 @@ export async function activatePluginSessionStoreAdapter(params: {
   adapter: SessionStoreAdapter;
   storePath: string;
 }): Promise<void> {
-  pluginAdapterConfig = { adapter: params.adapter, storePath: params.storePath };
   if (params.adapter.warmCache) {
     await params.adapter.warmCache();
   }
+  pluginAdapterConfig = { adapter: params.adapter, storePath: params.storePath };
 }
 
 export function clearPluginSessionStoreAdapter(): void {
@@ -549,7 +549,11 @@ async function saveSessionStoreUnlocked(
   if (pluginAdapterConfig && storePath === pluginAdapterConfig.storePath) {
     const adapter = pluginAdapterConfig.adapter;
     const saves = Object.entries(store).map(([key, entry]) => adapter.save(key, entry));
-    await Promise.allSettled(saves);
+    const results = await Promise.allSettled(saves);
+    const failed = results.filter((r) => r.status === "rejected");
+    if (failed.length > 0) {
+      log.warn(`plugin adapter sync: ${failed.length}/${results.length} save(s) failed`);
+    }
   }
 }
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -553,11 +553,15 @@ async function saveSessionStoreUnlocked(
 
   if (pluginAdapterConfig && storePath === pluginAdapterConfig.storePath) {
     const adapter = pluginAdapterConfig.adapter;
+    const adapterKeys = new Set(adapter.list());
+    const storeKeys = new Set(Object.keys(store));
+
+    const deletes = [...adapterKeys].filter((k) => !storeKeys.has(k)).map((k) => adapter.delete(k));
     const saves = Object.entries(store).map(([key, entry]) => adapter.save(key, entry));
-    const results = await Promise.allSettled(saves);
+    const results = await Promise.allSettled([...saves, ...deletes]);
     const failed = results.filter((r) => r.status === "rejected");
     if (failed.length > 0) {
-      log.warn(`plugin adapter sync: ${failed.length}/${results.length} save(s) failed`);
+      log.warn(`plugin adapter sync: ${failed.length}/${results.length} operation(s) failed`);
     }
   }
 }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -222,17 +222,22 @@ export function loadSessionStore(
 ): Record<string, SessionEntry> {
   if (pluginAdapterConfig && storePath === pluginAdapterConfig.storePath) {
     const adapter = pluginAdapterConfig.adapter;
+    let store: Record<string, SessionEntry>;
     if (adapter.toRecord) {
-      return structuredClone(adapter.toRecord());
-    }
-    const store: Record<string, SessionEntry> = {};
-    for (const key of adapter.list()) {
-      const entry = adapter.load(key);
-      if (entry) {
-        store[key] = entry;
+      store = structuredClone(adapter.toRecord());
+    } else {
+      store = {};
+      for (const key of adapter.list()) {
+        const entry = adapter.load(key);
+        if (entry) {
+          store[key] = entry;
+        }
       }
+      store = structuredClone(store);
     }
-    return structuredClone(store);
+    applySessionStoreMigrations(store);
+    normalizeSessionStore(store);
+    return store;
   }
 
   // Check cache first if enabled

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -552,16 +552,22 @@ async function saveSessionStoreUnlocked(
   }
 
   if (pluginAdapterConfig && storePath === pluginAdapterConfig.storePath) {
-    const adapter = pluginAdapterConfig.adapter;
-    const adapterKeys = new Set(adapter.list());
-    const storeKeys = new Set(Object.keys(store));
+    try {
+      const adapter = pluginAdapterConfig.adapter;
+      const adapterKeys = new Set(adapter.list());
+      const storeKeys = new Set(Object.keys(store));
 
-    const deletes = [...adapterKeys].filter((k) => !storeKeys.has(k)).map((k) => adapter.delete(k));
-    const saves = Object.entries(store).map(([key, entry]) => adapter.save(key, entry));
-    const results = await Promise.allSettled([...saves, ...deletes]);
-    const failed = results.filter((r) => r.status === "rejected");
-    if (failed.length > 0) {
-      log.warn(`plugin adapter sync: ${failed.length}/${results.length} operation(s) failed`);
+      const deletes = [...adapterKeys]
+        .filter((k) => !storeKeys.has(k))
+        .map((k) => adapter.delete(k));
+      const saves = Object.entries(store).map(([key, entry]) => adapter.save(key, entry));
+      const results = await Promise.allSettled([...saves, ...deletes]);
+      const failed = results.filter((r) => r.status === "rejected");
+      if (failed.length > 0) {
+        log.warn(`plugin adapter sync: ${failed.length}/${results.length} operation(s) failed`);
+      }
+    } catch (err) {
+      log.warn("plugin adapter sync failed", { error: err });
     }
   }
 }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -69,6 +69,30 @@ export function clearPluginSessionStoreAdapter(): void {
   pluginAdapterConfig = null;
 }
 
+async function syncPluginAdapter(
+  storePath: string,
+  store: Record<string, SessionEntry>,
+): Promise<void> {
+  if (!pluginAdapterConfig || storePath !== pluginAdapterConfig.storePath) {
+    return;
+  }
+  try {
+    const adapter = pluginAdapterConfig.adapter;
+    const adapterKeys = new Set(adapter.list());
+    const storeKeys = new Set(Object.keys(store));
+
+    const deletes = [...adapterKeys].filter((k) => !storeKeys.has(k)).map((k) => adapter.delete(k));
+    const saves = Object.entries(store).map(([key, entry]) => adapter.save(key, entry));
+    const results = await Promise.allSettled([...saves, ...deletes]);
+    const failed = results.filter((r) => r.status === "rejected");
+    if (failed.length > 0) {
+      log.warn(`plugin adapter sync: ${failed.length}/${results.length} operation(s) failed`);
+    }
+  } catch (err) {
+    log.warn("plugin adapter sync failed", { error: err });
+  }
+}
+
 // ============================================================================
 // Session Store Cache with TTL Support
 // ============================================================================
@@ -502,6 +526,7 @@ async function saveSessionStoreUnlocked(
   const json = JSON.stringify(store, null, 2);
   if (getSerializedSessionStore(storePath) === json) {
     updateSessionStoreWriteCaches({ storePath, store, serialized: json });
+    await syncPluginAdapter(storePath, store);
     return;
   }
 
@@ -510,6 +535,7 @@ async function saveSessionStoreUnlocked(
     for (let i = 0; i < 5; i++) {
       try {
         await writeSessionStoreAtomic({ storePath, store, serialized: json });
+        await syncPluginAdapter(storePath, store);
         return;
       } catch (err) {
         const code = getErrorCode(err);
@@ -551,25 +577,7 @@ async function saveSessionStoreUnlocked(
     throw err;
   }
 
-  if (pluginAdapterConfig && storePath === pluginAdapterConfig.storePath) {
-    try {
-      const adapter = pluginAdapterConfig.adapter;
-      const adapterKeys = new Set(adapter.list());
-      const storeKeys = new Set(Object.keys(store));
-
-      const deletes = [...adapterKeys]
-        .filter((k) => !storeKeys.has(k))
-        .map((k) => adapter.delete(k));
-      const saves = Object.entries(store).map(([key, entry]) => adapter.save(key, entry));
-      const results = await Promise.allSettled([...saves, ...deletes]);
-      const failed = results.filter((r) => r.status === "rejected");
-      if (failed.length > 0) {
-        log.warn(`plugin adapter sync: ${failed.length}/${results.length} operation(s) failed`);
-      }
-    } catch (err) {
-      log.warn("plugin adapter sync failed", { error: err });
-    }
-  }
+  await syncPluginAdapter(storePath, store);
 }
 
 export async function saveSessionStore(

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -115,6 +115,7 @@ export type SessionConfig = {
   /** Channel-specific reset overrides (e.g. { discord: { mode: "idle", idleMinutes: 10080 } }). */
   resetByChannel?: Record<string, SessionResetConfig>;
   store?: string;
+  storeAdapter?: "filesystem" | "external" | "plugin";
   typingIntervalSeconds?: number;
   typingMode?: TypingMode;
   /**

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -50,6 +50,7 @@ export const SessionSchema = z
       .optional(),
     resetByChannel: z.record(z.string(), SessionResetConfigSchema).optional(),
     store: z.string().optional(),
+    storeAdapter: z.enum(["filesystem", "external", "plugin"]).optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),
     typingMode: TypingModeSchema.optional(),
     parentForkMaxTokens: z.number().int().nonnegative().optional(),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -21,6 +21,8 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { activatePluginSessionStoreAdapter } from "../config/sessions/store.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -46,7 +48,7 @@ import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
-import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { createEmptyPluginRegistry, getPluginSessionStoreAdapter } from "../plugins/registry.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
@@ -476,6 +478,14 @@ export async function startGatewayServer(
         coreGatewayHandlers,
         baseMethods,
       });
+
+  // Plugin session store adapter: activate if a plugin registered one.
+  const pluginStoreAdapter = getPluginSessionStoreAdapter();
+  if (pluginStoreAdapter && cfgAtStart.session?.storeAdapter === "plugin") {
+    const storePath = resolveStorePath(cfgAtStart.session?.store, { agentId: defaultAgentId });
+    await activatePluginSessionStoreAdapter({ adapter: pluginStoreAdapter, storePath });
+  }
+
   const channelLogs = Object.fromEntries(
     listChannelPlugins().map((plugin) => [plugin.id, logChannels.child(plugin.id)]),
   ) as Record<ChannelId, ReturnType<typeof createSubsystemLogger>>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -481,7 +481,12 @@ export async function startGatewayServer(
 
   // Plugin session store adapter: activate if a plugin registered one.
   const pluginStoreAdapter = getPluginSessionStoreAdapter();
-  if (pluginStoreAdapter && cfgAtStart.session?.storeAdapter === "plugin") {
+  if (cfgAtStart.session?.storeAdapter === "plugin") {
+    if (!pluginStoreAdapter) {
+      throw new Error(
+        'session.storeAdapter is "plugin" but no plugin registered a session store adapter',
+      );
+    }
     const storePath = resolveStorePath(cfgAtStart.session?.store, { agentId: defaultAgentId });
     await activatePluginSessionStoreAdapter({ adapter: pluginStoreAdapter, storePath });
   }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -22,7 +22,10 @@ import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { activatePluginSessionStoreAdapter } from "../config/sessions/store.js";
+import {
+  activatePluginSessionStoreAdapter,
+  clearPluginSessionStoreAdapter,
+} from "../config/sessions/store.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -479,7 +482,9 @@ export async function startGatewayServer(
         baseMethods,
       });
 
-  // Plugin session store adapter: activate if a plugin registered one.
+  // Plugin session store adapter: clear stale state from any prior lifecycle,
+  // then activate if a plugin registered one for this startup.
+  clearPluginSessionStoreAdapter();
   const pluginStoreAdapter = getPluginSessionStoreAdapter();
   if (cfgAtStart.session?.storeAdapter === "plugin") {
     if (!pluginStoreAdapter) {

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -129,6 +129,8 @@ export type { OpenClawConfig } from "../config/config.js";
 /** @deprecated Use OpenClawConfig instead */
 export type { OpenClawConfig as ClawdbotConfig } from "../config/config.js";
 export { isDangerousNameMatchingEnabled } from "../config/dangerous-name-matching.js";
+export type { SessionStoreAdapter } from "../config/sessions/adapter.js";
+export type { SessionEntry } from "../config/sessions/types.js";
 
 export type { FileLockHandle, FileLockOptions } from "./file-lock.js";
 export { acquireFileLock, withFileLock } from "./file-lock.js";

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -173,6 +173,7 @@ const constrainLegacyPromptInjectionHook = (
 };
 
 export function createEmptyPluginRegistry(): PluginRegistry {
+  pluginSessionStoreAdapter = null;
   return {
     plugins: [],
     tools: [],
@@ -190,6 +191,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
 }
 
 export function createPluginRegistry(registryParams: PluginRegistryParams) {
+  pluginSessionStoreAdapter = null;
   const registry = createEmptyPluginRegistry();
   const coreGatewayMethods = new Set(Object.keys(registryParams.coreGatewayHandlers ?? {}));
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -3,6 +3,7 @@ import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelDock } from "../channels/dock.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { registerContextEngine } from "../context-engine/registry.js";
+import type { SessionStoreAdapter } from "../config/sessions/adapter.js";
 import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
@@ -42,6 +43,12 @@ import type {
   PluginHookHandlerMap,
   PluginHookRegistration as TypedPluginHookRegistration,
 } from "./types.js";
+
+let pluginSessionStoreAdapter: SessionStoreAdapter | null = null;
+
+export function getPluginSessionStoreAdapter(): SessionStoreAdapter | null {
+  return pluginSessionStoreAdapter;
+}
 
 export type PluginToolRegistration = {
   pluginId: string;
@@ -601,6 +608,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerService: (service) => registerService(record, service),
       registerCommand: (command) => registerCommand(record, command),
       registerContextEngine: (id, factory) => registerContextEngine(id, factory),
+      registerSessionStoreAdapter: (adapter) => {
+        pluginSessionStoreAdapter = adapter;
+      },
       resolvePath: (input: string) => resolveUserPath(input),
       on: (hookName, handler, opts) =>
         registerTypedHook(record, hookName, handler, opts, params.hookPolicy),

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2,8 +2,8 @@ import path from "node:path";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelDock } from "../channels/dock.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
-import { registerContextEngine } from "../context-engine/registry.js";
 import type { SessionStoreAdapter } from "../config/sessions/adapter.js";
+import { registerContextEngine } from "../context-engine/registry.js";
 import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
@@ -609,6 +609,14 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerCommand: (command) => registerCommand(record, command),
       registerContextEngine: (id, factory) => registerContextEngine(id, factory),
       registerSessionStoreAdapter: (adapter) => {
+        if (pluginSessionStoreAdapter) {
+          pushDiagnostic({
+            level: "warn",
+            pluginId: record.id,
+            source: record.source,
+            message: "session store adapter already registered; overriding previous adapter",
+          });
+        }
         pluginSessionStoreAdapter = adapter;
       },
       resolvePath: (input: string) => resolveUserPath(input),

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -8,6 +8,7 @@ import type { ChannelDock } from "../channels/dock.js";
 import type { ChannelId, ChannelPlugin } from "../channels/plugins/types.js";
 import type { createVpsAwareOAuthHandlers } from "../commands/oauth-flow.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { SessionStoreAdapter } from "../config/sessions/adapter.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import type { InternalHookHandler } from "../hooks/internal-hooks.js";
@@ -296,6 +297,8 @@ export type OpenClawPluginApi = {
     id: string,
     factory: import("../context-engine/registry.js").ContextEngineFactory,
   ) => void;
+  /** Register a custom session store adapter (e.g. Redis, DynamoDB). */
+  registerSessionStoreAdapter: (adapter: SessionStoreAdapter) => void;
   resolvePath: (input: string) => string;
   /** Register a lifecycle hook handler */
   on: <K extends PluginHookName>(


### PR DESCRIPTION
## Summary

- Add `registerSessionStoreAdapter()` to the plugin API, allowing plugins to provide custom session store backends
- New `SessionStoreAdapter` interface with `load`, `save`, `list`, `delete`, plus optional `toRecord()` (bulk read) and `warmCache()` (pre-populate on activation)
- When `session.storeAdapter: "plugin"`, reads are served from the plugin adapter and writes go to both filesystem and plugin adapter (write-through)
- Plugin adapter reads run standard migrations and normalization for consistent semantics regardless of backing store
- Fail-fast at gateway boot if `storeAdapter: "plugin"` but no plugin registered an adapter
- Diagnostic warning if multiple plugins attempt to register an adapter

## Motivation

The built-in session store uses a monolithic JSON file which becomes a bottleneck for deployments with many concurrent sessions. This PR provides the extension point for plugins to implement alternative backends (Redis, PostgreSQL, DynamoDB, etc.) without modifying core session management code.

The design preserves filesystem write-through as a safety net — the JSONL session files remain the source of truth for recovery, while the plugin adapter serves as the fast-path for reads.

## Design decisions

- **Write-through, not write-behind**: filesystem write always happens first, plugin adapter save is fire-and-forget at the end. This ensures session data is never lost even if the external store is temporarily unavailable.
- **Migrations on read**: plugin adapter reads run `applySessionStoreMigrations()` and `normalizeSessionStore()` since any backing store could return data that predates schema changes
- **Override warning**: if two plugins both try to register an adapter, a diagnostic warning is emitted (last registration wins)
- **Minimal interface**: the adapter interface is intentionally small — `load`/`save`/`list`/`delete` plus two optional methods. Complex features (caching, batching, connection pooling) are left to the adapter implementation.

## Files changed

- `src/config/sessions/adapter.ts` — new `SessionStoreAdapter` interface
- `src/config/sessions/store.ts` — plugin adapter routing in `loadSessionStore`/`saveSessionStoreUnlocked`, `activatePluginSessionStoreAdapter()`
- `src/plugins/types.ts` — `registerSessionStoreAdapter` on `OpenClawPluginApi`
- `src/plugins/registry.ts` — adapter registration storage + override warning
- `src/gateway/server.impl.ts` — plugin adapter activation after plugin load + fail-fast guard
- `src/config/types.base.ts` / `src/config/zod-schema.session.ts` — `"plugin"` added to `storeAdapter` enum
- `src/plugin-sdk/index.ts` — export `SessionStoreAdapter` and `SessionEntry` types
- 4 extension test mock updates (add `registerSessionStoreAdapter` to mock API)

## Test plan

- [x] Extension test mocks updated to include new API method
- [x] Verify gateway throws on boot when `storeAdapter: "plugin"` but no adapter registered
- [x] Verify plugin adapter reads return migrated + normalized data
- [x] Verify write-through: FS write completes before plugin adapter save
- [ ] Manual: install with a custom adapter plugin, verify read/write flow end-to-end