### PR TITLE
fix(control-ui): show all configured agents in webchat session dropdown

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -3,8 +3,9 @@ import {
   isCronSessionKey,
   parseSessionKey,
   resolveSessionDisplayName,
+  resolveSessionOptions,
 } from "./app-render.helpers.ts";
-import type { SessionsListResult } from "./types.ts";
+import type { AgentsListResult, SessionsListResult } from "./types.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
 
@@ -282,5 +283,109 @@ describe("isCronSessionKey", () => {
     expect(isCronSessionKey("main")).toBe(false);
     expect(isCronSessionKey("discord:group:eng")).toBe(false);
     expect(isCronSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
+  });
+});
+
+/* ================================================================
+ *  resolveSessionOptions – session dropdown entries
+ * ================================================================ */
+
+function sessions(rows: SessionRow[]): SessionsListResult {
+  return {
+    ts: 0,
+    path: "",
+    count: rows.length,
+    defaults: { model: null, contextTokens: null },
+    sessions: rows,
+  };
+}
+
+function agents(ids: string[], mainKey = "main"): AgentsListResult {
+  return {
+    defaultId: ids[0] ?? "main",
+    mainKey,
+    scope: "per-sender",
+    agents: ids.map((id) => ({ id, name: id })),
+  };
+}
+
+describe("resolveSessionOptions", () => {
+  it("includes agents without existing sessions", () => {
+    const result = resolveSessionOptions(
+      "agent:zhongshu:main",
+      sessions([row({ key: "agent:zhongshu:main" })]),
+      "agent:zhongshu:main",
+      false,
+      agents(["zhongshu", "menshu", "shangshu"]),
+    );
+    const keys = result.map((o) => o.key);
+    expect(keys).toContain("agent:menshu:main");
+    expect(keys).toContain("agent:shangshu:main");
+  });
+
+  it("marks agents without sessions as (new)", () => {
+    const result = resolveSessionOptions(
+      "agent:zhongshu:main",
+      sessions([row({ key: "agent:zhongshu:main" })]),
+      "agent:zhongshu:main",
+      false,
+      agents(["zhongshu", "menshu"]),
+    );
+    const menshu = result.find((o) => o.key === "agent:menshu:main");
+    expect(menshu?.displayName).toBe("menshu (new)");
+  });
+
+  it("does not duplicate agents that already have sessions", () => {
+    const result = resolveSessionOptions(
+      "agent:zhongshu:main",
+      sessions([row({ key: "agent:zhongshu:main" }), row({ key: "agent:menshu:main" })]),
+      "agent:zhongshu:main",
+      false,
+      agents(["zhongshu", "menshu"]),
+    );
+    const menshuEntries = result.filter((o) => o.key === "agent:menshu:main");
+    expect(menshuEntries).toHaveLength(1);
+  });
+
+  it("works without agentsList (backwards compatible)", () => {
+    const result = resolveSessionOptions(
+      "agent:zhongshu:main",
+      sessions([row({ key: "agent:zhongshu:main" })]),
+      "agent:zhongshu:main",
+      false,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("agent:zhongshu:main");
+  });
+
+  it("uses agent name for display when available", () => {
+    const agentsList: AgentsListResult = {
+      defaultId: "libu",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [{ id: "libu", name: "Ministry of Rites" }],
+    };
+    const result = resolveSessionOptions(
+      "agent:main:main",
+      sessions([row({ key: "agent:main:main" })]),
+      "agent:main:main",
+      false,
+      agentsList,
+    );
+    const libu = result.find((o) => o.key === "agent:libu:main");
+    expect(libu?.displayName).toBe("Ministry of Rites (new)");
+  });
+
+  it("respects custom mainKey from agentsList", () => {
+    const result = resolveSessionOptions(
+      "agent:main:home",
+      sessions([row({ key: "agent:main:home" })]),
+      "agent:main:home",
+      false,
+      agents(["main", "worker"], "home"),
+    );
+    const keys = result.map((o) => o.key);
+    expect(keys).toContain("agent:worker:home");
+    expect(keys).not.toContain("agent:worker:main");
   });
 });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -10,7 +10,7 @@ import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode } from "./theme.ts";
-import type { SessionsListResult } from "./types.ts";
+import type { AgentsListResult, SessionsListResult } from "./types.ts";
 
 type SessionDefaultsSnapshot = {
   mainSessionKey?: string;
@@ -133,6 +133,7 @@ export function renderChatControls(state: AppViewState) {
     state.sessionsResult,
     mainSessionKey,
     hideCron,
+    state.agentsList,
   );
   const disableThinkingToggle = state.onboarding;
   const disableFocusToggle = state.onboarding;
@@ -431,11 +432,12 @@ export function isCronSessionKey(key: string): boolean {
   return rest.startsWith("cron:");
 }
 
-function resolveSessionOptions(
+export function resolveSessionOptions(
   sessionKey: string,
   sessions: SessionsListResult | null,
   mainSessionKey?: string | null,
   hideCron = false,
+  agentsList?: AgentsListResult | null,
 ) {
   const seen = new Set<string>();
   const options: Array<{ key: string; displayName?: string }> = [];
@@ -470,6 +472,23 @@ function resolveSessionOptions(
         options.push({
           key: s.key,
           displayName: resolveSessionDisplayName(s.key, s),
+        });
+      }
+    }
+  }
+
+  // Add configured agents that don't have existing sessions yet,
+  // so users can start chatting with any configured agent.
+  if (agentsList?.agents) {
+    const mainKey = agentsList.mainKey || "main";
+    for (const agent of agentsList.agents) {
+      const agentSessionKey = `agent:${agent.id}:${mainKey}`;
+      if (!seen.has(agentSessionKey)) {
+        seen.add(agentSessionKey);
+        const name = agent.name || agent.id;
+        options.push({
+          key: agentSessionKey,
+          displayName: `${name} (new)`,
         });
       }
     }


### PR DESCRIPTION
## Summary
- The webchat session selector only displayed agents that already had sessions in the session store
- Modified `resolveSessionOptions` in `ui/src/ui/app-render.helpers.ts` to also include agents from the `agents.list` API response
- Agents without existing sessions appear in the dropdown with a "(new)" suffix, using the agent's configured name (or id as fallback)
- Added tests covering the new behavior (agent inclusion, deduplication, backwards compatibility, custom mainKey)

Fixes #41933

## Test plan
- [ ] Open webchat with multiple configured agents (e.g. zhongshu, menshu, shangshu, etc.)
- [ ] Verify all configured agents appear in the session dropdown, not just ones with existing sessions
- [ ] Verify agents without prior sessions show "(new)" suffix
- [ ] Verify selecting a new agent creates a session and the "(new)" label disappears on next refresh
- [ ] Verify agents with existing sessions are not duplicated in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)