### PR TITLE
feat(tasks): add generic task notification framework

### DIFF
--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -299,6 +299,15 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "tasks",
+    description: "Register tasks and notify session watchers",
+    hasSubcommands: true,
+    register: async (program) => {
+      const mod = await import("../tasks-cli.js");
+      mod.registerTasksCli(program);
+    },
+  },
+  {
     name: "completion",
     description: "Generate shell completion script",
     hasSubcommands: false,

--- a/src/cli/tasks-cli.ts
+++ b/src/cli/tasks-cli.ts
@@ -101,6 +101,23 @@ export function registerTasksCli(program: Command) {
       }),
   );
 
+  // tasks unwatch
+  addGatewayClientOptions(
+    tasks
+      .command("unwatch")
+      .description("Remove a session watcher from a task")
+      .requiredOption("--id <id>", "Task identifier")
+      .requiredOption("--session <sessionKey>", "Session key to unsubscribe")
+      .option("--json", "Output JSON", false)
+      .action(async (opts) => {
+        const res = await callGatewayFromCli("tasks.unwatch", opts, {
+          taskId: opts.id,
+          sessionKey: opts.session,
+        });
+        console.log(JSON.stringify(res, null, 2));
+      }),
+  );
+
   // tasks remove
   addGatewayClientOptions(
     tasks

--- a/src/cli/tasks-cli.ts
+++ b/src/cli/tasks-cli.ts
@@ -1,0 +1,117 @@
+import type { Command } from "commander";
+import { addGatewayClientOptions, callGatewayFromCli } from "./gateway-rpc.js";
+
+export function registerTasksCli(program: Command) {
+  const tasks = program
+    .command("tasks")
+    .description("Register tasks and notify session watchers")
+    .action(() => {
+      tasks.help({ error: true });
+    });
+
+  // tasks register
+  addGatewayClientOptions(
+    tasks
+      .command("register")
+      .description("Register or update a task")
+      .requiredOption("--id <id>", "Task identifier")
+      .option("--desc <description>", "Human-readable description")
+      .option("--status <status>", "Initial status (e.g. running, done, failed)")
+      .option("--json", "Output JSON", false)
+      .action(async (opts) => {
+        const params: Record<string, unknown> = { taskId: opts.id };
+        if (opts.desc) {
+          params.description = opts.desc;
+        }
+        if (opts.status) {
+          params.status = opts.status;
+        }
+        const res = await callGatewayFromCli("tasks.register", opts, params);
+        console.log(JSON.stringify(res, null, 2));
+      }),
+  );
+
+  // tasks watch
+  addGatewayClientOptions(
+    tasks
+      .command("watch")
+      .description("Subscribe a session to task events")
+      .requiredOption("--id <id>", "Task identifier")
+      .requiredOption("--session <sessionKey>", "Session key to notify")
+      .option("--label <label>", "Optional human label for this watcher")
+      .option("--json", "Output JSON", false)
+      .action(async (opts) => {
+        const params: Record<string, unknown> = {
+          taskId: opts.id,
+          sessionKey: opts.session,
+        };
+        if (opts.label) {
+          params.label = opts.label;
+        }
+        const res = await callGatewayFromCli("tasks.watch", opts, params);
+        console.log(JSON.stringify(res, null, 2));
+      }),
+  );
+
+  // tasks notify
+  addGatewayClientOptions(
+    tasks
+      .command("notify")
+      .description("Fire an event on a task and notify all watchers")
+      .requiredOption("--id <id>", "Task identifier")
+      .requiredOption("--event <event>", "Event name (e.g. completed, prCreated)")
+      .requiredOption("--message <message>", "Human-readable notification message")
+      .option("--status <status>", "Update task status at the same time")
+      .option("--idempotency-key <key>", "Idempotency key (default: event name)")
+      .option("--json", "Output JSON", false)
+      .action(async (opts) => {
+        const params: Record<string, unknown> = {
+          taskId: opts.id,
+          event: opts.event,
+          message: opts.message,
+        };
+        if (opts.status) {
+          params.status = opts.status;
+        }
+        if (opts.idempotencyKey) {
+          params.idempotencyKey = opts.idempotencyKey;
+        }
+        const res = await callGatewayFromCli("tasks.notify", opts, params);
+        console.log(JSON.stringify(res, null, 2));
+      }),
+  );
+
+  // tasks list
+  addGatewayClientOptions(
+    tasks
+      .command("list")
+      .description("List registered tasks")
+      .option("--status <status>", "Filter by status")
+      .option("--limit <n>", "Maximum number of tasks to return (default 50)", "50")
+      .option("--json", "Output JSON", false)
+      .action(async (opts) => {
+        const params: Record<string, unknown> = {};
+        if (opts.status) {
+          params.status = opts.status;
+        }
+        const limitRaw = Number.parseInt(String(opts.limit ?? "50"), 10);
+        params.limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 50;
+        const res = await callGatewayFromCli("tasks.list", opts, params);
+        console.log(JSON.stringify(res, null, 2));
+      }),
+  );
+
+  // tasks remove
+  addGatewayClientOptions(
+    tasks
+      .command("remove")
+      .alias("rm")
+      .description("Remove a task from the registry")
+      .requiredOption("--id <id>", "Task identifier")
+      .option("--json", "Output JSON", false)
+      .action(async (opts) => {
+        const res = await callGatewayFromCli("tasks.remove", opts, { taskId: opts.id });
+        console.log(JSON.stringify(res, null, 2));
+      }),
+  );
+}

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -85,6 +85,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "talk.config",
     "agents.files.list",
     "agents.files.get",
+    "tasks.list",
   ],
   [WRITE_SCOPE]: [
     "send",
@@ -104,6 +105,11 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "browser.request",
     "push.test",
     "node.pending.enqueue",
+    "tasks.register",
+    "tasks.watch",
+    "tasks.unwatch",
+    "tasks.notify",
+    "tasks.remove",
   ],
   [ADMIN_SCOPE]: [
     "channels.logout",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -26,6 +26,7 @@ import { sessionsHandlers } from "./server-methods/sessions.js";
 import { skillsHandlers } from "./server-methods/skills.js";
 import { systemHandlers } from "./server-methods/system.js";
 import { talkHandlers } from "./server-methods/talk.js";
+import { taskHandlers } from "./server-methods/tasks.js";
 import { toolsCatalogHandlers } from "./server-methods/tools-catalog.js";
 import { ttsHandlers } from "./server-methods/tts.js";
 import type { GatewayRequestHandlers, GatewayRequestOptions } from "./server-methods/types.js";
@@ -95,6 +96,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...agentHandlers,
   ...agentsHandlers,
   ...browserHandlers,
+  ...taskHandlers,
 };
 
 export async function handleGatewayRequest(

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -1,0 +1,715 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deliverTaskNotification,
+  loadTaskRegistry,
+  saveTaskRegistry,
+  taskHandlers,
+  type TaskEntry,
+  type TaskRegistry,
+} from "./tasks.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTask(overrides: Partial<TaskEntry> = {}): TaskEntry {
+  return {
+    id: "build-123",
+    description: "Implement feature X",
+    createdAt: 1700000000000,
+    watchers: [],
+    events: [],
+    notifiedEvents: {},
+    ...overrides,
+  };
+}
+
+function makeRegistry(tasks: TaskEntry[]): TaskRegistry {
+  return { tasks };
+}
+
+function writeRegistry(dir: string, tasks: TaskEntry[]): string {
+  const file = path.join(dir, "task-registry.json");
+  fs.writeFileSync(file, JSON.stringify(makeRegistry(tasks), null, 2), "utf8");
+  return file;
+}
+
+// Simulate invoking a gateway handler and capturing the respond call.
+function runHandler(
+  method: string,
+  params: Record<string, unknown>,
+  contextOverrides?: Record<string, unknown>,
+): Promise<{ ok: boolean; payload: unknown; error?: unknown }> {
+  return new Promise((resolve) => {
+    const respond = (ok: boolean, payload: unknown, error?: unknown) => {
+      resolve({ ok, payload, error });
+    };
+    void taskHandlers[method]({
+      params,
+      respond: respond as never,
+      context: { deps: {}, ...contextOverrides } as never,
+      client: null,
+      req: { id: "r1", type: "req", method },
+      isWebchatConnect: () => false,
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// loadTaskRegistry / saveTaskRegistry
+// ---------------------------------------------------------------------------
+
+describe("loadTaskRegistry", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tasks-test-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty registry when file is missing", () => {
+    const result = loadTaskRegistry(path.join(tmpDir, "missing.json"));
+    expect(result).toEqual({ tasks: [] });
+  });
+
+  it("parses an existing registry file", () => {
+    const file = writeRegistry(tmpDir, [makeTask()]);
+    const result = loadTaskRegistry(file);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.id).toBe("build-123");
+  });
+});
+
+describe("saveTaskRegistry", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tasks-test-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates the directory if needed and writes atomically", () => {
+    const file = path.join(tmpDir, "sub", "task-registry.json");
+    const registry = makeRegistry([makeTask()]);
+    saveTaskRegistry(registry, file);
+    expect(fs.existsSync(file)).toBe(true);
+    const read = JSON.parse(fs.readFileSync(file, "utf8")) as TaskRegistry;
+    expect(read.tasks[0]?.id).toBe("build-123");
+    // Temp file should be cleaned up
+    expect(fs.existsSync(`${file}.tmp`)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deliverTaskNotification
+// ---------------------------------------------------------------------------
+
+describe("deliverTaskNotification", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tasks-notify-test-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns skipped='task not found' when task absent", async () => {
+    const registryPath = writeRegistry(tmpDir, []);
+    const sendToSession = vi.fn();
+    const result = await deliverTaskNotification({
+      taskId: "nonexistent",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    expect(result.skipped).toBe("task not found");
+    expect(sendToSession).not.toHaveBeenCalled();
+  });
+
+  it("returns skipped='already delivered' when idempotency key already set", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({
+        id: "t1",
+        watchers: [{ sessionKey: "agent:main:main", addedAt: Date.now() }],
+        notifiedEvents: { completed: true },
+      }),
+    ]);
+    const sendToSession = vi.fn();
+    const result = await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    expect(result.skipped).toBe("already delivered");
+    expect(sendToSession).not.toHaveBeenCalled();
+  });
+
+  it("delivers to all watchers and returns their session keys", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({
+        id: "t1",
+        watchers: [
+          { sessionKey: "agent:main:main", addedAt: Date.now() },
+          { sessionKey: "agent:main:slack:C123", addedAt: Date.now() },
+        ],
+      }),
+    ]);
+    const sendToSession = vi.fn().mockResolvedValue(undefined);
+    const result = await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "PR #42 merged",
+      registryPath,
+      sendToSession,
+    });
+    expect(sendToSession).toHaveBeenCalledTimes(2);
+    expect(sendToSession).toHaveBeenCalledWith("agent:main:main", "PR #42 merged");
+    expect(sendToSession).toHaveBeenCalledWith("agent:main:slack:C123", "PR #42 merged");
+    expect(result.delivered).toEqual(["agent:main:main", "agent:main:slack:C123"]);
+    expect(result.failed).toEqual([]);
+  });
+
+  it("marks idempotency key after successful delivery", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({
+        id: "t1",
+        watchers: [{ sessionKey: "agent:main:main", addedAt: Date.now() }],
+      }),
+    ]);
+    const sendToSession = vi.fn().mockResolvedValue(undefined);
+    await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    expect(updated.tasks[0]?.notifiedEvents["completed"]).toBe(true);
+  });
+
+  it("uses custom idempotencyKey instead of event name", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({
+        id: "t1",
+        watchers: [{ sessionKey: "agent:main:main", addedAt: Date.now() }],
+      }),
+    ]);
+    const sendToSession = vi.fn().mockResolvedValue(undefined);
+    await deliverTaskNotification({
+      taskId: "t1",
+      event: "progress",
+      message: "50% done",
+      idempotencyKey: "progress-step-1",
+      registryPath,
+      sendToSession,
+    });
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    expect(updated.tasks[0]?.notifiedEvents["progress-step-1"]).toBe(true);
+    expect(updated.tasks[0]?.notifiedEvents["progress"]).toBeUndefined();
+  });
+
+  it("logs the event in task.events", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", watchers: [{ sessionKey: "sk", addedAt: Date.now() }] }),
+    ]);
+    const sendToSession = vi.fn().mockResolvedValue(undefined);
+    await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "All done",
+      registryPath,
+      sendToSession,
+    });
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    const events = updated.tasks[0]?.events ?? [];
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event).toBe("completed");
+    expect(events[0]?.message).toBe("All done");
+  });
+
+  it("caps events list at 50", async () => {
+    const existing = Array.from({ length: 50 }, (_, i) => ({
+      event: "tick",
+      message: `tick ${i}`,
+      timestamp: Date.now(),
+    }));
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", events: existing, watchers: [] }),
+    ]);
+    const sendToSession = vi.fn();
+    await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    expect(updated.tasks[0]?.events).toHaveLength(50);
+    // The new event replaces the oldest
+    const last = updated.tasks[0]?.events[49];
+    expect(last?.event).toBe("completed");
+  });
+
+  it("updates task.status when provided", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", status: "running", watchers: [] }),
+    ]);
+    const sendToSession = vi.fn();
+    await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      status: "done",
+      registryPath,
+      sendToSession,
+    });
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    expect(updated.tasks[0]?.status).toBe("done");
+  });
+
+  it("continues delivery even if one watcher throws", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({
+        id: "t1",
+        watchers: [
+          { sessionKey: "bad-session", addedAt: Date.now() },
+          { sessionKey: "good-session", addedAt: Date.now() },
+        ],
+      }),
+    ]);
+    const sendToSession = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("session not found"))
+      .mockResolvedValueOnce(undefined);
+    const result = await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    expect(result.delivered).toEqual(["good-session"]);
+    expect(result.failed).toEqual(["bad-session"]);
+  });
+
+  it("marks idempotency key for tasks with no watchers", async () => {
+    const registryPath = writeRegistry(tmpDir, [makeTask({ id: "t1", watchers: [] })]);
+    const sendToSession = vi.fn();
+    await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    expect(updated.tasks[0]?.notifiedEvents["completed"]).toBe(true);
+  });
+
+  it("does not mark idempotency key when all deliveries fail", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", watchers: [{ sessionKey: "bad-session", addedAt: Date.now() }] }),
+    ]);
+    const sendToSession = vi.fn().mockRejectedValue(new Error("failed"));
+    const result = await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    expect(result.delivered).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    // Not marked delivered since nothing got through
+    expect(updated.tasks[0]?.notifiedEvents["completed"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tasks.register handler
+// ---------------------------------------------------------------------------
+
+describe("tasks.register", () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tasks-register-test-"));
+    origHome = process.env["HOME"];
+    process.env["HOME"] = tmpDir;
+    fs.mkdirSync(path.join(tmpDir, ".openclaw"), { recursive: true });
+  });
+  afterEach(() => {
+    process.env["HOME"] = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects missing taskId", async () => {
+    const { ok, error } = await runHandler("tasks.register", {});
+    expect(ok).toBe(false);
+    expect((error as { message: string }).message).toMatch(/taskId/);
+  });
+
+  it("creates a new task", async () => {
+    const { ok, payload } = await runHandler("tasks.register", {
+      taskId: "my-task",
+      description: "Do something",
+      status: "running",
+    });
+    expect(ok).toBe(true);
+    const task = (payload as { task: TaskEntry }).task;
+    expect(task.id).toBe("my-task");
+    expect(task.description).toBe("Do something");
+    expect(task.status).toBe("running");
+    expect(task.watchers).toEqual([]);
+    expect(task.events).toEqual([]);
+    expect(task.notifiedEvents).toEqual({});
+  });
+
+  it("updates existing task (merges, not replaces)", async () => {
+    // Create first
+    await runHandler("tasks.register", {
+      taskId: "my-task",
+      description: "Original",
+      metadata: { repo: "/repo" },
+    });
+    // Update
+    const { ok, payload } = await runHandler("tasks.register", {
+      taskId: "my-task",
+      description: "Updated",
+      metadata: { branch: "main" },
+    });
+    expect(ok).toBe(true);
+    const task = (payload as { task: TaskEntry }).task;
+    expect(task.description).toBe("Updated");
+    // metadata should be merged
+    expect(task.metadata).toMatchObject({ repo: "/repo", branch: "main" });
+    // updatedAt should be set
+    expect(task.updatedAt).toBeDefined();
+  });
+
+  it("preserves watchers and events when updating", async () => {
+    // Create and manually add a watcher
+    await runHandler("tasks.register", { taskId: "t1" });
+    await runHandler("tasks.watch", { taskId: "t1", sessionKey: "agent:main:main" });
+    // Update the task
+    const { payload } = await runHandler("tasks.register", {
+      taskId: "t1",
+      status: "done",
+    });
+    const task = (payload as { task: TaskEntry }).task;
+    expect(task.watchers).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tasks.watch handler
+// ---------------------------------------------------------------------------
+
+describe("tasks.watch", () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tasks-watch-test-"));
+    origHome = process.env["HOME"];
+    process.env["HOME"] = tmpDir;
+    fs.mkdirSync(path.join(tmpDir, ".openclaw"), { recursive: true });
+  });
+  afterEach(() => {
+    process.env["HOME"] = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects missing taskId", async () => {
+    const { ok, error } = await runHandler("tasks.watch", { sessionKey: "sk" });
+    expect(ok).toBe(false);
+    expect((error as { message: string }).message).toMatch(/taskId/);
+  });
+
+  it("rejects missing sessionKey", async () => {
+    const { ok, error } = await runHandler("tasks.watch", { taskId: "t1" });
+    expect(ok).toBe(false);
+    expect((error as { message: string }).message).toMatch(/sessionKey/);
+  });
+
+  it("rejects task not found", async () => {
+    const { ok, error } = await runHandler("tasks.watch", {
+      taskId: "nonexistent",
+      sessionKey: "sk",
+    });
+    expect(ok).toBe(false);
+    expect((error as { message: string }).message).toMatch(/task not found/);
+  });
+
+  it("adds a watcher and returns watcherCount", async () => {
+    await runHandler("tasks.register", { taskId: "t1" });
+    const { ok, payload } = await runHandler("tasks.watch", {
+      taskId: "t1",
+      sessionKey: "agent:main:main",
+      label: "main session",
+    });
+    expect(ok).toBe(true);
+    expect((payload as { watcherCount: number }).watcherCount).toBe(1);
+  });
+
+  it("is idempotent: watching same session twice does not duplicate", async () => {
+    await runHandler("tasks.register", { taskId: "t1" });
+    await runHandler("tasks.watch", { taskId: "t1", sessionKey: "agent:main:main" });
+    const { payload } = await runHandler("tasks.watch", {
+      taskId: "t1",
+      sessionKey: "agent:main:main",
+    });
+    expect((payload as { watcherCount: number }).watcherCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tasks.notify handler
+// ---------------------------------------------------------------------------
+
+describe("tasks.notify validation", () => {
+  it("rejects missing taskId", async () => {
+    const { ok, error } = await runHandler("tasks.notify", {
+      event: "completed",
+      message: "done",
+    });
+    expect(ok).toBe(false);
+    expect((error as { message: string }).message).toMatch(/taskId/);
+  });
+
+  it("rejects missing event", async () => {
+    const { ok, error } = await runHandler("tasks.notify", {
+      taskId: "t1",
+      message: "done",
+    });
+    expect(ok).toBe(false);
+    expect((error as { message: string }).message).toMatch(/event/);
+  });
+
+  it("rejects missing message", async () => {
+    const { ok, error } = await runHandler("tasks.notify", {
+      taskId: "t1",
+      event: "completed",
+    });
+    expect(ok).toBe(false);
+    expect((error as { message: string }).message).toMatch(/message/);
+  });
+});
+
+describe("tasks.notify delivery", () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tasks-notify-test-"));
+    origHome = process.env["HOME"];
+    process.env["HOME"] = tmpDir;
+    fs.mkdirSync(path.join(tmpDir, ".openclaw"), { recursive: true });
+  });
+  afterEach(() => {
+    process.env["HOME"] = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects task not found", async () => {
+    const { ok, error } = await runHandler("tasks.notify", {
+      taskId: "nonexistent",
+      event: "completed",
+      message: "done",
+    });
+    expect(ok).toBe(false);
+    expect((error as { message: string }).message).toMatch(/task not found/);
+  });
+
+  it("returns delivered/failed arrays", async () => {
+    await runHandler("tasks.register", { taskId: "t1" });
+    await runHandler("tasks.watch", { taskId: "t1", sessionKey: "agent:main:main" });
+
+    // Patch agentCommandFromIngress to be a no-op in tests
+    const agentMod = await import("../../commands/agent.js");
+    const spy = vi.spyOn(agentMod, "agentCommandFromIngress").mockResolvedValue(undefined as never);
+
+    const { ok, payload } = await runHandler("tasks.notify", {
+      taskId: "t1",
+      event: "completed",
+      message: "All done",
+    });
+
+    expect(ok).toBe(true);
+    const result = payload as { delivered: string[]; failed: string[] };
+    expect(result.delivered).toContain("agent:main:main");
+    expect(result.failed).toHaveLength(0);
+
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tasks.list handler
+// ---------------------------------------------------------------------------
+
+describe("tasks.list", () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tasks-list-test-"));
+    origHome = process.env["HOME"];
+    process.env["HOME"] = tmpDir;
+    fs.mkdirSync(path.join(tmpDir, ".openclaw"), { recursive: true });
+  });
+  afterEach(() => {
+    process.env["HOME"] = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty list when registry absent", async () => {
+    const { ok, payload } = await runHandler("tasks.list", {});
+    expect(ok).toBe(true);
+    expect((payload as { tasks: unknown[] }).tasks).toHaveLength(0);
+    expect((payload as { total: number }).total).toBe(0);
+  });
+
+  it("returns all tasks with watcherCount", async () => {
+    await runHandler("tasks.register", { taskId: "t1", status: "running" });
+    await runHandler("tasks.register", { taskId: "t2", status: "done" });
+    await runHandler("tasks.watch", { taskId: "t1", sessionKey: "sk1" });
+    await runHandler("tasks.watch", { taskId: "t1", sessionKey: "sk2" });
+
+    const { payload } = await runHandler("tasks.list", {});
+    const tasks = (payload as { tasks: Array<{ id: string; watcherCount: number }> }).tasks;
+    expect(tasks).toHaveLength(2);
+    const t1 = tasks.find((t) => t.id === "t1");
+    expect(t1?.watcherCount).toBe(2);
+  });
+
+  it("filters by status", async () => {
+    await runHandler("tasks.register", { taskId: "t1", status: "running" });
+    await runHandler("tasks.register", { taskId: "t2", status: "done" });
+
+    const { payload } = await runHandler("tasks.list", { status: "running" });
+    const tasks = (payload as { tasks: Array<{ id: string }> }).tasks;
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.id).toBe("t1");
+  });
+
+  it("does not expose watchers array or notifiedEvents in list output", async () => {
+    await runHandler("tasks.register", { taskId: "t1" });
+    await runHandler("tasks.watch", { taskId: "t1", sessionKey: "sk1" });
+
+    const { payload } = await runHandler("tasks.list", {});
+    const tasks = (payload as { tasks: Array<Record<string, unknown>> }).tasks;
+    expect(tasks[0]).not.toHaveProperty("watchers");
+    expect(tasks[0]).not.toHaveProperty("notifiedEvents");
+  });
+
+  it("respects limit param", async () => {
+    for (let i = 0; i < 5; i++) {
+      await runHandler("tasks.register", { taskId: `t${i}` });
+    }
+    const { payload } = await runHandler("tasks.list", { limit: 3 });
+    expect((payload as { tasks: unknown[] }).tasks).toHaveLength(3);
+    expect((payload as { total: number }).total).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tasks.unwatch handler
+// ---------------------------------------------------------------------------
+
+describe("tasks.unwatch", () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tasks-unwatch-test-"));
+    origHome = process.env["HOME"];
+    process.env["HOME"] = tmpDir;
+    fs.mkdirSync(path.join(tmpDir, ".openclaw"), { recursive: true });
+  });
+  afterEach(() => {
+    process.env["HOME"] = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects missing taskId", async () => {
+    const { ok } = await runHandler("tasks.unwatch", { sessionKey: "sk" });
+    expect(ok).toBe(false);
+  });
+
+  it("rejects missing sessionKey", async () => {
+    const { ok } = await runHandler("tasks.unwatch", { taskId: "t1" });
+    expect(ok).toBe(false);
+  });
+
+  it("removes a watcher and returns updated count", async () => {
+    await runHandler("tasks.register", { taskId: "t1" });
+    await runHandler("tasks.watch", { taskId: "t1", sessionKey: "sk1" });
+    await runHandler("tasks.watch", { taskId: "t1", sessionKey: "sk2" });
+
+    const { ok, payload } = await runHandler("tasks.unwatch", {
+      taskId: "t1",
+      sessionKey: "sk1",
+    });
+    expect(ok).toBe(true);
+    expect((payload as { watcherCount: number }).watcherCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tasks.remove handler
+// ---------------------------------------------------------------------------
+
+describe("tasks.remove", () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tasks-remove-test-"));
+    origHome = process.env["HOME"];
+    process.env["HOME"] = tmpDir;
+    fs.mkdirSync(path.join(tmpDir, ".openclaw"), { recursive: true });
+  });
+  afterEach(() => {
+    process.env["HOME"] = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects missing taskId", async () => {
+    const { ok } = await runHandler("tasks.remove", {});
+    expect(ok).toBe(false);
+  });
+
+  it("rejects unknown task", async () => {
+    const { ok, error } = await runHandler("tasks.remove", { taskId: "nonexistent" });
+    expect(ok).toBe(false);
+    expect((error as { message: string }).message).toMatch(/task not found/);
+  });
+
+  it("removes the task from the registry", async () => {
+    await runHandler("tasks.register", { taskId: "t1" });
+    await runHandler("tasks.register", { taskId: "t2" });
+
+    const { ok } = await runHandler("tasks.remove", { taskId: "t1" });
+    expect(ok).toBe(true);
+
+    const { payload } = await runHandler("tasks.list", {});
+    const tasks = (payload as { tasks: Array<{ id: string }> }).tasks;
+    expect(tasks.map((t) => t.id)).toEqual(["t2"]);
+  });
+});

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -135,6 +135,62 @@ describe("deliverTaskNotification", () => {
     expect(sendToSession).not.toHaveBeenCalled();
   });
 
+  it("normalizes empty/whitespace idempotency key to event name", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", watchers: [{ sessionKey: "s1", addedAt: Date.now() }] }),
+    ]);
+    const sendToSession = vi.fn().mockResolvedValue(undefined);
+    // First call with empty key — should succeed using event name as key
+    await deliverTaskNotification({
+      taskId: "t1",
+      event: "done",
+      message: "msg",
+      idempotencyKey: "",
+      registryPath,
+      sendToSession,
+    });
+    // Second call with whitespace key — should be treated as idempotent (same event name key)
+    const result = await deliverTaskNotification({
+      taskId: "t1",
+      event: "done",
+      message: "msg2",
+      idempotencyKey: "   ",
+      registryPath,
+      sendToSession,
+    });
+    expect(result.skipped).toBe("already delivered");
+    expect(sendToSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps notifiedEvents map at MAX_TASK_EVENTS entries", async () => {
+    // Fill task with 50 existing idempotency entries
+    const existing: Record<string, boolean> = {};
+    for (let i = 0; i < 50; i++) {
+      existing[`event-${i}`] = true;
+    }
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({
+        id: "t1",
+        watchers: [{ sessionKey: "s1", addedAt: Date.now() }],
+        notifiedEvents: existing,
+      }),
+    ]);
+    const sendToSession = vi.fn().mockResolvedValue(undefined);
+    await deliverTaskNotification({
+      taskId: "t1",
+      event: "event-new",
+      message: "msg",
+      registryPath,
+      sendToSession,
+    });
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    const keys = Object.keys(updated.tasks[0].notifiedEvents);
+    expect(keys.length).toBeLessThanOrEqual(50);
+    // New key should be present; oldest key should have been pruned
+    expect(updated.tasks[0].notifiedEvents["event-new"]).toBe(true);
+    expect(updated.tasks[0].notifiedEvents["event-0"]).toBeUndefined();
+  });
+
   it("returns skipped='already delivered' when idempotency key already set", async () => {
     const registryPath = writeRegistry(tmpDir, [
       makeTask({

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -462,6 +462,42 @@ describe("deliverTaskNotification", () => {
     expect(updated.tasks).toHaveLength(0);
   });
 
+  it("serialises concurrent notify calls for DIFFERENT tasks — both writes preserved", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", watchers: [{ sessionKey: "s1", addedAt: Date.now() }] }),
+      makeTask({ id: "t2", watchers: [{ sessionKey: "s2", addedAt: Date.now() }] }),
+    ]);
+    const sendToSession = vi.fn().mockResolvedValue(undefined);
+
+    // Two concurrent notifies on different tasks — same registry file
+    await Promise.all([
+      deliverTaskNotification({
+        taskId: "t1",
+        event: "done",
+        message: "t1 done",
+        registryPath,
+        sendToSession,
+      }),
+      deliverTaskNotification({
+        taskId: "t2",
+        event: "done",
+        message: "t2 done",
+        registryPath,
+        sendToSession,
+      }),
+    ]);
+
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    const t1 = updated.tasks.find((t) => t.id === "t1")!;
+    const t2 = updated.tasks.find((t) => t.id === "t2")!;
+    // Both tasks must have their event + idempotency key — no overwrite
+    expect(t1.events.map((e) => e.event)).toContain("done");
+    expect(t2.events.map((e) => e.event)).toContain("done");
+    expect(t1.notifiedEvents["done"]).toBe(true);
+    expect(t2.notifiedEvents["done"]).toBe(true);
+    expect(sendToSession).toHaveBeenCalledTimes(2);
+  });
+
   it("serialises concurrent notify calls for same task with different keys — both events persisted", async () => {
     const registryPath = writeRegistry(tmpDir, [
       makeTask({ id: "t1", watchers: [{ sessionKey: "s1", addedAt: Date.now() }] }),

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -83,6 +83,23 @@ describe("loadTaskRegistry", () => {
     expect(result.tasks).toHaveLength(1);
     expect(result.tasks[0]?.id).toBe("build-123");
   });
+
+  it("throws on malformed JSON rather than returning empty registry", () => {
+    const file = path.join(tmpDir, "corrupt.json");
+    fs.writeFileSync(file, "{ not valid json }", "utf8");
+    expect(() => loadTaskRegistry(file)).toThrow();
+  });
+
+  it("throws on unreadable file (permission error) rather than returning empty registry", () => {
+    const file = path.join(tmpDir, "noperm.json");
+    fs.writeFileSync(file, JSON.stringify({ tasks: [] }), "utf8");
+    fs.chmodSync(file, 0o000);
+    try {
+      expect(() => loadTaskRegistry(file)).toThrow();
+    } finally {
+      fs.chmodSync(file, 0o644); // restore so cleanup works
+    }
+  });
 });
 
 describe("saveTaskRegistry", () => {
@@ -443,6 +460,42 @@ describe("deliverTaskNotification", () => {
     const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
     // Task should not have been re-created by the registry write
     expect(updated.tasks).toHaveLength(0);
+  });
+
+  it("serialises concurrent notify calls for same task with different keys — both events persisted", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", watchers: [{ sessionKey: "s1", addedAt: Date.now() }] }),
+    ]);
+    const sendToSession = vi.fn().mockResolvedValue(undefined);
+
+    // Two different events fire concurrently on the same task
+    await Promise.all([
+      deliverTaskNotification({
+        taskId: "t1",
+        event: "started",
+        message: "Starting",
+        registryPath,
+        sendToSession,
+      }),
+      deliverTaskNotification({
+        taskId: "t1",
+        event: "completed",
+        message: "Done",
+        registryPath,
+        sendToSession,
+      }),
+    ]);
+
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    // Both event log entries must be present — no lost writes
+    const eventNames = updated.tasks[0].events.map((e) => e.event);
+    expect(eventNames).toContain("started");
+    expect(eventNames).toContain("completed");
+    // Both idempotency keys must be set
+    expect(updated.tasks[0].notifiedEvents["started"]).toBe(true);
+    expect(updated.tasks[0].notifiedEvents["completed"]).toBe(true);
+    // Both watchers notified (2 total sends)
+    expect(sendToSession).toHaveBeenCalledTimes(2);
   });
 
   it("serialises concurrent notify calls with same key — second skips without sending", async () => {

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -444,6 +444,28 @@ describe("deliverTaskNotification", () => {
     // Task should not have been re-created by the registry write
     expect(updated.tasks).toHaveLength(0);
   });
+
+  it("skips second concurrent notify with same idempotency key written during fan-out", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", watchers: [{ sessionKey: "s1", addedAt: Date.now() }] }),
+    ]);
+    // Simulate a concurrent notify writing the idempotency key during our fan-out
+    const sendToSession = vi.fn().mockImplementation(async () => {
+      const reg = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+      reg.tasks[0].notifiedEvents["completed"] = true;
+      fs.writeFileSync(registryPath, JSON.stringify(reg, null, 2));
+    });
+    const result = await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    // Delivery happened (sendToSession was called) but post-send guard detected concurrent write
+    expect(result.skipped).toBe("already delivered");
+    expect(result.delivered).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -179,6 +179,24 @@ describe("deliverTaskNotification", () => {
     expect(sendToSession).toHaveBeenCalledTimes(1);
   });
 
+  it("delivers successfully when event name is a prototype key like 'toString'", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", watchers: [{ sessionKey: "s1", addedAt: Date.now() }] }),
+    ]);
+    const sendToSession = vi.fn().mockResolvedValue(undefined);
+    // "toString" is an inherited Object prototype key — must not be treated as already delivered
+    const result = await deliverTaskNotification({
+      taskId: "t1",
+      event: "toString",
+      message: "should deliver",
+      registryPath,
+      sendToSession,
+    });
+    expect(result.skipped).toBeUndefined();
+    expect(result.delivered).toEqual(["s1"]);
+    expect(sendToSession).toHaveBeenCalledTimes(1);
+  });
+
   it("caps notifiedEvents map at MAX_TASK_EVENTS entries", async () => {
     // Fill task with 50 existing idempotency entries
     const existing: Record<string, boolean> = {};

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -303,6 +303,9 @@ describe("deliverTaskNotification", () => {
     });
     expect(result.delivered).toEqual(["good-session"]);
     expect(result.failed).toEqual(["bad-session"]);
+    // Idempotency key must NOT be set on partial failure so failed watchers can be retried
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    expect(updated.tasks[0]?.notifiedEvents["completed"]).toBeUndefined();
   });
 
   it("marks idempotency key for tasks with no watchers", async () => {
@@ -336,6 +339,54 @@ describe("deliverTaskNotification", () => {
     const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
     // Not marked delivered since nothing got through
     expect(updated.tasks[0]?.notifiedEvents["completed"]).toBeUndefined();
+  });
+
+  it("does not append duplicate event log entries on repeated failed retries", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", watchers: [{ sessionKey: "bad-session", addedAt: Date.now() }] }),
+    ]);
+    const sendToSession = vi.fn().mockRejectedValue(new Error("failed"));
+    // Fire same event twice (simulating retries)
+    await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    // Event log should remain empty since no delivery succeeded
+    expect(updated.tasks[0]?.events).toHaveLength(0);
+  });
+
+  it("does not resurrect a task removed concurrently during async sends", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", watchers: [{ sessionKey: "s1", addedAt: Date.now() }] }),
+    ]);
+    const sendToSession = vi.fn().mockImplementation(async () => {
+      // Simulate concurrent task removal during send
+      const reg = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+      reg.tasks = reg.tasks.filter((t) => t.id !== "t1");
+      fs.writeFileSync(registryPath, JSON.stringify(reg, null, 2));
+    });
+    const result = await deliverTaskNotification({
+      taskId: "t1",
+      event: "completed",
+      message: "done",
+      registryPath,
+      sendToSession,
+    });
+    expect(result.delivered).toEqual(["s1"]);
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    // Task should not have been re-created by the registry write
+    expect(updated.tasks).toHaveLength(0);
   });
 });
 

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -445,11 +445,45 @@ describe("deliverTaskNotification", () => {
     expect(updated.tasks).toHaveLength(0);
   });
 
