### PR TITLE
docs(docker): add healthcheck docker-compose.yml examples

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -487,6 +487,48 @@ responsive. If checks keep failing, Docker marks the container as `unhealthy`,
 and orchestration systems (Docker Compose restart policy, Swarm, Kubernetes,
 etc.) can automatically restart or replace it.
 
+If you are writing your own `docker-compose.yml` (instead of using the bundled
+one), add a healthcheck to the gateway service so Docker can detect and restart
+an unresponsive container:
+
+```yaml
+services:
+  openclaw-gateway:
+    # ... existing config ...
+
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:18789/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s # check every 30 seconds
+      timeout: 5s # fail if no response within 5 seconds
+      retries: 5 # mark unhealthy after 5 consecutive failures
+      start_period: 20s # grace period for container startup
+```
+
+The built-in image already includes `node`, so the `node -e fetch(...)` probe
+does not require installing extra tools like `curl` or `wget`. If your custom
+image has `curl` available, the equivalent probe is:
+
+```yaml
+healthcheck:
+  test: ["CMD", "curl", "-fsS", "http://127.0.0.1:18789/healthz"]
+  interval: 30s
+  timeout: 5s
+  retries: 3
+  start_period: 30s
+```
+
+Pair the healthcheck with `restart: unless-stopped` so Docker Compose restarts
+the container if it exits or crashes. Note that the restart policy only triggers
+on container **exits** — it will not restart a container that is still running
+but marked `unhealthy`. Orchestrators such as Docker Swarm or Kubernetes can act
+on unhealthy status automatically.
+
 Authenticated deep health snapshot (gateway + channels):
 
 ```bash


### PR DESCRIPTION
## Summary

Add copy-paste-ready `docker-compose.yml` healthcheck snippets to the existing **Health checks** section in `docs/install/docker.md`.

## What changed

Added two healthcheck examples to the Health checks subsection:

1. **`node -e fetch()` probe** -- uses the built-in Node.js runtime, no extra tools required. Matches the pattern already used in the bundled `docker-compose.yml`.
2. **`curl`-based probe** -- alternative for custom images that have `curl` installed.

Each example includes inline comments explaining `interval`, `timeout`, `retries`, and `start_period` parameters. Also added a note about pairing with `restart: unless-stopped`.

## Why

The existing Health checks section documents the probe endpoints (`/healthz`, `/readyz`) and shows how to test them with `curl` commands, but does not provide a `docker-compose.yml` snippet. Users writing their own compose files (rather than using the bundled one) need a ready-to-copy example.

This comes from real-world deployment experience with [PocketClaw](https://github.com/ProjectAILiberation/PocketClaw), a portable OpenClaw distribution.

## Checklist

- [x] Docs-only change, no code affected
- [x] AI-assisted (GitHub Copilot) -- fully tested in production Docker deployment
- [x] Kept PR focused (one section, one concern)
- [x] Does not duplicate existing content -- complements the curl commands already documented
