### PR TITLE
test(doctor): cover multi-account Telegram tokenFile summary

### DIFF
--- a/src/infra/channel-summary.test.ts
+++ b/src/infra/channel-summary.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
+import { inspectTelegramAccount } from "../telegram/account-inspect.js";
+import { listTelegramAccountIds, resolveDefaultTelegramAccountId } from "../telegram/accounts.js";
+import { makeDirectPlugin } from "../test-utils/channel-plugin-test-fixtures.js";
 
 vi.mock("../channels/plugins/index.js", () => ({
   listChannelPlugins: vi.fn(),
@@ -79,6 +82,58 @@ describe("buildChannelSummary", () => {
     expect(lines).toContain("Slack: configured");
     expect(lines).toContain(
       "  - primary (Primary) (bot:config, signing:config, secret unavailable in this command path)",
+    );
+  });
+
+  it("treats multi-account Telegram tokenFile setups as configured", async () => {
+    vi.mocked(listChannelPlugins).mockReturnValue([
+      makeDirectPlugin({
+        id: "telegram",
+        label: "Telegram",
+        docsPath: "/channels/telegram",
+        config: {
+          listAccountIds: listTelegramAccountIds,
+          defaultAccountId: resolveDefaultTelegramAccountId,
+          inspectAccount: (cfg, accountId) => inspectTelegramAccount({ cfg, accountId }),
+          resolveAccount: (cfg, accountId) => inspectTelegramAccount({ cfg, accountId }),
+          isConfigured: (account) => Boolean((account as { configured?: boolean }).configured),
+          isEnabled: (account) => (account as { enabled?: boolean }).enabled !== false,
+        },
+      }),
+    ]);
+
+    const cfg = {
+      channels: {
+        telegram: {
+          enabled: true,
+          defaultAccount: "nimbus",
+          accounts: {
+            default: {
+              tokenFile: "/tmp/openclaw-telegram-default-token",
+            },
+            nimbus: {
+              tokenFile: "/tmp/openclaw-telegram-default-token",
+            },
+            flint: {
+              tokenFile: "/tmp/openclaw-telegram-flint-token",
+            },
+          },
+        },
+      },
+    } as never;
+
+    const lines = await buildChannelSummary(cfg, {
+      colorize: false,
+      includeAllowFrom: false,
+    });
+
+    expect(lines).toContain("Telegram: configured");
+    expect(lines).toContain(
+      "  - default (token:tokenFile, secret unavailable in this command path)",
+    );
+    expect(lines).toContain("  - flint (token:tokenFile, secret unavailable in this command path)");
+    expect(lines).toContain(
+      "  - nimbus (token:tokenFile, secret unavailable in this command path)",
     );
   });
 });

--- a/src/infra/channel-summary.test.ts
+++ b/src/infra/channel-summary.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { inspectTelegramAccount } from "../telegram/account-inspect.js";
 import { listTelegramAccountIds, resolveDefaultTelegramAccountId } from "../telegram/accounts.js";
@@ -70,6 +71,10 @@ function makeSlackHttpSummaryPlugin(): ChannelPlugin {
 }
 
 describe("buildChannelSummary", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("preserves Slack HTTP signing-secret unavailable state from source config", async () => {
     vi.mocked(listChannelPlugins).mockReturnValue([makeSlackHttpSummaryPlugin()]);
 
@@ -86,6 +91,19 @@ describe("buildChannelSummary", () => {
   });
 
   it("treats multi-account Telegram tokenFile setups as configured", async () => {
+    const tokenFiles = new Set([
+      "/tmp/openclaw-telegram-default-token",
+      "/tmp/openclaw-telegram-flint-token",
+    ]);
+    const realExistsSync = fs.existsSync.bind(fs);
+    vi.spyOn(fs, "existsSync").mockImplementation((pathValue) => {
+      const candidate = String(pathValue);
+      if (tokenFiles.has(candidate)) {
+        return false;
+      }
+      return realExistsSync(pathValue);
+    });
+
     vi.mocked(listChannelPlugins).mockReturnValue([
       makeDirectPlugin({
         id: "telegram",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: I observed a shipped OpenClaw build report `Telegram: not configured` for a live multi-account Telegram setup that routes correctly via `channels.telegram.accounts.*.tokenFile`.
- Why it matters: misleading doctor/status output sends operators down the wrong debugging path even when Telegram is actually up and responding.
- What changed: add regression coverage for `buildChannelSummary` so multi-account Telegram `tokenFile` setups stay summarized as configured, including read-only credential paths where the token file is configured but unavailable to the current command path.
- What did NOT change (scope boundary): no runtime behavior, routing, token resolution, or config migration logic changed in this PR.

AI-assisted: yes (Codex). Testing: targeted regression test only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None. This PR adds regression coverage only.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout via `pnpm exec vitest`
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `channels.telegram.defaultAccount=nimbus` with `channels.telegram.accounts.default|nimbus|flint.tokenFile=...`

### Steps

1. Configure Telegram with multiple accounts under `channels.telegram.accounts`.
2. Point those accounts at file-backed bot credentials via `tokenFile`.
3. Build the channel summary / doctor status in a read-only path.

### Expected

- Telegram is summarized as configured.
- Each configured account remains visible even if the current command path cannot read the backing token file.

### Actual

- On the observed shipped build, doctor/status reported `Telegram: not configured` even though Telegram was live and replying.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Observed field output from the affected build included `Telegram: not configured` while the same installation was responding over Telegram. Current `main` already resolves the config correctly in local inspection, so this PR locks that behavior in with regression coverage.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm exec vitest run src/infra/channel-summary.test.ts`; confirmed the new test passes and the summary line stays `Telegram: configured` for a multi-account `tokenFile` setup.
- Edge cases checked: duplicate `tokenFile` use across `default` and a named account; read-only paths where configured file-backed credentials are unavailable to the current process.
- What you did **not** verify: full `pnpm build && pnpm check && pnpm test`; live gateway execution against a running Telegram bot from this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/infra/channel-summary.test.ts`
- Known bad symptoms reviewers should watch for: none beyond an incorrect regression test assumption.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the regression test could encode behavior that maintainers do not want to guarantee for config-only/read-only Telegram summaries.
  - Mitigation: the test stays narrowly scoped to summary output and does not change any runtime logic.
