### PR TITLE
fix(agents): keep sandbox allow semantics while exposing explicit plugin tools from alsoAllow. Fixes #41757

### DIFF
--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -276,6 +276,9 @@ export function resolveEffectiveToolPolicy(params: {
     profile,
     providerProfile: agentProviderPolicy?.profile ?? providerPolicy?.profile,
     // alsoAllow is applied at the profile stage (to avoid being filtered out early).
+    // explicitProfileAlsoAllow contains only explicit tools.alsoAllow entries (no implicit
+    // exec/read/write/edit exposure).
+    explicitProfileAlsoAllow,
     profileAlsoAllow,
     providerProfileAlsoAllow: Array.isArray(agentProviderPolicy?.alsoAllow)
       ? agentProviderPolicy?.alsoAllow

--- a/src/agents/pi-tools.sandbox-plugin-allow-merge.test.ts
+++ b/src/agents/pi-tools.sandbox-plugin-allow-merge.test.ts
@@ -118,6 +118,21 @@ describe("computeSandboxStepPolicy", () => {
     });
     expect(result!.allow?.toSorted()).toEqual(["read", "start_task"]);
   });
+
+  it("matches plugin tools via wildcard alsoAllow patterns", () => {
+    const tools = asTools([{ name: "start_task" }, { name: "start_other" }, { name: "stop_task" }]);
+    const toolMeta = (t: AnyAgentTool) =>
+      t.name === "start_task" || t.name === "start_other" ? { pluginId: "p1" } : undefined;
+    const result = computeSandboxStepPolicy({
+      sandboxTools: { allow: ["gateway"] },
+      explicitProfileAlsoAllow: ["start_*"],
+      tools,
+      toolMeta,
+    });
+    expect(result).toBeDefined();
+    const allow = result!.allow?.toSorted();
+    expect(allow).toEqual(["gateway", "start_other", "start_task"]);
+  });
 });
 
 /**

--- a/src/agents/pi-tools.sandbox-plugin-allow-merge.test.ts
+++ b/src/agents/pi-tools.sandbox-plugin-allow-merge.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: () => undefined,
+  getOAuthProviders: () => [],
+}));
+
+const { mockApplyToolPolicyPipeline, mockBuildDefaultToolPolicyPipelineSteps } = vi.hoisted(() => ({
+  mockApplyToolPolicyPipeline: vi.fn((args: { tools: unknown[] }) => args.tools),
+  mockBuildDefaultToolPolicyPipelineSteps: vi.fn(() => []),
+}));
+
+vi.mock("./tool-policy-pipeline.js", () => ({
+  applyToolPolicyPipeline: mockApplyToolPolicyPipeline,
+  buildDefaultToolPolicyPipelineSteps: mockBuildDefaultToolPolicyPipelineSteps,
+}));
+
+vi.mock("../plugins/tools.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/tools.js")>();
+  return {
+    ...actual,
+    getPluginToolMeta: (tool: { name: string }) =>
+      tool.name === "read" ? { pluginId: "test-plugin", optional: false } : undefined,
+  };
+});
+
+import { computeSandboxStepPolicy, createOpenClawCodingTools } from "./pi-tools.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+type DummyTool = { name: string };
+
+/** Minimal tool shape for policy tests; computeSandboxStepPolicy only uses .name and toolMeta(tool). */
+function asTools(tools: DummyTool[]): AnyAgentTool[] {
+  return tools as unknown as AnyAgentTool[];
+}
+
+function createSandboxForTest() {
+  return {
+    enabled: true,
+    sessionKey: "agent:test:slack:dm:u1",
+    // Keep workspaceDir empty to avoid requiring fsBridge in this policy-focused test.
+    workspaceDir: "",
+    agentWorkspaceDir: "/tmp/openclaw-test-workspace",
+    workspaceAccess: "rw",
+    containerName: "sandbox-test",
+    containerWorkdir: "/workspace",
+    docker: { env: {} },
+    tools: { allow: ["gateway"] },
+    browserAllowHostControl: false,
+  };
+}
+
+/**
+ * Unit tests for computeSandboxStepPolicy with explicit fixtures. No dependency on
+ * createOpenClawCodingTools base tool list or pipeline; covers the pluginAllow merge
+ * code path directly.
+ */
+describe("computeSandboxStepPolicy", () => {
+  it("returns sandboxTools when allow is missing or empty", () => {
+    const tools = asTools([{ name: "start_task" }]);
+    const toolMeta = (t: AnyAgentTool) =>
+      t.name === "start_task" ? { pluginId: "p1" } : undefined;
+    expect(
+      computeSandboxStepPolicy({
+        sandboxTools: undefined,
+        explicitProfileAlsoAllow: ["start_task"],
+        tools,
+        toolMeta,
+      }),
+    ).toBeUndefined();
+    expect(
+      computeSandboxStepPolicy({
+        sandboxTools: { allow: [], deny: [] },
+        explicitProfileAlsoAllow: ["start_task"],
+        tools,
+        toolMeta,
+      })?.allow,
+    ).toEqual([]);
+  });
+
+  it("returns sandboxTools when explicitProfileAlsoAllow has no plugin tools in tool set", () => {
+    const tools = asTools([{ name: "read" }]);
+    const toolMeta = () => undefined;
+    const sandboxTools = { allow: ["read"] };
+    const result = computeSandboxStepPolicy({
+      sandboxTools,
+      explicitProfileAlsoAllow: ["start_task"],
+      tools,
+      toolMeta,
+    });
+    expect(result).toBe(sandboxTools);
+  });
+
+  it("merges sandbox allow with plugin-only names from explicit alsoAllow (explicit fixtures)", () => {
+    const tools = asTools([{ name: "read" }, { name: "start_task" }]);
+    const toolMeta = (t: AnyAgentTool) =>
+      t.name === "start_task" ? { pluginId: "workflow" } : undefined;
+    const result = computeSandboxStepPolicy({
+      sandboxTools: { allow: ["read", "exec"] },
+      explicitProfileAlsoAllow: ["start_task"],
+      tools,
+      toolMeta,
+    });
+    expect(result).toBeDefined();
+    expect(result!.allow?.toSorted()).toEqual(["exec", "read", "start_task"]);
+    expect(result!.deny).toBeUndefined();
+  });
+
+  it("does not merge core-only names from alsoAllow when they are not plugin tools", () => {
+    const tools = asTools([{ name: "read" }, { name: "start_task" }]);
+    const toolMeta = (t: AnyAgentTool) =>
+      t.name === "start_task" ? { pluginId: "p1" } : undefined;
+    const result = computeSandboxStepPolicy({
+      sandboxTools: { allow: ["read"] },
+      explicitProfileAlsoAllow: ["read", "exec", "start_task"],
+      tools,
+      toolMeta,
+    });
+    expect(result!.allow?.toSorted()).toEqual(["read", "start_task"]);
+  });
+});
+
+/**
+ * Integration path: createOpenClawCodingTools with sandbox + alsoAllow; asserts the
+ * sandbox step receives the merged allow. Pipeline is mocked so we only verify the
+ * policy passed to the sandbox step.
+ */
+describe("sandbox plugin allow merge", () => {
+  it("merges only plugin-resolved explicit alsoAllow entries into sandbox allow", () => {
+    mockApplyToolPolicyPipeline.mockClear();
+    const workspaceDir = "/tmp/openclaw-test-workspace";
+
+    createOpenClawCodingTools({
+      workspaceDir,
+      // oxlint-disable-next-line typescript/no-explicit-any -- test fixture
+      sandbox: createSandboxForTest() as any,
+      // oxlint-disable-next-line typescript/no-explicit-any -- test fixture
+      config: { tools: { profile: "messaging", alsoAllow: ["read", "exec"] } } as any,
+    });
+
+    expect(mockApplyToolPolicyPipeline).toHaveBeenCalled();
+    const lastCall = mockApplyToolPolicyPipeline.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+
+    const args = lastCall![0] as unknown as {
+      steps: Array<{ label: string; policy?: { allow?: string[] } }>;
+    };
+    const sandboxStep = args.steps.find((step) => step.label === "sandbox tools.allow");
+    expect(sandboxStep).toBeDefined();
+    expect(sandboxStep!.policy).toBeDefined();
+    expect(sandboxStep!.policy!.allow).toBeDefined();
+
+    const allow = sandboxStep!.policy!.allow!.toSorted();
+    // sandbox allow list ["gateway"] merged with plugin-resolved explicit alsoAllow ["read"]
+    expect(allow).toEqual(["gateway", "read"]);
+    // exec is in explicit alsoAllow but not plugin-resolved via getPluginToolMeta
+    expect(allow).not.toContain("exec");
+  });
+
+  /**
+   * Expands plugin-id selectors (e.g. alsoAllow: ["test-plugin"]) via expandPluginGroups
+   * before merging into sandbox allow.
+   * Fixture: getPluginToolMeta is mocked so the tool named "read" is the only plugin tool
+   * (pluginId "test-plugin"). Guard assertion ensures the base tool list includes "read".
+   */
+  it("expands plugin-id selectors in explicit alsoAllow before sandbox merge", () => {
+    mockApplyToolPolicyPipeline.mockClear();
+    const workspaceDir = "/tmp/openclaw-test-workspace";
+
+    createOpenClawCodingTools({
+      workspaceDir,
+      // oxlint-disable-next-line typescript/no-explicit-any -- test fixture
+      sandbox: createSandboxForTest() as any,
+      // oxlint-disable-next-line typescript/no-explicit-any -- test fixture
+      config: { tools: { profile: "messaging", alsoAllow: ["test-plugin"] } } as any,
+    });
+
+    expect(mockApplyToolPolicyPipeline).toHaveBeenCalled();
+    const lastCall = mockApplyToolPolicyPipeline.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+
+    const args = lastCall![0] as unknown as {
+      tools: Array<{ name: string }>;
+      steps: Array<{ label: string; policy?: { allow?: string[] } }>;
+    };
+    const baseToolNames = args.tools.map((t) => t.name);
+    expect(
+      baseToolNames,
+      "Fixture requires 'read' in the messaging profile tool list; update mock or fixture if profile changes.",
+    ).toContain("read");
+
+    const sandboxStep = args.steps.find((step) => step.label === "sandbox tools.allow");
+    expect(sandboxStep).toBeDefined();
+    expect(sandboxStep!.policy).toBeDefined();
+    expect(sandboxStep!.policy!.allow).toBeDefined();
+
+    const allow = sandboxStep!.policy!.allow!.toSorted();
+    expect(allow).toEqual(["gateway", "read"]);
+  });
+});

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -43,7 +43,7 @@ import {
 } from "./pi-tools.read.js";
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
-import type { SandboxContext } from "./sandbox.js";
+import type { SandboxContext, SandboxToolPolicy } from "./sandbox.js";
 import { isXaiProvider } from "./schema/clean-for-xai.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
