### PR TITLE
fix: prevent NO_REPLY token from leaking to Telegram

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -2,30 +2,15 @@ import { describe, expect, it } from "vitest";
 import { resolveSilentReplyFallbackText } from "./pi-embedded-subscribe.handlers.messages.js";
 
 describe("resolveSilentReplyFallbackText", () => {
-  it("preserves NO_REPLY even when messaging tool texts are present", () => {
-    expect(
-      resolveSilentReplyFallbackText({
-        text: "NO_REPLY",
-        messagingToolSentTexts: ["first", "final delivered text"],
-      }),
-    ).toBe("NO_REPLY");
+  it("preserves NO_REPLY unchanged", () => {
+    expect(resolveSilentReplyFallbackText("NO_REPLY")).toBe("NO_REPLY");
   });
 
-  it("keeps original text when response is not NO_REPLY", () => {
-    expect(
-      resolveSilentReplyFallbackText({
-        text: "normal assistant reply",
-        messagingToolSentTexts: ["final delivered text"],
-      }),
-    ).toBe("normal assistant reply");
+  it("passes through normal assistant text unchanged", () => {
+    expect(resolveSilentReplyFallbackText("normal assistant reply")).toBe("normal assistant reply");
   });
 
-  it("keeps NO_REPLY when there is no messaging tool text to mirror", () => {
-    expect(
-      resolveSilentReplyFallbackText({
-        text: "NO_REPLY",
-        messagingToolSentTexts: [],
-      }),
-    ).toBe("NO_REPLY");
+  it("passes through empty string unchanged", () => {
+    expect(resolveSilentReplyFallbackText("")).toBe("");
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { resolveSilentReplyFallbackText } from "./pi-embedded-subscribe.handlers.messages.js";
 
 describe("resolveSilentReplyFallbackText", () => {
-  it("replaces NO_REPLY with latest messaging tool text when available", () => {
+  it("preserves NO_REPLY even when messaging tool texts are present", () => {
     expect(
       resolveSilentReplyFallbackText({
         text: "NO_REPLY",
         messagingToolSentTexts: ["first", "final delivered text"],
       }),
-    ).toBe("final delivered text");
+    ).toBe("NO_REPLY");
   });
 
   it("keeps original text when response is not NO_REPLY", () => {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -40,15 +40,12 @@ function emitReasoningEnd(ctx: EmbeddedPiSubscribeContext) {
   void ctx.params.onReasoningEnd?.();
 }
 
-export function resolveSilentReplyFallbackText(params: {
-  text: string;
-  messagingToolSentTexts: string[];
-}): string {
-  // Do not replace NO_REPLY with messaging tool text: doing so causes the
-  // already-delivered text to flow back through the delivery pipeline and get
-  // sent again as a duplicate. Keep NO_REPLY so downstream suppression logic
-  // can handle it correctly. (See: #38826, #36811)
-  return params.text;
+export function resolveSilentReplyFallbackText(text: string): string {
+  // Previously this replaced NO_REPLY with the last messaging-tool-sent text,
+  // but that caused the already-delivered text to flow back through the delivery
+  // pipeline and get sent again as a duplicate. Keep NO_REPLY so downstream
+  // suppression logic can handle it correctly. (See: #38826, #36811)
+  return text;
 }
 
 export function handleMessageStart(
@@ -268,10 +265,9 @@ export function handleMessageEnd(
     rawThinking: extractAssistantThinking(assistantMessage),
   });
 
-  const text = resolveSilentReplyFallbackText({
-    text: ctx.stripBlockTags(rawText, { thinking: false, final: false }),
-    messagingToolSentTexts: ctx.state.messagingToolSentTexts,
-  });
+  const text = resolveSilentReplyFallbackText(
+    ctx.stripBlockTags(rawText, { thinking: false, final: false }),
+  );
   const rawThinking =
     ctx.state.includeReasoning || ctx.state.streamReasoning
       ? extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(rawText)

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -1,6 +1,5 @@
 import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
@@ -45,15 +44,11 @@ export function resolveSilentReplyFallbackText(params: {
   text: string;
   messagingToolSentTexts: string[];
 }): string {
-  const trimmed = params.text.trim();
-  if (trimmed !== SILENT_REPLY_TOKEN) {
-    return params.text;
-  }
-  const fallback = params.messagingToolSentTexts.at(-1)?.trim();
-  if (!fallback) {
-    return params.text;
-  }
-  return fallback;
+  // Do not replace NO_REPLY with messaging tool text: doing so causes the
+  // already-delivered text to flow back through the delivery pipeline and get
+  // sent again as a duplicate. Keep NO_REPLY so downstream suppression logic
+  // can handle it correctly. (See: #38826, #36811)
+  return params.text;
 }
 
 export function handleMessageStart(


### PR DESCRIPTION
## Problem

The `NO_REPLY` silent token leaks through to Telegram as a visible message instead of being suppressed. In some cases, only `NO` is delivered (the prefix is stripped but delivery still occurs).

This happens when:
1. The agent uses the `message` tool to send a reply to Telegram
2. The agent responds with `NO_REPLY` to avoid duplicate replies
3. `resolveSilentReplyFallbackText()` replaces `NO_REPLY` with the last messaging tool text
4. The replaced text flows into the delivery pipeline and gets sent *again* — or in edge cases, the raw `NO_REPLY` token itself leaks through

## Root Cause

`resolveSilentReplyFallbackText()` in `pi-embedded-subscribe.handlers.messages.ts` was designed to mirror sent text into chat history. But by replacing `NO_REPLY` before the delivery pipeline processes it, the downstream silent-token suppression logic (`isSilentReplyText`, `normalizeReplyPayload`) no longer recognizes the response as silent, causing re-delivery.

The existing `isMessagingToolDuplicateNormalized` dedupe check covers the `message_end` block reply path, but doesn't protect all delivery paths (streaming, followup queue, `normalizeReplyPayload`).

## Fix

`resolveSilentReplyFallbackText()` now returns the original text unchanged. When the agent has already sent text via the `message` tool and responds with `NO_REPLY`, the token is preserved so downstream suppression works correctly. The chat history already records the sent text via the messaging tool's own delivery path.

## Changes

- `src/agents/pi-embedded-subscribe.handlers.messages.ts`: Simplified `resolveSilentReplyFallbackText` to always return original text
- `src/agents/pi-embedded-subscribe.handlers.messages.test.ts`: Updated test expectations

## Testing

- All 3 existing tests pass (`vitest run`)
- Manually verified on Telegram that `NO_REPLY` is now suppressed after `message` tool sends

Fixes #38826, Fixes #36811