### PR TITLE
gateway: patch globalThis.fetch with proxy agent when http_proxy is set

### DIFF
--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -175,11 +175,11 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   // environments. Patch globalThis.fetch early so every bare fetch() call in
   // the process inherits the proxy settings — EnvHttpProxyAgent also honours
   // NO_PROXY, so loopback / localhost exclusions are preserved.
-  const proxyFetch = resolveProxyFetchFromEnv();
-  if (proxyFetch) {
-    globalThis.fetch = proxyFetch;
+  const proxyFetchResult = resolveProxyFetchFromEnv();
+  if (proxyFetchResult) {
+    globalThis.fetch = proxyFetchResult.fetch;
     gatewayLog.info(
-      "http_proxy env var detected — patched globalThis.fetch to route through proxy",
+      `${proxyFetchResult.envVar} detected — patched globalThis.fetch to route through proxy`,
     );
   }
 

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -17,6 +17,7 @@ import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setVerbose } from "../../globals.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
+import { resolveProxyFetchFromEnv } from "../../infra/net/proxy-fetch.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../../infra/restart-stale-pids.js";
 import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logging/console.js";
@@ -164,6 +165,22 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.error("Use --reset with --dev.");
     defaultRuntime.exit(1);
     return;
+  }
+
+  // Node.js 22's native fetch (undici) does not automatically read http_proxy /
+  // https_proxy environment variables, and TUN-mode VPNs do not intercept
+  // Node.js connections on macOS. Third-party SDKs embedded in the gateway
+  // (e.g. the Pi coding-agent SDK) call bare fetch() and therefore bypass any
+  // configured proxy, causing LLM requests to time out in proxy-required
+  // environments. Patch globalThis.fetch early so every bare fetch() call in
+  // the process inherits the proxy settings — EnvHttpProxyAgent also honours
+  // NO_PROXY, so loopback / localhost exclusions are preserved.
+  const proxyFetch = resolveProxyFetchFromEnv();
+  if (proxyFetch) {
+    globalThis.fetch = proxyFetch;
+    gatewayLog.info(
+      "http_proxy env var detected — patched globalThis.fetch to route through proxy",
+    );
   }
 
   setConsoleTimestampPrefix(true);

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -17,7 +17,7 @@ import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setVerbose } from "../../globals.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
-import { resolveProxyFetchFromEnv } from "../../infra/net/proxy-fetch.js";
+import { applyEnvProxyToGlobalDispatcher } from "../../infra/net/undici-global-dispatcher.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../../infra/restart-stale-pids.js";
 import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logging/console.js";
@@ -172,15 +172,13 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   // Node.js connections on macOS. Third-party SDKs embedded in the gateway
   // (e.g. the Pi coding-agent SDK) call bare fetch() and therefore bypass any
   // configured proxy, causing LLM requests to time out in proxy-required
