### PR TITLE
docs(plugins): add Codex CLI Session community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **Codex CLI Session** — Use your Codex subscription from OpenClaw: run local Codex CLI in chat via `/codex` and ACP commands; supports persistent and oneshot sessions.
+  npm: `codex-cli-session`
+  repo: `https://github.com/sunsiyuan/openclaw-codex-cli-session`
+  install: `openclaw plugins install codex-cli-session`


### PR DESCRIPTION
Adds **Codex CLI Session** to the community plugins list.

- **Plugin**: Use Codex subscription from OpenClaw via local Codex CLI in chat (`/codex`, ACP commands; persistent/oneshot sessions).
- **npm**: `codex-cli-session` (published on npm).
- **Repo**: https://github.com/sunsiyuan/openclaw-codex-cli-session
- **Install**: `openclaw plugins install codex-cli-session`

Meets listing requirements: public GitHub repo, README + issue tracker, package published on npmjs, maintainer will keep maintaining.