### PR TITLE
plugins: preserve config includes on install writes

### DIFF
--- a/src/cli/plugins-cli.test.ts
+++ b/src/cli/plugins-cli.test.ts
@@ -4,15 +4,20 @@ import path from "node:path";
 import { Command } from "commander";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
+import type { PluginInstallUpdate } from "../plugins/installs.js";
+import type { SlotSelectionResult } from "../plugins/slots.js";
+import type { PluginStatusReport } from "../plugins/status.js";
 
 const mockReadConfigFileSnapshotForWrite =
   vi.fn<() => Promise<{ snapshot: ConfigFileSnapshot; writeOptions: Record<string, unknown> }>>();
 const mockWriteConfigFile = vi.fn<
   (cfg: OpenClawConfig, options?: Record<string, unknown>) => Promise<void>
 >(async () => {});
-const mockInstallPluginFromPath = vi.fn();
-const mockInstallPluginFromNpmSpec = vi.fn();
-const mockClearPluginManifestRegistryCache = vi.fn();
+const mockInstallPluginFromPath =
+  vi.fn<(params: { path: string; dryRun?: boolean }) => Promise<unknown>>();
+const mockInstallPluginFromNpmSpec =
+  vi.fn<(params: { spec: string; dryRun?: boolean }) => Promise<unknown>>();
+const mockClearPluginManifestRegistryCache = vi.fn<() => void>();
 const mockEnablePluginInConfig = vi.fn(
   (config: OpenClawConfig, pluginId: string): { config: OpenClawConfig; enabled: true } => ({
     config: {
@@ -31,16 +36,7 @@ const mockEnablePluginInConfig = vi.fn(
   }),
 );
 const mockRecordPluginInstall = vi.fn(
-  (
-    config: OpenClawConfig,
-    install: {
-      pluginId: string;
-      source: string;
-      sourcePath: string;
-      installPath: string;
-      version?: string;
-    },
-  ): OpenClawConfig => ({
+  (config: OpenClawConfig, install: PluginInstallUpdate): OpenClawConfig => ({
     ...config,
     plugins: {
       ...config.plugins,
@@ -56,15 +52,26 @@ const mockRecordPluginInstall = vi.fn(
     },
   }),
 );
-const mockBuildPluginStatusReport = vi.fn(() => ({
+const mockBuildPluginStatusReport = vi.fn<() => PluginStatusReport>(() => ({
   workspaceDir: "/tmp",
   plugins: [],
+  tools: [],
+  hooks: [],
+  typedHooks: [],
+  channels: [],
+  providers: [],
+  gatewayHandlers: {},
+  httpRoutes: [],
+  cliRegistrars: [],
+  services: [],
+  commands: [],
   diagnostics: [],
 }));
 const mockApplyExclusiveSlotSelection = vi.fn(
-  ({ config }: { config: OpenClawConfig }): { config: OpenClawConfig; warnings: string[] } => ({
+  ({ config }: { config: OpenClawConfig }): SlotSelectionResult => ({
     config,
     warnings: [],
+    changed: false,
   }),
 );
 const runtime = {
@@ -83,8 +90,10 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../plugins/install.js", () => ({
-  installPluginFromPath: (...args: unknown[]) => mockInstallPluginFromPath(...args),
-  installPluginFromNpmSpec: (...args: unknown[]) => mockInstallPluginFromNpmSpec(...args),
+  installPluginFromPath: (params: { path: string; dryRun?: boolean }) =>
+    mockInstallPluginFromPath(params),
+  installPluginFromNpmSpec: (params: { spec: string; dryRun?: boolean }) =>
+    mockInstallPluginFromNpmSpec(params),
 }));
 
 vi.mock("../plugins/manifest-registry.js", () => ({
@@ -92,19 +101,22 @@ vi.mock("../plugins/manifest-registry.js", () => ({
 }));
 
 vi.mock("../plugins/enable.js", () => ({
-  enablePluginInConfig: (...args: unknown[]) => mockEnablePluginInConfig(...args),
+  enablePluginInConfig: (config: OpenClawConfig, pluginId: string) =>
+    mockEnablePluginInConfig(config, pluginId),
 }));
 
 vi.mock("../plugins/installs.js", () => ({
-  recordPluginInstall: (...args: unknown[]) => mockRecordPluginInstall(...args),
+  recordPluginInstall: (config: OpenClawConfig, install: PluginInstallUpdate) =>
+    mockRecordPluginInstall(config, install),
 }));
 
 vi.mock("../plugins/status.js", () => ({
-  buildPluginStatusReport: (...args: unknown[]) => mockBuildPluginStatusReport(...args),
+  buildPluginStatusReport: () => mockBuildPluginStatusReport(),
 }));
 
 vi.mock("../plugins/slots.js", () => ({
-  applyExclusiveSlotSelection: (...args: unknown[]) => mockApplyExclusiveSlotSelection(...args),
+  applyExclusiveSlotSelection: (params: { config: OpenClawConfig }) =>
+    mockApplyExclusiveSlotSelection(params),
 }));
 
 vi.mock("../runtime.js", () => ({

--- a/src/cli/plugins-cli.test.ts
+++ b/src/cli/plugins-cli.test.ts
@@ -1,0 +1,231 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
+
+const mockReadConfigFileSnapshotForWrite =
+  vi.fn<() => Promise<{ snapshot: ConfigFileSnapshot; writeOptions: Record<string, unknown> }>>();
+const mockWriteConfigFile = vi.fn<
+  (cfg: OpenClawConfig, options?: Record<string, unknown>) => Promise<void>
+>(async () => {});
+const mockInstallPluginFromPath = vi.fn();
+const mockInstallPluginFromNpmSpec = vi.fn();
+const mockClearPluginManifestRegistryCache = vi.fn();
+const mockEnablePluginInConfig = vi.fn(
+  (config: OpenClawConfig, pluginId: string): { config: OpenClawConfig; enabled: true } => ({
+    config: {
+      ...config,
+      plugins: {
+        ...config.plugins,
+        entries: {
+          ...config.plugins?.entries,
+          [pluginId]: {
+            enabled: true,
+          },
+        },
+      },
+    },
+    enabled: true,
+  }),
+);
+const mockRecordPluginInstall = vi.fn(
+  (
+    config: OpenClawConfig,
+    install: {
+      pluginId: string;
+      source: string;
+      sourcePath: string;
+      installPath: string;
+      version?: string;
+    },
+  ): OpenClawConfig => ({
+    ...config,
+    plugins: {
+      ...config.plugins,
+      installs: {
+        ...config.plugins?.installs,
+        [install.pluginId]: {
+          source: install.source,
+          sourcePath: install.sourcePath,
+          installPath: install.installPath,
+          version: install.version,
+        },
+      },
+    },
+  }),
+);
+const mockBuildPluginStatusReport = vi.fn(() => ({
+  workspaceDir: "/tmp",
+  plugins: [],
+  diagnostics: [],
+}));
+const mockApplyExclusiveSlotSelection = vi.fn(
+  ({ config }: { config: OpenClawConfig }): { config: OpenClawConfig; warnings: string[] } => ({
+    config,
+    warnings: [],
+  }),
+);
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => {
+    throw new Error("loadConfig should not be used for plugin install writes");
+  },
+  readConfigFileSnapshotForWrite: () => mockReadConfigFileSnapshotForWrite(),
+  writeConfigFile: (cfg: OpenClawConfig, options?: Record<string, unknown>) =>
+    mockWriteConfigFile(cfg, options),
+}));
+
+vi.mock("../plugins/install.js", () => ({
+  installPluginFromPath: (...args: unknown[]) => mockInstallPluginFromPath(...args),
+  installPluginFromNpmSpec: (...args: unknown[]) => mockInstallPluginFromNpmSpec(...args),
+}));
+
+vi.mock("../plugins/manifest-registry.js", () => ({
+  clearPluginManifestRegistryCache: () => mockClearPluginManifestRegistryCache(),
+}));
+
+vi.mock("../plugins/enable.js", () => ({
+  enablePluginInConfig: (...args: unknown[]) => mockEnablePluginInConfig(...args),
+}));
+
+vi.mock("../plugins/installs.js", () => ({
+  recordPluginInstall: (...args: unknown[]) => mockRecordPluginInstall(...args),
+}));
+
+vi.mock("../plugins/status.js", () => ({
+  buildPluginStatusReport: (...args: unknown[]) => mockBuildPluginStatusReport(...args),
+}));
+
+vi.mock("../plugins/slots.js", () => ({
+  applyExclusiveSlotSelection: (...args: unknown[]) => mockApplyExclusiveSlotSelection(...args),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: runtime,
+}));
+
+let registerPluginsCli: typeof import("./plugins-cli.js").registerPluginsCli;
+let processExitSpy: ReturnType<typeof vi.spyOn>;
+let tempPluginDir = "";
+
+function buildSnapshot(params: {
+  resolved: OpenClawConfig;
+  config: OpenClawConfig;
+}): ConfigFileSnapshot {
+  return {
+    path: "/tmp/openclaw.json",
+    exists: true,
+    raw: JSON.stringify(params.resolved),
+    parsed: { $include: "./plugins.json" },
+    resolved: params.resolved,
+    valid: true,
+    config: params.config,
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
+  };
+}
+
+async function runPluginsCommand(args: string[]) {
+  const program = new Command();
+  program.exitOverride();
+  registerPluginsCli(program);
+  await program.parseAsync(args, { from: "user" });
+}
+
+describe("plugins cli", () => {
+  beforeAll(async () => {
+    processExitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code ?? 0}`);
+    }) as never);
+    tempPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-cli-"));
+    ({ registerPluginsCli } = await import("./plugins-cli.js"));
+  });
+
+  afterAll(() => {
+    processExitSpy.mockRestore();
+    fs.rmSync(tempPluginDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("installs linked plugins from snapshot.resolved and preserves include-aware write options", async () => {
+    const resolved: OpenClawConfig = {
+      plugins: {
+        entries: {
+          existing: {
+            enabled: true,
+          },
+        },
+      },
+    };
+    const runtimeMerged: OpenClawConfig = {
+      ...resolved,
+      agents: {
+        defaults: {
+          model: "gpt-5.2",
+        },
+      } as never,
+      commands: {
+        ownerDisplay: "raw",
+      } as never,
+    };
+
+    mockReadConfigFileSnapshotForWrite.mockResolvedValueOnce({
+      snapshot: buildSnapshot({
+        resolved,
+        config: runtimeMerged,
+      }),
+      writeOptions: {
+        expectedConfigPath: "/tmp/openclaw.json",
+      },
+    });
+    mockInstallPluginFromPath.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "discord",
+      version: "2026.3.9",
+    });
+
+    await runPluginsCommand(["plugins", "install", tempPluginDir, "--link"]);
+
+    expect(mockInstallPluginFromPath).toHaveBeenCalledWith({
+      path: tempPluginDir,
+      dryRun: true,
+    });
+    expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+
+    const written = mockWriteConfigFile.mock.calls[0]?.[0];
+    const options = mockWriteConfigFile.mock.calls[0]?.[1] as Record<string, unknown>;
+
+    expect(written.plugins?.load?.paths).toEqual([tempPluginDir]);
+    expect(written.plugins?.entries).toEqual({
+      existing: {
+        enabled: true,
+      },
+      discord: {
+        enabled: true,
+      },
+    });
+    expect(written.plugins?.installs?.discord).toEqual({
+      source: "path",
+      sourcePath: tempPluginDir,
+      installPath: tempPluginDir,
+      version: "2026.3.9",
+    });
+    expect(written).not.toHaveProperty("agents.defaults");
+    expect(written).not.toHaveProperty("commands.ownerDisplay");
+    expect(options).toMatchObject({
+      expectedConfigPath: "/tmp/openclaw.json",
+      preserveIncludes: true,
+    });
+  });
+});

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { Command } from "commander";
 import type { OpenClawConfig } from "../config/config.js";
-import { loadConfig, writeConfigFile } from "../config/config.js";
+import { loadConfig, readConfigFileSnapshotForWrite, writeConfigFile } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { type BundledPluginSource, findBundledPluginSource } from "../plugins/bundled-sources.js";
@@ -153,11 +153,42 @@ function logSlotWarnings(warnings: string[]) {
   }
 }
 
+type PluginConfigWriteOptions = Parameters<typeof writeConfigFile>[1];
+
+async function readPluginConfigWriteContext(): Promise<{
+  config: OpenClawConfig;
+  writeOptions: PluginConfigWriteOptions;
+}> {
+  const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+  if (!snapshot.valid) {
+    const details = snapshot.issues
+      .map((issue) => `- ${issue.path || "<root>"}: ${issue.message}`)
+      .join("\n");
+    defaultRuntime.error(`Invalid config at ${snapshot.path}:\n${details || "- <root>: invalid"}`);
+    process.exit(1);
+  }
+  return {
+    config: snapshot.resolved,
+    writeOptions,
+  };
+}
+
+async function writePluginConfig(
+  config: OpenClawConfig,
+  writeOptions?: PluginConfigWriteOptions,
+): Promise<void> {
+  await writeConfigFile(config, {
+    ...writeOptions,
+    preserveIncludes: true,
+  });
+}
+
 async function installBundledPluginSource(params: {
   config: OpenClawConfig;
   rawSpec: string;
   bundledSource: BundledPluginSource;
   warning: string;
+  writeOptions?: PluginConfigWriteOptions;
 }) {
   const existing = params.config.plugins?.load?.paths ?? [];
   const mergedPaths = Array.from(new Set([...existing, params.bundledSource.localPath]));
@@ -189,7 +220,7 @@ async function installBundledPluginSource(params: {
   });
   const slotResult = applySlotSelectionForPlugin(next, params.bundledSource.pluginId);
   next = slotResult.config;
-  await writeConfigFile(next);
+  await writePluginConfig(next, params.writeOptions);
   logSlotWarnings(slotResult.warnings);
   defaultRuntime.log(theme.warn(params.warning));
   defaultRuntime.log(`Installed plugin: ${params.bundledSource.pluginId}`);
@@ -208,7 +239,7 @@ async function runPluginInstallCommand(params: {
   }
   const normalized = fileSpec && fileSpec.ok ? fileSpec.path : raw;
   const resolved = resolveUserPath(normalized);
-  const cfg = loadConfig();
+  const { config: cfg, writeOptions } = await readPluginConfigWriteContext();
 
   if (fs.existsSync(resolved)) {
     if (opts.link) {
@@ -242,7 +273,7 @@ async function runPluginInstallCommand(params: {
       });
       const slotResult = applySlotSelectionForPlugin(next, probe.pluginId);
       next = slotResult.config;
-      await writeConfigFile(next);
+      await writePluginConfig(next, writeOptions);
       logSlotWarnings(slotResult.warnings);
       defaultRuntime.log(`Linked plugin path: ${shortenHomePath(resolved)}`);
       defaultRuntime.log(`Restart the gateway to load plugins.`);
@@ -272,7 +303,7 @@ async function runPluginInstallCommand(params: {
     });
     const slotResult = applySlotSelectionForPlugin(next, result.pluginId);
     next = slotResult.config;
-    await writeConfigFile(next);
+    await writePluginConfig(next, writeOptions);
     logSlotWarnings(slotResult.warnings);
     defaultRuntime.log(`Installed plugin: ${result.pluginId}`);
     defaultRuntime.log(`Restart the gateway to load plugins.`);
@@ -310,6 +341,7 @@ async function runPluginInstallCommand(params: {
       rawSpec: raw,
       bundledSource: bundledPreNpmPlan.bundledSource,
       warning: bundledPreNpmPlan.warning,
+      writeOptions,
     });
     return;
   }
@@ -334,6 +366,7 @@ async function runPluginInstallCommand(params: {
       rawSpec: raw,
       bundledSource: bundledFallbackPlan.bundledSource,
       warning: bundledFallbackPlan.warning,
+      writeOptions,
     });
     return;
   }
@@ -356,7 +389,7 @@ async function runPluginInstallCommand(params: {
   });
   const slotResult = applySlotSelectionForPlugin(next, result.pluginId);
   next = slotResult.config;
-  await writeConfigFile(next);
+  await writePluginConfig(next, writeOptions);
   logSlotWarnings(slotResult.warnings);
   defaultRuntime.log(`Installed plugin: ${result.pluginId}`);
   defaultRuntime.log(`Restart the gateway to load plugins.`);
@@ -552,12 +585,12 @@ export function registerPluginsCli(program: Command) {
     .description("Enable a plugin in config")
     .argument("<id>", "Plugin id")
     .action(async (id: string) => {
-      const cfg = loadConfig();
+      const { config: cfg, writeOptions } = await readPluginConfigWriteContext();
       const enableResult = enablePluginInConfig(cfg, id);
       let next: OpenClawConfig = enableResult.config;
       const slotResult = applySlotSelectionForPlugin(next, id);
       next = slotResult.config;
-      await writeConfigFile(next);
+      await writePluginConfig(next, writeOptions);
       logSlotWarnings(slotResult.warnings);
       if (enableResult.enabled) {
         defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
@@ -575,9 +608,9 @@ export function registerPluginsCli(program: Command) {
     .description("Disable a plugin in config")
     .argument("<id>", "Plugin id")
     .action(async (id: string) => {
-      const cfg = loadConfig();
+      const { config: cfg, writeOptions } = await readPluginConfigWriteContext();
       const next = setPluginEnabledInConfig(cfg, id, false);
-      await writeConfigFile(next);
+      await writePluginConfig(next, writeOptions);
       defaultRuntime.log(`Disabled plugin "${id}". Restart the gateway to apply.`);
     });
 
@@ -590,7 +623,7 @@ export function registerPluginsCli(program: Command) {
     .option("--force", "Skip confirmation prompt", false)
     .option("--dry-run", "Show what would be removed without making changes", false)
     .action(async (id: string, opts: PluginUninstallOptions) => {
-      const cfg = loadConfig();
+      const { config: cfg, writeOptions } = await readPluginConfigWriteContext();
       const report = buildPluginStatusReport({ config: cfg });
       const extensionsDir = path.join(resolveStateDir(process.env, os.homedir), "extensions");
       const keepFiles = Boolean(opts.keepFiles || opts.keepConfig);
@@ -688,7 +721,7 @@ export function registerPluginsCli(program: Command) {
         defaultRuntime.log(theme.warn(warning));
       }
 
-      await writeConfigFile(result.config);
+      await writePluginConfig(result.config, writeOptions);
 
       const removed: string[] = [];
       if (result.actions.entry) {
@@ -733,7 +766,7 @@ export function registerPluginsCli(program: Command) {
     .option("--all", "Update all tracked plugins", false)
     .option("--dry-run", "Show what would change without writing", false)
     .action(async (id: string | undefined, opts: PluginUpdateOptions) => {
-      const cfg = loadConfig();
+      const { config: cfg, writeOptions } = await readPluginConfigWriteContext();
       const installs = cfg.plugins?.installs ?? {};
       const targets = opts.all ? Object.keys(installs) : id ? [id] : [];
 
@@ -783,7 +816,7 @@ export function registerPluginsCli(program: Command) {
       }
 
       if (!opts.dryRun && result.changed) {
-        await writeConfigFile(result.config);
+        await writePluginConfig(result.config, writeOptions);
         defaultRuntime.log("Restart the gateway to load plugins.");
       }
     });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -133,6 +133,11 @@ export type ConfigWriteOptions = {
    * even if schema/default normalization reintroduces them.
    */
   unsetPaths?: string[][];
+  /**
+   * Preserve existing `$include` directives when the write can be expressed as
+   * additive or overriding sibling keys on the current source document.
+   */
+  preserveIncludes?: boolean;
 };
 
 export type ReadConfigFileSnapshotForWriteResult = {
@@ -378,6 +383,47 @@ function createMergePatch(base: unknown, target: unknown): unknown {
   return patch;
 }
 
+function containsIncludeDirective(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some((item) => containsIncludeDirective(item));
+  }
+  if (!isPlainObject(value)) {
+    return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "$include")) {
+    return true;
+  }
+  return Object.values(value).some((item) => containsIncludeDirective(item));
+}
+
+function mergePatchHasDeletion(patch: unknown): boolean {
+  if (patch === null) {
+    return true;
+  }
+  if (!isPlainObject(patch)) {
+    return false;
+  }
+  return Object.values(patch).some((item) => mergePatchHasDeletion(item));
+}
+
+function preserveConfigIncludesOnWrite(params: {
+  parsed: unknown;
+  resolved: OpenClawConfig;
+  next: OpenClawConfig;
+}): Record<string, unknown> | null {
+  if (!containsIncludeDirective(params.parsed)) {
+    return null;
+  }
+
+  const patch = createMergePatch(params.resolved, params.next);
+  if (mergePatchHasDeletion(patch)) {
+    return null;
+  }
+
+  const preserved = applyMergePatch(params.parsed, patch);
+  return isPlainObject(preserved) ? preserved : null;
+}
+
 function collectEnvRefPaths(value: unknown, path: string, output: Map<string, string>): void {
   if (typeof value === "string") {
     if (containsEnvVarReference(value)) {
@@ -577,12 +623,13 @@ function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">)
   }
 }
 
-function stampConfigVersion(cfg: OpenClawConfig): OpenClawConfig {
+function stampConfigVersion(cfg: Record<string, unknown>): Record<string, unknown> {
   const now = new Date().toISOString();
+  const meta = isPlainObject(cfg.meta) ? cfg.meta : {};
   return {
     ...cfg,
     meta: {
-      ...cfg.meta,
+      ...meta,
       lastTouchedVersion: VERSION,
       lastTouchedAt: now,
     },
@@ -1153,7 +1200,15 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     }
     // Do NOT apply runtime defaults when writing — user config should only contain
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).
-    const stampedOutputConfig = stampConfigVersion(outputConfig);
+    const serializedOutputConfig =
+      options.preserveIncludes && snapshot.valid && snapshot.exists
+        ? (preserveConfigIncludesOnWrite({
+            parsed: snapshot.parsed,
+            resolved: snapshot.resolved,
+            next: outputConfig,
+          }) ?? outputConfig)
+        : outputConfig;
+    const stampedOutputConfig = stampConfigVersion(serializedOutputConfig);
     const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
     const nextHash = hashConfigRaw(json);
     const previousHash = resolveConfigSnapshotHash(snapshot);

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -489,6 +489,82 @@ describe("config io write", () => {
     });
   });
 
+  it("preserves root $include directives for additive writes when requested", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const includePath = path.join(home, ".openclaw", "plugins.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, '{ "$include": "./plugins.json" }\n', "utf-8");
+      await fs.writeFile(
+        includePath,
+        JSON.stringify(
+          {
+            plugins: {
+              entries: {
+                existing: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ).concat("\n"),
+        "utf-8",
+      );
+
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const snapshot = await io.readConfigFileSnapshot();
+      expect(snapshot.valid).toBe(true);
+
+      const pluginPath = path.join(home, "plugins", "discord");
+      await fs.mkdir(pluginPath, { recursive: true });
+
+      const next = structuredClone(snapshot.resolved);
+      next.plugins = {
+        ...next.plugins,
+        load: {
+          paths: [pluginPath],
+        },
+        entries: {
+          ...next.plugins?.entries,
+          discord: {
+            enabled: true,
+          },
+        },
+      };
+
+      await io.writeConfigFile(next, { preserveIncludes: true });
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        $include?: string;
+        plugins?: {
+          load?: { paths?: string[] };
+          entries?: Record<string, unknown>;
+        };
+      };
+      expect(persisted.$include).toBe("./plugins.json");
+      expect(persisted.plugins?.load?.paths).toEqual([pluginPath]);
+      expect(persisted.plugins?.entries?.discord).toEqual({
+        enabled: true,
+      });
+      expect(persisted.plugins?.entries).not.toHaveProperty("existing");
+
+      const included = JSON.parse(await fs.readFile(includePath, "utf-8")) as {
+        plugins?: { entries?: Record<string, unknown> };
+      };
+      expect(included.plugins?.entries).toEqual({
+        existing: {
+          enabled: true,
+        },
+      });
+    });
+  });
+
   it("appends config write audit JSONL entries with forensic metadata", async () => {
     await withSuiteHome(async (home) => {
       const { configPath, lines, last } = await writeGatewayPatchAndReadLastAuditEntry({


### PR DESCRIPTION
## Summary
- preserve include-aware write context when `plugins install` updates config
- avoid flattening root `$include` directives back into `openclaw.json`
- add CLI + config IO regression coverage for linked plugin install writes

Fixes #41050.

## What changed
- taught `plugins install` to write through `readConfigFileSnapshotForWrite()` instead of a plain config load/write path
- preserved include-aware write options when persisting plugin install mutations
- added a `plugins-cli` regression test covering `--link` install writes
- added config IO regression coverage for root `$include` preservation during additive writes

## Verification
- `corepack pnpm exec vitest run --config vitest.unit.config.ts src/config/io.write-config.test.ts src/cli/plugins-cli.test.ts`
- result: `17 passed`

## Notes
- the remaining test blocker during development was a hard-coded nonexistent fixture path; this was replaced with a real temp-directory-backed path so validation exercises the intended include-preservation logic
