### PR TITLE
feat(plugins): add registerSearchProvider extension point for custom web search providers

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -20,6 +20,10 @@ import {
   resolveTimeoutSeconds,
   writeCache,
 } from "./web-shared.js";
+import {
+  getSearchProvider,
+  hasSearchProvider,
+} from "../../plugins/search-registry.js";
 
 const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
@@ -150,7 +154,7 @@ function normalizeToIsoDate(value: string): string | undefined {
 }
 
 function createWebSearchSchema(params: {
-  provider: (typeof SEARCH_PROVIDERS)[number];
+  provider: string;
   perplexityTransport?: PerplexityTransport;
 }) {
   const querySchema = {
@@ -490,7 +494,7 @@ function resolveSearchApiKey(search?: WebSearchConfig): string | undefined {
   return fromConfig || fromEnv || undefined;
 }
 
-function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
+function missingSearchKeyPayload(provider: string) {
   if (provider === "brave") {
     return {
       error: "missing_brave_api_key",
@@ -530,11 +534,17 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
   };
 }
 
-function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDERS)[number] {
+function resolveSearchProvider(search?: WebSearchConfig): string {
   const raw =
     search && "provider" in search && typeof search.provider === "string"
       ? search.provider.trim().toLowerCase()
       : "";
+
+  // Check plugin-registered providers first.
+  if (raw && hasSearchProvider(raw)) {
+    return raw;
+  }
+
   if (raw === "brave") {
     return "brave";
   }
@@ -1013,7 +1023,7 @@ function normalizeBraveLanguageParams(params: { search_lang?: string; ui_lang?: 
  */
 function normalizeFreshness(
   value: string | undefined,
-  provider: (typeof SEARCH_PROVIDERS)[number],
+  provider: string,
 ): string | undefined {
   if (!value) {
     return undefined;
@@ -1476,7 +1486,7 @@ async function runBraveLlmContextSearch(params: {
         method: "GET",
         headers: {
           Accept: "application/json",
-          "X-Subscription-Token": params.apiKey,
+          "X-Subscription-Token": params.apiKey!,
         },
       },
     },
@@ -1498,10 +1508,10 @@ async function runBraveLlmContextSearch(params: {
 async function runWebSearch(params: {
   query: string;
   count: number;
-  apiKey: string;
+  apiKey: string | undefined;
   timeoutSeconds: number;
   cacheTtlMs: number;
-  provider: (typeof SEARCH_PROVIDERS)[number];
+  provider: string;
   country?: string;
   language?: string;
   search_lang?: string;
@@ -1521,8 +1531,10 @@ async function runWebSearch(params: {
   kimiBaseUrl?: string;
   kimiModel?: string;
   braveMode?: "web" | "llm-context";
+  pluginSearchConfig?: Record<string, unknown>;
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
+  const pluginProvider = getSearchProvider(params.provider);
   const providerSpecificKey =
     params.provider === "perplexity"
       ? `${params.perplexityTransport ?? "search_api"}:${params.perplexityBaseUrl ?? PERPLEXITY_DIRECT_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
@@ -1532,7 +1544,9 @@ async function runWebSearch(params: {
           ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
           : params.provider === "kimi"
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-            : "";
+            : pluginProvider
+              ? (pluginProvider.cacheKeyExtra?.(params.pluginSearchConfig ?? {}) ?? "plugin")
+              : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
       ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
@@ -1545,11 +1559,61 @@ async function runWebSearch(params: {
 
   const start = Date.now();
 
+  // Check plugin-registered search providers first.
+  if (pluginProvider) {
+    const searchConfig = params.pluginSearchConfig ?? {};
+
+    const result = await pluginProvider.search(
+      {
+        query: params.query,
+        count: params.count,
+        timeoutSeconds: params.timeoutSeconds,
+        country: params.country,
+        language: params.language,
+        freshness: params.freshness,
+        dateAfter: params.dateAfter,
+        dateBefore: params.dateBefore,
+      },
+      searchConfig,
+    );
+
+    const payload: Record<string, unknown> = {
+      query: params.query,
+      provider: params.provider,
+      tookMs: Date.now() - start,
+    };
+
+    if (result.results) {
+      payload.count = result.results.length;
+      payload.results = result.results.map((entry) => ({
+        title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
+        url: entry.url,
+        description: entry.description ? wrapWebContent(entry.description, "web_search") : "",
+        siteName: entry.siteName ?? (entry.url ? resolveSiteName(entry.url) : undefined),
+      }));
+    }
+    if (result.content) {
+      payload.externalContent = {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      };
+      payload.content = wrapWebContent(result.content, "web_search");
+    }
+    if (result.citations) {
+      payload.citations = result.citations;
+    }
+
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   if (params.provider === "perplexity") {
     if (params.perplexityTransport === "chat_completions") {
       const { content, citations } = await runPerplexitySearch({
         query: params.query,
-        apiKey: params.apiKey,
+        apiKey: params.apiKey!,
         baseUrl: params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL,
         model: params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL,
         timeoutSeconds: params.timeoutSeconds,
@@ -1576,7 +1640,7 @@ async function runWebSearch(params: {
 
     const results = await runPerplexitySearchApi({
       query: params.query,
-      apiKey: params.apiKey,
+      apiKey: params.apiKey!,
       count: params.count,
       timeoutSeconds: params.timeoutSeconds,
       country: params.country,
@@ -1609,7 +1673,7 @@ async function runWebSearch(params: {
   if (params.provider === "grok") {
     const { content, citations, inlineCitations } = await runGrokSearch({
       query: params.query,
-      apiKey: params.apiKey,
+      apiKey: params.apiKey!,
       model: params.grokModel ?? DEFAULT_GROK_MODEL,
       timeoutSeconds: params.timeoutSeconds,
       inlineCitations: params.grokInlineCitations ?? false,
@@ -1637,7 +1701,7 @@ async function runWebSearch(params: {
   if (params.provider === "kimi") {
     const { content, citations } = await runKimiSearch({
       query: params.query,
-      apiKey: params.apiKey,
+      apiKey: params.apiKey!,
       baseUrl: params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL,
       model: params.kimiModel ?? DEFAULT_KIMI_MODEL,
       timeoutSeconds: params.timeoutSeconds,
@@ -1664,7 +1728,7 @@ async function runWebSearch(params: {
   if (params.provider === "gemini") {
     const geminiResult = await runGeminiSearch({
       query: params.query,
-      apiKey: params.apiKey,
+      apiKey: params.apiKey!,
       model: params.geminiModel ?? DEFAULT_GEMINI_MODEL,
       timeoutSeconds: params.timeoutSeconds,
     });
@@ -1694,7 +1758,7 @@ async function runWebSearch(params: {
   if (effectiveBraveMode === "llm-context") {
     const { results: llmResults, sources } = await runBraveLlmContextSearch({
       query: params.query,
-      apiKey: params.apiKey,
+      apiKey: params.apiKey!,
       timeoutSeconds: params.timeoutSeconds,
       country: params.country,
       search_lang: params.search_lang,
@@ -1752,7 +1816,7 @@ async function runWebSearch(params: {
     url.searchParams.set("freshness", `1970-01-01to${params.dateBefore}`);
   }
 
-  const mapped = await withTrustedWebSearchEndpoint(
+  const mapped = (await withTrustedWebSearchEndpoint(
     {
       url: url.toString(),
       timeoutSeconds: params.timeoutSeconds,
@@ -1760,7 +1824,7 @@ async function runWebSearch(params: {
         method: "GET",
         headers: {
           Accept: "application/json",
-          "X-Subscription-Token": params.apiKey,
+          "X-Subscription-Token": params.apiKey!,
         },
       },
     },
@@ -1787,7 +1851,7 @@ async function runWebSearch(params: {
         };
       });
     },
-  );
+  )) as Array<{ title: string; url: string; description: string; published?: string; siteName?: string }>;
 
   const payload = {
     query: params.query,
@@ -1824,8 +1888,12 @@ export function createWebSearchTool(options?: {
   const braveConfig = resolveBraveConfig(search);
   const braveMode = resolveBraveMode(braveConfig);
 
-  const description =
-    provider === "perplexity"
+  // Use plugin provider description if available.
+  const pluginSearchProvider = getSearchProvider(provider);
+
+  const description = pluginSearchProvider
+    ? pluginSearchProvider.description
+    : provider === "perplexity"
       ? perplexityTransport.transport === "chat_completions"
         ? "Search the web using Perplexity Sonar via Perplexity/OpenRouter chat completions. Returns AI-synthesized answers with citations from web-grounded search."
         : "Search the web using the Perplexity Search API. Returns structured results (title, URL, snippet) for fast research. Supports domain, region, language, and freshness filtering."
@@ -1849,8 +1917,9 @@ export function createWebSearchTool(options?: {
     }),
     execute: async (_toolCallId, args) => {
       const perplexityRuntime = provider === "perplexity" ? perplexityTransport : undefined;
-      const apiKey =
-        provider === "perplexity"
+      const apiKey = pluginSearchProvider
+        ? (pluginSearchProvider.resolveApiKey?.((search as Record<string, unknown>) ?? {}) ?? "")
+        : provider === "perplexity"
           ? perplexityRuntime?.apiKey
           : provider === "grok"
             ? resolveGrokApiKey(grokConfig)
@@ -1860,7 +1929,8 @@ export function createWebSearchTool(options?: {
                 ? resolveGeminiApiKey(geminiConfig)
                 : resolveSearchApiKey(search);
 
-      if (!apiKey) {
+      // Plugin providers handle their own API key requirements.
+      if (!apiKey && !pluginSearchProvider) {
         return jsonResult(missingSearchKeyPayload(provider));
       }
 
@@ -2095,6 +2165,9 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         braveMode,
+        pluginSearchConfig: hasSearchProvider(provider)
+          ? ((search as Record<string, unknown> | undefined)?.[provider] as Record<string, unknown>) ?? {}
+          : undefined,
       });
       return jsonResult(result);
     },

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -103,6 +103,9 @@ export type {
   PluginLogger,
   ProviderAuthContext,
   ProviderAuthResult,
+  SearchProviderRegistration,
+  SearchProviderParams,
+  SearchProviderResult,
 } from "../plugins/types.js";
 export type {
   GatewayRequestHandler,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -3,6 +3,7 @@ import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelDock } from "../channels/dock.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { registerContextEngine } from "../context-engine/registry.js";
+import { registerSearchProviderEntry } from "./search-registry.js";
 import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
@@ -600,6 +601,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerCli: (registrar, opts) => registerCli(record, registrar, opts),
       registerService: (service) => registerService(record, service),
       registerCommand: (command) => registerCommand(record, command),
+      registerSearchProvider: (provider) => registerSearchProviderEntry(provider),
       registerContextEngine: (id, factory) => registerContextEngine(id, factory),
       resolvePath: (input: string) => resolveUserPath(input),
       on: (hookName, handler, opts) =>

--- a/src/plugins/search-registry.ts
+++ b/src/plugins/search-registry.ts
@@ -1,0 +1,72 @@
+/**
+ * Search Provider Registry
+ *
+ * Allows plugins to register custom web search providers via `registerSearchProvider()`.
+ * Registered providers integrate seamlessly with the built-in `web_search` tool.
+ */
+
+export type SearchProviderResult = {
+  /** Structured results (title + URL + snippet). */
+  results?: Array<{
+    title: string;
+    url: string;
+    description: string;
+    siteName?: string;
+  }>;
+  /** Free-form AI-synthesized content (for LLM-style providers). */
+  content?: string;
+  /** Citation URLs. */
+  citations?: string[];
+};
+
+export type SearchProviderParams = {
+  query: string;
+  count: number;
+  timeoutSeconds: number;
+  country?: string;
+  language?: string;
+  freshness?: string;
+  dateAfter?: string;
+  dateBefore?: string;
+};
+
+export type SearchProviderRegistration = {
+  /** Unique provider id (e.g. "duckduckgo"). Used in config: `tools.web.search.provider`. */
+  id: string;
+  /** Human-readable label. */
+  label: string;
+  /** Tool description shown to the LLM. */
+  description: string;
+  /** Whether this provider requires an API key. If false, apiKey checks are skipped. */
+  requiresApiKey?: boolean;
+  /** Resolve the API key from config. Only called if requiresApiKey is true. */
+  resolveApiKey?: (config: Record<string, unknown>) => string | undefined;
+  /** Provider-specific config fields for cache key differentiation. */
+  cacheKeyExtra?: (config: Record<string, unknown>) => string;
+  /** Execute the search. */
+  search: (
+    params: SearchProviderParams,
+    config: Record<string, unknown>,
+  ) => Promise<SearchProviderResult>;
+};
+
+const registry = new Map<string, SearchProviderRegistration>();
+
+export function registerSearchProviderEntry(provider: SearchProviderRegistration): void {
+  if (registry.has(provider.id)) {
+    throw new Error(`Search provider "${provider.id}" is already registered.`);
+  }
+  registry.set(provider.id, provider);
+}
+
+export function getSearchProvider(id: string): SearchProviderRegistration | undefined {
+  return registry.get(id);
+}
+
+export function getRegisteredSearchProviderIds(): string[] {
+  return Array.from(registry.keys());
+}
+
+export function hasSearchProvider(id: string): boolean {
+  return registry.has(id);
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -15,9 +15,15 @@ import type { HookEntry } from "../hooks/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { PluginRuntime } from "./runtime/types.js";
+import type { SearchProviderRegistration } from "./search-registry.js";
 
 export type { PluginRuntime } from "./runtime/types.js";
 export type { AnyAgentTool } from "../agents/tools/common.js";
+export type {
+  SearchProviderRegistration,
+  SearchProviderParams,
+  SearchProviderResult,
+} from "./search-registry.js";
 
 export type PluginLogger = {
   debug?: (message: string) => void;
@@ -291,6 +297,8 @@ export type OpenClawPluginApi = {
    * Use this for simple state-toggling or status commands that don't need AI reasoning.
    */
   registerCommand: (command: OpenClawPluginCommandDefinition) => void;
+  /** Register a custom web search provider for the built-in `web_search` tool. */
+  registerSearchProvider: (provider: SearchProviderRegistration) => void;
   /** Register a context engine implementation (exclusive slot — only one active at a time). */
   registerContextEngine: (
     id: string,


### PR DESCRIPTION
## Summary

Adds a new `registerSearchProvider()` method to the plugin API, enabling extensions to register custom web search providers that integrate seamlessly with the built-in `web_search` tool. No new tool name — plugin providers appear as native `web_search` providers.

## Motivation

Currently, adding a custom search provider (e.g. DuckDuckGo, Searx, Kagi) requires modifying `web-search.ts` directly — a ~2300-line core file that changes frequently. This makes it impossible to distribute search providers as extensions and causes recurring merge conflicts for forks.

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `src/plugins/search-registry.ts` | +72 | New provider registry with types: `SearchProviderRegistration`, `SearchProviderParams`, `SearchProviderResult` |
| `src/plugins/types.ts` | +8 | Export types + add `registerSearchProvider` to `OpenClawPluginApi` |
| `src/plugins/registry.ts` | +2 | Wire into plugin API constructor |
| `src/plugin-sdk/index.ts` | +3 | Export types for extension authors |
| `src/agents/tools/web-search.ts` | +95/-22 | Plugin provider dispatch in `resolveSearchProvider()`, `runWebSearch()`, `createWebSearchTool()` |

## Extension usage

```typescript
import type { OpenClawPluginApi } from "openclaw/plugin-sdk";

export default function register(api: OpenClawPluginApi) {
  api.registerSearchProvider({
    id: "duckduckgo",
    label: "DuckDuckGo",
    description: "Search via DuckDuckGo (no API key required).",
    requiresApiKey: false,
    cacheKeyExtra: (config) => `${config.proxy || "none"}`,
    search: async (params, config) => ({
      results: [{ title: "...", url: "...", description: "..." }],
    }),
  });
}
```

Config: `tools.web.search.provider: "duckduckgo"`

## Design decisions

- **No new tool** — plugin providers integrate into `web_search`, keeping the agent interface unchanged
- **Provider-first dispatch** — plugin registry checked before the hardcoded `if/else` chain
- **Config passthrough** — `search.<providerId>` object passed directly to the provider's `search()` function
- **Cache integration** — plugin providers participate in the existing cache via `cacheKeyExtra`
- **Flexible result format** — providers can return structured results (title/URL/snippet) OR free-form content with citations (LLM-style)
- **Zero breaking changes** — all existing built-in providers work identically

## Testing

Tested with a DuckDuckGo search extension ([openclaw-ext-duckduckgo-search](https://github.com/Openclaw-Extensions/duckduckgo-search)) that registers via this API and works end-to-end through the `web_search` tool.