### PR TITLE
plugins: suppress false duplicate-id warning across origins

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -130,7 +130,7 @@ afterEach(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
-  it("emits duplicate warning for truly distinct plugins with same id", () => {
+  it("emits duplicate warning for distinct plugins with same id in the same origin", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "test-plugin", configSchema: { type: "object" } };
@@ -146,11 +146,34 @@ describe("loadPluginManifestRegistry", () => {
       createPluginCandidate({
         idHint: "test-plugin",
         rootDir: dirB,
-        origin: "global",
+        origin: "bundled",
       }),
     ];
 
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+  });
+
+  it("suppresses duplicate warning for distinct roots when origins differ", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "cross-origin-plugin", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "cross-origin-plugin",
+        rootDir: dirA,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "cross-origin-plugin",
+        rootDir: dirB,
+        origin: "config",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -164,7 +164,8 @@ export function loadPluginManifestRegistry(params: {
   const diagnostics: PluginDiagnostic[] = [...discovery.diagnostics];
   const candidates: PluginCandidate[] = discovery.candidates;
   const records: PluginManifestRecord[] = [];
-  const seenIds = new Map<string, SeenIdEntry>();
+  const seenRootsById = new Map<string, Map<string, SeenIdEntry>>();
+  const seenOriginsById = new Map<string, Map<PluginOrigin, Set<string>>>();
   const realpathCache = new Map<string, string>();
 
   for (const candidate of candidates) {
@@ -200,43 +201,53 @@ export function loadPluginManifestRegistry(params: {
         : manifestRes.manifestPath;
     })();
 
-    const existing = seenIds.get(manifest.id);
-    if (existing) {
-      // Check whether both candidates point to the same physical directory
-      // (e.g. via symlinks or different path representations). If so, this
-      // is a false-positive duplicate and can be silently skipped.
-      const samePath = existing.candidate.rootDir === candidate.rootDir;
-      const samePlugin = (() => {
-        if (samePath) {
-          return true;
-        }
-        const existingReal = safeRealpathSync(existing.candidate.rootDir, realpathCache);
-        const candidateReal = safeRealpathSync(candidate.rootDir, realpathCache);
-        return Boolean(existingReal && candidateReal && existingReal === candidateReal);
-      })();
-      if (samePlugin) {
-        // Prefer higher-precedence origins even if candidates are passed in
-        // an unexpected order (config > workspace > global > bundled).
-        if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {
-          records[existing.recordIndex] = buildRecord({
-            manifest,
-            candidate,
-            manifestPath: manifestRes.manifestPath,
-            schemaCacheKey,
-            configSchema,
-          });
-          seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
-        }
-        continue;
+    const rootKey = safeRealpathSync(candidate.rootDir, realpathCache) ?? candidate.rootDir;
+    const rootsForId = seenRootsById.get(manifest.id) ?? new Map<string, SeenIdEntry>();
+    if (!seenRootsById.has(manifest.id)) {
+      seenRootsById.set(manifest.id, rootsForId);
+    }
+    const originsForId = seenOriginsById.get(manifest.id) ?? new Map<PluginOrigin, Set<string>>();
+    if (!seenOriginsById.has(manifest.id)) {
+      seenOriginsById.set(manifest.id, originsForId);
+    }
+
+    const existingSameRoot = rootsForId.get(rootKey);
+    if (existingSameRoot) {
+      // Same physical plugin discovered through multiple origins/sources.
+      // Keep only one record and pick the highest-precedence origin.
+      if (
+        PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existingSameRoot.candidate.origin]
+      ) {
+        records[existingSameRoot.recordIndex] = buildRecord({
+          manifest,
+          candidate,
+          manifestPath: manifestRes.manifestPath,
+          schemaCacheKey,
+          configSchema,
+        });
+        rootsForId.set(rootKey, {
+          candidate,
+          recordIndex: existingSameRoot.recordIndex,
+        });
       }
+      continue;
+    }
+
+    const rootsForOrigin = originsForId.get(candidate.origin) ?? new Set<string>();
+    const hadOriginRoot = rootsForOrigin.size > 0;
+    rootsForOrigin.add(rootKey);
+    originsForId.set(candidate.origin, rootsForOrigin);
+    rootsForId.set(rootKey, { candidate, recordIndex: records.length });
+
+    // Warn only when distinct roots collide within the same origin bucket.
+    // Cross-origin shadowing is expected and handled by precedence elsewhere.
+    if (hadOriginRoot) {
       diagnostics.push({
         level: "warn",
         pluginId: manifest.id,
         source: candidate.source,
         message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
       });
-    } else {
-      seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }
 
     records.push(


### PR DESCRIPTION
## Summary

This PR fixes issue #42099 by refining plugin manifest deduplication logic to avoid false-positive duplicate ID warnings during gateway startup.

## Root cause

The registry warned on duplicate plugin IDs too broadly, even when the same plugin ID appeared across different discovery origins as part of normal precedence/shadowing behavior.

## What changed

- Refactored duplicate tracking in the manifest registry to:
  - track discovered roots per plugin ID
  - track roots per origin for each plugin ID
- Emit duplicate warnings only when distinct roots collide within the same origin bucket.
- Keep cross-origin shadowing (config > workspace > global > bundled) silent.
- Preserve precedence selection when the same physical root is discovered multiple times.

## Tests

Updated and added tests in manifest-registry tests to cover:

- warning on real duplicates within the same origin
- no warning for distinct roots across different origins
- existing precedence behavior for same physical plugin across origins

## Safety and impact

- Reduces startup warning noise
- Keeps behavior unchanged for genuine duplicate conflicts
- No API or manifest format changes

Fixes #42099
