### PR TITLE
fix(auth,voice-call): clean oauth duplicates and guard webhooks

### DIFF
--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -49,6 +49,21 @@ function createBaseConfig(): VoiceCallConfig {
   return createVoiceCallBaseConfig({ tunnelProvider: "ngrok" });
 }
 
+function createTwilioConfig(params?: { publicUrl?: string }): VoiceCallConfig {
+  const config = createVoiceCallBaseConfig({
+    provider: "twilio",
+    tunnelProvider: "none",
+  });
+  config.twilio = {
+    accountSid: "AC123",
+    authToken: "secret",
+  };
+  if (params?.publicUrl) {
+    config.publicUrl = params.publicUrl;
+  }
+  return config;
+}
+
 describe("createVoiceCallRuntime lifecycle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -103,5 +118,28 @@ describe("createVoiceCallRuntime lifecycle", () => {
     expect(tunnelStop).toHaveBeenCalledTimes(1);
     expect(mocks.cleanupTailscaleExposure).toHaveBeenCalledTimes(1);
     expect(mocks.webhookStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when Twilio falls back to a loopback-only webhook", async () => {
+    await expect(
+      createVoiceCallRuntime({
+        config: createTwilioConfig(),
+        coreConfig: {} as CoreConfig,
+      }),
+    ).rejects.toThrow(/twilio requires a publicly reachable webhook url/i);
+  });
+
+  it("uses a configured public URL for Twilio when available", async () => {
+    const runtime = await createVoiceCallRuntime({
+      config: createTwilioConfig({
+        publicUrl: "https://voice.example.com/voice/webhook",
+      }),
+      coreConfig: {} as CoreConfig,
+    });
+
+    expect(runtime.webhookUrl).toBe("https://voice.example.com/voice/webhook");
+    expect(runtime.publicUrl).toBe("https://voice.example.com/voice/webhook");
+
+    await runtime.stop();
   });
 });

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -1,3 +1,4 @@
+import { URL } from "node:url";
 import type { VoiceCallConfig } from "./config.js";
 import { resolveVoiceCallConfig, validateProviderConfig } from "./config.js";
 import type { CoreConfig } from "./core-bridge.js";
@@ -78,6 +79,30 @@ function isLoopbackBind(bind: string | undefined): boolean {
     return false;
   }
   return bind === "127.0.0.1" || bind === "::1" || bind === "localhost";
