### PR TITLE
fix: avoid manual cron deadlock on reentrant lanes

### DIFF
--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -322,6 +322,44 @@ describe("command queue", () => {
     );
   });
 
+  it("runs same-lane nested work without deadlocking", async () => {
+    const lane = `reentrant-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(lane, 1);
+
+    const result = await Promise.race([
+      enqueueCommandInLane(lane, async () => {
+        const inner = await enqueueCommandInLane(lane, async () => "inner");
+        return `outer:${inner}`;
+      }),
+      new Promise<string>((_, reject) => {
+        setTimeout(() => reject(new Error("nested lane timed out")), 50);
+      }),
+    ]);
+
+    expect(result).toBe("outer:inner");
+  });
+
+  it("runs same-lane work without deadlocking through an intermediate lane", async () => {
+    const outerLane = `outer-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const middleLane = `middle-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(outerLane, 1);
+    setCommandLaneConcurrency(middleLane, 1);
+
+    const result = await Promise.race([
+      enqueueCommandInLane(outerLane, async () => {
+        return await enqueueCommandInLane(middleLane, async () => {
+          const inner = await enqueueCommandInLane(outerLane, async () => "inner");
+          return `middle:${inner}`;
+        });
+      }),
+      new Promise<string>((_, reject) => {
+        setTimeout(() => reject(new Error("cross-lane nested work timed out")), 50);
+      }),
+    ]);
+
+    expect(result).toBe("middle:inner");
+  });
+
   it("does not affect already-active tasks after markGatewayDraining", async () => {
     const { task, release } = enqueueBlockedMainTask(async () => "ok");
     markGatewayDraining();

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { diagnosticLogger as diag, logLaneDequeue, logLaneEnqueue } from "../logging/diagnostic.js";
 import { CommandLane } from "./lanes.js";
 /**
@@ -51,6 +52,7 @@ type LaneState = {
 
 const lanes = new Map<string, LaneState>();
 let nextTaskId = 1;
+const laneExecutionScope = new AsyncLocalStorage<string[]>();
 
 function getLaneState(lane: string): LaneState {
   const existing = lanes.get(lane);
@@ -110,8 +112,11 @@ function drainLane(lane: string) {
         state.activeTaskIds.add(taskId);
         void (async () => {
           const startTime = Date.now();
+          const parentStack = laneExecutionScope.getStore() ?? [];
           try {
-            const result = await entry.task();
+            const result = await laneExecutionScope.run([...parentStack, lane], async () => {
+              return await entry.task();
+            });
             const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
             if (completedCurrentGeneration) {
               diag.debug(
@@ -166,10 +171,15 @@ export function enqueueCommandInLane<T>(
     onWait?: (waitMs: number, queuedAhead: number) => void;
   },
 ): Promise<T> {
+  const cleaned = lane.trim() || CommandLane.Main;
+  // Re-entering a lane we already own would otherwise deadlock by queuing
+  // work behind the currently active task in that same lane.
+  if ((laneExecutionScope.getStore() ?? []).includes(cleaned)) {
+    return task();
+  }
   if (gatewayDraining) {
     return Promise.reject(new GatewayDrainingError());
   }
-  const cleaned = lane.trim() || CommandLane.Main;
   const warnAfterMs = opts?.warnAfterMs ?? 2_000;
   const state = getLaneState(cleaned);
   return new Promise<T>((resolve, reject) => {


### PR DESCRIPTION
## Summary

- Problem: manual `openclaw cron run <jobId>` can enqueue successfully but never execute because the same `cron` lane is re-entered through the embedded runner path.
- Why it matters: ad-hoc cron runs can sit until timeout even though scheduled runs still work.
- What changed: the command queue now detects when work re-enters a lane already active in the current async call stack and runs that inner work directly instead of queuing it behind itself.
- What did NOT change (scope boundary): this PR does not change cron delivery behavior, cron scheduling rules, or subagent queue limits.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41266
- Related #28866

## User-visible / Behavior Changes

- Manual cron runs no longer deadlock when the cron lane is re-entered through nested queueing.
- Scheduled cron behavior is unchanged.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local macOS dev environment for tests
- Runtime/container: Node.js dev environment
- Model/provider: not required for the regression tests
- Integration/channel (if any): not required for the regression tests
- Relevant config (redacted): not required

### Steps

1. Queue work in a lane.
2. Re-enter that same lane through nested async work.
3. Observe whether the inner task completes or waits behind itself forever.

### Expected

- Re-entrant same-lane work completes.
- The queue does not deadlock on `cron -> session -> cron` re-entry.

### Actual

- Before this change, nested re-entry could queue work behind the currently active task in the same lane and time out.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm vitest run src/process/command-queue.test.ts src/cron/service.issue-regressions.test.ts`, `pnpm exec oxlint src/process/command-queue.ts src/process/command-queue.test.ts`, and `pnpm build`
- Edge cases checked: direct same-lane re-entry and `cron -> session -> cron` re-entry
- What you did **not** verify: full live manual cron reproduction against a running gateway with a real model provider in this branch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the previous queue behavior in `src/process/command-queue.ts`
- Files/config to restore: `src/process/command-queue.ts`, `src/process/command-queue.test.ts`
- Known bad symptoms reviewers should watch for: unexpected behavior in other intentionally queued same-lane nested workflows

## Risks and Mitigations

- Risk: same-lane nested work now bypasses queueing when the lane is already active in the current async stack
  - Mitigation: behavior is covered by focused queue tests plus the existing cron regression test file, and the change is limited to re-entrant ownership of the same lane
