### PR TITLE
fix(android): refresh home-screen command session key on updates

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -390,9 +390,8 @@ class NodeRuntime(context: Context) {
   }
 
   private fun applyMainSessionKey(candidate: String?) {
-    val trimmed = normalizeMainKey(candidate) ?: return
-    if (isCanonicalMainSessionKey(_mainSessionKey.value)) return
-    if (_mainSessionKey.value == trimmed) return
+    val trimmed = normalizeMainKey(candidate)
+    if (!shouldReplaceMainSessionKey(_mainSessionKey.value, trimmed)) return
     _mainSessionKey.value = trimmed
     talkMode.setMainSessionKey(trimmed)
     chat.applyMainSessionKey(trimmed)

--- a/apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt
@@ -11,3 +11,9 @@ internal fun isCanonicalMainSessionKey(raw: String?): Boolean {
   if (trimmed == "global") return true
   return trimmed.startsWith("agent:")
 }
+
+internal fun shouldReplaceMainSessionKey(current: String?, candidate: String?): Boolean {
+  val next = candidate?.trim().orEmpty()
+  if (next.isEmpty()) return false
+  return next != current?.trim().orEmpty()
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -22,8 +22,8 @@ import android.speech.tts.UtteranceProgressListener
 import android.util.Log
 import androidx.core.content.ContextCompat
 import ai.openclaw.app.gateway.GatewaySession
-import ai.openclaw.app.isCanonicalMainSessionKey
 import ai.openclaw.app.normalizeMainKey
+import ai.openclaw.app.shouldReplaceMainSessionKey
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
@@ -158,8 +158,7 @@ class TalkModeManager(
 
   fun setMainSessionKey(sessionKey: String?) {
     val trimmed = sessionKey?.trim().orEmpty()
-    if (trimmed.isEmpty()) return
-    if (isCanonicalMainSessionKey(mainSessionKey)) return
+    if (!shouldReplaceMainSessionKey(mainSessionKey, trimmed)) return
     mainSessionKey = trimmed
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -22,6 +22,7 @@ import android.speech.tts.UtteranceProgressListener
 import android.util.Log
 import androidx.core.content.ContextCompat
 import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.isCanonicalMainSessionKey
 import ai.openclaw.app.normalizeMainKey
 import ai.openclaw.app.shouldReplaceMainSessionKey
 import java.io.File

--- a/apps/android/app/src/test/java/ai/openclaw/app/SessionKeyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SessionKeyTest.kt
@@ -1,0 +1,25 @@
+package ai.openclaw.app
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionKeyTest {
+  @Test
+  fun shouldReplaceMainSessionKeyRejectsBlankCandidate() {
+    assertFalse(shouldReplaceMainSessionKey("main", null))
+    assertFalse(shouldReplaceMainSessionKey("main", ""))
+    assertFalse(shouldReplaceMainSessionKey("main", "   "))
+  }
+
+  @Test
+  fun shouldReplaceMainSessionKeyRejectsEquivalentKey() {
+    assertFalse(shouldReplaceMainSessionKey("agent:main:main", "agent:main:main"))
+    assertFalse(shouldReplaceMainSessionKey("agent:main:main", "  agent:main:main  "))
+  }
+
+  @Test
+  fun shouldReplaceMainSessionKeyAcceptsCanonicalRotation() {
+    assertTrue(shouldReplaceMainSessionKey("agent:alpha:main", "agent:beta:main"))
+  }
+}


### PR DESCRIPTION
## Summary
- refresh Android main session key whenever gateway provides a newer non-empty key
- stop freezing key updates after the first canonical value, which could leave home-screen commands targeting stale sessions
- add unit coverage for main-session-key replacement behavior

## Testing
- ./gradlew :app:testDebugUnitTest --tests ai.openclaw.android.SessionKeyTest *(fails in this environment: Java Runtime not available)*
