### PR TITLE
fix(install): prevent host shell termination in iex sessions

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -277,16 +277,16 @@ function Main {
     if (!(Ensure-ExecutionPolicy)) {
         Write-Host ""
         Write-Host "Installation cannot continue due to execution policy restrictions" -Level error
-        exit 1
+        return $false
     }
     
     if (!(Ensure-Node)) {
-        exit 1
+        return $false
     }
     
     if ($InstallMethod -eq "git") {
         if (!(Ensure-Git)) {
-            exit 1
+            return $false
         }
         
         if ($DryRun) {
@@ -304,7 +304,7 @@ function Main {
             Write-Host "[DRY RUN] Would install OpenClaw via npm (tag: $Tag)" -Level info
         } else {
             if (!(Install-OpenClawNpm -Version $Tag)) {
-                exit 1
+                return $false
             }
         }
     }
@@ -324,6 +324,17 @@ function Main {
     
     Write-Host ""
     Write-Host "🦞 OpenClaw installed successfully!" -Level success
+    return $true
 }
 
-Main
+$success = Main
+if (-not $success) {
+    $global:LASTEXITCODE = 1
+    
+    # Check if running via Invoke-Expression (e.g., iwr | iex)
+    if ($MyInvocation.Line -match "iex|Invoke-Expression") {
+        return 
+    }
+    
+    exit 1
+}


### PR DESCRIPTION
- Replace hard 'exit 1' with context-aware logic using $MyInvocation.Line.
- Ensure the script returns instead of exiting when piped into Invoke-Expression.
- This fixes the "disappearing terminal" issue on Windows LTSC and native pwsh.

### The Problem
When running the installer via `iwr | iex` (common for Windows users), the script uses a hard `exit 1` upon failure. This forcefully terminates the parent PowerShell host, causing the terminal window to vanish instantly. Users on Windows Native/LTSC are left with no diagnostic output or error messages.

### The Solution
This PR introduces **context-aware exit logic** using `$MyInvocation.Line`:
- **Interactive Detection**: If the script is invoked via `iex` or `Invoke-Expression`, it now performs a `return` instead of `exit`. This keeps the shell alive for debugging.
- **State Preservation**: Manually sets `$global:LASTEXITCODE = 1` before returning, ensuring that CI/CD pipelines and downstream scripts can still detect the failure.
- **Clean Fix**: Unlike previous attempts, this PR focuses purely on the runtime behavior and does not introduce fragile regex-based tests or linting regressions.

Closes #41797