### PR TITLE
slack: fix draft stream race causing double responses on voice messages

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -301,6 +301,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         return;
       }
 
+      // Flush in-flight draft stream operations before inspecting draft state.
+      // Without this, fast model responses may check messageId() while the
+      // initial chat.postMessage is still pending, causing deliverNormally to
+      // post a duplicate alongside the draft (double-response bug).
+      if (previewStreamingEnabled) {
+        await draftStream.flush();
+      }
+
       const mediaCount = payload.mediaUrls?.length ?? (payload.mediaUrl ? 1 : 0);
       const draftMessageId = draftStream?.messageId();
       const draftChannelId = draftStream?.channelId();


### PR DESCRIPTION
## Summary

- Fix race condition in Slack draft stream delivery that causes duplicate responses on voice messages
- Flush in-flight draft stream operations before inspecting `messageId()` in the deliver callback

Fixes #42226

## Problem

When a model responds quickly (common with voice messages producing short replies), the `deliver` callback in `dispatch.ts` checks `draftStream.messageId()` while the draft's initial `chat.postMessage` is still in-flight. Since `messageId()` returns `undefined`, `canFinalizeViaPreviewEdit` evaluates to `false`, and `deliverNormally()` posts a new message. Then `draftStream.flush()` after `dispatchInboundMessage` also delivers the pending draft — resulting in two identical messages.

## Fix

Added `await draftStream.flush()` before inspecting draft state. This ensures any in-flight draft operations complete so `messageId()` is correctly populated, allowing the preview-edit finalization path to work as intended.

## Test plan

- [ ] Send a voice message in Slack with default streaming config (`streaming: "partial"`)
- [ ] Verify only one response appears (no duplicate)
- [ ] Verify the response shows "(edited)" (draft stream preview → finalized via `chat.update`)
- [ ] Send a long text message to verify normal streaming still works correctly
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
