### PR TITLE
feat(insta360): add Insta360 OSC camera control plugin

### DIFF
--- a/extensions/insta360/__snapshots__/index.test.ts.snap
+++ b/extensions/insta360/__snapshots__/index.test.ts.snap
@@ -1,0 +1,91 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`insta360 plugin registration > tool schema matches snapshot 1`] = `
+{
+  "properties": {
+    "action": {
+      "description": "Camera action: info, status, photo, record_start, record_stop, settings, list_files, download, delete.",
+      "enum": [
+        "info",
+        "status",
+        "photo",
+        "record_start",
+        "record_stop",
+        "settings",
+        "list_files",
+        "download",
+        "delete",
+      ],
+      "type": "string",
+    },
+    "count": {
+      "description": "Number of files to list (default 10).",
+      "type": "number",
+    },
+    "fileUrls": {
+      "description": "File URLs for download/delete.",
+      "items": {
+        "type": "string",
+      },
+      "type": "array",
+    },
+    "hdr": {
+      "description": "Enable HDR (photo only).",
+      "type": "boolean",
+    },
+    "options": {
+      "description": "Camera settings for the 'settings' action.",
+      "properties": {
+        "exposureProgram": {
+          "description": "1=Manual, 2=Auto, 4=Shutter Priority, 9=ISO Priority.",
+          "type": "number",
+        },
+        "iso": {
+          "description": "ISO value.",
+          "type": "number",
+        },
+        "shutterSpeed": {
+          "description": "Shutter speed.",
+          "type": "number",
+        },
+        "whiteBalance": {
+          "description": "White balance preset.",
+          "enum": [
+            "auto",
+            "incandescent",
+            "fluorescent",
+            "daylight",
+            "cloudy-daylight",
+          ],
+          "type": "string",
+        },
+      },
+      "type": "object",
+    },
+    "stitching": {
+      "description": "Photo stitching mode.",
+      "enum": [
+        "none",
+        "ondevice",
+      ],
+      "type": "string",
+    },
+    "timelapseInterval": {
+      "description": "Timelapse interval in seconds (0.2-120). Only for timelapse.",
+      "type": "number",
+    },
+    "videoType": {
+      "description": "Video type for record_start.",
+      "enum": [
+        "normal",
+        "timelapse",
+      ],
+      "type": "string",
+    },
+  },
+  "required": [
+    "action",
+  ],
+  "type": "object",
+}
+`;

--- a/extensions/insta360/index.test.ts
+++ b/extensions/insta360/index.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("insta360 plugin registration", () => {
+  it("registers tool, command, and service", async () => {
+    const api = {
+      pluginConfig: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      resolvePath: (p: string) => p.replace("~", "/home/test"),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      registerService: vi.fn(),
+    };
+
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    expect(api.registerTool).toHaveBeenCalledOnce();
+    expect(api.registerTool.mock.calls[0][0].name).toBe("insta360_camera");
+
+    expect(api.registerCommand).toHaveBeenCalledOnce();
+    expect(api.registerCommand.mock.calls[0][0].name).toBe("cam");
+
+    expect(api.registerService).toHaveBeenCalledOnce();
+    expect(api.registerService.mock.calls[0][0].id).toBe("insta360-monitor");
+  });
+
+  it("tool schema matches snapshot", async () => {
+    const api = {
+      pluginConfig: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      resolvePath: (p: string) => p.replace("~", "/home/test"),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      registerService: vi.fn(),
+    };
+
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    const schema = api.registerTool.mock.calls[0][0].parameters;
+    expect(JSON.parse(JSON.stringify(schema))).toMatchSnapshot();
+  });
+});

