### PR TITLE
fix(gateway): aggregate usage.cost across agents

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import * as sessionUtils from "../session-utils.js";
 
 vi.mock("../../infra/session-cost-usage.js", async () => {
   const actual = await vi.importActual<typeof import("../../infra/session-cost-usage.js")>(
@@ -157,5 +158,127 @@ describe("gateway usage helpers", () => {
     expect(a.totals.totalTokens).toBe(1);
     expect(b.totals.totalTokens).toBe(1);
     expect(vi.mocked(loadCostUsageSummary)).toHaveBeenCalledTimes(1);
+  });
+
+  it("aggregates usage.cost across all configured agents", async () => {
+    vi.spyOn(sessionUtils, "listAgentsForGateway").mockReturnValue({
+      agents: [{ id: "main" }, { id: "slack-agent" }],
+    } as ReturnType<typeof sessionUtils.listAgentsForGateway>);
+    vi.mocked(loadCostUsageSummary).mockImplementation(async (params) => {
+      if (params?.agentId === "slack-agent") {
+        return {
+          updatedAt: Date.now(),
+          days: 1,
+          daily: [
+            {
+              date: "2026-02-05",
+              input: 1,
+              output: 2,
+              cacheRead: 3,
+              cacheWrite: 4,
+              totalTokens: 10,
+              totalCost: 1.25,
+              inputCost: 0.2,
+              outputCost: 0.3,
+              cacheReadCost: 0.35,
+              cacheWriteCost: 0.4,
+              missingCostEntries: 0,
+            },
+          ],
+          totals: {
+            input: 1,
+            output: 2,
+            cacheRead: 3,
+            cacheWrite: 4,
+            totalTokens: 10,
+            totalCost: 1.25,
+            inputCost: 0.2,
+            outputCost: 0.3,
+            cacheReadCost: 0.35,
+            cacheWriteCost: 0.4,
+            missingCostEntries: 0,
+          },
+        };
+      }
+      return {
+        updatedAt: Date.now(),
+        days: 1,
+        daily: [
+          {
+            date: "2026-02-05",
+            input: 5,
+            output: 6,
+            cacheRead: 7,
+            cacheWrite: 8,
+            totalTokens: 30,
+            totalCost: 2.75,
+            inputCost: 0.5,
+            outputCost: 0.7,
+            cacheReadCost: 0.75,
+            cacheWriteCost: 0.8,
+            missingCostEntries: 1,
+          },
+        ],
+        totals: {
+          input: 5,
+          output: 6,
+          cacheRead: 7,
+          cacheWrite: 8,
+          totalTokens: 30,
+          totalCost: 2.75,
+          inputCost: 0.5,
+          outputCost: 0.7,
+          cacheReadCost: 0.75,
+          cacheWriteCost: 0.8,
+          missingCostEntries: 1,
+        },
+      };
+    });
+
+    const config = {} as OpenClawConfig;
+    const summary = await __test.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+    });
+
+    expect(vi.mocked(loadCostUsageSummary)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(loadCostUsageSummary)).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ agentId: "main", startMs: 1, endMs: 2 }),
+    );
+    expect(vi.mocked(loadCostUsageSummary)).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ agentId: "slack-agent", startMs: 1, endMs: 2 }),
+    );
+    expect(summary.totals).toEqual({
+      input: 6,
+      output: 8,
+      cacheRead: 10,
+      cacheWrite: 12,
+      totalTokens: 40,
+      totalCost: 4,
+      inputCost: 0.7,
+      outputCost: 1,
+      cacheReadCost: 1.1,
+      cacheWriteCost: 1.2000000000000002,
+      missingCostEntries: 1,
+    });
+    expect(summary.daily).toEqual([
+      {
+        date: "2026-02-05",
+        input: 6,
+        output: 8,
+        cacheRead: 10,
+        cacheWrite: 12,
+        totalTokens: 40,
+        totalCost: 4,
+        inputCost: 0.7,
+        outputCost: 1,
+        cacheReadCost: 1.1,
+        cacheWriteCost: 1.2000000000000002,
+        missingCostEntries: 1,
+      },
+    ]);
   });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -59,6 +59,72 @@ type CostUsageCacheEntry = {
 
 const costUsageCache = new Map<string, CostUsageCacheEntry>();
 
+function createEmptyCostUsageTotals(): CostUsageSummary["totals"] {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    totalCost: 0,
+    inputCost: 0,
+    outputCost: 0,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+    missingCostEntries: 0,
+  };
+}
+
+function mergeCostUsageTotals(
+  target: CostUsageSummary["totals"],
+  source: Partial<CostUsageSummary["totals"]> | undefined,
+): void {
+  if (!source) {
+    return;
+  }
+  target.input += source.input ?? 0;
+  target.output += source.output ?? 0;
+  target.cacheRead += source.cacheRead ?? 0;
+  target.cacheWrite += source.cacheWrite ?? 0;
+  target.totalTokens += source.totalTokens ?? 0;
+  target.totalCost += source.totalCost ?? 0;
+  target.inputCost += source.inputCost ?? 0;
+  target.outputCost += source.outputCost ?? 0;
+  target.cacheReadCost += source.cacheReadCost ?? 0;
+  target.cacheWriteCost += source.cacheWriteCost ?? 0;
+  target.missingCostEntries += source.missingCostEntries ?? 0;
+}
+
+function mergeCostUsageSummaries(params: {
+  summaries: CostUsageSummary[];
+  startMs: number;
+  endMs: number;
+}): CostUsageSummary {
+  const totals = createEmptyCostUsageTotals();
+  const dailyMap = new Map<string, CostUsageSummary["daily"][number]>();
+
+  for (const summary of params.summaries) {
+    mergeCostUsageTotals(totals, summary.totals);
+    for (const day of summary.daily ?? []) {
+      const existing =
+        dailyMap.get(day.date) ??
+        ({
+          date: day.date,
+          ...createEmptyCostUsageTotals(),
+        } satisfies CostUsageSummary["daily"][number]);
+      mergeCostUsageTotals(existing, day);
+      dailyMap.set(day.date, existing);
+    }
+  }
+
+  return {
+    updatedAt: Date.now(),
+    days: Math.ceil((params.endMs - params.startMs) / DAY_MS) + 1,
+    daily: Array.from(dailyMap.values()).toSorted((a, b) => a.date.localeCompare(b.date)),
+    totals,
+  };
+}
+
 function resolveSessionUsageFileOrRespond(
   key: string,
   respond: RespondFn,
@@ -284,7 +350,11 @@ async function loadCostUsageSummaryCached(params: {
   endMs: number;
   config: ReturnType<typeof loadConfig>;
 }): Promise<CostUsageSummary> {
-  const cacheKey = `${params.startMs}-${params.endMs}`;
+  const agentIds = listAgentsForGateway(params.config)
+    .agents.map((agent) => agent.id)
+    .toSorted();
+  const effectiveAgentIds = agentIds.length ? agentIds : ["main"];
+  const cacheKey = `${params.startMs}-${params.endMs}-${effectiveAgentIds.join(",")}`;
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
@@ -299,11 +369,23 @@ async function loadCostUsageSummaryCached(params: {
   }
 
   const entry: CostUsageCacheEntry = cached ?? {};
-  const inFlight = loadCostUsageSummary({
-    startMs: params.startMs,
-    endMs: params.endMs,
-    config: params.config,
-  })
+  const inFlight = Promise.all(
+    effectiveAgentIds.map((agentId) =>
+      loadCostUsageSummary({
+        startMs: params.startMs,
+        endMs: params.endMs,
+        config: params.config,
+        agentId,
+      }),
+    ),
+  )
+    .then((summaries) =>
+      mergeCostUsageSummaries({
+        summaries,
+        startMs: params.startMs,
+        endMs: params.endMs,
+      }),
+    )
     .then((summary) => {
       costUsageCache.set(cacheKey, { summary, updatedAt: Date.now() });
       return summary;


### PR DESCRIPTION
## Summary
- aggregate `usage.cost` across all configured gateway agents instead of only the main agent
- merge per-agent daily/totals data before caching so the Usage header and daily cost chart use the same scope
- add a gateway unit test covering multi-agent aggregation

## Testing
- `./node_modules/.bin/vitest run src/gateway/server-methods/usage.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts --config vitest.gateway.config.ts`
- `./node_modules/.bin/oxfmt --check src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.test.ts`
- `node --import tsx - <<'TS' ... __test.loadCostUsageSummaryCached(...) ... TS` (local smoke check against configured agents)

Fixes #41986.
