### PR TITLE
fix(tui): render external-channel session messages live

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -680,7 +680,7 @@ describe("agent event handler", () => {
     expect(nodePayload.runId).toBe("run-fallback-client");
   });
 
-  it("suppresses chat and node session events for non-control-UI-visible runs", () => {
+  it("still emits chat events for non-control-UI-visible runs so TUI can display external channel sessions", () => {
     const { broadcast, nodeSendToSession, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-hidden",
     });
@@ -699,8 +699,10 @@ describe("agent event handler", () => {
     });
     emitLifecycleEnd(handler, "run-hidden", 2);
 
-    expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
-    expect(nodeSendToSession).not.toHaveBeenCalled();
+    // Chat events must still be emitted so TUI clients viewing external-channel
+    // sessions (e.g. Telegram) can render live responses.
+    expect(chatBroadcastCalls(broadcast).length).toBeGreaterThan(0);
+    expect(nodeSendToSession).toHaveBeenCalled();
   });
 
   it("uses agent event sessionKey when run-context lookup cannot resolve", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -590,7 +590,7 @@ export function createAgentEventHandler({
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
 
-    if (isControlUiVisible && sessionKey) {
+    if (sessionKey) {
       // Send tool events to node/channel subscribers only when verbose is enabled;
       // WS clients already received the event above via broadcastToConnIds.
       if (!isToolEvent || toolVerbose !== "off") {


### PR DESCRIPTION
## Summary

Fixes #41937

Inbound Telegram (and other external-channel) messages update the session correctly, but the TUI never renders the assistant response live — it only appears after a manual session/history reload. The root cause is the `isControlUiVisible` gate added in #36030: runs originating from non-webchat channels set `isControlUiVisible: false`, which suppresses `chat` event broadcasts (`delta`/`final`) entirely. The TUI relies on these broadcasts to stream assistant responses.

**Fix:** Remove the `isControlUiVisible` condition from the chat-event emission path in `createAgentEventHandler`. The TUI already filters events by session key (`isSameSessionKey`), so there is no risk of cross-session noise. The `isControlUiVisible` flag remains in use for pre-tool-start delta flushing.

## Changes

- `src/gateway/server-chat.ts`: Change `if (isControlUiVisible && sessionKey)` → `if (sessionKey)` so chat delta/final events are broadcast for all runs that have a resolved session key.
- `src/gateway/server-chat.agent-events.test.ts`: Update the test that previously verified suppression to now verify that external-channel runs emit chat events.

## Test plan

- [x] `pnpm test -- --run src/gateway/server-chat.agent-events.test.ts` — 23/23 pass
- [x] `pnpm test -- --run src/tui/tui-event-handlers.test.ts` — 17/17 pass
- [x] `pnpm test -- --run src/infra/agent-events.test.ts` — 4/4 pass
- [x] `pnpm tsgo` — no type errors
- [x] `pnpm check` — lint/format clean