### PR TITLE
fix(voice-call): prevent race condition that kills media stream on outbound conversation calls

### DIFF
--- a/extensions/voice-call/src/manager.notify.test.ts
+++ b/extensions/voice-call/src/manager.notify.test.ts
@@ -50,4 +50,85 @@ describe("CallManager notify and mapping", () => {
       expect(provider.playTtsCalls[0]?.text).toBe("Hello there");
     },
   );
+
+  it("defers initial message on answered for twilio conversation mode with streaming enabled", async () => {
+    const { manager, provider } = await createManagerHarness(
+      { streaming: { enabled: true, streamPath: "/voice/stream" } },
+      new FakeProvider("twilio"),
+    );
+
+    const { callId, success } = await manager.initiateCall("+15550000003", undefined, {
+      message: "Hello there",
+      mode: "conversation",
+    });
+    expect(success).toBe(true);
+
+    manager.processEvent({
+      id: "evt-3",
+      type: "call.answered",
+      callId,
+      providerCallId: "call-uuid",
+      timestamp: Date.now(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Initial message must not be spoken at answer time — stream is not yet connected.
+    // The stream's onConnect handler is responsible for deferred playback.
+    expect(provider.playTtsCalls).toHaveLength(0);
+  });
+
+  it("still speaks initial message on answered for non-twilio providers with streaming enabled", async () => {
+    const { manager, provider } = await createManagerHarness(
+      { streaming: { enabled: true, streamPath: "/voice/stream" } },
+      new FakeProvider("plivo"),
+    );
+
+    const { callId, success } = await manager.initiateCall("+15550000004", undefined, {
+      message: "Hello there",
+      mode: "conversation",
+    });
+    expect(success).toBe(true);
+
+    manager.processEvent({
+      id: "evt-4",
+      type: "call.answered",
+      callId,
+      providerCallId: "call-uuid",
+      timestamp: Date.now(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Non-Twilio providers have no onConnect stream handler, so must speak at answer time.
+    expect(provider.playTtsCalls).toHaveLength(1);
+    expect(provider.playTtsCalls[0]?.text).toBe("Hello there");
+  });
+
+  it("speaks initial message on answered for twilio notify mode even with streaming enabled", async () => {
+    const { manager, provider } = await createManagerHarness(
+      { streaming: { enabled: true, streamPath: "/voice/stream" } },
+      new FakeProvider("twilio"),
+    );
+
+    const { callId, success } = await manager.initiateCall("+15550000005", undefined, {
+      message: "Hello there",
+      mode: "notify",
+    });
+    expect(success).toBe(true);
+
+    manager.processEvent({
+      id: "evt-5",
+      type: "call.answered",
+      callId,
+      providerCallId: "call-uuid",
+      timestamp: Date.now(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Notify mode uses inline TwiML — no stream onConnect fires, so must speak at answer time.
+    expect(provider.playTtsCalls).toHaveLength(1);
+    expect(provider.playTtsCalls[0]?.text).toBe("Hello there");
+  });
 });

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { VoiceCallConfig } from "./config.js";
+import type { VoiceCallConfig, CallMode } from "./config.js";
 import type { CallManagerContext } from "./manager/context.js";
 import { processEvent as processManagerEvent } from "./manager/events.js";
 import { getCallByProviderCallId as getCallByProviderCallIdFromMaps } from "./manager/lookup.js";
@@ -281,8 +281,8 @@ export class CallManager {
       return;
     }
 
-    const mode = (call.metadata?.mode as string) ?? "conversation";
-    if (this.config.streaming?.enabled && mode !== "notify") {
+    const mode = (call.metadata?.mode as CallMode) ?? "conversation";
+    if (this.provider.name === "twilio" && this.config.streaming?.enabled && mode !== "notify") {
       return;
     }
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -281,6 +281,11 @@ export class CallManager {
       return;
     }
 
+    const mode = (call.metadata?.mode as string) ?? "conversation";
+    if (this.config.streaming?.enabled && mode !== "notify") {
+      return;
+    }
+
     void this.speakInitialMessage(call.providerCallId);
   }
 


### PR DESCRIPTION
## Summary

Fixes #42113

When an outbound conversation call is answered with streaming enabled, `maybeSpeakInitialMessageOnAnswered()` fires immediately — before the Twilio media stream has connected. Since no stream is active yet, `playTts()` falls back to updating the call with `<Say>`+`<Gather>` TwiML via the Calls API. This **replaces** the `<Connect><Stream>` TwiML, causing Twilio to tear down the WebSocket media stream within ~11ms of it connecting.

## Changes

**`extensions/voice-call/src/manager.ts`**

Added an early return in `maybeSpeakInitialMessageOnAnswered()` when:
- `this.config.streaming?.enabled` is true, AND
- Call mode is not `"notify"`

This defers initial message speech to the stream's `onConnect` handler in `webhook.ts`, which already calls `speakInitialMessage` with a 500ms delay after the stream connects — guaranteeing the stream is active and TTS routes through the media stream instead of falling back to `<Say>`.

## Timeline comparison

**Before (broken):**
```
answered → speakInitialMessage → no stream → <Say> fallback
→ replaces <Connect><Stream> → stream connects briefly → dies (11ms)
```

**After (fixed):**
```
answered → skip (streaming enabled)
→ stream connects → 500ms delay → speakInitialMessage → stream TTS ✓
```

## Testing

Tested on a live Twilio outbound call:
- **Before fix**: Stream connected and died within 11ms, caller heard nothing
- **After fix**: Stream stayed alive for 40+ seconds, STT detected speech events throughout, call ended normally on hangup

Notify mode is unaffected — it uses inline TwiML and does not rely on streaming.