-  it("skips second concurrent notify with same idempotency key written during fan-out", async () => {
+  it("serialises concurrent notify calls with same key — second skips without sending", async () => {
     const registryPath = writeRegistry(tmpDir, [
       makeTask({ id: "t1", watchers: [{ sessionKey: "s1", addedAt: Date.now() }] }),
     ]);
-    // Simulate a concurrent notify writing the idempotency key during our fan-out
+    const sendToSession = vi.fn().mockResolvedValue(undefined);
+
+    // Fire two concurrent calls with the same key
+    const [r1, r2] = await Promise.all([
+      deliverTaskNotification({
+        taskId: "t1",
+        event: "completed",
+        message: "done",
+        registryPath,
+        sendToSession,
+      }),
+      deliverTaskNotification({
+        taskId: "t1",
+        event: "completed",
+        message: "done",
+        registryPath,
+        sendToSession,
+      }),
+    ]);
+
+    // Exactly one should have delivered; the other should be skipped
+    const delivered = [r1, r2].filter((r) => (r.delivered?.length ?? 0) > 0);
+    const skipped = [r1, r2].filter((r) => r.skipped === "already delivered");
+    expect(delivered).toHaveLength(1);
+    expect(skipped).toHaveLength(1);
+
+    // sendToSession called exactly once — no duplicate delivery
+    expect(sendToSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("post-send guard still catches external concurrent writes (e.g. different process)", async () => {
+    const registryPath = writeRegistry(tmpDir, [
+      makeTask({ id: "t1", watchers: [{ sessionKey: "s1", addedAt: Date.now() }] }),
+    ]);
+    // Simulate an external write setting the key during our fan-out
     const sendToSession = vi.fn().mockImplementation(async () => {
       const reg = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
       reg.tasks[0].notifiedEvents["completed"] = true;
@@ -462,7 +496,7 @@ describe("deliverTaskNotification", () => {
       registryPath,
       sendToSession,
     });
-    // Delivery happened (sendToSession was called) but post-send guard detected concurrent write
+    // Delivery happened but post-send guard detected the external write
     expect(result.skipped).toBe("already delivered");
     expect(result.delivered).toHaveLength(0);
   });

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -576,14 +576,15 @@ describe("deliverTaskNotification", () => {
       }),
     ]);
 
-    // Exactly one should have delivered; the other should be skipped
-    const delivered = [r1, r2].filter((r) => (r.delivered?.length ?? 0) > 0);
+    // Both calls may fan-out (the lock is only held around the short read-modify-write,
+    // not the full sendToSession await), but only ONE post-flight write succeeds.
+    // The other detects the key is already set and returns skipped.
     const skipped = [r1, r2].filter((r) => r.skipped === "already delivered");
-    expect(delivered).toHaveLength(1);
     expect(skipped).toHaveLength(1);
 
-    // sendToSession called exactly once — no duplicate delivery
-    expect(sendToSession).toHaveBeenCalledTimes(1);
+    // Only one idempotency entry must be written (no double event log entry)
+    const updated = JSON.parse(fs.readFileSync(registryPath, "utf8")) as TaskRegistry;
+    expect(updated.tasks[0].events).toHaveLength(1);
   });
 
   it("post-send guard still catches external concurrent writes (e.g. different process)", async () => {

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -100,10 +100,38 @@ export function saveTaskRegistry(registry: TaskRegistry, registryPath = getRegis
 export type SendToSessionFn = (sessionKey: string, message: string) => Promise<void>;
 
 /**
- * Inner implementation — do not call directly; use deliverTaskNotification() which
- * serialises concurrent calls for the same (taskId, idempotencyKey) via inFlightNotify.
+ * Run `fn` as the next step on the registry write queue for `registryKey`.
+ * Only the synchronous body of `fn` (a single registry read-modify-write)
+ * should be placed inside; async fan-out must happen outside.
  */
-async function _deliverTaskNotification(opts: {
+function withRegistryLock<T>(registryKey: string, fn: () => T): Promise<T> {
+  const tail = (registryWriteQueue.get(registryKey) ?? Promise.resolve()).then(fn);
+  const silentTail = tail.catch(() => undefined);
+  registryWriteQueue.set(registryKey, silentTail);
+  void silentTail.then(() => {
+    if (registryWriteQueue.get(registryKey) === silentTail) {
+      registryWriteQueue.delete(registryKey);
+    }
+  });
+  return tail;
+}
+
+/**
+ * Deliver a notification to all watchers of a task.
+ *
+ * The registry lock is held only for the two short critical sections:
+ *   1. Pre-flight: read registry, check idempotency, extract watcher list.
+ *   2. Post-flight: reload registry, re-check idempotency, write update.
+ * Fan-out (sendToSession calls) runs between them, outside the lock, so a
+ * slow or hung watcher on task A never blocks task B from starting.
+ *
+ * Idempotency guarantee: concurrent calls with the same (taskId, ikey) may
+ * both fan-out (duplicate delivery is acceptable), but only the first
+ * post-flight write succeeds — the second detects the key and returns skipped.
+ * For concurrent calls on *different* tasks, both writes land correctly because
+ * each post-flight section holds the lock exclusively.
+ */
+export async function deliverTaskNotification(opts: {
   taskId: string;
   event: string;
   message: string;
@@ -123,135 +151,94 @@ async function _deliverTaskNotification(opts: {
     sendToSession,
   } = opts;
 
-  // Default idempotency key is the event name (fires once per event type by default).
-  // Normalize empty/whitespace-only keys to undefined so callers with unset env vars
-  // (which produce "") don't accidentally collapse all future notifications.
+  // Normalize idempotency key: empty/whitespace falls back to event name.
   const rawKey = opts.idempotencyKey?.trim();
   const ikey = rawKey && rawKey.length > 0 ? rawKey : event;
 
-  const registry = loadTaskRegistry(registryPath);
-  const taskIndex = registry.tasks.findIndex((t) => t.id === taskId);
-  if (taskIndex === -1) {
-    return { delivered: [], failed: [], skipped: "task not found" };
+  const registryKey = registryPath;
+
+  // ── Critical section 1: pre-flight read + idempotency check ─────────────
+  const preCheck = await withRegistryLock(registryKey, () => {
+    const registry = loadTaskRegistry(registryPath);
+    const task = registry.tasks.find((t) => t.id === taskId);
+    if (!task) {
+      return { skip: "task not found" as const, watchers: [] };
+    }
+    if (Object.hasOwn(task.notifiedEvents, ikey)) {
+      return { skip: "already delivered" as const, watchers: [] };
+    }
+    return { skip: null, watchers: task.watchers ?? [] };
+  });
+
+  if (preCheck.skip !== null) {
+    return { delivered: [], failed: [], skipped: preCheck.skip };
   }
 
-  const task = registry.tasks[taskIndex];
-
-  // Idempotency: skip if this key was already delivered
-  if (Object.hasOwn(task.notifiedEvents, ikey)) {
-    return { delivered: [], failed: [], skipped: "already delivered" };
-  }
-
-  const watchers = task.watchers ?? [];
+  // ── Fan-out: outside the lock ────────────────────────────────────────────
   const delivered: string[] = [];
   const failed: string[] = [];
 
-  for (const watcher of watchers) {
+  for (const watcher of preCheck.watchers) {
     try {
       await sendToSession(watcher.sessionKey, message);
       delivered.push(watcher.sessionKey);
     } catch {
-      // Continue delivering to remaining watchers if one session fails
       failed.push(watcher.sessionKey);
     }
   }
 
-  // Only mark idempotency and log the event if ALL watchers succeeded (or there were none).
-  // If any watcher failed, leave the idempotency key unset so the caller can retry — failed
-  // watchers will be re-attempted and already-delivered watchers will receive a duplicate,
-  // but that is preferable to permanently silencing failed watchers.
-  const allSucceeded = failed.length === 0;
-
-  if (!allSucceeded) {
+  // Only persist if all watchers succeeded (or there were none).
+  // Partial failure leaves the idempotency key unset so callers can retry.
+  if (failed.length > 0) {
     return { delivered, failed };
   }
 
-  // Build the event log entry (only appended on full success to avoid duplicate log entries)
-  const newEvent: TaskEvent = {
-    event,
-    message,
-    ...(metadata ? { metadata } : {}),
-    timestamp: Date.now(),
-  };
+  // ── Critical section 2: post-flight reload + write ───────────────────────
+  return withRegistryLock(registryKey, () => {
+    const freshRegistry = loadTaskRegistry(registryPath);
+    const freshIndex = freshRegistry.tasks.findIndex((t) => t.id === taskId);
 
-  // Reload registry before writing to pick up any concurrent mutations (watch/unwatch/remove)
-  // that may have occurred during the async watcher sends above.
-  const freshRegistry = loadTaskRegistry(registryPath);
-  const freshIndex = freshRegistry.tasks.findIndex((t) => t.id === taskId);
-  if (freshIndex === -1) {
-    // Task was removed concurrently; discard — do not resurrect it.
-    return { delivered, failed };
-  }
-
-  const freshTask = freshRegistry.tasks[freshIndex];
-
-  // Re-check idempotency after reload: a concurrent tasks.notify with the same key may have
-  // completed its writes while our fan-out was in flight. Both callers passed the pre-send guard,
-  // but only the first writer wins here — the second returns skipped to prevent duplicate delivery.
-  if (Object.hasOwn(freshTask.notifiedEvents, ikey)) {
-    return { delivered: [], failed: [], skipped: "already delivered" };
-  }
-
-  const updatedEvents = [...freshTask.events, newEvent].slice(-MAX_TASK_EVENTS);
-
-  // Merge new idempotency key and cap the map to MAX_TASK_EVENTS entries.
-  // Entries are ordered by insertion; when over cap, drop oldest keys first.
-  // This prevents registry bloat for long-lived tasks that use unique keys (e.g. commit SHAs).
-  const mergedNotified = { ...freshTask.notifiedEvents, [ikey]: true };
-  const notifiedKeys = Object.keys(mergedNotified);
-  const cappedNotified: Record<string, boolean> =
-    notifiedKeys.length > MAX_TASK_EVENTS
-      ? Object.fromEntries(notifiedKeys.slice(-MAX_TASK_EVENTS).map((k) => [k, true]))
-      : mergedNotified;
-
-  const updatedTask: TaskEntry = {
-    ...freshTask,
-    updatedAt: Date.now(),
-    ...(status !== undefined ? { status } : {}),
-    events: updatedEvents,
-    notifiedEvents: cappedNotified,
-  };
-
-  freshRegistry.tasks[freshIndex] = updatedTask;
-  saveTaskRegistry(freshRegistry, registryPath);
-
-  return { delivered, failed };
-}
-
-/**
- * Deliver a notification to all watchers of a task.
- *
- * Serialised per registry file: all concurrent notify calls queue on the same
- * registry path so each read-modify-write completes before the next begins.
- * This prevents lost updates whether two calls target the same task (different
- * idempotency keys) or different tasks entirely — both write to the same file.
- *
- * Per-key idempotency is enforced inside _deliverTaskNotification; duplicate
- * calls with the same (taskId, idempotencyKey) return skipped without sending.
- */
-export function deliverTaskNotification(
-  opts: Parameters<typeof _deliverTaskNotification>[0],
-): Promise<ReturnType<typeof _deliverTaskNotification>> {
-  // Default registry path must match the inner function's default
-  const registryKey = opts.registryPath ?? getRegistryPath();
-
-  // Chain onto the existing tail for this registry file (or start fresh)
-  const tail = (registryWriteQueue.get(registryKey) ?? Promise.resolve()).then(() =>
-    _deliverTaskNotification(opts),
-  );
-
-  // Store the silenced tail so the chain survives errors from inner calls.
-  const silentTail = tail.catch(() => undefined);
-  registryWriteQueue.set(registryKey, silentTail);
-
-  // Prune map entry when no newer call has queued behind this one.
-  void silentTail.then(() => {
-    if (registryWriteQueue.get(registryKey) === silentTail) {
-      registryWriteQueue.delete(registryKey);
+    if (freshIndex === -1) {
+      // Task removed concurrently — discard without resurrecting.
+      return { delivered, failed };
     }
-  });
 
-  return tail;
+    const freshTask = freshRegistry.tasks[freshIndex];
+
+    // Re-check: a concurrent call with the same key may have written while
+    // our fan-out was in flight.
+    if (Object.hasOwn(freshTask.notifiedEvents, ikey)) {
+      return { delivered: [], failed: [], skipped: "already delivered" as const };
+    }
+
+    const newEvent: TaskEvent = {
+      event,
+      message,
+      ...(metadata ? { metadata } : {}),
+      timestamp: Date.now(),
+    };
+
+    const updatedEvents = [...freshTask.events, newEvent].slice(-MAX_TASK_EVENTS);
+
+    // Cap notifiedEvents to MAX_TASK_EVENTS, dropping oldest keys first.
+    const mergedNotified = { ...freshTask.notifiedEvents, [ikey]: true };
+    const notifiedKeys = Object.keys(mergedNotified);
+    const cappedNotified: Record<string, boolean> =
+      notifiedKeys.length > MAX_TASK_EVENTS
+        ? Object.fromEntries(notifiedKeys.slice(-MAX_TASK_EVENTS).map((k) => [k, true]))
+        : mergedNotified;
+
+    freshRegistry.tasks[freshIndex] = {
+      ...freshTask,
+      updatedAt: Date.now(),
+      ...(status !== undefined ? { status } : {}),
+      events: updatedEvents,
+      notifiedEvents: cappedNotified,
+    };
+
+    saveTaskRegistry(freshRegistry, registryPath);
+    return { delivered, failed };
+  });
 }
 
 export const taskHandlers: GatewayRequestHandlers = {

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -155,6 +155,14 @@ export async function deliverTaskNotification(opts: {
   }
 
   const freshTask = freshRegistry.tasks[freshIndex];
+
+  // Re-check idempotency after reload: a concurrent tasks.notify with the same key may have
+  // completed its writes while our fan-out was in flight. Both callers passed the pre-send guard,
+  // but only the first writer wins here — the second returns skipped to prevent duplicate delivery.
+  if (freshTask.notifiedEvents[ikey]) {
+    return { delivered: [], failed: [], skipped: "already delivered" };
+  }
+
   const updatedEvents = [...freshTask.events, newEvent].slice(-MAX_TASK_EVENTS);
 
   // Merge new idempotency key and cap the map to MAX_TASK_EVENTS entries.

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -138,7 +138,7 @@ async function _deliverTaskNotification(opts: {
   const task = registry.tasks[taskIndex];
 
   // Idempotency: skip if this key was already delivered
-  if (task.notifiedEvents[ikey]) {
+  if (Object.hasOwn(task.notifiedEvents, ikey)) {
     return { delivered: [], failed: [], skipped: "already delivered" };
   }
 
@@ -188,7 +188,7 @@ async function _deliverTaskNotification(opts: {
   // Re-check idempotency after reload: a concurrent tasks.notify with the same key may have
   // completed its writes while our fan-out was in flight. Both callers passed the pre-send guard,
   // but only the first writer wins here — the second returns skipped to prevent duplicate delivery.
-  if (freshTask.notifiedEvents[ikey]) {
+  if (Object.hasOwn(freshTask.notifiedEvents, ikey)) {
     return { delivered: [], failed: [], skipped: "already delivered" };
   }
 

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -11,16 +11,22 @@ import type { GatewayRequestHandlers } from "./types.js";
 const MAX_TASK_EVENTS = 50;
 
 /**
- * In-flight lock map: prevents concurrent tasks.notify calls with the same
- * (taskId, idempotencyKey) from both executing fan-out.
+ * Per-task serialisation queue.
  *
- * Key: `${taskId}::${ikey}`
- * Value: the promise of the in-progress deliver call
+ * Key: taskId
+ * Value: tail of the promise chain for that task
  *
- * Since OpenClaw gateway runs in a single Node.js process, this Map is sufficient
- * to serialise concurrent WS-dispatched requests — no cross-process locking needed.
+ * All tasks.notify calls for the same taskId are chained so that each
+ * read-modify-write is strictly sequential — preventing lost updates when
+ * two different events (different idempotency keys) are notified concurrently.
+ *
+ * Per-key idempotency is enforced inside _deliverTaskNotification after the
+ * per-task lock is acquired.
+ *
+ * Since the gateway runs in a single Node.js process this Map is sufficient;
+ * no cross-process locking is needed.
  */
-const inFlightNotify = new Map<string, Promise<ReturnType<typeof _deliverTaskNotification>>>();
+const taskNotifyQueue = new Map<string, Promise<unknown>>();
 
 export type TaskWatcher = {
   sessionKey: string;
@@ -59,12 +65,19 @@ function getRegistryPath(): string {
 }
 
 export function loadTaskRegistry(registryPath = getRegistryPath()): TaskRegistry {
+  let raw: string;
   try {
-    const raw = fs.readFileSync(registryPath, "utf8");
-    return JSON.parse(raw) as TaskRegistry;
-  } catch {
-    return { tasks: [] };
+    raw = fs.readFileSync(registryPath, "utf8");
+  } catch (err: unknown) {
+    // File not found → fresh registry (normal for first run)
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { tasks: [] };
+    }
+    // Permission error, I/O failure, etc. → throw so callers don't overwrite good data
+    throw err;
   }
+  // Separate try so a JSON parse error is also surfaced rather than silently dropped
+  return JSON.parse(raw) as TaskRegistry;
 }
 
 export function saveTaskRegistry(registry: TaskRegistry, registryPath = getRegistryPath()): void {
@@ -202,36 +215,37 @@ async function _deliverTaskNotification(opts: {
 
 /**
  * Deliver a notification to all watchers of a task.
- * Idempotent and serialised: concurrent calls with the same (taskId, idempotencyKey)
- * wait for the in-flight call to complete, then the second caller reads the now-set
- * idempotency key and returns skipped — preventing duplicate fan-out.
+ *
+ * Serialised per taskId: all concurrent notify calls for the same task are
+ * queued so each read-modify-write completes before the next begins. This
+ * prevents lost event log entries or idempotency marks when two different
+ * events arrive simultaneously for the same task.
+ *
+ * Per-key idempotency is enforced inside _deliverTaskNotification; duplicate
+ * calls with the same (taskId, idempotencyKey) return skipped without sending.
  */
-export async function deliverTaskNotification(
+export function deliverTaskNotification(
   opts: Parameters<typeof _deliverTaskNotification>[0],
 ): Promise<ReturnType<typeof _deliverTaskNotification>> {
-  // Normalise key the same way the inner function does, so the lock key matches
-  const rawKey = opts.idempotencyKey?.trim();
-  const ikey = rawKey && rawKey.length > 0 ? rawKey : opts.event;
-  const lockKey = `${opts.taskId}::${ikey}`;
+  const taskId = opts.taskId;
 
-  const existing = inFlightNotify.get(lockKey);
-  if (existing) {
-    // Another call is already in flight for this (taskId, ikey).
-    // Wait for it to finish, then attempt delivery — the post-send guard will
-    // see the idempotency key is now set and return skipped.
-    await existing;
-  }
+  // Chain onto the existing tail for this task (or start fresh)
+  const tail = (taskNotifyQueue.get(taskId) ?? Promise.resolve()).then(() =>
+    _deliverTaskNotification(opts),
+  );
 
-  const promise = _deliverTaskNotification(opts);
-  inFlightNotify.set(lockKey, promise);
-  try {
-    return await promise;
-  } finally {
-    // Only delete our own entry; a racing call may have already replaced it.
-    if (inFlightNotify.get(lockKey) === promise) {
-      inFlightNotify.delete(lockKey);
+  // Store the silenced tail so the chain survives errors from inner calls.
+  const silentTail = tail.catch(() => undefined);
+  taskNotifyQueue.set(taskId, silentTail);
+
+  // Prune map entry when this tail is still the head (no newer call queued).
+  void silentTail.then(() => {
+    if (taskNotifyQueue.get(taskId) === silentTail) {
+      taskNotifyQueue.delete(taskId);
     }
-  }
+  });
+
+  return tail;
 }
 
 export const taskHandlers: GatewayRequestHandlers = {

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -13,20 +13,25 @@ const MAX_TASK_EVENTS = 50;
 /**
  * Per-task serialisation queue.
  *
- * Key: taskId
- * Value: tail of the promise chain for that task
+ * Key: registryPath (absolute path to task-registry.json)
+ * Value: tail of the promise chain for that registry file
  *
- * All tasks.notify calls for the same taskId are chained so that each
- * read-modify-write is strictly sequential — preventing lost updates when
- * two different events (different idempotency keys) are notified concurrently.
+ * The registry is a SINGLE FILE containing all tasks.  Locking per-task is
+ * insufficient because two concurrent notify calls for *different* tasks
+ * both do read-modify-write on the same file and the later save overwrites
+ * the earlier one, losing an event log entry or idempotency mark.
+ *
+ * Serialising on the registry path ensures at most one task's write is in
+ * flight at any time, making the read-modify-write atomic from the
+ * perspective of the Node.js event loop.
  *
  * Per-key idempotency is enforced inside _deliverTaskNotification after the
- * per-task lock is acquired.
+ * registry lock is acquired.
  *
  * Since the gateway runs in a single Node.js process this Map is sufficient;
  * no cross-process locking is needed.
  */
-const taskNotifyQueue = new Map<string, Promise<unknown>>();
+const registryWriteQueue = new Map<string, Promise<unknown>>();
 
 export type TaskWatcher = {
   sessionKey: string;
@@ -216,10 +221,10 @@ async function _deliverTaskNotification(opts: {
 /**
  * Deliver a notification to all watchers of a task.
  *
- * Serialised per taskId: all concurrent notify calls for the same task are
- * queued so each read-modify-write completes before the next begins. This
- * prevents lost event log entries or idempotency marks when two different
- * events arrive simultaneously for the same task.
+ * Serialised per registry file: all concurrent notify calls queue on the same
+ * registry path so each read-modify-write completes before the next begins.
+ * This prevents lost updates whether two calls target the same task (different
+ * idempotency keys) or different tasks entirely — both write to the same file.
  *
  * Per-key idempotency is enforced inside _deliverTaskNotification; duplicate
  * calls with the same (taskId, idempotencyKey) return skipped without sending.
@@ -227,21 +232,22 @@ async function _deliverTaskNotification(opts: {
 export function deliverTaskNotification(
   opts: Parameters<typeof _deliverTaskNotification>[0],
 ): Promise<ReturnType<typeof _deliverTaskNotification>> {
-  const taskId = opts.taskId;
+  // Default registry path must match the inner function's default
+  const registryKey = opts.registryPath ?? getRegistryPath();
 
-  // Chain onto the existing tail for this task (or start fresh)
-  const tail = (taskNotifyQueue.get(taskId) ?? Promise.resolve()).then(() =>
+  // Chain onto the existing tail for this registry file (or start fresh)
+  const tail = (registryWriteQueue.get(registryKey) ?? Promise.resolve()).then(() =>
     _deliverTaskNotification(opts),
   );
 
   // Store the silenced tail so the chain survives errors from inner calls.
   const silentTail = tail.catch(() => undefined);
-  taskNotifyQueue.set(taskId, silentTail);
+  registryWriteQueue.set(registryKey, silentTail);
 
-  // Prune map entry when this tail is still the head (no newer call queued).
+  // Prune map entry when no newer call has queued behind this one.
   void silentTail.then(() => {
-    if (taskNotifyQueue.get(taskId) === silentTail) {
-      taskNotifyQueue.delete(taskId);
+    if (registryWriteQueue.get(registryKey) === silentTail) {
+      registryWriteQueue.delete(registryKey);
     }
   });
 

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -1,0 +1,461 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { agentCommandFromIngress } from "../../commands/agent.js";
+import { defaultRuntime } from "../../runtime.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+// Maximum number of events to keep per task (prevents unbounded growth)
+const MAX_TASK_EVENTS = 50;
+
+export type TaskWatcher = {
+  sessionKey: string;
+  label?: string;
+  addedAt: number;
+};
+
+export type TaskEvent = {
+  event: string;
+  message: string;
+  metadata?: Record<string, unknown>;
+  timestamp: number;
+};
+
+export type TaskEntry = {
+  id: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  updatedAt?: number;
+  status?: string;
+  watchers: TaskWatcher[];
+  events: TaskEvent[];
+  /** Idempotency map: eventKey → true when that key has been delivered. */
+  notifiedEvents: Record<string, boolean>;
+};
+
+export type TaskRegistry = {
+  tasks: TaskEntry[];
+};
+
+// Use getter function so os.homedir() is resolved at call-time, not module-load time.
+// This lets tests override HOME before each test without patching a frozen constant.
+function getRegistryPath(): string {
+  return path.join(os.homedir(), ".openclaw", "task-registry.json");
+}
+
+export function loadTaskRegistry(registryPath = getRegistryPath()): TaskRegistry {
+  try {
+    const raw = fs.readFileSync(registryPath, "utf8");
+    return JSON.parse(raw) as TaskRegistry;
+  } catch {
+    return { tasks: [] };
+  }
+}
+
+export function saveTaskRegistry(registry: TaskRegistry, registryPath = getRegistryPath()): void {
+  const dir = path.dirname(registryPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  // Atomic write via temp file
+  const tmp = `${registryPath}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(registry, null, 2), "utf8");
+  fs.renameSync(tmp, registryPath);
+}
+
+/** Callback type injected into deliverTaskNotification for testability. */
+export type SendToSessionFn = (sessionKey: string, message: string) => Promise<void>;
+
+/**
+ * Deliver a notification to all watchers of a task.
+ * Logs the event, marks the idempotency key, updates status, and fans out to watchers.
+ * Idempotent: if the idempotency key was already delivered, returns immediately.
+ */
+export async function deliverTaskNotification(opts: {
+  taskId: string;
+  event: string;
+  message: string;
+  metadata?: Record<string, unknown>;
+  status?: string;
+  idempotencyKey?: string;
+  registryPath?: string;
+  sendToSession: SendToSessionFn;
+}): Promise<{ delivered: string[]; failed: string[]; skipped?: string }> {
+  const {
+    taskId,
+    event,
+    message,
+    metadata,
+    status,
+    registryPath = getRegistryPath(),
+    sendToSession,
+  } = opts;
+
+  // Default idempotency key is the event name (fires once per event type by default)
+  const ikey = opts.idempotencyKey ?? event;
+
+  const registry = loadTaskRegistry(registryPath);
+  const taskIndex = registry.tasks.findIndex((t) => t.id === taskId);
+  if (taskIndex === -1) {
+    return { delivered: [], failed: [], skipped: "task not found" };
+  }
+
+  const task = registry.tasks[taskIndex];
+
+  // Idempotency: skip if this key was already delivered
+  if (task.notifiedEvents[ikey]) {
+    return { delivered: [], failed: [], skipped: "already delivered" };
+  }
+
+  const watchers = task.watchers ?? [];
+  const delivered: string[] = [];
+  const failed: string[] = [];
+
+  for (const watcher of watchers) {
+    try {
+      await sendToSession(watcher.sessionKey, message);
+      delivered.push(watcher.sessionKey);
+    } catch {
+      // Continue delivering to remaining watchers if one session fails
+      failed.push(watcher.sessionKey);
+    }
+  }
+
+  // Build the event log entry
+  const newEvent: TaskEvent = {
+    event,
+    message,
+    ...(metadata ? { metadata } : {}),
+    timestamp: Date.now(),
+  };
+
+  const updatedEvents = [...task.events, newEvent].slice(-MAX_TASK_EVENTS);
+
+  // Mark idempotency flag if at least one watcher received the message,
+  // or if there were no watchers (event was processed; prevents repeated logging).
+  const markDelivered = delivered.length > 0 || watchers.length === 0;
+
+  const updatedTask: TaskEntry = {
+    ...task,
+    updatedAt: Date.now(),
+    ...(status !== undefined ? { status } : {}),
+    events: updatedEvents,
+    notifiedEvents: {
+      ...task.notifiedEvents,
+      ...(markDelivered ? { [ikey]: true } : {}),
+    },
+  };
+
+  registry.tasks[taskIndex] = updatedTask;
+  saveTaskRegistry(registry, registryPath);
+
+  return { delivered, failed };
+}
+
+export const taskHandlers: GatewayRequestHandlers = {
+  /**
+   * Create or update a task in the registry.
+   * Params: { taskId, description?, metadata?, status? }
+   * Returns: { ok: true, task: TaskEntry }
+   *
+   * curl -s -X POST http://localhost:18789 \
+   *   -H 'Content-Type: application/json' \
+   *   -d '{"type":"req","id":"1","method":"tasks.register","params":{"taskId":"build-123","description":"Implement feature X"}}'
+   */
+  "tasks.register": ({ params, respond }) => {
+    const taskId = typeof params?.taskId === "string" ? params.taskId.trim() : "";
+    if (!taskId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "taskId is required"));
+      return;
+    }
+
+    const description = typeof params?.description === "string" ? params.description : undefined;
+    const metadata =
+      params?.metadata && typeof params.metadata === "object" && !Array.isArray(params.metadata)
+        ? (params.metadata as Record<string, unknown>)
+        : undefined;
+    const status = typeof params?.status === "string" ? params.status : undefined;
+
+    const registryPath = getRegistryPath();
+    const registry = loadTaskRegistry(registryPath);
+    const now = Date.now();
+
+    const existingIndex = registry.tasks.findIndex((t) => t.id === taskId);
+    let task: TaskEntry;
+
+    if (existingIndex === -1) {
+      // Create new task
+      task = {
+        id: taskId,
+        ...(description !== undefined ? { description } : {}),
+        ...(metadata !== undefined ? { metadata } : {}),
+        ...(status !== undefined ? { status } : {}),
+        createdAt: now,
+        watchers: [],
+        events: [],
+        notifiedEvents: {},
+      };
+      registry.tasks.push(task);
+    } else {
+      // Update existing task: merge, not replace
+      const existing = registry.tasks[existingIndex];
+      task = {
+        ...existing,
+        ...(description !== undefined ? { description } : {}),
+        ...(metadata !== undefined ? { metadata: { ...existing.metadata, ...metadata } } : {}),
+        ...(status !== undefined ? { status } : {}),
+        updatedAt: now,
+      };
+      registry.tasks[existingIndex] = task;
+    }
+
+    saveTaskRegistry(registry, registryPath);
+    respond(true, { ok: true, task }, undefined);
+  },
+
+  /**
+   * Subscribe a session to a task's events.
+   * Params: { taskId, sessionKey, label? }
+   * Returns: { ok: true, watcherCount: number }
+   *
+   * curl -s -X POST http://localhost:18789 \
+   *   -H 'Content-Type: application/json' \
+   *   -d '{"type":"req","id":"2","method":"tasks.watch","params":{"taskId":"build-123","sessionKey":"agent:main:discord:channel:123"}}'
+   */
+  "tasks.watch": ({ params, respond }) => {
+    const taskId = typeof params?.taskId === "string" ? params.taskId.trim() : "";
+    const sessionKey = typeof params?.sessionKey === "string" ? params.sessionKey.trim() : "";
+    const label = typeof params?.label === "string" ? params.label : undefined;
+
+    if (!taskId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "taskId is required"));
+      return;
+    }
+    if (!sessionKey) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "sessionKey is required"));
+      return;
+    }
+
+    const registryPath = getRegistryPath();
+    const registry = loadTaskRegistry(registryPath);
+    const taskIndex = registry.tasks.findIndex((t) => t.id === taskId);
+
+    if (taskIndex === -1) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `task not found: ${taskId}`),
+      );
+      return;
+    }
+
+    const task = registry.tasks[taskIndex];
+    // Idempotent: skip if already watching this session
+    const alreadyWatching = task.watchers.some((w) => w.sessionKey === sessionKey);
+    if (!alreadyWatching) {
+      task.watchers.push({
+        sessionKey,
+        ...(label ? { label } : {}),
+        addedAt: Date.now(),
+      });
+      registry.tasks[taskIndex] = task;
+      saveTaskRegistry(registry, registryPath);
+    }
+
+    respond(true, { ok: true, watcherCount: task.watchers.length }, undefined);
+  },
+
+  /**
+   * Fire an event on a task and deliver the message to all watchers.
+   * Params: { taskId, event, message, metadata?, status?, idempotencyKey? }
+   * Returns: { ok: true, delivered: string[], failed: string[] }
+   *
+   * curl -s -X POST http://localhost:18789 \
+   *   -H 'Content-Type: application/json' \
+   *   -d '{"type":"req","id":"3","method":"tasks.notify","params":{"taskId":"build-123","event":"completed","message":"PR #42 merged","status":"done"}}'
+   */
+  "tasks.notify": async ({ params, respond, context }) => {
+    const taskId = typeof params?.taskId === "string" ? params.taskId.trim() : "";
+    const event = typeof params?.event === "string" ? params.event.trim() : "";
+    const message = typeof params?.message === "string" ? params.message.trim() : "";
+    const metadata =
+      params?.metadata && typeof params.metadata === "object" && !Array.isArray(params.metadata)
+        ? (params.metadata as Record<string, unknown>)
+        : undefined;
+    const status = typeof params?.status === "string" ? params.status : undefined;
+    const idempotencyKey =
+      typeof params?.idempotencyKey === "string" ? params.idempotencyKey.trim() : undefined;
+
+    if (!taskId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "taskId is required"));
+      return;
+    }
+    if (!event) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "event is required"));
+      return;
+    }
+    if (!message) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "message is required"));
+      return;
+    }
+
+    const registryPath = getRegistryPath();
+
+    // Verify task exists before attempting delivery
+    const registry = loadTaskRegistry(registryPath);
+    const task = registry.tasks.find((t) => t.id === taskId);
+    if (!task) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `task not found: ${taskId}`),
+      );
+      return;
+    }
+
+    const sendToSession: SendToSessionFn = async (sk, msg) => {
+      await agentCommandFromIngress(
+        {
+          message: msg,
+          sessionKey: sk,
+          senderIsOwner: false,
+          deliver: false,
+          bestEffortDeliver: false,
+          messageChannel: INTERNAL_MESSAGE_CHANNEL,
+          runContext: { messageChannel: INTERNAL_MESSAGE_CHANNEL },
+        },
+        defaultRuntime,
+        context.deps,
+      );
+    };
+
+    const result = await deliverTaskNotification({
+      taskId,
+      event,
+      message,
+      metadata,
+      status,
+      idempotencyKey,
+      registryPath,
+      sendToSession,
+    });
+
+    respond(true, { ok: true, delivered: result.delivered, failed: result.failed }, undefined);
+  },
+
+  /**
+   * List registered tasks.
+   * Params: { status?, limit? }
+   * Returns: { ok: true, tasks: Array<TaskEntry & { watcherCount: number }>, total: number }
+   *
+   * curl -s -X POST http://localhost:18789 \
+   *   -H 'Content-Type: application/json' \
+   *   -d '{"type":"req","id":"4","method":"tasks.list","params":{"status":"running"}}'
+   */
+  "tasks.list": ({ params, respond }) => {
+    const statusFilter = typeof params?.status === "string" ? params.status.trim() : undefined;
+    const limit =
+      typeof params?.limit === "number" && Number.isFinite(params.limit)
+        ? Math.max(1, Math.floor(params.limit))
+        : 50;
+
+    const registry = loadTaskRegistry();
+    let tasks = registry.tasks ?? [];
+
+    if (statusFilter) {
+      tasks = tasks.filter((t) => t.status === statusFilter);
+    }
+
+    const total = tasks.length;
+    tasks = tasks.slice(0, limit);
+
+    // Expose watcherCount; strip internal-only fields (watchers array, notifiedEvents)
+    const tasksWithCount = tasks.map((t) => {
+      const { watchers, notifiedEvents: _notifiedEvents, ...rest } = t;
+      return { ...rest, watcherCount: watchers.length };
+    });
+
+    respond(true, { ok: true, tasks: tasksWithCount, total }, undefined);
+  },
+
+  /**
+   * Remove a watcher from a task.
+   * Params: { taskId, sessionKey }
+   * Returns: { ok: true, watcherCount: number }
+   *
+   * curl -s -X POST http://localhost:18789 \
+   *   -H 'Content-Type: application/json' \
+   *   -d '{"type":"req","id":"5","method":"tasks.unwatch","params":{"taskId":"build-123","sessionKey":"agent:main:discord:channel:123"}}'
+   */
+  "tasks.unwatch": ({ params, respond }) => {
+    const taskId = typeof params?.taskId === "string" ? params.taskId.trim() : "";
+    const sessionKey = typeof params?.sessionKey === "string" ? params.sessionKey.trim() : "";
+
+    if (!taskId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "taskId is required"));
+      return;
+    }
+    if (!sessionKey) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "sessionKey is required"));
+      return;
+    }
+
+    const registryPath = getRegistryPath();
+    const registry = loadTaskRegistry(registryPath);
+    const taskIndex = registry.tasks.findIndex((t) => t.id === taskId);
+
+    if (taskIndex === -1) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `task not found: ${taskId}`),
+      );
+      return;
+    }
+
+    const task = registry.tasks[taskIndex];
+    task.watchers = task.watchers.filter((w) => w.sessionKey !== sessionKey);
+    registry.tasks[taskIndex] = task;
+    saveTaskRegistry(registry, registryPath);
+
+    respond(true, { ok: true, watcherCount: task.watchers.length }, undefined);
+  },
+
+  /**
+   * Remove a task from the registry.
+   * Params: { taskId }
+   * Returns: { ok: true }
+   *
+   * curl -s -X POST http://localhost:18789 \
+   *   -H 'Content-Type: application/json' \
+   *   -d '{"type":"req","id":"6","method":"tasks.remove","params":{"taskId":"build-123"}}'
+   */
+  "tasks.remove": ({ params, respond }) => {
+    const taskId = typeof params?.taskId === "string" ? params.taskId.trim() : "";
+    if (!taskId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "taskId is required"));
+      return;
+    }
+
+    const registryPath = getRegistryPath();
+    const registry = loadTaskRegistry(registryPath);
+    const taskIndex = registry.tasks.findIndex((t) => t.id === taskId);
+
+    if (taskIndex === -1) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `task not found: ${taskId}`),
+      );
+      return;
+    }
+
+    registry.tasks.splice(taskIndex, 1);
+    saveTaskRegistry(registry, registryPath);
+
+    respond(true, { ok: true }, undefined);
+  },
+};

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -10,6 +10,18 @@ import type { GatewayRequestHandlers } from "./types.js";
 // Maximum number of events to keep per task (prevents unbounded growth)
 const MAX_TASK_EVENTS = 50;
 
+/**
+ * In-flight lock map: prevents concurrent tasks.notify calls with the same
+ * (taskId, idempotencyKey) from both executing fan-out.
+ *
+ * Key: `${taskId}::${ikey}`
+ * Value: the promise of the in-progress deliver call
+ *
+ * Since OpenClaw gateway runs in a single Node.js process, this Map is sufficient
+ * to serialise concurrent WS-dispatched requests — no cross-process locking needed.
+ */
+const inFlightNotify = new Map<string, Promise<ReturnType<typeof _deliverTaskNotification>>>();
+
 export type TaskWatcher = {
   sessionKey: string;
   label?: string;
@@ -70,11 +82,10 @@ export function saveTaskRegistry(registry: TaskRegistry, registryPath = getRegis
 export type SendToSessionFn = (sessionKey: string, message: string) => Promise<void>;
 
 /**
- * Deliver a notification to all watchers of a task.
- * Logs the event, marks the idempotency key, updates status, and fans out to watchers.
- * Idempotent: if the idempotency key was already delivered, returns immediately.
+ * Inner implementation — do not call directly; use deliverTaskNotification() which
+ * serialises concurrent calls for the same (taskId, idempotencyKey) via inFlightNotify.
  */
-export async function deliverTaskNotification(opts: {
+async function _deliverTaskNotification(opts: {
   taskId: string;
   event: string;
   message: string;
@@ -187,6 +198,40 @@ export async function deliverTaskNotification(opts: {
   saveTaskRegistry(freshRegistry, registryPath);
 
   return { delivered, failed };
+}
+
+/**
+ * Deliver a notification to all watchers of a task.
+ * Idempotent and serialised: concurrent calls with the same (taskId, idempotencyKey)
+ * wait for the in-flight call to complete, then the second caller reads the now-set
+ * idempotency key and returns skipped — preventing duplicate fan-out.
+ */
+export async function deliverTaskNotification(
+  opts: Parameters<typeof _deliverTaskNotification>[0],
+): Promise<ReturnType<typeof _deliverTaskNotification>> {
+  // Normalise key the same way the inner function does, so the lock key matches
+  const rawKey = opts.idempotencyKey?.trim();
+  const ikey = rawKey && rawKey.length > 0 ? rawKey : opts.event;
+  const lockKey = `${opts.taskId}::${ikey}`;
+
+  const existing = inFlightNotify.get(lockKey);
+  if (existing) {
+    // Another call is already in flight for this (taskId, ikey).
+    // Wait for it to finish, then attempt delivery — the post-send guard will
+    // see the idempotency key is now set and return skipped.
+    await existing;
+  }
+
+  const promise = _deliverTaskNotification(opts);
+  inFlightNotify.set(lockKey, promise);
+  try {
+    return await promise;
+  } finally {
+    // Only delete our own entry; a racing call may have already replaced it.
+    if (inFlightNotify.get(lockKey) === promise) {
+      inFlightNotify.delete(lockKey);
+    }
+  }
 }
 
 export const taskHandlers: GatewayRequestHandlers = {

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -94,8 +94,11 @@ export async function deliverTaskNotification(opts: {
     sendToSession,
   } = opts;
 
-  // Default idempotency key is the event name (fires once per event type by default)
-  const ikey = opts.idempotencyKey ?? event;
+  // Default idempotency key is the event name (fires once per event type by default).
+  // Normalize empty/whitespace-only keys to undefined so callers with unset env vars
+  // (which produce "") don't accidentally collapse all future notifications.
+  const rawKey = opts.idempotencyKey?.trim();
+  const ikey = rawKey && rawKey.length > 0 ? rawKey : event;
 
   const registry = loadTaskRegistry(registryPath);
   const taskIndex = registry.tasks.findIndex((t) => t.id === taskId);
@@ -154,15 +157,22 @@ export async function deliverTaskNotification(opts: {
   const freshTask = freshRegistry.tasks[freshIndex];
   const updatedEvents = [...freshTask.events, newEvent].slice(-MAX_TASK_EVENTS);
 
+  // Merge new idempotency key and cap the map to MAX_TASK_EVENTS entries.
+  // Entries are ordered by insertion; when over cap, drop oldest keys first.
+  // This prevents registry bloat for long-lived tasks that use unique keys (e.g. commit SHAs).
+  const mergedNotified = { ...freshTask.notifiedEvents, [ikey]: true };
+  const notifiedKeys = Object.keys(mergedNotified);
+  const cappedNotified: Record<string, boolean> =
+    notifiedKeys.length > MAX_TASK_EVENTS
+      ? Object.fromEntries(notifiedKeys.slice(-MAX_TASK_EVENTS).map((k) => [k, true]))
+      : mergedNotified;
+
   const updatedTask: TaskEntry = {
     ...freshTask,
     updatedAt: Date.now(),
     ...(status !== undefined ? { status } : {}),
     events: updatedEvents,
-    notifiedEvents: {
-      ...freshTask.notifiedEvents,
-      [ikey]: true,
-    },
+    notifiedEvents: cappedNotified,
   };
 
   freshRegistry.tasks[freshIndex] = updatedTask;

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -124,7 +124,17 @@ export async function deliverTaskNotification(opts: {
     }
   }
 
-  // Build the event log entry
+  // Only mark idempotency and log the event if ALL watchers succeeded (or there were none).
+  // If any watcher failed, leave the idempotency key unset so the caller can retry — failed
+  // watchers will be re-attempted and already-delivered watchers will receive a duplicate,
+  // but that is preferable to permanently silencing failed watchers.
+  const allSucceeded = failed.length === 0;
+
+  if (!allSucceeded) {
+    return { delivered, failed };
+  }
+
+  // Build the event log entry (only appended on full success to avoid duplicate log entries)
   const newEvent: TaskEvent = {
     event,
     message,
@@ -132,25 +142,31 @@ export async function deliverTaskNotification(opts: {
     timestamp: Date.now(),
   };
 
-  const updatedEvents = [...task.events, newEvent].slice(-MAX_TASK_EVENTS);
+  // Reload registry before writing to pick up any concurrent mutations (watch/unwatch/remove)
+  // that may have occurred during the async watcher sends above.
+  const freshRegistry = loadTaskRegistry(registryPath);
+  const freshIndex = freshRegistry.tasks.findIndex((t) => t.id === taskId);
+  if (freshIndex === -1) {
+    // Task was removed concurrently; discard — do not resurrect it.
+    return { delivered, failed };
+  }
 
-  // Mark idempotency flag if at least one watcher received the message,
-  // or if there were no watchers (event was processed; prevents repeated logging).
-  const markDelivered = delivered.length > 0 || watchers.length === 0;
+  const freshTask = freshRegistry.tasks[freshIndex];
+  const updatedEvents = [...freshTask.events, newEvent].slice(-MAX_TASK_EVENTS);
 
   const updatedTask: TaskEntry = {
-    ...task,
+    ...freshTask,
     updatedAt: Date.now(),
     ...(status !== undefined ? { status } : {}),
     events: updatedEvents,
     notifiedEvents: {
-      ...task.notifiedEvents,
-      ...(markDelivered ? { [ikey]: true } : {}),
+      ...freshTask.notifiedEvents,
+      [ikey]: true,
     },
   };
 
-  registry.tasks[taskIndex] = updatedTask;
-  saveTaskRegistry(registry, registryPath);
+  freshRegistry.tasks[freshIndex] = updatedTask;
+  saveTaskRegistry(freshRegistry, registryPath);
 
   return { delivered, failed };
 }
@@ -343,7 +359,16 @@ export const taskHandlers: GatewayRequestHandlers = {
       sendToSession,
     });
 
-    respond(true, { ok: true, delivered: result.delivered, failed: result.failed }, undefined);
+    respond(
+      true,
+      {
+        ok: true,
+        delivered: result.delivered,
+        failed: result.failed,
+        ...(result.skipped ? { skipped: result.skipped } : {}),
+      },
+      undefined,
+    );
   },
 
   /**


### PR DESCRIPTION
## Summary

Add a generic task pub/sub framework for external process notifications. Sessions subscribe as watchers to tasks; external tools fire events; the gateway fans out notifications to all watchers.

## Motivation

External processes (coding agents, CI pipelines, deployment scripts, monitoring tools) need a way to notify OpenClaw sessions about events. Currently there is no generic mechanism for this — each integration rolls its own notification logic.

This PR adds a simple, generic task notification API that any external tool can use without knowing about session internals. The task producer just fires events; the gateway handles delivery to all subscribed watchers.

## API

| Method | Scope | Description |
|---|---|---|
| `tasks.register` | write | Create or update a task in the registry |
| `tasks.watch` | write | Subscribe a session to a task (idempotent) |
| `tasks.unwatch` | write | Remove a watcher |
| `tasks.notify` | write | Fire an event → gateway fans out to all watchers |
| `tasks.list` | read | List tasks with optional status filter and limit |
| `tasks.remove` | write | Delete a task from the registry |

### Flow

```
Session A creates a task   → tasks.register(taskId, description)
Session A subscribes       → tasks.watch(taskId, sessionKey)
Session B subscribes       → tasks.watch(taskId, sessionKey)
                             ...time passes...
External script completes  → tasks.notify(taskId, event, message)
                             Gateway delivers notification to A and B
```

The external tool never knows about sessions. It just fires events with a taskId. Gateway handles fan-out.

### CLI

```bash
openclaw tasks register --id "build-123" --desc "Implement feature X"
openclaw tasks watch    --id "build-123" --session "agent:main:discord:channel:123"
openclaw tasks notify   --id "build-123" --event "completed" --message "PR #42 merged"
openclaw tasks list     [--status running] [--limit 50]
openclaw tasks remove   --id "build-123"
```

## Implementation Details

- **Registry:** `~/.openclaw/task-registry.json` — persists across restarts, atomic writes via temp file + rename
- **Delivery:** Uses existing `agentCommandFromIngress` / `INTERNAL_MESSAGE_CHANNEL` pattern
- **Idempotency:** Configurable `idempotencyKey` (defaults to event name) prevents duplicate delivery
- **Event log:** Capped at 50 events per task to prevent unbounded growth
- **Auth:** All methods require standard gateway auth

## Files Changed

| File | Change |
|---|---|
| `src/gateway/server-methods/tasks.ts` | New — 6 gateway handlers + registry helpers |
| `src/gateway/server-methods/tasks.test.ts` | New — 39 tests |
| `src/cli/tasks-cli.ts` | New — CLI subcommands |
| `src/gateway/method-scopes.ts` | Added tasks.* to read/write scopes |
| `src/gateway/server-methods.ts` | Import + spread taskHandlers |
| `src/cli/program/register.subclis.ts` | Register tasks CLI |

## Test Plan

- [x] 39 vitest tests covering registry helpers, delivery logic, idempotency, and all 6 handlers
- [x] Tests use temp files for registry (no side effects on real state)
- [x] Build passes