### PR TITLE
fix(bluebubbles): handle null text in debounce flush (clean)

### DIFF
--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -48,7 +48,7 @@ function combineDebounceEntries(entries: BlueBubblesDebounceEntry[]): Normalized
   const textParts: string[] = [];
 
   for (const entry of entries) {
-    const text = entry.message.text.trim();
+    const text = entry.message.text?.trim();
     if (!text) {
       continue;
     }
@@ -154,7 +154,7 @@ export function createBlueBubblesDebounceRegistry(params: {
             return false;
           }
           // Skip debouncing for control commands - process immediately
-          if (core.channel.text.hasControlCommand(msg.text, config)) {
+          if (msg.text && core.channel.text.hasControlCommand(msg.text, config)) {
             return false;
           }
           // Debounce all other messages to coalesce rapid-fire webhook events
@@ -178,7 +178,7 @@ export function createBlueBubblesDebounceRegistry(params: {
           // Multiple messages - combine and process
           const combined = combineDebounceEntries(entries);
 
-          if (core.logging.shouldLogVerbose()) {
+          if (core.logging.shouldLogVerbose() && combined.text) {
             const count = entries.length;
             const preview = combined.text.slice(0, 50);
             runtime.log?.(

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -439,7 +439,7 @@ export type BlueBubblesParticipant = {
 };
 
 export type NormalizedWebhookMessage = {
-  text: string;
+  text: string | null;
   senderId: string;
   senderName?: string;
   messageId?: string;

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -435,7 +435,7 @@ export async function processMessage(
   const groupFlag = resolveGroupFlagFromChatGuid(message.chatGuid);
   const isGroup = typeof groupFlag === "boolean" ? groupFlag : message.isGroup;
 
-  const text = message.text.trim();
+  const text = message.text?.trim() ?? "";
   const attachments = message.attachments ?? [];
   const placeholder = buildMessagePlaceholder(message);
   // Check if text is a tapback pattern (e.g., 'Loved "hello"') and transform to emoji format


### PR DESCRIPTION
## Bug Fix

Fixes #35777

### Problem
When a BlueBubbles webhook delivers a message with text: null, the debounce queue flush handler calls .trim() on null, causing a TypeError crash. This kills the entire flush batch, losing all queued messages.

### Solution
1. Updated NormalizedWebhookMessage.text type from string to string | null
2. Added optional chaining (?.) in monitor-debounce.ts
3. Added null guards for logging operations
4. Added null-safe fallback in monitor-processing.ts

### Testing
- [x] Ran pnpm check - passed with 0 errors

### AI-Assisted
This fix was prepared with AI assistance (Claude).