### PR TITLE
feat(slack): ingest attachment content into agent context

### DIFF
--- a/src/slack/monitor/file-content-office.ts
+++ b/src/slack/monitor/file-content-office.ts
@@ -1,0 +1,181 @@
+import JSZip from "jszip";
+import { getFileExtension, normalizeMimeType } from "../../media/mime.js";
+
+type OfficeKind = "docx" | "xlsx" | "pptx";
+
+const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+
+function decodeXmlEntities(raw: string): string {
+  return raw
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex: string) =>
+      String.fromCodePoint(Number.parseInt(hex, 16)),
+    )
+    .replace(/&#([0-9]+);/g, (_, num: string) => String.fromCodePoint(Number.parseInt(num, 10)));
+}
+
+function normalizeExtractedText(raw: string): string {
+  return decodeXmlEntities(raw).replace(/\s+/g, " ").trim();
+}
+
+function resolveOfficeKind(params: { mimeType?: string; fileName: string }): OfficeKind | null {
+  const mimeType = normalizeMimeType(params.mimeType);
+  if (mimeType === DOCX_MIME) {
+    return "docx";
+  }
+  if (mimeType === XLSX_MIME) {
+    return "xlsx";
+  }
+  if (mimeType === PPTX_MIME) {
+    return "pptx";
+  }
+  const ext = getFileExtension(params.fileName);
+  if (ext === ".docx") {
+    return "docx";
+  }
+  if (ext === ".xlsx") {
+    return "xlsx";
+  }
+  if (ext === ".pptx") {
+    return "pptx";
+  }
+  return null;
+}
+
+function extractTagValues(xml: string, tagPattern: RegExp): string[] {
+  const values: string[] = [];
+  for (const match of xml.matchAll(tagPattern)) {
+    const value = normalizeExtractedText(match[1] ?? "");
+    if (value) {
+      values.push(value);
+    }
+  }
+  return values;
+}
+
+async function extractDocxText(zip: JSZip): Promise<string> {
+  const paths = Object.keys(zip.files)
+    .filter((path) => /^word\/(document|header\d+|footer\d+|footnotes|endnotes)\.xml$/i.test(path))
+    .toSorted();
+  const chunks: string[] = [];
+  for (const path of paths) {
+    const file = zip.file(path);
+    if (!file) {
+      continue;
+    }
+    const xml = await file.async("text");
+    chunks.push(...extractTagValues(xml, /<w:t\b[^>]*>([\s\S]*?)<\/w:t>/gi));
+  }
+  return chunks.join("\n");
+}
+
+async function extractXlsxText(zip: JSZip): Promise<string> {
+  const sharedStrings = new Map<number, string>();
+  const sharedFile = zip.file("xl/sharedStrings.xml");
+  if (sharedFile) {
+    const xml = await sharedFile.async("text");
+    const siMatches = xml.matchAll(/<si\b[^>]*>([\s\S]*?)<\/si>/gi);
+    let idx = 0;
+    for (const match of siMatches) {
+      const text = extractTagValues(match[1] ?? "", /<t\b[^>]*>([\s\S]*?)<\/t>/gi).join("");
+      if (text) {
+        sharedStrings.set(idx, text);
+      }
+      idx += 1;
+    }
+  }
+
+  const sheetPaths = Object.keys(zip.files)
+    .filter((path) => /^xl\/worksheets\/sheet\d+\.xml$/i.test(path))
+    .toSorted();
+  const rows: string[] = [];
+  for (const path of sheetPaths) {
+    const file = zip.file(path);
+    if (!file) {
+      continue;
+    }
+    const xml = await file.async("text");
+    for (const rowMatch of xml.matchAll(/<row\b[^>]*>([\s\S]*?)<\/row>/gi)) {
+      const rowXml = rowMatch[1] ?? "";
+      const cells: string[] = [];
+      for (const cellMatch of rowXml.matchAll(/<c\b([^>]*)>([\s\S]*?)<\/c>/gi)) {
+        const attrs = cellMatch[1] ?? "";
+        const cellXml = cellMatch[2] ?? "";
+        const typeMatch = /\bt="([^"]+)"/i.exec(attrs);
+        const cellType = typeMatch?.[1];
+        if (cellType === "s") {
+          const valueMatch = /<v>([\s\S]*?)<\/v>/i.exec(cellXml);
+          const index = Number.parseInt((valueMatch?.[1] ?? "").trim(), 10);
+          const resolved = sharedStrings.get(index);
+          if (resolved) {
+            cells.push(resolved);
+          }
+          continue;
+        }
+        if (cellType === "inlineStr") {
+          const inline = extractTagValues(cellXml, /<t\b[^>]*>([\s\S]*?)<\/t>/gi).join("");
+          if (inline) {
+            cells.push(inline);
+          }
+          continue;
+        }
+        const rawValueMatch = /<v>([\s\S]*?)<\/v>/i.exec(cellXml);
+        const rawValue = normalizeExtractedText(rawValueMatch?.[1] ?? "");
+        if (rawValue) {
+          cells.push(rawValue);
+        }
+      }
+      if (cells.length > 0) {
+        rows.push(cells.join(", "));
+      }
+    }
+  }
+  return rows.join("\n");
+}
+
+async function extractPptxText(zip: JSZip): Promise<string> {
+  const slidePaths = Object.keys(zip.files)
+    .filter((path) => /^ppt\/slides\/slide\d+\.xml$/i.test(path))
+    .toSorted();
+  const chunks: string[] = [];
+  for (const path of slidePaths) {
+    const file = zip.file(path);
+    if (!file) {
+      continue;
+    }
+    const xml = await file.async("text");
+    chunks.push(...extractTagValues(xml, /<a:t\b[^>]*>([\s\S]*?)<\/a:t>/gi));
+  }
+  return chunks.join("\n");
+}
+
+export async function extractOfficeOpenXmlText(params: {
+  buffer: Buffer;
+  mimeType?: string;
+  fileName: string;
+}): Promise<string | null> {
+  const kind = resolveOfficeKind({ mimeType: params.mimeType, fileName: params.fileName });
+  if (!kind) {
+    return null;
+  }
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(params.buffer);
+  } catch {
+    return null;
+  }
+  const text =
+    kind === "docx"
+      ? await extractDocxText(zip)
+      : kind === "xlsx"
+        ? await extractXlsxText(zip)
+        : await extractPptxText(zip);
+  const normalized = normalizeExtractedText(text);
+  return normalized || null;
+}

