### PR TITLE
Add threadForkPolicy config option to prevent context pollution

### DIFF
--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveSessionFilePath, type SessionEntry } from "../../config/sessions.js";
+import type { ThreadForkPolicy } from "../../config/types.base.js";
 
 /**
  * Default max parent token count beyond which thread/session parent forking is skipped.
@@ -12,12 +13,27 @@ import { resolveSessionFilePath, type SessionEntry } from "../../config/sessions
  */
 const DEFAULT_PARENT_FORK_MAX_TOKENS = 100_000;
 
+/**
+ * Default thread fork policy.
+ * - "fork": Fork from parent channel session (backward compatible)
+ * - "none": Start fresh thread session (no inherited context)
+ */
+const DEFAULT_THREAD_FORK_POLICY: ThreadForkPolicy = "fork";
+
 export function resolveParentForkMaxTokens(cfg: OpenClawConfig): number {
   const configured = cfg.session?.parentForkMaxTokens;
   if (typeof configured === "number" && Number.isFinite(configured) && configured >= 0) {
     return Math.floor(configured);
   }
   return DEFAULT_PARENT_FORK_MAX_TOKENS;
+}
+
+export function resolveThreadForkPolicy(cfg: OpenClawConfig): ThreadForkPolicy {
+  const configured = cfg.session?.threadForkPolicy;
+  if (configured === "none" || configured === "fork") {
+    return configured;
+  }
+  return DEFAULT_THREAD_FORK_POLICY;
 }
 
 export function forkSessionFromParent(params: {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -497,7 +497,7 @@ export async function initSessionState(params: {
       log.info(
         `skipping parent fork (policy=none): parentKey=${parentSessionKey} → sessionKey=${sessionKey}`,
       );
-      sessionEntry.forkedFromParent = true;
+      sessionEntry.forkedFromParent = true; // marks as processed to prevent re-attempts
     } else {
       const parentTokens = sessionStore[parentSessionKey].totalTokens ?? 0;
       if (parentForkMaxTokens > 0 && parentTokens > parentForkMaxTokens) {
@@ -508,7 +508,7 @@ export async function initSessionState(params: {
           `skipping parent fork (parent too large): parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
             `parentTokens=${parentTokens} maxTokens=${parentForkMaxTokens}`,
         );
-        sessionEntry.forkedFromParent = true;
+        sessionEntry.forkedFromParent = true; // marks as processed to prevent re-attempts
       } else {
         log.warn(
           `forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -45,7 +45,7 @@ import {
   resolveLastChannelRaw,
   resolveLastToRaw,
 } from "./session-delivery.js";
-import { forkSessionFromParent, resolveParentForkMaxTokens } from "./session-fork.js";
+import { forkSessionFromParent, resolveParentForkMaxTokens, resolveThreadForkPolicy } from "./session-fork.js";
 import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./session-hooks.js";
 
 const log = createSubsystemLogger("session-init");
@@ -479,38 +479,49 @@ export async function initSessionState(params: {
   }
   const parentSessionKey = ctx.ParentSessionKey?.trim();
   const alreadyForked = sessionEntry.forkedFromParent === true;
+  const threadForkPolicy = resolveThreadForkPolicy(cfg);
+
   if (
     parentSessionKey &&
     parentSessionKey !== sessionKey &&
     sessionStore[parentSessionKey] &&
     !alreadyForked
   ) {
-    const parentTokens = sessionStore[parentSessionKey].totalTokens ?? 0;
-    if (parentForkMaxTokens > 0 && parentTokens > parentForkMaxTokens) {
-      // Parent context is too large — forking would create a thread session
-      // that immediately overflows the model's context window. Start fresh
-      // instead and mark as forked to prevent re-attempts. See #26905.
-      log.warn(
-        `skipping parent fork (parent too large): parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-          `parentTokens=${parentTokens} maxTokens=${parentForkMaxTokens}`,
+    // Check thread fork policy first
+    if (threadForkPolicy === "none") {
+      // Skip forking entirely - start fresh thread session
+      log.info(
+        `skipping parent fork (policy=none): parentKey=${parentSessionKey} → sessionKey=${sessionKey}`,
       );
       sessionEntry.forkedFromParent = true;
     } else {
-      log.warn(
-        `forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-          `parentTokens=${parentTokens}`,
-      );
-      const forked = forkSessionFromParent({
-        parentEntry: sessionStore[parentSessionKey],
-        agentId,
-        sessionsDir: path.dirname(storePath),
-      });
-      if (forked) {
-        sessionId = forked.sessionId;
-        sessionEntry.sessionId = forked.sessionId;
-        sessionEntry.sessionFile = forked.sessionFile;
+      const parentTokens = sessionStore[parentSessionKey].totalTokens ?? 0;
+      if (parentForkMaxTokens > 0 && parentTokens > parentForkMaxTokens) {
+        // Parent context is too large — forking would create a thread session
+        // that immediately overflows the model's context window. Start fresh
+        // instead and mark as forked to prevent re-attempts. See #26905.
+        log.warn(
+          `skipping parent fork (parent too large): parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
+            `parentTokens=${parentTokens} maxTokens=${parentForkMaxTokens}`,
+        );
         sessionEntry.forkedFromParent = true;
-        log.warn(`forked session created: file=${forked.sessionFile}`);
+      } else {
+        log.warn(
+          `forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
+            `parentTokens=${parentTokens}`,
+        );
+        const forked = forkSessionFromParent({
+          parentEntry: sessionStore[parentSessionKey],
+          agentId,
+          sessionsDir: path.dirname(storePath),
+        });
+        if (forked) {
+          sessionId = forked.sessionId;
+          sessionEntry.sessionId = forked.sessionId;
+          sessionEntry.sessionFile = forked.sessionFile;
+          sessionEntry.forkedFromParent = true;
+          log.warn(`forked session created: file=${forked.sessionFile}`);
+        }
       }
     }
   }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -45,7 +45,11 @@ import {
   resolveLastChannelRaw,
   resolveLastToRaw,
 } from "./session-delivery.js";
-import { forkSessionFromParent, resolveParentForkMaxTokens, resolveThreadForkPolicy } from "./session-fork.js";
+import {
+  forkSessionFromParent,
+  resolveParentForkMaxTokens,
+  resolveThreadForkPolicy,
+} from "./session-fork.js";
 import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./session-hooks.js";
 
 const log = createSubsystemLogger("session-init");

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -7,6 +7,7 @@ export type DmScope = "main" | "per-peer" | "per-channel-peer" | "per-account-ch
 export type ReplyToMode = "off" | "first" | "all";
 export type GroupPolicy = "open" | "disabled" | "allowlist";
 export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
+export type ThreadForkPolicy = "fork" | "none";
 
 export type OutboundRetryConfig = {
   /** Max retry attempts for outbound requests (default: 3). */
@@ -123,6 +124,12 @@ export type SessionConfig = {
    * starts a fresh thread session instead. Set to 0 to disable this guard.
    */
   parentForkMaxTokens?: number;
+  /**
+   * Thread session fork policy.
+   * - "fork": Fork from parent channel session (inherits context) - DEFAULT for backward compatibility.
+   * - "none": Start fresh thread session (no inherited context) - recommended for Discord.
+   */
+  threadForkPolicy?: ThreadForkPolicy;
   mainKey?: string;
   sendPolicy?: SessionSendPolicyConfig;
   agentToAgent?: {

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -53,6 +53,7 @@ export const SessionSchema = z
     typingIntervalSeconds: z.number().int().positive().optional(),
     typingMode: TypingModeSchema.optional(),
     parentForkMaxTokens: z.number().int().nonnegative().optional(),
+    threadForkPolicy: z.union([z.literal("fork"), z.literal("none")]).optional(),
     mainKey: z.string().optional(),
     sendPolicy: SessionSendPolicySchema.optional(),
     agentToAgent: z


### PR DESCRIPTION
## Summary

Adds a new `threadForkPolicy` config option to control whether Discord thread sessions inherit context from their parent channel session.

## Problem

When a user creates a new Discord thread after a conversation in the parent channel, the new thread's session **forks from the parent channel's session**, inheriting all previous conversation context. This causes context pollution where thread A contains context from the parent channel or other threads.

See #41823 for detailed analysis.

## Solution

Add `threadForkPolicy` config option with two values:

- `fork` (default) - Fork from parent channel session (backward compatible)
- `none` - Start fresh thread session (no inherited context, recommended for Discord)

## Usage

```json
{
  "session": {
    "threadForkPolicy": "none"
  }
}
```

## Changes

- Add `ThreadForkPolicy` type in `types.base.ts`
- Add `threadForkPolicy` config option to `SessionConfig`
- Modify fork logic in `session.ts` to respect `threadForkPolicy`
- When set to `none`, thread sessions start fresh without parent context

## Testing

- [ ] CI builds pass
- [ ] Manual testing with Discord threads

Fixes #41823

AI-assisted: Claude Code