### PR TITLE
UI: add global locale switch and complete zh-CN dashboard translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,6 +330,8 @@
     "tui:dev": "OPENCLAW_PROFILE=dev CLAWDBOT_PROFILE=dev node scripts/run-node.mjs --dev tui",
     "ui:build": "node scripts/ui.js build",
     "ui:dev": "node scripts/ui.js dev",
+    "ui:i18n:check:zh-CN": "node --import tsx scripts/ui-i18n-report.ts --locale zh-CN --strict",
+    "ui:i18n:report": "node --import tsx scripts/ui-i18n-report.ts",
     "ui:install": "node scripts/ui.js install"
   },
   "dependencies": {

--- a/scripts/ui-i18n-report.ts
+++ b/scripts/ui-i18n-report.ts
@@ -1,11 +1,11 @@
 import { parseArgs } from "node:util";
+import type { Locale, TranslationMap } from "../ui/src/i18n/lib/types.ts";
 import { de } from "../ui/src/i18n/locales/de.ts";
 import { en } from "../ui/src/i18n/locales/en.ts";
 import { es } from "../ui/src/i18n/locales/es.ts";
 import { pt_BR } from "../ui/src/i18n/locales/pt-BR.ts";
 import { zh_CN } from "../ui/src/i18n/locales/zh-CN.ts";
 import { zh_TW } from "../ui/src/i18n/locales/zh-TW.ts";
-import type { Locale, TranslationMap } from "../ui/src/i18n/lib/types.ts";
 
 type LocaleRegistry = Record<Locale, TranslationMap>;
 

--- a/scripts/ui-i18n-report.ts
+++ b/scripts/ui-i18n-report.ts
@@ -1,0 +1,121 @@
+import { parseArgs } from "node:util";
+import { de } from "../ui/src/i18n/locales/de.ts";
+import { en } from "../ui/src/i18n/locales/en.ts";
+import { es } from "../ui/src/i18n/locales/es.ts";
+import { pt_BR } from "../ui/src/i18n/locales/pt-BR.ts";
+import { zh_CN } from "../ui/src/i18n/locales/zh-CN.ts";
+import { zh_TW } from "../ui/src/i18n/locales/zh-TW.ts";
+import type { Locale, TranslationMap } from "../ui/src/i18n/lib/types.ts";
+
+type LocaleRegistry = Record<Locale, TranslationMap>;
+
+const LOCALES: LocaleRegistry = {
+  en,
+  "zh-CN": zh_CN,
+  "zh-TW": zh_TW,
+  "pt-BR": pt_BR,
+  de,
+  es,
+};
+
+type Report = {
+  locale: Locale;
+  translated: number;
+  total: number;
+  missing: string[];
+  extra: string[];
+};
+
+function flattenTranslationKeys(map: TranslationMap, prefix = ""): string[] {
+  const keys: string[] = [];
+  for (const [key, value] of Object.entries(map)) {
+    const next = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "string") {
+      keys.push(next);
+      continue;
+    }
+    keys.push(...flattenTranslationKeys(value, next));
+  }
+  return keys;
+}
+
+function buildReport(locale: Locale): Report {
+  const source = new Set(flattenTranslationKeys(LOCALES.en));
+  const target = new Set(flattenTranslationKeys(LOCALES[locale]));
+  const missing = [...source].filter((key) => !target.has(key)).toSorted();
+  const extra = [...target].filter((key) => !source.has(key)).toSorted();
+  const translated = source.size - missing.length;
+  return {
+    locale,
+    translated,
+    total: source.size,
+    missing,
+    extra,
+  };
+}
+
+function formatCoverage(translated: number, total: number): string {
+  if (total === 0) {
+    return "0.0";
+  }
+  return ((translated / total) * 100).toFixed(1);
+}
+
+function parseLocaleValues(raw: string[]): Locale[] {
+  const supported = new Set<Locale>(Object.keys(LOCALES) as Locale[]);
+  const locales: Locale[] = [];
+  for (const entry of raw) {
+    if (!supported.has(entry as Locale)) {
+      console.error(
+        `Unsupported locale "${entry}". Supported locales: ${[...supported].join(", ")}`,
+      );
+      process.exit(1);
+    }
+    locales.push(entry as Locale);
+  }
+  return locales;
+}
+
+function printReport(report: Report) {
+  const coverage = formatCoverage(report.translated, report.total);
+  console.log(
+    `${report.locale}: ${report.translated}/${report.total} (${coverage}%) translated, missing=${report.missing.length}, extra=${report.extra.length}`,
+  );
+  if (report.missing.length > 0) {
+    console.log("  Missing keys:");
+    report.missing.forEach((key) => console.log(`    - ${key}`));
+  }
+  if (report.extra.length > 0) {
+    console.log("  Extra keys:");
+    report.extra.forEach((key) => console.log(`    - ${key}`));
+  }
+}
+
+const args = parseArgs({
+  options: {
+    locale: {
+      type: "string",
+      multiple: true,
+    },
+    strict: {
+      type: "boolean",
+      default: false,
+    },
+  },
+  allowPositionals: false,
+});
+
+const selectedLocales =
+  args.values.locale && args.values.locale.length > 0
+    ? parseLocaleValues(args.values.locale)
+    : (Object.keys(LOCALES) as Locale[]).filter((locale) => locale !== "en");
+
+const reports = selectedLocales.map(buildReport);
+for (const report of reports) {
+  printReport(report);
+}
+
+const hasProblems = reports.some((report) => report.missing.length > 0 || report.extra.length > 0);
+if (args.values.strict && hasProblems) {
+  process.exit(1);
+}