--- a/extensions/insta360/index.ts
+++ b/extensions/insta360/index.ts
@@ -1,0 +1,340 @@
+import path from "node:path";
+import { Type } from "@sinclair/typebox";
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginService,
+} from "openclaw/plugin-sdk/insta360";
+import { parseInsta360Config } from "./src/config.js";
+import { downloadFile } from "./src/download.js";
+import { RecordingMonitor } from "./src/monitor.js";
+import { OscClient } from "./src/osc-client.js";
+import { validateFileUrls, validateDownloadPath } from "./src/validation.js";
+
+const ACTIONS = [
+  "info",
+  "status",
+  "photo",
+  "record_start",
+  "record_stop",
+  "settings",
+  "list_files",
+  "download",
+  "delete",
+] as const;
+
+const VIDEO_TYPES = ["normal", "timelapse"] as const;
+const STITCHING_MODES = ["none", "ondevice"] as const;
+const WHITE_BALANCE_PRESETS = [
+  "auto",
+  "incandescent",
+  "fluorescent",
+  "daylight",
+  "cloudy-daylight",
+] as const;
+
+function stringEnum<T extends readonly string[]>(values: T, description: string) {
+  return Type.Unsafe<T[number]>({
+    type: "string",
+    enum: [...values],
+    description,
+  });
+}
+
+const Insta360Schema = Type.Object({
+  action: stringEnum(ACTIONS, `Camera action: ${ACTIONS.join(", ")}.`),
+  hdr: Type.Optional(Type.Boolean({ description: "Enable HDR (photo only)." })),
+  stitching: Type.Optional(stringEnum(STITCHING_MODES, "Photo stitching mode.")),
+  videoType: Type.Optional(stringEnum(VIDEO_TYPES, "Video type for record_start.")),
+  timelapseInterval: Type.Optional(
+    Type.Number({ description: "Timelapse interval in seconds (0.2-120). Only for timelapse." }),
+  ),
+  options: Type.Optional(
+    Type.Object(
+      {
+        iso: Type.Optional(Type.Number({ description: "ISO value." })),
+        shutterSpeed: Type.Optional(Type.Number({ description: "Shutter speed." })),
+        whiteBalance: Type.Optional(stringEnum(WHITE_BALANCE_PRESETS, "White balance preset.")),
+        exposureProgram: Type.Optional(
+          Type.Number({ description: "1=Manual, 2=Auto, 4=Shutter Priority, 9=ISO Priority." }),
+        ),
+      },
+      { description: "Camera settings for the 'settings' action." },
+    ),
+  ),
+  fileUrls: Type.Optional(
+    Type.Array(Type.String(), { description: "File URLs for download/delete." }),
+  ),
+  count: Type.Optional(Type.Number({ description: "Number of files to list (default 10)." })),
+});
+
+function json(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function text(msg: string) {
+  return { content: [{ type: "text" as const, text: msg }] };
+}
+
+export default function register(api: OpenClawPluginApi) {
+  const cfg = parseInsta360Config(api.pluginConfig);
+  let client: OscClient | null = null;
+  let monitor: RecordingMonitor | null = null;
+  let initialized = false;
+
+  function getClient(): OscClient {
+    if (!client) {
+      client = new OscClient(cfg.cameraHost);
+    }
+    return client;
+  }
+
+  function resolveDownloadDir(): string {
+    if (cfg.downloadPath) {
+      return api.resolvePath(cfg.downloadPath);
+    }
+    return api.resolvePath("~/.openclaw/plugins/insta360/media");
+  }
+
+  async function ensureInitialized(): Promise<void> {
+    if (initialized) return;
+    const c = getClient();
+    const { info } = await c.init();
+    const manufacturer = (info.manufacturer as string) ?? "";
+    if (!manufacturer.toLowerCase().includes("insta360")) {
+      throw new Error(
+        `Device at ${cfg.cameraHost} is not an Insta360 camera (manufacturer: ${manufacturer})`,
+      );
+    }
+    initialized = true;
+  }
+
+  // --- Tool ---
+  api.registerTool({
+    name: "insta360_camera",
+    label: "Insta360 Camera",
+    description: [
+      "Control an Insta360 camera via OSC protocol.",
+      "Actions: info, status, photo, record_start, record_stop, settings, list_files, download, delete.",
+      "For photo: optionally set hdr=true, stitching='ondevice'.",
+      "For record_start: set videoType='timelapse' and timelapseInterval (0.2-120s) for timelapse.",
+      "For settings: pass options object with iso, shutterSpeed, whiteBalance, exposureProgram.",
+      "For download/delete: pass fileUrls array from list_files results.",
+    ].join(" "),
+    parameters: Insta360Schema,
+    async execute(_toolCallId: string, params: Record<string, unknown>) {
+      const action = params.action as string;
+
+      try {
+        const c = getClient();
+
+        switch (action) {
+          case "info": {
+            const info = await c.getInfo();
+            return json(info);
+          }
+
+          case "status": {
+            const state = await c.getState();
+            return json(state);
+          }
+
+          case "photo": {
+            await ensureInitialized();
+            const setOpts: Record<string, unknown> = { captureMode: "image" };
+            if (params.hdr) setOpts.hdr = "hdr";
+            if (params.stitching) setOpts.photoStitching = params.stitching;
+            await c.execute("camera.setOptions", { options: setOpts });
+            const result = await c.executeAndWait("camera.takePicture");
+            return json(result);
+          }
+
+          case "record_start": {
+            await ensureInitialized();
+            const videoType = (params.videoType as string) ?? "normal";
+            const setOpts: Record<string, unknown> = {
+              captureMode: "video",
+              _videoType: videoType,
+            };
+            if (videoType === "timelapse" && typeof params.timelapseInterval === "number") {
+              setOpts._timelapseInterval = params.timelapseInterval;
+            }
+            await c.execute("camera.setOptions", { options: setOpts });
+            const result = await c.execute("camera.startCapture");
+
+            // Start monitor — route alerts to logger (visible in gateway logs + UI)
+            if (!monitor?.isRunning) {
+              const sessionKey =
+                typeof params._sessionKey === "string" ? params._sessionKey : "recording";
+              monitor = new RecordingMonitor({
+                client: c,
+                onAlert: (msg) => api.logger.warn(`[insta360] ${msg}`),
+                lowBatteryThreshold: cfg.lowBatteryThreshold,
+                lowStorageMB: cfg.lowStorageMB,
+                pollIntervalMs: cfg.pollIntervalMs,
+              });
+              monitor.start(sessionKey);
+            }
+
+            return json(result);
+          }
+
+          case "record_stop": {
+            try {
+              const result = await c.execute("camera.stopCapture");
+              // Stop monitor only after capture successfully stopped
+              monitor?.stop();
+              return json(result);
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              if (msg.includes("disabled") || msg.includes("not recording")) {
+                monitor?.stop();
+                return text("Recording already stopped.");
+              }
+              // Camera command failed — keep monitor running for disconnect alerts
+              throw err;
+            }
+          }
+
+          case "settings": {
+            const options = params.options as Record<string, unknown> | undefined;
+            if (!options || Object.keys(options).length === 0) {
+              return text(
+                "No settings provided. Pass options: { iso, shutterSpeed, whiteBalance, exposureProgram }",
+              );
+            }
+            const result = await c.execute("camera.setOptions", { options });
+            return json(result);
+          }
+
+          case "list_files": {
+            await ensureInitialized();
+            const count = typeof params.count === "number" ? params.count : 10;
+            const result = await c.execute("camera.listFiles", {
+              fileType: "all",
+              entryCount: count,
+              maxThumbSize: 0,
+            });
+            return json(result);
+          }
+
+          case "download": {
+            await ensureInitialized();
+            const urls = params.fileUrls as string[] | undefined;
+            if (!urls?.length) return text("No fileUrls provided.");
+            validateFileUrls(urls, cfg.cameraHost);
+            const downloadDir = resolveDownloadDir();
+            const results: { url: string; dest: string; bytes: number }[] = [];
+            for (const url of urls) {
+              const fileName = url.split("/").pop() ?? `file-${Date.now()}`;
+              const destPath = path.join(downloadDir, fileName);
+              validateDownloadPath(destPath, downloadDir);
+              const r = await downloadFile(url, destPath);
+              results.push({ url, dest: r.destPath, bytes: r.bytesWritten });
+            }
+            return json({ downloaded: results });
+          }
+
+          case "delete": {
+            await ensureInitialized();
+            const urls = params.fileUrls as string[] | undefined;
+            if (!urls?.length) return text("No fileUrls provided.");
+            validateFileUrls(urls, cfg.cameraHost);
+            const result = await c.execute("camera.delete", { fileUrls: urls });
+            return json(result);
+          }
+
+          default:
+            return text(`Unknown action: ${action}`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("ECONNREFUSED") || msg.includes("ETIMEDOUT")) {
+          return text(`Cannot reach camera at ${cfg.cameraHost}. Check WiFi connection.`);
+        }
+        if (msg.includes("unactivated")) {
+          return text("Camera not activated. Use the Insta360 app to activate first.");
+        }
+        return text(`Error: ${msg}`);
+      }
+    },
+  } as unknown as AnyAgentTool);
+
+  // --- Command ---
+  api.registerCommand({
+    name: "cam",
+    description:
+      "Quick Insta360 control: /cam photo | record [timelapse] | stop | status | files [count]",
+    handler: async (ctx) => {
+      const args = ctx.args?.trim() ?? "";
+      const tokens = args.split(/\s+/).filter(Boolean);
+      const action = tokens[0]?.toLowerCase() ?? "";
+      const c = getClient();
+
+      try {
+        switch (action) {
+          case "photo": {
+            await ensureInitialized();
+            await c.execute("camera.setOptions", { options: { captureMode: "image" } });
+            const result = await c.executeAndWait("camera.takePicture");
+            return { text: JSON.stringify(result, null, 2) };
+          }
+          case "record": {
+            await ensureInitialized();
+            const videoType = tokens[1] ?? "normal";
+            await c.execute("camera.setOptions", {
+              options: { captureMode: "video", _videoType: videoType },
+            });
+            const result = await c.execute("camera.startCapture");
+            return {
+              text: `Recording started (${videoType}).\n${JSON.stringify(result, null, 2)}`,
+            };
+          }
+          case "stop": {
+            const result = await c.execute("camera.stopCapture");
+            monitor?.stop();
+            return { text: `Recording stopped.\n${JSON.stringify(result, null, 2)}` };
+          }
+          case "status": {
+            const state = await c.getState();
+            const s = (state.state ?? state) as Record<string, unknown>;
+            const batt =
+              typeof s.batteryLevel === "number" ? Math.round(s.batteryLevel * 100) : "?";
+            const storage =
+              typeof s._storageRemainInMB === "number" ? Math.round(s._storageRemainInMB) : "?";
+            const card = (s._cardState as string) ?? "unknown";
+            return { text: `Battery: ${batt}% | Storage: ${storage}MB | SD: ${card}` };
+          }
+          case "files": {
+            const count = Number.parseInt(tokens[1] ?? "10", 10) || 10;
+            const result = await c.execute("camera.listFiles", {
+              fileType: "all",
+              entryCount: count,
+              maxThumbSize: 0,
+            });
+            return { text: JSON.stringify(result, null, 2) };
+          }
+          default:
+            return {
+              text: "Usage: /cam photo | record [timelapse] | stop | status | files [count]",
+            };
+        }
+      } catch (err) {
+        return { text: `Error: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    },
+  });
+
+  // --- Service ---
+  api.registerService({
+    id: "insta360-monitor",
+    start: async () => {
+      api.logger.info("insta360: plugin loaded");
+    },
+    stop: async () => {
+      monitor?.stop();
+      initialized = false;
+      client = null;
+    },
+  } as OpenClawPluginService);
+}

--- a/extensions/insta360/openclaw.plugin.json
+++ b/extensions/insta360/openclaw.plugin.json
@@ -1,0 +1,55 @@
+{
+  "id": "insta360",
+  "name": "Insta360 Camera",
+  "description": "Control Insta360 cameras via OSC protocol",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "cameraHost": {
+        "type": "string",
+        "default": "http://192.168.42.1"
+      },
+      "downloadPath": {
+        "type": "string"
+      },
+      "lowBatteryThreshold": {
+        "type": "number",
+        "default": 15
+      },
+      "lowStorageMB": {
+        "type": "number",
+        "default": 500
+      },
+      "pollIntervalMs": {
+        "type": "number",
+        "default": 30000
+      }
+    }
+  },
+  "uiHints": {
+    "cameraHost": {
+      "label": "Camera Host",
+      "placeholder": "http://192.168.42.1",
+      "help": "Camera OSC API address. Default works when connected to camera WiFi."
+    },
+    "downloadPath": {
+      "label": "Download Path",
+      "placeholder": "~/.openclaw/plugins/insta360/media/",
+      "help": "Local directory for downloaded files."
+    },
+    "lowBatteryThreshold": {
+      "label": "Low Battery Alert (%)",
+      "help": "Alert when battery drops below this percentage during recording."
+    },
+    "lowStorageMB": {
+      "label": "Low Storage Alert (MB)",
+      "help": "Alert when free storage drops below this value during recording."
+    },
+    "pollIntervalMs": {
+      "label": "Poll Interval (ms)",
+      "advanced": true,
+      "help": "Status polling interval during recording. Minimum 5000ms."
+    }
+  }
+}

--- a/extensions/insta360/package.json
+++ b/extensions/insta360/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/insta360",
+  "version": "2026.3.10",
+  "private": true,
+  "description": "OpenClaw plugin for Insta360 camera control via OSC",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/insta360/src/config.test.ts
+++ b/extensions/insta360/src/config.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { parseInsta360Config } from "./config.js";
+
+describe("parseInsta360Config", () => {
+  it("returns defaults when no config provided", () => {
+    const config = parseInsta360Config(undefined);
+    expect(config.cameraHost).toBe("http://192.168.42.1");
+    expect(config.downloadPath).toBe("");
+    expect(config.lowBatteryThreshold).toBe(15);
+    expect(config.lowStorageMB).toBe(500);
+    expect(config.pollIntervalMs).toBe(30000);
+  });
+
+  it("returns defaults when empty object provided", () => {
+    const config = parseInsta360Config({});
+    expect(config.cameraHost).toBe("http://192.168.42.1");
+    expect(config.downloadPath).toBe("");
+    expect(config.lowBatteryThreshold).toBe(15);
+    expect(config.lowStorageMB).toBe(500);
+    expect(config.pollIntervalMs).toBe(30000);
+  });
+
+  it("parses valid config", () => {
+    const config = parseInsta360Config({
+      cameraHost: "http://192.168.1.100",
+      downloadPath: "/tmp/insta360",
+      lowBatteryThreshold: 20,
+      lowStorageMB: 1000,
+      pollIntervalMs: 60000,
+    });
+    expect(config.cameraHost).toBe("http://192.168.1.100");
+    expect(config.downloadPath).toBe("/tmp/insta360");
+    expect(config.lowBatteryThreshold).toBe(20);
+    expect(config.lowStorageMB).toBe(1000);
+    expect(config.pollIntervalMs).toBe(60000);
+  });
+
+  it("clamps pollIntervalMs minimum to 5000", () => {
+    const config = parseInsta360Config({ pollIntervalMs: 100 });
+    expect(config.pollIntervalMs).toBe(5000);
+  });
+
+  it("keeps pollIntervalMs at exactly 5000 when set to 5000", () => {
+    const config = parseInsta360Config({ pollIntervalMs: 5000 });
+    expect(config.pollIntervalMs).toBe(5000);
+  });
+
+  it("clamps lowBatteryThreshold to minimum 1", () => {
+    const config = parseInsta360Config({ lowBatteryThreshold: 0 });
+    expect(config.lowBatteryThreshold).toBe(1);
+  });
+
+  it("clamps lowBatteryThreshold to maximum 100", () => {
+    const config = parseInsta360Config({ lowBatteryThreshold: 150 });
+    expect(config.lowBatteryThreshold).toBe(100);
+  });
+
+  it("rejects non-http cameraHost (ftp://evil.com)", () => {
+    expect(() => parseInsta360Config({ cameraHost: "ftp://evil.com" })).toThrow();
+  });
+
+  it("rejects public IP cameraHost (http://8.8.8.8)", () => {
+    expect(() => parseInsta360Config({ cameraHost: "http://8.8.8.8" })).toThrow();
+  });
+
+  it("accepts 192.168.x.x private IP range", () => {
+    const config = parseInsta360Config({ cameraHost: "http://192.168.0.1" });
+    expect(config.cameraHost).toBe("http://192.168.0.1");
+  });
+
+  it("accepts 10.x.x.x private IP range", () => {
+    const config = parseInsta360Config({ cameraHost: "http://10.0.0.1" });
+    expect(config.cameraHost).toBe("http://10.0.0.1");
+  });
+
+  it("accepts 172.16.x.x private IP range", () => {
+    const config = parseInsta360Config({ cameraHost: "http://172.16.0.1" });
+    expect(config.cameraHost).toBe("http://172.16.0.1");
+  });
+
+  it("accepts 172.31.x.x private IP range", () => {
+    const config = parseInsta360Config({ cameraHost: "http://172.31.255.255" });
+    expect(config.cameraHost).toBe("http://172.31.255.255");
+  });
+
+  it("accepts localhost", () => {
+    const config = parseInsta360Config({ cameraHost: "http://localhost" });
+    expect(config.cameraHost).toBe("http://localhost");
+  });
+
+  it("accepts 127.0.0.1 loopback", () => {
+    const config = parseInsta360Config({ cameraHost: "http://127.0.0.1" });
+    expect(config.cameraHost).toBe("http://127.0.0.1");
+  });
+
+  it("normalizes cameraHost with trailing path to origin only", () => {
+    const config = parseInsta360Config({ cameraHost: "http://192.168.42.1/osc/extra" });
+    expect(config.cameraHost).toBe("http://192.168.42.1");
+  });
+
+  it("normalizes cameraHost with port to origin", () => {
+    const config = parseInsta360Config({ cameraHost: "http://192.168.42.1:8080" });
+    expect(config.cameraHost).toBe("http://192.168.42.1:8080");
+  });
+
+  it("rejects 172.32.x.x (outside 172.16-31 range)", () => {
+    expect(() => parseInsta360Config({ cameraHost: "http://172.32.0.1" })).toThrow();
+  });
+
+  it("rejects lowStorageMB <= 0", () => {
+    expect(() => parseInsta360Config({ lowStorageMB: 0 })).toThrow();
+  });
+
+  it("rejects negative lowStorageMB", () => {
+    expect(() => parseInsta360Config({ lowStorageMB: -100 })).toThrow();
+  });
+});

--- a/extensions/insta360/src/config.ts
+++ b/extensions/insta360/src/config.ts
@@ -1,0 +1,150 @@
+export type Insta360Config = {
+  /** Base URL of the Insta360 camera OSC endpoint. Must be http:// on a private IP. */
+  cameraHost: string;
+  /** Local path to download media files to. Empty string means no auto-download. */
+  downloadPath: string;
+  /** Battery percentage at which a low-battery alert is fired. Clamped 1-100. */
+  lowBatteryThreshold: number;
+  /** Free storage in MB below which a low-storage alert is fired. Must be > 0. */
+  lowStorageMB: number;
+  /** How often to poll camera status in milliseconds. Minimum 5000. */
+  pollIntervalMs: number;
+};
+
+const DEFAULT_CAMERA_HOST = "http://192.168.42.1";
+const DEFAULT_DOWNLOAD_PATH = "";
+const DEFAULT_LOW_BATTERY_THRESHOLD = 15;
+const DEFAULT_LOW_STORAGE_MB = 500;
+const DEFAULT_POLL_INTERVAL_MS = 30000;
+const MIN_POLL_INTERVAL_MS = 5000;
+
+/** Returns true if the hostname/IP is a private/loopback address. */
+function isPrivateHost(host: string): boolean {
+  // Allow localhost
+  if (host === "localhost") {
+    return true;
+  }
+
+  // Validate IPv4 private ranges: 10.x.x.x, 192.168.x.x, 172.16-31.x.x, 127.0.0.1
+  const parts = host.split(".");
+  if (parts.length !== 4) {
+    return false;
+  }
+  const octets = parts.map(Number);
+  if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+
+  // 127.0.0.1 loopback
+  if (a === 127 && b === 0 && octets[2] === 0 && octets[3] === 1) {
+    return true;
+  }
+  // 10.x.x.x
+  if (a === 10) {
+    return true;
+  }
+  // 192.168.x.x
+  if (a === 192 && b === 168) {
+    return true;
+  }
+  // 172.16-31.x.x
+  if (a === 172 && b >= 16 && b <= 31) {
+    return true;
+  }
+
+  return false;
+}
+
+function validateCameraHost(value: string): void {
+  if (!value.startsWith("http://")) {
+    throw new Error(`cameraHost must use http:// scheme, got: ${value}`);
+  }
+  // Extract hostname (strip http:// and any trailing path/port)
+  const withoutScheme = value.slice("http://".length);
+  const hostname = withoutScheme.split("/")[0].split(":")[0];
+
+  if (!isPrivateHost(hostname)) {
+    throw new Error(
+      `cameraHost must be a private IP or localhost (10.x, 192.168.x, 172.16-31.x, 127.0.0.1, localhost), got host: ${hostname}`,
+    );
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parse and validate plugin config from `api.pluginConfig`.
+ * Returns an `Insta360Config` with all fields resolved to their defaults when absent.
+ * Throws on invalid values that cannot be safely defaulted or clamped.
+ */
+export function parseInsta360Config(raw: unknown): Insta360Config {
+  if (raw === undefined || raw === null) {
+    return {
+      cameraHost: DEFAULT_CAMERA_HOST,
+      downloadPath: DEFAULT_DOWNLOAD_PATH,
+      lowBatteryThreshold: DEFAULT_LOW_BATTERY_THRESHOLD,
+      lowStorageMB: DEFAULT_LOW_STORAGE_MB,
+      pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+    };
+  }
+
+  if (!isRecord(raw)) {
+    throw new Error("insta360 config must be an object");
+  }
+
+  // cameraHost
+  let cameraHost = DEFAULT_CAMERA_HOST;
+  if (raw.cameraHost !== undefined) {
+    if (typeof raw.cameraHost !== "string") {
+      throw new Error("cameraHost must be a string");
+    }
+    validateCameraHost(raw.cameraHost);
+    // Normalize to origin to avoid path duplication (e.g. "http://192.168.42.1/osc" + "/osc/info")
+    cameraHost = new URL(raw.cameraHost).origin;
+  }
+
+  // downloadPath
+  let downloadPath = DEFAULT_DOWNLOAD_PATH;
+  if (raw.downloadPath !== undefined) {
+    if (typeof raw.downloadPath !== "string") {
+      throw new Error("downloadPath must be a string");
+    }
+    downloadPath = raw.downloadPath;
+  }
+
+  // lowBatteryThreshold — clamp to 1-100
+  let lowBatteryThreshold = DEFAULT_LOW_BATTERY_THRESHOLD;
+  if (raw.lowBatteryThreshold !== undefined) {
+    if (typeof raw.lowBatteryThreshold !== "number" || !Number.isFinite(raw.lowBatteryThreshold)) {
+      throw new Error("lowBatteryThreshold must be a number");
+    }
+    lowBatteryThreshold = Math.min(100, Math.max(1, raw.lowBatteryThreshold));
+  }
+
+  // lowStorageMB — must be > 0
+  let lowStorageMB = DEFAULT_LOW_STORAGE_MB;
+  if (raw.lowStorageMB !== undefined) {
+    if (
+      typeof raw.lowStorageMB !== "number" ||
+      !Number.isFinite(raw.lowStorageMB) ||
+      raw.lowStorageMB <= 0
+    ) {
+      throw new Error("lowStorageMB must be a positive number");
+    }
+    lowStorageMB = raw.lowStorageMB;
+  }
+
+  // pollIntervalMs — clamp minimum to 5000
+  let pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+  if (raw.pollIntervalMs !== undefined) {
+    if (typeof raw.pollIntervalMs !== "number" || !Number.isFinite(raw.pollIntervalMs)) {
+      throw new Error("pollIntervalMs must be a number");
+    }
+    pollIntervalMs = Math.max(MIN_POLL_INTERVAL_MS, raw.pollIntervalMs);
+  }
+
+  return { cameraHost, downloadPath, lowBatteryThreshold, lowStorageMB, pollIntervalMs };
+}

--- a/extensions/insta360/src/download.test.ts
+++ b/extensions/insta360/src/download.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { downloadFile } from "./download.js";
+
+const mockFetch = vi.fn();
+
+describe("downloadFile", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "insta360-dl-"));
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("streams response body to file", async () => {
+    const body = Readable.toWeb(Readable.from(Buffer.from("fake-image-data")));
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      body,
+      headers: new Headers({ "content-length": "15" }),
+    });
+
+    const dest = path.join(tmpDir, "photo.jpg");
+    const result = await downloadFile("http://192.168.42.1/DCIM/photo.jpg", dest);
+    expect(result.bytesWritten).toBeGreaterThan(0);
+    const content = await fs.readFile(dest, "utf8");
+    expect(content).toBe("fake-image-data");
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, body: null });
+    const dest = path.join(tmpDir, "missing.jpg");
+    await expect(downloadFile("http://192.168.42.1/DCIM/missing.jpg", dest)).rejects.toThrow("404");
+  });
+});

--- a/extensions/insta360/src/download.ts
+++ b/extensions/insta360/src/download.ts
@@ -1,0 +1,38 @@
+import { createWriteStream } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+export type DownloadResult = {
+  bytesWritten: number;
+  destPath: string;
+};
+
+export async function downloadFile(
+  url: string,
+  destPath: string,
+  opts?: { timeoutMs?: number },
+): Promise<DownloadResult> {
+  const timeoutMs = opts?.timeoutMs ?? 10 * 60_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok || !response.body) {
+      throw new Error(`Download failed: ${response.status} for ${url}`);
+    }
+
+    await fs.mkdir(path.dirname(destPath), { recursive: true });
+    const dest = createWriteStream(destPath);
+    await pipeline(
+      Readable.fromWeb(response.body as import("node:stream/web").ReadableStream),
+      dest,
+    );
+
+    return { bytesWritten: dest.bytesWritten, destPath };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/extensions/insta360/src/monitor.test.ts
+++ b/extensions/insta360/src/monitor.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RecordingMonitor } from "./monitor.js";
+import type { OscClient } from "./osc-client.js";
+
+describe("RecordingMonitor", () => {
+  let monitor: RecordingMonitor;
+  let mockClient: { getState: ReturnType<typeof vi.fn> };
+  let mockAlert: (message: string, sessionKey: string) => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockClient = { getState: vi.fn() };
+    mockAlert = vi.fn<(message: string, sessionKey: string) => void>();
+    monitor = new RecordingMonitor({
+      client: mockClient as unknown as OscClient,
+      onAlert: mockAlert,
+      lowBatteryThreshold: 15,
+      lowStorageMB: 500,
+      pollIntervalMs: 30000,
+    });
+  });
+
+  afterEach(() => {
+    monitor.stop();
+    vi.useRealTimers();
+  });
+
+  it("does not poll when not started", () => {
+    expect(mockClient.getState).not.toHaveBeenCalled();
+  });
+
+  it("polls after start and alerts on low battery", async () => {
+    mockClient.getState.mockResolvedValue({
+      state: {
+        batteryLevel: 0.1,
+        _storageRemainInMB: 1000,
+        _cardState: "pass",
+      },
+    });
+
+    monitor.start("session-123");
+    await vi.advanceTimersByTimeAsync(30000);
+
+    expect(mockClient.getState).toHaveBeenCalled();
+    expect(mockAlert).toHaveBeenCalledWith(expect.stringContaining("battery"), "session-123");
+  });
+
+  it("alerts on low storage", async () => {
+    mockClient.getState.mockResolvedValue({
+      state: {
+        batteryLevel: 0.8,
+        _storageRemainInMB: 100,
+        _cardState: "pass",
+      },
+    });
+
+    monitor.start("session-123");
+    await vi.advanceTimersByTimeAsync(30000);
+
+    expect(mockAlert).toHaveBeenCalledWith(expect.stringContaining("storage"), "session-123");
+  });
+
+  it("alerts on camera disconnect and enters backoff", async () => {
+    mockClient.getState
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    monitor.start("session-123");
+    // First poll — fails once, disconnectCount=1 (no alert yet)
+    await vi.advanceTimersByTimeAsync(30000);
+    // Second poll — fails again, disconnectCount=2, alerts
+    await vi.advanceTimersByTimeAsync(30000);
+
+    expect(mockAlert).toHaveBeenCalledWith(expect.stringContaining("disconnected"), "session-123");
+  });
+
+  it("stops polling on stop()", async () => {
+    mockClient.getState.mockResolvedValue({
+      state: { batteryLevel: 0.8, _storageRemainInMB: 1000, _cardState: "pass" },
+    });
+
+    monitor.start("session-123");
+    monitor.stop();
+    await vi.advanceTimersByTimeAsync(60000);
+
+    expect(mockClient.getState).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/insta360/src/monitor.ts
+++ b/extensions/insta360/src/monitor.ts
@@ -1,0 +1,81 @@
+import type { OscClient } from "./osc-client.js";
+
+type MonitorOptions = {
+  client: OscClient;
+  onAlert: (message: string, sessionKey: string) => void;
+  lowBatteryThreshold: number;
+  lowStorageMB: number;
+  pollIntervalMs: number;
+};
+
+export class RecordingMonitor {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private sessionKey: string | null = null;
+  private disconnectCount = 0;
+  private readonly opts: MonitorOptions;
+  private lastAlert: string | null = null;
+
+  constructor(opts: MonitorOptions) {
+    this.opts = opts;
+  }
+
+  start(sessionKey: string): void {
+    this.stop();
+    this.sessionKey = sessionKey;
+    this.disconnectCount = 0;
+    this.lastAlert = null;
+    this.timer = setInterval(() => {
+      this.poll().catch(() => {});
+    }, this.opts.pollIntervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.sessionKey = null;
+    this.disconnectCount = 0;
+    this.lastAlert = null;
+  }
+
+  get isRunning(): boolean {
+    return this.timer !== null;
+  }
+
+  private alert(message: string): void {
+    if (!this.sessionKey || message === this.lastAlert) return;
+    this.lastAlert = message;
+    this.opts.onAlert(message, this.sessionKey);
+  }
+
+  private async poll(): Promise<void> {
+    if (!this.sessionKey) return;
+
+    let state: Record<string, unknown>;
+    try {
+      const response = await this.opts.client.getState();
+      state = (response.state ?? response) as Record<string, unknown>;
+      this.disconnectCount = 0;
+    } catch {
+      this.disconnectCount++;
+      if (this.disconnectCount >= 2) {
+        this.alert("Camera disconnected during recording. Check WiFi connection.");
+      }
+      return;
+    }
+
+    const batteryLevel = typeof state.batteryLevel === "number" ? state.batteryLevel : 1;
+    const batteryPct = Math.round(batteryLevel * 100);
+    if (batteryPct <= this.opts.lowBatteryThreshold) {
+      this.alert(`Low battery: ${batteryPct}%. Consider stopping recording.`);
+    }
+
+    const storageMB =
+      typeof state._storageRemainInMB === "number" ? state._storageRemainInMB : Infinity;
+    if (storageMB <= this.opts.lowStorageMB) {
+      this.alert(`Low storage: ${Math.round(storageMB)}MB remaining. Consider stopping recording.`);
+    }
+  }
+}

--- a/extensions/insta360/src/osc-client.test.ts
+++ b/extensions/insta360/src/osc-client.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { OscClient } from "./osc-client.js";
+
+const BASE_URL = "http://192.168.1.1";
+
+function makeOkResponse(body: Record<string, unknown>): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("OscClient", () => {
+  describe("getInfo", () => {
+    it("sends GET to /osc/info with correct headers", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse({ model: "X4" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      const result = await client.getInfo();
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE_URL}/osc/info`);
+      expect(opts.method).toBe("GET");
+      expect(opts.headers["Content-Type"]).toBe("application/json;charset=utf-8");
+      expect(opts.headers["Accept"]).toBe("application/json");
+      expect(opts.headers["X-XSRF-Protected"]).toBe("1");
+      expect(result).toEqual({ model: "X4" });
+    });
+  });
+
+  describe("getState", () => {
+    it("sends POST to /osc/state", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse({ state: { battery: 80 } }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      const result = await client.getState();
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE_URL}/osc/state`);
+      expect(opts.method).toBe("POST");
+      expect(result).toEqual({ state: { battery: 80 } });
+    });
+  });
+
+  describe("execute", () => {
+    it("sends POST to /osc/commands/execute with correct body", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(makeOkResponse({ name: "camera.takePicture", state: "done" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      const result = await client.execute("camera.takePicture", { mode: "normal" });
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE_URL}/osc/commands/execute`);
+      expect(opts.method).toBe("POST");
+      const body = JSON.parse(opts.body as string);
+      expect(body).toEqual({ name: "camera.takePicture", parameters: { mode: "normal" } });
+      expect(result).toEqual({ name: "camera.takePicture", state: "done" });
+    });
+
+    it("sends execute without parameters when none provided", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(makeOkResponse({ name: "camera.takePicture", state: "done" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      await client.execute("camera.takePicture");
+
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body as string);
+      expect(body).toEqual({ name: "camera.takePicture", parameters: undefined });
+    });
+  });
+
+  describe("serial queue", () => {
+    it("runs 3 concurrent execute calls in order", async () => {
+      const order: number[] = [];
+      let resolvers: Array<() => void> = [];
+
+      const fetchMock = vi.fn().mockImplementation(() => {
+        return new Promise<Response>((resolve) => {
+          resolvers.push(() => {
+            order.push(resolvers.length);
+            resolve(makeOkResponse({ state: "done" }));
+          });
+        });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      vi.useRealTimers();
+
+      const client = new OscClient(BASE_URL);
+
+      const p1 = client.execute("cmd1");
+      const p2 = client.execute("cmd2");
+      const p3 = client.execute("cmd3");
+
+      // Allow the first fetch to be initiated
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Resolve fetch calls one at a time and verify serial ordering
+      expect(resolvers).toHaveLength(1); // only first has started
+      resolvers[0]();
+      await p1;
+      // Flush microtasks so next enqueue fires fetch
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(resolvers).toHaveLength(2); // second now started
+      resolvers[1]();
+      await p2;
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(resolvers).toHaveLength(3); // third now started
+      resolvers[2]();
+      await p3;
+
+      expect(order).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe("error isolation", () => {
+    it("second command succeeds even when first command rejects", async () => {
+      vi.useRealTimers();
+      let callCount = 0;
+      const fetchMock = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.reject(new Error("Camera error"));
+        }
+        return Promise.resolve(makeOkResponse({ state: "done" }));
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+
+      const p1 = client.execute("cmd1");
+      const p2 = client.execute("cmd2");
+
+      await expect(p1).rejects.toThrow("Camera error");
+      const result = await p2;
+      expect(result).toEqual({ state: "done" });
+    });
+  });
+
+  describe("pollCommandStatus", () => {
+    it("sends POST to /osc/commands/status with id", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse({ id: "abc123", state: "done" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      const result = await client.pollCommandStatus("abc123");
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE_URL}/osc/commands/status`);
+      expect(opts.method).toBe("POST");
+      const body = JSON.parse(opts.body as string);
+      expect(body).toEqual({ id: "abc123" });
+      expect(result).toEqual({ id: "abc123", state: "done" });
+    });
+  });
+
+  describe("executeAndWait", () => {
+    it("polls until state is not inProgress (inProgress -> inProgress -> done)", async () => {
+      vi.useRealTimers();
+      let fetchCount = 0;
+      const fetchMock = vi.fn().mockImplementation(() => {
+        fetchCount++;
+        if (fetchCount === 1) {
+          // execute response
+          return Promise.resolve(makeOkResponse({ id: "cmd1", state: "inProgress" }));
+        } else if (fetchCount === 2) {
+          // first poll: still inProgress
+          return Promise.resolve(makeOkResponse({ id: "cmd1", state: "inProgress" }));
+        } else {
+          // second poll: done
+          return Promise.resolve(makeOkResponse({ id: "cmd1", state: "done", results: {} }));
+        }
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      const result = await client.executeAndWait(
+        "camera.startCapture",
+        {},
+        {
+          pollStartMs: 10,
+          pollMaxMs: 50,
+          timeoutMs: 5000,
+        },
+      );
+
+      expect(fetchCount).toBe(3);
+      expect(result).toEqual({ id: "cmd1", state: "done", results: {} });
+    });
+
+    it("throws timeout error when command stays inProgress past timeoutMs", async () => {
+      vi.useRealTimers();
+      const fetchMock = vi.fn().mockImplementation(() => {
+        return Promise.resolve(makeOkResponse({ id: "cmd1", state: "inProgress" }));
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      await expect(
+        client.executeAndWait(
+          "camera.startCapture",
+          {},
+          {
+            pollStartMs: 10,
+            pollMaxMs: 50,
+            timeoutMs: 100,
+          },
+        ),
+      ).rejects.toThrow("Command camera.startCapture timed out after 100ms");
+    });
+  });
+
+  describe("transient retry", () => {
+    it("retries once on ECONNREFUSED and succeeds on second attempt", async () => {
+      vi.useRealTimers();
+      let callCount = 0;
+      const fetchMock = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          const err = new Error("connect ECONNREFUSED");
+          (err as NodeJS.ErrnoException).code = "ECONNREFUSED";
+          return Promise.reject(err);
+        }
+        return Promise.resolve(makeOkResponse({ model: "X4" }));
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      const result = await client.getInfo();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ model: "X4" });
+    });
+
+    it("does not retry on non-transient errors", async () => {
+      vi.useRealTimers();
+      const fetchMock = vi.fn().mockRejectedValue(new Error("Auth failed"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      await expect(client.getInfo()).rejects.toThrow("Auth failed");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("HTTP error handling", () => {
+    it("throws on non-ok HTTP response", async () => {
+      vi.useRealTimers();
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: "service unavailable" }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      await expect(client.getInfo()).rejects.toThrow("returned 503");
+    });
+  });
+
+  describe("queue depth limit", () => {
+    it("rejects with busy error when queue depth exceeds 10", async () => {
+      vi.useRealTimers();
+      // Never resolves — keeps the queue full
+      const fetchMock = vi.fn().mockImplementation(() => new Promise(() => {}));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+
+      const promises: Promise<unknown>[] = [];
+      // First call starts immediately (not queued), then we need 10 more to fill the queue
+      for (let i = 0; i < 11; i++) {
+        promises.push(client.execute(`cmd${i}`).catch(() => {}));
+      }
+
+      // The 12th call should be rejected
+      await expect(client.execute("overflow")).rejects.toThrow(
+        "Camera busy, too many queued commands",
+      );
+    });
+  });
+
+  describe("init", () => {
+    it("calls getInfo then getState and returns both", async () => {
+      vi.useRealTimers();
+      const infoBody = { model: "X4", firmwareVersion: "1.0" };
+      const stateBody = { state: { battery: 75 } };
+      let callCount = 0;
+      const fetchMock = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(makeOkResponse(infoBody));
+        }
+        return Promise.resolve(makeOkResponse(stateBody));
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new OscClient(BASE_URL);
+      const result = await client.init();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ info: infoBody, state: stateBody });
+    });
+  });
+});

--- a/extensions/insta360/src/osc-client.ts
+++ b/extensions/insta360/src/osc-client.ts
@@ -1,0 +1,186 @@
+/**
+ * OSC HTTP client for Insta360 cameras.
+ * Ensures serial command execution per OSC spec (never send a new command before the previous returns).
+ */
+
+export type OscResponse = Record<string, unknown>;
+
+const TRANSIENT_CODES = new Set(["ECONNREFUSED", "ETIMEDOUT", "ECONNRESET"]);
+
+const OSC_HEADERS = {
+  "Content-Type": "application/json;charset=utf-8",
+  Accept: "application/json",
+  "X-XSRF-Protected": "1",
+};
+
+/** Maximum number of commands that may be waiting in the queue (not counting the active one). */
+const QUEUE_DEPTH_LIMIT = 10;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface ExecuteAndWaitOpts {
+  /** Initial polling interval in ms (default 500). */
+  pollStartMs?: number;
+  /** Maximum polling interval after exponential back-off (default 5000). */
+  pollMaxMs?: number;
+  /** Total timeout in ms before throwing (default 60000). */
+  timeoutMs?: number;
+}
+
+export class OscClient {
+  private readonly baseUrl: string;
+
+  /**
+   * Tail of the promise chain — each enqueued command replaces this.
+   * Initialised to a resolved promise so the first command starts immediately.
+   */
+  private mutex: Promise<unknown> = Promise.resolve();
+
+  /** Number of commands currently waiting behind the active one. */
+  private queueDepth = 0;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Execute fn through the serial mutex queue, enforcing the depth limit. */
+  private enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.queueDepth >= QUEUE_DEPTH_LIMIT) {
+      return Promise.reject(new Error("Camera busy, too many queued commands"));
+    }
+
+    this.queueDepth++;
+
+    // Chain onto the current tail of the queue.
+    // Errors must not block subsequent commands, so we always resolve the chain link.
+    const next = this.mutex.then(
+      () => {
+        this.queueDepth--;
+        return fn();
+      },
+      () => {
+        // Previous command failed — still decrement and run next.
+        this.queueDepth--;
+        return fn();
+      },
+    );
+
+    // Settle the chain so subsequent commands wait on `next` completing (not rejecting).
+    this.mutex = next.then(
+      () => {},
+      () => {},
+    );
+
+    return next;
+  }
+
+  /**
+   * Raw fetch with transient-error retry (single retry after 1 s for
+   * ECONNREFUSED / ETIMEDOUT / ECONNRESET).
+   */
+  private async request(url: string, opts: RequestInit): Promise<OscResponse> {
+    const attempt = async (): Promise<OscResponse> => {
+      const res = await fetch(url, { ...opts, headers: OSC_HEADERS });
+      if (!res.ok) {
+        throw new Error(
+          `OSC request failed: ${opts.method ?? "GET"} ${url} returned ${res.status}`,
+        );
+      }
+      return res.json() as Promise<OscResponse>;
+    };
+
+    try {
+      return await attempt();
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code && TRANSIENT_CODES.has(code)) {
+        await delay(1000);
+        return attempt();
+      }
+      throw err;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /** GET /osc/info — camera model and capabilities. */
+  getInfo(): Promise<OscResponse> {
+    return this.enqueue(() => this.request(`${this.baseUrl}/osc/info`, { method: "GET" }));
+  }
+
+  /** POST /osc/state — current camera state (battery, capture status, …). */
+  getState(): Promise<OscResponse> {
+    return this.enqueue(() => this.request(`${this.baseUrl}/osc/state`, { method: "POST" }));
+  }
+
+  /** POST /osc/commands/execute — run a named OSC command with optional parameters. */
+  execute(name: string, parameters?: Record<string, unknown>): Promise<OscResponse> {
+    return this.enqueue(() =>
+      this.request(`${this.baseUrl}/osc/commands/execute`, {
+        method: "POST",
+        body: JSON.stringify({ name, parameters }),
+      }),
+    );
+  }
+
+  /** POST /osc/commands/status — poll for the result of an async command. */
+  pollCommandStatus(id: string): Promise<OscResponse> {
+    return this.enqueue(() =>
+      this.request(`${this.baseUrl}/osc/commands/status`, {
+        method: "POST",
+        body: JSON.stringify({ id }),
+      }),
+    );
+  }
+
+  /**
+   * Execute a command and poll until it finishes (state !== "inProgress").
+   * Uses exponential back-off between polls and throws on timeout.
+   */
+  async executeAndWait(
+    name: string,
+    parameters?: Record<string, unknown>,
+    opts: ExecuteAndWaitOpts = {},
+  ): Promise<OscResponse> {
+    const pollStartMs = opts.pollStartMs ?? 500;
+    const pollMaxMs = opts.pollMaxMs ?? 5000;
+    const timeoutMs = opts.timeoutMs ?? 60_000;
+
+    const startAt = Date.now();
+    let response = await this.execute(name, parameters);
+
+    let interval = pollStartMs;
+
+    while (response.state === "inProgress") {
+      if (Date.now() - startAt >= timeoutMs) {
+        throw new Error(`Command ${name} timed out after ${timeoutMs}ms`);
+      }
+      await delay(interval);
+      // Double backoff, capped at pollMaxMs
+      interval = Math.min(interval * 2, pollMaxMs);
+
+      const id = response.id as string;
+      response = await this.pollCommandStatus(id);
+    }
+
+    return response;
+  }
+
+  /**
+   * Initialise the connection — required before first capture per OSC spec.
+   * Returns both info and state so callers can inspect camera capabilities.
+   */
+  async init(): Promise<{ info: OscResponse; state: OscResponse }> {
+    const info = await this.getInfo();
+    const state = await this.getState();
+    return { info, state };
+  }
+}

--- a/extensions/insta360/src/validation.test.ts
+++ b/extensions/insta360/src/validation.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { validateFileUrls, validateDownloadPath } from "./validation.js";
+
+describe("validateFileUrls", () => {
+  const cameraHost = "http://192.168.1.1";
+
+  it("accepts URLs matching camera host", () => {
+    expect(() =>
+      validateFileUrls(
+        ["http://192.168.1.1/file1.mp4", "http://192.168.1.1/file2.mp4"],
+        cameraHost,
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects URLs not matching camera host", () => {
+    expect(() => validateFileUrls(["http://evil.com/file.mp4"], cameraHost)).toThrow(
+      "URL http://evil.com/file.mp4 does not match camera host http://192.168.1.1",
+    );
+  });
+
+  it("rejects empty array", () => {
+    expect(() => validateFileUrls([], cameraHost)).toThrow("No file URLs provided.");
+  });
+});
+
+describe("validateDownloadPath", () => {
+  const baseDir = "/tmp/downloads";
+
+  it("rejects path traversal", () => {
+    expect(() => validateDownloadPath("/tmp/downloads/../../etc/passwd", baseDir)).toThrow(
+      "Path /tmp/downloads/../../etc/passwd resolves outside allowed directory /tmp/downloads",
+    );
+  });
+
+  it("accepts valid subpath", () => {
+    expect(() => validateDownloadPath("/tmp/downloads/video.mp4", baseDir)).not.toThrow();
+  });
+});

--- a/extensions/insta360/src/validation.ts
+++ b/extensions/insta360/src/validation.ts
@@ -1,0 +1,34 @@
+import path from "node:path";
+
+/**
+ * Validates that all provided URLs match the camera host origin.
+ * Prevents SSRF by ensuring requests only go to the expected camera.
+ */
+export function validateFileUrls(urls: string[], cameraHost: string): void {
+  if (urls.length === 0) {
+    throw new Error("No file URLs provided.");
+  }
+
+  const expectedOrigin = new URL(cameraHost).origin;
+
+  for (const url of urls) {
+    const parsed = new URL(url);
+    if (parsed.origin !== expectedOrigin) {
+      throw new Error(`URL ${url} does not match camera host ${expectedOrigin}`);
+    }
+  }
+}
+
+/**
+ * Validates that a file path resolves within the allowed base directory.
+ * Prevents path traversal attacks when downloading files.
+ */
+export function validateDownloadPath(filePath: string, baseDir: string): void {
+  const resolvedFile = path.resolve(filePath);
+  const resolvedBase = path.resolve(baseDir);
+
+  // Allow paths that are equal to baseDir or are strictly inside it
+  if (resolvedFile !== resolvedBase && !resolvedFile.startsWith(resolvedBase + path.sep)) {
+    throw new Error(`Path ${filePath} resolves outside allowed directory ${baseDir}`);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -120,6 +120,10 @@
       "types": "./dist/plugin-sdk/irc.d.ts",
       "default": "./dist/plugin-sdk/irc.js"
     },
+    "./plugin-sdk/insta360": {
+      "types": "./dist/plugin-sdk/insta360.d.ts",
+      "default": "./dist/plugin-sdk/insta360.js"
+    },
     "./plugin-sdk/llm-task": {
       "types": "./dist/plugin-sdk/llm-task.d.ts",
       "default": "./dist/plugin-sdk/llm-task.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,12 @@ importers:
 
   extensions/imessage: {}
 
+  extensions/insta360:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+
   extensions/irc:
     dependencies:
       zod:
@@ -1275,89 +1281,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1447,24 +1469,28 @@ packages:
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@lancedb/lancedb-linux-arm64-musl@0.26.2':
     resolution: {integrity: sha512-pR6Hs/0iphItrJYYLf/yrqCC+scPcHpCGl6rHqcU2GHxo5RFpzlMzqW1DiXScGiBRuCcD9HIMec+kBsOgXv4GQ==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@lancedb/lancedb-linux-x64-gnu@0.26.2':
     resolution: {integrity: sha512-u4UUSPwd2YecgGqWjh9W0MHKgsVwB2Ch2ROpF8AY+IA7kpGsbB18R1/t7v2B0q7pahRy20dgsaku5LH1zuzMRQ==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@lancedb/lancedb-linux-x64-musl@0.26.2':
     resolution: {integrity: sha512-XIS4qkVfGlzmsUPqAG2iKt8ykuz28GfemGC0ijXwu04kC1pYiCFzTpB3UIZjm5oM7OTync1aQ3mGTj1oCciSPA==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@lancedb/lancedb-win32-arm64-msvc@0.26.2':
     resolution: {integrity: sha512-//tZDPitm2PxNvalHP+m+Pf6VvFAeQgcht1+HJnutjH4gp6xYW6ynQlWWFDBmz9WRkUT+mXu2O4FUIhbdNaJSQ==}
@@ -1560,30 +1586,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
     resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
     resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
     resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.2':
     resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
     resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
@@ -1671,30 +1702,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.95':
     resolution: {integrity: sha512-PXy0UT1J/8MPG8UAkWp6Fd51ZtIZINFzIjGH909JjQrtCuJf3X6nanHYdz1A+Wq9o4aoPAw1YEUpFS1lelsVlg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.95':
     resolution: {integrity: sha512-2IzCkW2RHRdcgF9W5/plHvYFpc6uikyjMb5SxjqmNxfyDFz9/HB89yhi8YQo0SNqrGRI7yBVDec7Pt+uMyRWsg==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.95':
     resolution: {integrity: sha512-OV/ol/OtcUr4qDhQg8G7SdViZX8XyQeKpPsVv/j3+7U178FGoU4M+yIocdVo1ih/A8GQ63+LjF4jDoEjaVU8Pw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.95':
     resolution: {integrity: sha512-Z5KzqBK/XzPz5+SFHKz7yKqClEQ8pOiEDdgk5SlphBLVNb8JFIJkxhtJKSvnJyHh2rjVgiFmvtJzMF0gNwwKyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.95':
     resolution: {integrity: sha512-aj0YbRpe8qVJ4OzMsK7NfNQePgcf9zkGFzNZ9mSuaxXzhpLHmlF2GivNdCdNOg8WzA/NxV6IU4c5XkXadUMLeA==}
@@ -1735,36 +1771,28 @@ packages:
     engines: {node: '>=20.0.0'}
     cpu: [arm64, x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-llama-cpp/linux-armv7l@3.16.2':
     resolution: {integrity: sha512-9G6W/MkQ/DLwGmpcj143NQ50QJg5gQZfzVf5RYx77VczBqhgwkgYHILekYrOs4xanOeqeJ8jnOnQQSp1YaJZUg==}
     engines: {node: '>=20.0.0'}
     cpu: [arm, x64]
     os: [linux]
-
-  '@node-llama-cpp/linux-x64-cuda-ext@3.16.2':
-    resolution: {integrity: sha512-47d9myCJauZyzAlN7IK1eIt/4CcBMslF+yHy4q+yJotD/RV/S6qRpK2kGn+ybtdVjkPGNCoPkHKcyla9iIVjbw==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@node-llama-cpp/linux-x64-cuda@3.16.2':
-    resolution: {integrity: sha512-LTBQFqjin7tyrLNJz0XWTB5QAHDsZV71/qiiRRjXdBKSZHVVaPLfdgxypGu7ggPeBNsv+MckRXdlH5C7yMtE4A==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [linux]
+    libc: [glibc]
 
   '@node-llama-cpp/linux-x64-vulkan@3.16.2':
     resolution: {integrity: sha512-HDLAw4ZhwJuhKuF6n4x520yZXAQZahUOXtCGvPubjfpmIOElKrfDvCVlRsthAP0JwcwINzIQlVys3boMIXfBgw==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-llama-cpp/linux-x64@3.16.2':
     resolution: {integrity: sha512-OXYf8rVfoDyvN+YrfKk8F9An9a5GOxVIM8OcR1U911tc0oRNf8yfJrQ8KrM75R26gwq0Y6YZwVTP0vRCInwWOw==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-llama-cpp/mac-arm64-metal@3.16.2':
     resolution: {integrity: sha512-nEZ74qB0lUohF88yR741YUrUqz/qD+FJFzUTHj0FwxAynSZCjvwtzEDtavRlh3qd3yLD/0ChNn00/RQ54ISImw==}
@@ -1782,24 +1810,6 @@ packages:
     resolution: {integrity: sha512-XHNFQzUjYODtkZjIn4NbQVrBtGB9RI9TpisiALryqfrIqagQmjBh6dmxZWlt5uduKAfT7M2/2vrABGR490FACA==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64, x64]
-    os: [win32]
-
-  '@node-llama-cpp/win-x64-cuda-ext@3.16.2':
-    resolution: {integrity: sha512-sdv4Kzn9bOQWNBRvw6B/zcn8dQRfZhjIHv5AfDBIOfRlSCgjebFpBeYUoU4wZPpjr3ISwcqO5MEWsw+AbUdV3Q==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@node-llama-cpp/win-x64-cuda@3.16.2':
-    resolution: {integrity: sha512-jStDELHrU3rKQMOk5Hs5bWEazyjE2hzHwpNf6SblOpaGkajM/HJtxEZoL0mLHJx5qeXs4oOVkr7AzuLy0WPpNA==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@node-llama-cpp/win-x64-vulkan@3.16.2':
-    resolution: {integrity: sha512-9xuHFCOhCQjZgQSFrk79EuSKn9nGWt/SAq/3wujQSQLtgp8jGdtZgwcmuDUoemInf10en2dcOmEt7t8dQdC3XA==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
     os: [win32]
 
   '@node-llama-cpp/win-x64@3.16.2':
@@ -2149,48 +2159,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.36.0':
     resolution: {integrity: sha512-SPGLJkOIHSIC6ABUQ5V8NqJpvYhMJueJv26NYqfCnwi/Mn6A61amkpJJ9Suy0Nmvs+OWESJpcebrBUbXPGZyQQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.36.0':
     resolution: {integrity: sha512-3EuoyB8x9x8ysYJjbEO/M9fkSk72zQKnXCvpZMDHXlnY36/1qMp55Nm0PrCwjGO/1pen5hdOVkz9WmP3nAp2IQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.36.0':
     resolution: {integrity: sha512-MpY3itLwpGh8dnywtrZtaZ604T1m715SydCKy0+qTxetv+IHzuA+aO/AGzrlzUNYZZmtWtmDBrChZGibvZxbRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.36.0':
     resolution: {integrity: sha512-mmDhe4Vtx+XwQPRPn/V25+APnkApYgZ23q+6GVsNYY98pf3aU0aI3Me96pbRs/AfJ1jIiGC+/6q71FEu8dHcHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.36.0':
     resolution: {integrity: sha512-AYXhU+DmNWLSnvVwkHM92fuYhogtVHab7UQrPNaDf1sxadugg9gWVmcgJDlIwxJdpk5CVW/TFvwUKwI432zhhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.36.0':
     resolution: {integrity: sha512-H16QhhQ3usoakMleiAAQ2mg0NsBDAdyE9agUgfC8IHHh3jZEbr0rIKwjEqwbOHK5M0EmfhJmr+aGO/MgZPsneA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.36.0':
     resolution: {integrity: sha512-EFFGkixA39BcmHiCe2ECdrq02D6FCve5ka6ObbvrheXl4V+R0U/E+/uLyVx1X65LW8TA8QQHdnbdDallRekohw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.36.0':
     resolution: {integrity: sha512-zr/t369wZWFOj1qf06Z5gGNjFymfUNDrxKMmr7FKiDRVI1sNsdKRCuRL4XVjtcptKQ+ao3FfxLN1vrynivmCYg==}
@@ -2293,48 +2311,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.51.0':
     resolution: {integrity: sha512-YSJua5irtG4DoMAjUapDTPhkQLHhBIY0G9JqlZS6/SZPzqDkPku/1GdWs0D6h/wyx0Iz31lNCfIaWKBQhzP0wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.51.0':
     resolution: {integrity: sha512-7L4Wj2IEUNDETKssB9IDYt16T6WlF+X2jgC/hBq3diGHda9vJLpAgb09+D3quFq7TdkFtI7hwz/jmuQmQFPc1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.51.0':
     resolution: {integrity: sha512-cBUHqtOXy76G41lOB401qpFoKx1xq17qYkhWrLSM7eEjiHM9sOtYqpr6ZdqCnN9s6ZpzudX4EkeHOFH2E9q0vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.51.0':
     resolution: {integrity: sha512-WKbg8CysgZcHfZX0ixQFBRSBvFZUHa3SBnEjHY2FVYt2nbNJEjzTxA3ZR5wMU0NOCNKIAFUFvAh5/XJKPRJuJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.51.0':
     resolution: {integrity: sha512-N1QRUvJTxqXNSu35YOufdjsAVmKVx5bkrggOWAhTWBc3J4qjcBwr1IfyLh/6YCg8sYRSR1GraldS9jUgJL/U4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.51.0':
     resolution: {integrity: sha512-e0Mz0DizsCoqNIjeOg6OUKe8JKJWZ5zZlwsd05Bmr51Jo3AOL4UJnPvwKumr4BBtBrDZkCmOLhCvDGm95nJM2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.51.0':
     resolution: {integrity: sha512-wD8HGTWhYBKXvRDvoBVB1y+fEYV01samhWQSy1Zkxq2vpezvMnjaFKRuiP6tBNITLGuffbNDEXOwcAhJ3gI5Ug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.51.0':
     resolution: {integrity: sha512-5NSwQ2hDEJ0GPXqikjWtwzgAQCsS7P9aLMNenjjKa+gknN3lTCwwwERsT6lKXSirfU3jLjexA2XQvQALh5h27w==}
@@ -2426,24 +2452,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@reflink/reflink-linux-arm64-musl@0.1.19':
     resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@reflink/reflink-linux-x64-gnu@0.1.19':
     resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@reflink/reflink-linux-x64-musl@0.1.19':
     resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@reflink/reflink-win32-arm64-msvc@0.1.19':
     resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
@@ -2496,36 +2526,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.7':
     resolution: {integrity: sha512-G43ZElEvaby+YSOgrXfBgpeQv42LdS0ivFFYQufk2tBDWeBfzE/+ob5DmO8Izbyn4Y8k6GgLF11jFDYNnmU/3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.7':
     resolution: {integrity: sha512-Y48ShVxGE2zUTt0A0PR3grCLNxW4DWtAfe5lxf6L3uYEQujwo/LGuRogMsAtOJeYLCPTJo2i714LOdnK34cHpw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.7':
     resolution: {integrity: sha512-KU5DUYvX3qI8/TX6D3RA4awXi4Ge/1+M6Jqv7kRiUndpqoVGgD765xhV3Q6QvtABnYjLJenrWDl3S1B5U56ixA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.7':
     resolution: {integrity: sha512-1THb6FdBkAEL12zvUue2bmK4W1+P+tz8Pgu5uEzq+xrtYa3iBzmmKNlyfUzCFNCqsPd8WJEQrYdLcw4iMW4AVw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.7':
     resolution: {integrity: sha512-12o73atFNWDgYnLyA52QEUn9AH8pHIe12W28cmqjyHt4bIEYRzMICvYVCPa2IQm6DJBvCBrEhD9K+ct4wr2hwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.7':
     resolution: {integrity: sha512-+uUgGwvuUCXl894MTsmTS2J0BnCZccFsmzV7y1jFxW5pTSxkuwL5agyPuDvDOztPeS6RrdqWkn7sT0jRd0ECkg==}
@@ -2587,66 +2623,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -3170,12 +3219,6 @@ packages:
     resolution: {integrity: sha512-KdhoF/V4sBty4vKXMljpjSp8YBUyFSOTkxlxoe4qqK3NiNSEADp5VwGEv+2BkmaG68xtfoSnOKoQIDog17S0Fw==}
     cpu: [x64]
     os: [darwin]
-    hasBin: true
-
-  '@tloncorp/tlon-skill-linux-arm64@0.2.2':
-    resolution: {integrity: sha512-h1ih72PCEWZUuJx0ugmJgB934wzhKqSd0Qa1/UGgCJJoIr7JPxZEIBoM4QJ8mBo+8nBbYWb1tCacL20lSGgKjw==}
-    cpu: [arm64]
-    os: [linux]
     hasBin: true
 
   '@tloncorp/tlon-skill-linux-x64@0.2.2':
@@ -4447,7 +4490,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   google-auth-library@10.6.1:
     resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
@@ -4853,24 +4896,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -8350,12 +8397,6 @@ snapshots:
   '@node-llama-cpp/linux-armv7l@3.16.2':
     optional: true
 
-  '@node-llama-cpp/linux-x64-cuda-ext@3.16.2':
-    optional: true
-
-  '@node-llama-cpp/linux-x64-cuda@3.16.2':
-    optional: true
-
   '@node-llama-cpp/linux-x64-vulkan@3.16.2':
     optional: true
 
@@ -8369,15 +8410,6 @@ snapshots:
     optional: true
 
   '@node-llama-cpp/win-arm64@3.16.2':
-    optional: true
-
-  '@node-llama-cpp/win-x64-cuda-ext@3.16.2':
-    optional: true
-
-  '@node-llama-cpp/win-x64-cuda@3.16.2':
-    optional: true
-
-  '@node-llama-cpp/win-x64-vulkan@3.16.2':
     optional: true
 
   '@node-llama-cpp/win-x64@3.16.2':
@@ -9913,9 +9945,6 @@ snapshots:
   '@tloncorp/tlon-skill-darwin-x64@0.2.2':
     optional: true
 
-  '@tloncorp/tlon-skill-linux-arm64@0.2.2':
-    optional: true
-
   '@tloncorp/tlon-skill-linux-x64@0.2.2':
     optional: true
 
@@ -9923,7 +9952,6 @@ snapshots:
     optionalDependencies:
       '@tloncorp/tlon-skill-darwin-arm64': 0.2.2
       '@tloncorp/tlon-skill-darwin-x64': 0.2.2
-      '@tloncorp/tlon-skill-linux-arm64': 0.2.2
       '@tloncorp/tlon-skill-linux-x64': 0.2.2
 
   '@tokenizer/inflate@0.4.1':
@@ -12192,16 +12220,11 @@ snapshots:
       '@node-llama-cpp/linux-arm64': 3.16.2
       '@node-llama-cpp/linux-armv7l': 3.16.2
       '@node-llama-cpp/linux-x64': 3.16.2
-      '@node-llama-cpp/linux-x64-cuda': 3.16.2
-      '@node-llama-cpp/linux-x64-cuda-ext': 3.16.2
       '@node-llama-cpp/linux-x64-vulkan': 3.16.2
       '@node-llama-cpp/mac-arm64-metal': 3.16.2
       '@node-llama-cpp/mac-x64': 3.16.2
       '@node-llama-cpp/win-arm64': 3.16.2
       '@node-llama-cpp/win-x64': 3.16.2
-      '@node-llama-cpp/win-x64-cuda': 3.16.2
-      '@node-llama-cpp/win-x64-cuda-ext': 3.16.2
-      '@node-llama-cpp/win-x64-vulkan': 3.16.2
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color

--- a/src/plugin-sdk/insta360.ts
+++ b/src/plugin-sdk/insta360.ts
@@ -1,0 +1,10 @@
+// Narrow plugin-sdk surface for the bundled insta360 plugin.
+// Keep this list additive and scoped to symbols used under extensions/insta360.
+
+export type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginCommandDefinition,
+  OpenClawPluginService,
+  PluginCommandContext,
+} from "../plugins/types.js";


### PR DESCRIPTION
## Summary

- Add new extension plugin (`extensions/insta360/`) for controlling Insta360 cameras (ONE X/X2/X3/X4/X5) via the Open Spherical Camera (OSC) HTTP protocol
- Pure TypeScript ESM, single dependency (`@sinclair/typebox`), no native deps
- Includes agent tool (`insta360_camera`), slash command (`/cam`), recording monitor service, and streaming file download

### Components

- **OscClient** (`src/osc-client.ts`): HTTP client with async mutex queue (serial command execution per OSC spec), exponential backoff polling, transient error retry, HTTP status validation
- **Agent Tool** (`insta360_camera`): 9 actions — info, status, photo, record_start, record_stop, settings, list_files, download, delete
- **Slash Command** (`/cam`): Quick control — `/cam photo | record [timelapse] | stop | status | files [count]`
- **Recording Monitor** (`src/monitor.ts`): Session-aware polling with low battery/storage alerts and disconnect detection
- **File Download** (`src/download.ts`): Streaming via `node:stream/promises` pipeline with 10-minute timeout
- **Config** (`src/config.ts`): Private IP validation, cameraHost origin normalization, threshold clamping
- **Validation** (`src/validation.ts`): SSRF mitigation (URL origin check) and path traversal prevention

### Security

- `cameraHost` restricted to private IP ranges (10.x, 192.168.x, 172.16-31.x, 127.0.0.1, localhost)
- Manufacturer validation (`"Insta360"`) on first connection before sensitive operations
- File URLs validated against configured camera host origin before download/delete
- Download paths validated against base directory to prevent traversal

## Test plan

- [x] 48 tests across 6 test files, all passing
- [x] `pnpm build` — no errors, no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings
- [x] `pnpm tsgo` — no type errors
- [x] `pnpm check` — lint/format clean
- [x] `pnpm lint:plugins:no-monolithic-plugin-sdk-entry-imports` — passes
- [ ] Manual test with real Insta360 camera over WiFi