### PR TITLE
fix(memory): add depth limit to chokidar watchers to prevent FD exhaustion

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -20,12 +20,13 @@ describe("ensureSkillsWatcher", () => {
 
     expect(watchMock).toHaveBeenCalledTimes(1);
     const firstCall = (
-      watchMock.mock.calls as unknown as Array<[string[], { ignored?: unknown }]>
+      watchMock.mock.calls as unknown as Array<[string[], { ignored?: unknown; depth?: number }]>
     )[0];
     const targets = firstCall?.[0] ?? [];
     const opts = firstCall?.[1] ?? {};
 
     expect(opts.ignored).toBe(mod.DEFAULT_SKILLS_WATCH_IGNORED);
+    expect(opts.depth).toBe(2);
     const posix = (p: string) => p.replaceAll("\\", "/");
     expect(targets).toEqual(
       expect.arrayContaining([

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -175,6 +175,7 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
     // Avoid FD exhaustion on macOS when a workspace contains huge trees.
     // This watcher only needs to react to SKILL.md changes.
     ignored: DEFAULT_SKILLS_WATCH_IGNORED,
+    depth: 2,
   });
 
   const state: SkillsWatchState = { watcher, pathsKey, debounceMs };

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -417,7 +417,6 @@ export abstract class MemoryManagerSyncOps {
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
       ignored: (watchPath) => shouldIgnoreMemoryWatchPath(String(watchPath)),
-      depth: 2,
       awaitWriteFinish: {
         stabilityThreshold: this.settings.sync.watchDebounceMs,
         pollInterval: 100,

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -417,6 +417,7 @@ export abstract class MemoryManagerSyncOps {
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
       ignored: (watchPath) => shouldIgnoreMemoryWatchPath(String(watchPath)),
+      depth: 2,
       awaitWriteFinish: {
         stabilityThreshold: this.settings.sync.watchDebounceMs,
         pollInterval: 100,

--- a/src/memory/manager.watcher-config.test.ts
+++ b/src/memory/manager.watcher-config.test.ts
@@ -96,6 +96,7 @@ describe("memory watcher config", () => {
       ]),
     );
     expect(options.ignoreInitial).toBe(true);
+    expect(options.depth).toBe(2);
     expect(options.awaitWriteFinish).toEqual({ stabilityThreshold: 25, pollInterval: 100 });
 
     const ignored = options.ignored as ((watchPath: string) => boolean) | undefined;

--- a/src/memory/manager.watcher-config.test.ts
+++ b/src/memory/manager.watcher-config.test.ts
@@ -96,7 +96,7 @@ describe("memory watcher config", () => {
       ]),
     );
     expect(options.ignoreInitial).toBe(true);
-    expect(options.depth).toBe(2);
+    expect(options.depth).toBeUndefined();
     expect(options.awaitWriteFinish).toEqual({ stabilityThreshold: 25, pollInterval: 100 });
 
     const ignored = options.ignored as ((watchPath: string) => boolean) | undefined;


### PR DESCRIPTION
Closes #41606

When memory or skills directories contain deeply nested trees (e.g. node_modules left behind), chokidar recursively watches every subdirectory. On machines with low ulimit this exhausts file descriptors and crashes the daemon.

This adds `depth: 2` to both the memory watcher in `manager-sync-ops.ts` and the skills watcher in `refresh.ts`. Memory files live at `memory/*.md` (depth 1) and skills at `skills/<name>/SKILL.md` (depth 2), so deeper watching was never needed.

Existing tests updated to verify the depth option is passed through.

Co-authored-by: Daniel dos Santos Reis <dsantoreis@gmail.com>