### PR TITLE
fix(feishu): preserve bare URL links with underscores

### DIFF
--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -177,3 +177,60 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
     expect(createMock).not.toHaveBeenCalled();
   });
 });
+
+describe("Feishu post payload formatting", () => {
+  const createMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveFeishuSendTargetMock.mockReturnValue({
+      client: {
+        im: {
+          message: {
+            reply: vi.fn(),
+            create: createMock,
+          },
+        },
+      },
+      receiveId: "ou_target",
+      receiveIdType: "open_id",
+    });
+    createMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "om_new" },
+    });
+  });
+
+  it("uses an explicit link tag for bare URLs so underscores stay clickable", async () => {
+    const url = "https://dami-oss.oss-cn-guangzhou.aliyuncs.com/fdc/output_20260210_222435.png";
+
+    await sendMessageFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: url,
+    });
+
+    const payload = createMock.mock.calls[0]?.[0]?.data;
+    expect(payload.msg_type).toBe("post");
+    expect(JSON.parse(payload.content)).toEqual({
+      zh_cn: {
+        content: [[{ tag: "a", text: url, href: url }]],
+      },
+    });
+  });
+
+  it("keeps markdown formatting for normal text payloads", async () => {
+    await sendMessageFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "Hello **world**",
+    });
+
+    const payload = createMock.mock.calls[0]?.[0]?.data;
+    expect(JSON.parse(payload.content)).toEqual({
+      zh_cn: {
+        content: [[{ tag: "md", text: "Hello **world**" }]],
+      },
+    });
+  });
+});

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -253,22 +253,33 @@ export type SendFeishuMessageParams = {
   accountId?: string;
 };
 
+const FEISHU_BARE_URL_RE = /^https?:\/\/\S+$/i;
+
 function buildFeishuPostMessagePayload(params: { messageText: string }): {
   content: string;
   msgType: string;
 } {
   const { messageText } = params;
+  const trimmed = messageText.trim();
+  const line =
+    FEISHU_BARE_URL_RE.test(trimmed) && !trimmed.includes("\n")
+      ? [
+          {
+            tag: "a",
+            text: trimmed,
+            href: trimmed,
+          },
+        ]
+      : [
+          {
+            tag: "md",
+            text: messageText,
+          },
+        ];
   return {
     content: JSON.stringify({
       zh_cn: {
-        content: [
-          [
-            {
-              tag: "md",
-              text: messageText,
-            },
-          ],
-        ],
+        content: [line],
       },
     }),
     msgType: "post",


### PR DESCRIPTION
## Summary
- detect bare URL-only Feishu text payloads and send them as explicit `a` link tags instead of markdown
- keep the existing markdown path for normal formatted messages
- add regression coverage for underscore-containing URLs and plain markdown text

## Testing
- `corepack pnpm exec vitest run extensions/feishu/src/send.reply-fallback.test.ts extensions/feishu/src/send.test.ts extensions/feishu/src/outbound.test.ts`
- `corepack pnpm exec oxfmt --check extensions/feishu/src/send.ts extensions/feishu/src/send.reply-fallback.test.ts`
- `corepack pnpm exec oxlint extensions/feishu/src/send.ts extensions/feishu/src/send.reply-fallback.test.ts`

Closes #41860.
