### PR TITLE
fix: apply agent skillFilter in gateway path

### DIFF
--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -1,5 +1,5 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
+import { resolveAgentSkillsFilter, resolveSessionAgentIds } from "../../agents/agent-scope.js";
 import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import type { EmbeddedContextFile } from "../../agents/pi-embedded-helpers.js";
@@ -34,10 +34,12 @@ export async function resolveCommandsSystemPromptBundle(
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
   });
+  const skillFilter = resolveAgentSkillsFilter(params.cfg, params.agentId);
   const skillsSnapshot = (() => {
     try {
       return buildWorkspaceSkillSnapshot(workspaceDir, {
         config: params.cfg,
+        skillFilter,
         eligibility: { remote: getRemoteSkillEligibility() },
         snapshotVersion: getSkillsSnapshotVersion(workspaceDir),
       });

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -34,7 +34,12 @@ export async function resolveCommandsSystemPromptBundle(
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
   });
-  const skillFilter = resolveAgentSkillsFilter(params.cfg, params.agentId);
+  const { sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.sessionKey,
+    config: params.cfg,
+    agentId: params.agentId,
+  });
+  const skillFilter = resolveAgentSkillsFilter(params.cfg, sessionAgentId);
   const skillsSnapshot = (() => {
     try {
       return buildWorkspaceSkillSnapshot(workspaceDir, {
@@ -74,11 +79,6 @@ export async function resolveCommandsSystemPromptBundle(
   })();
   const toolSummaries = buildToolSummaryMap(tools);
   const toolNames = tools.map((t) => t.name);
-  const { sessionAgentId } = resolveSessionAgentIds({
-    sessionKey: params.sessionKey,
-    config: params.cfg,
-    agentId: params.agentId,
-  });
   const defaultModelRef = resolveDefaultModelForAgent({
     cfg: params.cfg,
     agentId: sessionAgentId,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -39,6 +39,7 @@ import {
 import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
+import { matchesSkillFilter } from "../agents/skills/filter.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import { normalizeSpawnedRunMetadata } from "../agents/spawned-context.js";
 import { resolveAgentTimeoutMs } from "../agents/timeout.js";
@@ -873,9 +874,14 @@ async function agentCommandInternal(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
+    const cachedSnapshot = sessionEntry?.skillsSnapshot;
+    const needsSkillsSnapshot =
+      isNewSession ||
+      !cachedSnapshot ||
+      (skillsSnapshotVersion > 0 && (cachedSnapshot.version ?? 0) < skillsSnapshotVersion) ||
+      !matchesSkillFilter(cachedSnapshot.skillFilter, skillFilter);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {
           config: cfg,


### PR DESCRIPTION
## Summary

- **`commands-system-prompt.ts`**: The per-agent `skills` filter (`agents.list[].skills`) was not passed to `buildWorkspaceSkillSnapshot()` in the gateway system-prompt path (cron and get-reply paths already had it)
- **`agent.ts`**: The CLI `openclaw agent` path only rebuilt skill snapshots on new sessions. If the agent's `skills` config changed after session creation, the stale cached snapshot was reused indefinitely — ignoring the new filter and version
- Added `resolveAgentSkillsFilter()` call in `commands-system-prompt.ts`
- Added `matchesSkillFilter()` and `snapshotVersion` comparison to the refresh condition in `agent.ts`, matching the gateway and cron paths

## Test plan

- [x] `filter.test.ts` — 4 tests pass
- [x] `run.skill-filter.test.ts` — 13 tests pass
- [x] `skills.buildworkspaceskillsnapshot.test.ts` — 8 tests pass
- [x] Manual: deleted stale session, ran `openclaw agent --agent group-chat --message "test" --json` — confirmed 7 skills (matching config) instead of 23 (stale bundled-only snapshot)
- [x] Manual: verified `buildWorkspaceSkillSnapshot(groupDir, { config, skillFilter })` returns exactly the 7 configured skills

Closes #41972

🤖 Generated with [Claude Code](https://claude.com/claude-code)