### PR TITLE
fix(directives): preserve code-block indentation in outbound replies

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -55,6 +55,15 @@ describe("parseInlineDirectives", () => {
     expect(result.text).toBe("First line\n    indented continuation");
   });
 
+  test("no injected space when tag appears at the start of a non-first line (Codex review)", () => {
+    // Regression for the case flagged in the Codex bot review on PR #41968.
+    // With the old " " replacement, "line1\n[[tag]]line2" became "line1\n line2".
+    const input = "line1\n[[audio_as_voice]]line2";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("line1\nline2");
+    expect(result.audioAsVoice).toBe(true);
+  });
+
   // ── existing directive-extraction behaviour ─────────────────────────────
 
   test("detects audio_as_voice tag and strips it by default", () => {

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,8 +1,96 @@
 import { describe, expect, test } from "vitest";
 import {
+  parseInlineDirectives,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "./directive-tags.js";
+
+describe("parseInlineDirectives", () => {
+  // ── #41699 regression: code-block indentation must not be stripped ──────
+
+  test("preserves indentation in plain text with no directive tags", () => {
+    const input = 'def foo():\n    return {\n        "key": "value"\n    }';
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe(input);
+    expect(result.audioAsVoice).toBe(false);
+    expect(result.hasAudioTag).toBe(false);
+  });
+
+  test("preserves code-block indentation when audio tag is at message start", () => {
+    const input = "[[audio_as_voice]] Here is the code:\n    def foo():\n        return 1";
+    const result = parseInlineDirectives(input);
+    expect(result.audioAsVoice).toBe(true);
+    // indentation inside the code block must be intact
+    expect(result.text).toContain("    def foo():");
+    expect(result.text).toContain("        return 1");
+  });
+
+  test("preserves indentation in JSON code block with directive tag", () => {
+    const payload = `\`\`\`json\n{\n  "root": {\n    "child": {\n      "name": "test"\n    }\n  }\n}\n\`\`\``;
+    const input = `[[audio_as_voice]] ${payload}`;
+    const result = parseInlineDirectives(input);
+    // Every indented line must survive
+    expect(result.text).toContain('  "root": {');
+    expect(result.text).toContain('    "child": {');
+    expect(result.text).toContain('      "name": "test"');
+  });
+
+  test("collapses inline double-spaces that result from tag removal", () => {
+    // The tag is inline between words; stripping it leaves a double-space
+    const input = "Hello [[audio_as_voice]] World";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("Hello World");
+  });
+
+  test("trims leading/trailing whitespace left by tag removal at string boundaries", () => {
+    const input = "[[audio_as_voice]] Some reply text";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("Some reply text");
+  });
+
+  test("strips trailing line whitespace from tag removal but not leading indentation", () => {
+    // tag at end of first line, followed by an indented second line
+    const input = "First line [[audio_as_voice]]\n    indented continuation";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("First line\n    indented continuation");
+  });
+
+  // ── existing directive-extraction behaviour ─────────────────────────────
+
+  test("detects audio_as_voice tag and strips it by default", () => {
+    const result = parseInlineDirectives("[[audio_as_voice]] speak this");
+    expect(result.audioAsVoice).toBe(true);
+    expect(result.hasAudioTag).toBe(true);
+    expect(result.text).toBe("speak this");
+  });
+
+  test("detects reply_to_current tag", () => {
+    const result = parseInlineDirectives("[[reply_to_current]] hello", {
+      currentMessageId: "msg-42",
+    });
+    expect(result.replyToCurrent).toBe(true);
+    expect(result.replyToId).toBe("msg-42");
+    expect(result.hasReplyTag).toBe(true);
+  });
+
+  test("detects explicit reply_to id", () => {
+    const result = parseInlineDirectives("[[reply_to: abc-123]] hello");
+    expect(result.replyToExplicitId).toBe("abc-123");
+    expect(result.replyToId).toBe("abc-123");
+  });
+
+  test("returns empty string for undefined input", () => {
+    const result = parseInlineDirectives(undefined);
+    expect(result.text).toBe("");
+    expect(result.audioAsVoice).toBe(false);
+  });
+
+  test("returns text unchanged when no [[  tags present", () => {
+    const input = "  leading spaces and trailing  ";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe(input);
+  });
+});
 
 describe("stripInlineDirectiveTagsForDisplay", () => {
   test("removes reply and audio directives", () => {

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -135,7 +135,11 @@ export function parseInlineDirectives(
   cleaned = cleaned.replace(AUDIO_TAG_RE, (match) => {
     audioAsVoice = true;
     hasAudioTag = true;
-    return stripAudioTag ? " " : match;
+    // Replace with empty string rather than a space so that no injected
+    // whitespace is left at line boundaries (see #41699, Codex review).
+    // Adjacent inline spaces (e.g. "Hello [[tag]] World") are collapsed by
+    // normalizeDirectiveWhitespace.
+    return stripAudioTag ? "" : match;
   });
 
   cleaned = cleaned.replace(REPLY_TAG_RE, (match, idRaw: string | undefined) => {
@@ -148,7 +152,7 @@ export function parseInlineDirectives(
         lastExplicitId = id;
       }
     }
-    return stripReplyTags ? " " : match;
+    return stripReplyTags ? "" : match;
   });
 
   cleaned = normalizeDirectiveWhitespace(cleaned);

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -17,11 +17,28 @@ type InlineDirectiveParseOptions = {
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 
+/**
+ * Clean up whitespace artifacts left by stripping directive tags.
+ * Only collapses inline multi-spaces and trailing line-spaces, then trims the
+ * whole string.  Leading indentation on each line is intentionally preserved so
+ * that code blocks in outbound replies are not corrupted (see #41699).
+ *
+ * Key invariant: `(?<=\S)` ensures we only collapse spaces that immediately
+ * follow a non-whitespace character (i.e. truly "inline" double-spaces left by
+ * tag removal).  Spaces at the start of a line are always preceded by `\n` or
+ * another space, so they are never touched.
+ */
 function normalizeDirectiveWhitespace(text: string): string {
-  return text
-    .replace(/[ \t]+/g, " ")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .trim();
+  return (
+    text
+      // Collapse multiple consecutive spaces/tabs that follow a non-whitespace
+      // character.  This removes inline double-spaces created by tag removal
+      // without ever touching leading indentation.
+      .replace(/(?<=\S)[ \t]{2,}/g, " ")
+      // Strip trailing horizontal whitespace before each newline.
+      .replace(/[ \t]+(?=\n)/g, "")
+      .trim()
+  );
 }
 
 type StripInlineDirectiveTagsResult = {
@@ -97,8 +114,10 @@ export function parseInlineDirectives(
     };
   }
   if (!text.includes("[[")) {
+    // No directive tags present – return the original text unchanged so that
+    // code-block indentation and intentional whitespace are fully preserved.
     return {
-      text: normalizeDirectiveWhitespace(text),
+      text,
       audioAsVoice: false,
       replyToCurrent: false,
       hasAudioTag: false,


### PR DESCRIPTION
## Summary

Fixes #41699 — `parseInlineDirectives` applied an aggressive global whitespace normalization
(`/[ \t]+/g` + `/[ \t]*\n[ \t]*/g`) to the **entire** outbound message body, stripping leading
indentation from every line including inside fenced code blocks.  JSON / Python / YAML content
arrived at channels with all indentation removed.

## Root cause

`normalizeDirectiveWhitespace` was introduced to tidy up whitespace artifacts left by stripping
`[[audio_as_voice]]` / `[[reply_to_current]]` tags (e.g. a stray double-space in `"Hello  World"`
after inline tag removal).  The two regexes it used were far too broad:

| regex | intent | side-effect |
|---|---|---|
| `/[ \t]+/g → " "` | collapse double spaces | collapses leading indentation |
| `/[ \t]*\n[ \t]*/g → "\n"` | strip space around newlines | strips all per-line leading whitespace |

A second bug: text with no `[[` tags (the early-return path) was also run through this function
even though there was nothing to clean up.

## Fix

- **`normalizeDirectiveWhitespace`** now uses two targeted patterns:
  - `/(?<=\S)[ \t]{2,}/g → " "` — only collapses inline multi-spaces that follow a
    non-whitespace character; line-leading indentation is always preceded by `\n` or another space
    so it is never touched.
  - `/[ \t]+(?=\n)/g → ""` — strips trailing horizontal whitespace before newlines (also an
    artifact of tag removal).
  - `.trim()` cleans up leading/trailing space at string boundaries.
- **Early-return path** (no `[[` in text): returns `text` unchanged; there are no directive
  artifacts to clean up.

## Test plan

New tests added to `src/utils/directive-tags.test.ts` for `parseInlineDirectives`:

- [x] Plain text with no directive tags: indentation fully preserved (regression for the no-`[[` path)
- [x] Audio tag at message start followed by an indented code block: indentation preserved
- [x] Audio tag with a multi-level JSON code block: all indentation levels preserved
- [x] Inline double-space from tag removal is collapsed to a single space
- [x] Leading/trailing whitespace from tag at string boundary is trimmed
- [x] Trailing line whitespace from inline tag removal is cleaned up, leading indentation untouched
- [x] Existing `stripInlineDirectiveTagsForDisplay` / `stripInlineDirectiveTagsFromMessageForDisplay` tests: all pass
- [x] `src/gateway/server-methods/chat.directive-tags.test.ts`: all 22 tests pass
- [x] `pnpm check` (lint + format + type): clean

Made with [Cursor](https://cursor.com)