### PR TITLE
Daemon: fix sudo systemd unit home resolution

### DIFF
--- a/src/daemon/paths.test.ts
+++ b/src/daemon/paths.test.ts
@@ -1,0 +1,45 @@
+import os from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveHomeDir } from "./paths.js";
+
+describe("resolveHomeDir", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns HOME when available in a normal shell", () => {
+    expect(resolveHomeDir({ HOME: "/home/alice" })).toBe("/home/alice");
+  });
+
+  it("prefers the sudo caller home when HOME points at root", () => {
+    vi.spyOn(os, "userInfo").mockReturnValue({
+      uid: 1000,
+      gid: 1000,
+      username: "alice",
+      homedir: "/home/alice",
+      shell: "/bin/bash",
+    });
+
+    expect(resolveHomeDir({ HOME: "/root", SUDO_USER: "alice" })).toBe("/home/alice");
+  });
+
+  it("uses sudo caller home when HOME is missing", () => {
+    vi.spyOn(os, "userInfo").mockReturnValue({
+      uid: 1001,
+      gid: 1001,
+      username: "bob",
+      homedir: "/home/bob",
+      shell: "/bin/bash",
+    });
+
+    expect(resolveHomeDir({ SUDO_USER: "bob" })).toBe("/home/bob");
+  });
+
+  it("keeps HOME when sudo user lookup fails", () => {
+    vi.spyOn(os, "userInfo").mockImplementation(() => {
+      throw new Error("lookup failed");
+    });
+
+    expect(resolveHomeDir({ HOME: "/root", SUDO_USER: "alice" })).toBe("/root");
+  });
+});

--- a/src/daemon/paths.ts
+++ b/src/daemon/paths.ts
@@ -1,11 +1,32 @@
+import os from "node:os";
 import path from "node:path";
 import { resolveGatewayProfileSuffix } from "./constants.js";
 
 const windowsAbsolutePath = /^[a-zA-Z]:[\\/]/;
 const windowsUncPath = /^\\\\/;
 
+function resolveSudoUserHome(env: Record<string, string | undefined>): string | undefined {
+  const sudoUser = env.SUDO_USER?.trim();
+  if (!sudoUser || sudoUser === "root") {
+    return undefined;
+  }
+  try {
+    const info = os.userInfo({ username: sudoUser });
+    const homedir = info.homedir.trim();
+    return homedir || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveHomeDir(env: Record<string, string | undefined>): string {
   const home = env.HOME?.trim() || env.USERPROFILE?.trim();
+  const sudoUserHome = resolveSudoUserHome(env);
+  // Under sudo, HOME is often /root even though systemd --user runs as SUDO_USER.
+  // Prefer the sudo caller's home so unit file writes and systemctl scope match.
+  if (sudoUserHome && (!home || home === "/root" || home === "/var/root")) {
+    return sudoUserHome;
+  }
   if (!home) {
     throw new Error("Missing HOME");
   }


### PR DESCRIPTION
## Summary
- fix systemd unit home resolution under sudo installs
- prefer `SUDO_USER` home when `HOME` is missing or points to root
- add regression tests for sudo-home resolution in daemon paths

## Root cause
When `openclaw` is run with sudo, `systemctl --user` targets the sudo caller's user scope. But unit path resolution used `HOME` directly, which can be `/root` in sudo shells. That could write the unit to `/root/.config/systemd/user/...` while enable/restart ran in the caller scope, causing:

`systemctl enable failed: Unit file openclaw-gateway.service does not exist.`

## Validation
- Added focused tests in `src/daemon/paths.test.ts` for the sudo/home scenarios.
- I could not run tests in this environment because it is on Node 18 while this repo requires Node 22+.

Fixes #42025
