### PR TITLE
fix(imessage): strip inline reply tags from outbound text

### DIFF
--- a/src/imessage/monitor/deliver.test.ts
+++ b/src/imessage/monitor/deliver.test.ts
@@ -149,4 +149,26 @@ describe("deliverReplies", () => {
       messageId: "imsg-1",
     });
   });
+
+  it("strips inline reply directive tags before sending outbound text", async () => {
+    await deliverReplies({
+      replies: [{ text: "[[reply_to:1578]] Hey Matt.", replyToId: "1578" }],
+      target: "chat_id:40",
+      client,
+      accountId: "acct-4",
+      runtime,
+      maxBytes: 2048,
+      textLimit: 4000,
+    });
+
+    expect(sendMessageIMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageIMessageMock).toHaveBeenCalledWith(
+      "chat_id:40",
+      "Hey Matt.",
+      expect.objectContaining({
+        accountId: "acct-4",
+        replyToId: "1578",
+      }),
+    );
+  });
 });

--- a/src/imessage/monitor/deliver.test.ts
+++ b/src/imessage/monitor/deliver.test.ts
@@ -166,6 +166,8 @@ describe("deliverReplies", () => {
       "chat_id:40",
       "Hey Matt.",
       expect.objectContaining({
+        client,
+        maxBytes: 2048,
         accountId: "acct-4",
         replyToId: "1578",
       }),

--- a/src/imessage/monitor/sanitize-outbound.test.ts
+++ b/src/imessage/monitor/sanitize-outbound.test.ts
@@ -48,6 +48,16 @@ describe("sanitizeOutboundText", () => {
     expect(result).not.toMatch(/^assistant:$/m);
   });
 
+  it("strips inline reply directive tags", () => {
+    const text = "[[reply_to:1578]] Hey Matt.";
+    expect(sanitizeOutboundText(text)).toBe("Hey Matt.");
+  });
+
+  it("strips inline reply_to_current directive tags with whitespace", () => {
+    const text = "[[ reply_to_current ]]\nHello world";
+    expect(sanitizeOutboundText(text)).toBe("Hello world");
+  });
+
   it("collapses excessive blank lines after stripping", () => {
     const text = "Hello\n\n\n\n\nWorld";
     expect(sanitizeOutboundText(text)).toBe("Hello\n\nWorld");

--- a/src/imessage/monitor/sanitize-outbound.ts
+++ b/src/imessage/monitor/sanitize-outbound.ts
@@ -1,4 +1,5 @@
 import { stripAssistantInternalScaffolding } from "../../shared/text/assistant-visible-text.js";
+import { stripInlineDirectiveTagsForDisplay } from "../../utils/directive-tags.js";
 
 /**
  * Patterns that indicate assistant-internal metadata leaked into text.
@@ -23,6 +24,7 @@ export function sanitizeOutboundText(text: string): string {
   cleaned = cleaned.replace(INTERNAL_SEPARATOR_RE, "");
   cleaned = cleaned.replace(ASSISTANT_ROLE_MARKER_RE, "");
   cleaned = cleaned.replace(ROLE_TURN_MARKER_RE, "");
+  cleaned = stripInlineDirectiveTagsForDisplay(cleaned).text;
 
   // Collapse excessive blank lines left after stripping.
   cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trim();


### PR DESCRIPTION
## Summary
- strip inline `[[reply_to:...]]` and `[[reply_to_current]]` tags from outbound iMessage text
- reuse the shared inline-directive display stripping helper instead of duplicating parsing
- add focused regression tests for sanitizeOutboundText and iMessage delivery

## Testing
- corepack pnpm test src/imessage/monitor/sanitize-outbound.test.ts src/imessage/monitor/deliver.test.ts

Fixes #41576