### PR TITLE
docs: add openclaw-feishu-custom to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **Feishu Custom** — Extends the bundled Feishu plugin with Bitable table creation, custom role management, and permission sharing tools. Solves the common issue where agent-created Bitable tables leave users without edit access.
+  npm: `openclaw-feishu-custom`
+  repo: `https://github.com/endachao/openclaw-feishu-custom`
+  install: `openclaw plugins install openclaw-feishu-custom`


### PR DESCRIPTION
Adds **openclaw-feishu-custom** to the community plugins listing.

## Plugin info

- **npm**: [`openclaw-feishu-custom`](https://www.npmjs.com/package/openclaw-feishu-custom)
- **repo**: https://github.com/endachao/openclaw-feishu-custom
- **install**: `openclaw plugins install openclaw-feishu-custom`

## What it does

Extends the bundled `feishu` plugin with Bitable management tools that the official plugin doesn't cover:

- Create single/batch tables in a Bitable app
- Create custom roles with table-level permissions
- Add members to roles
- Share resources via Drive permission API

Solves the common issue where agent-created Bitable tables leave users without edit access.

## Checklist

- [x] Published on npm
- [x] Public GitHub repo with docs and issue tracker
- [x] README in Chinese and English
- [x] Actively maintained