+}
+
+function providerRequiresReachableWebhook(providerName: VoiceCallProvider["name"]): boolean {
+  return providerName === "twilio" || providerName === "telnyx" || providerName === "plivo";
+}
+
+function isProviderUnreachableWebhookUrl(webhookUrl: string): boolean {
+  try {
+    const parsed = new URL(webhookUrl);
+    const host = parsed.hostname.trim().toLowerCase();
+
+    // External telephony providers cannot call back into loopback or wildcard
+    // listener addresses. Failing closed here prevents "call placed, then dropped"
+    // behavior when tunnel/public URL setup is missing or broken.
+    return (
+      host === "127.0.0.1" ||
+      host === "localhost" ||
+      host === "::1" ||
+      host === "0.0.0.0" ||
+      host === "::"
+    );
+  } catch {
+    return false;
+  }
 }
 
 function resolveProvider(config: VoiceCallConfig): VoiceCallProvider {
@@ -201,6 +226,17 @@ export async function createVoiceCallRuntime(params: {
     }
 
     const webhookUrl = publicUrl ?? localUrl;
+
+    if (
+      providerRequiresReachableWebhook(provider.name) &&
+      isProviderUnreachableWebhookUrl(webhookUrl)
+    ) {
+      throw new Error(
+        `[voice-call] ${provider.name} requires a publicly reachable webhook URL. ` +
+          `Refusing to use local-only webhook ${webhookUrl}. ` +
+          "Set plugins.entries.voice-call.config.publicUrl or enable tunnel/tailscale exposure.",
+      );
+    }
 
     if (publicUrl && provider.name === "twilio") {
       (provider as TwilioProvider).setPublicUrl(publicUrl);

--- a/src/agents/auth-profiles.profiles-oauth-cleanup.e2e.test.ts
+++ b/src/agents/auth-profiles.profiles-oauth-cleanup.e2e.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureAuthProfileStore, upsertAuthProfile } from "./auth-profiles.js";
+
+describe("upsertAuthProfile OAuth cleanup", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0, tempDirs.length)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("removes duplicate oauth profiles for the same provider/email and keeps the updated profile", () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-cleanup-"));
+    tempDirs.push(agentDir);
+    const authPath = path.join(agentDir, "auth-profiles.json");
+
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "hprop17@gmail.com",
+            access: "old-access-default",
+            refresh: "old-refresh-default",
+            expires: Date.now() - 1_000,
+          },
+          "openai-codex:chatgpt-hprop17-subscription": {
+            type: "oauth",
+            provider: "openai-codex",
+            email: "hprop17@gmail.com",
+            access: "old-access-duplicate",
+            refresh: "old-refresh-duplicate",
+            expires: Date.now() - 2_000,
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:chatgpt-hprop17-subscription", "openai-codex:default"],
+        },
+        lastGood: {
+          "openai-codex": "openai-codex:chatgpt-hprop17-subscription",
+        },
+        usageStats: {
+          "openai-codex:chatgpt-hprop17-subscription": {
+            errorCount: 3,
+            cooldownUntil: Date.now() + 120_000,
+          },
+        },
+      }),
+    );
+
+    upsertAuthProfile({
+      profileId: "openai-codex:default",
+      credential: {
+        type: "oauth",
+        provider: "openai-codex",
+        email: "hprop17@gmail.com",
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+        expires: Date.now() + 60_000,
+      },
+      agentDir,
+    });
+
+    const reloaded = ensureAuthProfileStore(agentDir);
+    expect(reloaded.profiles["openai-codex:default"]).toMatchObject({
+      access: "fresh-access",
+      refresh: "fresh-refresh",
+      email: "hprop17@gmail.com",
+    });
+    expect(reloaded.profiles["openai-codex:chatgpt-hprop17-subscription"]).toBeUndefined();
+    expect(reloaded.usageStats?.["openai-codex:chatgpt-hprop17-subscription"]).toBeUndefined();
+    expect(reloaded.order?.["openai-codex"]).toEqual(["openai-codex:default"]);
+    expect(reloaded.lastGood?.["openai-codex"]).toBe("openai-codex:default");
+  });
+});

