### PR TITLE
Gateway: add container LAN alias for loopback (#42074)

### DIFF
--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -1,6 +1,8 @@
+import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import {
   isCanonicalDottedDecimalIPv4,
   isIpInCidr,
@@ -8,6 +10,42 @@ import {
   isPrivateOrLoopbackIpAddress,
   normalizeIpAddress,
 } from "../shared/net/ip.js";
+
+let isContainerRuntimeCache: boolean | null = null;
+
+export function isContainerRuntime(): boolean {
+  if (isContainerRuntimeCache !== null) {
+    return isContainerRuntimeCache;
+  }
+
+  const containerEnv = process.env.OPENCLAW_CONTAINER;
+  if (containerEnv !== undefined) {
+    isContainerRuntimeCache = isTruthyEnvValue(containerEnv);
+    return isContainerRuntimeCache;
+  }
+
+  try {
+    if (fs.existsSync("/.dockerenv")) {
+      isContainerRuntimeCache = true;
+      return true;
+    }
+  } catch {
+    // ignore
+  }
+
+  try {
+    const cgroup = fs.readFileSync("/proc/1/cgroup", "utf8");
+    if (/(docker|kubepods|containerd)/i.test(cgroup)) {
+      isContainerRuntimeCache = true;
+      return true;
+    }
+  } catch {
+    // ignore
+  }
+
+  isContainerRuntimeCache = false;
+  return false;
+}
 
 /**
  * Pick the primary non-internal IPv4 address (LAN IP).
@@ -294,16 +332,46 @@ export async function canBindToHost(host: string): Promise<boolean> {
 
 export async function resolveGatewayListenHosts(
   bindHost: string,
-  opts?: { canBindToHost?: (host: string) => Promise<boolean> },
+  opts?: {
+    canBindToHost?: (host: string) => Promise<boolean>;
+    includeLanAliasForLoopback?: boolean;
+    pickLanIPv4?: () => string | undefined;
+  },
 ): Promise<string[]> {
   if (bindHost !== "127.0.0.1") {
     return [bindHost];
   }
   const canBind = opts?.canBindToHost ?? canBindToHost;
-  if (await canBind("::1")) {
-    return [bindHost, "::1"];
+  const hosts = [bindHost];
+
+  // Container loopback binds need a LAN alias so published ports reach the gateway.
+  const shouldAddLanAlias =
+    opts?.includeLanAliasForLoopback ??
+    isContainerRuntime();
+
+  if (shouldAddLanAlias) {
+    const pickLanIp = opts?.pickLanIPv4 ?? pickPrimaryLanIPv4;
+    const lanIp = pickLanIp();
+    if (lanIp && lanIp !== bindHost) {
+      try {
+        if (await canBind(lanIp)) {
+          hosts.push(lanIp);
+        }
+      } catch {
+        // ignore container alias bind failures and keep loopback-only
+      }
+    }
   }
-  return [bindHost];
+
+  try {
+    if (await canBind("::1")) {
+      hosts.push("::1");
+    }
+  } catch {
+    // ignore IPv6 bind failures
+  }
+
+  return hosts;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Problem: Dashboard/Gateway HTTP returned empty responses on macOS when Docker gateway was bound to loopback; host -> published port traffic never hit the gateway.
- Why it matters: Dashboard pairing/UI unreachable for Docker users following `OPENCLAW_GATEWAY_BIND=loopback`, blocking control access while bots still worked.
- What changed: Detect container runtime and, for loopback binds, also listen on the container’s primary LAN IP (plus new tests for the alias logic).
- What did NOT change: No changes to auth policy, control UI content, or non-loopback binding behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42074
- Related #

## User-visible / Behavior Changes

- Gateway in containers now also binds a LAN alias when configured for loopback, so Docker-published port 18789 responds on host macOS browsers. No config changes required; behavior is transparent.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (reported), dev attempt on Windows host (this session)
- Runtime/container: Docker gateway container with `OPENCLAW_GATEWAY_BIND=loopback`
- Model/provider: N/A
- Integration/channel (if any): Dashboard
- Relevant config (redacted): `OPENCLAW_GATEWAY_BIND=loopback`, default ports

### Steps

1. Run gateway in Docker with port 18789 published, bind=loopback.
2. Open `http://127.0.0.1:18789/` from host browser.
3. Observe HTTP response.

### Expected

- Control UI shell loads and pairing flow appears.

### Actual

- Before: ERR_EMPTY_RESPONSE / empty reply.
- After: Should load normally (not re-verified here due to missing pnpm/tooling).

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)
- (None collected in this session; pnpm unavailable)

## Human Verification (required)

- Verified scenarios: Code inspection only; no runtime test (pnpm install blocked).
- Edge cases checked: Added unit tests for alias binding with/without bindable LAN IP and IPv6.
- What you did **not** verify: End-to-end dashboard load in Docker; full test suite.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `src/gateway/net.ts` and `src/gateway/net.test.ts`.
- Files/config to restore: Same as above.
- Known bad symptoms reviewers should watch for: Gateway failing to start due to unexpected bind errors on additional LAN alias; dashboard still unreachable.

## Risks and Mitigations

- Risk: Additional bind attempt on LAN IP could fail on unusual container networking setups.
  - Mitigation: Bind errors on the alias are caught and ignored; loopback listener remains.