### PR TITLE
fix(doctor): case-insensitive safe-bin trusted dir matching on macOS/Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - Discord/voice: keep default agent-proxy realtime sessions from auto-speaking filler before the forced OpenClaw consult answer, finish Discord playback on realtime response completion, and queue later exact-speech answers until playback idles to avoid mid-sentence replacement.
 - Gateway: return deterministic `400 invalid_request_error` responses for malformed encoded session-kill HTTP paths instead of letting route-shaped requests fall through to later Gateway handlers. (#72439) Thanks @rubencu.
 - Control UI: serve root PWA and favicon assets from `/__openclaw__/` SPA routes so tab icons, install metadata, and the service worker do not 404 after internal navigation. Fixes #80072. Thanks @CodeNovice2017.
+- Exec/safe bins: compare trusted safe-bin dirs with path-specific case folding on case-insensitive filesystems so Windows and default macOS paths match without weakening case-sensitive mounts. (#42131) Thanks @hkochar.
 - OpenAI/realtime voice: honor disabled input-audio interruption locally so server VAD speech-start events do not clear Discord playback after operators set `interruptResponseOnInputAudio: false`.
 - Telegram: keep no-response DM turns quiet instead of rewriting them into visible silent-reply chatter. Fixes #78188. (#78228) Thanks @Beandon13.
 - Telegram: handle managed select button callbacks before the raw callback fallback while preserving delimiter-containing option values such as `env|prod`. (#79816) Thanks @moeedahmed.

--- a/src/infra/exec-safe-bin-trust.test.ts
+++ b/src/infra/exec-safe-bin-trust.test.ts
@@ -10,6 +10,13 @@ import {
   listWritableExplicitTrustedSafeBinDirs,
 } from "./exec-safe-bin-trust.js";
 
+function swapAsciiCase(value: string): string {
+  return value.replace(/[A-Za-z]/g, (char) => {
+    const lower = char.toLowerCase();
+    return char === lower ? char.toUpperCase() : lower;
+  });
+}
+
 describe("exec safe bin trust", () => {
   it("keeps default trusted dirs limited to immutable system paths", () => {
     const dirs = getTrustedSafeBinDirs({ refresh: true });
@@ -62,6 +69,62 @@ describe("exec safe bin trust", () => {
         trustedDirs: trusted,
       }),
     ).toBe(false);
+  });
+
+  it("matches trusted dirs through path-local case folding on case-insensitive filesystems", async () => {
+    await withTempDir({ prefix: "OpenClaw-Safe-Bin-" }, async (dir) => {
+      const swapped = swapAsciiCase(dir);
+      if (swapped === dir) {
+        return;
+      }
+      const originalStat = await fs.stat(dir);
+      let swappedStat: Awaited<ReturnType<typeof fs.stat>>;
+      try {
+        swappedStat = await fs.stat(swapped);
+      } catch {
+        return;
+      }
+      if (originalStat.dev !== swappedStat.dev || originalStat.ino !== swappedStat.ino) {
+        return;
+      }
+
+      const dirs = buildTrustedSafeBinDirs({
+        baseDirs: [],
+        extraDirs: [swapped],
+      });
+
+      expect(
+        isTrustedSafeBinPath({
+          resolvedPath: path.join(dir, "jq"),
+          trustedDirs: dirs,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  it("keeps case-distinct trusted dirs separate on case-sensitive filesystems", async () => {
+    await withTempDir({ prefix: "openclaw-safe-bin-case-" }, async (parent) => {
+      const trustedDir = path.join(parent, "ToolBin");
+      const untrustedDir = path.join(parent, "toolbin");
+      await fs.mkdir(trustedDir);
+      try {
+        await fs.mkdir(untrustedDir);
+      } catch {
+        return;
+      }
+
+      const dirs = buildTrustedSafeBinDirs({
+        baseDirs: [],
+        extraDirs: [trustedDir],
+      });
+
+      expect(
+        isTrustedSafeBinPath({
+          resolvedPath: path.join(untrustedDir, "jq"),
+          trustedDirs: dirs,
+        }),
+      ).toBe(false);
+    });
   });
 
   it("does not trust PATH entries by default", () => {

--- a/src/infra/exec-safe-bin-trust.ts
+++ b/src/infra/exec-safe-bin-trust.ts
@@ -28,12 +28,54 @@ export type WritableTrustedSafeBinDir = {
 
 let trustedSafeBinCache: TrustedSafeBinCache | null = null;
 
-function normalizeTrustedDir(value: string): string | null {
+function swapAsciiCase(value: string): string {
+  return value.replace(/[A-Za-z]/g, (char) => {
+    const lower = char.toLowerCase();
+    return char === lower ? char.toUpperCase() : lower;
+  });
+}
+
+function sameFsObject(a: fs.Stats, b: fs.Stats): boolean {
+  return a.dev === b.dev && a.ino === b.ino;
+}
+
+function pathCaseInsensitive(value: string): boolean {
+  let candidate = value;
+  for (;;) {
+    const swapped = swapAsciiCase(candidate);
+    if (swapped !== candidate) {
+      try {
+        const original = fs.statSync(candidate);
+        try {
+          const alternate = fs.statSync(swapped);
+          return sameFsObject(original, alternate);
+        } catch {
+          return false;
+        }
+      } catch {
+        // The compared path may not exist yet; probe the closest existing parent.
+      }
+    }
+
+    const parent = path.dirname(candidate);
+    if (parent === candidate) {
+      return process.platform === "win32";
+    }
+    candidate = parent;
+  }
+}
+
+function normalizeTrustComparisonPath(value: string): string {
+  const resolved = path.resolve(value);
+  return pathCaseInsensitive(resolved) ? resolved.toLowerCase() : resolved;
+}
+
+function normalizeTrustedDir(value: string, forComparison = true): string | null {
   const trimmed = value.trim();
   if (!trimmed) {
     return null;
   }
-  return path.resolve(trimmed);
+  return forComparison ? normalizeTrustComparisonPath(trimmed) : path.resolve(trimmed);
 }
 
 export function normalizeTrustedSafeBinDirs(entries?: readonly string[] | null): string[] {
@@ -44,9 +86,9 @@ export function normalizeTrustedSafeBinDirs(entries?: readonly string[] | null):
   return Array.from(new Set(normalized));
 }
 
-function resolveTrustedSafeBinDirs(entries: readonly string[]): string[] {
+function resolveTrustedSafeBinDirs(entries: readonly string[], forComparison = true): string[] {
   const resolved = entries
-    .map((entry) => normalizeTrustedDir(entry))
+    .map((entry) => normalizeTrustedDir(entry, forComparison))
     .filter((entry): entry is string => Boolean(entry));
   return Array.from(new Set(resolved)).toSorted();
 }
@@ -92,7 +134,7 @@ export function getTrustedSafeBinDirs(
 
 export function isTrustedSafeBinPath(params: TrustedSafeBinPathParams): boolean {
   const trustedDirs = params.trustedDirs ?? getTrustedSafeBinDirs();
-  const resolvedDir = path.dirname(path.resolve(params.resolvedPath));
+  const resolvedDir = normalizeTrustComparisonPath(path.dirname(path.resolve(params.resolvedPath)));
   return trustedDirs.has(resolvedDir);
 }
 
@@ -102,7 +144,7 @@ export function listWritableExplicitTrustedSafeBinDirs(
   if (process.platform === "win32") {
     return [];
   }
-  const resolved = resolveTrustedSafeBinDirs(normalizeTrustedSafeBinDirs(entries));
+  const resolved = resolveTrustedSafeBinDirs(normalizeTrustedSafeBinDirs(entries), false);
   const hits: WritableTrustedSafeBinDir[] = [];
   for (const dir of resolved) {
     let stat: fs.Stats;


### PR DESCRIPTION
## Summary

`normalizeConfiguredSafeBins()` can lowercase configured safe-bin paths, while trusted safe-bin directory comparisons were exact-case. On case-insensitive filesystems such as default macOS APFS and typical Windows NTFS, that can produce false "outside trusted safe-bin dirs" doctor/runtime warnings even when `safeBinTrustedDirs` is configured correctly.

The maintainer update keeps the fix path-local: trusted-dir comparison keys are case-folded only when probing the actual compared path shows the filesystem treats that path case-insensitively. Case-sensitive paths keep exact matching, so case-distinct sibling directories do not inherit trust.

## Changes

- `src/infra/exec-safe-bin-trust.ts`: normalize trusted-dir comparison keys with path-local case-sensitivity probing instead of a global temp-dir/platform probe.
- `src/infra/exec-safe-bin-trust.ts`: keep writable trusted-dir diagnostics reporting the configured resolved path rather than the folded comparison key.
- `src/infra/exec-safe-bin-trust.test.ts`: add regression coverage for case-insensitive matching and case-sensitive sibling separation.
- `CHANGELOG.md`: add the required fix entry.

## Reproduction

1. On a case-insensitive macOS or Windows filesystem, configure a safe-bin trusted dir with different casing than the resolved executable dirname.
2. Run the safe-bin trust check through `openclaw doctor` or the runtime policy path.
3. Before the fix, the `Set.has()` comparison can miss because one side is folded and the other preserves case.
4. After the fix, the compared path is folded only when the actual filesystem path resolves case-insensitively.

## Real behavior proof

- **Behavior or issue addressed:** Safe-bin trusted-dir comparison accepts different path casing only when the actual filesystem path resolves case-insensitively.
- **Real environment tested:** macOS Darwin local maintainer setup, Node v26.0.0, prepared head `290418af5a6516477df180c0526993fb412e87b5`.
- **Exact steps or command run after this patch:** Created a real temporary directory, built a swapped-case spelling of that directory path, verified the original and swapped paths stat to the same filesystem object, built trusted safe-bin dirs from the swapped-case path, and checked an executable path under the original-case directory with `isTrustedSafeBinPath`.
- **Evidence after fix:** Copied live terminal output from the maintainer machine:

```console
$ pnpm exec tsx -e '...exercise buildTrustedSafeBinDirs/isTrustedSafeBinPath against a real temp dir with swapped path casing...'
{
  "platform": "darwin",
  "dir": "/var/folders/7b/8hcnb089297c2t35zvm__3y00000gn/T/OpenClaw-Safe-Bin-Proof-LFRwff",
  "swapped": "/VAR/FOLDERS/7B/8HCNB089297C2T35ZVM__3Y00000GN/t/oPENcLAW-sAFE-bIN-pROOF-lfrWFF",
  "sameObject": true,
  "trusted": true
}
```

- **Observed result after fix:** The swapped-case trusted dir and original-case resolved executable dirname were treated as the same trusted directory only after the filesystem proved both path spellings point to the same object.
- **What was not tested:** Live Windows NTFS/PowerShell proof was not run in this maintainer pass; CI and the recurring tracker automation should keep the PR unmerged until required checks and review gates are green.

## Test plan

- [x] `pnpm test src/infra/exec-safe-bin-trust.test.ts src/infra/exec-safe-bin-runtime-policy.test.ts src/commands/doctor-config-flow.safe-bins.test.ts` passed before the final base refresh: 33 tests.
- [x] `pnpm test:changed` passed before the final base refresh: 346 files / 3454 tests.
- [x] `pnpm exec oxfmt --check CHANGELOG.md src/infra/exec-safe-bin-trust.ts src/infra/exec-safe-bin-trust.test.ts` passed after the final rebase.
- [ ] Fresh CI passes on prepared head `290418af5a6516477df180c0526993fb412e87b5`.

