### PR TITLE
fix(memory): honor env proxy for remote embedding fetch

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -9691,14 +9691,14 @@
         "filename": "docs/concepts/memory.md",
         "hashed_secret": "1a8abbf465c52363ab4c9c6ad945b8e857cbea55",
         "is_verified": false,
-        "line_number": 325
+        "line_number": 326
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/concepts/memory.md",
         "hashed_secret": "b9f640d6095b9f6b5a65983f7b76dbbb254e0044",
         "is_verified": false,
-        "line_number": 726
+        "line_number": 727
       }
     ],
     "docs/concepts/model-providers.md": [
@@ -10318,14 +10318,14 @@
         "filename": "docs/zh-CN/concepts/memory.md",
         "hashed_secret": "1a8abbf465c52363ab4c9c6ad945b8e857cbea55",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 151
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/zh-CN/concepts/memory.md",
         "hashed_secret": "b9f640d6095b9f6b5a65983f7b76dbbb254e0044",
         "is_verified": false,
-        "line_number": 398
+        "line_number": 399
       }
     ],
     "docs/zh-CN/concepts/model-providers.md": [
@@ -13013,5 +13013,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T03:11:06Z"
+  "generated_at": "2026-03-10T05:14:38Z"
 }

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -309,6 +309,7 @@ Notes:
 
 - `remote.baseUrl` is optional (defaults to the Gemini API base URL).
 - `remote.headers` lets you add extra headers if needed.
+- Remote memory embedding calls honor standard proxy env vars (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, and `NO_PROXY`) when set.
 - Default model: `gemini-embedding-001`.
 
 If you want to use a **custom OpenAI-compatible endpoint** (OpenRouter, vLLM, or a proxy),

