### PR TITLE
fix(infra): tolerate already-loaded bootstrap and drop -k from post-bootstrap kickstart

### DIFF
--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -367,7 +367,14 @@ export function triggerOpenClawRestart(): RestartAttempt {
     encoding: "utf8",
     timeout: SPAWN_TIMEOUT_MS,
   });
-  if (boot.error || (boot.status !== 0 && boot.status !== null)) {
+  // bootstrap exits 37 ("Operation already in progress") when the service is
+  // already loaded — this is harmless and means the plist is still registered.
+  // Treat it the same as exit 0 so we proceed to the kickstart retry.
+  const LAUNCHCTL_ALREADY_LOADED = 37;
+  if (
+    boot.error ||
+    (boot.status !== 0 && boot.status !== LAUNCHCTL_ALREADY_LOADED && boot.status !== null)
+  ) {
     return {
       ok: false,
       method: "launchctl",
@@ -375,7 +382,11 @@ export function triggerOpenClawRestart(): RestartAttempt {
       tried,
     };
   }
-  const retryArgs = ["kickstart", "-k", target];
+  // After bootstrap the service is freshly registered and launchd may already
+  // be starting it (KeepAlive: true).  Use plain kickstart (no -k) so we don't
+  // kill a service that is still initialising — that can cause launchd to
+  // deregister the agent entirely, which is the original bug.
+  const retryArgs = ["kickstart", target];
   tried.push(`launchctl ${retryArgs.join(" ")}`);
   const retry = spawnSync("launchctl", retryArgs, {
     encoding: "utf8",


### PR DESCRIPTION
## Summary

Fixes #41934

On macOS, when a config change triggers a gateway restart via `triggerOpenClawRestart()`, the LaunchAgent can become permanently unloaded from launchd, leaving the gateway unreachable.

Two bugs in the `launchctl` fallback path in `src/infra/restart.ts`:

1. **`launchctl bootstrap` exit code 37 treated as fatal** — exit 37 means "Operation already in progress" (service already loaded), which is benign. The code previously returned early on any non-zero exit, aborting the restart fallback.

2. **`kickstart -k` after bootstrap kills a starting service** — after a fresh `bootstrap`, launchd may already be starting the service (due to `KeepAlive: true`). Sending `-k` (SIGKILL + restart) at that point can cause launchd to deregister the agent entirely. Changed to plain `kickstart` (no `-k`) which just ensures the service starts without killing it first.

## Test plan

- [x] `pnpm check` passes (lint + format + typecheck)
- [x] `pnpm test -- src/infra/restart.test.ts src/infra/process-respawn.test.ts` — 19/19 tests pass
- [ ] Manual: on macOS with LaunchAgent installed, trigger config change requiring restart; verify gateway auto-restarts and `launchctl print gui/$UID/ai.openclaw.gateway` still shows the service registered