--- a/src/slack/monitor/file-content.test.ts
+++ b/src/slack/monitor/file-content.test.ts
@@ -1,8 +1,23 @@
+import JSZip from "jszip";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MediaFetchError } from "../../media/fetch.js";
 import * as mediaFetch from "../../media/fetch.js";
 import * as pdfExtract from "../../media/pdf-extract.js";
 import { resolveSlackFileContent } from "./file-content.js";
+
+async function makeOoxmlZip(opts: {
+  mainMime: string;
+  partPath: string;
+  partBody: string;
+}): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `<?xml version="1.0" encoding="UTF-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="${opts.partPath}" ContentType="${opts.mainMime}.main+xml"/></Types>`,
+  );
+  zip.file(opts.partPath.slice(1), opts.partBody);
+  return await zip.generateAsync({ type: "nodebuffer" });
+}
 
 describe("resolveSlackFileContent", () => {
   beforeEach(() => {
@@ -66,6 +81,72 @@ describe("resolveSlackFileContent", () => {
     expect(result.issues).toEqual([]);
     expect(result.snippets).toHaveLength(1);
     expect(result.snippets[0]?.text).toContain("PDF body text");
+  });
+
+  it("extracts DOCX/XLSX/PPTX text", async () => {
+    const docxBuffer = await makeOoxmlZip({
+      mainMime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      partPath: "/word/document.xml",
+      partBody:
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>DOCX text</w:t></w:r></w:p></w:body></w:document>',
+    });
+
+    const xlsxZip = new JSZip();
+    xlsxZip.file(
+      "[Content_Types].xml",
+      '<?xml version="1.0" encoding="UTF-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/></Types>',
+    );
+    xlsxZip.file(
+      "xl/sharedStrings.xml",
+      '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><si><t>Header</t></si><si><t>Value</t></si></sst>',
+    );
+    xlsxZip.file(
+      "xl/worksheets/sheet1.xml",
+      '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row></sheetData></worksheet>',
+    );
+    const xlsxBuffer = await xlsxZip.generateAsync({ type: "nodebuffer" });
+
+    const pptxBuffer = await makeOoxmlZip({
+      mainMime: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      partPath: "/ppt/slides/slide1.xml",
+      partBody:
+        '<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>PPTX text</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>',
+    });
+
+    const fetchRemoteMediaMock = vi.spyOn(mediaFetch, "fetchRemoteMedia");
+    fetchRemoteMediaMock
+      .mockResolvedValueOnce({
+        buffer: docxBuffer,
+        contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        fileName: "a.docx",
+      })
+      .mockResolvedValueOnce({
+        buffer: xlsxBuffer,
+        contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        fileName: "b.xlsx",
+      })
+      .mockResolvedValueOnce({
+        buffer: pptxBuffer,
+        contentType: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        fileName: "c.pptx",
+      });
+
+    const result = await resolveSlackFileContent({
+      files: [
+        { name: "a.docx", url_private: "https://files.slack.com/a.docx" },
+        { name: "b.xlsx", url_private: "https://files.slack.com/b.xlsx" },
+        { name: "c.pptx", url_private: "https://files.slack.com/c.pptx" },
+      ],
+      token: "xoxb-test",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result.issues).toEqual([]);
+    expect(result.snippets).toHaveLength(3);
+    expect(result.snippets[0]?.text).toContain("DOCX text");
+    expect(result.snippets[1]?.text).toContain("Header");
+    expect(result.snippets[1]?.text).toContain("Value");
+    expect(result.snippets[2]?.text).toContain("PPTX text");
   });
 
   it("reports permission errors for missing scope/auth", async () => {

--- a/src/slack/monitor/file-content.test.ts
+++ b/src/slack/monitor/file-content.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MediaFetchError } from "../../media/fetch.js";
+import * as mediaFetch from "../../media/fetch.js";
+import * as pdfExtract from "../../media/pdf-extract.js";
+import { resolveSlackFileContent } from "./file-content.js";
+
+describe("resolveSlackFileContent", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("extracts markdown/text/json/csv content into snippets", async () => {
+    const fetchRemoteMediaMock = vi.spyOn(mediaFetch, "fetchRemoteMedia");
+    fetchRemoteMediaMock
+      .mockResolvedValueOnce({
+        buffer: Buffer.from("# Heading\nBody"),
+        contentType: "text/markdown",
+        fileName: "a.md",
+      })
+      .mockResolvedValueOnce({
+        buffer: Buffer.from('{"a":1,"b":2}'),
+        contentType: "application/json",
+        fileName: "b.json",
+      })
+      .mockResolvedValueOnce({
+        buffer: Buffer.from("x,y\n1,2"),
+        contentType: "text/csv",
+        fileName: "c.csv",
+      });
+
+    const result = await resolveSlackFileContent({
+      files: [
+        { name: "a.md", url_private: "https://files.slack.com/a.md" },
+        { name: "b.json", url_private: "https://files.slack.com/b.json" },
+        { name: "c.csv", url_private: "https://files.slack.com/c.csv" },
+      ],
+      token: "xoxb-test",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result.issues).toEqual([]);
+    expect(result.snippets).toHaveLength(3);
+    expect(result.snippets[0]?.fileName).toBe("a.md");
+    expect(result.snippets[0]?.text).toContain("Heading");
+    expect(result.snippets[1]?.text).toContain('"a": 1');
+    expect(result.snippets[2]?.text).toContain("x,y");
+  });
+
+  it("extracts PDF text when available", async () => {
+    vi.spyOn(mediaFetch, "fetchRemoteMedia").mockResolvedValueOnce({
+      buffer: Buffer.from("%PDF"),
+      contentType: "application/pdf",
+      fileName: "doc.pdf",
+    });
+    vi.spyOn(pdfExtract, "extractPdfContent").mockResolvedValueOnce({
+      text: "PDF body text",
+      images: [],
+    });
+
+    const result = await resolveSlackFileContent({
+      files: [{ name: "doc.pdf", url_private: "https://files.slack.com/doc.pdf" }],
+      token: "xoxb-test",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result.issues).toEqual([]);
+    expect(result.snippets).toHaveLength(1);
+    expect(result.snippets[0]?.text).toContain("PDF body text");
+  });
+
+  it("reports permission errors for missing scope/auth", async () => {
+    vi.spyOn(mediaFetch, "fetchRemoteMedia").mockRejectedValueOnce(
+      new Error("An API error occurred: missing_scope"),
+    );
+
+    const result = await resolveSlackFileContent({
+      files: [{ name: "secret.md", url_private: "https://files.slack.com/secret.md" }],
+      token: "xoxb-test",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result.snippets).toEqual([]);
+    expect(result.issues).toEqual([
+      {
+        fileName: "secret.md",
+        reason: "permission",
+      },
+    ]);
+  });
+
+  it("reports size and unsupported format failures", async () => {
+    const fetchRemoteMediaMock = vi.spyOn(mediaFetch, "fetchRemoteMedia");
+    fetchRemoteMediaMock
+      .mockRejectedValueOnce(new MediaFetchError("max_bytes", "too large"))
+      .mockResolvedValueOnce({
+        buffer: Buffer.from([0xff, 0xd8, 0xff]),
+        contentType: "image/jpeg",
+        fileName: "photo.jpg",
+      });
+
+    const result = await resolveSlackFileContent({
+      files: [
+        { name: "too-big.txt", url_private: "https://files.slack.com/too-big.txt" },
+        { name: "photo.jpg", url_private: "https://files.slack.com/photo.jpg" },
+      ],
+      token: "xoxb-test",
+      maxBytes: 1024,
+    });
+
+    expect(result.snippets).toEqual([]);
+    expect(result.issues).toEqual([
+      {
+        fileName: "too-big.txt",
+        reason: "size_exceeded",
+      },
+      {
+        fileName: "photo.jpg",
+        reason: "unsupported_format",
+      },
+    ]);
+  });
+});

--- a/src/slack/monitor/file-content.ts
+++ b/src/slack/monitor/file-content.ts
@@ -2,6 +2,7 @@ import { MediaFetchError, fetchRemoteMedia } from "../../media/fetch.js";
 import { getFileExtension, normalizeMimeType } from "../../media/mime.js";
 import { extractPdfContent } from "../../media/pdf-extract.js";
 import type { SlackFile } from "../types.js";
+import { extractOfficeOpenXmlText } from "./file-content-office.js";
 import { MAX_SLACK_MEDIA_FILES, SLACK_MEDIA_SSRF_POLICY, createSlackMediaFetch } from "./media.js";
 
 export type SlackFileContentIssueReason =
@@ -31,6 +32,9 @@ const DEFAULT_PER_FILE_TEXT_CHARS = 8000;
 const DEFAULT_TOTAL_TEXT_CHARS = 24000;
 const JSON_MIME = "application/json";
 const PDF_MIME = "application/pdf";
+const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
 const TEXT_MIME_PREFIX = "text/";
 const TEXT_EXTENSIONS = new Set([".txt", ".md", ".markdown", ".json", ".csv"]);
 
@@ -109,6 +113,25 @@ async function extractTextFromBuffer(params: {
       return null;
     }
     return clampChars(normalized, params.maxChars);
+  }
+
+  if (
+    mimeType === DOCX_MIME ||
+    mimeType === XLSX_MIME ||
+    mimeType === PPTX_MIME ||
+    getFileExtension(params.fileName) === ".docx" ||
+    getFileExtension(params.fileName) === ".xlsx" ||
+    getFileExtension(params.fileName) === ".pptx"
+  ) {
+    const officeText = await extractOfficeOpenXmlText({
+      buffer: params.buffer,
+      mimeType,
+      fileName: params.fileName,
+    });
+    if (!officeText) {
+      return null;
+    }
+    return clampChars(officeText, params.maxChars);
   }
 
   if (!isTextSupported({ mimeType, fileName: params.fileName })) {

--- a/src/slack/monitor/file-content.ts
+++ b/src/slack/monitor/file-content.ts
@@ -1,0 +1,210 @@
+import { MediaFetchError, fetchRemoteMedia } from "../../media/fetch.js";
+import { getFileExtension, normalizeMimeType } from "../../media/mime.js";
+import { extractPdfContent } from "../../media/pdf-extract.js";
+import type { SlackFile } from "../types.js";
+import { MAX_SLACK_MEDIA_FILES, SLACK_MEDIA_SSRF_POLICY, createSlackMediaFetch } from "./media.js";
+
+export type SlackFileContentIssueReason =
+  | "permission"
+  | "size_exceeded"
+  | "unsupported_format"
+  | "download_failed";
+
+export type SlackFileContentIssue = {
+  fileName: string;
+  reason: SlackFileContentIssueReason;
+};
+
+export type SlackFileTextSnippet = {
+  fileName: string;
+  mimeType?: string;
+  text: string;
+  truncated: boolean;
+};
+
+export type SlackFileContentResult = {
+  snippets: SlackFileTextSnippet[];
+  issues: SlackFileContentIssue[];
+};
+
+const DEFAULT_PER_FILE_TEXT_CHARS = 8000;
+const DEFAULT_TOTAL_TEXT_CHARS = 24000;
+const JSON_MIME = "application/json";
+const PDF_MIME = "application/pdf";
+const TEXT_MIME_PREFIX = "text/";
+const TEXT_EXTENSIONS = new Set([".txt", ".md", ".markdown", ".json", ".csv"]);
+
+function resolveFileName(file?: SlackFile): string {
+  const trimmed = file?.name?.trim();
+  return trimmed || "file";
+}
+
+function resolveFileMime(file: SlackFile, fetchedMime?: string): string | undefined {
+  const normalizedFetched = normalizeMimeType(fetchedMime);
+  if (normalizedFetched) {
+    return normalizedFetched;
+  }
+  const normalizedFile = normalizeMimeType(file.mimetype);
+  if (normalizedFile) {
+    return normalizedFile;
+  }
+  return undefined;
+}
+
+function isTextSupported(params: { mimeType?: string; fileName: string }): boolean {
+  if (params.mimeType === JSON_MIME) {
+    return true;
+  }
+  if (params.mimeType?.startsWith(TEXT_MIME_PREFIX)) {
+    return true;
+  }
+  const ext = getFileExtension(params.fileName);
+  return Boolean(ext && TEXT_EXTENSIONS.has(ext));
+}
+
+function clampChars(text: string, maxChars: number): { text: string; truncated: boolean } {
+  if (text.length <= maxChars) {
+    return { text, truncated: false };
+  }
+  return { text: text.slice(0, maxChars), truncated: true };
+}
+
+function normalizeText(raw: string): string {
+  return raw.replace(/^\uFEFF/, "").trim();
+}
+
+function classifyDownloadError(error: unknown): SlackFileContentIssueReason {
+  if (error instanceof MediaFetchError && error.code === "max_bytes") {
+    return "size_exceeded";
+  }
+  const message = String(error).toLowerCase();
+  if (
+    message.includes("missing_scope") ||
+    message.includes("not_authed") ||
+    message.includes("invalid_auth") ||
+    message.includes("token_revoked") ||
+    message.includes("no_permission")
+  ) {
+    return "permission";
+  }
+  return "download_failed";
+}
+
+async function extractTextFromBuffer(params: {
+  buffer: Buffer;
+  mimeType?: string;
+  fileName: string;
+  maxChars: number;
+}): Promise<{ text: string; truncated: boolean } | null> {
+  const mimeType = params.mimeType;
+  if (mimeType === PDF_MIME || getFileExtension(params.fileName) === ".pdf") {
+    const extracted = await extractPdfContent({
+      buffer: params.buffer,
+      maxPages: 20,
+      maxPixels: 4_000_000,
+      minTextChars: 1,
+    });
+    const normalized = normalizeText(extracted.text);
+    if (!normalized) {
+      return null;
+    }
+    return clampChars(normalized, params.maxChars);
+  }
+
+  if (!isTextSupported({ mimeType, fileName: params.fileName })) {
+    return null;
+  }
+
+  let text = params.buffer.toString("utf-8");
+  if (mimeType === JSON_MIME || getFileExtension(params.fileName) === ".json") {
+    const trimmed = text.trim();
+    if (trimmed) {
+      try {
+        text = JSON.stringify(JSON.parse(trimmed), null, 2);
+      } catch {
+        // Keep raw content when JSON parse fails.
+      }
+    }
+  }
+
+  const normalized = normalizeText(text);
+  if (!normalized) {
+    return null;
+  }
+  return clampChars(normalized, params.maxChars);
+}
+
+export async function resolveSlackFileContent(params: {
+  files?: SlackFile[];
+  token: string;
+  maxBytes: number;
+  maxCharsPerFile?: number;
+  maxTotalChars?: number;
+}): Promise<SlackFileContentResult> {
+  const files = params.files ?? [];
+  if (files.length === 0) {
+    return { snippets: [], issues: [] };
+  }
+
+  const maxCharsPerFile = Math.max(256, params.maxCharsPerFile ?? DEFAULT_PER_FILE_TEXT_CHARS);
+  const maxTotalChars = Math.max(maxCharsPerFile, params.maxTotalChars ?? DEFAULT_TOTAL_TEXT_CHARS);
+  let remainingChars = maxTotalChars;
+
+  const snippets: SlackFileTextSnippet[] = [];
+  const issues: SlackFileContentIssue[] = [];
+  const fetchImpl = createSlackMediaFetch(params.token);
+
+  for (const file of files.slice(0, MAX_SLACK_MEDIA_FILES)) {
+    const fileName = resolveFileName(file);
+    const url = file.url_private_download ?? file.url_private;
+    if (!url) {
+      issues.push({ fileName, reason: "download_failed" });
+      continue;
+    }
+    if (typeof file.size === "number" && file.size > params.maxBytes) {
+      issues.push({ fileName, reason: "size_exceeded" });
+      continue;
+    }
+    if (remainingChars <= 0) {
+      issues.push({ fileName, reason: "size_exceeded" });
+      continue;
+    }
+
+    try {
+      const fetched = await fetchRemoteMedia({
+        url,
+        fetchImpl,
+        filePathHint: file.name,
+        maxBytes: params.maxBytes,
+        ssrfPolicy: SLACK_MEDIA_SSRF_POLICY,
+      });
+      if (fetched.buffer.byteLength > params.maxBytes) {
+        issues.push({ fileName, reason: "size_exceeded" });
+        continue;
+      }
+      const mimeType = resolveFileMime(file, fetched.contentType);
+      const maxChars = Math.min(maxCharsPerFile, remainingChars);
+      const extracted = await extractTextFromBuffer({
+        buffer: fetched.buffer,
+        mimeType,
+        fileName,
+        maxChars,
+      });
+      if (!extracted) {
+        issues.push({ fileName, reason: "unsupported_format" });
+        continue;
+      }
+      remainingChars -= extracted.text.length;
+      snippets.push({
+        fileName,
+        mimeType,
+        text: extracted.text,
+        truncated: extracted.truncated,
+      });
+    } catch (error) {
+      issues.push({ fileName, reason: classifyDownloadError(error) });
+    }
+  }
+
+  return { snippets, issues };
+}

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -50,7 +50,7 @@ function resolveRequestUrl(input: RequestInfo | URL): string {
   throw new Error("Unsupported fetch input: expected string, URL, or Request");
 }
 
-function createSlackMediaFetch(token: string): FetchLike {
+export function createSlackMediaFetch(token: string): FetchLike {
   let includeAuth = true;
   return async (input, init) => {
     const url = resolveRequestUrl(input);
@@ -108,7 +108,7 @@ export async function fetchWithSlackAuth(url: string, token: string): Promise<Re
   return fetch(resolvedUrl.toString(), { redirect: "follow" });
 }
 
-const SLACK_MEDIA_SSRF_POLICY = {
+export const SLACK_MEDIA_SSRF_POLICY = {
   allowedHostnames: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
   allowRfc2544BenchmarkRange: true,
 };

--- a/src/slack/monitor/message-handler/prepare-content.ts
+++ b/src/slack/monitor/message-handler/prepare-content.ts
@@ -1,5 +1,6 @@
 import { logVerbose } from "../../../globals.js";
 import type { SlackFile, SlackMessageEvent } from "../../types.js";
+import { type SlackFileContentIssueReason, resolveSlackFileContent } from "../file-content.js";
 import {
   MAX_SLACK_MEDIA_FILES,
   resolveSlackAttachmentContent,
@@ -12,6 +13,20 @@ export type SlackResolvedMessageContent = {
   rawBody: string;
   effectiveDirectMedia: SlackMediaResult[] | null;
 };
+
+function formatSlackFileIssue(reason: SlackFileContentIssueReason): string {
+  switch (reason) {
+    case "permission":
+      return "permission denied (missing scope or auth)";
+    case "size_exceeded":
+      return "size exceeds limit";
+    case "unsupported_format":
+      return "unsupported format";
+    case "download_failed":
+    default:
+      return "download failed";
+  }
+}
 
 function filterInheritedParentFiles(params: {
   files: SlackFile[] | undefined;
@@ -60,16 +75,30 @@ export async function resolveSlackMessageContent(params: {
     token: params.botToken,
     maxBytes: params.mediaMaxBytes,
   });
+  const fileContent = await resolveSlackFileContent({
+    files: ownFiles,
+    token: params.botToken,
+    maxBytes: params.mediaMaxBytes,
+  });
 
   const mergedMedia = [...(media ?? []), ...(attachmentContent?.media ?? [])];
   const effectiveDirectMedia = mergedMedia.length > 0 ? mergedMedia : null;
   const mediaPlaceholder = effectiveDirectMedia
     ? effectiveDirectMedia.map((item) => item.placeholder).join(" ")
     : undefined;
+  const extractedFileContent = fileContent.snippets
+    .map((snippet) => {
+      const truncatedNotice = snippet.truncated ? "\n[truncated]" : "";
+      return `[Slack file content: ${snippet.fileName}]\n${snippet.text}${truncatedNotice}`;
+    })
+    .join("\n\n");
+  const fileIssueSummary = fileContent.issues
+    .map((issue) => `[Slack file skipped: ${issue.fileName}] ${formatSlackFileIssue(issue.reason)}`)
+    .join("\n");
 
   const fallbackFiles = ownFiles ?? [];
   const fileOnlyFallback =
-    !mediaPlaceholder && fallbackFiles.length > 0
+    !mediaPlaceholder && !extractedFileContent && !fileIssueSummary && fallbackFiles.length > 0
       ? fallbackFiles
           .slice(0, MAX_SLACK_MEDIA_FILES)
           .map((file) => file.name?.trim() || "file")
@@ -90,6 +119,8 @@ export async function resolveSlackMessageContent(params: {
       (params.message.text ?? "").trim(),
       attachmentContent?.text,
       botAttachmentText,
+      extractedFileContent,
+      fileIssueSummary,
       mediaPlaceholder,
       fileOnlyPlaceholder,
     ]

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -238,7 +238,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared).toBeNull();
   });
 
-  it("delivers file-only message with placeholder when media download fails", async () => {
+  it("delivers file-only message with skip reasons when media download fails", async () => {
     // Files without url_private will fail to download, simulating a download
     // failure.  The message should still be delivered with a fallback
     // placeholder instead of being silently dropped (#25064).
@@ -250,12 +250,13 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     expect(prepared).toBeTruthy();
-    expect(prepared!.ctxPayload.RawBody).toContain("[Slack file:");
+    expect(prepared!.ctxPayload.RawBody).toContain("[Slack file skipped: voice.ogg]");
+    expect(prepared!.ctxPayload.RawBody).toContain("[Slack file skipped: photo.jpg]");
     expect(prepared!.ctxPayload.RawBody).toContain("voice.ogg");
     expect(prepared!.ctxPayload.RawBody).toContain("photo.jpg");
   });
 
-  it("falls back to generic file label when a Slack file name is empty", async () => {
+  it("falls back to generic file label in skip summary when a Slack file name is empty", async () => {
     const prepared = await prepareWithDefaultCtx(
       createSlackMessage({
         text: "",
@@ -264,7 +265,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     expect(prepared).toBeTruthy();
-    expect(prepared!.ctxPayload.RawBody).toContain("[Slack file: file]");
+    expect(prepared!.ctxPayload.RawBody).toContain("[Slack file skipped: file]");
   });
 
   it("extracts attachment text for bot messages with empty text when allowBots is true (#27616)", async () => {


### PR DESCRIPTION
## Summary
- ingest Slack attachment content into inbound agent context instead of only placeholder text
- add a dedicated Slack file extraction layer with size/type guards and classified failure reasons
- extract text from md/txt/json/csv and PDF, then append readable content blocks to the raw inbound body
- extend extraction to Office OpenXML attachments (`docx`, `xlsx`, `pptx`) via a separate module for future format expansion

## Details
- capture Slack message file metadata and fetch file bytes using existing Slack token auth
- reuse Slack media fetch policy and expose helper for consistent fetch behavior
- classify and surface skip/failure reasons in context:
  - `permission`
  - `size_exceeded`
  - `unsupported_format`
  - `download_failed`
- enforce security-minded constraints:
  - file size caps
  - allowed-format filtering
  - bounded extracted text length
  - no sensitive full-body logging

## Testing
- `corepack pnpm vitest run src/slack/monitor/file-content.test.ts`
- `corepack pnpm vitest run src/slack/monitor/message-handler/prepare.test.ts --pool=forks`