--- a/src/agents/auth-profiles/oauth-cleanup.ts
+++ b/src/agents/auth-profiles/oauth-cleanup.ts
@@ -1,0 +1,227 @@
+import { normalizeProviderId } from "../model-selection.js";
+import type { AuthProfileStore, OAuthCredential } from "./types.js";
+
+export type OAuthProfileCleanupResult = {
+  changed: boolean;
+  removedProfileIds: string[];
+  resetProfileIds: string[];
+};
+
+function normalizeEmail(raw: string | undefined): string | null {
+  const value = raw?.trim().toLowerCase();
+  return value ? value : null;
+}
+
+function normalizeRefresh(raw: string | undefined): string | null {
+  const value = raw?.trim();
+  return value ? value : null;
+}
+
+function isOAuthCredential(value: unknown): value is OAuthCredential {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const typed = value as { type?: string };
+  return typed.type === "oauth";
+}
+
+function getProfileDedupeKey(profileId: string, credential: OAuthCredential): string | null {
+  const provider = normalizeProviderId(credential.provider);
+  const email = normalizeEmail(credential.email);
+  if (email) {
+    return `${provider}::email::${email}`;
+  }
+  const refresh = normalizeRefresh(credential.refresh);
+  if (refresh) {
+    return `${provider}::refresh::${refresh}`;
+  }
+  return null;
+}
+
+function getProfileExpiry(credential: OAuthCredential): number {
+  const value = credential.expires;
+  return typeof value === "number" && Number.isFinite(value) ? value : -1;
+}
+
+function selectProfileToKeep(params: {
+  profileIds: string[];
+  store: AuthProfileStore;
+  preferred: Set<string>;
+}): string {
+  let keep = params.profileIds[0] ?? "";
+  let keepScore = Number.NEGATIVE_INFINITY;
+
+  for (const profileId of params.profileIds) {
+    const cred = params.store.profiles[profileId];
+    if (!isOAuthCredential(cred)) {
+      continue;
+    }
+    const preferredScore = params.preferred.has(profileId) ? 10_000_000_000_000 : 0;
+    const defaultScore = profileId.endsWith(":default") ? 1 : 0;
+    const expiryScore = getProfileExpiry(cred);
+    const score = preferredScore + expiryScore + defaultScore;
+    if (score > keepScore || (score === keepScore && profileId.localeCompare(keep) < 0)) {
+      keep = profileId;
+      keepScore = score;
+    }
+  }
+
+  return keep;
+}
+
+function resetProfileFailureState(store: AuthProfileStore, profileId: string): boolean {
+  if (!store.usageStats?.[profileId]) {
+    return false;
+  }
+  store.usageStats[profileId] = {
+    ...store.usageStats[profileId],
+    errorCount: 0,
+    cooldownUntil: undefined,
+    disabledUntil: undefined,
+    disabledReason: undefined,
+    failureCounts: undefined,
+    lastFailureAt: undefined,
+  };
+  return true;
+}
+
+function pruneDanglingStoreReferences(store: AuthProfileStore): boolean {
+  let changed = false;
+
+  if (store.usageStats) {
+    for (const profileId of Object.keys(store.usageStats)) {
+      if (store.profiles[profileId]) {
+        continue;
+      }
+      delete store.usageStats[profileId];
+      changed = true;
+    }
+    if (Object.keys(store.usageStats).length === 0) {
+      store.usageStats = undefined;
+      changed = true;
+    }
+  }
+
+  if (store.order) {
+    for (const provider of Object.keys(store.order)) {
+      const existing = store.order[provider] ?? [];
+      const filtered = existing.filter((id) => Boolean(store.profiles[id]));
+      const deduped = [...new Set(filtered)];
+      if (deduped.length > 0) {
+        if (deduped.length !== existing.length) {
+          store.order[provider] = deduped;
+          changed = true;
+        }
+      } else {
+        delete store.order[provider];
+        changed = true;
+      }
+    }
+    if (Object.keys(store.order).length === 0) {
+      store.order = undefined;
+      changed = true;
+    }
+  }
+
+  if (store.lastGood) {
+    for (const [provider, profileId] of Object.entries(store.lastGood)) {
+      if (store.profiles[profileId]) {
+        continue;
+      }
+      const providerKey = normalizeProviderId(provider);
+      const replacement = Object.entries(store.profiles).find(
+        ([, cred]) => normalizeProviderId(cred.provider) === providerKey,
+      )?.[0];
+      if (replacement) {
+        store.lastGood[provider] = replacement;
+      } else {
+        delete store.lastGood[provider];
+      }
+      changed = true;
+    }
+    if (Object.keys(store.lastGood).length === 0) {
+      store.lastGood = undefined;
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+export function cleanupOAuthProfiles(params: {
+  store: AuthProfileStore;
+  provider?: string;
+  keepProfileIds?: string[];
+  resetUsageForProfileIds?: string[];
+}): OAuthProfileCleanupResult {
+  const providerFilter = params.provider ? normalizeProviderId(params.provider) : null;
+  const preferred = new Set((params.keepProfileIds ?? []).map((id) => String(id).trim()));
+  const resetTargetIds = new Set(
+    (params.resetUsageForProfileIds ?? []).map((id) => String(id).trim()).filter(Boolean),
+  );
+  const groups = new Map<string, string[]>();
+
+  for (const [profileId, credential] of Object.entries(params.store.profiles)) {
+    if (!isOAuthCredential(credential)) {
+      continue;
+    }
+    if (providerFilter && normalizeProviderId(credential.provider) !== providerFilter) {
+      continue;
+    }
+    const dedupeKey = getProfileDedupeKey(profileId, credential);
+    if (!dedupeKey) {
+      continue;
+    }
+    const existing = groups.get(dedupeKey) ?? [];
+    existing.push(profileId);
+    groups.set(dedupeKey, existing);
+  }
+
+  let changed = false;
+  const removedProfileIds: string[] = [];
+  const resetProfileIds: string[] = [];
+
+  for (const profileIds of groups.values()) {
+    if (profileIds.length <= 1) {
+      continue;
+    }
+    const keep = selectProfileToKeep({
+      profileIds,
+      store: params.store,
+      preferred,
+    });
+    for (const profileId of profileIds) {
+      if (profileId === keep) {
+        continue;
+      }
+      if (params.store.profiles[profileId]) {
+        delete params.store.profiles[profileId];
+        removedProfileIds.push(profileId);
+        changed = true;
+      }
+      if (params.store.usageStats?.[profileId]) {
+        delete params.store.usageStats[profileId];
+      }
+    }
+  }
+
+  for (const profileId of resetTargetIds) {
+    if (!params.store.profiles[profileId]) {
+      continue;
+    }
+    if (resetProfileFailureState(params.store, profileId)) {
+      resetProfileIds.push(profileId);
+      changed = true;
+    }
+  }
+
+  if (pruneDanglingStoreReferences(params.store)) {
+    changed = true;
+  }
+
+  return {
+    changed,
+    removedProfileIds,
+    resetProfileIds,
+  };
+}

--- a/src/agents/auth-profiles/oauth.refresh-token-reused-cleanup.e2e.test.ts
+++ b/src/agents/auth-profiles/oauth.refresh-token-reused-cleanup.e2e.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureEnv } from "../../test-utils/env.js";
+import { resolveApiKeyForProfile } from "./oauth.js";
+import { ensureAuthProfileStore } from "./store.js";
+import type { AuthProfileStore } from "./types.js";
+
+describe("resolveApiKeyForProfile refresh_token_reused cleanup", () => {
+  const envSnapshot = captureEnv([
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_AGENT_DIR",
+    "PI_CODING_AGENT_DIR",
+  ]);
+  let tmpDir: string;
+  let mainAgentDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-reuse-cleanup-"));
+    mainAgentDir = path.join(tmpDir, "agents", "main", "agent");
+    await fs.mkdir(mainAgentDir, { recursive: true });
+
+    process.env.OPENCLAW_STATE_DIR = tmpDir;
+    process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+    process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    envSnapshot.restore();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("prunes duplicate oauth profiles and clears failure state when refresh token is reused", async () => {
+    const profileId = "openai-codex:default";
+    const duplicateProfileId = "openai-codex:chatgpt-hprop17-subscription";
+    const now = Date.now();
+
+    const seededStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "oauth",
+          provider: "openai-codex",
+          email: "hprop17@gmail.com",
+          access: "expired-access-default",
+          refresh: "expired-refresh-default",
+          expires: now - 60_000,
+        },
+        [duplicateProfileId]: {
+          type: "oauth",
+          provider: "openai-codex",
+          email: "hprop17@gmail.com",
+          access: "expired-access-duplicate",
+          refresh: "expired-refresh-duplicate",
+          expires: now - 120_000,
+        },
+      },
+      usageStats: {
+        [profileId]: {
+          errorCount: 5,
+          cooldownUntil: now + 300_000,
+          failureCounts: { auth: 5 },
+          lastFailureAt: now - 10_000,
+        },
+      },
+    };
+    await fs.writeFile(
+      path.join(mainAgentDir, "auth-profiles.json"),
+      JSON.stringify(seededStore),
+      "utf8",
+    );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            error: "invalid_grant",
+            error_code: "refresh_token_reused",
+            message: "refresh token has already been used",
+          }),
+          {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }),
+    );
+
+    const store = ensureAuthProfileStore(mainAgentDir);
+    await expect(
+      resolveApiKeyForProfile({
+        store,
+        profileId,
+        agentDir: mainAgentDir,
+      }),
+    ).rejects.toThrow(/OAuth token refresh failed/);
+
+    const reloaded = JSON.parse(
+      await fs.readFile(path.join(mainAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+
+    expect(reloaded.profiles[duplicateProfileId]).toBeUndefined();
+    expect(reloaded.profiles[profileId]).toBeDefined();
+    expect(reloaded.usageStats?.[profileId]?.errorCount).toBe(0);
+    expect(reloaded.usageStats?.[profileId]?.cooldownUntil).toBeUndefined();
+    expect(reloaded.usageStats?.[profileId]?.disabledUntil).toBeUndefined();
+    expect(reloaded.usageStats?.[profileId]?.failureCounts).toBeUndefined();
+    expect(reloaded.usageStats?.[profileId]?.lastFailureAt).toBeUndefined();
+  });
+});

