### PR TITLE
fix: increase default bootstrapMaxChars from 20k to 40k chars

### DIFF
--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -82,7 +82,7 @@ export function stripThoughtSignatures<T>(
   }) as T;
 }
 
-export const DEFAULT_BOOTSTRAP_MAX_CHARS = 20_000;
+export const DEFAULT_BOOTSTRAP_MAX_CHARS = 40_000;
 export const DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS = 150_000;
 export const DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE = "once";
 const MIN_BOOTSTRAP_FILE_BUDGET_CHARS = 64;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -758,7 +758,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.workspace":
     "Default workspace path exposed to agent runtime tools for filesystem context and repo-aware behavior. Set this explicitly when running from wrappers so path resolution stays deterministic.",
   "agents.defaults.bootstrapMaxChars":
-    "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
+    "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 40000).",
   "agents.defaults.bootstrapTotalMaxChars":
     "Max total characters across all injected workspace bootstrap files (default: 150000).",
   "agents.defaults.bootstrapPromptTruncationWarning":


### PR DESCRIPTION
This addresses the issue where large workspace bootstrap files (MEMORY.md, etc.) cause silent agent failure when they exceed the default limit.

The default was too conservative for typical use cases with larger memory files. Doubling it to 40k chars provides more headroom while still keeping system prompt sizes reasonable.

Fixes: Agent silently fails when bootstrap file exceeds bootstrapMaxChars limit