### PR TITLE
fix(ui): preserve gateway token when editing WebSocket URL

### DIFF
--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -198,7 +198,7 @@ describe("control UI routing", () => {
     expect(window.location.hash).toBe("");
   });
 
-  it("clears the current token when the gateway URL changes", async () => {
+  it("preserves the current token when the gateway URL changes", async () => {
     const app = mountApp("/ui/overview#token=abc123");
     await app.updateComplete;
 
@@ -211,7 +211,7 @@ describe("control UI routing", () => {
     await app.updateComplete;
 
     expect(app.settings.gatewayUrl).toBe("wss://other-gateway.example/openclaw");
-    expect(app.settings.token).toBe("");
+    expect(app.settings.token).toBe("abc123");
   });
 
   it("keeps a hash token pending until the gateway URL change is confirmed", async () => {

--- a/ui/src/ui/views/overview-settings.ts
+++ b/ui/src/ui/views/overview-settings.ts
@@ -1,0 +1,8 @@
+import type { UiSettings } from "../storage.ts";
+
+export function updateOverviewGatewayUrl(settings: UiSettings, gatewayUrl: string): UiSettings {
+  return {
+    ...settings,
+    gatewayUrl,
+  };
+}

--- a/ui/src/ui/views/overview.node.test.ts
+++ b/ui/src/ui/views/overview.node.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../../src/gateway/protocol/connect-error-details.js";
+import type { UiSettings } from "../storage.ts";
 import { shouldShowPairingHint } from "./overview-hints.ts";
+import { updateOverviewGatewayUrl } from "./overview-settings.ts";
+
+function createSettings(overrides: Partial<UiSettings> = {}): UiSettings {
+  return {
+    gatewayUrl: "ws://127.0.0.1:18789",
+    token: "abc123",
+    sessionKey: "main",
+    lastActiveSessionKey: "main",
+    theme: "system",
+    chatFocusMode: false,
+    chatShowThinking: true,
+    splitRatio: 0.6,
+    navCollapsed: false,
+    navGroupsCollapsed: {},
+    ...overrides,
+  };
+}
 
 describe("shouldShowPairingHint", () => {
   it("returns true for 'pairing required' close reason", () => {
@@ -35,5 +53,16 @@ describe("shouldShowPairingHint", () => {
         ConnectErrorDetailCodes.PAIRING_REQUIRED,
       ),
     ).toBe(true);
+  });
+});
+
+describe("updateOverviewGatewayUrl", () => {
+  it("preserves the current token while editing the gateway URL", () => {
+    expect(
+      updateOverviewGatewayUrl(createSettings(), "wss://other-gateway.example/openclaw"),
+    ).toMatchObject({
+      gatewayUrl: "wss://other-gateway.example/openclaw",
+      token: "abc123",
+    });
   });
 });

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -7,6 +7,7 @@ import type { GatewayHelloOk } from "../gateway.ts";
 import { formatNextRun } from "../presenter.ts";
 import type { UiSettings } from "../storage.ts";
 import { shouldShowPairingHint } from "./overview-hints.ts";
+import { updateOverviewGatewayUrl } from "./overview-settings.ts";
 
 export type OverviewProps = {
   connected: boolean;
@@ -205,11 +206,7 @@ export function renderOverview(props: OverviewProps) {
               .value=${props.settings.gatewayUrl}
               @input=${(e: Event) => {
                 const v = (e.target as HTMLInputElement).value;
-                props.onSettingsChange({
-                  ...props.settings,
-                  gatewayUrl: v,
-                  token: v.trim() === props.settings.gatewayUrl.trim() ? props.settings.token : "",
-                });
+                props.onSettingsChange(updateOverviewGatewayUrl(props.settings, v));
               }}
               placeholder="ws://100.x.y.z:18789"
             />


### PR DESCRIPTION
## Summary
- preserve the in-memory Gateway Token while editing the WebSocket URL in Overview > Gateway Access
- keep the URL confirmation/import flow unchanged
- add targeted regression coverage for the state transition

## Testing
- corepack pnpm --dir ui exec vitest run --config vitest.node.config.ts src/ui/views/overview.node.test.ts

Fixes #41545