### PR TITLE
fix(feishu): report connection lifecycle status to gateway health monitor

### DIFF
--- a/extensions/feishu/src/monitor.health-lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.health-lifecycle.test.ts
@@ -1,0 +1,218 @@
+import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+const probeFeishuMock = vi.hoisted(() => vi.fn());
+const feishuClientMockModule = vi.hoisted(() => ({
+  createFeishuWSClient: vi.fn(() => ({ start: vi.fn() })),
+  createEventDispatcher: vi.fn(() => {
+    let handlers: Record<string, (...args: unknown[]) => Promise<void>> = {};
+    return {
+      register: vi.fn((registrations: Record<string, (...args: unknown[]) => Promise<void>>) => {
+        handlers = { ...handlers, ...registrations };
+      }),
+      /** Test helper: fire a registered event by name. */
+      _fire: async (name: string, data?: unknown) => {
+        if (handlers[name]) {
+          await handlers[name](data);
+        }
+      },
+      _handlers: () => handlers,
+    };
+  }),
+}));
+const feishuRuntimeMockModule = vi.hoisted(() => ({
+  getFeishuRuntime: () => ({
+    channel: {
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: () => ({
+          enqueue: async () => {},
+          flushKey: async () => {},
+        }),
+      },
+      text: {
+        hasControlCommand: () => false,
+      },
+    },
+  }),
+}));
+
+vi.mock("./probe.js", () => ({
+  probeFeishu: probeFeishuMock,
+}));
+vi.mock("./client.js", () => feishuClientMockModule);
+vi.mock("./runtime.js", () => feishuRuntimeMockModule);
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function buildSingleAccountConfig(mode: "websocket" | "webhook" = "websocket"): ClawdbotConfig {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        appId: "cli_test",
+        appSecret: "secret_test", // pragma: allowlist secret
+        connectionMode: mode,
+      },
+    },
+  } as ClawdbotConfig;
+}
+
+afterEach(() => {
+  stopFeishuMonitor();
+  vi.restoreAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("Feishu monitor health lifecycle", () => {
+  it("reports connected status and mode=websocket via setStatus on WS start", async () => {
+    probeFeishuMock.mockResolvedValue({
+      ok: true,
+      botOpenId: "bot_test",
+      botName: "TestBot",
+    });
+
+    const abortController = new AbortController();
+    const setStatus = vi.fn();
+
+    const monitorPromise = monitorFeishuProvider({
+      config: buildSingleAccountConfig("websocket"),
+      abortSignal: abortController.signal,
+      setStatus,
+    });
+
+    // Let microtasks settle so start() is called
+    await new Promise((r) => setTimeout(r, 50));
+
+    try {
+      // setStatus should have been called with connected: true and mode: websocket
+      expect(setStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connected: true,
+          mode: "websocket",
+        }),
+      );
+      const patch = setStatus.mock.calls.find(
+        (c: unknown[]) => (c[0] as Record<string, unknown>).connected === true,
+      )?.[0] as Record<string, unknown> | undefined;
+      expect(patch).toBeDefined();
+      expect(patch!.lastEventAt).toBeTypeOf("number");
+      expect(patch!.lastConnectedAt).toBeTypeOf("number");
+    } finally {
+      abortController.abort();
+      await monitorPromise;
+    }
+  });
+
+  it("updates lastEventAt when an inbound message event is received", async () => {
+    probeFeishuMock.mockResolvedValue({
+      ok: true,
+      botOpenId: "bot_test",
+      botName: "TestBot",
+    });
+
+    const abortController = new AbortController();
+    const setStatus = vi.fn();
+
+    const monitorPromise = monitorFeishuProvider({
+      config: buildSingleAccountConfig("websocket"),
+      abortSignal: abortController.signal,
+      setStatus,
+    });
+
+    // Let microtasks settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    try {
+      // Reset to isolate event-driven calls
+      const connectCalls = setStatus.mock.calls.length;
+
+      // Fire a message event through the dispatcher
+      const dispatcher = feishuClientMockModule.createEventDispatcher.mock.results.at(-1)?.value;
+      expect(dispatcher).toBeDefined();
+      await dispatcher._fire("im.message.receive_v1", {
+        message: {
+          message_id: "om_test_1",
+          chat_id: "oc_test",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+        sender: {
+          sender_id: { open_id: "ou_sender" },
+        },
+      });
+
+      // Should have a new setStatus call with lastEventAt
+      const eventCalls = setStatus.mock.calls.slice(connectCalls);
+      expect(eventCalls.length).toBeGreaterThanOrEqual(1);
+      const eventPatch = eventCalls[0][0] as Record<string, unknown>;
+      expect(eventPatch.lastEventAt).toBeTypeOf("number");
+    } finally {
+      abortController.abort();
+      await monitorPromise;
+    }
+  });
+
+  it("updates lastEventAt on reaction events", async () => {
+    probeFeishuMock.mockResolvedValue({
+      ok: true,
+      botOpenId: "bot_test",
+      botName: "TestBot",
+    });
+
+    const abortController = new AbortController();
+    const setStatus = vi.fn();
+
+    const monitorPromise = monitorFeishuProvider({
+      config: buildSingleAccountConfig("websocket"),
+      abortSignal: abortController.signal,
+      setStatus,
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    try {
+      const callsBefore = setStatus.mock.calls.length;
+
+      const dispatcher = feishuClientMockModule.createEventDispatcher.mock.results.at(-1)?.value;
+      await dispatcher._fire("im.message.reaction.created_v1", {
+        message_id: "om_test_1",
+        reaction_type: { emoji_type: "OK" },
+        operator_type: "user",
+        user_id: { open_id: "ou_sender" },
+      });
+
+      const newCalls = setStatus.mock.calls.slice(callsBefore);
+      expect(newCalls.length).toBeGreaterThanOrEqual(1);
+      expect((newCalls[0][0] as Record<string, unknown>).lastEventAt).toBeTypeOf("number");
+    } finally {
+      abortController.abort();
+      await monitorPromise;
+    }
+  });
+
+  it("does not call setStatus when callback is not provided", async () => {
+    probeFeishuMock.mockResolvedValue({
+      ok: true,
+      botOpenId: "bot_test",
+    });
+
+    const abortController = new AbortController();
+
+    // No setStatus — should not throw
+    const monitorPromise = monitorFeishuProvider({
+      config: buildSingleAccountConfig("websocket"),
+      abortSignal: abortController.signal,
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    abortController.abort();
+    await monitorPromise;
+  });
+});

--- a/extensions/feishu/src/monitor.health-lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.health-lifecycle.test.ts
@@ -85,8 +85,12 @@ describe("Feishu monitor health lifecycle", () => {
       setStatus,
     });
 
-    // Let microtasks settle so start() is called
-    await new Promise((r) => setTimeout(r, 50));
+    // Wait for start() to be called and setStatus to fire
+    await vi.waitFor(() => {
+      expect(setStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ connected: true, mode: "websocket" }),
+      );
+    });
 
     try {
       // setStatus should have been called with connected: true and mode: websocket
@@ -124,8 +128,10 @@ describe("Feishu monitor health lifecycle", () => {
       setStatus,
     });
 
-    // Let microtasks settle
-    await new Promise((r) => setTimeout(r, 50));
+    // Wait for connection to establish
+    await vi.waitFor(() => {
+      expect(setStatus).toHaveBeenCalled();
+    });
 
     try {
       // Reset to isolate event-driven calls
@@ -174,7 +180,9 @@ describe("Feishu monitor health lifecycle", () => {
       setStatus,
     });
 
-    await new Promise((r) => setTimeout(r, 50));
+    await vi.waitFor(() => {
+      expect(setStatus).toHaveBeenCalled();
+    });
 
     try {
       const callsBefore = setStatus.mock.calls.length;
@@ -196,6 +204,37 @@ describe("Feishu monitor health lifecycle", () => {
     }
   });
 
+  it("reports connected:false on abort", async () => {
+    probeFeishuMock.mockResolvedValue({
+      ok: true,
+      botOpenId: "bot_test",
+      botName: "TestBot",
+    });
+
+    const abortController = new AbortController();
+    const setStatus = vi.fn();
+
+    const monitorPromise = monitorFeishuProvider({
+      config: buildSingleAccountConfig("websocket"),
+      abortSignal: abortController.signal,
+      setStatus,
+    });
+
+    await vi.waitFor(() => {
+      expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({ connected: true }));
+    });
+
+    // Abort and verify disconnect is reported
+    abortController.abort();
+    await monitorPromise;
+
+    const disconnectCall = setStatus.mock.calls.find(
+      (c: unknown[]) => (c[0] as Record<string, unknown>).connected === false,
+    );
+    expect(disconnectCall).toBeDefined();
+    expect((disconnectCall![0] as Record<string, unknown>).accountId).toBeDefined();
+  });
+
   it("does not call setStatus when callback is not provided", async () => {
     probeFeishuMock.mockResolvedValue({
       ok: true,
@@ -210,7 +249,10 @@ describe("Feishu monitor health lifecycle", () => {
       abortSignal: abortController.signal,
     });
 
-    await new Promise((r) => setTimeout(r, 50));
+    // Give the monitor a tick to start
+    await vi.waitFor(() => {
+      expect(feishuClientMockModule.createFeishuWSClient).toHaveBeenCalled();
+    });
 
     abortController.abort();
     await monitorPromise;

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -22,12 +22,27 @@ import {
 } from "./monitor.state.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
+/**
+ * Callback to push partial connection-lifecycle status to the gateway health
+ * monitor.  Fields mirror ChannelAccountSnapshot but are narrowed to the
+ * subset relevant for health-check liveness.
+ */
+export type ChannelStatusCallback = (patch: {
+  accountId: string;
+  connected?: boolean;
+  lastConnectedAt?: number;
+  lastEventAt?: number;
+  mode?: string;
+}) => void;
+
 export type MonitorTransportParams = {
   account: ResolvedFeishuAccount;
   accountId: string;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   eventDispatcher: Lark.EventDispatcher;
+  /** Optional callback to push connection lifecycle status to the gateway health monitor. */
+  setStatus?: ChannelStatusCallback;
 };
 
 function isFeishuWebhookPayload(value: unknown): value is Record<string, unknown> {
@@ -98,6 +113,7 @@ export async function monitorWebSocket({
   runtime,
   abortSignal,
   eventDispatcher,
+  setStatus,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
@@ -141,6 +157,17 @@ export async function monitorWebSocket({
     try {
       wsClient.start({ eventDispatcher });
       log(`feishu[${accountId}]: WebSocket client started`);
+
+      // Report connection lifecycle status so the gateway health monitor
+      // can detect stale/half-dead WebSocket connections.
+      const now = Date.now();
+      setStatus?.({
+        accountId,
+        connected: true,
+        lastConnectedAt: now,
+        lastEventAt: now,
+        mode: "websocket",
+      });
     } catch (err) {
       cleanup();
       reject(err);
@@ -154,6 +181,7 @@ export async function monitorWebhook({
   runtime,
   abortSignal,
   eventDispatcher,
+  setStatus,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
@@ -285,6 +313,13 @@ export async function monitorWebhook({
 
     server.listen(port, host, () => {
       log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);
+      setStatus?.({
+        accountId,
+        connected: true,
+        lastConnectedAt: Date.now(),
+        lastEventAt: Date.now(),
+        mode: "webhook",
+      });
     });
 
     server.on("error", (err) => {

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -30,8 +30,8 @@ import type { ResolvedFeishuAccount } from "./types.js";
 export type ChannelStatusCallback = (patch: {
   accountId: string;
   connected?: boolean;
-  lastConnectedAt?: number;
-  lastEventAt?: number;
+  lastConnectedAt?: number | null;
+  lastEventAt?: number | null;
   mode?: string;
 }) => void;
 
@@ -142,6 +142,7 @@ export async function monitorWebSocket({
 
     function handleAbort() {
       log(`feishu[${accountId}]: abort signal received, stopping`);
+      setStatus?.({ accountId, connected: false });
       cleanup();
       resolve();
     }
@@ -299,6 +300,7 @@ export async function monitorWebhook({
 
     const handleAbort = () => {
       log(`feishu[${accountId}]: abort signal received, stopping Webhook server`);
+      setStatus?.({ accountId, connected: false });
       cleanup();
       resolve();
     };
@@ -313,11 +315,12 @@ export async function monitorWebhook({
 
     server.listen(port, host, () => {
       log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);
+      const now = Date.now();
       setStatus?.({
         accountId,
         connected: true,
-        lastConnectedAt: Date.now(),
-        lastEventAt: Date.now(),
+        lastConnectedAt: now,
+        lastEventAt: now,
         mode: "webhook",
       });
     });

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -12,12 +12,15 @@ import {
   isWebhookRateLimitedForTest,
   stopFeishuMonitorState,
 } from "./monitor.state.js";
+import type { ChannelStatusCallback } from "./monitor.transport.js";
 
 export type MonitorFeishuOpts = {
   config?: ClawdbotConfig;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   accountId?: string;
+  /** Optional callback to push connection lifecycle status to the gateway health monitor. */
+  setStatus?: ChannelStatusCallback;
 };
 
 export {
@@ -49,6 +52,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
       account,
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
+      setStatus: opts.setStatus,
     });
   }
 
@@ -86,6 +90,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
         botOpenIdSource: { kind: "prefetched", botOpenId, botName },
+        setStatus: opts.setStatus,
       }),
     );
   }


### PR DESCRIPTION
## Problem

The Feishu channel plugin never reported `connected`, `lastEventAt`, or `mode` status to the gateway health monitor. This means the stale-socket detection logic in `channel-health-policy.ts` was **entirely bypassed** — the health monitor always evaluated Feishu as `"healthy"` regardless of actual WebSocket liveness.

**Root cause chain:**
1. `evaluateChannelHealth()` checks `snapshot.connected === true` before entering the stale-socket detection block (line 116)
2. Feishu never called `setStatus({ connected: true })` — `connected` was always `undefined`
3. `undefined === true` → `false` → stale-socket check skipped → always `"healthy"`

This caused silent ~30-minute connection drops (Feishu server-side idle timeout for connections without application-level traffic) to go undetected. The health monitor could not trigger restarts, creating message delivery gaps until the Lark SDK's internal reconnect logic eventually kicked in.

**For comparison:** Discord reports `connected`/`lastEventAt` in 3 places (connect, gateway debug events, inbound messages). Slack reports on every inbound event. Feishu reported in 0 places.

## Fix

Thread a `setStatus` callback from the channel gateway context through:
`channel.ts` → `monitor.ts` → `monitor.account.ts` → `monitor.transport.ts`

### On connection start (WebSocket or Webhook):
```ts
setStatus?.({
  accountId,
  connected: true,
  lastConnectedAt: now,
  lastEventAt: now,
  mode: "websocket", // or "webhook"
});
```

### On every inbound event:
All 7 event handlers in `registerEventHandlers()` now call `onEvent?.()`, which maps to:
```ts
setStatus({ accountId, lastEventAt: Date.now() })
```

Events tracked: `im.message.receive_v1`, `im.message.message_read_v1`, `im.chat.member.bot.added_v1`, `im.chat.member.bot.deleted_v1`, `im.message.reaction.created_v1`, `im.message.reaction.deleted_v1`, `card.action.trigger`

### New type:
```ts
export type ChannelStatusCallback = (patch: {
  accountId: string;
  connected?: boolean;
  lastConnectedAt?: number;
  lastEventAt?: number;
  mode?: string;
}) => void;
```

## Why not add WebSocket ping?

The Lark SDK (`@larksuiteoapi/node-sdk`) already has a built-in `pingLoop` that sends WebSocket pings every ~120 seconds (configurable by the server's `ClientConfig.PingInterval`). The WS connection itself stays alive — the problem was that OpenClaw's health monitor had **no visibility** into Feishu's connection state.

## Tests

- **4 new tests** in `monitor.health-lifecycle.test.ts`:
  - Reports `connected: true` + `mode: "websocket"` on WS start
  - Updates `lastEventAt` on inbound message events
  - Updates `lastEventAt` on reaction events
  - No-op when `setStatus` callback is not provided
- **352 existing feishu tests** — all pass (no regressions)
- **42 channel-health-policy/monitor tests** — all pass

## Files changed

| File | Change |
|------|--------|
| `extensions/feishu/src/monitor.transport.ts` | Add `ChannelStatusCallback` type, `setStatus` param, call on connect |
| `extensions/feishu/src/monitor.account.ts` | Add `onEvent` to event handlers, thread `setStatus` |
| `extensions/feishu/src/monitor.ts` | Thread `setStatus` through to `monitorSingleAccount` |
| `extensions/feishu/src/channel.ts` | Pass `ctx.setStatus` to `monitorFeishuProvider` |
| `extensions/feishu/src/monitor.health-lifecycle.test.ts` | New test file |

Refs: #35532