### PR TITLE
feat(typing): make typing indicator TTL configurable via typingTtlSeconds

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -114,12 +114,9 @@ export async function getReplyFromConfig(
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
   const typingIntervalSeconds =
     typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
-  const configuredTypingTtlSeconds =
-    agentCfg?.typingTtlSeconds ?? sessionCfg?.typingTtlSeconds;
+  const configuredTypingTtlSeconds = agentCfg?.typingTtlSeconds ?? sessionCfg?.typingTtlSeconds;
   const typingTtlMs =
-    typeof configuredTypingTtlSeconds === "number"
-      ? configuredTypingTtlSeconds * 1000
-      : undefined;
+    typeof configuredTypingTtlSeconds === "number" ? configuredTypingTtlSeconds * 1000 : undefined;
   const typing = createTypingController({
     onReplyStart: opts?.onReplyStart,
     onCleanup: opts?.onTypingCleanup,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -114,10 +114,17 @@ export async function getReplyFromConfig(
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
   const typingIntervalSeconds =
     typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
+  const configuredTypingTtlSeconds =
+    agentCfg?.typingTtlSeconds ?? sessionCfg?.typingTtlSeconds;
+  const typingTtlMs =
+    typeof configuredTypingTtlSeconds === "number"
+      ? configuredTypingTtlSeconds * 1000
+      : undefined;
   const typing = createTypingController({
     onReplyStart: opts?.onReplyStart,
     onCleanup: opts?.onTypingCleanup,
     typingIntervalSeconds,
+    ...(typingTtlMs !== undefined && { typingTtlMs }),
     silentToken: SILENT_REPLY_TOKEN,
     log: defaultRuntime.log,
   });

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -215,6 +215,7 @@ export type AgentDefaultsConfig = {
    */
   imageMaxDimensionPx?: number;
   typingIntervalSeconds?: number;
+  typingTtlSeconds?: number;
   /** Typing indicator start mode (never|instant|thinking|message). */
   typingMode?: TypingMode;
   /** Periodic background heartbeat runs. */

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -116,6 +116,7 @@ export type SessionConfig = {
   resetByChannel?: Record<string, SessionResetConfig>;
   store?: string;
   typingIntervalSeconds?: number;
+  typingTtlSeconds?: number;
   typingMode?: TypingMode;
   /**
    * Max parent transcript token count allowed for thread/session forking.

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -157,6 +157,7 @@ export const AgentDefaultsSchema = z
     mediaMaxMb: z.number().positive().optional(),
     imageMaxDimensionPx: z.number().int().positive().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),
+    typingTtlSeconds: z.number().int().positive().optional(),
     typingMode: TypingModeSchema.optional(),
     heartbeat: HeartbeatSchema,
     maxConcurrent: z.number().int().positive().optional(),

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -51,6 +51,7 @@ export const SessionSchema = z
     resetByChannel: z.record(z.string(), SessionResetConfigSchema).optional(),
     store: z.string().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),
+    typingTtlSeconds: z.number().int().positive().optional(),
     typingMode: TypingModeSchema.optional(),
     parentForkMaxTokens: z.number().int().nonnegative().optional(),
     mainKey: z.string().optional(),


### PR DESCRIPTION
## Summary

- Problem: The typing indicator TTL (`typingTtlMs`) is hardcoded to 2 minutes, causing "ghost typing" when responses take longer.
- Why it matters: Users see the typing indicator stop mid-generation, creating confusion about whether the agent is still working.
- What changed: Added `typingTtlSeconds` config option to agent defaults and session config, wired through to the typing controller.
- What did NOT change (scope boundary): Default behavior unchanged (2 minutes). The `typingIntervalSeconds` config is untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41516

## User-visible / Behavior Changes

New optional config key `typingTtlSeconds` available in agent defaults and session config. When set, controls how long the typing indicator stays active before auto-stopping. Default remains 120 seconds (2 minutes) when not configured.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` - new optional `typingTtlSeconds` key
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `typingTtlSeconds` from config; default behavior is preserved.
- Known bad symptoms reviewers should watch for: Typing indicator stopping too early or not at all if misconfigured.

## Risks and Mitigations

None