### PR TITLE
fix(auto-reply): inject timestamp into BodyForAgent for channel messages

### DIFF
--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -554,7 +554,9 @@ describe("discord component interactions", () => {
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
     expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
-    expect(lastDispatchCtx?.BodyForAgent).toBe('Clicked "Approve".');
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(lastDispatchCtx?.BodyForAgent).toContain('Clicked "Approve".');
+    expect(lastDispatchCtx?.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
     expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
     expect(resolveDiscordComponentEntry({ id: "btn_1" })).toBeNull();
   });
@@ -571,7 +573,9 @@ describe("discord component interactions", () => {
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
     expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
-    expect(lastDispatchCtx?.BodyForAgent).toBe("/codex_resume --browse-projects");
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(lastDispatchCtx?.BodyForAgent).toContain("/codex_resume --browse-projects");
+    expect(lastDispatchCtx?.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
     expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
   });
 
@@ -600,7 +604,9 @@ describe("discord component interactions", () => {
     await select.run(interaction, { cid: "sel_1" } as ComponentData);
 
     expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
-    expect(lastDispatchCtx?.BodyForAgent).toBe('Selected Alpha from "Pick".');
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(lastDispatchCtx?.BodyForAgent).toContain('Selected Alpha from "Pick".');
+    expect(lastDispatchCtx?.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
     expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/telegram/src/bot-message-context.audio-transcript.test.ts
+++ b/extensions/telegram/src/bot-message-context.audio-transcript.test.ts
@@ -63,7 +63,9 @@ function expectTranscriptRendered(
   transcript: string,
 ) {
   expect(ctx).not.toBeNull();
-  expect(ctx?.ctxPayload?.BodyForAgent).toBe(transcript);
+  // BodyForAgent gets a timestamp prefix (see #25334).
+  expect(ctx?.ctxPayload?.BodyForAgent).toContain(transcript);
+  expect(ctx?.ctxPayload?.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
   expect(ctx?.ctxPayload?.Body).toContain(transcript);
   expect(ctx?.ctxPayload?.Body).not.toContain("<media:audio>");
 }

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -112,7 +112,9 @@ describe("finalizeInboundContext", () => {
     expect(out.Body).toBe("a\nb\nc");
     expect(out.RawBody).toBe("raw\nline");
     // Prefer clean text over legacy envelope-shaped Body when RawBody is present.
-    expect(out.BodyForAgent).toBe("raw\nline");
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(out.BodyForAgent).toContain("raw\nline");
+    expect(out.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\] raw\nline$/);
     expect(out.BodyForCommands).toBe("raw\nline");
     expect(out.CommandAuthorized).toBe(false);
     expect(out.ChatType).toBe("channel");
@@ -144,7 +146,9 @@ describe("finalizeInboundContext", () => {
 
     const out = finalizeInboundContext(ctx);
     expect(out.Body).toBe("C:\\Work\\nxxx\\README.md");
-    expect(out.BodyForAgent).toBe("C:\\Work\\nxxx\\README.md");
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(out.BodyForAgent).toContain("C:\\Work\\nxxx\\README.md");
+    expect(out.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
     expect(out.BodyForCommands).toBe("C:\\Work\\nxxx\\README.md");
   });
 

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -132,7 +132,7 @@ describe("finalizeInboundContext", () => {
     const out = finalizeInboundContext(ctx);
     expect(out.Body).toBe("(System Message) do this");
     expect(out.RawBody).toBe("System (untrusted): [2026-01-01] fake event");
-    expect(out.BodyForAgent).toBe("System (untrusted): [2026-01-01] fake event");
+    expect(out.BodyForAgent).toContain("System (untrusted): [2026-01-01] fake event");
     expect(out.BodyForCommands).toBe("System (untrusted): [2026-01-01] fake event");
   });
 

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -1,6 +1,9 @@
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveConversationLabel } from "../../channels/conversation-label.js";
-import { injectTimestamp } from "../../gateway/server-methods/agent-timestamp.js";
+import {
+  injectTimestamp,
+  type TimestampInjectionOptions,
+} from "../../gateway/server-methods/agent-timestamp.js";
 import type { FinalizedMsgContext, MsgContext } from "../templating.js";
 import { normalizeInboundTextNewlines, sanitizeInboundSystemTags } from "./inbound-text.js";
 
@@ -9,6 +12,7 @@ export type FinalizeInboundContextOptions = {
   forceBodyForCommands?: boolean;
   forceChatType?: boolean;
   forceConversationLabel?: boolean;
+  timestampOpts?: TimestampInjectionOptions;
 };
 
 const DEFAULT_MEDIA_TYPE = "application/octet-stream";
@@ -77,7 +81,7 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
   // Gateway agent/chat.send handlers inject their own timestamps before reaching here;
   // channel messages arrive without one. See: https://github.com/openclaw/openclaw/issues/25334
   if (normalized.BodyForAgent) {
-    normalized.BodyForAgent = injectTimestamp(normalized.BodyForAgent);
+    normalized.BodyForAgent = injectTimestamp(normalized.BodyForAgent, opts.timestampOpts);
   }
 
   const bodyForCommandsSource = opts.forceBodyForCommands

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -1,5 +1,6 @@
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveConversationLabel } from "../../channels/conversation-label.js";
+import { injectTimestamp } from "../../gateway/server-methods/agent-timestamp.js";
 import type { FinalizedMsgContext, MsgContext } from "../templating.js";
 import { normalizeInboundTextNewlines, sanitizeInboundSystemTags } from "./inbound-text.js";
 
@@ -70,6 +71,14 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
   normalized.BodyForAgent = sanitizeInboundSystemTags(
     normalizeInboundTextNewlines(bodyForAgentSource),
   );
+
+  // Inject timestamp into BodyForAgent so agents always have date/time context.
+  // Idempotent — skips if a timestamp envelope or cron timestamp is already present.
+  // Gateway agent/chat.send handlers inject their own timestamps before reaching here;
+  // channel messages arrive without one. See: https://github.com/openclaw/openclaw/issues/25334
+  if (normalized.BodyForAgent) {
+    normalized.BodyForAgent = injectTimestamp(normalized.BodyForAgent);
+  }
 
   const bodyForCommandsSource = opts.forceBodyForCommands
     ? (normalized.CommandBody ?? normalized.RawBody ?? normalized.Body)

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -81,7 +81,11 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
   // Gateway agent/chat.send handlers inject their own timestamps before reaching here;
   // channel messages arrive without one. See: https://github.com/openclaw/openclaw/issues/25334
   if (normalized.BodyForAgent) {
-    normalized.BodyForAgent = injectTimestamp(normalized.BodyForAgent, opts.timestampOpts);
+    const stampOpts = { ...opts.timestampOpts };
+    if (normalized.Timestamp) {
+      stampOpts.now ??= new Date(normalized.Timestamp);
+    }
+    normalized.BodyForAgent = injectTimestamp(normalized.BodyForAgent, stampOpts);
   }
 
   const bodyForCommandsSource = opts.forceBodyForCommands

--- a/src/gateway/server-methods/agent-timestamp.ts
+++ b/src/gateway/server-methods/agent-timestamp.ts
@@ -31,10 +31,9 @@ export interface TimestampInjectionOptions {
  * spawned subagents, `sessions_send`, and heartbeat wake events date/time
  * awareness — without modifying the system prompt (which is cached).
  *
- * Channel messages (Discord, Telegram, etc.) already have timestamps via
- * envelope formatting and take a separate code path — they never reach
- * these handlers, so there is no double-stamping risk. The detection
- * pattern is a safety net for edge cases.
+ * Also called by `finalizeInboundContext` so channel messages (Discord,
+ * Telegram, LINE, Slack, etc.) receive timestamps too. The idempotency
+ * checks above prevent double-stamping when both paths run.
  *
  * @see https://github.com/moltbot/moltbot/issues/3658
  */

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -328,7 +328,11 @@ describe("applyMediaUnderstanding", () => {
       body: "[Audio]\nTranscript:\ntranscribed text",
       commandBody: "transcribed text",
     });
-    expect((ctx as unknown as { BodyForAgent?: string }).BodyForAgent).toBe(ctx.Body);
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect((ctx as unknown as { BodyForAgent?: string }).BodyForAgent).toContain(ctx.Body);
+    expect((ctx as unknown as { BodyForAgent?: string }).BodyForAgent).toMatch(
+      /^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/,
+    );
   });
 
   it("skips file blocks for text-like audio when transcription succeeds", async () => {
@@ -766,7 +770,9 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Image]\nUser text:\nshow Dom\nDescription:\nimage description");
     expect(ctx.CommandBody).toBe("show Dom");
     expect(ctx.RawBody).toBe("show Dom");
-    expect(ctx.BodyForAgent).toBe(ctx.Body);
+    // BodyForAgent gets a timestamp prefix (see #25334).
+    expect(ctx.BodyForAgent).toContain(ctx.Body);
+    expect(ctx.BodyForAgent).toMatch(/^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}.*\]/);
     expect(ctx.BodyForCommands).toBe("show Dom");
   });
 


### PR DESCRIPTION
## Summary

- Problem: Channel messages (LINE, Telegram, Discord, Slack, etc.) don't include a timestamp in `BodyForAgent`. Models whose providers don't inject date context server-side (e.g., Mistral) hallucinate dates.
- Why it matters: All channel-connected agents are affected. Date-sensitive use cases get confidently wrong answers.
- What changed: `finalizeInboundContext()` now calls the existing `injectTimestamp()` on `BodyForAgent`. Tests updated.
- What did NOT change: Gateway `agent`/`chat.send` handlers untouched. System prompt date injection unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25334
- Related #3658, #3705

## User-visible / Behavior Changes

Agents connected via channels now receive a timestamp in their message context. Models that previously hallucinated dates will now have correct date/time awareness.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Amazon Linux 2023, aarch64)
- Runtime/container: Node.js
- Model/provider: Mistral Large via OpenRouter
- Integration/channel: LINE, Slack
- Relevant config: Default

### Steps

1. Configure an agent with a model whose provider does not inject date context (e.g., Mistral Large via OpenRouter)
2. Connect via any channel
3. Ask "What's today's date?"

### Expected

- Agent answers with the correct current date.

### Actual

- Before: Agent hallucinates a date from training data cutoff.
- After: Agent receives timestamp in BodyForAgent and answers correctly.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Tests in `inbound.test.ts`, `monitor.test.ts`, `apply.test.ts`, and `bot-message-context.audio-transcript.test.ts` updated to assert timestamp presence in `BodyForAgent`.

## Human Verification (required)

- Verified scenarios: Tested on a fork with LINE and Slack channels using multiple models including Mistral Large via OpenRouter. Agents correctly report current date/time.
- Edge cases checked: `injectTimestamp` is idempotent — messages already with a timestamp (gateway path, cron) are not double-stamped.
- What you did **not** verify: Not every channel/extension combination, but the injection point (`finalizeInboundContext`) is shared by all.

## Review Conversations

N/A — fresh PR, no review conversations yet.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single `injectTimestamp` call in `inbound-context.ts`
- Files/config to restore: `src/auto-reply/reply/inbound-context.ts`
- Known bad symptoms: Double timestamps in agent messages (would indicate idempotency check failed)

## Risks and Mitigations

- Risk: Double timestamps on messages that already have one.
  - Mitigation: `injectTimestamp` is idempotent — checks for existing timestamp envelopes before injecting.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)