### PR TITLE
fix: respect HTTP proxy environment variables for all outbound requests

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -4,6 +4,7 @@ import { loadDotEnv } from "../infra/dotenv.js";
 import { normalizeEnv } from "../infra/env.js";
 import { formatUncaughtError } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
+import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { installUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
@@ -90,6 +91,14 @@ export async function runCli(argv: string[] = process.argv) {
 
   // Enforce the minimum supported runtime before doing any work.
   assertSupportedRuntime();
+
+  // Node.js fetch() ignores proxy env vars (HTTPS_PROXY, etc.) by default.
+  // Install undici's EnvHttpProxyAgent as the global dispatcher so all
+  // outbound HTTP — including LLM streaming — routes through the proxy.
+  if (hasProxyEnvConfigured()) {
+    const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+  }
 
   try {
     if (await tryRouteCli(normalizedArgv)) {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -96,8 +96,13 @@ export async function runCli(argv: string[] = process.argv) {
   // Install undici's EnvHttpProxyAgent as the global dispatcher so all
   // outbound HTTP — including LLM streaming — routes through the proxy.
   if (hasProxyEnvConfigured()) {
-    const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
-    setGlobalDispatcher(new EnvHttpProxyAgent());
+    try {
+      const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
+      setGlobalDispatcher(new EnvHttpProxyAgent());
+    } catch (err) {
+      // Non-fatal: log and continue without proxy. A bad proxy URL should not crash the CLI.
+      console.warn("[openclaw] Failed to install proxy dispatcher:", err);
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Node.js `fetch()` (backed by undici) does not automatically honor proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, etc.), unlike `curl` and most other HTTP clients.
- This means that in corporate or firewalled environments where outbound traffic must go through a proxy, all OpenClaw network requests — including LLM API calls and streaming — silently bypass the proxy and time out.
- Fix: install undici's `EnvHttpProxyAgent` as the global dispatcher early in `runCli()`, gated behind the existing `hasProxyEnvConfigured()` check. This is a no-op when no proxy env vars are set.
- The existing `ensureGlobalUndiciStreamTimeouts()` already detects `EnvHttpProxyAgent` and preserves the proxy dispatcher type when applying stream timeouts — no changes needed there.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

None when no proxy env vars are set. When `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` is configured, all outbound HTTP requests now correctly route through the proxy instead of silently bypassing it and timing out.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No — same requests, same destinations; only the transport path changes (direct → via user-configured proxy)
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux 5.15.0-43-generic x86_64
- Runtime/container: Node.js v22.22.1
- Model/provider: minimax/MiniMax-M2.5 (via `api.minimaxi.com`)
- Integration/channel (if any): CLI (`openclaw agent`)
- Relevant config (redacted): `HTTPS_PROXY=http://<corporate-proxy>:1234`

### Steps

1. Set `HTTPS_PROXY` to a corporate proxy; ensure direct outbound HTTPS is blocked by firewall.
2. Start the gateway: `openclaw gateway --port 18789 --allow-unconfigured`
3. Run any agent command that triggers an LLM API call, e.g. `openclaw agent --agent test --message "Hello"`

### Expected

- Agent receives LLM response and outputs it to stdout.

### Actual

- **Before fix:** Request hangs for ~30 minutes until undici's `bodyTimeout` fires, then fails with a timeout error. Node.js `fetch()` ignores `HTTPS_PROXY` and attempts a direct connection that the firewall blocks.
- **After fix:** Request completes normally via the proxy.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `openclaw agent` behind a corporate HTTPS proxy; confirmed LLM streaming works end-to-end. Ran the PinchBench `task_00_sanity` benchmark — passed 100%.
- Edge cases checked: Verified `openclaw --version` and `openclaw --help` fast paths are unaffected (proxy init only runs inside `runCli()`). Verified no-op behavior when proxy env vars are unset.
- What you did **not** verify: Behavior with `NO_PROXY` exclusion lists; SOCKS proxy support; proxy requiring authentication.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No — uses existing standard env vars
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Unset all proxy env vars (`unset HTTPS_PROXY HTTP_PROXY ALL_PROXY`), or revert the single commit.
- Files/config to restore: `src/cli/run-main.ts` — remove the 6-line `if (hasProxyEnvConfigured())` block and the `proxy-env.js` import.
- Known bad symptoms reviewers should watch for: Unexpected proxy-related errors on startup if a user has proxy env vars set but the proxy is unreachable.

## Risks and Mitigations

- Risk: A user has stale/incorrect proxy env vars inherited from their shell; OpenClaw would now attempt to use them and fail instead of connecting directly.
  - Mitigation: This matches the behavior of `curl`, `wget`, and every other proxy-aware tool. The fix is gated behind `hasProxyEnvConfigured()` — clearing the env vars restores the previous direct-connect behavior.