### PR TITLE
Feat/image tools compression quality

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -835,6 +835,43 @@ Higher values preserve more visual detail.
 }
 ```
 
+### `agents.defaults.imageCompression`
+
+Image quality settings for the `image` tool. Controls resolution and JPEG quality when sending images to vision models.
+
+Default: `"medium"` (max 1200px side, quality 70).
+
+**Presets:**
+
+- `"none"` - No compression, send original image (may hit API limits)
+- `"low"` - Max 800px side, quality 50 (smallest payload)
+- `"medium"` - Max 1200px side, quality 70 (balanced)
+- `"high"` - Max 2000px side, quality 95 (best quality for text-heavy images)
+
+```json5
+{
+  agents: { defaults: { imageCompression: "high" } },
+}
+```
+
+**Detailed settings** for fine-grained control:
+
+```json5
+{
+  agents: {
+    defaults: {
+      imageCompression: {
+        maxWidth: 2000,
+        maxHeight: 2000,
+        quality: 95,
+      },
+    },
+  },
+}
+```
+
+Use `"high"` or detailed settings with higher quality values (85-95) for text-heavy images like documents, contracts, or licenses where OCR accuracy matters.
+
 ### `agents.defaults.userTimezone`
 
 Timezone for system prompt context (not message timestamps). Falls back to host timezone.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -127,6 +127,7 @@ When validation fails:
     - `agents.defaults.models` defines the model catalog and acts as the allowlist for `/model`.
     - Model refs use `provider/model` format (e.g. `anthropic/claude-opus-4-6`).
     - `agents.defaults.imageMaxDimensionPx` controls transcript/tool image downscaling (default `1200`); lower values usually reduce vision-token usage on screenshot-heavy runs.
+    - `agents.defaults.imageCompression` controls image quality when analyzing images with the `image` tool. Use presets (`"none"`, `"low"`, `"medium"`, `"high"`) or detailed settings (`{ maxWidth, maxHeight, quality }`). Default is `"medium"`. For text-heavy images like documents or contracts, use `"high"` for better OCR accuracy.
     - See [Models CLI](/concepts/models) for switching models in chat and [Model Failover](/concepts/model-failover) for auth rotation and fallback behavior.
     - For custom/self-hosted providers, see [Custom providers](/gateway/configuration-reference#custom-providers-and-base-urls) in the reference.
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -89,6 +89,7 @@ import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
 import { normalizeToolName } from "../../tool-policy.js";
+import { resolveImageCompressionSettings } from "../../tools/image-compression.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
@@ -1711,6 +1712,10 @@ export async function runEmbeddedAttempt(
 
           // Detect and load images referenced in the prompt for vision-capable models.
           // Images are prompt-local only (pi-like behavior).
+          const imageCompressionConfig = params.config?.agents?.defaults?.imageCompression;
+          const compressionSettings = resolveImageCompressionSettings({
+            compression: imageCompressionConfig,
+          });
           const imageResult = await detectAndLoadPromptImages({
             prompt: effectivePrompt,
             workspaceDir: effectiveWorkspace,
@@ -1724,6 +1729,7 @@ export async function runEmbeddedAttempt(
               sandbox?.enabled && sandbox?.fsBridge
                 ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
                 : undefined,
+            compressionSettings,
           });
 
           cacheTrace?.recordStage("prompt:images", {

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ImageContent } from "@mariozechner/pi-ai";
+import { resizeToJpeg } from "../../../media/image-ops.js";
 import { resolveUserPath } from "../../../utils.js";
 import { loadWebMedia } from "../../../web/media.js";
 import type { ImageSanitizationLimits } from "../../image-sanitization.js";
@@ -60,6 +61,60 @@ function isImageExtension(filePath: string): boolean {
 
 function normalizeRefForDedupe(raw: string): string {
   return process.platform === "win32" ? raw.toLowerCase() : raw;
+}
+
+/**
+ * Compresses existing images (from message attachments) using imageCompression settings.
+ * This is needed because existingImages bypass loadWebMedia and go directly to sanitization.
+ */
+async function compressExistingImages(
+  images: ImageContent[],
+  compressionSettings?: {
+    optimize: boolean;
+    maxSide?: number;
+    quality?: number;
+  },
+): Promise<ImageContent[]> {
+  // Skip if no compression needed or no settings provided
+  if (
+    !compressionSettings?.optimize ||
+    compressionSettings.maxSide === undefined ||
+    compressionSettings.quality === undefined
+  ) {
+    return images;
+  }
+
+  const compressed: ImageContent[] = [];
+  for (const image of images) {
+    try {
+      console.log(
+        `[media] Compressing existing image: maxSide=${compressionSettings.maxSide}, quality=${compressionSettings.quality}`,
+      );
+      const buffer = Buffer.from(image.data, "base64");
+      const originalSize = buffer.length;
+      const resized = await resizeToJpeg({
+        buffer,
+        maxSide: compressionSettings.maxSide,
+        quality: compressionSettings.quality,
+        withoutEnlargement: true,
+      });
+      console.log(
+        `[media] Existing image compressed: ${originalSize} -> ${resized.length} bytes (side=${compressionSettings.maxSide}, q=${compressionSettings.quality})`,
+      );
+      compressed.push({
+        type: "image",
+        data: resized.toString("base64"),
+        mimeType: "image/jpeg",
+      });
+    } catch (err) {
+      // If compression fails, include original image
+      log.debug(
+        `Native image: failed to compress existing image: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      compressed.push(image);
+    }
+  }
+  return compressed;
 }
 
 async function sanitizeImagesWithLog(
@@ -331,9 +386,15 @@ export async function detectAndLoadPromptImages(params: {
   // Detect images from current prompt
   const allRefs = detectImageReferences(params.prompt);
 
+  // Compress existing images (from message attachments) early
+  const compressedExisting = await compressExistingImages(
+    params.existingImages ?? [],
+    params.compressionSettings,
+  );
+
   if (allRefs.length === 0) {
     return {
-      images: params.existingImages ?? [],
+      images: compressedExisting,
       detectedRefs: [],
       loadedCount: 0,
       skippedCount: 0,
@@ -342,7 +403,7 @@ export async function detectAndLoadPromptImages(params: {
 
   log.debug(`Native image: detected ${allRefs.length} image refs in prompt`);
 
-  const promptImages: ImageContent[] = [...(params.existingImages ?? [])];
+  const promptImages: ImageContent[] = [...compressedExisting];
 
   let loadedCount = 0;
   let skippedCount = 0;

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -198,6 +198,12 @@ export async function loadImageFromRef(
     maxBytes?: number;
     workspaceOnly?: boolean;
     sandbox?: { root: string; bridge: SandboxFsBridge };
+    /** Compression settings from imageCompression config */
+    compressionSettings?: {
+      optimize: boolean;
+      maxSide?: number;
+      quality?: number;
+    };
   },
 ): Promise<ImageContent | null> {
   try {
@@ -239,8 +245,16 @@ export async function loadImageFromRef(
           maxBytes: options.maxBytes,
           sandboxValidated: true,
           readFile: createSandboxBridgeReadFile({ sandbox: options.sandbox }),
+          skipOptimization: options?.compressionSettings?.optimize === false,
+          maxSideOverride: options?.compressionSettings?.maxSide,
+          qualityOverride: options?.compressionSettings?.quality,
         })
-      : await loadWebMedia(targetPath, options?.maxBytes);
+      : await loadWebMedia(targetPath, {
+          maxBytes: options?.maxBytes,
+          skipOptimization: options?.compressionSettings?.optimize === false,
+          maxSideOverride: options?.compressionSettings?.maxSide,
+          qualityOverride: options?.compressionSettings?.quality,
+        });
 
     if (media.kind !== "image") {
       log.debug(`Native image: not an image file: ${targetPath} (got ${media.kind})`);
@@ -291,6 +305,12 @@ export async function detectAndLoadPromptImages(params: {
   maxDimensionPx?: number;
   workspaceOnly?: boolean;
   sandbox?: { root: string; bridge: SandboxFsBridge };
+  /** Compression settings from imageCompression config */
+  compressionSettings?: {
+    optimize: boolean;
+    maxSide?: number;
+    quality?: number;
+  };
 }): Promise<{
   /** Images for the current prompt (existingImages + detected in current prompt) */
   images: ImageContent[];
@@ -332,6 +352,7 @@ export async function detectAndLoadPromptImages(params: {
       maxBytes: params.maxBytes,
       workspaceOnly: params.workspaceOnly,
       sandbox: params.sandbox,
+      compressionSettings: params.compressionSettings,
     });
     if (image) {
       promptImages.push(image);

--- a/src/agents/tools/image-compression.test.ts
+++ b/src/agents/tools/image-compression.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { resolveImageCompressionSettings, IMAGE_COMPRESSION_PRESETS } from "./image-compression.js";
+
+describe("resolveImageCompressionSettings", () => {
+  it("returns medium preset by default", () => {
+    const result = resolveImageCompressionSettings({});
+    expect(result.maxSide).toBe(1200);
+    expect(result.quality).toBe(70);
+  });
+
+  it("resolves 'none' preset", () => {
+    const result = resolveImageCompressionSettings({ compression: "none" });
+    expect(result.optimize).toBe(false);
+  });
+
+  it("resolves 'low' preset", () => {
+    const result = resolveImageCompressionSettings({ compression: "low" });
+    expect(result.maxSide).toBe(800);
+    expect(result.quality).toBe(50);
+  });
+
+  it("resolves 'medium' preset", () => {
+    const result = resolveImageCompressionSettings({ compression: "medium" });
+    expect(result.maxSide).toBe(1200);
+    expect(result.quality).toBe(70);
+  });
+
+  it("resolves 'high' preset", () => {
+    const result = resolveImageCompressionSettings({ compression: "high" });
+    expect(result.maxSide).toBe(2000);
+    expect(result.quality).toBe(95);
+  });
+
+  it("resolves detailed config with maxWidth", () => {
+    const result = resolveImageCompressionSettings({
+      compression: { maxWidth: 1500 },
+    });
+    expect(result.maxSide).toBe(1500);
+    expect(result.quality).toBe(95); // default quality for detail mode
+  });
+
+  it("resolves detailed config with all fields", () => {
+    const result = resolveImageCompressionSettings({
+      compression: { maxWidth: 1800, maxHeight: 1600, quality: 85 },
+    });
+    expect(result.maxSide).toBe(1600); // min of maxWidth and maxHeight
+    expect(result.quality).toBe(85);
+  });
+
+  it("uses quality from detail config", () => {
+    const result = resolveImageCompressionSettings({
+      compression: { quality: 90 },
+    });
+    expect(result.maxSide).toBe(2000); // default max side for detail mode
+    expect(result.quality).toBe(90);
+  });
+});
+
+describe("IMAGE_COMPRESSION_PRESETS", () => {
+  it("has correct values", () => {
+    expect(IMAGE_COMPRESSION_PRESETS.none).toEqual({ optimize: false });
+    expect(IMAGE_COMPRESSION_PRESETS.low).toEqual({ maxSide: 800, quality: 50, optimize: true });
+    expect(IMAGE_COMPRESSION_PRESETS.medium).toEqual({
+      maxSide: 1200,
+      quality: 70,
+      optimize: true,
+    });
+    expect(IMAGE_COMPRESSION_PRESETS.high).toEqual({ maxSide: 2000, quality: 95, optimize: true });
+  });
+});

--- a/src/agents/tools/image-compression.ts
+++ b/src/agents/tools/image-compression.ts
@@ -1,0 +1,63 @@
+import type { ImageCompressionConfig } from "../../config/types.agent-defaults.js";
+
+/**
+ * Resolved image compression settings used by the image tool.
+ */
+export type ResolvedImageCompressionSettings = {
+  /** Whether to apply compression/optimization */
+  optimize: boolean;
+  /** Maximum side length in pixels (applied to both width and height) */
+  maxSide?: number;
+  /** JPEG quality (1-100) */
+  quality?: number;
+};
+
+/**
+ * Preset compression settings.
+ */
+export const IMAGE_COMPRESSION_PRESETS: Record<
+  "none" | "low" | "medium" | "high",
+  ResolvedImageCompressionSettings
+> = {
+  none: { optimize: false },
+  low: { optimize: true, maxSide: 800, quality: 50 },
+  medium: { optimize: true, maxSide: 1200, quality: 70 },
+  high: { optimize: true, maxSide: 2000, quality: 95 },
+};
+
+const DEFAULT_DETAIL_SETTINGS = {
+  maxSide: 2000,
+  quality: 95,
+};
+
+/**
+ * Resolves image compression config to concrete settings.
+ * Falls back to "medium" preset when no config is provided.
+ */
+export function resolveImageCompressionSettings(params: {
+  compression?: ImageCompressionConfig;
+}): ResolvedImageCompressionSettings {
+  const { compression } = params;
+
+  // No config: use medium preset (balanced default)
+  if (compression === undefined) {
+    return IMAGE_COMPRESSION_PRESETS.medium;
+  }
+
+  // String preset
+  if (typeof compression === "string") {
+    return IMAGE_COMPRESSION_PRESETS[compression];
+  }
+
+  // Detailed config
+  const maxWidth = compression.maxWidth ?? DEFAULT_DETAIL_SETTINGS.maxSide;
+  const maxHeight = compression.maxHeight ?? DEFAULT_DETAIL_SETTINGS.maxSide;
+  const quality = compression.quality ?? DEFAULT_DETAIL_SETTINGS.quality;
+  const maxSide = Math.min(maxWidth, maxHeight);
+
+  return {
+    optimize: true,
+    maxSide,
+    quality,
+  };
+}

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -298,6 +298,11 @@ export function createImageTool(options?: {
     compression: compressionConfig,
   });
 
+  // Debug log for compression settings
+  console.log(
+    `[image-tool] compression config: ${JSON.stringify(compressionConfig)} -> settings: ${JSON.stringify(compressionSettings)}`,
+  );
+
   // If model has native vision, images in the prompt are auto-injected
   // so this tool is only needed when image wasn't provided in the prompt
   const description = options?.modelHasVision
@@ -455,36 +460,69 @@ export function createImageTool(options?: {
               };
         const resolvedPath = isDataUrl ? null : resolvedPathInfo.resolved;
 
-        const media = isDataUrl
-          ? decodeDataUrl(resolvedImage)
-          : sandboxConfig
-            ? await loadWebMedia(resolvedPath ?? resolvedImage, {
-                maxBytes,
-                sandboxValidated: true,
-                readFile: createSandboxBridgeReadFile({ sandbox: sandboxConfig }),
-                skipOptimization: !compressionSettings.optimize,
-                maxSideOverride: compressionSettings.maxSide,
-                qualityOverride: compressionSettings.quality,
-              })
-            : await loadWebMedia(resolvedPath ?? resolvedImage, {
-                maxBytes,
-                localRoots,
-                skipOptimization: !compressionSettings.optimize,
-                maxSideOverride: compressionSettings.maxSide,
-                qualityOverride: compressionSettings.quality,
-              });
-        if (media.kind !== "image") {
-          throw new Error(`Unsupported media type: ${media.kind}`);
-        }
+        // Process image and apply compression if enabled
+        let imageBuffer: Buffer;
+        let imageMimeType: string;
 
-        const mimeType =
-          ("contentType" in media && media.contentType) ||
-          ("mimeType" in media && media.mimeType) ||
-          "image/png";
-        const base64 = media.buffer.toString("base64");
+        if (isDataUrl) {
+          // Decode data URL and apply compression if enabled
+          const decoded = decodeDataUrl(resolvedImage);
+          if (
+            compressionSettings.optimize &&
+            compressionSettings.maxSide &&
+            compressionSettings.quality
+          ) {
+            console.log(
+              `[media] Compressing data URL image: maxSide=${compressionSettings.maxSide}, quality=${compressionSettings.quality}`,
+            );
+            const { resizeToJpeg } = await import("../../media/image-ops.js");
+            const compressed = await resizeToJpeg({
+              buffer: decoded.buffer,
+              maxSide: compressionSettings.maxSide,
+              quality: compressionSettings.quality,
+              withoutEnlargement: true,
+            });
+            console.log(
+              `[media] Data URL compressed: ${decoded.buffer.length} -> ${compressed.length} bytes`,
+            );
+            imageBuffer = compressed;
+            imageMimeType = "image/jpeg";
+          } else {
+            imageBuffer = decoded.buffer;
+            imageMimeType = decoded.mimeType;
+          }
+        } else if (sandboxConfig) {
+          const media = await loadWebMedia(resolvedPath ?? resolvedImage, {
+            maxBytes,
+            sandboxValidated: true,
+            readFile: createSandboxBridgeReadFile({ sandbox: sandboxConfig }),
+            skipOptimization: !compressionSettings.optimize,
+            maxSideOverride: compressionSettings.maxSide,
+            qualityOverride: compressionSettings.quality,
+          });
+          if (media.kind !== "image") {
+            throw new Error(`Unsupported media type: ${media.kind}`);
+          }
+          imageBuffer = media.buffer;
+          imageMimeType = media.contentType ?? "image/png";
+        } else {
+          const media = await loadWebMedia(resolvedPath ?? resolvedImage, {
+            maxBytes,
+            localRoots,
+            skipOptimization: !compressionSettings.optimize,
+            maxSideOverride: compressionSettings.maxSide,
+            qualityOverride: compressionSettings.quality,
+          });
+          if (media.kind !== "image") {
+            throw new Error(`Unsupported media type: ${media.kind}`);
+          }
+          imageBuffer = media.buffer;
+          imageMimeType = media.contentType ?? "image/png";
+        }
+        const base64 = imageBuffer.toString("base64");
         loadedImages.push({
           base64,
-          mimeType,
+          mimeType: imageMimeType,
           resolvedImage,
           ...(resolvedPathInfo.rewrittenFrom
             ? { rewrittenFrom: resolvedPathInfo.rewrittenFrom }

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { resolveUserPath } from "../../utils.js";
 import { loadWebMedia } from "../../web/media.js";
 import { isMinimaxVlmModel, isMinimaxVlmProvider, minimaxUnderstandImage } from "../minimax-vlm.js";
+import { resolveImageCompressionSettings } from "./image-compression.js";
 import {
   coerceImageAssistantText,
   coerceImageModelConfig,
@@ -292,6 +293,11 @@ export function createImageTool(options?: {
     return null;
   }
 
+  const compressionConfig = options?.config?.agents?.defaults?.imageCompression;
+  const compressionSettings = resolveImageCompressionSettings({
+    compression: compressionConfig,
+  });
+
   // If model has native vision, images in the prompt are auto-injected
   // so this tool is only needed when image wasn't provided in the prompt
   const description = options?.modelHasVision
@@ -456,10 +462,16 @@ export function createImageTool(options?: {
                 maxBytes,
                 sandboxValidated: true,
                 readFile: createSandboxBridgeReadFile({ sandbox: sandboxConfig }),
+                skipOptimization: !compressionSettings.optimize,
+                maxSideOverride: compressionSettings.maxSide,
+                qualityOverride: compressionSettings.quality,
               })
             : await loadWebMedia(resolvedPath ?? resolvedImage, {
                 maxBytes,
                 localRoots,
+                skipOptimization: !compressionSettings.optimize,
+                maxSideOverride: compressionSettings.maxSide,
+                qualityOverride: compressionSettings.quality,
               });
         if (media.kind !== "image") {
           throw new Error(`Unsupported media type: ${media.kind}`);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -988,6 +988,13 @@ export const FIELD_HELP: Record<string, string> = {
     "Maximum number of PDF pages to process for the PDF tool (default: 20).",
   "agents.defaults.imageMaxDimensionPx":
     "Max image side length in pixels when sanitizing transcript/tool-result image payloads (default: 1200).",
+  "agents.defaults.imageCompression": `Controls image quality when analyzing images with the image tool.
+Accepts a preset ("none", "low", "medium", "high") or detailed settings:
+- none: No compression, send original image (may hit API limits)
+- low: max 800px side, quality 50 (smallest payload, lowest quality)
+- medium: max 1200px side, quality 70 (balanced, default)
+- high: max 2000px side, quality 95 (best quality, larger payload)
+Or use detailed config: { maxWidth: 2000, maxHeight: 2000, quality: 95 }`,
   "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",
   "agents.defaults.compaction":
     "Compaction tuning for when context nears token limits, including history share, reserve headroom, and pre-compaction memory flush behavior. Use this when long-running sessions need stable continuity under tight context windows.",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -442,6 +442,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.pdfMaxBytesMb": "PDF Max Size (MB)",
   "agents.defaults.pdfMaxPages": "PDF Max Pages",
   "agents.defaults.imageMaxDimensionPx": "Image Max Dimension (px)",
+  "agents.defaults.imageCompression": "Image Compression",
   "agents.defaults.humanDelay.mode": "Human Delay Mode",
   "agents.defaults.humanDelay.minMs": "Human Delay Min (ms)",
   "agents.defaults.humanDelay.maxMs": "Human Delay Max (ms)",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -8,6 +8,33 @@ import type {
 } from "./types.base.js";
 import type { MemorySearchConfig } from "./types.tools.js";
 
+/**
+ * Image compression preset modes for the image tool.
+ * - "none": No compression, send original image
+ * - "low": Aggressive compression (max 800px side, quality 50)
+ * - "medium": Balanced compression (max 1200px side, quality 70)
+ * - "high": Minimal compression (max 2000px side, quality 95)
+ */
+export type ImageCompressionPreset = "none" | "low" | "medium" | "high";
+
+/**
+ * Detailed image compression settings for fine-grained control.
+ */
+export type ImageCompressionDetailConfig = {
+  /** Maximum image width in pixels. Default: 2000 */
+  maxWidth?: number;
+  /** Maximum image height in pixels. Default: 2000 */
+  maxHeight?: number;
+  /** JPEG quality (1-100). Default: 95 */
+  quality?: number;
+};
+
+/**
+ * Image compression configuration for the image tool.
+ * Accepts either a preset string or detailed settings object.
+ */
+export type ImageCompressionConfig = ImageCompressionPreset | ImageCompressionDetailConfig;
+
 export type AgentModelEntryConfig = {
   alias?: string;
   /** Provider-specific API parameters (e.g., GLM-4.7 thinking mode). */
@@ -214,6 +241,14 @@ export type AgentDefaultsConfig = {
    * Default: 1200.
    */
   imageMaxDimensionPx?: number;
+  /**
+   * Image compression settings for the image tool.
+   * Controls quality/resolution when sending images to vision models.
+   * - Preset mode: "none" | "low" | "medium" | "high"
+   * - Detail mode: { maxWidth?: number; maxHeight?: number; quality?: number }
+   * Default: "medium" (max 1200px side, quality 70)
+   */
+  imageCompression?: ImageCompressionConfig;
   typingIntervalSeconds?: number;
   /** Typing indicator start mode (never|instant|thinking|message). */
   typingMode?: TypingMode;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -156,6 +156,18 @@ export const AgentDefaultsSchema = z
     timeoutSeconds: z.number().int().positive().optional(),
     mediaMaxMb: z.number().positive().optional(),
     imageMaxDimensionPx: z.number().int().positive().optional(),
+    imageCompression: z
+      .union([
+        z.union([z.literal("none"), z.literal("low"), z.literal("medium"), z.literal("high")]),
+        z
+          .object({
+            maxWidth: z.number().int().positive().optional(),
+            maxHeight: z.number().int().positive().optional(),
+            quality: z.number().int().min(1).max(100).optional(),
+          })
+          .strict(),
+      ])
+      .optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),
     typingMode: TypingModeSchema.optional(),
     heartbeat: HeartbeatSchema,

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -247,6 +247,9 @@ async function loadWebMediaInternal(
     localRoots,
     sandboxValidated = false,
     readFile: readFileOverride,
+    maxSideOverride,
+    qualityOverride,
+    skipOptimization,
   } = options;
   // Strip MEDIA: prefix used by agent tools (e.g. TTS) to tag media paths.
   // Be lenient: LLM output may add extra whitespace (e.g. "  MEDIA :  /tmp/x.png").
@@ -298,7 +301,8 @@ async function loadWebMediaInternal(
     const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind ?? "document");
     if (params.kind === "image") {
       const isGif = params.contentType === "image/gif";
-      if (isGif || !optimizeImages) {
+      // Skip optimization if explicitly requested, GIF, or optimization disabled
+      if (isGif || !optimizeImages || skipOptimization) {
         if (params.buffer.length > cap) {
           throw new Error(formatCapLimit(isGif ? "GIF" : "Media", cap, params.buffer.length));
         }
@@ -309,6 +313,41 @@ async function loadWebMediaInternal(
           fileName: params.fileName,
         };
       }
+
+      // Use custom settings if both overrides provided
+      if (maxSideOverride !== undefined && qualityOverride !== undefined) {
+        const originalSize = params.buffer.length;
+        const optimized = await optimizeImageToJpegWithOverrides(params.buffer, cap, {
+          contentType: params.contentType,
+          fileName: params.fileName,
+          maxSide: maxSideOverride,
+          quality: qualityOverride,
+        });
+        logOptimizedImage({
+          originalSize,
+          optimized: {
+            buffer: optimized.buffer,
+            optimizedSize: optimized.optimizedSize,
+            resizeSide: optimized.resizeSide,
+            format: "jpeg",
+            quality: optimized.quality,
+          },
+        });
+
+        if (optimized.buffer.length > cap) {
+          throw new Error(formatCapReduce("Media", cap, optimized.buffer.length));
+        }
+
+        return {
+          buffer: optimized.buffer,
+          contentType: "image/jpeg",
+          kind: params.kind,
+          fileName: isHeicSource({ fileName: params.fileName })
+            ? toJpegFileName(params.fileName)
+            : params.fileName,
+        };
+      }
+
       return {
         ...(await optimizeAndClampImage(params.buffer, cap, {
           contentType: params.contentType,

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -32,6 +32,12 @@ type WebMediaOptions = {
   /** Caller already validated the local path (sandbox/other guards); requires readFile override. */
   sandboxValidated?: boolean;
   readFile?: (filePath: string) => Promise<Buffer>;
+  /** Custom max side length for image optimization (overrides default grid) */
+  maxSideOverride?: number;
+  /** Custom quality for image optimization (overrides default grid) */
+  qualityOverride?: number;
+  /** Skip image optimization entirely */
+  skipOptimization?: boolean;
 };
 
 function resolveWebMediaOptions(params: {
@@ -488,6 +494,53 @@ export async function optimizeImageToJpeg(
   }
 
   throw new Error("Failed to optimize image");
+}
+
+/**
+ * Optimize image to JPEG with optional custom maxSide and quality overrides.
+ * When both overrides are provided, uses them directly instead of grid search.
+ */
+export async function optimizeImageToJpegWithOverrides(
+  buffer: Buffer,
+  maxBytes: number,
+  opts: {
+    contentType?: string;
+    fileName?: string;
+    maxSide?: number;
+    quality?: number;
+  } = {},
+): Promise<{
+  buffer: Buffer;
+  optimizedSize: number;
+  resizeSide: number;
+  quality: number;
+}> {
+  // If both overrides provided, use them directly
+  if (opts.maxSide !== undefined && opts.quality !== undefined) {
+    let source = buffer;
+    if (isHeicSource(opts)) {
+      try {
+        source = await convertHeicToJpeg(buffer);
+      } catch (err) {
+        throw new Error(`HEIC image conversion failed: ${String(err)}`, { cause: err });
+      }
+    }
+    const out = await resizeToJpeg({
+      buffer: source,
+      maxSide: opts.maxSide,
+      quality: opts.quality,
+      withoutEnlargement: true,
+    });
+    return {
+      buffer: out,
+      optimizedSize: out.length,
+      resizeSide: opts.maxSide,
+      quality: opts.quality,
+    };
+  }
+
+  // Otherwise fall back to existing grid search
+  return optimizeImageToJpeg(buffer, maxBytes, opts);
 }
 
 export { optimizeImageToPng };

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -316,6 +316,9 @@ async function loadWebMediaInternal(
 
       // Use custom settings if both overrides provided
       if (maxSideOverride !== undefined && qualityOverride !== undefined) {
+        console.log(
+          `[media] Using compression overrides: maxSide=${maxSideOverride}, quality=${qualityOverride}`,
+        );
         const originalSize = params.buffer.length;
         const optimized = await optimizeImageToJpegWithOverrides(params.buffer, cap, {
           contentType: params.contentType,
@@ -323,6 +326,9 @@ async function loadWebMediaInternal(
           maxSide: maxSideOverride,
           quality: qualityOverride,
         });
+        console.log(
+          `[media] Compressed: ${originalSize} -> ${optimized.optimizedSize} bytes (side=${optimized.resizeSide}, q=${optimized.quality})`,
+        );
         logOptimizedImage({
           originalSize,
           optimized: {


### PR DESCRIPTION
## Summary

- **Problem:** The image tool automatically compresses images when sending to vision models, but compression parameters (resolution, quality) were not configurable.
- **Why it matters:** Text-rich images (documents, contracts, business licenses) require higher quality settings for accurate OCR recognition. The default compression (max 2048px, quality 80–40) was too aggressive, causing loss of critical details.
- **What changed:** Added `agents.defaults.imageCompression` config option supporting both preset modes (`none`, `low`, `medium`, `high`) and detailed settings (`{ maxWidth, maxHeight, quality }`). Applied compression settings across all image processing paths: Image Tool, Native Vision (prompt image references), and message attachment images.
- **What did NOT change (scope boundary):** The existing `imageMaxDimensionPx` config and `agents/tool-images` transcript sanitization remain unchanged — these handle conversation history image cleanup, not vision model input quality.

---

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

---

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

---

## Linked Issue/PR


- Related Issue：
[[Feature]: Image tools support configuring image compression quality.](https://github.com/openclaw/openclaw/issues/41632)

---

## User-visible / Behavior Changes

New config option: `agents.defaults.imageCompression`

| Preset | Max Side | Quality | Use Case                       |
|--------|----------|---------|--------------------------------|
| `none`   | —        | —       | No compression, original image |
| `low`    | 800px    | 50      | Smallest payload               |
| `medium` | 1200px   | 70      | Balanced **(default)**         |
| `high`   | 2000px   | 95      | Text-heavy documents           |

Example config:

```yaml
agents:
  defaults:
    imageCompression: high  # or detailed:
    # imageCompression:
    #   maxWidth: 2000
    #   maxHeight: 2000
    #   quality: 95
```

---

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

---

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1. Set `agents.defaults.imageCompression: high` in config
2. Send a text-heavy image (e.g., a contract or business license) to the vision model
3. Observe OCR accuracy compared to default compression settings

### Expected

- Image is processed at higher resolution (max 2000px, quality 95)
- OCR output retains critical text details

### Actual

- Image is compressed according to the configured preset or detailed settings
- Text recognition accuracy improves for document-type images

---

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**64 tests passing across:**
- ✅ `src/agents/tools/image-compression.test.ts` (9 tests)
- ✅ `src/agents/pi-embedded-runner/run/images.test.ts` (27 tests)
- ✅ `src/agents/tools/image-tool.test.ts` (28 tests)

---

## Human Verification (required)

- **Verified scenarios:** Config parsing, preset resolution, detailed config handling
- **Edge cases checked:** Data URL images, message attachments, and prompt references all correctly apply compression settings
- **What you did NOT verify:** Actual OCR accuracy improvement — requires real-world user testing with document images

---

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

---

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — New optional config key `agents.defaults.imageCompression`
- Migration needed? `No`

---

## Failure Recovery (if this breaks)

- **How to disable/revert quickly:** Remove `imageCompression` from config, or explicitly set it to `none` to bypass all compression
- **Files/config to restore:** `agents.defaults.imageCompression` entry in agent config
- **Known bad symptoms to watch for:**
  - API payload size errors when using `none` preset with large images
  - Unexpected token cost increases when `high` preset is set globally

---

## Risks and Mitigations

- **Risk:** Higher quality settings (`high` / `none`) increase token usage and API costs
  - **Mitigation:** Default is `medium`; users must explicitly opt into `high` or `none`
- **Risk:** `none` preset may exceed API payload size limits for large images
  - **Mitigation:** Documentation warns against this; recommended only when strictly necessary