--- a/src/agents/auth-profiles/oauth.refresh-token-reused-cleanup.e2e.test.ts
+++ b/src/agents/auth-profiles/oauth.refresh-token-reused-cleanup.e2e.test.ts
@@ -3,6 +3,18 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../../test-utils/env.js";
+const oauthMocks = vi.hoisted(() => ({
+  getOAuthApiKey: vi.fn(),
+}));
+
+vi.mock("@mariozechner/pi-ai/oauth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mariozechner/pi-ai/oauth")>();
+  return {
+    ...actual,
+    getOAuthApiKey: oauthMocks.getOAuthApiKey,
+  };
+});
+
 import { resolveApiKeyForProfile } from "./oauth.js";
 import { ensureAuthProfileStore } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
@@ -28,6 +40,7 @@ describe("resolveApiKeyForProfile refresh_token_reused cleanup", () => {
 
   afterEach(async () => {
     vi.unstubAllGlobals();
+    oauthMocks.getOAuthApiKey.mockReset();
     envSnapshot.restore();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
@@ -72,21 +85,14 @@ describe("resolveApiKeyForProfile refresh_token_reused cleanup", () => {
       "utf8",
     );
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => {
-        return new Response(
-          JSON.stringify({
-            error: "invalid_grant",
-            error_code: "refresh_token_reused",
-            message: "refresh token has already been used",
-          }),
-          {
-            status: 401,
-            headers: { "Content-Type": "application/json" },
-          },
-        );
-      }),
+    oauthMocks.getOAuthApiKey.mockRejectedValue(
+      new Error(
+        JSON.stringify({
+          error: "invalid_grant",
+          error_code: "refresh_token_reused",
+          message: "refresh token has already been used",
+        }),
+      ),
     );
 
     const store = ensureAuthProfileStore(mainAgentDir);

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -10,9 +10,14 @@ import { normalizeProviderId } from "../model-selection.js";
 import { AUTH_STORE_LOCK_OPTIONS, log } from "./constants.js";
 import { resolveTokenExpiryState } from "./credential-state.js";
 import { formatAuthDoctorHint } from "./doctor.js";
+import { cleanupOAuthProfiles } from "./oauth-cleanup.js";
 import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
-import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
+import {
+  ensureAuthProfileStore,
+  saveAuthProfileStore,
+  updateAuthProfileStoreWithLock,
+} from "./store.js";
 import type { AuthProfileStore } from "./types.js";
 
 const OAUTH_PROVIDER_IDS = new Set<string>(getOAuthProviders().map((provider) => provider.id));
@@ -302,6 +307,59 @@ async function resolveProfileSecretString(params: {
   return resolvedValue;
 }
 
+function isRefreshTokenReusedError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  const texts: string[] = [];
+
+  const collect = (value: unknown) => {
+    if (!value || seen.has(value)) {
+      return;
+    }
+    seen.add(value);
+    if (typeof value === "string") {
+      texts.push(value);
+      return;
+    }
+    if (value instanceof Error) {
+      texts.push(value.message);
+      collect((value as Error & { cause?: unknown }).cause);
+      return;
+    }
+    if (value === undefined) {
+      texts.push("undefined");
+      return;
+    }
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+      texts.push(value.toString());
+      return;
+    }
+    if (typeof value === "symbol") {
+      texts.push(value.description ?? "symbol");
+      return;
+    }
+    if (typeof value === "function") {
+      texts.push(value.name || "function");
+      return;
+    }
+    const record = value as Record<string, unknown>;
+    for (const key of ["error", "error_code", "message", "code"]) {
+      const field = record[key];
+      if (typeof field === "string") {
+        texts.push(field);
+      }
+    }
+    collect(record.cause);
+    try {
+      texts.push(JSON.stringify(record));
+    } catch {
+      // ignore non-serializable objects
+    }
+  };
+
+  collect(error);
+  return texts.some((text) => /\brefresh_token_reused\b/i.test(text));
+}
+
 export async function resolveApiKeyForProfile(
   params: ResolveApiKeyForProfileParams,
 ): Promise<{ apiKey: string; provider: string; email?: string } | null> {
@@ -467,6 +525,36 @@ export async function resolveApiKeyForProfile(
         apiKey: cred.access,
         provider: cred.provider,
         email: cred.email,
+      });
+    }
+
+    const refreshTokenReused = isRefreshTokenReusedError(error);
+    let cleanupChanged = false;
+    let removedProfileIds: string[] = [];
+    let resetProfileIds: string[] = [];
+    await updateAuthProfileStoreWithLock({
+      agentDir: params.agentDir,
+      updater: (lockedStore) => {
+        const result = cleanupOAuthProfiles({
+          store: lockedStore,
+          provider: cred.provider,
+          keepProfileIds: [profileId],
+          resetUsageForProfileIds: [profileId],
+        });
+        cleanupChanged = result.changed;
+        removedProfileIds = result.removedProfileIds;
+        resetProfileIds = result.resetProfileIds;
+        return result.changed;
+      },
+    });
+    if (cleanupChanged) {
+      log.warn("OAuth refresh failed; cleaned oauth profile state", {
+        provider: cred.provider,
+        profileId,
+        refreshTokenReused,
+        removedProfileIds,
+        resetProfileIds,
+        agentDir: params.agentDir,
       });
     }
 

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -1,6 +1,7 @@
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { normalizeProviderId, normalizeProviderIdForAuth } from "../model-selection.js";
+import { cleanupOAuthProfiles } from "./oauth-cleanup.js";
 import {
   ensureAuthProfileStore,
   saveAuthProfileStore,
@@ -60,6 +61,13 @@ export function upsertAuthProfile(params: {
         : params.credential;
   const store = ensureAuthProfileStore(params.agentDir);
   store.profiles[params.profileId] = credential;
+  if (credential.type === "oauth") {
+    cleanupOAuthProfiles({
+      store,
+      provider: credential.provider,
+      keepProfileIds: [params.profileId],
+    });
+  }
   saveAuthProfileStore(store, params.agentDir);
 }
 
@@ -72,6 +80,13 @@ export async function upsertAuthProfileWithLock(params: {
     agentDir: params.agentDir,
     updater: (store) => {
       store.profiles[params.profileId] = params.credential;
+      if (params.credential.type === "oauth") {
+        cleanupOAuthProfiles({
+          store,
+          provider: params.credential.provider,
+          keepProfileIds: [params.profileId],
+        });
+      }
       return true;
     },
   });


### PR DESCRIPTION
## Summary

- Problem: local branch contained mixed iOS experiment noise + uncommitted source changes, making it unclear and risky to merge.
- Why it matters: this isolates and preserves only intentional runtime/auth fixes while dropping local iOS debugging churn.
- What changed:
  - Added fail-closed voice-call webhook guard for external providers (`twilio`/`telnyx`/`plivo`) against loopback-only webhook URLs.
  - Added OAuth profile cleanup utility and wired it into profile upsert + refresh-failure flow to prune duplicate OAuth profiles and reset stale failure state.
  - Added targeted tests for both voice-call guard and OAuth cleanup/reuse scenarios.
- What did NOT change: iOS local TLS/entitlements/project.yml debugging edits were removed from this branch.
- AI-assisted: Yes (Codex). Human-reviewed before submission.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Voice-call runtime now fails fast when configured with external telephony provider and unreachable local-only webhook URL.
- OAuth profile state now self-cleans duplicate provider/email entries during upsert and refresh-token-reused failure handling.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v25.6.1, pnpm 10.23.0

### Steps

1. `pnpm check`
2. `pnpm exec vitest run extensions/voice-call/src/runtime.test.ts src/agents/auth-profiles/oauth.test.ts`
3. `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/auth-profiles.profiles-oauth-cleanup.e2e.test.ts src/agents/auth-profiles/oauth.refresh-token-reused-cleanup.e2e.test.ts`

### Actual

- All commands passed.

## Human Verification (required)

- Verified scenarios: voice-call webhook guard behavior and OAuth duplicate/reused-token cleanup behavior.
- What you did **not** verify: full `pnpm test` suite.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: cleanup logic could remove unintended OAuth profiles if dedupe key selection is wrong.
  - Mitigation: deterministic dedupe key + targeted e2e coverage for duplicate email and refresh-token-reused paths.
