### PR TITLE
fix(line): migrate media downloads to saveMediaBuffer for sandbox access

### DIFF
--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -551,7 +551,13 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
 
   if (isDownloadableLineMessageType(message.type)) {
     try {
-      const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
+      const fileName = message.type === "file" ? message.fileName : undefined;
+      const media = await downloadLineMedia(
+        message.id,
+        account.channelAccessToken,
+        mediaMaxBytes,
+        fileName,
+      );
       allMedia.push({
         path: media.path,
         contentType: media.contentType,

--- a/src/line/download.test.ts
+++ b/src/line/download.test.ts
@@ -1,15 +1,13 @@
-import fs from "node:fs";
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
-const getMessageContentMock = vi.hoisted(() => vi.fn());
+const getMessageContentWithHttpInfoMock = vi.hoisted(() => vi.fn());
+const saveMediaBufferMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@line/bot-sdk", () => ({
   messagingApi: {
     MessagingApiBlobClient: class {
-      getMessageContent(messageId: string) {
-        return getMessageContentMock(messageId);
+      getMessageContentWithHttpInfo(messageId: string) {
+        return getMessageContentWithHttpInfoMock(messageId);
       }
     },
   },
@@ -17,6 +15,10 @@ vi.mock("@line/bot-sdk", () => ({
 
 vi.mock("../globals.js", () => ({
   logVerbose: () => {},
+}));
+
+vi.mock("../media/store.js", () => ({
+  saveMediaBuffer: (...args: unknown[]) => saveMediaBufferMock(...args),
 }));
 
 import { downloadLineMedia } from "./download.js";
@@ -32,66 +34,63 @@ describe("downloadLineMedia", () => {
     vi.clearAllMocks();
   });
 
-  it("does not derive temp file path from external messageId", async () => {
-    const messageId = "a/../../../../etc/passwd";
+  it("saves media via saveMediaBuffer to inbound directory", async () => {
     const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([jpeg]));
+    getMessageContentWithHttpInfoMock.mockResolvedValueOnce({
+      body: chunks([jpeg]),
+      httpResponse: { headers: new Headers({ "content-type": "image/jpeg" }) },
+    });
+    saveMediaBufferMock.mockResolvedValueOnce({
+      id: "test-uuid.jpg",
+      path: "/home/user/.openclaw/media/inbound/test-uuid.jpg",
+      size: jpeg.length,
+      contentType: "image/jpeg",
+    });
 
-    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
+    const result = await downloadLineMedia("msg-123", "token");
 
-    const result = await downloadLineMedia(messageId, "token");
-    const writtenPath = writeSpy.mock.calls[0]?.[0];
+    expect(saveMediaBufferMock).toHaveBeenCalledOnce();
+    const [buffer, contentType, subdir, maxBytes, originalFilename] =
+      saveMediaBufferMock.mock.calls[0];
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(buffer.length).toBe(jpeg.length);
+    expect(contentType).toBe("image/jpeg");
+    expect(subdir).toBe("inbound");
+    expect(maxBytes).toBe(10 * 1024 * 1024);
+    expect(originalFilename).toBeUndefined();
 
-    expect(result.size).toBe(jpeg.length);
+    expect(result.path).toBe("/home/user/.openclaw/media/inbound/test-uuid.jpg");
     expect(result.contentType).toBe("image/jpeg");
-    expect(typeof writtenPath).toBe("string");
-    if (typeof writtenPath !== "string") {
-      throw new Error("expected string temp file path");
-    }
-    expect(result.path).toBe(writtenPath);
-    expect(writtenPath).toContain("line-media-");
-    expect(writtenPath).toMatch(/\.jpg$/);
-    expect(writtenPath).not.toContain(messageId);
-    expect(writtenPath).not.toContain("..");
-
-    const tmpRoot = path.resolve(resolvePreferredOpenClawTmpDir());
-    const rel = path.relative(tmpRoot, path.resolve(writtenPath));
-    expect(rel === ".." || rel.startsWith(`..${path.sep}`)).toBe(false);
+    expect(result.size).toBe(jpeg.length);
   });
 
-  it("rejects oversized media before writing to disk", async () => {
-    getMessageContentMock.mockResolvedValueOnce(chunks([Buffer.alloc(4), Buffer.alloc(4)]));
-    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValue(undefined);
+  it("passes originalFilename and custom maxBytes to saveMediaBuffer", async () => {
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    getMessageContentWithHttpInfoMock.mockResolvedValueOnce({
+      body: chunks([buf]),
+      httpResponse: { headers: new Headers({ "content-type": "image/png" }) },
+    });
+    saveMediaBufferMock.mockResolvedValueOnce({
+      id: "uuid.png",
+      path: "/home/user/.openclaw/media/inbound/uuid.png",
+      size: buf.length,
+      contentType: "image/png",
+    });
+
+    await downloadLineMedia("msg-456", "token", 5 * 1024 * 1024, "report.png");
+
+    const [, , , maxBytes, originalFilename] = saveMediaBufferMock.mock.calls[0];
+    expect(maxBytes).toBe(5 * 1024 * 1024);
+    expect(originalFilename).toBe("report.png");
+  });
+
+  it("rejects oversized media during streaming before saving", async () => {
+    getMessageContentWithHttpInfoMock.mockResolvedValueOnce({
+      body: chunks([Buffer.alloc(4), Buffer.alloc(4)]),
+      httpResponse: { headers: new Headers() },
+    });
 
     await expect(downloadLineMedia("mid", "token", 7)).rejects.toThrow(/Media exceeds/i);
-    expect(writeSpy).not.toHaveBeenCalled();
-  });
-
-  it("classifies M4A ftyp major brand as audio/mp4", async () => {
-    const m4aHeader = Buffer.from([
-      0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20,
-    ]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([m4aHeader]));
-    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
-
-    const result = await downloadLineMedia("mid-audio", "token");
-    const writtenPath = writeSpy.mock.calls[0]?.[0];
-
-    expect(result.contentType).toBe("audio/mp4");
-    expect(result.path).toMatch(/\.m4a$/);
-    expect(writtenPath).toBe(result.path);
-  });
-
-  it("detects MP4 video from ftyp major brand (isom)", async () => {
-    const mp4 = Buffer.from([
-      0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,
-    ]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([mp4]));
-    vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
-
-    const result = await downloadLineMedia("mid-mp4", "token");
-
-    expect(result.contentType).toBe("video/mp4");
-    expect(result.path).toMatch(/\.mp4$/);
+    expect(saveMediaBufferMock).not.toHaveBeenCalled();
   });
 });

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -18,15 +18,15 @@ export async function downloadLineMedia(
     channelAccessToken,
   });
 
-  const httpResponse = await client.getMessageContentWithHttpInfo(messageId);
+  const response = await client.getMessageContentWithHttpInfo(messageId);
 
-  const contentType = httpResponse.httpResponse.headers.get("content-type") ?? undefined;
+  const contentType = response.httpResponse.headers.get("content-type") ?? undefined;
 
-  // httpResponse.body is a Readable stream
+  // response.body is a Readable stream
   const chunks: Buffer[] = [];
   let totalSize = 0;
 
-  for await (const chunk of httpResponse.body as AsyncIterable<Buffer>) {
+  for await (const chunk of response.body as AsyncIterable<Buffer>) {
     totalSize += chunk.length;
     if (totalSize > maxBytes) {
       throw new Error(`Media exceeds ${Math.round(maxBytes / (1024 * 1024))}MB limit`);

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -1,7 +1,6 @@
-import fs from "node:fs";
 import { messagingApi } from "@line/bot-sdk";
 import { logVerbose } from "../globals.js";
-import { buildRandomTempFilePath } from "../plugin-sdk/temp-path.js";
+import { saveMediaBuffer } from "../media/store.js";
 
 interface DownloadResult {
   path: string;
@@ -9,24 +8,25 @@ interface DownloadResult {
   size: number;
 }
 
-const AUDIO_BRANDS = new Set(["m4a ", "m4b ", "m4p ", "m4r ", "f4a ", "f4b "]);
-
 export async function downloadLineMedia(
   messageId: string,
   channelAccessToken: string,
   maxBytes = 10 * 1024 * 1024,
+  originalFilename?: string,
 ): Promise<DownloadResult> {
   const client = new messagingApi.MessagingApiBlobClient({
     channelAccessToken,
   });
 
-  const response = await client.getMessageContent(messageId);
+  const httpResponse = await client.getMessageContentWithHttpInfo(messageId);
 
-  // response is a Readable stream
+  const contentType = httpResponse.httpResponse.headers.get("content-type") ?? undefined;
+
+  // httpResponse.body is a Readable stream
   const chunks: Buffer[] = [];
   let totalSize = 0;
 
-  for await (const chunk of response as AsyncIterable<Buffer>) {
+  for await (const chunk of httpResponse.body as AsyncIterable<Buffer>) {
     totalSize += chunk.length;
     if (totalSize > maxBytes) {
       throw new Error(`Media exceeds ${Math.round(maxBytes / (1024 * 1024))}MB limit`);
@@ -36,90 +36,15 @@ export async function downloadLineMedia(
 
   const buffer = Buffer.concat(chunks);
 
-  // Determine content type from magic bytes
-  const contentType = detectContentType(buffer);
-  const ext = getExtensionForContentType(contentType);
+  // Save to ~/.openclaw/media/inbound/ so sandbox can access the file.
+  // Previously saved to /tmp/openclaw/ which was outside the sandbox root.
+  const saved = await saveMediaBuffer(buffer, contentType, "inbound", maxBytes, originalFilename);
 
-  // Use random temp names; never derive paths from external message identifiers.
-  const filePath = buildRandomTempFilePath({ prefix: "line-media", extension: ext });
-
-  await fs.promises.writeFile(filePath, buffer);
-
-  logVerbose(`line: downloaded media ${messageId} to ${filePath} (${buffer.length} bytes)`);
+  logVerbose(`line: downloaded media ${messageId} to ${saved.path} (${saved.size} bytes)`);
 
   return {
-    path: filePath,
-    contentType,
-    size: buffer.length,
+    path: saved.path,
+    contentType: saved.contentType,
+    size: saved.size,
   };
-}
-
-function detectContentType(buffer: Buffer): string {
-  const hasFtypBox =
-    buffer.length >= 12 &&
-    buffer[4] === 0x66 &&
-    buffer[5] === 0x74 &&
-    buffer[6] === 0x79 &&
-    buffer[7] === 0x70;
-
-  // Check magic bytes
-  if (buffer.length >= 2) {
-    // JPEG
-    if (buffer[0] === 0xff && buffer[1] === 0xd8) {
-      return "image/jpeg";
-    }
-    // PNG
-    if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) {
-      return "image/png";
-    }
-    // GIF
-    if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) {
-      return "image/gif";
-    }
-    // WebP
-    if (
-      buffer[0] === 0x52 &&
-      buffer[1] === 0x49 &&
-      buffer[2] === 0x46 &&
-      buffer[3] === 0x46 &&
-      buffer[8] === 0x57 &&
-      buffer[9] === 0x45 &&
-      buffer[10] === 0x42 &&
-      buffer[11] === 0x50
-    ) {
-      return "image/webp";
-    }
-    if (hasFtypBox) {
-      // ISO BMFF containers share `ftyp`; use major brand to separate common
-      // M4A audio payloads from video mp4 containers.
-      const majorBrand = buffer.toString("ascii", 8, 12).toLowerCase();
-      if (AUDIO_BRANDS.has(majorBrand)) {
-        return "audio/mp4";
-      }
-      return "video/mp4";
-    }
-  }
-
-  return "application/octet-stream";
-}
-
-function getExtensionForContentType(contentType: string): string {
-  switch (contentType) {
-    case "image/jpeg":
-      return ".jpg";
-    case "image/png":
-      return ".png";
-    case "image/gif":
-      return ".gif";
-    case "image/webp":
-      return ".webp";
-    case "video/mp4":
-      return ".mp4";
-    case "audio/mp4":
-      return ".m4a";
-    case "audio/mpeg":
-      return ".mp3";
-    default:
-      return ".bin";
-  }
 }

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -357,7 +357,7 @@ export async function saveMediaBuffer(
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });
   const uuid = crypto.randomUUID();
   const headerExt = extensionForMime(contentType?.split(";")[0]?.trim() ?? undefined);
-  const mime = await detectMime({ buffer, headerMime: contentType });
+  const mime = await detectMime({ buffer, headerMime: contentType, filePath: originalFilename });
   const ext = headerExt ?? extensionForMime(mime) ?? "";
 
   let id: string;


### PR DESCRIPTION
## Summary

- Problem: LINE media downloads are saved to `/tmp` via `buildRandomTempFilePath`, which is outside the sandbox root (`~/.openclaw/media/`). Sandboxed agents cannot access downloaded LINE media files (images, videos, audio, documents).
- Why it matters: Any LINE deployment using sandbox mode silently loses media context — the agent receives `<media:...>` placeholders but the files are inaccessible.
- What changed: `downloadLineMedia` now uses `saveMediaBuffer` (writes to `~/.openclaw/media/inbound/`), captures the `Content-Type` header from LINE API responses, and passes `originalFilename` from file messages through to `detectMime` for extension-based MIME fallback.
- What did NOT change (scope boundary): No changes to non-LINE media paths. No changes to `saveMediaBuffer` itself (only the `filePath` argument to `detectMime` was missing). No new dependencies.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27722
- Related #27787, #33145

## User-visible / Behavior Changes

- LINE media files (image, video, audio, file) are now saved to `~/.openclaw/media/inbound/` instead of `/tmp/openclaw/`. Sandboxed agents can access these files.
- `Content-Type` from LINE API response headers is now used for MIME detection, improving accuracy over buffer-only sniffing.
- LINE `file` messages (PDF, DOCX, etc.) now preserve the original filename in the saved file path, enabling extension-based MIME fallback for uncommon file types.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same LINE API endpoint, switched from `getMessageContent` to `getMessageContentWithHttpInfo` (same HTTP call, richer response object)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — files move from `/tmp` to `~/.openclaw/media/inbound/`, both are local storage. `saveMediaBuffer` applies the same size limits.
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- Runtime/container: Node.js in Docker
- Integration/channel: LINE Messaging API
- Relevant config: `channels.line` with sandbox enabled

### Steps

1. Configure a LINE channel with sandbox mode enabled
2. Send an image or PDF file to the LINE bot
3. Check `~/.openclaw/media/inbound/` for the downloaded file

### Expected

- Media file appears in `~/.openclaw/media/inbound/` with correct MIME type and extension
- Agent can access the file within the sandbox

### Actual (before fix)

- Media file saved to `/tmp/openclaw/line-media-*.ext`
- Sandboxed agent cannot access the file (outside sandbox root)

## Evidence

- [x] Failing test/log before + passing after
- All existing tests pass. `download.test.ts` tests updated to match the new `saveMediaBuffer`-based flow (mock `saveMediaBuffer` instead of `fs.writeFile`).

## Human Verification (required)

- Verified scenarios: Reviewed upstream `download.ts`, `bot-handlers.ts`, and `store.ts` to confirm the changes are still applicable (no upstream changes to these code paths since the original fork implementation).
- Edge cases checked: `originalFilename` is `undefined` for non-file message types (image/video/audio) — `saveMediaBuffer` handles this gracefully. Oversized media rejection still works (streaming size check before `saveMediaBuffer` call).
- What you did **not** verify: Live LINE API integration test (requires LINE channel credentials and sandbox environment).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

N/A — fresh PR, no review conversations yet.

## Compatibility / Migration

- Backward compatible? `Yes` — media files are now saved to a different path, but all consumers use the returned `path` from `downloadLineMedia`, not hardcoded paths.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit, LINE media downloads fall back to `/tmp` storage (non-sandbox-accessible).
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: LINE media files not appearing in `~/.openclaw/media/inbound/` after download.

## Risks and Mitigations

- Risk: `getMessageContentWithHttpInfo` API may behave differently across `@line/bot-sdk` versions (response shape).
  - Mitigation: The SDK types guarantee `httpResponse.headers` exists. The `Content-Type` header extraction has a `?? undefined` fallback for missing headers.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)