### PR TITLE
fix(gateway): skip health checks for channels removed from config

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -12,6 +12,7 @@ function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelM
     stopChannel: vi.fn(async () => {}),
     markChannelLoggedOut: vi.fn(),
     isManuallyStopped: vi.fn(() => false),
+    isChannelConfigured: vi.fn(() => true),
     resetRestartAttempts: vi.fn(),
     ...overrides,
   };

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -114,6 +114,11 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
         if (!accounts) {
           continue;
         }
+        // Skip channels that have been removed from the current config to avoid
+        // emitting system events (restarts) for stale runtime state.
+        if (!channelManager.isChannelConfigured(channelId as ChannelId)) {
+          continue;
+        }
         for (const [accountId, status] of Object.entries(accounts)) {
           if (!status) {
             continue;

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -104,6 +104,7 @@ export type ChannelManager = {
   stopChannel: (channel: ChannelId, accountId?: string) => Promise<void>;
   markChannelLoggedOut: (channelId: ChannelId, cleared: boolean, accountId?: string) => void;
   isManuallyStopped: (channelId: ChannelId, accountId: string) => boolean;
+  isChannelConfigured: (channelId: ChannelId) => boolean;
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
 };
 
@@ -441,6 +442,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     return manuallyStopped.has(restartKey(channelId, accountId));
   };
 
+  const isChannelConfigured_ = (channelId: ChannelId): boolean => {
+    const cfg = loadConfig();
+    return cfg.channels?.[channelId] != null;
+  };
+
   const resetRestartAttempts_ = (channelId: ChannelId, accountId: string): void => {
     restartAttempts.delete(restartKey(channelId, accountId));
   };
@@ -452,6 +458,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     stopChannel,
     markChannelLoggedOut,
     isManuallyStopped: isManuallyStopped_,
+    isChannelConfigured: isChannelConfigured_,
     resetRestartAttempts: resetRestartAttempts_,
   };
 }

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -27,6 +27,7 @@ function createManager(snapshot: ChannelRuntimeSnapshot): ChannelManager {
     stopChannel: vi.fn(),
     markChannelLoggedOut: vi.fn(),
     isManuallyStopped: vi.fn(() => false),
+    isChannelConfigured: vi.fn(() => true),
     resetRestartAttempts: vi.fn(),
   };
 }


### PR DESCRIPTION
## Summary

- Problem: Health monitor continues to emit system events for channels removed from config, consuming API tokens and creating log noise.
- Why it matters: Each stale event triggers an embedded agent run, wasting tokens and potentially cascading into rate limit errors.
- What changed: Added `isChannelConfigured()` to channel manager; health monitor now skips channels not in current config.
- What did NOT change (scope boundary): Health check logic for configured channels is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41514

## User-visible / Behavior Changes

Channels removed from `openclaw.json` will no longer trigger health monitor restart events after gateway restart.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the guard in the health monitor loop.
- Known bad symptoms: Channels that should be monitored being skipped (would only happen if `isChannelConfigured` returns false incorrectly).

## Risks and Mitigations

- Risk: Runtime snapshot may contain channel IDs in a format that doesn't match config keys.
  - Mitigation: Uses the same `ChannelId` type throughout; existing channel manager already maps between runtime and config.