### PR TITLE
feat(telegram): support proxy via env vars (OPENCLAW_TELEGRAM_PROXY, HTTP_PROXY)

### DIFF
--- a/src/telegram/audit-membership-runtime.ts
+++ b/src/telegram/audit-membership-runtime.ts
@@ -5,7 +5,7 @@ import type {
   TelegramGroupMembershipAudit,
   TelegramGroupMembershipAuditEntry,
 } from "./audit.js";
-import { makeProxyFetch } from "./proxy.js";
+import { resolveTelegramProxyFetch } from "./proxy.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 
@@ -16,7 +16,7 @@ type TelegramGroupMembershipAuditData = Omit<TelegramGroupMembershipAudit, "elap
 export async function auditTelegramGroupMembershipImpl(
   params: AuditTelegramGroupMembershipParams,
 ): Promise<TelegramGroupMembershipAuditData> {
-  const fetcher = params.proxyUrl ? makeProxyFetch(params.proxyUrl) : fetch;
+  const fetcher = resolveTelegramProxyFetch(params.proxyUrl) ?? fetch;
   const base = `${TELEGRAM_API_BASE}/bot${params.token}`;
   const groups: TelegramGroupMembershipAuditEntry[] = [];
 

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -11,7 +11,7 @@ import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { TelegramExecApprovalHandler } from "./exec-approvals-handler.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingSession } from "./polling-session.js";
-import { makeProxyFetch } from "./proxy.js";
+import { resolveTelegramProxyFetch } from "./proxy.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
 import { startTelegramWebhook } from "./webhook.js";
 
@@ -110,8 +110,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       );
     }
 
