### PR TITLE
outbound: propagate audioAsVoice through delivery pipeline

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -402,6 +402,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
       replyToId,
       threadId,
       silent,
+      audioAsVoice,
     }) => {
       const send = deps?.sendTelegram ?? getTelegramRuntime().channel.telegram.sendMessageTelegram;
       const replyToMessageId = parseTelegramReplyToMessageId(replyToId);
@@ -415,6 +416,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         replyToMessageId,
         accountId: accountId ?? undefined,
         silent: silent ?? undefined,
+        asVoice: audioAsVoice ?? undefined,
       });
       return { channel: "telegram", ...result };
     },

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -99,6 +99,7 @@ export type ChannelOutboundContext = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;
+  audioAsVoice?: boolean;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -118,6 +118,7 @@ type ChannelHandler = {
     overrides?: {
       replyToId?: string | null;
       threadId?: string | number | null;
+      audioAsVoice?: boolean;
     },
   ) => Promise<OutboundDeliveryResult>;
 };
@@ -191,6 +192,7 @@ function createPluginHandler(
           ...resolveCtx(overrides),
           text: caption,
           mediaUrl,
+          audioAsVoice: overrides?.audioAsVoice,
         });
       }
       return sendText({
@@ -332,6 +334,7 @@ function buildPayloadSummary(payload: ReplyPayload): NormalizedOutboundPayload {
     text: payload.text ?? "",
     mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
     channelData: payload.channelData,
+    ...(payload.audioAsVoice ? { audioAsVoice: true } : {}),
   };
 }
 
@@ -724,6 +727,7 @@ async function deliverOutboundPayloadsCore(
       const sendOverrides = {
         replyToId: effectivePayload.replyToId ?? params.replyToId ?? undefined,
         threadId: params.threadId ?? undefined,
+        audioAsVoice: effectivePayload.audioAsVoice || undefined,
       };
       if (handler.sendPayload && effectivePayload.channelData) {
         const delivery = await handler.sendPayload(effectivePayload, sendOverrides);

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -9,6 +9,7 @@ export type NormalizedOutboundPayload = {
   text: string;
   mediaUrls: string[];
   channelData?: Record<string, unknown>;
+  audioAsVoice?: boolean;
 };
 
 export type OutboundPayloadJson = {
@@ -94,6 +95,7 @@ export function normalizeOutboundPayloads(
       text,
       mediaUrls,
       ...(hasChannelData ? { channelData } : {}),
+      ...(payload.audioAsVoice ? { audioAsVoice: true } : {}),
     });
   }
   return normalizedPayloads;


### PR DESCRIPTION
## Summary

- Propagate `audioAsVoice` flag from `ReplyPayload` through `normalizeOutboundPayloads`, `buildPayloadSummary`, `ChannelHandler.sendMedia`, and the plugin outbound context so Telegram's `sendMedia` adapter can pass it as `asVoice` to `sendMessageTelegram`
- Without this fix, TTS audio files are sent as MP3 attachments (`sendAudio`) instead of voice notes (`sendVoice`) because `audioAsVoice` is dropped during payload normalization

Fixes #42060

## Changes

1. **`src/infra/outbound/payloads.ts`**: Add `audioAsVoice?: boolean` to `NormalizedOutboundPayload` type; include it in `normalizeOutboundPayloads` output
2. **`src/infra/outbound/deliver.ts`**: Add `audioAsVoice` to `buildPayloadSummary`, `ChannelHandler.sendMedia` overrides, `createPluginHandler` context forwarding, and `sendOverrides` at the delivery call site
3. **`src/channels/plugins/types.adapters.ts`**: Add `audioAsVoice?: boolean` to `ChannelOutboundContext`
4. **`extensions/telegram/src/channel.ts`**: Destructure `audioAsVoice` in Telegram `sendMedia` adapter and pass as `asVoice`

## Test plan

- [ ] Send a TTS audio reply via Telegram — should arrive as a voice note (waveform) instead of an MP3 file attachment
- [ ] Regular media messages (images, documents) should be unaffected
- [ ] `pnpm check` passes