### PR TITLE
fix(install.ps1): avoid exiting the host PowerShell session

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -277,16 +277,16 @@ function Main {
     if (!(Ensure-ExecutionPolicy)) {
         Write-Host ""
         Write-Host "Installation cannot continue due to execution policy restrictions" -Level error
-        exit 1
+        return $false
     }
     
     if (!(Ensure-Node)) {
-        exit 1
+        return $false
     }
     
     if ($InstallMethod -eq "git") {
         if (!(Ensure-Git)) {
-            exit 1
+            return $false
         }
         
         if ($DryRun) {
@@ -304,7 +304,7 @@ function Main {
             Write-Host "[DRY RUN] Would install OpenClaw via npm (tag: $Tag)" -Level info
         } else {
             if (!(Install-OpenClawNpm -Version $Tag)) {
-                exit 1
+                return $false
             }
         }
     }
@@ -324,6 +324,7 @@ function Main {
     
     Write-Host ""
     Write-Host "🦞 OpenClaw installed successfully!" -Level success
+    return $true
 }
 
-Main
+[void](Main)

--- a/test/install-ps1.test.mjs
+++ b/test/install-ps1.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const scriptPath = path.resolve(__dirname, "../scripts/install.ps1");
+const script = readFileSync(scriptPath, "utf8");
+const mainMatch = script.match(/function Main \{([\s\S]*?)\n\}\n\n\[void\]\(Main\)/);
+
+test("scripts/install.ps1 does not hard-exit the host PowerShell process from Main", () => {
+  assert.ok(mainMatch?.[1], "could not locate Main() body");
+  assert.doesNotMatch(mainMatch[1], /\bexit\s+1\b/);
+});
+
+test("scripts/install.ps1 suppresses Main's boolean return value at script entry", () => {
+  assert.match(script, /\[void\]\(Main\)/);
+});


### PR DESCRIPTION
## Summary
- replace `exit 1` in `scripts/install.ps1`'s `Main` function with `return $false`
- invoke `Main` via `[void](Main)` so boolean return values do not print to the console
- add a regression test that ensures `Main` no longer hard-exits the host PowerShell session

## Why
When `install.ps1` is run via `iwr -useb https://openclaw.ai/install.ps1 | iex`, `exit 1` inside `Main` terminates the caller's PowerShell process instead of just stopping the installer. Returning from `Main` keeps the shell open while still failing the installer path cleanly.

## Testing
- `node --test test/install-ps1.test.mjs`
- `git diff --check`

Closes #41797.