-    const proxyFetch =
-      opts.proxyFetch ?? (account.config.proxy ? makeProxyFetch(account.config.proxy) : undefined);
+    const proxyFetch = opts.proxyFetch ?? resolveTelegramProxyFetch(account.config.proxy);
 
     execApprovalsHandler = new TelegramExecApprovalHandler({
       token,

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -1,6 +1,6 @@
 import type { BaseProbeResult } from "../channels/plugins/types.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
-import { makeProxyFetch } from "./proxy.js";
+import { resolveTelegramProxyFetch } from "./proxy.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 
@@ -23,7 +23,7 @@ export async function probeTelegram(
   proxyUrl?: string,
 ): Promise<TelegramProbe> {
   const started = Date.now();
-  const fetcher = proxyUrl ? makeProxyFetch(proxyUrl) : fetch;
+  const fetcher = resolveTelegramProxyFetch(proxyUrl) ?? fetch;
   const base = `${TELEGRAM_API_BASE}/bot${token}`;
   const retryDelayMs = Math.max(50, Math.min(1000, timeoutMs));
 

--- a/src/telegram/proxy.test.ts
+++ b/src/telegram/proxy.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   const undiciFetch = vi.fn();
   const proxyAgentSpy = vi.fn();
   const setGlobalDispatcher = vi.fn();
+  const envHttpProxyAgentSpy = vi.fn();
   class ProxyAgent {
     static lastCreated: ProxyAgent | undefined;
     proxyUrl: string;
@@ -13,11 +14,18 @@ const mocks = vi.hoisted(() => {
       proxyAgentSpy(proxyUrl);
     }
   }
+  class EnvHttpProxyAgent {
+    constructor() {
+      envHttpProxyAgentSpy();
+    }
+  }
 
   return {
     ProxyAgent,
+    EnvHttpProxyAgent,
     undiciFetch,
     proxyAgentSpy,
+    envHttpProxyAgentSpy,
     setGlobalDispatcher,
     getLastAgent: () => ProxyAgent.lastCreated,
   };
@@ -25,11 +33,24 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("undici", () => ({
   ProxyAgent: mocks.ProxyAgent,
+  EnvHttpProxyAgent: mocks.EnvHttpProxyAgent,
   fetch: mocks.undiciFetch,
   setGlobalDispatcher: mocks.setGlobalDispatcher,
 }));
 
-import { makeProxyFetch } from "./proxy.js";
+import {
+  makeProxyFetch,
+  resolveTelegramProxyFetch,
+  resolveTelegramProxyUrl,
+  TELEGRAM_PROXY_ENV,
+} from "./proxy.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  mocks.proxyAgentSpy.mockClear();
+  mocks.envHttpProxyAgentSpy.mockClear();
+  mocks.undiciFetch.mockReset();
+});
 
 describe("makeProxyFetch", () => {
   it("uses undici fetch with ProxyAgent dispatcher", async () => {
@@ -45,5 +66,98 @@ describe("makeProxyFetch", () => {
       expect.objectContaining({ dispatcher: mocks.getLastAgent() }),
     );
     expect(mocks.setGlobalDispatcher).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveTelegramProxyUrl", () => {
+  it("returns config proxy when provided", () => {
+    expect(resolveTelegramProxyUrl("http://config-proxy:8080")).toBe("http://config-proxy:8080");
+  });
+
+  it("trims whitespace from config proxy", () => {
+    expect(resolveTelegramProxyUrl("  http://config-proxy:8080  ")).toBe(
+      "http://config-proxy:8080",
+    );
+  });
+
+  it("falls back to OPENCLAW_TELEGRAM_PROXY env var", () => {
+    vi.stubEnv(TELEGRAM_PROXY_ENV, "http://env-proxy:9090");
+    expect(resolveTelegramProxyUrl()).toBe("http://env-proxy:9090");
+  });
+
+  it("prefers config proxy over env var", () => {
+    vi.stubEnv(TELEGRAM_PROXY_ENV, "http://env-proxy:9090");
+    expect(resolveTelegramProxyUrl("http://config-proxy:8080")).toBe("http://config-proxy:8080");
+  });
+
+  it("returns undefined when nothing is configured", () => {
+    expect(resolveTelegramProxyUrl()).toBeUndefined();
+  });
+
+  it("ignores blank config proxy and uses env var", () => {
+    vi.stubEnv(TELEGRAM_PROXY_ENV, "http://env-proxy:9090");
+    expect(resolveTelegramProxyUrl("  ")).toBe("http://env-proxy:9090");
+  });
+});
+
+describe("resolveTelegramProxyFetch", () => {
+  it("returns ProxyAgent fetch when config proxy is set", () => {
+    mocks.undiciFetch.mockResolvedValue({ ok: true });
+    const result = resolveTelegramProxyFetch("http://config-proxy:8080");
+
+    expect(result).toBeTypeOf("function");
+    expect(mocks.proxyAgentSpy).toHaveBeenCalledWith("http://config-proxy:8080");
+  });
+
+  it("returns ProxyAgent fetch when OPENCLAW_TELEGRAM_PROXY env is set", () => {
+    vi.stubEnv(TELEGRAM_PROXY_ENV, "http://env-proxy:9090");
+    mocks.undiciFetch.mockResolvedValue({ ok: true });
+    const result = resolveTelegramProxyFetch();
+
+    expect(result).toBeTypeOf("function");
+    expect(mocks.proxyAgentSpy).toHaveBeenCalledWith("http://env-proxy:9090");
+  });
+
+  it("falls back to HTTP_PROXY env var via resolveProxyFetchFromEnv", () => {
+    vi.stubEnv("HTTP_PROXY", "http://http-proxy:3128");
+    mocks.undiciFetch.mockResolvedValue({ ok: true });
+    const result = resolveTelegramProxyFetch();
+
+    expect(result).toBeTypeOf("function");
+    expect(mocks.envHttpProxyAgentSpy).toHaveBeenCalled();
+  });
+
+  it("falls back to HTTPS_PROXY env var via resolveProxyFetchFromEnv", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://https-proxy:3128");
+    mocks.undiciFetch.mockResolvedValue({ ok: true });
+    const result = resolveTelegramProxyFetch();
+
+    expect(result).toBeTypeOf("function");
+    expect(mocks.envHttpProxyAgentSpy).toHaveBeenCalled();
+  });
+
+  it("returns undefined when no proxy is configured", () => {
+    expect(resolveTelegramProxyFetch()).toBeUndefined();
+  });
+
+  it("prefers config proxy over HTTP_PROXY env", () => {
+    vi.stubEnv("HTTP_PROXY", "http://http-proxy:3128");
+    mocks.undiciFetch.mockResolvedValue({ ok: true });
+    const result = resolveTelegramProxyFetch("http://config-proxy:8080");
+
+    expect(result).toBeTypeOf("function");
+    expect(mocks.proxyAgentSpy).toHaveBeenCalledWith("http://config-proxy:8080");
+    expect(mocks.envHttpProxyAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("prefers OPENCLAW_TELEGRAM_PROXY over HTTP_PROXY", () => {
+    vi.stubEnv(TELEGRAM_PROXY_ENV, "http://tg-proxy:9090");
+    vi.stubEnv("HTTP_PROXY", "http://http-proxy:3128");
+    mocks.undiciFetch.mockResolvedValue({ ok: true });
+    const result = resolveTelegramProxyFetch();
+
+    expect(result).toBeTypeOf("function");
+    expect(mocks.proxyAgentSpy).toHaveBeenCalledWith("http://tg-proxy:9090");
+    expect(mocks.envHttpProxyAgentSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -1,1 +1,36 @@
+import process from "node:process";
+import { makeProxyFetch, resolveProxyFetchFromEnv } from "../infra/net/proxy-fetch.js";
+
 export { makeProxyFetch } from "../infra/net/proxy-fetch.js";
+
+export const TELEGRAM_PROXY_ENV = "OPENCLAW_TELEGRAM_PROXY";
+
+/**
+ * Resolve the Telegram proxy URL from config or environment.
+ * Priority: config proxy > OPENCLAW_TELEGRAM_PROXY env var.
+ */
+export function resolveTelegramProxyUrl(configProxy?: string): string | undefined {
+  const fromConfig = configProxy?.trim();
+  if (fromConfig) {
+    return fromConfig;
+  }
+  const fromEnv = process.env[TELEGRAM_PROXY_ENV]?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a proxy-aware fetch for Telegram API requests.
+ * Priority:
+ * 1. Config proxy URL (channels.telegram.proxy or OPENCLAW_TELEGRAM_PROXY)
+ * 2. Standard HTTP_PROXY/HTTPS_PROXY env vars
+ */
+export function resolveTelegramProxyFetch(configProxy?: string): typeof fetch | undefined {
+  const proxyUrl = resolveTelegramProxyUrl(configProxy);
+  if (proxyUrl) {
+    return makeProxyFetch(proxyUrl);
+  }
+  return resolveProxyFetchFromEnv();
+}

--- a/src/telegram/send.proxy.test.ts
+++ b/src/telegram/send.proxy.test.ts
@@ -13,8 +13,8 @@ const { loadConfig } = vi.hoisted(() => ({
   loadConfig: vi.fn(() => ({})),
 }));
 
-const { makeProxyFetch } = vi.hoisted(() => ({
-  makeProxyFetch: vi.fn(),
+const { resolveTelegramProxyFetch } = vi.hoisted(() => ({
+  resolveTelegramProxyFetch: vi.fn(),
 }));
 
 const { resolveTelegramFetch } = vi.hoisted(() => ({
@@ -30,7 +30,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
 });
 
 vi.mock("./proxy.js", () => ({
-  makeProxyFetch,
+  resolveTelegramProxyFetch,
 }));
 
 vi.mock("./fetch.js", () => ({
@@ -59,13 +59,13 @@ describe("telegram proxy client", () => {
   const prepareProxyFetch = () => {
     const proxyFetch = vi.fn();
     const fetchImpl = vi.fn();
-    makeProxyFetch.mockReturnValue(proxyFetch as unknown as typeof fetch);
+    resolveTelegramProxyFetch.mockReturnValue(proxyFetch as unknown as typeof fetch);
     resolveTelegramFetch.mockReturnValue(fetchImpl as unknown as typeof fetch);
     return { proxyFetch, fetchImpl };
   };
 
   const expectProxyClient = (fetchImpl: ReturnType<typeof vi.fn>) => {
-    expect(makeProxyFetch).toHaveBeenCalledWith(proxyUrl);
+    expect(resolveTelegramProxyFetch).toHaveBeenCalledWith(proxyUrl);
     expect(resolveTelegramFetch).toHaveBeenCalledWith(expect.any(Function), { network: undefined });
     expect(botCtorSpy).toHaveBeenCalledWith(
       "tok",
@@ -83,7 +83,7 @@ describe("telegram proxy client", () => {
     loadConfig.mockReturnValue({
       channels: { telegram: { accounts: { foo: { proxy: proxyUrl } } } },
     });
-    makeProxyFetch.mockClear();
+    resolveTelegramProxyFetch.mockClear();
     resolveTelegramFetch.mockClear();
   });
 

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -28,7 +28,7 @@ import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
 import { isRecoverableTelegramNetworkError, isSafeToRetrySendError } from "./network-errors.js";
-import { makeProxyFetch } from "./proxy.js";
+import { resolveTelegramProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { maybePersistResolvedTelegramTarget } from "./target-writeback.js";
 import {
@@ -133,8 +133,7 @@ function createTelegramHttpLogger(cfg: ReturnType<typeof loadConfig>) {
 function resolveTelegramClientOptions(
   account: ResolvedTelegramAccount,
 ): ApiClientOptions | undefined {
-  const proxyUrl = account.config.proxy?.trim();
-  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
+  const proxyFetch = resolveTelegramProxyFetch(account.config.proxy);
   const fetchImpl = resolveTelegramFetch(proxyFetch, {
     network: account.config.network,
   });


### PR DESCRIPTION
## Summary

  - Add `OPENCLAW_TELEGRAM_PROXY` env var for Telegram-specific proxy configuration without editing config files
  - Fall back to standard `HTTP_PROXY`/`HTTPS_PROXY` env vars when no explicit proxy is configured
  - Wire proxy resolution into all Telegram API paths: polling, send, probe, and group membership audit

### Proxy resolution priority

  1. Config file (`channels.telegram.proxy` or per-account `channels.telegram.accounts.<id>.proxy`)
  2. `OPENCLAW_TELEGRAM_PROXY` env var
  3. Standard `HTTP_PROXY` / `HTTPS_PROXY` / `http_proxy` / `https_proxy` env vars

### Changes

  - `src/telegram/proxy.ts` — new `resolveTelegramProxyUrl()` and `resolveTelegramProxyFetch()` helpers
  - `src/telegram/monitor.ts` — use new resolver (polling + webhook entry point)
  - `src/telegram/send.ts` — use new resolver (outbound message path)
  - `src/telegram/probe.ts` — use new resolver (health probe)
  - `src/telegram/audit-membership-runtime.ts` — use new resolver (group audit)

## Test plan

  - [x] 14 new unit tests covering all resolution paths and priority ordering
  - [x] Existing proxy, monitor, fetch, probe, and audit tests pass (45 total)
  - [x] Type-check passes