### PR TITLE
feat(models): support provider connect timeout

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -7,6 +7,7 @@ import {
   isOllamaCompatProvider,
   prependSystemPromptAddition,
   resolveAttemptFsWorkspaceOnly,
+  resolveProviderConnectTimeoutMs,
   resolveOllamaCompatNumCtxEnabled,
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
@@ -556,6 +557,69 @@ describe("resolveOllamaCompatNumCtxEnabled", () => {
         providerId: "ollama",
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveProviderConnectTimeoutMs", () => {
+  it("returns provider-specific connect timeout when configured", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://127.0.0.1:11434/v1",
+            connectTimeoutMs: 120_000,
+            models: [],
+          },
+        },
+      },
+    };
+    expect(resolveProviderConnectTimeoutMs({ config: cfg, providerId: "ollama" })).toBe(120_000);
+  });
+
+  it("matches provider timeout by normalized provider id", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "my-ollama": {
+            baseUrl: "http://127.0.0.1:11434/v1",
+            connectTimeoutMs: 90_000,
+            models: [],
+          },
+        },
+      },
+    };
+    expect(resolveProviderConnectTimeoutMs({ config: cfg, providerId: "My_Ollama" })).toBe(90_000);
+  });
+
+  it("returns undefined when timeout is missing or invalid", () => {
+    const missingCfg: OpenClawConfig = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+          },
+        },
+      },
+    };
+    expect(resolveProviderConnectTimeoutMs({ config: missingCfg, providerId: "openai" })).toBe(
+      undefined,
+    );
+
+    const invalidCfg = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            connectTimeoutMs: 0,
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(resolveProviderConnectTimeoutMs({ config: invalidCfg, providerId: "openai" })).toBe(
+      undefined,
+    );
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -205,6 +205,43 @@ export function resolveOllamaCompatNumCtxEnabled(params: {
   return true;
 }
 
+export function resolveProviderConnectTimeoutMs(params: {
+  config?: OpenClawConfig;
+  providerId?: string;
+}): number | undefined {
+  const providerId = params.providerId?.trim();
+  if (!providerId) {
+    return undefined;
+  }
+  const providers = params.config?.models?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  const resolveTimeout = (candidate?: { connectTimeoutMs?: unknown }): number | undefined => {
+    const raw = candidate?.connectTimeoutMs;
+    if (typeof raw !== "number" || !Number.isFinite(raw)) {
+      return undefined;
+    }
+    const timeoutMs = Math.floor(raw);
+    if (timeoutMs < 1) {
+      return undefined;
+    }
+    return timeoutMs;
+  };
+  const direct = providers[providerId];
+  const directTimeout = resolveTimeout(direct);
+  if (directTimeout !== undefined) {
+    return directTimeout;
+  }
+  const normalized = normalizeProviderId(providerId);
+  for (const [candidateId, candidate] of Object.entries(providers)) {
+    if (normalizeProviderId(candidateId) === normalized) {
+      return resolveTimeout(candidate);
+    }
+  }
+  return undefined;
+}
+
 export function shouldInjectOllamaCompatNumCtx(params: {
   model: { api?: string; provider?: string; baseUrl?: string };
   config?: OpenClawConfig;
@@ -749,7 +786,13 @@ export async function runEmbeddedAttempt(
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   const prevCwd = process.cwd();
   const runAbortController = new AbortController();
-  ensureGlobalUndiciStreamTimeouts();
+  const providerConnectTimeoutMs = resolveProviderConnectTimeoutMs({
+    config: params.config,
+    providerId: params.provider,
+  });
+  ensureGlobalUndiciStreamTimeouts(
+    providerConnectTimeoutMs !== undefined ? { timeoutMs: providerConnectTimeoutMs } : undefined,
+  );
 
   log.debug(
     `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -699,6 +699,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Provider map keyed by provider ID containing connection/auth settings and concrete model definitions. Use stable provider keys so references from agents and tooling remain portable across environments.",
   "models.providers.*.baseUrl":
     "Base URL for the provider endpoint used to serve model requests for that provider entry. Use HTTPS endpoints and keep URLs environment-specific through config templating where needed.",
+  "models.providers.*.connectTimeoutMs":
+    "Connection and first-response timeout in milliseconds applied to provider fetch streaming (undici headers/body timeout). Increase this for slower local inference backends that need longer time before first token.",
   "models.providers.*.apiKey":
     "Provider credential used for API-key based authentication when the provider requires direct key auth. Use secret/env substitution and avoid storing real keys in committed config files.",
   "models.providers.*.auth":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -414,6 +414,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "models.mode": "Model Catalog Mode",
   "models.providers": "Model Providers",
   "models.providers.*.baseUrl": "Model Provider Base URL",
+  "models.providers.*.connectTimeoutMs": "Model Provider Connect Timeout (ms)",
   "models.providers.*.apiKey": "Model Provider API Key", // pragma: allowlist secret
   "models.providers.*.auth": "Model Provider Auth Mode",
   "models.providers.*.api": "Model Provider API Adapter",

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -51,6 +51,7 @@ export type ModelDefinitionConfig = {
 
 export type ModelProviderConfig = {
   baseUrl: string;
+  connectTimeoutMs?: number;
   apiKey?: SecretInput;
   auth?: ModelProviderAuthMode;
   api?: ModelApi;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -229,6 +229,7 @@ export const ModelDefinitionSchema = z
 export const ModelProviderSchema = z
   .object({
     baseUrl: z.string().min(1),
+    connectTimeoutMs: z.number().int().min(1000).max(3_600_000).optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
     auth: z
       .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token")])


### PR DESCRIPTION
## Summary
- add `models.providers.*.connectTimeoutMs` config support
- wire provider-level timeout into embedded run startup via undici global dispatcher tuning
- add schema/types/help/labels and unit coverage for timeout resolution
## Test plan
- [x] pnpm vitest run src/config/schema.help.quality.test.ts
- [ ] pnpm vitest run src/agents/pi-embedded-runner/run/attempt.test.ts (blocked locally by missing @mariozechner/pi-ai/oauth package)