### PR TITLE
fix(restart): drain active work before gateway restart

### DIFF
--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -48,6 +48,7 @@ const GatewayToolSchema = Type.Object({
   // restart
   delayMs: Type.Optional(Type.Number()),
   reason: Type.Optional(Type.String()),
+  force: Type.Optional(Type.Boolean()),
   // config.get, config.schema.lookup, config.apply, update.run
   gatewayUrl: Type.Optional(Type.String()),
   gatewayToken: Type.Optional(Type.String()),
@@ -99,6 +100,7 @@ export function createGatewayTool(opts?: {
             : undefined;
         const note =
           typeof params.note === "string" && params.note.trim() ? params.note.trim() : undefined;
+        const force = params.force === true;
         // Extract channel + threadId for routing after restart
         // Supports both :thread: (most channels) and :topic: (Telegram)
         const { deliveryContext, threadId } = extractDeliveryInfo(sessionKey);
@@ -122,11 +124,12 @@ export function createGatewayTool(opts?: {
           // ignore: sentinel is best-effort
         }
         log.info(
-          `gateway tool: restart requested (delayMs=${delayMs ?? "default"}, reason=${reason ?? "none"})`,
+          `gateway tool: restart requested (delayMs=${delayMs ?? "default"}, reason=${reason ?? "none"}, force=${force})`,
         );
         const scheduled = scheduleGatewaySigusr1Restart({
           delayMs,
           reason,
+          force,
         });
         return jsonResult(scheduled);
       }

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -130,6 +130,7 @@ export function createGatewayTool(opts?: {
           delayMs,
           reason,
           force,
+          maxWaitMs: 0,
         });
         return jsonResult(scheduled);
       }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -10,6 +10,7 @@ import { isTruthyEnvValue } from "../infra/env.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
 import {
+  SCHEDULED_RESTART_MAX_WAIT_MS,
   deferGatewayRestartUntilIdle,
   emitGatewayRestart,
   setGatewaySigusr1RestartPolicy,
@@ -202,6 +203,7 @@ export function createGatewayReloadHandlers(params: {
 
       deferGatewayRestartUntilIdle({
         getPendingCount: () => getActiveCounts().totalActive,
+        maxWaitMs: SCHEDULED_RESTART_MAX_WAIT_MS,
         hooks: {
           onReady: () => {
             restartPending = false;

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -232,20 +232,87 @@ describe("infra runtime", () => {
       }
     });
 
-    it("emits SIGUSR1 after deferral timeout even if still pending", async () => {
+    it("waits indefinitely when maxWaitMs is 0 (gateway tool path)", async () => {
       const emitSpy = vi.spyOn(process, "emit");
       const handler = () => {};
       process.on("SIGUSR1", handler);
       try {
-        setPreRestartDeferralCheck(() => 5); // always pending
-        scheduleGatewaySigusr1Restart({ delayMs: 0 });
+        let pending = 5;
+        setPreRestartDeferralCheck(() => pending);
+        scheduleGatewaySigusr1Restart({ delayMs: 0, maxWaitMs: 0 });
 
         // Fire initial timeout
         await vi.advanceTimersByTimeAsync(0);
         expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
 
-        // Advance past the 90s max deferral wait
-        await vi.advanceTimersByTimeAsync(90_000);
+        // Advance well past the scheduled restart max — should still NOT restart
+        await vi.advanceTimersByTimeAsync(600_000);
+        expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
+
+        // Drain pending work — now it restarts
+        pending = 0;
+        await vi.advanceTimersByTimeAsync(500);
+        expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("times out at SCHEDULED_RESTART_MAX_WAIT_MS boundary by default", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        setPreRestartDeferralCheck(() => 5);
+        scheduleGatewaySigusr1Restart({ delayMs: 0 });
+
+        // Fire initial timeout — starts deferral polling
+        await vi.advanceTimersByTimeAsync(0);
+        expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
+
+        // At exactly SCHEDULED_RESTART_MAX_WAIT_MS (300_000), >= triggers timeout
+        await vi.advanceTimersByTimeAsync(300_000);
+        expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("upgrades pending non-force restart to force when force request arrives", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        setPreRestartDeferralCheck(() => 5); // always pending
+        const first = scheduleGatewaySigusr1Restart({ delayMs: 100, reason: "non-force" });
+        expect(first.coalesced).toBe(false);
+
+        // Force request should NOT coalesce — should reschedule with force
+        const second = scheduleGatewaySigusr1Restart({
+          delayMs: 100,
+          reason: "force-upgrade",
+          force: true,
+        });
+        expect(second.coalesced).toBe(false);
+
+        // Fire the rescheduled timer — force skips deferral entirely
+        await vi.advanceTimersByTimeAsync(100);
+        expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("emits SIGUSR1 immediately when force is true even if pending", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        setPreRestartDeferralCheck(() => 5); // always pending
+        scheduleGatewaySigusr1Restart({ delayMs: 0, force: true });
+
+        // Fire initial timeout — force skips deferral entirely
+        await vi.advanceTimersByTimeAsync(0);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
       } finally {
         process.removeListener("SIGUSR1", handler);

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -19,8 +19,12 @@ export type RestartAttempt = {
 const SPAWN_TIMEOUT_MS = 2000;
 const SIGUSR1_AUTH_GRACE_MS = 5000;
 const DEFAULT_DEFERRAL_POLL_MS = 500;
-// Cover slow in-flight embedded compaction work before forcing restart.
-const DEFAULT_DEFERRAL_MAX_WAIT_MS = 90_000;
+// 0 = wait indefinitely for drain (used by gateway tool — user has force for break-glass).
+const DEFAULT_DEFERRAL_MAX_WAIT_MS = 0;
+// Finite timeout for non-interactive restart paths (config watcher, /restart, RPCs)
+// where the user has no force escape hatch. 5 minutes is generous for most agent turns.
+export const SCHEDULED_RESTART_MAX_WAIT_MS = 300_000;
+const DEFERRAL_WARN_INTERVAL_MS = 30_000;
 const RESTART_COOLDOWN_MS = 30_000;
 
 const restartLog = createSubsystemLogger("restart");
@@ -38,6 +42,7 @@ let lastRestartEmittedAt = 0;
 let pendingRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRestartDueAt = 0;
 let pendingRestartReason: string | undefined;
+let pendingRestartForce = false;
 
 function hasUnconsumedRestartSignal(): boolean {
   return emittedRestartToken > consumedRestartToken;
@@ -50,6 +55,7 @@ function clearPendingScheduledRestart(): void {
   pendingRestartTimer = null;
   pendingRestartDueAt = 0;
   pendingRestartReason = undefined;
+  pendingRestartForce = false;
 }
 
 export type RestartAuditInfo = {
@@ -198,11 +204,17 @@ export function deferGatewayRestartUntilIdle(opts: {
   hooks?: RestartDeferralHooks;
   pollMs?: number;
   maxWaitMs?: number;
+  force?: boolean;
 }): void {
+  if (opts.force) {
+    emitGatewayRestart();
+    return;
+  }
+
   const pollMsRaw = opts.pollMs ?? DEFAULT_DEFERRAL_POLL_MS;
   const pollMs = Math.max(10, Math.floor(pollMsRaw));
   const maxWaitMsRaw = opts.maxWaitMs ?? DEFAULT_DEFERRAL_MAX_WAIT_MS;
-  const maxWaitMs = Math.max(pollMs, Math.floor(maxWaitMsRaw));
+  const maxWaitMs = maxWaitMsRaw > 0 ? Math.max(pollMs, Math.floor(maxWaitMsRaw)) : 0;
 
   let pending: number;
   try {
@@ -220,6 +232,7 @@ export function deferGatewayRestartUntilIdle(opts: {
 
   opts.hooks?.onDeferring?.(pending);
   const startedAt = Date.now();
+  let lastWarnAt = startedAt;
   const poll = setInterval(() => {
     let current: number;
     try {
@@ -236,11 +249,17 @@ export function deferGatewayRestartUntilIdle(opts: {
       emitGatewayRestart();
       return;
     }
-    const elapsedMs = Date.now() - startedAt;
-    if (elapsedMs >= maxWaitMs) {
+    const now = Date.now();
+    const elapsedMs = now - startedAt;
+    if (maxWaitMs > 0 && elapsedMs >= maxWaitMs) {
       clearInterval(poll);
       opts.hooks?.onTimeout?.(current, elapsedMs);
       emitGatewayRestart();
+      return;
+    }
+    if (now - lastWarnAt >= DEFERRAL_WARN_INTERVAL_MS) {
+      lastWarnAt = now;
+      restartLog.warn(`restart deferred: ${current} items still active (${elapsedMs}ms elapsed)`);
     }
   }, pollMs);
 }
@@ -407,6 +426,8 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   delayMs?: number;
   reason?: string;
   audit?: RestartAuditInfo;
+  force?: boolean;
+  maxWaitMs?: number;
 }): ScheduledRestart {
   const delayMsRaw =
     typeof opts?.delayMs === "number" && Number.isFinite(opts.delayMs)
@@ -440,10 +461,11 @@ export function scheduleGatewaySigusr1Restart(opts?: {
 
   if (pendingRestartTimer) {
     const remainingMs = Math.max(0, pendingRestartDueAt - nowMs);
+    const shouldUpgradeToForce = opts?.force && !pendingRestartForce;
     const shouldPullEarlier = requestedDueAt < pendingRestartDueAt;
-    if (shouldPullEarlier) {
+    if (shouldUpgradeToForce || shouldPullEarlier) {
       restartLog.warn(
-        `restart request rescheduled earlier reason=${reason ?? "unspecified"} pendingReason=${pendingRestartReason ?? "unspecified"} oldDelayMs=${remainingMs} newDelayMs=${Math.max(0, requestedDueAt - nowMs)} ${formatRestartAudit(opts?.audit)}`,
+        `restart request rescheduled${shouldUpgradeToForce ? " (upgraded to force)" : " earlier"} reason=${reason ?? "unspecified"} pendingReason=${pendingRestartReason ?? "unspecified"} oldDelayMs=${remainingMs} newDelayMs=${Math.max(0, requestedDueAt - nowMs)} ${formatRestartAudit(opts?.audit)}`,
       );
       clearPendingScheduledRestart();
     } else {
@@ -463,19 +485,30 @@ export function scheduleGatewaySigusr1Restart(opts?: {
     }
   }
 
+  const force = opts?.force === true;
+  const maxWaitMs = opts?.maxWaitMs ?? SCHEDULED_RESTART_MAX_WAIT_MS;
   pendingRestartDueAt = requestedDueAt;
   pendingRestartReason = reason;
+  pendingRestartForce = force;
   pendingRestartTimer = setTimeout(
     () => {
       pendingRestartTimer = null;
       pendingRestartDueAt = 0;
       pendingRestartReason = undefined;
+      pendingRestartForce = false;
+      if (force) {
+        emitGatewayRestart();
+        return;
+      }
       const pendingCheck = preRestartCheck;
       if (!pendingCheck) {
         emitGatewayRestart();
         return;
       }
-      deferGatewayRestartUntilIdle({ getPendingCount: pendingCheck });
+      deferGatewayRestartUntilIdle({
+        getPendingCount: pendingCheck,
+        maxWaitMs,
+      });
     },
     Math.max(0, requestedDueAt - nowMs),
   );

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -204,13 +204,7 @@ export function deferGatewayRestartUntilIdle(opts: {
   hooks?: RestartDeferralHooks;
   pollMs?: number;
   maxWaitMs?: number;
-  force?: boolean;
 }): void {
-  if (opts.force) {
-    emitGatewayRestart();
-    return;
-  }
-
   const pollMsRaw = opts.pollMs ?? DEFAULT_DEFERRAL_POLL_MS;
   const pollMs = Math.max(10, Math.floor(pollMsRaw));
   const maxWaitMsRaw = opts.maxWaitMs ?? DEFAULT_DEFERRAL_MAX_WAIT_MS;


### PR DESCRIPTION
### Problem
Gateway restart kills active agent runs immediately. The 90-second deferral timeout is too short for long-running turns (compaction, multi-tool chains), and there is no way to force-restart when the drain wait is inappropriate. Config-watcher and gateway-tool restarts share the same timeout, but have different needs: tool-initiated restarts have a human operator who can force; config-watcher restarts do not.

### Root Cause
`restart.ts` uses a single `DEFAULT_DEFERRAL_MAX_WAIT_MS = 90_000` for all restart paths. Gateway tool restarts pass through the same deferral with no force escape hatch, and non-interactive paths (config watcher, `/restart`) have no separate timeout.

### Fix
Split restart drain behavior by path:
- **Gateway tool** (`scheduleGatewaySigusr1Restart`): defaults to `maxWaitMs=0` (wait indefinitely for drain). User has `force: true` param as break-glass to skip deferral entirely.
- **Non-interactive paths** (`server-reload-handlers.ts`): use `SCHEDULED_RESTART_MAX_WAIT_MS = 300_000` (5 minutes) -- generous for most agent turns but still finite.
- Force flag propagates through the restart pipeline: a pending non-force restart is upgraded to force when a force request arrives.
- Added 30s periodic warn log during drain wait for observability.

### What did NOT change
No changes to launchd integration, SIGUSR1 signal handling, or restart cooldown logic.

## Validation
- `pnpm build` -- clean
- `pnpm check` -- clean
- `pnpm test src/infra/infra-runtime.test.ts` -- 17 tests passed

## AI Disclosure
AI-assisted (Claude). Fully tested and reviewed.

Resubmission of #42127 (closed for clean commit history).
Closes #32961
Related to #26412