### PR TITLE
fix(net): honour HTTPS_PROXY in fetchWithSsrFGuard by routing through ProxyAgent

### DIFF
--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -138,7 +138,15 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
         lookupFn: params.lookupFn,
         policy: params.policy,
       });
-      if (params.pinDns !== false) {
+      const httpsProxy =
+        parsedUrl.protocol === "https:" &&
+        (process.env.HTTPS_PROXY || process.env.https_proxy || process.env.ALL_PROXY);
+      if (httpsProxy && params.pinDns !== false) {
+        // When an HTTPS proxy is configured, route through it instead of pinning DNS.
+        // Hostname allowlist checks above still apply; only DNS pinning is skipped.
+        const { ProxyAgent } = await import("undici");
+        dispatcher = new ProxyAgent(httpsProxy);
+      } else if (params.pinDns !== false) {
         dispatcher = createPinnedDispatcher(pinned);
       }
 


### PR DESCRIPTION
## Summary

- **Problem:** `fetchWithSsrFGuard` always creates a `createPinnedDispatcher` for DNS-pinning (SSRF protection), which directly connects to the resolved IP and bypasses any system HTTP/HTTPS proxy (`HTTPS_PROXY`, `https_proxy`, `ALL_PROXY`).
- **Why it matters:** Any outbound HTTPS call routed through this guard (e.g. memory embedding API calls) silently ignores the system proxy, causing `fetch failed` errors in environments where direct access to external APIs is blocked (geo-restricted regions, corporate networks, etc.).
- **What changed:** When `HTTPS_PROXY` / `https_proxy` / `ALL_PROXY` is set and the request protocol is `https:`, we create an undici `ProxyAgent` dispatcher instead of the pinned dispatcher. Hostname allowlist/SSRF checks (phase 1 pre-DNS) still run before this branch, so the security boundary is preserved.
- **What did NOT change:** Non-proxy environments are unaffected — the existing `createPinnedDispatcher` path is taken when no proxy env var is present. `http:` requests and `pinDns: false` callers are also unaffected.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage
- [x] API / contracts

## Linked Issue/PR

- Related: memory embedding `fetch failed` under HTTPS proxy environments

## User-visible / Behavior Changes

Memory embedding (and any other `fetchWithSsrFGuard`-routed HTTPS call) now works when `HTTPS_PROXY` / `https_proxy` / `ALL_PROXY` is set in the environment. No config change required — the proxy env vars are the standard mechanism.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same calls, different transport
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk: DNS pinning is skipped when routing through proxy (proxy handles DNS). Hostname allowlist validation (pre-DNS, phase 1) still fires, so cross-host SSRF via redirect remains blocked. In proxy environments, operators are already trusting the proxy for DNS.

## Repro + Verification

### Environment

- OS: macOS (darwin arm64)
- Runtime: Node.js v22.22.0
- Provider: openai (`text-embedding-3-small`)
- Proxy: SOCKS5/HTTP proxy via `HTTPS_PROXY=http://127.0.0.1:7897`

### Steps

1. Set `HTTPS_PROXY=http://127.0.0.1:7897` (or equivalent)
2. Configure `agents.defaults.memorySearch.provider = openai` with a valid `remote.apiKey`
3. Run `openclaw memory search "query"`

### Expected

- Returns semantic search results

### Actual (before fix)

```
Memory search failed: fetch failed
```

The pinned dispatcher connects directly to `api.openai.com`'s resolved IP, bypassing the proxy entirely.

### Actual (after fix)

```
Memory search returned N results
```

## Evidence

- `memory index --force` → `Memory index updated (main). Indexed: 13/13 files · 19 chunks`
- `memory search "待办" --min-score 0.1` → returns relevant snippets from memory files
- Node.js fetch via `ProxyAgent` to `api.openai.com/v1/embeddings` → HTTP 200, 1536-dim vector

## Human Verification (required)

- Verified: memory index and semantic search work end-to-end with `HTTPS_PROXY` set, on Node.js v22.22.0, macOS arm64
- Verified: without proxy env var, existing `createPinnedDispatcher` path is unchanged
- Edge cases checked: `http:` requests still use pinned dispatcher; `pinDns: false` callers unaffected
- Not verified: Windows (`ALL_PROXY` with SOCKS5), corporate MITM proxies with custom CA

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Unset `HTTPS_PROXY` / `https_proxy` / `ALL_PROXY` to fall back to direct connection
- Revert: restore the original `if (params.pinDns !== false)` block in `src/infra/net/fetch-guard.ts`

## Risks and Mitigations

- Risk: In proxy environments, DNS resolution is delegated to the proxy (no local pinning).
  - Mitigation: Phase-1 hostname allowlist check still runs before the proxy branch; only requests to explicitly allowed hosts reach this code path.

Made with [Cursor](https://cursor.com)