### PR TITLE
fix: false error of Windows path when binding the host path to the sandbox.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/ClawHub: annotate 429 errors from ClawHub with the reset window from `RateLimit-Reset`/`Retry-After` and append a `Sign in for higher rate limits.` hint when the request was unauthenticated, so users can see when downloads will recover and how to lift the cap. Thanks @romneyda.
 - Plugins/runtime state: add `registerIfAbsent` for atomic keyed-store dedupe claims that return whether a plugin successfully claimed a key without overwriting an existing live value. Thanks @amknight.
 - Plugin SDK: add plugin-owned `SessionEntry` slot projection and scoped trusted-policy session extension reads. (#75609; replaces part of #73384/#74483) Thanks @100yenadmin.
+- Sandbox/Windows: accept drive-absolute Docker bind sources while keeping sandbox blocked-path and allowed-root policy comparisons Windows-case-insensitive. (#42174) Thanks @6607changchun.
 
 ### Fixes
 

--- a/extensions/whatsapp/src/setup-finalize.ts
+++ b/extensions/whatsapp/src/setup-finalize.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import {
   DEFAULT_ACCOUNT_ID,
-  normalizeE164,
   pathExists,
   splitSetupEntries,
   type DmPolicy,

--- a/src/agents/sandbox/host-paths.test.ts
+++ b/src/agents/sandbox/host-paths.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  getSandboxHostPathPolicyKey,
+  isSandboxHostPathAbsolute,
   normalizeSandboxHostPath,
   resolveSandboxHostPathViaExistingAncestor,
 } from "./host-paths.js";
@@ -11,11 +13,48 @@ describe("normalizeSandboxHostPath", () => {
   it("normalizes dot segments and strips trailing slash", () => {
     expect(normalizeSandboxHostPath("/tmp/a/../b//")).toBe("/tmp/b");
   });
+
+  it("normalizes Windows drive-letter paths without losing the drive root", () => {
+    expect(normalizeSandboxHostPath("c:\\Users\\Kai\\..\\Project\\")).toBe("C:/Users/Project");
+    expect(normalizeSandboxHostPath("d:/")).toBe("D:/");
+  });
+});
+
+describe("isSandboxHostPathAbsolute", () => {
+  it("accepts POSIX and drive-absolute Windows paths", () => {
+    expect(isSandboxHostPathAbsolute("/tmp/project")).toBe(true);
+    expect(isSandboxHostPathAbsolute("C:/Users/kai/project")).toBe(true);
+    expect(isSandboxHostPathAbsolute("C:\\Users\\kai\\project")).toBe(true);
+  });
+
+  it("rejects relative paths, named volumes, and drive-relative Windows paths", () => {
+    expect(isSandboxHostPathAbsolute("relative/path")).toBe(false);
+    expect(isSandboxHostPathAbsolute("my-volume")).toBe(false);
+    expect(isSandboxHostPathAbsolute("C:relative\\path")).toBe(false);
+  });
+});
+
+describe("getSandboxHostPathPolicyKey", () => {
+  it("compares Windows drive-letter paths case-insensitively", () => {
+    expect(getSandboxHostPathPolicyKey("c:\\Users\\Kai\\.SSH\\config")).toBe(
+      "c:/users/kai/.ssh/config",
+    );
+  });
 });
 
 describe("resolveSandboxHostPathViaExistingAncestor", () => {
   it("keeps non-absolute paths unchanged", () => {
     expect(resolveSandboxHostPathViaExistingAncestor("relative/path")).toBe("relative/path");
+  });
+
+  it("normalizes Windows paths without resolving them through POSIX cwd on non-Windows hosts", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    expect(resolveSandboxHostPathViaExistingAncestor("C:/Users/kai/project")).toBe(
+      "C:/Users/kai/project",
+    );
   });
 
   it("resolves symlink parents when the final leaf does not exist", () => {

--- a/src/agents/sandbox/host-paths.ts
+++ b/src/agents/sandbox/host-paths.ts
@@ -31,7 +31,7 @@ export function normalizeSandboxHostPath(raw: string): string {
   let normalTrimmed = trimmed.replaceAll("\\", "/");
   const windowsPrefix = /^[A-Za-z]:/;
   if (windowsPrefix.test(normalTrimmed)) {
-    normalTrimmed = normalTrimmed.toUpperCase();
+    normalTrimmed = normalTrimmed.charAt(0).toUpperCase() + normalTrimmed.slice(1);
   }
   const normalized = posix.normalize(normalTrimmed);
   return normalized.replace(/\/+$/, "") || "/";

--- a/src/agents/sandbox/host-paths.ts
+++ b/src/agents/sandbox/host-paths.ts
@@ -21,13 +21,19 @@ function stripWindowsNamespacePrefix(input: string): string {
 
 /**
  * Normalize a POSIX host path: resolve `.`, `..`, collapse `//`, strip trailing `/`.
+ * If it starts with the drive letter, convert it to the upper case.
  */
 export function normalizeSandboxHostPath(raw: string): string {
   const trimmed = stripWindowsNamespacePrefix(raw.trim());
   if (!trimmed) {
     return "/";
   }
-  const normalized = posix.normalize(trimmed.replaceAll("\\", "/"));
+  let normalTrimmed = trimmed.replaceAll("\\", "/");
+  const windowsPrefix = /^[A-Za-z]:/;
+  if (windowsPrefix.test(normalTrimmed)){
+    normalTrimmed = normalTrimmed.toUpperCase();
+  }
+  const normalized = posix.normalize(normalTrimmed);
   return normalized.replace(/\/+$/, "") || "/";
 }
 
@@ -36,7 +42,8 @@ export function normalizeSandboxHostPath(raw: string): string {
  * even when the final source leaf does not exist yet.
  */
 export function resolveSandboxHostPathViaExistingAncestor(sourcePath: string): string {
-  if (!sourcePath.startsWith("/")) {
+  const windowsPrefix = /^[A-Za-z]:/;
+  if (!sourcePath.startsWith("/") && !windowsPrefix.test(sourcePath)) {
     return sourcePath;
   }
   return normalizeSandboxHostPath(resolvePathViaExistingAncestorSync(sourcePath));

--- a/src/agents/sandbox/host-paths.ts
+++ b/src/agents/sandbox/host-paths.ts
@@ -30,7 +30,7 @@ export function normalizeSandboxHostPath(raw: string): string {
   }
   let normalTrimmed = trimmed.replaceAll("\\", "/");
   const windowsPrefix = /^[A-Za-z]:/;
-  if (windowsPrefix.test(normalTrimmed)){
+  if (windowsPrefix.test(normalTrimmed)) {
     normalTrimmed = normalTrimmed.toUpperCase();
   }
   const normalized = posix.normalize(normalTrimmed);

--- a/src/agents/sandbox/host-paths.ts
+++ b/src/agents/sandbox/host-paths.ts
@@ -19,9 +19,18 @@ function stripWindowsNamespacePrefix(input: string): string {
   return input;
 }
 
+export function isWindowsDriveAbsolutePath(raw: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(stripWindowsNamespacePrefix(raw.trim()));
+}
+
+export function isSandboxHostPathAbsolute(raw: string): boolean {
+  const trimmed = stripWindowsNamespacePrefix(raw.trim());
+  return trimmed.startsWith("/") || isWindowsDriveAbsolutePath(trimmed);
+}
+
 /**
- * Normalize a POSIX host path: resolve `.`, `..`, collapse `//`, strip trailing `/`.
- * If it starts with the drive letter, convert it to the upper case.
+ * Normalize a host path: resolve `.`, `..`, collapse `//`, strip trailing `/`.
+ * Windows drive-letter paths preserve the drive root and uppercase the drive letter.
  */
 export function normalizeSandboxHostPath(raw: string): string {
   const trimmed = stripWindowsNamespacePrefix(raw.trim());
@@ -29,12 +38,23 @@ export function normalizeSandboxHostPath(raw: string): string {
     return "/";
   }
   let normalTrimmed = trimmed.replaceAll("\\", "/");
-  const windowsPrefix = /^[A-Za-z]:/;
-  if (windowsPrefix.test(normalTrimmed)) {
+  if (isWindowsDriveAbsolutePath(normalTrimmed)) {
     normalTrimmed = normalTrimmed.charAt(0).toUpperCase() + normalTrimmed.slice(1);
   }
   const normalized = posix.normalize(normalTrimmed);
-  return normalized.replace(/\/+$/, "") || "/";
+  const withoutTrailingSlash = normalized.replace(/\/+$/, "") || "/";
+  if (/^[A-Z]:$/.test(withoutTrailingSlash)) {
+    return `${withoutTrailingSlash}/`;
+  }
+  return withoutTrailingSlash;
+}
+
+export function getSandboxHostPathPolicyKey(raw: string): string {
+  const normalized = normalizeSandboxHostPath(raw);
+  if (isWindowsDriveAbsolutePath(normalized)) {
+    return normalized.toLowerCase();
+  }
+  return normalized;
 }
 
 /**
@@ -42,9 +62,11 @@ export function normalizeSandboxHostPath(raw: string): string {
  * even when the final source leaf does not exist yet.
  */
 export function resolveSandboxHostPathViaExistingAncestor(sourcePath: string): string {
-  const windowsPrefix = /^[A-Za-z]:/;
-  if (!sourcePath.startsWith("/") && !windowsPrefix.test(sourcePath)) {
+  if (!isSandboxHostPathAbsolute(sourcePath)) {
     return sourcePath;
+  }
+  if (isWindowsDriveAbsolutePath(sourcePath) && process.platform !== "win32") {
+    return normalizeSandboxHostPath(sourcePath);
   }
   return normalizeSandboxHostPath(resolvePathViaExistingAncestorSync(sourcePath));
 }

--- a/src/agents/sandbox/validate-sandbox-security.test.ts
+++ b/src/agents/sandbox/validate-sandbox-security.test.ts
@@ -174,6 +174,25 @@ describe("validateBindMounts", () => {
     expect(() => validateBindMounts(["/home/tester/.netrc:/mnt/netrc:ro"])).toThrow(/blocked path/);
   });
 
+  it("allows drive-absolute Windows bind sources", () => {
+    expect(() => validateBindMounts(["D:/data/openclaw/src:/src:ro"])).not.toThrow();
+    expect(() => validateBindMounts(["D:\\data\\openclaw\\output:/output:rw"])).not.toThrow();
+  });
+
+  it("compares Windows allowed roots case-insensitively", () => {
+    expect(() =>
+      validateBindMounts(["d:/DATA/OpenClaw/src:/src:ro"], {
+        allowedSourceRoots: ["D:/data/openclaw"],
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      validateBindMounts(["D:/other/project:/src:ro"], {
+        allowedSourceRoots: ["d:/data/openclaw"],
+      }),
+    ).toThrow(/outside allowed roots/);
+  });
+
   it("blocks credential binds through canonical home aliases", () => {
     if (process.platform === "win32") {
       return;
@@ -193,14 +212,7 @@ describe("validateBindMounts", () => {
 
   it("blocks symlink escapes into blocked directories", () => {
     if (process.platform === "win32") {
-      // Symlinks to non-existent targets like /etc require
-      // SeCreateSymbolicLinkPrivilege on Windows.  The Windows branch of this
-      // test does not need a real symlink — it only asserts that Windows source
-      // paths are rejected as non-POSIX.
-      const dir = mkdtempSync(join(tmpdir(), "openclaw-sbx-"));
-      const fakePath = join(dir, "etc-link", "passwd");
-      const run = () => validateBindMounts([`${fakePath}:/mnt/passwd:ro`]);
-      expect(run).toThrow(/non-absolute source path/);
+      // Symlink setup for blocked POSIX targets like /etc is POSIX-only.
       return;
     }
 
@@ -213,7 +225,7 @@ describe("validateBindMounts", () => {
 
   it("blocks symlink-parent escapes with non-existent leaf outside allowed roots", () => {
     if (process.platform === "win32") {
-      // Windows source paths (e.g. C:\\...) are intentionally rejected as non-POSIX.
+      // Windows symlink semantics differ; POSIX symlink escape coverage runs on POSIX hosts.
       return;
     }
     const dir = mkdtempSync(join(tmpdir(), "openclaw-sbx-"));
@@ -233,7 +245,7 @@ describe("validateBindMounts", () => {
 
   it("blocks symlink-parent escapes into blocked paths when leaf does not exist", () => {
     if (process.platform === "win32") {
-      // Windows source paths (e.g. C:\\...) are intentionally rejected as non-POSIX.
+      // Symlink setup for blocked POSIX targets like /var/run is POSIX-only.
       return;
     }
     const dir = mkdtempSync(join(tmpdir(), "openclaw-sbx-"));

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -116,9 +116,8 @@ function normalizeHostPath(raw: string): string {
 export function getBlockedBindReason(bind: string): BlockedBindReason | null {
   const sourceRaw = parseBindSourcePath(bind);
   const windowsPrefix = /^[A-Za-z]:/;
+  if(!sourceRaw.startsWith("/") && !windowsPrefix.test(sourceRaw))
     return { kind: "non_absolute", sourcePath: sourceRaw };
-  }
-
   const normalized = normalizeHostPath(sourceRaw);
   const blockedHostPaths = getBlockedHostPaths();
   const directReason = getBlockedReasonForSourcePath(normalized, blockedHostPaths);

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -101,6 +101,7 @@ function parseBindTargetPath(bind: string): string {
 
 /**
  * Normalize a POSIX path: resolve `.`, `..`, collapse `//`, strip trailing `/`.
+ * If it starts with the drive letter, convert it to the upper case.
  */
 function normalizeHostPath(raw: string): string {
   return normalizeSandboxHostPath(raw);

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -115,7 +115,8 @@ function normalizeHostPath(raw: string): string {
  */
 export function getBlockedBindReason(bind: string): BlockedBindReason | null {
   const sourceRaw = parseBindSourcePath(bind);
-  if (!sourceRaw.startsWith("/")) {
+  const windowsPrefix = /^[A-Z]:/;
+  if (!sourceRaw.startsWith("/") && !windowsPrefix.test(sourceRaw)) {
     return { kind: "non_absolute", sourcePath: sourceRaw };
   }
 

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -115,8 +115,7 @@ function normalizeHostPath(raw: string): string {
  */
 export function getBlockedBindReason(bind: string): BlockedBindReason | null {
   const sourceRaw = parseBindSourcePath(bind);
-  const windowsPrefix = /^[A-Z]:/;
-  if (!sourceRaw.startsWith("/") && !windowsPrefix.test(sourceRaw)) {
+  const windowsPrefix = /^[A-Za-z]:/;
     return { kind: "non_absolute", sourcePath: sourceRaw };
   }
 

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -116,7 +116,7 @@ function normalizeHostPath(raw: string): string {
 export function getBlockedBindReason(bind: string): BlockedBindReason | null {
   const sourceRaw = parseBindSourcePath(bind);
   const windowsPrefix = /^[A-Za-z]:/;
-  if(!sourceRaw.startsWith("/") && !windowsPrefix.test(sourceRaw))
+  if (!sourceRaw.startsWith("/") && !windowsPrefix.test(sourceRaw))
     return { kind: "non_absolute", sourcePath: sourceRaw };
   const normalized = normalizeHostPath(sourceRaw);
   const blockedHostPaths = getBlockedHostPaths();

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -12,6 +12,8 @@ import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js"
 import { splitSandboxBindSpec } from "./bind-spec.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import {
+  getSandboxHostPathPolicyKey,
+  isSandboxHostPathAbsolute,
   normalizeSandboxHostPath,
   resolveSandboxHostPathViaExistingAncestor,
 } from "./host-paths.js";
@@ -116,8 +118,7 @@ function normalizeHostPath(raw: string): string {
  */
 export function getBlockedBindReason(bind: string): BlockedBindReason | null {
   const sourceRaw = parseBindSourcePath(bind);
-  const windowsPrefix = /^[A-Za-z]:/;
-  if (!sourceRaw.startsWith("/") && !windowsPrefix.test(sourceRaw)) {
+  if (!isSandboxHostPathAbsolute(sourceRaw)) {
     return { kind: "non_absolute", sourcePath: sourceRaw };
   }
   const normalized = normalizeHostPath(sourceRaw);
@@ -142,8 +143,10 @@ function getBlockedReasonForSourcePath(
   if (sourceNormalized === "/") {
     return { kind: "covers", blockedPath: "/" };
   }
+  const sourceKey = getSandboxHostPathPolicyKey(sourceNormalized);
   for (const blocked of blockedHostPaths) {
-    if (sourceNormalized === blocked || sourceNormalized.startsWith(blocked + "/")) {
+    const blockedKey = getSandboxHostPathPolicyKey(blocked);
+    if (sourceKey === blockedKey || sourceKey.startsWith(`${blockedKey}/`)) {
       return { kind: "targets", blockedPath: blocked };
     }
   }
@@ -192,10 +195,9 @@ function normalizeAllowedRoots(roots: string[] | undefined): string[] {
   if (!roots?.length) {
     return [];
   }
-  const windowsPrefix = /^[A-Za-z]:/;
   const normalized = roots
     .map((entry) => entry.trim())
-    .filter((entry) => entry.startsWith("/") || windowsPrefix.test(entry))
+    .filter(isSandboxHostPathAbsolute)
     .map(normalizeHostPath);
   const expanded = new Set<string>();
   for (const root of normalized) {
@@ -212,7 +214,9 @@ function isPathInsidePosix(root: string, target: string): boolean {
   if (root === "/") {
     return true;
   }
-  return target === root || target.startsWith(`${root}/`);
+  const rootKey = getSandboxHostPathPolicyKey(root);
+  const targetKey = getSandboxHostPathPolicyKey(target);
+  return targetKey === rootKey || targetKey.startsWith(`${rootKey}/`);
 }
 
 function getOutsideAllowedRootsReason(
@@ -276,7 +280,7 @@ function formatBindBlockedError(params: { bind: string; reason: BlockedBindReaso
   if (params.reason.kind === "non_absolute") {
     return new Error(
       `Sandbox security: bind mount "${params.bind}" uses a non-absolute source path ` +
-        `"${params.reason.sourcePath}". Only absolute POSIX paths are supported for sandbox binds.`,
+        `"${params.reason.sourcePath}". Only absolute POSIX or Windows drive-letter paths are supported for sandbox binds.`,
     );
   }
   if (params.reason.kind === "outside_allowed_roots") {

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -190,9 +190,10 @@ function normalizeAllowedRoots(roots: string[] | undefined): string[] {
   if (!roots?.length) {
     return [];
   }
+  const windowsPrefix = /^[A-Za-z]:/;
   const normalized = roots
     .map((entry) => entry.trim())
-    .filter((entry) => entry.startsWith("/"))
+    .filter((entry) => entry.startsWith("/") || windowsPrefix.test(entry))
     .map(normalizeHostPath);
   const expanded = new Set<string>();
   for (const root of normalized) {

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -116,8 +116,9 @@ function normalizeHostPath(raw: string): string {
 export function getBlockedBindReason(bind: string): BlockedBindReason | null {
   const sourceRaw = parseBindSourcePath(bind);
   const windowsPrefix = /^[A-Za-z]:/;
-  if (!sourceRaw.startsWith("/") && !windowsPrefix.test(sourceRaw))
+  if (!sourceRaw.startsWith("/") && !windowsPrefix.test(sourceRaw)) {
     return { kind: "non_absolute", sourcePath: sourceRaw };
+  }
   const normalized = normalizeHostPath(sourceRaw);
   const blockedHostPaths = getBlockedHostPaths();
   const directReason = getBlockedReasonForSourcePath(normalized, blockedHostPaths);

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -62,6 +62,42 @@ describe("sandbox docker config", () => {
     }
   });
 
+  it("accepts Windows drive-letter binds in sandbox.docker config", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              binds: ["D:/data/openclaw/src:/src:ro", "D:\\data\\openclaw\\output:/output:rw"],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.sandbox?.docker?.binds).toEqual([
+        "D:/data/openclaw/src:/src:ro",
+        "D:\\data\\openclaw\\output:/output:rw",
+      ]);
+    }
+  });
+
+  it("rejects drive-relative Windows binds in sandbox.docker config", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              binds: ["D:relative\\path:/src:ro"],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
   it("accepts non-empty Docker GPU passthrough config", () => {
     const res = validateConfigObject({
       agents: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { splitSandboxBindSpec } from "../agents/sandbox/bind-spec.js";
 import { getBlockedNetworkModeReason } from "../agents/sandbox/network-mode.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import {
@@ -16,7 +17,6 @@ import {
   TtsConfigSchema,
 } from "./zod-schema.core.js";
 import { sensitive } from "./zod-schema.sensitive.js";
-import { splitSandboxBindSpec } from "../agents/sandbox/bind-spec.js";
 
 export const HeartbeatSchema = z
   .object({
@@ -160,19 +160,19 @@ const SandboxDockerSchema = z
           continue;
         }
 
-// Replace the colonCount block with:
-const windowsPrefix = /^[A-Za-z]:/;
-const parsed = splitSandboxBindSpec(bind);
-const source = (parsed ? parsed.host : bind).trim();
-if (!source.startsWith("/") && !windowsPrefix.test(source)) {
-  ctx.addIssue({
-    code: z.ZodIssueCode.custom,
-    path: ["binds", i],
-    message:
-      `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
-      "Only absolute POSIX paths are supported for sandbox binds.",
-  });
-}
+        // Replace the colonCount block with:
+        const windowsPrefix = /^[A-Za-z]:/;
+        const parsed = splitSandboxBindSpec(bind);
+        const source = (parsed ? parsed.host : bind).trim();
+        if (!source.startsWith("/") && !windowsPrefix.test(source)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["binds", i],
+            message:
+              `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
+              "Only absolute POSIX paths are supported for sandbox binds.",
+          });
+        }
         if (!source.startsWith("/") && !windowsPrefix.test(source)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -158,9 +158,19 @@ const SandboxDockerSchema = z
           });
           continue;
         }
-        const firstColon = bind.indexOf(":");
+        let colonCount = 0;
+        for(let bindIndex = 0; bindIndex < bind.length; bindIndex += 1){
+          if (bind.indexOf(bindIndex) === ':'){
+            colonCount += 1;
+          }
+        }
+        let firstColon = bind.indexOf(":");
+        if (colonCount == 3){
+          firstColon = bind.indexOf(":", firstColon + 1);
+        }
+        const windowsPrefix = /^[A-Z]:/;
         const source = (firstColon <= 0 ? bind : bind.slice(0, firstColon)).trim();
-        if (!source.startsWith("/")) {
+        if (!source.startsWith("/") && !windowsPrefix.test(source)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ["binds", i],

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -160,19 +160,9 @@ const SandboxDockerSchema = z
           continue;
         }
 
-        // Replace the colonCount block with:
         const windowsPrefix = /^[A-Za-z]:/;
         const parsed = splitSandboxBindSpec(bind);
         const source = (parsed ? parsed.host : bind).trim();
-        if (!source.startsWith("/") && !windowsPrefix.test(source)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["binds", i],
-            message:
-              `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
-              "Only absolute POSIX paths are supported for sandbox binds.",
-          });
-        }
         if (!source.startsWith("/") && !windowsPrefix.test(source)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -158,18 +158,21 @@ const SandboxDockerSchema = z
           });
           continue;
         }
-        let colonCount = 0;
-        for(let bindIndex = 0; bindIndex < bind.length; bindIndex += 1){
-          if (bind.indexOf(bindIndex) === ':'){
-            colonCount += 1;
-          }
-        }
-        let firstColon = bind.indexOf(":");
-        if (colonCount == 3){
-          firstColon = bind.indexOf(":", firstColon + 1);
-        }
-        const windowsPrefix = /^[A-Z]:/;
-        const source = (firstColon <= 0 ? bind : bind.slice(0, firstColon)).trim();
+import { splitSandboxBindSpec } from "../agents/sandbox/bind-spec.js";
+
+// Replace the colonCount block with:
+const windowsPrefix = /^[A-Za-z]:/;
+const parsed = splitSandboxBindSpec(bind);
+const source = (parsed ? parsed.host : bind).trim();
+if (!source.startsWith("/") && !windowsPrefix.test(source)) {
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    path: ["binds", i],
+    message:
+      `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
+      "Only absolute POSIX paths are supported for sandbox binds.",
+  });
+}
         if (!source.startsWith("/") && !windowsPrefix.test(source)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -16,6 +16,7 @@ import {
   TtsConfigSchema,
 } from "./zod-schema.core.js";
 import { sensitive } from "./zod-schema.sensitive.js";
+import { splitSandboxBindSpec } from "../agents/sandbox/bind-spec.js";
 
 export const HeartbeatSchema = z
   .object({
@@ -158,7 +159,6 @@ const SandboxDockerSchema = z
           });
           continue;
         }
-import { splitSandboxBindSpec } from "../agents/sandbox/bind-spec.js";
 
 // Replace the colonCount block with:
 const windowsPrefix = /^[A-Za-z]:/;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { splitSandboxBindSpec } from "../agents/sandbox/bind-spec.js";
+import { isSandboxHostPathAbsolute } from "../agents/sandbox/host-paths.js";
 import { getBlockedNetworkModeReason } from "../agents/sandbox/network-mode.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import {
@@ -160,16 +161,15 @@ const SandboxDockerSchema = z
           continue;
         }
 
-        const windowsPrefix = /^[A-Za-z]:/;
         const parsed = splitSandboxBindSpec(bind);
         const source = (parsed ? parsed.host : bind).trim();
-        if (!source.startsWith("/") && !windowsPrefix.test(source)) {
+        if (!isSandboxHostPathAbsolute(source)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ["binds", i],
             message:
               `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
-              "Only absolute POSIX paths are supported for sandbox binds.",
+              "Only absolute POSIX or Windows drive-letter paths are supported for sandbox binds.",
           });
         }
       }

--- a/src/security/audit-sandbox-docker-config.test.ts
+++ b/src/security/audit-sandbox-docker-config.test.ts
@@ -127,6 +127,23 @@ describe("security audit sandbox docker config", () => {
           ],
         },
         {
+          name: "Windows drive-letter bind is absolute",
+          cfg: {
+            agents: {
+              defaults: {
+                sandbox: {
+                  mode: "all",
+                  docker: {
+                    binds: ["D:/data/openclaw/src:/src:ro"],
+                  },
+                },
+              },
+            },
+          } as OpenClawConfig,
+          expectedFindings: [],
+          expectedAbsent: ["sandbox.bind_mount_non_absolute"],
+        },
+        {
           name: "container namespace join network mode",
           cfg: {
             agents: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The drive letter of the path on Windows does not start with the slash, leading to false error of the sandbox security. So I added the passby branch to avoid it. When launching the gateway with the custom bindings on Windows, the drive letter is recoginzed as a relative path, leading to false error of the sand security. 
- Why it matters: This bug affects the usage of the custom binding features on Windows, which causes the custom binding feature to be completely unusable on Windows, as absolute Windows paths (e.g., D:/path) are incorrectly rejected by the security check.
- What changed: Adding the branch of Windows path support to the sandbox security validation.
- What did NOT change (scope boundary): The current permission check and the posix-like path validation are not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.
The host path on Windows can be binded to the sandbox.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`)  No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11 26200.7840
- Runtime/container: Local Machine for the host, and Docker Desktop 4.34.3 with WSL2 backend for docker.
- Model/provider: deepseek-V3.2 reasoner
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

```json
"agents": {
    "defaults": {
      "sandbox": {
        "mode": "all",
        "scope": "session",
        "workspaceAccess": "ro",
        "docker": {
          "image": "192.168.1.102:8080/library/ubuntu:latest",
          "network": "bridge",
          "binds": ["D:/data/openclaw/src:/src:ro", "D:/data/openclaw/output:/output:rw"]
        }
      }
    }
  },
```

1. Modify the openclaw.json like the above fragment.
2. Launch the gateway

### Expected

- The gateway starts successfully, and the skills are able to executed in the docker container with proper binding.

### Actual

- The gateway fails to start.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**before**

🦞 OpenClaw 2026.3.8 (3a12cf5) — One CLI to rule them all, and one more restart because you changed the port.

│
◇  Config ───────────────────────────────────────────────────╮
│                                                            │
│  Config invalid; doctor will run with best-effort config.  │
│                                                            │
├────────────────────────────────────────────────────────────╯
Config invalid
File: ~\.openclaw\openclaw.json
Problem:
  - agents.defaults.sandbox.docker.binds.0: Sandbox security: bind mount "D:/data/openclaw/src:/src:ro" uses a non-absolute source path "D". Only absolute POSIX paths are supported for sandbox binds.
  - agents.defaults.sandbox.docker.binds.1: Sandbox security: bind mount "D:/data/openclaw/output:/output:rw" uses a non-absolute source path "D". Only absolute POSIX paths are supported for sandbox binds.

Run: openclaw doctor --fix
Gateway aborted: config is invalid.
agents.defaults.sandbox.docker.binds.0: Sandbox security: bind mount "D:/data/openclaw/src:/src:ro" uses a non-absolute source path "D". Only absolute POSIX paths are supported for sandbox binds.
agents.defaults.sandbox.docker.binds.1: Sandbox security: bind mount "D:/data/openclaw/output:/output:rw" uses a non-absolute source path "D". Only absolute POSIX paths are supported for sandbox binds.
Fix the config and retry, or run "openclaw doctor" to repair.

**after**

🦞 OpenClaw 2026.3.8 (3a12cf5) — We ship features faster than Apple ships calculator updates.

Restarted Scheduled Task: OpenClaw Gateway

## Human Verification (required)

What you personally verified (not just CI), and how: I put some files in the src directory, and then launched the gateway and tested the agent with several prompts. The agent successfully obtained these files and read the correct content of the files. Besides, I have checked the container, the src and output directory are correctly binded. The src directory is read-only and the output directory is read-write. The original permission check is not corrupted.

- Verified scenarios: Agent successfully reads files from the read‑only /src directory. Agent writes files to the read‑write /output directory and the files persist on the host. Inside the container, /src is mounted as ro and /output as rw (confirmed via docker inspect). Bind mounts using D:/... syntax are accepted by the security validation and work as expected.
- Edge cases checked: 
- What you did **not** verify: The regression testing of the original posix-like path validation as this patch is only a side-enhancement of the original conditions.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Directly revert this commit and reinstall.
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Windows paths of custom bindings will be rejected (if regression occurs)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.
None
