### PR TITLE
Fix Telegram media proxy support

### DIFF
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -1,5 +1,10 @@
 import path from "node:path";
-import { fetchWithSsrFGuard, withStrictGuardedFetchMode } from "../infra/net/fetch-guard.js";
+import {
+  fetchWithSsrFGuard,
+  GUARDED_FETCH_MODE,
+  type GuardedFetchMode,
+  withStrictGuardedFetchMode,
+} from "../infra/net/fetch-guard.js";
 import type { LookupFn, SsrFPolicy } from "../infra/net/ssrf.js";
 import { detectMime, extensionForMime } from "./mime.js";
 import { readResponseWithLimit } from "./read-response-with-limit.js";
@@ -35,6 +40,10 @@ type FetchMediaOptions = {
   readIdleTimeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
+  /** Whether to pin DNS to the resolved IP to prevent DNS rebinding. Defaults to true. */
+  pinDns?: boolean;
+  /** Guarded fetch mode. Defaults to "strict". */
+  mode?: GuardedFetchMode;
 };
 
 function stripQuotes(value: string): string {
@@ -92,22 +101,24 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     readIdleTimeoutMs,
     ssrfPolicy,
     lookupFn,
+    pinDns,
+    mode,
   } = options;
 
   let res: Response;
   let finalUrl = url;
   let release: (() => Promise<void>) | null = null;
   try {
-    const result = await fetchWithSsrFGuard(
-      withStrictGuardedFetchMode({
-        url,
-        fetchImpl,
-        init: requestInit,
-        maxRedirects,
-        policy: ssrfPolicy,
-        lookupFn,
-      }),
-    );
+    const result = await fetchWithSsrFGuard({
+      url,
+      fetchImpl,
+      init: requestInit,
+      maxRedirects,
+      policy: ssrfPolicy,
+      lookupFn,
+      pinDns,
+      mode: mode ?? GUARDED_FETCH_MODE.STRICT,
+    });
     res = result.response;
     finalUrl = result.finalUrl;
     release = result.release;

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -3,7 +3,6 @@ import {
   fetchWithSsrFGuard,
   GUARDED_FETCH_MODE,
   type GuardedFetchMode,
-  withStrictGuardedFetchMode,
 } from "../infra/net/fetch-guard.js";
 import type { LookupFn, SsrFPolicy } from "../infra/net/ssrf.js";
 import { detectMime, extensionForMime } from "./mime.js";

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -126,6 +126,11 @@ async function downloadAndSaveTelegramFile(params: {
     maxBytes: params.maxBytes,
     readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,
     ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
+    // Disable DNS pinning for Telegram media downloads to allow the custom
+    // fetchImpl (which may have its own proxy/dispatcher) to handle networking.
+    // SSRF protection is still provided by TELEGRAM_MEDIA_SSRF_POLICY which
+    // restricts downloads to api.telegram.org.
+    pinDns: false,
   });
   const originalName = params.telegramFileName ?? fetched.fileName ?? params.filePath;
   return saveMediaBuffer(


### PR DESCRIPTION
Fixes MediaFetchError when downloading Telegram media behind proxy. Adds pinDns option to allow proxy agent to work.