### PR TITLE
fix(cron): clear lastError when delivery succeeds

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1785,7 +1785,7 @@ describe("Cron issue regressions", () => {
     expect(job.state.nextRunAtMs).toBe(expectedNextMs);
   });
 
-  it("clears consecutiveErrors and lastError when delivery succeeds despite agent error (#41764)", () => {
+  it("preserves error details and increments consecutiveErrors on delivered error, but suppresses alerts (#41764)", () => {
     const startedAt = Date.parse("2026-03-10T12:00:00.000Z");
     const endedAt = startedAt + 5_000;
     const state = createCronServiceState({
@@ -1819,10 +1819,13 @@ describe("Cron issue regressions", () => {
       endedAt,
     });
 
-    // Delivery succeeded → error tracking should be reset
+    // Delivery succeeded → error details preserved for diagnostics,
+    // consecutiveErrors incremented for retry/disable guards, but
+    // failure alert suppressed (not re-triggered) since output was delivered.
     expect(job.state.lastDeliveryStatus).toBe("delivered");
-    expect(job.state.lastError).toBeUndefined();
-    expect(job.state.consecutiveErrors).toBe(0);
-    expect(job.state.lastFailureAlertAtMs).toBeUndefined();
+    expect(job.state.lastError).toBe("Message failed");
+    expect(job.state.consecutiveErrors).toBe(4);
+    // lastFailureAlertAtMs unchanged — no new alert was emitted
+    expect(job.state.lastFailureAlertAtMs).toBe(startedAt - 60_000);
   });
 });

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1784,4 +1784,45 @@ describe("Cron issue regressions", () => {
     expect(job.state.lastRunAtMs).toBe(startedAt);
     expect(job.state.nextRunAtMs).toBe(expectedNextMs);
   });
+
+  it("clears consecutiveErrors and lastError when delivery succeeds despite agent error (#41764)", () => {
+    const startedAt = Date.parse("2026-03-10T12:00:00.000Z");
+    const endedAt = startedAt + 5_000;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-41764-delivered-error.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "delivered-despite-error",
+      name: "delivered-despite-error",
+      scheduledAt: startedAt,
+      schedule: { kind: "cron", expr: "*/5 * * * *" },
+      payload: { kind: "agentTurn", message: "check" },
+      state: {
+        nextRunAtMs: startedAt - 1_000,
+        runningAtMs: startedAt - 500,
+        consecutiveErrors: 3,
+        lastFailureAlertAtMs: startedAt - 60_000,
+      },
+    });
+
+    applyJobResult(state, job, {
+      status: "error",
+      error: "Message failed",
+      delivered: true,
+      startedAt,
+      endedAt,
+    });
+
+    // Delivery succeeded → error tracking should be reset
+    expect(job.state.lastDeliveryStatus).toBe("delivered");
+    expect(job.state.lastError).toBeUndefined();
+    expect(job.state.consecutiveErrors).toBe(0);
+    expect(job.state.lastFailureAlertAtMs).toBeUndefined();
+  });
 });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -337,7 +337,9 @@ export function applyJobResult(
   job.updatedAtMs = result.endedAt;
 
   // Track consecutive errors for backoff / auto-disable.
-  if (result.status === "error") {
+  // When delivery succeeded despite an agent error, treat as success for
+  // error tracking — prevents false failure alerts for jobs that always deliver.
+  if (result.status === "error" && deliveryStatus !== "delivered") {
     job.state.consecutiveErrors = (job.state.consecutiveErrors ?? 0) + 1;
     const alertConfig = resolveFailureAlert(state, job);
     if (alertConfig && job.state.consecutiveErrors >= alertConfig.after) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -325,11 +325,13 @@ export function applyJobResult(
   job.state.lastDelivered = result.delivered;
   const deliveryStatus = resolveDeliveryStatus({ job, delivered: result.delivered });
   job.state.lastDeliveryStatus = deliveryStatus;
-  // Clear lastError when delivery succeeded to prevent contradictory state
-  // where lastError is set but deliveryStatus is "delivered" (#41764).
-  job.state.lastError = deliveryStatus === "delivered" ? undefined : result.error;
+  // Always preserve error details for diagnostics, even when delivery
+  // succeeded.  The delivery status already indicates the output reached the
+  // user; clearing the error text would make it impossible to debug why the
+  // run was still marked as an error (#41764).
+  job.state.lastError = result.error;
   job.state.lastErrorReason =
-    result.status === "error" && typeof result.error === "string" && deliveryStatus !== "delivered"
+    result.status === "error" && typeof result.error === "string"
       ? (resolveFailoverReasonFromError(result.error) ?? undefined)
       : undefined;
   job.state.lastDeliveryError =
@@ -337,11 +339,13 @@ export function applyJobResult(
   job.updatedAtMs = result.endedAt;
 
   // Track consecutive errors for backoff / auto-disable.
-  // When delivery succeeded despite an agent error, treat as success for
-  // error tracking — prevents false failure alerts for jobs that always deliver.
-  if (result.status === "error" && deliveryStatus !== "delivered") {
+  // Always increment on error so one-shot `at` jobs respect maxAttempts
+  // even when delivery succeeded; only suppress failure *alerts* when
+  // the output was delivered.
+  if (result.status === "error") {
     job.state.consecutiveErrors = (job.state.consecutiveErrors ?? 0) + 1;
-    const alertConfig = resolveFailureAlert(state, job);
+    const alertConfig =
+      deliveryStatus !== "delivered" ? resolveFailureAlert(state, job) : undefined;
     if (alertConfig && job.state.consecutiveErrors >= alertConfig.after) {
       const isBestEffort =
         job.delivery?.bestEffort === true ||

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -322,14 +322,16 @@ export function applyJobResult(
   job.state.lastRunStatus = result.status;
   job.state.lastStatus = result.status;
   job.state.lastDurationMs = Math.max(0, result.endedAt - result.startedAt);
-  job.state.lastError = result.error;
-  job.state.lastErrorReason =
-    result.status === "error" && typeof result.error === "string"
-      ? (resolveFailoverReasonFromError(result.error) ?? undefined)
-      : undefined;
   job.state.lastDelivered = result.delivered;
   const deliveryStatus = resolveDeliveryStatus({ job, delivered: result.delivered });
   job.state.lastDeliveryStatus = deliveryStatus;
+  // Clear lastError when delivery succeeded to prevent contradictory state
+  // where lastError is set but deliveryStatus is "delivered" (#41764).
+  job.state.lastError = deliveryStatus === "delivered" ? undefined : result.error;
+  job.state.lastErrorReason =
+    result.status === "error" && typeof result.error === "string" && deliveryStatus !== "delivered"
+      ? (resolveFailoverReasonFromError(result.error) ?? undefined)
+      : undefined;
   job.state.lastDeliveryError =
     deliveryStatus === "not-delivered" && result.error ? result.error : undefined;
   job.updatedAtMs = result.endedAt;


### PR DESCRIPTION
Closes #41764

## Problem

`applyJobResult()` unconditionally sets `job.state.lastError = result.error` regardless of delivery outcome. When the agent execution encounters a non-fatal error but delivery ultimately succeeds, the job state shows both `lastError: "Message failed"` and `deliveryStatus: "delivered"` simultaneously — a contradictory state that confuses monitoring.

## Fix

Compute `deliveryStatus` before setting `lastError`. When delivery succeeded (`deliveryStatus === "delivered"`), clear `lastError` and `lastErrorReason` since the job ultimately completed its purpose.

```ts
// Before: unconditional
job.state.lastError = result.error;

// After: conditional on delivery outcome
job.state.lastError = deliveryStatus === "delivered" ? undefined : result.error;
```