-  // environments. Patch globalThis.fetch early so every bare fetch() call in
-  // the process inherits the proxy settings — EnvHttpProxyAgent also honours
-  // NO_PROXY, so loopback / localhost exclusions are preserved.
-  const proxyFetchResult = resolveProxyFetchFromEnv();
-  if (proxyFetchResult) {
-    globalThis.fetch = proxyFetchResult.fetch;
-    gatewayLog.info(
-      `${proxyFetchResult.envVar} detected — patched globalThis.fetch to route through proxy`,
-    );
+  // environments. Install an EnvHttpProxyAgent as the global undici dispatcher
+  // early so every bare fetch() call inherits the proxy — this approach keeps
+  // ensureGlobalUndiciStreamTimeouts() composable (it detects env-proxy and
+  // applies timeout settings on top). NO_PROXY exclusions are also honoured.
+  const proxyEnvVar = applyEnvProxyToGlobalDispatcher();
+  if (proxyEnvVar) {
+    gatewayLog.info(`${proxyEnvVar} detected — set undici global dispatcher to EnvHttpProxyAgent`);
   }
 
   setConsoleTimestampPrefix(true);

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -65,8 +65,10 @@ describe("resolveProxyFetchFromEnv", () => {
   it("returns undefined when no proxy env vars are set", () => {
     vi.stubEnv("HTTPS_PROXY", "");
     vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("ALL_PROXY", "");
     vi.stubEnv("https_proxy", "");
     vi.stubEnv("http_proxy", "");
+    vi.stubEnv("all_proxy", "");
 
     expect(resolveProxyFetchFromEnv()).toBeUndefined();
   });
@@ -75,16 +77,19 @@ describe("resolveProxyFetchFromEnv", () => {
     // Stub empty vars first — on Windows, process.env is case-insensitive so
     // HTTPS_PROXY and https_proxy share the same slot. Value must be set LAST.
     vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("ALL_PROXY", "");
     vi.stubEnv("https_proxy", "");
     vi.stubEnv("http_proxy", "");
+    vi.stubEnv("all_proxy", "");
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
     undiciFetch.mockResolvedValue({ ok: true });
 
-    const fetchFn = resolveProxyFetchFromEnv();
-    expect(fetchFn).toBeDefined();
+    const result = resolveProxyFetchFromEnv();
+    expect(result).toBeDefined();
+    expect(result!.envVar).toBe("HTTPS_PROXY");
     expect(envAgentSpy).toHaveBeenCalled();
 
-    await fetchFn!("https://api.example.com");
+    await result!.fetch("https://api.example.com");
     expect(undiciFetch).toHaveBeenCalledWith(
       "https://api.example.com",
       expect.objectContaining({ dispatcher: EnvHttpProxyAgent.lastCreated }),
@@ -93,47 +98,86 @@ describe("resolveProxyFetchFromEnv", () => {
 
   it("returns proxy fetch when HTTP_PROXY is set", () => {
     vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("ALL_PROXY", "");
     vi.stubEnv("https_proxy", "");
     vi.stubEnv("http_proxy", "");
+    vi.stubEnv("all_proxy", "");
     vi.stubEnv("HTTP_PROXY", "http://fallback.test:3128");
 
-    const fetchFn = resolveProxyFetchFromEnv();
-    expect(fetchFn).toBeDefined();
+    const result = resolveProxyFetchFromEnv();
+    expect(result).toBeDefined();
+    expect(result!.envVar).toBe("HTTP_PROXY");
     expect(envAgentSpy).toHaveBeenCalled();
   });
 
   it("returns proxy fetch when lowercase https_proxy is set", () => {
     vi.stubEnv("HTTPS_PROXY", "");
     vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("ALL_PROXY", "");
     vi.stubEnv("http_proxy", "");
+    vi.stubEnv("all_proxy", "");
     vi.stubEnv("https_proxy", "http://lower.test:1080");
 
-    const fetchFn = resolveProxyFetchFromEnv();
-    expect(fetchFn).toBeDefined();
+    const result = resolveProxyFetchFromEnv();
+    expect(result).toBeDefined();
+    expect(result!.envVar).toBe("https_proxy");
     expect(envAgentSpy).toHaveBeenCalled();
   });
 
   it("returns proxy fetch when lowercase http_proxy is set", () => {
     vi.stubEnv("HTTPS_PROXY", "");
     vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("ALL_PROXY", "");
     vi.stubEnv("https_proxy", "");
+    vi.stubEnv("all_proxy", "");
     vi.stubEnv("http_proxy", "http://lower-http.test:1080");
 
-    const fetchFn = resolveProxyFetchFromEnv();
-    expect(fetchFn).toBeDefined();
+    const result = resolveProxyFetchFromEnv();
+    expect(result).toBeDefined();
+    expect(result!.envVar).toBe("http_proxy");
+    expect(envAgentSpy).toHaveBeenCalled();
+  });
+
+  it("returns proxy fetch when ALL_PROXY is set", () => {
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("https_proxy", "");
+    vi.stubEnv("http_proxy", "");
+    vi.stubEnv("all_proxy", "");
+    vi.stubEnv("ALL_PROXY", "socks5://proxy.corp:1080");
+
+    const result = resolveProxyFetchFromEnv();
+    expect(result).toBeDefined();
+    expect(result!.envVar).toBe("ALL_PROXY");
+    expect(envAgentSpy).toHaveBeenCalled();
+  });
+
+  it("returns proxy fetch when lowercase all_proxy is set", () => {
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("ALL_PROXY", "");
+    vi.stubEnv("https_proxy", "");
+    vi.stubEnv("http_proxy", "");
+    vi.stubEnv("all_proxy", "socks5://proxy.corp:1080");
+
+    const result = resolveProxyFetchFromEnv();
+    expect(result).toBeDefined();
+    expect(result!.envVar).toBe("all_proxy");
     expect(envAgentSpy).toHaveBeenCalled();
   });
 
   it("returns undefined when EnvHttpProxyAgent constructor throws", () => {
     vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("ALL_PROXY", "");
     vi.stubEnv("https_proxy", "");
     vi.stubEnv("http_proxy", "");
+    vi.stubEnv("all_proxy", "");
     vi.stubEnv("HTTPS_PROXY", "not-a-valid-url");
     envAgentSpy.mockImplementationOnce(() => {
       throw new Error("Invalid URL");
     });
 
-    const fetchFn = resolveProxyFetchFromEnv();
-    expect(fetchFn).toBeUndefined();
+    const result = resolveProxyFetchFromEnv();
+    expect(result).toBeUndefined();
   });
 });

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -120,7 +120,9 @@ describe("resolveProxyFetchFromEnv", () => {
 
     const result = resolveProxyFetchFromEnv();
     expect(result).toBeDefined();
-    expect(result!.envVar).toBe("https_proxy");
+    // Windows process.env is case-insensitive; the key may be normalised to
+    // uppercase by the OS, so accept either casing for the log value.
+    expect(result!.envVar.toUpperCase()).toBe("HTTPS_PROXY");
     expect(envAgentSpy).toHaveBeenCalled();
   });
 
@@ -134,7 +136,8 @@ describe("resolveProxyFetchFromEnv", () => {
 
     const result = resolveProxyFetchFromEnv();
     expect(result).toBeDefined();
-    expect(result!.envVar).toBe("http_proxy");
+    // Windows process.env is case-insensitive; accept either casing.
+    expect(result!.envVar.toUpperCase()).toBe("HTTP_PROXY");
     expect(envAgentSpy).toHaveBeenCalled();
   });
 
@@ -162,7 +165,8 @@ describe("resolveProxyFetchFromEnv", () => {
 
     const result = resolveProxyFetchFromEnv();
     expect(result).toBeDefined();
-    expect(result!.envVar).toBe("all_proxy");
+    // Windows process.env is case-insensitive; accept either casing.
+    expect(result!.envVar.toUpperCase()).toBe("ALL_PROXY");
     expect(envAgentSpy).toHaveBeenCalled();
   });
 

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -1,5 +1,6 @@
 import { EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 import { logWarn } from "../../logger.js";
+import { PROXY_ENV_KEYS } from "./proxy-env.js";
 
 /**
  * Create a fetch function that routes requests through the given HTTP proxy.
@@ -18,27 +19,31 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
 
 /**
  * Resolve a proxy-aware fetch from standard environment variables
- * (HTTPS_PROXY, HTTP_PROXY, https_proxy, http_proxy).
+ * (HTTPS_PROXY, HTTP_PROXY, ALL_PROXY and their lowercase variants).
  * Respects NO_PROXY / no_proxy exclusions via undici's EnvHttpProxyAgent.
  * Returns undefined when no proxy is configured.
  * Gracefully returns undefined if the proxy URL is malformed.
+ * Also returns the name of the env var that triggered the proxy, for logging.
  */
-export function resolveProxyFetchFromEnv(): typeof fetch | undefined {
-  const proxyUrl =
-    process.env.HTTPS_PROXY ||
-    process.env.HTTP_PROXY ||
-    process.env.https_proxy ||
-    process.env.http_proxy;
-  if (!proxyUrl?.trim()) {
+export function resolveProxyFetchFromEnv(): { fetch: typeof fetch; envVar: string } | undefined {
+  let detectedKey: string | undefined;
+  for (const key of PROXY_ENV_KEYS) {
+    if (process.env[key]?.trim()) {
+      detectedKey = key;
+      break;
+    }
+  }
+  if (!detectedKey) {
     return undefined;
   }
   try {
     const agent = new EnvHttpProxyAgent();
-    return ((input: RequestInfo | URL, init?: RequestInit) =>
+    const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
       undiciFetch(input as string | URL, {
         ...(init as Record<string, unknown>),
         dispatcher: agent,
       }) as unknown as Promise<Response>) as typeof fetch;
+    return { fetch: proxyFetch, envVar: detectedKey };
   } catch (err) {
     logWarn(
       `Proxy env var set but agent creation failed — falling back to direct fetch: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -1,5 +1,7 @@
 import * as net from "node:net";
 import { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { logWarn } from "../../logger.js";
+import { PROXY_ENV_KEYS } from "./proxy-env.js";
 
 export const DEFAULT_UNDICI_STREAM_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -110,4 +112,42 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
 
 export function resetGlobalUndiciStreamTimeoutsForTests(): void {
   lastAppliedDispatcherKey = null;
+}
+
+/**
+ * If any proxy env var (HTTPS_PROXY, HTTP_PROXY, ALL_PROXY, or their lowercase
+ * variants) is set, install an EnvHttpProxyAgent as the global undici dispatcher
+ * so that bare fetch() calls — including those from third-party SDKs that do not
+ * accept a custom fetch — route through the configured proxy.
+ *
+ * Using setGlobalDispatcher() rather than replacing globalThis.fetch keeps the
+ * approach composable: subsequent ensureGlobalUndiciStreamTimeouts() calls can
+ * still detect and upgrade the dispatcher with timeout settings.
+ *
+ * Returns the name of the env var that triggered the change, or undefined when
+ * no proxy is configured or the dispatcher could not be set.
+ */
+export function applyEnvProxyToGlobalDispatcher(): string | undefined {
+  let detectedKey: string | undefined;
+  for (const key of PROXY_ENV_KEYS) {
+    if (process.env[key]?.trim()) {
+      detectedKey = key;
+      break;
+    }
+  }
+  if (!detectedKey) {
+    return undefined;
+  }
+  try {
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+    // Reset memoised key so the next ensureGlobalUndiciStreamTimeouts() call
+    // picks up the new env-proxy dispatcher and applies timeout settings.
+    lastAppliedDispatcherKey = null;
+    return detectedKey;
+  } catch (err) {
+    logWarn(
+      `Proxy env var set but EnvHttpProxyAgent dispatcher could not be installed — bare fetch() calls may bypass the proxy: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
 }

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -482,7 +482,7 @@ export async function runProviderEntry(params: {
 
   // Resolve proxy-aware fetch from env vars (HTTPS_PROXY, HTTP_PROXY, etc.)
   // so provider HTTP calls are routed through the proxy when configured.
-  const fetchFn = resolveProxyFetchFromEnv();
+  const fetchFn = resolveProxyFetchFromEnv()?.fetch;
 
   if (capability === "audio") {
     if (!provider.transcribeAudio) {

--- a/src/media-understanding/runner.proxy.test.ts
+++ b/src/media-understanding/runner.proxy.test.ts
@@ -121,8 +121,10 @@ describe("runCapability proxy fetch passthrough", () => {
   it("does not pass fetchFn when no proxy env vars are set", async () => {
     vi.stubEnv("HTTPS_PROXY", "");
     vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("ALL_PROXY", "");
     vi.stubEnv("https_proxy", "");
     vi.stubEnv("http_proxy", "");
+    vi.stubEnv("all_proxy", "");
 
     const seenFetchFn = await runAudioCapabilityWithFetchCapture({
       fixturePrefix: "openclaw-audio-no-proxy",


### PR DESCRIPTION
## Summary

- Node.js 22's native `fetch` (undici) does **not** automatically read `http_proxy` / `https_proxy` environment variables
- On macOS, TUN-mode VPNs (e.g. ClashX Pro) do not intercept Node.js/undici connections
- Third-party SDKs embedded in the gateway — in particular the Pi coding-agent SDK — call bare `fetch()` and therefore bypass any configured proxy, causing LLM requests to silently time out in proxy-required environments (common in China, corporate networks, etc.)
- The fix patches `globalThis.fetch` with undici's `EnvHttpProxyAgent` early in gateway startup, so every bare `fetch()` call in the process inherits the proxy settings; `EnvHttpProxyAgent` also honours `NO_PROXY`, so loopback/localhost exclusions are preserved

## Root cause

`openai-codex-responses.js` in `@mariozechner/pi-ai` calls bare `fetch(...)` (global, no custom dispatcher). This is reasonable for cross-runtime portability (browser, Bun, Cloudflare Workers), but Node.js's native fetch deliberately does not read Unix proxy env vars. The fix is at the gateway layer rather than in the SDK.

## Test plan

- [x] `pnpm tsgo` — no type errors
- [x] `pnpm check` — lint/format clean
- [x] `pnpm test -- src/cli/gateway-cli` — all 27 tests pass
- [x] Manually verified: LLM requests via `openai-codex/gpt-5.2` succeed after this patch when `http_proxy` is set in the gateway environment (previously timed out after ~3.5 min)

> AI-assisted (Claude Sonnet 4.6) — fully tested and reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)