@@ -53,8 +53,11 @@ import {
 } from "./tool-policy-pipeline.js";
 import {
   applyOwnerOnlyToolPolicy,
+  buildPluginToolGroups,
   collectExplicitAllowlist,
+  expandPluginGroups,
   mergeAlsoAllowPolicy,
+  normalizeToolName,
   resolveToolProfilePolicy,
 } from "./tool-policy.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
@@ -187,6 +190,38 @@ export function resolveToolLoopDetectionConfig(params: {
   };
 }
 
+/**
+ * Computes the sandbox step policy: when sandbox.tools.allow is non-empty,
+ * merges it with plugin-resolved names from explicit tools.alsoAllow (see #41757).
+ * Exported for tests so the merge path can be covered with explicit fixtures.
+ */
+export function computeSandboxStepPolicy(params: {
+  sandboxTools: SandboxToolPolicy | undefined;
+  explicitProfileAlsoAllow: string[] | undefined;
+  tools: AnyAgentTool[];
+  toolMeta: (tool: AnyAgentTool) => { pluginId: string } | undefined;
+}): SandboxToolPolicy | undefined {
+  const { sandboxTools, explicitProfileAlsoAllow, tools, toolMeta } = params;
+  const sandboxAllow = sandboxTools?.allow;
+  if (!sandboxTools || !sandboxAllow || sandboxAllow.length === 0) {
+    return sandboxTools;
+  }
+  const pluginToolGroups = buildPluginToolGroups({ tools, toolMeta });
+  const expandedExplicitAlsoAllow = expandPluginGroups(explicitProfileAlsoAllow, pluginToolGroups);
+  const pluginToolNameSet = new Set(pluginToolGroups.all);
+  const pluginAllow =
+    expandedExplicitAlsoAllow && expandedExplicitAlsoAllow.length > 0
+      ? expandedExplicitAlsoAllow.filter((name) => pluginToolNameSet.has(normalizeToolName(name)))
+      : undefined;
+  if (!pluginAllow || pluginAllow.length === 0) {
+    return sandboxTools;
+  }
+  return {
+    allow: Array.from(new Set([...sandboxAllow, ...pluginAllow])),
+    deny: sandboxTools.deny,
+  };
+}
+
 export const __testing = {
   cleanToolSchemaForGemini,
   normalizeToolParams,
@@ -284,6 +319,7 @@ export function createOpenClawCodingTools(options?: {
     agentProviderPolicy,
     profile,
     providerProfile,
+    explicitProfileAlsoAllow,
     profileAlsoAllow,
     providerProfileAlsoAllow,
   } = resolveEffectiveToolPolicy({
@@ -569,6 +605,19 @@ export function createOpenClawCodingTools(options?: {
   // Security: treat unknown/undefined as unauthorized (opt-in, not opt-out)
   const senderIsOwner = options?.senderIsOwner === true;
   const toolsByAuthorization = applyOwnerOnlyToolPolicy(toolsForModelProvider, senderIsOwner);
+  // Sandbox step: merge sandbox allow with the agent's explicit tools.alsoAllow entries
+  // (plugins, or explicitly re-exposed tools) so they are not dropped (see #41757).
+  // Sandbox deny still applies. Preserve sandbox semantics where an empty allowlist
+  // means "allow all" (sandbox/tool-policy.ts): only merge when sandbox.tools.allow
+  // is non-empty, and only with explicitProfileAlsoAllow (no implicit exec/fs exposure).
+  // Only compute plugin groups and expansion when sandbox is enabled and allow is non-empty.
+  const sandboxStepPolicy = computeSandboxStepPolicy({
+    sandboxTools: sandbox?.tools,
+    explicitProfileAlsoAllow,
+    tools: toolsByAuthorization,
+    toolMeta: (tool) => getPluginToolMeta(tool),
+  });
+
   const subagentFiltered = applyToolPolicyPipeline({
     tools: toolsByAuthorization,
     toolMeta: (tool) => getPluginToolMeta(tool),
@@ -586,7 +635,7 @@ export function createOpenClawCodingTools(options?: {
         groupPolicy,
         agentId,
       }),
-      { policy: sandbox?.tools, label: "sandbox tools.allow" },
+      { policy: sandboxStepPolicy, label: "sandbox tools.allow" },
       { policy: subagentPolicy, label: "subagent tools.allow" },
     ],
   });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -15,6 +15,7 @@ import {
   type ProcessToolDefaults,
 } from "./bash-tools.js";
 import { listChannelAgentTools } from "./channel-tools.js";
+import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
 import type { ModelAuthMode } from "./model-auth.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
@@ -209,15 +210,40 @@ export function computeSandboxStepPolicy(params: {
   const pluginToolGroups = buildPluginToolGroups({ tools, toolMeta });
   const expandedExplicitAlsoAllow = expandPluginGroups(explicitProfileAlsoAllow, pluginToolGroups);
   const pluginToolNameSet = new Set(pluginToolGroups.all);
-  const pluginAllow =
-    expandedExplicitAlsoAllow && expandedExplicitAlsoAllow.length > 0
-      ? expandedExplicitAlsoAllow.filter((name) => pluginToolNameSet.has(normalizeToolName(name)))
-      : undefined;
-  if (!pluginAllow || pluginAllow.length === 0) {
+  if (!expandedExplicitAlsoAllow || expandedExplicitAlsoAllow.length === 0) {
+    return sandboxTools;
+  }
+
+  const concretePluginNames: string[] = [];
+  const wildcardEntries: string[] = [];
+  for (const entry of expandedExplicitAlsoAllow) {
+    const normalized = normalizeToolName(entry);
+    if (pluginToolNameSet.has(normalized)) {
+      concretePluginNames.push(normalized);
+    } else {
+      wildcardEntries.push(normalized);
+    }
+  }
+
+  let wildcardPluginNames: string[] = [];
+  if (wildcardEntries.length > 0 && pluginToolGroups.all.length > 0) {
+    const patterns = compileGlobPatterns({
+      raw: wildcardEntries,
+      normalize: normalizeToolName,
+    });
+    if (patterns.length > 0) {
+      wildcardPluginNames = pluginToolGroups.all.filter((toolName) =>
+        matchesAnyGlobPattern(toolName, patterns),
+      );
+    }
+  }
+
+  const pluginAllowSet = new Set([...concretePluginNames, ...wildcardPluginNames]);
+  if (pluginAllowSet.size === 0) {
     return sandboxTools;
   }
   return {
-    allow: Array.from(new Set([...sandboxAllow, ...pluginAllow])),
+    allow: Array.from(new Set([...sandboxAllow, ...pluginAllowSet])),
     deny: sandboxTools.deny,
   };
 }

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { DEFAULT_TOOL_ALLOW } from "./sandbox/constants.js";
 import { applyToolPolicyPipeline } from "./tool-policy-pipeline.js";
 
 type DummyTool = { name: string };
@@ -62,5 +63,82 @@ describe("tool-policy-pipeline", () => {
       ],
     });
     expect(filtered.map((t) => (t as unknown as DummyTool).name)).toEqual(["exec"]);
+  });
+
+  /**
+   * Reproduces issue #41757: with sandbox enabled, the sandbox step uses
+   * DEFAULT_TOOL_ALLOW (or tools.sandbox.tools.allow) and filters the tool list.
+   * Plugin tools (e.g. start_task) that are in the agent's tools.alsoAllow are
+   * not in DEFAULT_TOOL_ALLOW, so they get removed even though the agent
+   * explicitly allowed them.
+   */
+  test("sandbox step removes plugin tool not in DEFAULT_TOOL_ALLOW (#41757 repro)", () => {
+    const coreAndPluginTools = [
+      { name: "read" },
+      { name: "exec" },
+      { name: "sessions_spawn" },
+      { name: "start_task" }, // plugin tool, in agent tools.alsoAllow, not in DEFAULT_TOOL_ALLOW
+    ] as unknown as DummyTool[];
+    const filtered = applyToolPolicyPipeline({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tools: coreAndPluginTools as any,
+      toolMeta: (t) =>
+        (t as unknown as DummyTool).name === "start_task" ? { pluginId: "start-task" } : undefined,
+      warn: () => {},
+      steps: [
+        // Simulate profile/agent step: allow all of these (including start_task via alsoAllow).
+        {
+          policy: { allow: ["read", "exec", "sessions_spawn", "start_task"] },
+          label: "agent tools.allow + alsoAllow",
+          stripPluginOnlyAllowlist: true,
+        },
+        // Sandbox step: default allow list does not include plugin tool names.
+        {
+          policy: { allow: [...DEFAULT_TOOL_ALLOW] },
+          label: "sandbox tools.allow",
+        },
+      ],
+    });
+    const names = filtered.map((t) => (t as unknown as DummyTool).name);
+    expect(names).toContain("read");
+    expect(names).toContain("exec");
+    expect(names).not.toContain("start_task");
+  });
+
+  /**
+   * After #41757 fix: when sandbox step uses a policy whose allow list is merged
+   * with agent tools.alsoAllow (e.g. DEFAULT_TOOL_ALLOW + start_task), the
+   * plugin tool is retained instead of being dropped.
+   */
+  test("sandbox step retains plugin tool when allow is merged with alsoAllow (#41757 fix)", () => {
+    const coreAndPluginTools = [
+      { name: "read" },
+      { name: "exec" },
+      { name: "sessions_spawn" },
+      { name: "start_task" },
+    ] as unknown as DummyTool[];
+    const mergedAllow = [...DEFAULT_TOOL_ALLOW, "start_task"];
+    const filtered = applyToolPolicyPipeline({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tools: coreAndPluginTools as any,
+      toolMeta: (t) =>
+        (t as unknown as DummyTool).name === "start_task" ? { pluginId: "start-task" } : undefined,
+      warn: () => {},
+      steps: [
+        {
+          policy: { allow: ["read", "exec", "sessions_spawn", "start_task"] },
+          label: "agent tools.allow + alsoAllow",
+          stripPluginOnlyAllowlist: true,
+        },
+        {
+          policy: { allow: mergedAllow },
+          label: "sandbox tools.allow (merged with alsoAllow)",
+        },
+      ],
+    });
+    const names = filtered.map((t) => (t as unknown as DummyTool).name);
+    expect(names).toContain("read");
+    expect(names).toContain("exec");
+    expect(names).toContain("start_task");
   });
 });


### PR DESCRIPTION
# PR: Sandbox tool step merges agent tools.alsoAllow so plugin tools are not dropped

## Summary

With sandbox enabled, plugin tools in `agents.list[].tools.alsoAllow` were dropped from the session tool list because the sandbox step applied only `sandbox.tools.allow` (or `DEFAULT_TOOL_ALLOW`), which has no plugin names. **Fix:** when sandbox is on and `sandbox.tools.allow` is non-empty, the sandbox step policy is now `allow = union(sandbox.tools.allow, plugin-only names from explicit tools.alsoAllow)`; we expand alsoAllow via `expandPluginGroups(buildPluginToolGroups(...))` and merge only plugin tool names. Empty `sandbox.tools.allow` is unchanged ("allow all"). No change to `resolveSandboxToolPolicyForAgent`, container/FS/network, or config semantics.

## Change Type

- [x] Bug fix

## Scope

- [x] Skills / tool execution (tool policy pipeline, pi-tools)

## Linked Issue

- Closes #41757

---

## Reproduction

1. Plugin with tool `start_task`, trusted. Agent: `sandbox: { mode: "all" }`, `tools: { profile: "messaging", alsoAllow: ["read", "web_fetch", "start_task"] }`.
2. Open session, ask agent what tools it has.
3. **Before:** `start_task` missing. **After fix:** `start_task` appears.

---

## What this PR does

- **Root cause:** Pipeline in `createOpenClawCodingTools` applies profile/agent/group then a **sandbox step** with `sandbox?.tools` from `resolveSandboxToolPolicyForAgent` (allow = config or `DEFAULT_TOOL_ALLOW`). That step had no plugin names, so plugin tools in alsoAllow were filtered out.
- **Fix:** Sandbox step policy is computed by `computeSandboxStepPolicy()`: if no sandbox or `sandbox.tools.allow` empty → return `sandbox?.tools`. Else: expand explicit `tools.alsoAllow` with `expandPluginGroups(buildPluginToolGroups(...))`, keep only names in plugin tool set, then `allow = union(sandbox.tools.allow, pluginAllow)`, `deny = sandbox.tools.deny`. Core tools in alsoAllow are not merged. The function is exported for tests (explicit-fixture unit coverage).
- **Code (this PR):** `src/agents/pi-tools.ts`, `src/agents/pi-tools.policy.ts`, `src/agents/pi-tools.sandbox-plugin-allow-merge.test.ts`, `src/agents/tool-policy-pipeline.test.ts`.

**Flow (short):** `resolveSandboxContext` → `SandboxContext.tools` (allow/deny from config only). `createOpenClawCodingTools` → `resolveEffectiveToolPolicy` → `explicitProfileAlsoAllow` → base tools → **sandbox step** uses `sandboxStepPolicy` from `computeSandboxStepPolicy(...)` (merge sandbox allow + plugin-only from explicitProfileAlsoAllow) → pipeline → model.

---

## Decision needed

Sandbox tool policy is currently resolved only from `tools.sandbox.tools.allow/deny` (and agent overrides); it does not read `tools.alsoAllow`. So with sandbox on, plugin tools listed in `alsoAllow` are dropped unless the user **duplicates** them in `tools.sandbox.tools.allow`.

**Design choice:**

- **(A) By design:** Sandbox has its own allow list; users who want a plugin tool in sandbox must list it in `tools.sandbox.tools.allow`. If that is intended, this PR can be closed and the issue handled with docs (e.g. "list plugin tools in `tools.sandbox.tools.allow` when using sandbox").
- **(B) Sandbox should respect alsoAllow:** Sandbox only narrows the set already allowed by profile/agent; plugin tools in `tools.alsoAllow` should remain available in sandbox without duplicate config. This PR implements (B).

Please indicate whether (A) or (B) matches the intended design; if (A), we will close the PR accordingly.

---

## User-visible / Security / Tests

- **Behavior:** With sandbox on, plugin tools in `tools.alsoAllow` now appear and are callable unless denied by `tools.sandbox.tools.deny`.
- **Security:** Only plugin tool names from alsoAllow are added; core tools in alsoAllow are not merged. Sandbox container/FS/network unchanged.
- **Tests:** `tool-policy-pipeline.test.ts` (repro + fix); `pi-tools.sandbox-plugin-allow-merge.test.ts` (merge path with tool name and plugin-id alsoAllow). Existing tests pass.
- **Compatibility:** Backward compatible. No config change. To forbid a plugin tool in sandbox, add it to `tools.sandbox.tools.deny`.