--- a/ui/src/i18n/README.md
+++ b/ui/src/i18n/README.md
@@ -1,0 +1,29 @@
+# Control UI i18n
+
+This folder contains translations for the OpenClaw dashboard UI.
+
+## File layout
+
+- `locales/en.ts`: English source of truth.
+- `locales/<locale>.ts`: locale translations loaded at runtime.
+- `lib/registry.ts`: supported locale list + lazy-load mapping.
+- `lib/types.ts`: locale type union.
+
+## Add or update a translation
+
+1. Copy keys from `locales/en.ts` and translate values in your locale file.
+2. Run `pnpm ui:i18n:report` to see missing or extra keys.
+3. For Chinese (Simplified) parity gate, run `pnpm ui:i18n:check:zh-CN`.
+
+## Add a new locale
+
+1. Add `ui/src/i18n/locales/<locale>.ts`.
+2. Add the locale to `Locale` in `ui/src/i18n/lib/types.ts`.
+3. Register lazy loading in `ui/src/i18n/lib/registry.ts`.
+4. Add a display name under `languages.*` in `locales/en.ts` (and optionally in other locales).
+5. Run `pnpm ui:i18n:report -- --locale <locale>`.
+
+## Notes
+
+- Missing keys fall back to English.
+- Keep keys stable; do not rename keys unless all locales are updated.

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -8,11 +8,13 @@ export const en: TranslationMap = {
     offline: "Offline",
     connect: "Connect",
     refresh: "Refresh",
+    language: "Language",
     enabled: "Enabled",
     disabled: "Disabled",
     na: "n/a",
     docs: "Docs",
     resources: "Resources",
+    openInNewTab: "opens in new tab",
   },
   nav: {
     chat: "Chat",
@@ -52,6 +54,24 @@ export const en: TranslationMap = {
     debug: "Gateway snapshots, events, and manual RPC calls.",
     logs: "Live tail of the gateway file logs.",
   },
+  shell: {
+    subtitle: "Gateway Dashboard",
+    update: {
+      available: "Update available:",
+      updating: "Updating...",
+      updateNow: "Update now",
+      running: "(running v{version}).",
+    },
+  },
+  theme: {
+    label: "Theme",
+    system: "System",
+    systemAria: "System theme",
+    light: "Light",
+    lightAria: "Light theme",
+    dark: "Dark",
+    darkAria: "Dark theme",
+  },
   overview: {
     access: {
       title: "Gateway Access",
@@ -59,6 +79,7 @@ export const en: TranslationMap = {
       wsUrl: "WebSocket URL",
       token: "Gateway Token",
       password: "Password (not stored)",
+      passwordPlaceholder: "system or shared password",
       sessionKey: "Default Session Key",
       language: "Language",
       connectHint: "Click Connect to apply connection changes.",
@@ -95,6 +116,8 @@ export const en: TranslationMap = {
       required: "This gateway requires auth. Add a token or password, then click Connect.",
       failed:
         "Auth failed. Re-copy a tokenized URL with {command}, or update the token, then click Connect.",
+      tokenizedUrlHint: "tokenized URL",
+      setTokenHint: "set token",
     },
     pairing: {
       hint: "This device needs pairing approval from the gateway host.",
@@ -104,6 +127,16 @@ export const en: TranslationMap = {
     insecure: {
       hint: "This page is HTTP, so the browser blocks device identity. Use HTTPS (Tailscale Serve) or open {url} on the gateway host.",
       stayHttp: "If you must stay on HTTP, set {config} (token-only).",
+    },
+    docs: {
+      devicePairingTitle: "Device pairing docs ({openInNewTab})",
+      devicePairingLink: "Docs: Device pairing",
+      controlUiAuthTitle: "Control UI auth docs ({openInNewTab})",
+      controlUiAuthLink: "Docs: Control UI auth",
+      tailscaleServeTitle: "Tailscale Serve docs ({openInNewTab})",
+      tailscaleServeLink: "Docs: Tailscale Serve",
+      insecureHttpTitle: "Insecure HTTP docs ({openInNewTab})",
+      insecureHttpLink: "Docs: Insecure HTTP",
     },
   },
   chat: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -78,8 +78,8 @@ export const en: TranslationMap = {
       subtitle: "Where the dashboard connects and how it authenticates.",
       wsUrl: "WebSocket URL",
       token: "Gateway Token",
-      password: "Password (not stored)",
-      passwordPlaceholder: "system or shared password",
+      password: "Password (not stored)", // pragma: allowlist secret
+      passwordPlaceholder: "system or shared password", // pragma: allowlist secret
       sessionKey: "Default Session Key",
       language: "Language",
       connectHint: "Click Connect to apply connection changes.",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -8,11 +8,13 @@ export const zh_CN: TranslationMap = {
     offline: "离线",
     connect: "连接",
     refresh: "刷新",
+    language: "语言",
     enabled: "已启用",
     disabled: "已禁用",
     na: "不适用",
     docs: "文档",
     resources: "资源",
+    openInNewTab: "在新标签页中打开",
   },
   nav: {
     chat: "聊天",
@@ -52,6 +54,24 @@ export const zh_CN: TranslationMap = {
     debug: "网关快照、事件和手动 RPC 调用。",
     logs: "网关文件日志的实时追踪。",
   },
+  shell: {
+    subtitle: "网关控制台",
+    update: {
+      available: "发现新版本：",
+      updating: "更新中...",
+      updateNow: "立即更新",
+      running: "（当前运行 v{version}）。",
+    },
+  },
+  theme: {
+    label: "主题",
+    system: "跟随系统",
+    systemAria: "系统主题",
+    light: "浅色",
+    lightAria: "浅色主题",
+    dark: "深色",
+    darkAria: "深色主题",
+  },
   overview: {
     access: {
       title: "网关访问",
@@ -59,6 +79,7 @@ export const zh_CN: TranslationMap = {
       wsUrl: "WebSocket URL",
       token: "网关令牌",
       password: "密码 (不存储)",
+      passwordPlaceholder: "系统密码或共享密码",
       sessionKey: "默认会话密钥",
       language: "语言",
       connectHint: "点击连接以应用连接更改。",
@@ -94,6 +115,8 @@ export const zh_CN: TranslationMap = {
     auth: {
       required: "此网关需要身份验证。添加令牌或密码，然后点击连接。",
       failed: "身份验证失败。请使用 {command} 重新复制令牌化 URL，或更新令牌，然后点击连接。",
+      tokenizedUrlHint: "带令牌的 URL",
+      setTokenHint: "设置令牌",
     },
     pairing: {
       hint: "此设备需要网关主机的配对批准。",
@@ -103,6 +126,16 @@ export const zh_CN: TranslationMap = {
     insecure: {
       hint: "此页面为 HTTP，因此浏览器阻止设备标识。请使用 HTTPS (Tailscale Serve) 或在网关主机上打开 {url}。",
       stayHttp: "如果您必须保持 HTTP，请设置 {config} (仅限令牌)。",
+    },
+    docs: {
+      devicePairingTitle: "设备配对文档（{openInNewTab}）",
+      devicePairingLink: "文档：设备配对",
+      controlUiAuthTitle: "控制台鉴权文档（{openInNewTab}）",
+      controlUiAuthLink: "文档：控制台鉴权",
+      tailscaleServeTitle: "Tailscale Serve 文档（{openInNewTab}）",
+      tailscaleServeLink: "文档：Tailscale Serve",
+      insecureHttpTitle: "不安全 HTTP 文档（{openInNewTab}）",
+      insecureHttpLink: "文档：不安全 HTTP",
     },
   },
   chat: {
@@ -140,6 +173,8 @@ export const zh_CN: TranslationMap = {
       searchJobs: "搜索任务",
       searchPlaceholder: "名称、描述或代理",
       enabled: "启用状态",
+      schedule: "调度",
+      lastRun: "上次运行",
       all: "全部",
       sort: "排序",
       nextRun: "下次运行",
@@ -148,6 +183,7 @@ export const zh_CN: TranslationMap = {
       direction: "方向",
       ascending: "升序",
       descending: "降序",
+      reset: "重置",
       noMatching: "没有匹配的任务。",
       loading: "加载中...",
       loadMore: "加载更多任务",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -78,8 +78,8 @@ export const zh_CN: TranslationMap = {
       subtitle: "仪表板连接的位置及其身份验证方式。",
       wsUrl: "WebSocket URL",
       token: "网关令牌",
-      password: "密码 (不存储)",
-      passwordPlaceholder: "系统密码或共享密码",
+      password: "密码 (不存储)", // pragma: allowlist secret
+      passwordPlaceholder: "系统密码或共享密码", // pragma: allowlist secret
       sessionKey: "默认会话密钥",
       language: "语言",
       connectHint: "点击连接以应用连接更改。",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -190,6 +190,42 @@
   height: 12px;
 }
 
+.topbar-locale {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+}
+
+.topbar-locale__label {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.topbar-locale__select {
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 500;
+  min-width: 96px;
+  padding: 0;
+  outline: none;
+}
+
+.topbar-locale__select:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
 /* ===========================================
    Navigation Sidebar
    =========================================== */

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -94,6 +94,20 @@
     display: none;
   }
 
+  .topbar-locale {
+    padding: 0 6px;
+    gap: 4px;
+  }
+
+  .topbar-locale__label {
+    display: none;
+  }
+
+  .topbar-locale__select {
+    min-width: 88px;
+    font-size: 11px;
+  }
+
   /* Nav */
   .nav {
     padding: 8px 10px;
@@ -358,6 +372,16 @@
 
   .topbar-status .pill {
     padding: 3px 6px;
+    font-size: 10px;
+  }
+
+  .topbar-locale {
+    min-height: 28px;
+    padding: 0 4px;
+  }
+
+  .topbar-locale__select {
+    min-width: 72px;
     font-size: 10px;
   }
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,6 +1,6 @@
 import { html } from "lit";
 import { repeat } from "lit/directives/repeat.js";
-import { t } from "../i18n/index.ts";
+import { i18n, isSupportedLocale, SUPPORTED_LOCALES, t } from "../i18n/index.ts";
 import { refreshChat } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
@@ -489,6 +489,34 @@ function countHiddenCronSessions(sessionKey: string, sessions: SessionsListResul
 
 const THEME_ORDER: ThemeMode[] = ["system", "light", "dark"];
 
+export function renderLocaleSwitcher(state: AppViewState) {
+  const currentLocale = i18n.getLocale();
+
+  return html`
+    <label class="topbar-locale">
+      <span class="topbar-locale__label">${t("common.language")}</span>
+      <select
+        class="topbar-locale__select"
+        .value=${currentLocale}
+        @change=${(event: Event) => {
+          const value = (event.target as HTMLSelectElement).value;
+          if (!isSupportedLocale(value)) {
+            return;
+          }
+          void i18n.setLocale(value);
+          state.applySettings({ ...state.settings, locale: value });
+        }}
+        aria-label=${t("common.language")}
+      >
+        ${SUPPORTED_LOCALES.map((loc) => {
+          const key = loc.replace(/-([a-zA-Z])/g, (_, c: string) => c.toUpperCase());
+          return html`<option value=${loc}>${t(`languages.${key}`)}</option>`;
+        })}
+      </select>
+    </label>
+  `;
+}
+
 export function renderThemeToggle(state: AppViewState) {
   const index = Math.max(0, THEME_ORDER.indexOf(state.theme));
   const applyTheme = (next: ThemeMode) => (event: MouseEvent) => {
@@ -503,14 +531,14 @@ export function renderThemeToggle(state: AppViewState) {
 
   return html`
     <div class="theme-toggle" style="--theme-index: ${index};">
-      <div class="theme-toggle__track" role="group" aria-label="Theme">
+      <div class="theme-toggle__track" role="group" aria-label=${t("theme.label")}>
         <span class="theme-toggle__indicator"></span>
         <button
           class="theme-toggle__button ${state.theme === "system" ? "active" : ""}"
           @click=${applyTheme("system")}
           aria-pressed=${state.theme === "system"}
-          aria-label="System theme"
-          title="System"
+          aria-label=${t("theme.systemAria")}
+          title=${t("theme.system")}
         >
           ${renderMonitorIcon()}
         </button>
@@ -518,8 +546,8 @@ export function renderThemeToggle(state: AppViewState) {
           class="theme-toggle__button ${state.theme === "light" ? "active" : ""}"
           @click=${applyTheme("light")}
           aria-pressed=${state.theme === "light"}
-          aria-label="Light theme"
-          title="Light"
+          aria-label=${t("theme.lightAria")}
+          title=${t("theme.light")}
         >
           ${renderSunIcon()}
         </button>
@@ -527,8 +555,8 @@ export function renderThemeToggle(state: AppViewState) {
           class="theme-toggle__button ${state.theme === "dark" ? "active" : ""}"
           @click=${applyTheme("dark")}
           aria-pressed=${state.theme === "dark"}
-          aria-label="Dark theme"
-          title="Dark"
+          aria-label=${t("theme.darkAria")}
+          title=${t("theme.dark")}
         >
           ${renderMoonIcon()}
         </button>

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3,7 +3,12 @@ import { parseAgentSessionKey } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChatAvatar } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
-import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers.ts";
+import {
+  renderChatControls,
+  renderLocaleSwitcher,
+  renderTab,
+  renderThemeToggle,
+} from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
@@ -255,7 +260,7 @@ export function renderApp(state: AppViewState) {
             </div>
             <div class="brand-text">
               <div class="brand-title">OPENCLAW</div>
-              <div class="brand-sub">Gateway Dashboard</div>
+              <div class="brand-sub">${t("shell.subtitle")}</div>
             </div>
           </div>
         </div>
@@ -270,6 +275,7 @@ export function renderApp(state: AppViewState) {
             <span>${t("common.health")}</span>
             <span class="mono">${state.connected ? t("common.ok") : t("common.offline")}</span>
           </div>
+          ${renderLocaleSwitcher(state)}
           ${renderThemeToggle(state)}
         </div>
       </header>
@@ -310,7 +316,7 @@ export function renderApp(state: AppViewState) {
               href="https://docs.openclaw.ai"
               target=${EXTERNAL_LINK_TARGET}
               rel=${buildExternalLinkRel()}
-              title="${t("common.docs")} (opens in new tab)"
+              title="${t("common.docs")} (${t("common.openInNewTab")})"
             >
               <span class="nav-item__icon" aria-hidden="true">${icons.book}</span>
               <span class="nav-item__text">${t("common.docs")}</span>
@@ -322,13 +328,13 @@ export function renderApp(state: AppViewState) {
         ${
           availableUpdate
             ? html`<div class="update-banner callout danger" role="alert">
-              <strong>Update available:</strong> v${availableUpdate.latestVersion}
-              (running v${availableUpdate.currentVersion}).
+              <strong>${t("shell.update.available")}</strong> v${availableUpdate.latestVersion}
+              ${t("shell.update.running", { version: availableUpdate.currentVersion })}
               <button
                 class="btn btn--sm update-banner__btn"
                 ?disabled=${state.updateRunning || !state.connected}
                 @click=${() => runUpdate(state)}
-              >${state.updateRunning ? "Updating…" : "Update now"}</button>
+              >${state.updateRunning ? t("shell.update.updating") : t("shell.update.updateNow")}</button>
             </div>`
             : nothing
         }

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -62,8 +62,8 @@ export function renderOverview(props: OverviewProps) {
             href="https://docs.openclaw.ai/web/control-ui#device-pairing-first-connection"
             target=${EXTERNAL_LINK_TARGET}
             rel=${buildExternalLinkRel()}
-            title="Device pairing docs (opens in new tab)"
-            >Docs: Device pairing</a
+            title=${t("overview.docs.devicePairingTitle", { openInNewTab: t("common.openInNewTab") })}
+            >${t("overview.docs.devicePairingLink")}</a
           >
         </div>
       </div>
@@ -110,8 +110,10 @@ export function renderOverview(props: OverviewProps) {
         <div class="muted" style="margin-top: 8px">
           ${t("overview.auth.required")}
           <div style="margin-top: 6px">
-            <span class="mono">openclaw dashboard --no-open</span> → tokenized URL<br />
-            <span class="mono">openclaw doctor --generate-gateway-token</span> → set token
+            <span class="mono">openclaw dashboard --no-open</span> →
+            ${t("overview.auth.tokenizedUrlHint")}<br />
+            <span class="mono">openclaw doctor --generate-gateway-token</span> →
+            ${t("overview.auth.setTokenHint")}
           </div>
           <div style="margin-top: 6px">
             <a
@@ -119,8 +121,10 @@ export function renderOverview(props: OverviewProps) {
               href="https://docs.openclaw.ai/web/dashboard"
               target=${EXTERNAL_LINK_TARGET}
               rel=${buildExternalLinkRel()}
-              title="Control UI auth docs (opens in new tab)"
-              >Docs: Control UI auth</a
+              title=${t("overview.docs.controlUiAuthTitle", {
+                openInNewTab: t("common.openInNewTab"),
+              })}
+              >${t("overview.docs.controlUiAuthLink")}</a
             >
           </div>
         </div>
@@ -135,8 +139,10 @@ export function renderOverview(props: OverviewProps) {
             href="https://docs.openclaw.ai/web/dashboard"
             target=${EXTERNAL_LINK_TARGET}
             rel=${buildExternalLinkRel()}
-            title="Control UI auth docs (opens in new tab)"
-            >Docs: Control UI auth</a
+            title=${t("overview.docs.controlUiAuthTitle", {
+              openInNewTab: t("common.openInNewTab"),
+            })}
+            >${t("overview.docs.controlUiAuthLink")}</a
           >
         </div>
       </div>
@@ -174,8 +180,10 @@ export function renderOverview(props: OverviewProps) {
             href="https://docs.openclaw.ai/gateway/tailscale"
             target=${EXTERNAL_LINK_TARGET}
             rel=${buildExternalLinkRel()}
-            title="Tailscale Serve docs (opens in new tab)"
-            >Docs: Tailscale Serve</a
+            title=${t("overview.docs.tailscaleServeTitle", {
+              openInNewTab: t("common.openInNewTab"),
+            })}
+            >${t("overview.docs.tailscaleServeLink")}</a
           >
           <span class="muted"> · </span>
           <a
@@ -183,8 +191,10 @@ export function renderOverview(props: OverviewProps) {
             href="https://docs.openclaw.ai/web/control-ui#insecure-http"
             target=${EXTERNAL_LINK_TARGET}
             rel=${buildExternalLinkRel()}
-            title="Insecure HTTP docs (opens in new tab)"
-            >Docs: Insecure HTTP</a
+            title=${t("overview.docs.insecureHttpTitle", {
+              openInNewTab: t("common.openInNewTab"),
+            })}
+            >${t("overview.docs.insecureHttpLink")}</a
           >
         </div>
       </div>
@@ -238,7 +248,7 @@ export function renderOverview(props: OverviewProps) {
                       const v = (e.target as HTMLInputElement).value;
                       props.onPasswordChange(v);
                     }}
-                    placeholder="system or shared password"
+                    placeholder=${t("overview.access.passwordPlaceholder")}
                   />
                 </label>
               `


### PR DESCRIPTION
## Summary

This PR improves dashboard i18n by:

- adding a global language switcher in the top bar (works across all tabs)
- completing missing zh-CN keys and replacing remaining hardcoded English in key dashboard surfaces
- adding a contributor-friendly i18n workflow:
  - `scripts/ui-i18n-report.ts`
  - `pnpm ui:i18n:report`
  - `pnpm ui:i18n:check:zh-CN`
  - `ui/src/i18n/README.md`

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
