### PR TITLE
fix(feishu): escape underscores in markdown URLs to prevent display issues

### DIFF
--- a/extensions/feishu/src/post.ts
+++ b/extensions/feishu/src/post.ts
@@ -27,6 +27,22 @@ function escapeMarkdownText(text: string): string {
   return text.replace(MARKDOWN_SPECIAL_CHARS, "\\$1");
 }
 
+/**
+ * Escape underscores in URLs within markdown links to prevent Feishu
+ * from interpreting them as italic markers.
+ * E.g., [text](https://example.com/output_20260210.png) becomes
+ *       [text](https://example.com/output\_20260210.png)
+ */
+function escapeUnderscoresInMarkdownLinks(text: string): string {
+  // Match markdown links: [text](url)
+  const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+  return text.replace(linkRegex, (match, linkText, url) => {
+    // Escape underscores in the URL
+    const escapedUrl = url.replace(/_/g, "\\_");
+    return `[${linkText}](${escapedUrl})`;
+  });
+}
+
 function toBoolean(value: unknown): boolean {
   return value === true || value === 1 || value === "true";
 }
@@ -260,7 +276,9 @@ export function parsePostContent(content: string): PostParseResult {
 
     const title = escapeMarkdownText(payload.title.trim());
     const body = paragraphs.join("\n").trim();
-    const textContent = [title, body].filter(Boolean).join("\n\n").trim();
+    const textContent = escapeUnderscoresInMarkdownLinks(
+      [title, body].filter(Boolean).join("\n\n").trim(),
+    );
 
     return {
       textContent: textContent || FALLBACK_POST_TEXT,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -3,7 +3,7 @@ import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedMessage, buildMentionedCardContent } from "./mention.js";
-import { parsePostContent } from "./post.js";
+import { parsePostContent, escapeUnderscoresInMarkdownLinks } from "./post.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
@@ -290,7 +290,9 @@ export async function sendMessageFeishu(
   if (mentions && mentions.length > 0) {
     rawText = buildMentionedMessage(mentions, rawText);
   }
-  const messageText = getFeishuRuntime().channel.text.convertMarkdownTables(rawText, tableMode);
+  const messageText = escapeUnderscoresInMarkdownLinks(
+    getFeishuRuntime().channel.text.convertMarkdownTables(rawText, tableMode),
+  );
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
 
@@ -459,7 +461,9 @@ export async function editMessageFeishu(params: {
     cfg,
     channel: "feishu",
   });
-  const messageText = getFeishuRuntime().channel.text.convertMarkdownTables(text ?? "", tableMode);
+  const messageText = escapeUnderscoresInMarkdownLinks(
+    getFeishuRuntime().channel.text.convertMarkdownTables(text ?? "", tableMode),
+  );
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
 


### PR DESCRIPTION
When sending URLs with underscores (e.g., output_20260210.png) to Feishu, the underscores were being interpreted as markdown italic markers, causing the link to be truncated or not displayed correctly.

This fix escapes underscores in URLs within markdown links before sending.

Fixes #41860