--- a/docs/zh-CN/concepts/memory.md
+++ b/docs/zh-CN/concepts/memory.md
@@ -135,6 +135,7 @@ agents: {
 
 - `remote.baseUrl` 是可选的（默认为 Gemini API 基础 URL）。
 - `remote.headers` 让你可以在需要时添加额外的标头。
+- 远程 memory embedding 请求在设置时会遵循标准代理环境变量（`HTTPS_PROXY`、`HTTP_PROXY`、`ALL_PROXY` 和 `NO_PROXY`）。
 - 默认模型：`gemini-embedding-001`。
 
 如果你想使用**自定义 OpenAI 兼容端点**（OpenRouter、vLLM 或代理），可以使用 `remote` 配置与 OpenAI 提供商：

--- a/src/memory/remote-http.test.ts
+++ b/src/memory/remote-http.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { withRemoteHttpResponse } from "./remote-http.js";
+
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: vi.fn(),
+  withTrustedEnvProxyGuardedFetchMode: (params: Record<string, unknown>) => ({
+    ...params,
+    mode: "trusted_env_proxy",
+  }),
+}));
+
+describe("withRemoteHttpResponse", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses trusted env proxy guarded fetch mode by default", async () => {
+    const release = vi.fn(async () => {});
+    vi.mocked(fetchWithSsrFGuard).mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      finalUrl: "https://example.com",
+      release,
+    });
+
+    const parsed = await withRemoteHttpResponse({
+      url: "https://example.com/embeddings",
+      init: { method: "POST", body: JSON.stringify({ input: "hello" }) },
+      ssrfPolicy: { allowedHostnames: ["example.com"] },
+      onResponse: async (response) => await response.json(),
+    });
+
+    expect(parsed).toEqual({ ok: true });
+    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com/embeddings",
+        policy: { allowedHostnames: ["example.com"] },
+        auditContext: "memory-remote",
+        mode: "trusted_env_proxy",
+      }),
+    );
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("still releases dispatcher when response handling throws", async () => {
+    const release = vi.fn(async () => {});
+    vi.mocked(fetchWithSsrFGuard).mockResolvedValueOnce({
+      response: new Response("ok", { status: 200 }),
+      finalUrl: "https://example.com",
+      release,
+    });
+
+    await expect(
+      withRemoteHttpResponse({
+        url: "https://example.com/embeddings",
+        auditContext: "memory-embed",
+        onResponse: async () => {
+          throw new Error("parse failed");
+        },
+      }),
+    ).rejects.toThrow("parse failed");
+
+    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auditContext: "memory-embed",
+        mode: "trusted_env_proxy",
+      }),
+    );
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/memory/remote-http.ts
+++ b/src/memory/remote-http.ts
@@ -1,4 +1,7 @@
-import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import {
+  fetchWithSsrFGuard,
+  withTrustedEnvProxyGuardedFetchMode,
+} from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 
 export function buildRemoteBaseUrlPolicy(baseUrl: string): SsrFPolicy | undefined {
@@ -26,12 +29,14 @@ export async function withRemoteHttpResponse<T>(params: {
   auditContext?: string;
   onResponse: (response: Response) => Promise<T>;
 }): Promise<T> {
-  const { response, release } = await fetchWithSsrFGuard({
-    url: params.url,
-    init: params.init,
-    policy: params.ssrfPolicy,
-    auditContext: params.auditContext ?? "memory-remote",
-  });
+  const { response, release } = await fetchWithSsrFGuard(
+    withTrustedEnvProxyGuardedFetchMode({
+      url: params.url,
+      init: params.init,
+      policy: params.ssrfPolicy,
+      auditContext: params.auditContext ?? "memory-remote",
+    }),
+  );
   try {
     return await params.onResponse(response);
   } finally {


### PR DESCRIPTION
## Summary

AI-assisted PR.

- Problem: memory remote embedding calls used `fetchWithSsrFGuard` in default strict mode, so proxy env vars were ignored.
- Why it matters: operators behind corporate/regional egress controls (proxy-required networks) saw `memory search ... fetch failed` for Gemini/OpenAI/Voyage/Mistral/Ollama remote endpoints.
- What changed: memory remote HTTP helper now explicitly uses `withTrustedEnvProxyGuardedFetchMode(...)` and tests assert trusted mode is applied.
- What did NOT change (scope boundary): no provider-specific request payload/headers changed; no SSRF policy shape changed; no changes to non-memory fetch paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30075
- Related #38503

## User-visible / Behavior Changes

- Remote memory embedding requests now honor proxy env vars (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`) via guarded fetch trusted-env-proxy mode.
- Added docs note in memory concept docs (EN + zh-CN).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.x
- Runtime/container: Node.js 25.x / pnpm workspace
- Model/provider: `gemini/gemini-embedding-001`
- Integration/channel (if any): memory CLI path (`memory status/search` remote embedding)
- Relevant config (redacted):

```json
{
  "agents": {
    "defaults": {
      "memorySearch": {
        "provider": "gemini",
        "remote": { "apiKey": "***REDACTED***" },
        "model": "gemini-embedding-001"
      }
    }
  }
}
```

### Steps

1. Configure `agents.defaults.memorySearch.provider = "gemini"` with valid API key.
2. Set proxy env (e.g. `HTTP_PROXY`/`HTTPS_PROXY`).
3. Trigger memory embedding path (CLI probe/search or direct helper invocation).

### Expected

- Remote embedding request can use env proxy path and succeed in proxy-required environments.

### Actual

- After fix: request succeeds and returns 200 in local proxy-enabled verification.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Unit tests run:

```bash
pnpm vitest run --config vitest.unit.config.ts src/memory/remote-http.test.ts src/memory/post-json.test.ts src/memory/embeddings-remote-fetch.test.ts
pnpm vitest run --config vitest.unit.config.ts src/memory/embeddings.test.ts src/memory/embeddings-ollama.test.ts src/memory/embeddings-voyage.test.ts
pnpm vitest run --config vitest.unit.config.ts src/infra/net/fetch-guard.ssrf.test.ts
```

Proxy-enabled live check (redacted key):

```json
{"ok":true,"status":200,"bodyLen":60698}
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `withRemoteHttpResponse` now calls guarded fetch with `mode: "trusted_env_proxy"`.
  - Existing memory embedding tests remain green.
  - Live Gemini embed request succeeds with proxy env vars present.
- Edge cases checked:
  - Custom audit context still passes through.
  - Dispatcher release still occurs when response parsing throws.
- What you did **not** verify:
  - Full `pnpm check` / full matrix / e2e docker suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `fix(memory): honor env proxy for remote embedding fetch`.
- Files/config to restore:
  - `src/memory/remote-http.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected proxy routing for memory remote calls in environments with globally forced proxy vars.

## Risks and Mitigations

- Risk:
  - In environments with misconfigured proxy env vars, remote memory calls may now route through that proxy path and fail differently.
  - Mitigation:
    - Behavior is now consistent with other trusted operator-controlled fetch paths; `NO_PROXY` can exclude internal endpoints.
