### PR TITLE
fix(tui): strip security notice wrappers from session preview text

### DIFF
--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -571,15 +571,34 @@ function truncatePreviewText(text: string, maxChars: number): string {
   return `${text.slice(0, maxChars - 3)}...`;
 }
 
+/**
+ * Strip security notice wrappers (external untrusted content markers and
+ * the SECURITY NOTICE warning block) so they don't leak into TUI previews.
+ */
+function stripSecurityNoticeForPreview(text: string): string {
+  return text
+    .replace(/<<<\s*(?:END_)?EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]*")?\s*>>>/g, "")
+    .replace(
+      /SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[^\n]*(?:\n- [^\n]*)*/g,
+      "",
+    )
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 function extractPreviewText(message: TranscriptPreviewMessage): string | null {
   if (typeof message.content === "string") {
-    const normalized = stripInlineDirectiveTagsForDisplay(message.content).text.trim();
+    const normalized = stripSecurityNoticeForPreview(
+      stripInlineDirectiveTagsForDisplay(message.content).text,
+    ).trim();
     return normalized ? normalized : null;
   }
   if (Array.isArray(message.content)) {
     const parts = message.content
       .map((entry) =>
-        typeof entry?.text === "string" ? stripInlineDirectiveTagsForDisplay(entry.text).text : "",
+        typeof entry?.text === "string"
+          ? stripSecurityNoticeForPreview(stripInlineDirectiveTagsForDisplay(entry.text).text)
+          : "",
       )
       .filter((text) => text.trim().length > 0);
     if (parts.length > 0) {
@@ -587,7 +606,9 @@ function extractPreviewText(message: TranscriptPreviewMessage): string | null {
     }
   }
   if (typeof message.text === "string") {
-    const normalized = stripInlineDirectiveTagsForDisplay(message.text).text.trim();
+    const normalized = stripSecurityNoticeForPreview(
+      stripInlineDirectiveTagsForDisplay(message.text).text,
+    ).trim();
     return normalized ? normalized : null;
   }
   return null;

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -582,7 +582,7 @@ function stripSecurityNoticeForPreview(text: string): string {
       /SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[^\n]*(?:\n\s*- [^\n]*)*/g,
       "",
     )
-    .replace(/^Source:\s+[^\n]*(?:\n(?:From|Subject):\s+[^\n]*)*\n---\n?/gm, "")
+    .replace(/^\s*Source:\s+[^\n]*(?:\n(?:From|Subject):\s+[^\n]*)*\n---\n?/g, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -577,7 +577,10 @@ function truncatePreviewText(text: string, maxChars: number): string {
  */
 function stripSecurityNoticeForPreview(text: string): string {
   const hadMarkers = /<<<\s*(?:END_)?EXTERNAL_UNTRUSTED_CONTENT/.test(text);
-  let result = text.replace(/<<<\s*(?:END_)?EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]*")?\s*>>>/g, "");
+  let result = text.replace(
+    /<<<\s*(?:END_)?EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]*")?\s*>>>/g,
+    "",
+  );
   // Only strip security notice and wrapper metadata when external content markers were present
   if (hadMarkers) {
     result = result

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -576,15 +576,18 @@ function truncatePreviewText(text: string, maxChars: number): string {
  * the SECURITY NOTICE warning block) so they don't leak into TUI previews.
  */
 function stripSecurityNoticeForPreview(text: string): string {
-  return text
+  const hadMarkers = /<<<\s*(?:END_)?EXTERNAL_UNTRUSTED_CONTENT/.test(text);
+  let result = text
     .replace(/<<<\s*(?:END_)?EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]*")?\s*>>>/g, "")
     .replace(
       /SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[^\n]*(?:\n\s*- [^\n]*)*/g,
       "",
-    )
-    .replace(/^\s*Source:\s+[^\n]*(?:\n(?:From|Subject):\s+[^\n]*)*\n---\n?/g, "")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+    );
+  // Only strip wrapper metadata when external content markers were present
+  if (hadMarkers) {
+    result = result.replace(/^\s*Source:\s+[^\n]*(?:\n(?:From|Subject):\s+[^\n]*)*\n---\n?/g, "");
+  }
+  return result.replace(/\n{3,}/g, "\n\n").trim();
 }
 
 function extractPreviewText(message: TranscriptPreviewMessage): string | null {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -577,15 +577,15 @@ function truncatePreviewText(text: string, maxChars: number): string {
  */
 function stripSecurityNoticeForPreview(text: string): string {
   const hadMarkers = /<<<\s*(?:END_)?EXTERNAL_UNTRUSTED_CONTENT/.test(text);
-  let result = text
-    .replace(/<<<\s*(?:END_)?EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]*")?\s*>>>/g, "")
-    .replace(
-      /SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[^\n]*(?:\n\s*- [^\n]*)*/g,
-      "",
-    );
-  // Only strip wrapper metadata when external content markers were present
+  let result = text.replace(/<<<\s*(?:END_)?EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]*")?\s*>>>/g, "");
+  // Only strip security notice and wrapper metadata when external content markers were present
   if (hadMarkers) {
-    result = result.replace(/^\s*Source:\s+[^\n]*(?:\n(?:From|Subject):\s+[^\n]*)*\n---\n?/g, "");
+    result = result
+      .replace(
+        /SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[^\n]*(?:\n\s*- [^\n]*)*/g,
+        "",
+      )
+      .replace(/^\s*Source:\s+[^\n]*(?:\n(?:From|Subject):\s+[^\n]*)*\n---\n?/g, "");
   }
   return result.replace(/\n{3,}/g, "\n\n").trim();
 }

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -579,9 +579,10 @@ function stripSecurityNoticeForPreview(text: string): string {
   return text
     .replace(/<<<\s*(?:END_)?EXTERNAL_UNTRUSTED_CONTENT(?:\s+id="[^"]*")?\s*>>>/g, "")
     .replace(
-      /SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[^\n]*(?:\n- [^\n]*)*/g,
+      /SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source[^\n]*(?:\n\s*- [^\n]*)*/g,
       "",
     )
+    .replace(/^Source:\s+[^\n]*(?:\n(?:From|Subject):\s+[^\n]*)*\n---\n?/gm, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }


### PR DESCRIPTION
## Summary

- Problem: TUI session popover shows raw `SECURITY NOTICE: The following content is from an EXTERNAL, UNTRUSTED source...` text instead of meaningful content.
- Why it matters: Makes the TUI session list unmanageable when sessions have used web_fetch or similar tools.
- What changed: Added `stripSecurityNoticeForPreview()` to strip external content markers and security warning text from session preview snippets.
- What did NOT change (scope boundary): Full session transcripts are unaffected. Only the preview text shown in the session list is cleaned.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41522

## User-visible / Behavior Changes

Session previews in the TUI session list now show meaningful content instead of the internal security notice wrapper text from web_fetch tool results.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the `stripSecurityNoticeForPreview` calls in `extractPreviewText()`.
- Known bad symptoms: Preview text being empty if the stripping regex is too aggressive.

## Risks and Mitigations

- Risk: Regex may strip legitimate content that happens to match the security notice pattern.
  - Mitigation: Patterns are specific to the internal `<<<EXTERNAL_UNTRUSTED_CONTENT` markers which are machine-generated, not user-authored.