### PR TITLE
fix(pruning): allow pruning old image tool results to prevent context overflow

### DIFF
--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -266,6 +266,19 @@ export function pruneContextMessages(params: {
   const prunableToolIndexes: number[] = [];
   let next: AgentMessage[] | null = null;
 
+  // Collect image-containing tool result indexes so we can protect only the
+  // most recent ones and allow older image results to be pruned (#41789).
+  const MAX_PROTECTED_IMAGE_RESULTS = 3;
+  const imageToolIndexes: number[] = [];
+  for (let i = pruneStartIndex; i < cutoffIndex; i++) {
+    const msg = messages[i];
+    if (msg?.role === "toolResult" && isToolPrunable(msg.toolName) && hasImageBlocks(msg.content)) {
+      imageToolIndexes.push(i);
+    }
+  }
+  // Only the N most recent image results are protected; older ones are prunable.
+  const protectedImageIndexes = new Set(imageToolIndexes.slice(-MAX_PROTECTED_IMAGE_RESULTS));
+
   for (let i = pruneStartIndex; i < cutoffIndex; i++) {
     const msg = messages[i];
     if (!msg || msg.role !== "toolResult") {
@@ -274,7 +287,7 @@ export function pruneContextMessages(params: {
     if (!isToolPrunable(msg.toolName)) {
       continue;
     }
-    if (hasImageBlocks(msg.content)) {
+    if (hasImageBlocks(msg.content) && protectedImageIndexes.has(i)) {
       continue;
     }
     prunableToolIndexes.push(i);


### PR DESCRIPTION
Closes #41789

## Problem

`pruneContextMessages()` unconditionally skips all `toolResult` messages that contain image blocks:

```ts
if (hasImageBlocks(msg.content)) {
  continue; // never prunable
}
```

In screenshot-heavy sessions (e.g., browser automation), image tool results accumulate indefinitely and can never be removed, causing unrecoverable context overflow.

## Fix

Instead of protecting **all** image tool results, only protect the **3 most recent** ones. Older image results are added to the prunable set like regular tool results.

```ts
const MAX_PROTECTED_IMAGE_RESULTS = 3;
// ... collect image tool indexes, protect only the last N
if (hasImageBlocks(msg.content) && protectedImageIndexes.has(i)) {
  continue; // only recent images are protected
}
```

## Trade-off

Recent screenshots are typically the most relevant for ongoing tasks. Older ones have diminishing value and their ~8KB estimated size per image adds up quickly. The constant `MAX_PROTECTED_IMAGE_RESULTS = 3` can be tuned or made configurable if needed.