### PR TITLE
feat(gohighlevel): add GoHighLevel CRM channel extension

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,6 +20,11 @@
           - "src/feishu/**"
           - "extensions/feishu/**"
           - "docs/channels/feishu.md"
+"channel: gohighlevel":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/gohighlevel/**"
+          - "docs/channels/gohighlevel.md"
 "channel: googlechat":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Channels/GoHighLevel: add GoHighLevel CRM channel extension with webhook-based inbound messages, outbound reply delivery via GHL Conversations API, escalation tagging for human handoff, Workflow payload normalization, multi-account support, DM policy controls, and onboarding wizard.
+
 ### Breaking
 
 ### Fixes

--- a/docs/channels/gohighlevel.md
+++ b/docs/channels/gohighlevel.md
@@ -1,0 +1,264 @@
+---
+summary: "GoHighLevel CRM channel support, capabilities, and configuration"
+read_when:
+  - Working on GoHighLevel channel features
+  - Setting up GHL CRM integration
+title: "GoHighLevel"
+---
+
+# GoHighLevel (plugin)
+
+Status: text DMs via GHL Conversations API webhook; supports SMS, webchat, email, Instagram, Facebook, and Google My Business message types. Escalation tagging is built in.
+
+## Plugin required
+
+GoHighLevel ships as a plugin and is not bundled with the core install.
+
+Install via CLI (npm registry):
+
+```bash
+openclaw plugins install @openclaw/gohighlevel
+```
+
+Local checkout (when running from a git repo):
+
+```bash
+openclaw plugins install ./extensions/gohighlevel
+```
+
+If you choose GoHighLevel during configure/onboarding and a git checkout is detected,
+OpenClaw will offer the local install path automatically.
+
+Details: [Plugins](/tools/plugin)
+
+## Quick setup (beginner)
+
+1. Install the GoHighLevel plugin.
+2. Create a **Private Integration Token** in your GHL sub-account (Settings > Integrations > Private Integrations).
+3. Note your **Location ID** (visible in Settings > Business Profile or the URL bar when logged in).
+4. Create a **GHL Workflow** with a "Customer Replied" trigger that sends a webhook to your gateway.
+5. Configure OpenClaw with the API key and Location ID.
+6. Start the gateway. GHL will POST customer replies to your webhook path.
+
+Minimal config:
+
+```json5
+{
+  channels: {
+    gohighlevel: {
+      enabled: true,
+      apiKey: "<PRIVATE_INTEGRATION_TOKEN>",
+      locationId: "<LOCATION_ID>",
+    },
+  },
+}
+```
+
+Or use environment variables for the default account:
+
+```bash
+export GHL_API_KEY="pit-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+export GHL_LOCATION_ID="xxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+`GHL_TOKEN` is accepted as a fallback for `GHL_API_KEY`.
+
+## Webhook setup
+
+GoHighLevel does not push raw inbound messages by default. You need a **Workflow** to forward them.
+
+### Creating the Workflow
+
+1. In your GHL sub-account, go to **Automation > Workflows**.
+2. Create a new workflow.
+3. Add a **trigger**: select **Customer Replied**.
+4. Add an **action**: select **Webhook / Custom Webhook**.
+5. Set the webhook URL to your gateway's public URL followed by the webhook path (default: `/gohighlevel`).
+   - Example: `https://your-gateway.example.com/gohighlevel`
+   - Run `openclaw status` to find your gateway's public URL.
+6. Save and publish the workflow.
+
+### Custom webhook path
+
+Override the default `/gohighlevel` path:
+
+```json5
+{
+  channels: {
+    gohighlevel: {
+      webhookPath: "/my-custom-ghl-path",
+    },
+  },
+}
+```
+
+Or use `webhookUrl` to extract the path from a full URL:
+
+```json5
+{
+  channels: {
+    gohighlevel: {
+      webhookUrl: "https://your-gateway.example.com/my-custom-ghl-path",
+    },
+  },
+}
+```
+
+### Webhook signature verification
+
+If you configure a webhook secret in GHL, set it in OpenClaw to verify HMAC-SHA256 signatures:
+
+```json5
+{
+  channels: {
+    gohighlevel: {
+      webhookSecret: "<YOUR_WEBHOOK_SECRET>",
+    },
+  },
+}
+```
+
+When a secret is configured, requests without a valid `X-GHL-Signature` header are rejected with 401.
+
+## DM policy
+
+GoHighLevel conversations are always direct (1:1 with contacts). The DM policy controls who can reach your bot.
+
+| Policy           | Behavior                                       |
+| ---------------- | ---------------------------------------------- |
+| `open` (default) | Any contact can message the bot                |
+| `allowlist`      | Only contacts in `dm.allowFrom` can message    |
+| `pairing`        | New contacts must be approved via pairing code |
+
+```json5
+{
+  channels: {
+    gohighlevel: {
+      dm: {
+        policy: "allowlist",
+        allowFrom: ["<contactId1>", "+15551234567"],
+      },
+    },
+  },
+}
+```
+
+See [Pairing](/channels/pairing) for details on the pairing flow.
+
+## Escalation tagging
+
+When the AI replies with a phrase that signals the conversation needs human attention, OpenClaw automatically tags the GHL contact for handoff.
+
+Default trigger phrases:
+
+- "let me look into that for you"
+- "i'll get back to you shortly"
+- "let me check on that"
+
+The default tag applied is `escalation`. Use GHL automations to route tagged contacts to a human agent.
+
+### Configuration
+
+```json5
+{
+  channels: {
+    gohighlevel: {
+      escalation: {
+        enabled: true, // default: true
+        tag: "needs-human", // default: "escalation"
+        patterns: ["let me transfer you", "i need to check with my team"],
+      },
+    },
+  },
+}
+```
+
+Set `escalation.enabled: false` to disable tagging entirely.
+
+## Multi-account support
+
+Run multiple GHL sub-accounts from one gateway:
+
+```json5
+{
+  channels: {
+    gohighlevel: {
+      enabled: true,
+      accounts: {
+        clinic: {
+          apiKey: "<CLINIC_TOKEN>",
+          locationId: "<CLINIC_LOCATION>",
+          webhookPath: "/ghl-clinic",
+        },
+        realty: {
+          apiKey: "<REALTY_TOKEN>",
+          locationId: "<REALTY_LOCATION>",
+          webhookPath: "/ghl-realty",
+        },
+      },
+    },
+  },
+}
+```
+
+Each account gets its own webhook path and credentials.
+
+## Media attachments
+
+Inbound media attachments (images, files) from GHL webhook payloads are downloaded and passed to the agent. Configure the maximum download size:
+
+```json5
+{
+  channels: {
+    gohighlevel: {
+      mediaMaxMb: 20, // default: 20 MB
+    },
+  },
+}
+```
+
+## Message types
+
+GHL supports multiple message types. The type from the inbound webhook is preserved and used for outbound replies:
+
+- `SMS` (default)
+- `Email`
+- `WhatsApp`
+- `GMB` (Google My Business)
+- `IG` (Instagram)
+- `FB` (Facebook)
+- `Custom`
+- `Live_Chat`
+
+## Capabilities
+
+| Feature                     | Supported           |
+| --------------------------- | ------------------- |
+| Text messages               | Yes                 |
+| Media attachments (inbound) | Yes                 |
+| Reactions                   | No                  |
+| Threads                     | No                  |
+| Group chats                 | No                  |
+| Streaming                   | Blocked (coalesced) |
+
+Text replies are chunked at 1600 characters by default.
+
+## Troubleshooting
+
+### Webhook not receiving messages
+
+- Verify the GHL Workflow is published and the "Customer Replied" trigger is active.
+- Check that the webhook URL matches your gateway's public URL + webhook path.
+- Run `openclaw status --deep` to verify the webhook is registered and probing succeeds.
+
+### Authentication errors
+
+- Ensure your Private Integration Token is valid and has the required scopes (Conversations, Contacts).
+- Check that the Location ID matches the sub-account where the token was created.
+- `GHL API 401` in logs means the token is invalid or expired.
+
+### Escalation tags not appearing
+
+- Confirm `escalation.enabled` is not set to `false`.
+- Check that the AI reply text contains one of the configured trigger patterns (case-insensitive substring match).
+- Verify the API key has permission to update contact tags.

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -16,6 +16,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [BlueBubbles](/channels/bluebubbles) — **Recommended for iMessage**; uses the BlueBubbles macOS server REST API with full feature support (edit, unsend, effects, reactions, group management — edit currently broken on macOS 26 Tahoe).
 - [Discord](/channels/discord) — Discord Bot API + Gateway; supports servers, channels, and DMs.
 - [Feishu](/channels/feishu) — Feishu/Lark bot via WebSocket (plugin, installed separately).
+- [GoHighLevel](/channels/gohighlevel) — GoHighLevel CRM conversations via webhook; supports SMS, webchat, email, IG, FB, GMB with escalation tagging (plugin, installed separately).
 - [Google Chat](/channels/googlechat) — Google Chat API app via HTTP webhook.
 - [iMessage (legacy)](/channels/imessage) — Legacy macOS integration via imsg CLI (deprecated, use BlueBubbles for new setups).
 - [IRC](/channels/irc) — Classic IRC servers; channels + DMs with pairing/allowlist controls.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -901,6 +901,7 @@
                   "channels/bluebubbles",
                   "channels/discord",
                   "channels/feishu",
+                  "channels/gohighlevel",
                   "channels/googlechat",
                   "channels/imessage",
                   "channels/irc",

--- a/extensions/gohighlevel/index.ts
+++ b/extensions/gohighlevel/index.ts
@@ -1,0 +1,19 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { gohighlevelDock, gohighlevelPlugin } from "./src/channel.js";
+import { handleGoHighLevelWebhookRequest } from "./src/monitor.js";
+import { setGoHighLevelRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "gohighlevel",
+  name: "GoHighLevel",
+  description: "OpenClaw GoHighLevel channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setGoHighLevelRuntime(api.runtime);
+    api.registerChannel({ plugin: gohighlevelPlugin, dock: gohighlevelDock });
+    api.registerHttpHandler(handleGoHighLevelWebhookRequest);
+  },
+};
+
+export default plugin;

--- a/extensions/gohighlevel/index.ts
+++ b/extensions/gohighlevel/index.ts
@@ -1,7 +1,6 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/gohighlevel";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/gohighlevel";
 import { gohighlevelDock, gohighlevelPlugin } from "./src/channel.js";
-import { handleGoHighLevelWebhookRequest } from "./src/monitor.js";
 import { setGoHighLevelRuntime } from "./src/runtime.js";
 
 const plugin = {
@@ -12,7 +11,6 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setGoHighLevelRuntime(api.runtime);
     api.registerChannel({ plugin: gohighlevelPlugin, dock: gohighlevelDock });
-    api.registerHttpHandler(handleGoHighLevelWebhookRequest);
   },
 };
 

--- a/extensions/gohighlevel/openclaw.plugin.json
+++ b/extensions/gohighlevel/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "gohighlevel",
+  "channels": ["gohighlevel"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/gohighlevel/package.json
+++ b/extensions/gohighlevel/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/gohighlevel",
+  "version": "2026.2.27",
+  "private": true,
+  "description": "OpenClaw GoHighLevel channel plugin",
+  "type": "module",
+  "dependencies": {},
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "gohighlevel",
+      "label": "GoHighLevel",
+      "selectionLabel": "GoHighLevel (CRM)",
+      "detailLabel": "GoHighLevel",
+      "docsPath": "/channels/gohighlevel",
+      "docsLabel": "gohighlevel",
+      "blurb": "GoHighLevel CRM — AI chatbot for SMS, webchat, email, IG, FB, and GMB.",
+      "aliases": [
+        "ghl",
+        "highlevel"
+      ],
+      "order": 70
+    },
+    "install": {
+      "npmSpec": "@openclaw/gohighlevel",
+      "localPath": "extensions/gohighlevel",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/gohighlevel/package.json
+++ b/extensions/gohighlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gohighlevel",
-  "version": "2026.2.27",
+  "version": "2026.3.9",
   "private": true,
   "description": "OpenClaw GoHighLevel channel plugin",
   "type": "module",

--- a/extensions/gohighlevel/src/accounts.test.ts
+++ b/extensions/gohighlevel/src/accounts.test.ts
@@ -5,6 +5,7 @@ import { resolveGoHighLevelAccount, listGoHighLevelAccountIds } from "./accounts
 describe("resolveGoHighLevelAccount", () => {
   afterEach(() => {
     delete process.env.GHL_API_KEY;
+    delete process.env.GHL_TOKEN;
     delete process.env.GHL_LOCATION_ID;
   });
 
@@ -52,6 +53,36 @@ describe("resolveGoHighLevelAccount", () => {
     const account = resolveGoHighLevelAccount({ cfg });
     expect(account.credentialSource).toBe("none");
     expect(account.apiKey).toBeUndefined();
+  });
+
+  it("resolves from GHL_TOKEN env var as fallback", () => {
+    process.env.GHL_TOKEN = "token-key";
+    process.env.GHL_LOCATION_ID = "token-loc";
+
+    const cfg = {
+      channels: {
+        gohighlevel: { enabled: true },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg });
+    expect(account.credentialSource).toBe("env");
+    expect(account.apiKey).toBe("token-key");
+    expect(account.locationId).toBe("token-loc");
+  });
+
+  it("prefers GHL_API_KEY over GHL_TOKEN", () => {
+    process.env.GHL_API_KEY = "api-key";
+    process.env.GHL_TOKEN = "token-key";
+
+    const cfg = {
+      channels: {
+        gohighlevel: { enabled: true },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg });
+    expect(account.apiKey).toBe("api-key");
   });
 
   it("does not use env vars for non-default account", () => {

--- a/extensions/gohighlevel/src/accounts.test.ts
+++ b/extensions/gohighlevel/src/accounts.test.ts
@@ -1,0 +1,94 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { resolveGoHighLevelAccount, listGoHighLevelAccountIds } from "./accounts.js";
+
+describe("resolveGoHighLevelAccount", () => {
+  afterEach(() => {
+    delete process.env.GHL_API_KEY;
+    delete process.env.GHL_LOCATION_ID;
+  });
+
+  it("resolves from inline config", () => {
+    const cfg = {
+      channels: {
+        gohighlevel: {
+          enabled: true,
+          apiKey: "pit-test-key",
+          locationId: "loc123",
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg });
+    expect(account.credentialSource).toBe("inline");
+    expect(account.apiKey).toBe("pit-test-key");
+    expect(account.locationId).toBe("loc123");
+    expect(account.enabled).toBe(true);
+  });
+
+  it("resolves from env vars for default account", () => {
+    process.env.GHL_API_KEY = "env-key";
+    process.env.GHL_LOCATION_ID = "env-loc";
+
+    const cfg = {
+      channels: {
+        gohighlevel: { enabled: true },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg });
+    expect(account.credentialSource).toBe("env");
+    expect(account.apiKey).toBe("env-key");
+    expect(account.locationId).toBe("env-loc");
+  });
+
+  it("returns none when no credentials are available", () => {
+    const cfg = {
+      channels: {
+        gohighlevel: { enabled: true },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg });
+    expect(account.credentialSource).toBe("none");
+    expect(account.apiKey).toBeUndefined();
+  });
+
+  it("does not use env vars for non-default account", () => {
+    process.env.GHL_API_KEY = "env-key";
+
+    const cfg = {
+      channels: {
+        gohighlevel: {
+          enabled: true,
+          accounts: {
+            secondary: { enabled: true },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg, accountId: "secondary" });
+    expect(account.credentialSource).toBe("none");
+  });
+});
+
+describe("listGoHighLevelAccountIds", () => {
+  it("returns default when no accounts configured", () => {
+    const cfg = {
+      channels: { gohighlevel: { enabled: true } },
+    } as unknown as OpenClawConfig;
+    expect(listGoHighLevelAccountIds(cfg)).toEqual(["default"]);
+  });
+
+  it("returns configured account ids sorted", () => {
+    const cfg = {
+      channels: {
+        gohighlevel: {
+          accounts: { beta: {}, alpha: {} },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(listGoHighLevelAccountIds(cfg)).toEqual(["alpha", "beta"]);
+  });
+});

--- a/extensions/gohighlevel/src/accounts.test.ts
+++ b/extensions/gohighlevel/src/accounts.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/gohighlevel";
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { resolveGoHighLevelAccount, listGoHighLevelAccountIds } from "./accounts.js";
 

--- a/extensions/gohighlevel/src/accounts.ts
+++ b/extensions/gohighlevel/src/accounts.ts
@@ -1,0 +1,126 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import type { GoHighLevelAccountConfig } from "./config-schema.js";
+
+export type GoHighLevelCredentialSource = "env" | "inline" | "none";
+
+export type ResolvedGoHighLevelAccount = {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  config: GoHighLevelAccountConfig;
+  credentialSource: GoHighLevelCredentialSource;
+  apiKey?: string;
+  locationId?: string;
+};
+
+const ENV_API_KEY = "GHL_API_KEY";
+const ENV_LOCATION_ID = "GHL_LOCATION_ID";
+
+function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
+  const accounts = cfg.channels?.["gohighlevel"]?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return [];
+  }
+  return Object.keys(accounts).filter(Boolean);
+}
+
+export function listGoHighLevelAccountIds(cfg: OpenClawConfig): string[] {
+  const ids = listConfiguredAccountIds(cfg);
+  if (ids.length === 0) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+  return ids.toSorted((a, b) => a.localeCompare(b));
+}
+
+export function resolveDefaultGoHighLevelAccountId(cfg: OpenClawConfig): string {
+  const channel = cfg.channels?.["gohighlevel"];
+  if (channel?.defaultAccount?.trim()) {
+    return channel.defaultAccount.trim();
+  }
+  const ids = listGoHighLevelAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function resolveAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): GoHighLevelAccountConfig | undefined {
+  const accounts = cfg.channels?.["gohighlevel"]?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return undefined;
+  }
+  return accounts[accountId];
+}
+
+function mergeGoHighLevelAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): GoHighLevelAccountConfig {
+  const raw = cfg.channels?.["gohighlevel"] ?? {};
+  const { accounts: _ignored, defaultAccount: _ignored2, ...base } = raw;
+  const account = resolveAccountConfig(cfg, accountId) ?? {};
+  return { ...base, ...account } as GoHighLevelAccountConfig;
+}
+
+function resolveCredentials(params: { accountId: string; account: GoHighLevelAccountConfig }): {
+  apiKey?: string;
+  locationId?: string;
+  source: GoHighLevelCredentialSource;
+} {
+  const { account, accountId } = params;
+
+  // Inline config takes priority
+  if (account.apiKey?.trim()) {
+    return {
+      apiKey: account.apiKey.trim(),
+      locationId: account.locationId?.trim(),
+      source: "inline",
+    };
+  }
+
+  // Fall back to env vars for default account
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    const envKey = process.env[ENV_API_KEY]?.trim();
+    if (envKey) {
+      return {
+        apiKey: envKey,
+        locationId: account.locationId?.trim() || process.env[ENV_LOCATION_ID]?.trim(),
+        source: "env",
+      };
+    }
+  }
+
+  return { source: "none" };
+}
+
+export function resolveGoHighLevelAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedGoHighLevelAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const baseEnabled = params.cfg.channels?.["gohighlevel"]?.enabled !== false;
+  const merged = mergeGoHighLevelAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+  const credentials = resolveCredentials({ accountId, account: merged });
+
+  return {
+    accountId,
+    name: merged.name?.trim() || undefined,
+    enabled,
+    config: merged,
+    credentialSource: credentials.source,
+    apiKey: credentials.apiKey,
+    locationId: credentials.locationId,
+  };
+}
+
+export function listEnabledGoHighLevelAccounts(cfg: OpenClawConfig): ResolvedGoHighLevelAccount[] {
+  return listGoHighLevelAccountIds(cfg)
+    .map((accountId) => resolveGoHighLevelAccount({ cfg, accountId }))
+    .filter((account) => account.enabled);
+}

--- a/extensions/gohighlevel/src/accounts.ts
+++ b/extensions/gohighlevel/src/accounts.ts
@@ -14,7 +14,8 @@ export type ResolvedGoHighLevelAccount = {
   locationId?: string;
 };
 
-const ENV_API_KEY = "GHL_API_KEY";
+/** Env var names — check GHL_API_KEY first, fall back to GHL_TOKEN for compat. */
+const ENV_API_KEY_NAMES = ["GHL_API_KEY", "GHL_TOKEN"] as const;
 const ENV_LOCATION_ID = "GHL_LOCATION_ID";
 
 function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
@@ -84,7 +85,7 @@ function resolveCredentials(params: { accountId: string; account: GoHighLevelAcc
 
   // Fall back to env vars for default account
   if (accountId === DEFAULT_ACCOUNT_ID) {
-    const envKey = process.env[ENV_API_KEY]?.trim();
+    const envKey = ENV_API_KEY_NAMES.map((n) => process.env[n]?.trim()).find(Boolean);
     if (envKey) {
       return {
         apiKey: envKey,

--- a/extensions/gohighlevel/src/accounts.ts
+++ b/extensions/gohighlevel/src/accounts.ts
@@ -1,5 +1,5 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/gohighlevel";
 import type { GoHighLevelAccountConfig } from "./config-schema.js";
 
 export type GoHighLevelCredentialSource = "env" | "inline" | "none";

--- a/extensions/gohighlevel/src/api.ts
+++ b/extensions/gohighlevel/src/api.ts
@@ -82,6 +82,20 @@ export async function getGHLConversation(params: {
   return result.conversation ?? {};
 }
 
+/** Add a tag to a GHL contact. */
+export async function addGHLContactTag(params: {
+  account: ResolvedGoHighLevelAccount;
+  contactId: string;
+  tag: string;
+}): Promise<void> {
+  const { account, contactId, tag } = params;
+  const url = `${GHL_API_BASE}/contacts/${contactId}/tags`;
+  await fetchJson<{ tags?: string[] }>(account, url, {
+    method: "POST",
+    body: JSON.stringify({ tags: [tag] }),
+  });
+}
+
 /** Probe the GHL API to verify credentials are valid. */
 export async function probeGoHighLevel(account: ResolvedGoHighLevelAccount): Promise<{
   ok: boolean;

--- a/extensions/gohighlevel/src/api.ts
+++ b/extensions/gohighlevel/src/api.ts
@@ -1,0 +1,112 @@
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk";
+import type { ResolvedGoHighLevelAccount } from "./accounts.js";
+import type { GHLContact, GHLConversation, GHLSendMessageResponse } from "./types.js";
+
+const GHL_API_BASE = "https://services.leadconnectorhq.com";
+const GHL_API_VERSION = "2021-07-28";
+
+function buildHeaders(account: ResolvedGoHighLevelAccount): Record<string, string> {
+  if (!account.apiKey) {
+    throw new Error("GoHighLevel API key is not configured");
+  }
+  return {
+    Authorization: `Bearer ${account.apiKey}`,
+    Version: GHL_API_VERSION,
+    "Content-Type": "application/json",
+  };
+}
+
+async function fetchJson<T>(
+  account: ResolvedGoHighLevelAccount,
+  url: string,
+  init: RequestInit,
+): Promise<T> {
+  const headers = buildHeaders(account);
+  const { response: res } = await fetchWithSsrFGuard({
+    url,
+    init: {
+      ...init,
+      headers: {
+        ...headers,
+        ...(init.headers as Record<string, string> | undefined),
+      },
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`GHL API ${res.status}: ${text || res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/** Send a message via GHL Conversations API. */
+export async function sendGHLMessage(params: {
+  account: ResolvedGoHighLevelAccount;
+  conversationId: string;
+  message: string;
+  messageType?: string;
+}): Promise<GHLSendMessageResponse> {
+  const { account, conversationId, message, messageType } = params;
+  const url = `${GHL_API_BASE}/conversations/messages`;
+  return await fetchJson<GHLSendMessageResponse>(account, url, {
+    method: "POST",
+    body: JSON.stringify({
+      type: messageType ?? "SMS",
+      contactId: conversationId,
+      message,
+    }),
+  });
+}
+
+/** Retrieve a contact by ID. */
+export async function getGHLContact(params: {
+  account: ResolvedGoHighLevelAccount;
+  contactId: string;
+}): Promise<GHLContact> {
+  const { account, contactId } = params;
+  const url = `${GHL_API_BASE}/contacts/${contactId}`;
+  const result = await fetchJson<{ contact?: GHLContact }>(account, url, { method: "GET" });
+  return result.contact ?? {};
+}
+
+/** Retrieve a conversation by ID. */
+export async function getGHLConversation(params: {
+  account: ResolvedGoHighLevelAccount;
+  conversationId: string;
+}): Promise<GHLConversation> {
+  const { account, conversationId } = params;
+  const url = `${GHL_API_BASE}/conversations/${conversationId}`;
+  const result = await fetchJson<{ conversation?: GHLConversation }>(account, url, {
+    method: "GET",
+  });
+  return result.conversation ?? {};
+}
+
+/** Probe the GHL API to verify credentials are valid. */
+export async function probeGoHighLevel(account: ResolvedGoHighLevelAccount): Promise<{
+  ok: boolean;
+  status?: number;
+  error?: string;
+}> {
+  try {
+    if (!account.apiKey) {
+      return { ok: false, error: "no API key configured" };
+    }
+    const url = `${GHL_API_BASE}/locations/${account.locationId ?? "unknown"}`;
+    const headers = buildHeaders(account);
+    const { response: res } = await fetchWithSsrFGuard({
+      url,
+      init: { method: "GET", headers },
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return { ok: false, status: res.status, error: text || res.statusText };
+    }
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/extensions/gohighlevel/src/api.ts
+++ b/extensions/gohighlevel/src/api.ts
@@ -1,4 +1,4 @@
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/gohighlevel";
 import type { ResolvedGoHighLevelAccount } from "./accounts.js";
 import type { GHLContact, GHLConversation, GHLSendMessageResponse } from "./types.js";
 

--- a/extensions/gohighlevel/src/auth.test.ts
+++ b/extensions/gohighlevel/src/auth.test.ts
@@ -1,0 +1,40 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { verifyGHLSignature } from "./auth.js";
+
+function sign(body: string, secret: string): string {
+  return createHmac("sha256", secret).update(body).digest("hex");
+}
+
+describe("verifyGHLSignature", () => {
+  const secret = "test-webhook-secret";
+  const body = '{"type":"InboundMessage","contactId":"abc123"}';
+
+  it("accepts a valid signature", () => {
+    const signature = sign(body, secret);
+    expect(verifyGHLSignature({ signature, body, secret })).toBe(true);
+  });
+
+  it("rejects a tampered body", () => {
+    const signature = sign(body, secret);
+    expect(verifyGHLSignature({ signature, body: body + "x", secret })).toBe(false);
+  });
+
+  it("rejects a wrong secret", () => {
+    const signature = sign(body, "wrong-secret");
+    expect(verifyGHLSignature({ signature, body, secret })).toBe(false);
+  });
+
+  it("rejects empty signature", () => {
+    expect(verifyGHLSignature({ signature: "", body, secret })).toBe(false);
+  });
+
+  it("rejects empty secret", () => {
+    const signature = sign(body, secret);
+    expect(verifyGHLSignature({ signature, body, secret: "" })).toBe(false);
+  });
+
+  it("rejects signature with wrong length", () => {
+    expect(verifyGHLSignature({ signature: "abc", body, secret })).toBe(false);
+  });
+});

--- a/extensions/gohighlevel/src/auth.ts
+++ b/extensions/gohighlevel/src/auth.ts
@@ -1,0 +1,28 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Verify the HMAC-SHA256 signature of an incoming GHL webhook request.
+ * GHL signs the raw body with the webhook secret.
+ */
+export function verifyGHLSignature(params: {
+  signature: string;
+  body: string;
+  secret: string;
+}): boolean {
+  const { signature, body, secret } = params;
+  if (!signature || !secret) {
+    return false;
+  }
+
+  const expected = createHmac("sha256", secret).update(body).digest("hex");
+
+  if (signature.length !== expected.length) {
+    return false;
+  }
+
+  try {
+    return timingSafeEqual(Buffer.from(signature, "utf8"), Buffer.from(expected, "utf8"));
+  } catch {
+    return false;
+  }
+}

--- a/extensions/gohighlevel/src/channel.ts
+++ b/extensions/gohighlevel/src/channel.ts
@@ -1,0 +1,410 @@
+import type {
+  ChannelDock,
+  ChannelPlugin,
+  ChannelStatusIssue,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk";
+import {
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  missingTargetError,
+  PAIRING_APPROVED_MESSAGE,
+  setAccountEnabledInConfigSection,
+  applyAccountNameToChannelSection,
+  migrateBaseNameToDefaultAccount,
+  normalizeAccountId,
+} from "openclaw/plugin-sdk";
+import {
+  listGoHighLevelAccountIds,
+  resolveDefaultGoHighLevelAccountId,
+  resolveGoHighLevelAccount,
+  type ResolvedGoHighLevelAccount,
+} from "./accounts.js";
+import { sendGHLMessage, probeGoHighLevel } from "./api.js";
+import { GoHighLevelConfigSchema } from "./config-schema.js";
+import { resolveGoHighLevelWebhookPath, startGoHighLevelMonitor } from "./monitor.js";
+import { gohighlevelOnboardingAdapter } from "./onboarding.js";
+import { getGoHighLevelRuntime } from "./runtime.js";
+
+const meta = {
+  id: "gohighlevel",
+  label: "GoHighLevel",
+  selectionLabel: "GoHighLevel (CRM)",
+  docsPath: "/channels/gohighlevel",
+  docsLabel: "gohighlevel",
+  blurb: "GoHighLevel CRM — AI chatbot for SMS, webchat, email, IG, FB, and GMB.",
+  aliases: ["ghl", "highlevel"],
+  order: 70,
+} as const;
+
+const formatAllowFromEntry = (entry: string) =>
+  entry
+    .trim()
+    .replace(/^(gohighlevel|ghl|highlevel):/i, "")
+    .toLowerCase();
+
+function resolveAllowFrom(account: ResolvedGoHighLevelAccount): string[] {
+  return (account.config.dm?.allowFrom ?? account.config.allowFrom ?? []).map((v) => String(v));
+}
+
+function resolveDmPolicyValue(account: ResolvedGoHighLevelAccount): string {
+  return account.config.dm?.policy ?? account.config.dmPolicy ?? "open";
+}
+
+export const gohighlevelDock: ChannelDock = {
+  id: "gohighlevel",
+  capabilities: {
+    chatTypes: ["direct"],
+    reactions: false,
+    media: true,
+    threads: false,
+    blockStreaming: true,
+  },
+  outbound: { textChunkLimit: 1600 },
+  config: {
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      resolveAllowFrom(resolveGoHighLevelAccount({ cfg, accountId })),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry))
+        .filter(Boolean)
+        .map(formatAllowFromEntry),
+  },
+};
+
+export const gohighlevelPlugin: ChannelPlugin<ResolvedGoHighLevelAccount> = {
+  id: "gohighlevel",
+  meta: {
+    ...meta,
+    aliases: [...meta.aliases],
+  },
+  onboarding: gohighlevelOnboardingAdapter,
+  pairing: {
+    idLabel: "gohighlevelContactId",
+    normalizeAllowEntry: (entry) => formatAllowFromEntry(entry),
+    notifyApproval: async ({ cfg, id }) => {
+      const account = resolveGoHighLevelAccount({ cfg });
+      if (account.credentialSource === "none") {
+        return;
+      }
+      await sendGHLMessage({
+        account,
+        conversationId: id,
+        message: PAIRING_APPROVED_MESSAGE,
+      });
+    },
+  },
+  capabilities: {
+    chatTypes: ["direct"],
+    reactions: false,
+    threads: false,
+    media: true,
+    nativeCommands: false,
+    blockStreaming: true,
+  },
+  streaming: {
+    blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
+  },
+  reload: { configPrefixes: ["channels.gohighlevel"] },
+  configSchema: buildChannelConfigSchema(GoHighLevelConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listGoHighLevelAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveGoHighLevelAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultGoHighLevelAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "gohighlevel",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "gohighlevel",
+        accountId,
+        clearBaseFields: [
+          "apiKey",
+          "locationId",
+          "webhookPath",
+          "webhookUrl",
+          "webhookSecret",
+          "name",
+        ],
+      }),
+    isConfigured: (account) => account.credentialSource !== "none",
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.credentialSource !== "none",
+      credentialSource: account.credentialSource,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      resolveAllowFrom(resolveGoHighLevelAccount({ cfg, accountId })),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry))
+        .filter(Boolean)
+        .map(formatAllowFromEntry),
+    resolveDefaultTo: ({ cfg, accountId }) =>
+      resolveGoHighLevelAccount({ cfg, accountId }).config.defaultTo?.trim() || undefined,
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const useAccountPath = Boolean(cfg.channels?.["gohighlevel"]?.accounts?.[resolvedAccountId]);
+      const allowFromPath = useAccountPath
+        ? `channels.gohighlevel.accounts.${resolvedAccountId}.dm.`
+        : "channels.gohighlevel.dm.";
+      return {
+        policy: resolveDmPolicyValue(account),
+        allowFrom: resolveAllowFrom(account),
+        allowFromPath,
+        approveHint: formatPairingApproveHint("gohighlevel"),
+        normalizeEntry: (raw: string) => formatAllowFromEntry(raw),
+      };
+    },
+    collectWarnings: ({ account }) => {
+      const warnings: string[] = [];
+      if (resolveDmPolicyValue(account) === "open") {
+        warnings.push(
+          `- GoHighLevel DMs are open to anyone. Set channels.gohighlevel.dm.policy="pairing" or "allowlist" for tighter control.`,
+        );
+      }
+      return warnings;
+    },
+  },
+  messaging: {
+    normalizeTarget: (raw) => raw?.trim() || undefined,
+    targetResolver: {
+      looksLikeId: (raw) => Boolean(raw.trim()),
+      hint: "<contactId>",
+    },
+  },
+  directory: {
+    self: async () => null,
+    listPeers: async ({ cfg, accountId, query, limit }) => {
+      const account = resolveGoHighLevelAccount({ cfg, accountId });
+      const q = query?.trim().toLowerCase() || "";
+      const allowFromList = resolveAllowFrom(account);
+      const peers = Array.from(
+        new Set(
+          allowFromList
+            .map((entry) => String(entry).trim())
+            .filter((entry) => Boolean(entry) && entry !== "*"),
+        ),
+      )
+        .filter((id) => (q ? id.toLowerCase().includes(q) : true))
+        .slice(0, limit && limit > 0 ? limit : undefined)
+        .map((id) => ({ kind: "user" as const, id }));
+      return peers;
+    },
+  },
+  resolver: {
+    resolveTargets: async ({ inputs }) => {
+      return inputs.map((input) => {
+        const normalized = input.trim();
+        if (!normalized) {
+          return { input, resolved: false, note: "empty target" };
+        }
+        return { input, resolved: true, id: normalized };
+      });
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "gohighlevel",
+        accountId,
+        name,
+      }),
+    validateInput: ({ accountId, input }) => {
+      if (input.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
+        return "GHL_API_KEY env var can only be used for the default account.";
+      }
+      if (!input.useEnv && !input.token) {
+        return "GoHighLevel requires --token (API key).";
+      }
+      return null;
+    },
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      const namedConfig = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "gohighlevel",
+        accountId,
+        name: input.name,
+      });
+      const next =
+        accountId !== DEFAULT_ACCOUNT_ID
+          ? migrateBaseNameToDefaultAccount({ cfg: namedConfig, channelKey: "gohighlevel" })
+          : namedConfig;
+      const patch = input.useEnv ? {} : input.token ? { apiKey: input.token } : {};
+      const locationId = input.audience?.trim();
+      const webhookPath = input.webhookPath?.trim();
+      const webhookUrl = input.webhookUrl?.trim();
+      const configPatch = {
+        ...patch,
+        ...(locationId ? { locationId } : {}),
+        ...(webhookPath ? { webhookPath } : {}),
+        ...(webhookUrl ? { webhookUrl } : {}),
+      };
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...next,
+          channels: {
+            ...next.channels,
+            gohighlevel: {
+              ...next.channels?.["gohighlevel"],
+              enabled: true,
+              ...configPatch,
+            },
+          },
+        } as OpenClawConfig;
+      }
+      return {
+        ...next,
+        channels: {
+          ...next.channels,
+          gohighlevel: {
+            ...next.channels?.["gohighlevel"],
+            enabled: true,
+            accounts: {
+              ...next.channels?.["gohighlevel"]?.accounts,
+              [accountId]: {
+                ...next.channels?.["gohighlevel"]?.accounts?.[accountId],
+                enabled: true,
+                ...configPatch,
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    chunker: (text, limit) => getGoHighLevelRuntime().channel.text.chunkMarkdownText(text, limit),
+    chunkerMode: "markdown",
+    textChunkLimit: 1600,
+    resolveTarget: ({ to }) => {
+      const trimmed = to?.trim() ?? "";
+      if (!trimmed) {
+        return { ok: false, error: missingTargetError("GoHighLevel", "<contactId>") };
+      }
+      return { ok: true, to: trimmed };
+    },
+    sendText: async ({ cfg, to, text, accountId }) => {
+      const account = resolveGoHighLevelAccount({ cfg, accountId });
+      const result = await sendGHLMessage({
+        account,
+        conversationId: to,
+        message: text,
+      });
+      return {
+        channel: "gohighlevel",
+        messageId: result?.messageId ?? "",
+        chatId: to,
+      };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    collectStatusIssues: (accounts): ChannelStatusIssue[] =>
+      accounts.flatMap((entry) => {
+        const accountId = String(entry.accountId ?? DEFAULT_ACCOUNT_ID);
+        const enabled = entry.enabled !== false;
+        const configured = entry.configured === true;
+        if (!enabled || !configured) {
+          return [];
+        }
+        const issues: ChannelStatusIssue[] = [];
+        if (!entry.audience) {
+          issues.push({
+            channel: "gohighlevel",
+            accountId,
+            kind: "config",
+            message: "GoHighLevel locationId is missing (set channels.gohighlevel.locationId).",
+            fix: "Set channels.gohighlevel.locationId to your GHL Location ID.",
+          });
+        }
+        return issues;
+      }),
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      credentialSource: snapshot.credentialSource ?? "none",
+      webhookPath: snapshot.webhookPath ?? null,
+      running: snapshot.running ?? false,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+      probe: snapshot.probe,
+      lastProbeAt: snapshot.lastProbeAt ?? null,
+    }),
+    probeAccount: async ({ account }) => probeGoHighLevel(account),
+    buildAccountSnapshot: ({ account, runtime, probe }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.credentialSource !== "none",
+      credentialSource: account.credentialSource,
+      audience: account.locationId,
+      webhookPath: account.config.webhookPath,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+      dmPolicy: resolveDmPolicyValue(account),
+      probe,
+    }),
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      ctx.log?.info(`[${account.accountId}] starting GoHighLevel webhook`);
+      ctx.setStatus({
+        accountId: account.accountId,
+        running: true,
+        lastStartAt: Date.now(),
+        webhookPath: resolveGoHighLevelWebhookPath({ account }),
+        audience: account.locationId,
+      });
+      const unregister = await startGoHighLevelMonitor({
+        account,
+        config: ctx.cfg,
+        runtime: ctx.runtime,
+        abortSignal: ctx.abortSignal,
+        webhookPath: account.config.webhookPath,
+        webhookUrl: account.config.webhookUrl,
+        statusSink: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
+      });
+      // Keep the promise pending until abort (webhook mode is passive).
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal.aborted) {
+          resolve();
+          return;
+        }
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      unregister?.();
+      ctx.setStatus({
+        accountId: account.accountId,
+        running: false,
+        lastStopAt: Date.now(),
+      });
+    },
+  },
+};

--- a/extensions/gohighlevel/src/channel.ts
+++ b/extensions/gohighlevel/src/channel.ts
@@ -3,7 +3,7 @@ import type {
   ChannelPlugin,
   ChannelStatusIssue,
   OpenClawConfig,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/gohighlevel";
 import {
   buildChannelConfigSchema,
   DEFAULT_ACCOUNT_ID,
@@ -15,7 +15,7 @@ import {
   applyAccountNameToChannelSection,
   migrateBaseNameToDefaultAccount,
   normalizeAccountId,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/gohighlevel";
 import {
   listGoHighLevelAccountIds,
   resolveDefaultGoHighLevelAccountId,

--- a/extensions/gohighlevel/src/config-schema.ts
+++ b/extensions/gohighlevel/src/config-schema.ts
@@ -1,0 +1,65 @@
+import {
+  DmPolicySchema,
+  GroupPolicySchema,
+  MarkdownConfigSchema,
+  ReplyRuntimeConfigSchemaShape,
+  requireOpenAllowFrom,
+} from "openclaw/plugin-sdk";
+import { z } from "zod";
+
+/** DM config specific to GoHighLevel (policy + allowFrom). */
+const GoHighLevelDmSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    policy: DmPolicySchema.optional().default("open"),
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  })
+  .strict()
+  .optional();
+
+export const GoHighLevelAccountSchemaBase = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    markdown: MarkdownConfigSchema,
+    apiKey: z.string().optional(),
+    locationId: z.string().optional(),
+    webhookPath: z.string().optional(),
+    webhookUrl: z.string().optional(),
+    webhookSecret: z.string().optional(),
+    dm: GoHighLevelDmSchema,
+    dmPolicy: DmPolicySchema.optional().default("open"),
+    groupPolicy: GroupPolicySchema.optional().default("open"),
+    allowFrom: z.array(z.string()).optional(),
+    groupAllowFrom: z.array(z.string()).optional(),
+    defaultTo: z.string().optional(),
+    ...ReplyRuntimeConfigSchemaShape,
+  })
+  .strict();
+
+export const GoHighLevelAccountSchema = GoHighLevelAccountSchemaBase.superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.gohighlevel.dmPolicy="open" requires channels.gohighlevel.allowFrom to include "*"',
+  });
+});
+
+export const GoHighLevelConfigSchema = GoHighLevelAccountSchemaBase.extend({
+  accounts: z.record(z.string(), GoHighLevelAccountSchema.optional()).optional(),
+}).superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.gohighlevel.dmPolicy="open" requires channels.gohighlevel.allowFrom to include "*"',
+  });
+});
+
+export type GoHighLevelAccountConfig = z.infer<typeof GoHighLevelAccountSchemaBase>;
+export type GoHighLevelConfig = z.infer<typeof GoHighLevelConfigSchema>;

--- a/extensions/gohighlevel/src/config-schema.ts
+++ b/extensions/gohighlevel/src/config-schema.ts
@@ -4,7 +4,7 @@ import {
   MarkdownConfigSchema,
   ReplyRuntimeConfigSchemaShape,
   requireOpenAllowFrom,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/gohighlevel";
 import { z } from "zod";
 
 /** DM config specific to GoHighLevel (policy + allowFrom). */

--- a/extensions/gohighlevel/src/config-schema.ts
+++ b/extensions/gohighlevel/src/config-schema.ts
@@ -17,6 +17,16 @@ const GoHighLevelDmSchema = z
   .strict()
   .optional();
 
+/** Escalation tagging: auto-tag a GHL contact when a reply matches trigger phrases. */
+const GoHighLevelEscalationSchema = z
+  .object({
+    enabled: z.boolean().optional().default(true),
+    tag: z.string().optional().default("escalation"),
+    patterns: z.array(z.string()).optional(),
+  })
+  .strict()
+  .optional();
+
 export const GoHighLevelAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -28,6 +38,7 @@ export const GoHighLevelAccountSchemaBase = z
     webhookUrl: z.string().optional(),
     webhookSecret: z.string().optional(),
     dm: GoHighLevelDmSchema,
+    escalation: GoHighLevelEscalationSchema,
     dmPolicy: DmPolicySchema.optional().default("open"),
     groupPolicy: GroupPolicySchema.optional().default("open"),
     allowFrom: z.array(z.string()).optional(),

--- a/extensions/gohighlevel/src/monitor.test.ts
+++ b/extensions/gohighlevel/src/monitor.test.ts
@@ -1,0 +1,192 @@
+import { createHmac } from "node:crypto";
+import { type IncomingMessage, type ServerResponse } from "node:http";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock the runtime and API before importing
+vi.mock("./runtime.js", () => ({
+  getGoHighLevelRuntime: () => ({
+    logging: { shouldLogVerbose: () => false },
+    channel: {
+      routing: {
+        resolveAgentRoute: () => ({
+          agentId: "default",
+          accountId: "default",
+          sessionKey: "test-session",
+        }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/test",
+        readSessionUpdatedAt: () => undefined,
+        recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: () => ({}),
+        formatAgentEnvelope: ({ body }: { body: string }) => body,
+        finalizeInboundContext: (ctx: Record<string, unknown>) => ctx,
+        dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockResolvedValue(undefined),
+      },
+      text: {
+        chunkMarkdownText: (text: string) => [text],
+        chunkMarkdownTextWithMode: (text: string) => [text],
+        resolveChunkMode: () => "markdown",
+      },
+      pairing: {
+        buildPairingReply: () => "pairing reply",
+      },
+      media: {
+        fetchRemoteMedia: vi.fn(),
+        saveMediaBuffer: vi.fn(),
+      },
+    },
+  }),
+}));
+
+vi.mock("./api.js", () => ({
+  sendGHLMessage: vi.fn().mockResolvedValue({ messageId: "msg-1" }),
+}));
+
+// Import after mocks
+import { handleGoHighLevelWebhookRequest, registerGoHighLevelWebhookTarget } from "./monitor.js";
+
+function createMockReq(options: {
+  method?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}): IncomingMessage {
+  const { method = "POST", url = "/gohighlevel", headers = {}, body = "" } = options;
+  const req = {
+    method,
+    url,
+    headers: { ...headers, host: "localhost" },
+    on: vi.fn((event: string, cb: (chunk?: Buffer) => void) => {
+      if (event === "data" && body) {
+        cb(Buffer.from(body));
+      }
+      if (event === "end") {
+        cb();
+      }
+      return req;
+    }),
+    removeListener: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+    destroyed: false,
+  } as unknown as IncomingMessage;
+  return req;
+}
+
+function createMockRes(): ServerResponse & { _status: number; _body: string } {
+  const res = {
+    _status: 200,
+    _body: "",
+    statusCode: 200,
+    headersSent: false,
+    setHeader: vi.fn(),
+    end: vi.fn(function (this: { _body: string }, body?: string) {
+      this._body = body ?? "";
+    }),
+  } as unknown as ServerResponse & { _status: number; _body: string };
+  Object.defineProperty(res, "statusCode", {
+    get() {
+      return res._status;
+    },
+    set(v: number) {
+      res._status = v;
+    },
+  });
+  return res;
+}
+
+describe("handleGoHighLevelWebhookRequest", () => {
+  const account = {
+    accountId: "default",
+    enabled: true,
+    config: {
+      dmPolicy: "open",
+      webhookSecret: "test-secret",
+    },
+    credentialSource: "inline" as const,
+    apiKey: "test-key",
+    locationId: "loc-123",
+  };
+
+  let unregister: () => void;
+
+  beforeEach(async () => {
+    // Register a webhook target using the actual runtime mock
+    const { getGoHighLevelRuntime } = vi.mocked(await import("./runtime.js"));
+    unregister = registerGoHighLevelWebhookTarget({
+      account: account as never,
+      config: {} as never,
+      runtime: { log: vi.fn(), error: vi.fn() },
+      core: getGoHighLevelRuntime() as never,
+      path: "/gohighlevel",
+    });
+  });
+
+  it("returns false for unregistered paths", async () => {
+    const req = createMockReq({ url: "/unknown" });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(false);
+  });
+
+  it("rejects non-POST requests with 405", async () => {
+    const req = createMockReq({ method: "GET" });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(405);
+  });
+
+  it("rejects requests with invalid signature", async () => {
+    const body = JSON.stringify({
+      direction: "inbound",
+      contactId: "c1",
+      conversationId: "conv1",
+      body: "hello",
+    });
+    const req = createMockReq({
+      body,
+      headers: { "x-ghl-signature": "invalid-sig" },
+    });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(401);
+  });
+
+  it("accepts requests with valid signature and returns 200", async () => {
+    const body = JSON.stringify({
+      direction: "inbound",
+      contactId: "c1",
+      conversationId: "conv1",
+      body: "hello",
+    });
+    const signature = createHmac("sha256", "test-secret").update(body).digest("hex");
+    const req = createMockReq({
+      body,
+      headers: { "x-ghl-signature": signature },
+    });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+  });
+
+  it("rejects empty body", async () => {
+    const req = createMockReq({ body: "" });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const req = createMockReq({ body: "not json{" });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(400);
+  });
+});

--- a/extensions/gohighlevel/src/monitor.test.ts
+++ b/extensions/gohighlevel/src/monitor.test.ts
@@ -242,4 +242,34 @@ describe("handleGoHighLevelWebhookRequest", () => {
     expect(handled).toBe(true);
     expect(res._status).toBe(400);
   });
+
+  it("accepts real GHL Workflow payload with nested message.body", async () => {
+    // Real GHL Workflow payloads nest the body under `message.body` and
+    // include `customData` with configured fields — top-level `body` is NOT set.
+    const workflowPayload = {
+      contact_id: "dbSKd404POvJ6ZSyRSlX",
+      first_name: "Rakesh",
+      last_name: "Parikatil",
+      full_name: "Rakesh Parikatil",
+      phone: "+13238287989",
+      email: "rparikatil@yahoo.com",
+      tags: "lead-type-adult,junior-advanced",
+      contact_type: "lead",
+      location: { name: "LBTA", id: "loc-123" },
+      message: { type: 2, body: "Yes" },
+      workflow: { id: "d64c0407", name: "Customer Replied Webhook" },
+      customData: { event_type: "customer.replied", body: "Yes" },
+    };
+    const body = JSON.stringify(workflowPayload);
+    const signature = createHmac("sha256", "test-secret").update(body).digest("hex");
+    const req = createMockReq({
+      body,
+      headers: { "x-ghl-signature": signature },
+    });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+    expect(res._body).toBe("{}");
+  });
 });

--- a/extensions/gohighlevel/src/monitor.test.ts
+++ b/extensions/gohighlevel/src/monitor.test.ts
@@ -47,7 +47,11 @@ vi.mock("./api.js", () => ({
 }));
 
 // Import after mocks
-import { handleGoHighLevelWebhookRequest, registerGoHighLevelWebhookTarget } from "./monitor.js";
+import {
+  handleGoHighLevelWebhookRequest,
+  registerGoHighLevelWebhookTarget,
+  resolveGoHighLevelWebhookPath,
+} from "./monitor.js";
 
 function createMockReq(options: {
   method?: string;
@@ -271,5 +275,101 @@ describe("handleGoHighLevelWebhookRequest", () => {
     expect(handled).toBe(true);
     expect(res._status).toBe(200);
     expect(res._body).toBe("{}");
+  });
+
+  it("accepts already-normalized inbound payload without workflow fields", async () => {
+    // Direct API webhooks use the standard InboundMessage shape.
+    const payload = {
+      type: "InboundMessage",
+      direction: "inbound",
+      contactId: "c2",
+      conversationId: "conv2",
+      body: "direct webhook",
+      messageType: "SMS",
+    };
+    const body = JSON.stringify(payload);
+    const signature = createHmac("sha256", "test-secret").update(body).digest("hex");
+    const req = createMockReq({
+      body,
+      headers: { "x-ghl-signature": signature },
+    });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+  });
+
+  it("accepts Workflow payload with customData.body but no message.body", async () => {
+    // Some Workflow configurations only populate customData, not message.
+    const payload = {
+      contact_id: "c3",
+      phone: "+15551234567",
+      customData: { event_type: "customer.replied", body: "from customData" },
+    };
+    const body = JSON.stringify(payload);
+    const signature = createHmac("sha256", "test-secret").update(body).digest("hex");
+    const req = createMockReq({
+      body,
+      headers: { "x-ghl-signature": signature },
+    });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+  });
+
+  it("accepts webhook without signature when no secret is configured", async () => {
+    // Register a target with no webhook secret
+    const { getGoHighLevelRuntime } = vi.mocked(await import("./runtime.js"));
+    const noSecretAccount = {
+      ...account,
+      accountId: "no-secret",
+      config: { dmPolicy: "open" as const },
+    };
+    const unsub = registerGoHighLevelWebhookTarget({
+      account: noSecretAccount as never,
+      config: {} as never,
+      runtime: { log: vi.fn(), error: vi.fn() },
+      core: getGoHighLevelRuntime() as never,
+      path: "/ghl-no-secret",
+    });
+
+    const body = JSON.stringify({
+      direction: "inbound",
+      contactId: "c4",
+      conversationId: "conv4",
+      body: "no sig needed",
+    });
+    const req = createMockReq({ url: "/ghl-no-secret", body });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+    unsub();
+  });
+});
+
+describe("resolveGoHighLevelWebhookPath", () => {
+  it("returns default /gohighlevel when no path configured", () => {
+    const path = resolveGoHighLevelWebhookPath({
+      account: { config: {} } as never,
+    });
+    expect(path).toBe("/gohighlevel");
+  });
+
+  it("returns configured webhookPath", () => {
+    const path = resolveGoHighLevelWebhookPath({
+      account: { config: { webhookPath: "/my-ghl" } } as never,
+    });
+    expect(path).toBe("/my-ghl");
+  });
+
+  it("extracts path from webhookUrl", () => {
+    const path = resolveGoHighLevelWebhookPath({
+      account: {
+        config: { webhookUrl: "https://example.com/ghl-hook" },
+      } as never,
+    });
+    expect(path).toBe("/ghl-hook");
   });
 });

--- a/extensions/gohighlevel/src/monitor.test.ts
+++ b/extensions/gohighlevel/src/monitor.test.ts
@@ -1,6 +1,7 @@
 import { createHmac } from "node:crypto";
 import { type IncomingMessage, type ServerResponse } from "node:http";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { GoHighLevelAccountSchemaBase } from "./config-schema.js";
 
 // Mock the runtime and API before importing
 vi.mock("./runtime.js", () => ({
@@ -96,6 +97,58 @@ function createMockRes(): ServerResponse & { _status: number; _body: string } {
   });
   return res;
 }
+
+describe("escalation config schema", () => {
+  it("accepts escalation config with custom patterns and tag", () => {
+    const result = GoHighLevelAccountSchemaBase.safeParse({
+      escalation: {
+        enabled: true,
+        tag: "needs-human",
+        patterns: ["please hold", "transferring you"],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.escalation?.tag).toBe("needs-human");
+      expect(result.data.escalation?.patterns).toEqual(["please hold", "transferring you"]);
+    }
+  });
+
+  it("defaults escalation.enabled to true when omitted", () => {
+    const result = GoHighLevelAccountSchemaBase.safeParse({
+      escalation: { tag: "custom-tag" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.escalation?.enabled).toBe(true);
+    }
+  });
+
+  it("allows disabling escalation", () => {
+    const result = GoHighLevelAccountSchemaBase.safeParse({
+      escalation: { enabled: false },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.escalation?.enabled).toBe(false);
+    }
+  });
+
+  it("accepts config without escalation section", () => {
+    const result = GoHighLevelAccountSchemaBase.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.escalation).toBeUndefined();
+    }
+  });
+
+  it("rejects unknown fields inside escalation", () => {
+    const result = GoHighLevelAccountSchemaBase.safeParse({
+      escalation: { unknown: true },
+    });
+    expect(result.success).toBe(false);
+  });
+});
 
 describe("handleGoHighLevelWebhookRequest", () => {
   const account = {

--- a/extensions/gohighlevel/src/monitor.ts
+++ b/extensions/gohighlevel/src/monitor.ts
@@ -12,7 +12,7 @@ import {
   isRequestBodyLimitError,
 } from "openclaw/plugin-sdk";
 import type { ResolvedGoHighLevelAccount } from "./accounts.js";
-import { sendGHLMessage } from "./api.js";
+import { addGHLContactTag, sendGHLMessage } from "./api.js";
 import { verifyGHLSignature } from "./auth.js";
 import { getGoHighLevelRuntime } from "./runtime.js";
 import type { GHLWebhookPayload } from "./types.js";
@@ -360,6 +360,20 @@ async function processMessageWithPipeline(params: {
   });
 }
 
+const ESCALATION_PATTERNS = [
+  "let me look into that for you",
+  "i'll get back to you shortly",
+  "let me check on that",
+  // Legacy patterns in case prompt changes
+  "connect you with robert",
+  "reach him at (619) 602-9713",
+];
+
+function isEscalationReply(text: string): boolean {
+  const lower = text.toLowerCase();
+  return ESCALATION_PATTERNS.some((p) => lower.includes(p));
+}
+
 async function deliverGHLReply(params: {
   payload: { text?: string; mediaUrls?: string[]; mediaUrl?: string };
   account: ResolvedGoHighLevelAccount;
@@ -389,6 +403,13 @@ async function deliverGHLReply(params: {
       } catch (err) {
         runtime.error?.(`GHL message send failed: ${String(err)}`);
       }
+    }
+
+    // Tag contact for escalation when the bot defers to Robert
+    if (isEscalationReply(payload.text)) {
+      addGHLContactTag({ account, contactId, tag: "escalation" }).catch((err) => {
+        runtime.error?.(`GHL escalation tag failed: ${String(err)}`);
+      });
     }
   }
 }

--- a/extensions/gohighlevel/src/monitor.ts
+++ b/extensions/gohighlevel/src/monitor.ts
@@ -1,0 +1,436 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import {
+  createScopedPairingAccess,
+  createReplyPrefixOptions,
+  readRequestBodyWithLimit,
+  registerWebhookTarget,
+  rejectNonPostWebhookRequest,
+  resolveWebhookPath,
+  resolveWebhookTargets,
+  requestBodyErrorToText,
+  isRequestBodyLimitError,
+} from "openclaw/plugin-sdk";
+import type { ResolvedGoHighLevelAccount } from "./accounts.js";
+import { sendGHLMessage } from "./api.js";
+import { verifyGHLSignature } from "./auth.js";
+import { getGoHighLevelRuntime } from "./runtime.js";
+import type { GHLWebhookPayload } from "./types.js";
+
+export type GoHighLevelRuntimeEnv = {
+  log?: (message: string) => void;
+  error?: (message: string) => void;
+};
+
+export type GoHighLevelMonitorOptions = {
+  account: ResolvedGoHighLevelAccount;
+  config: OpenClawConfig;
+  runtime: GoHighLevelRuntimeEnv;
+  abortSignal: AbortSignal;
+  webhookPath?: string;
+  webhookUrl?: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+type GoHighLevelCoreRuntime = ReturnType<typeof getGoHighLevelRuntime>;
+
+type WebhookTarget = {
+  account: ResolvedGoHighLevelAccount;
+  config: OpenClawConfig;
+  runtime: GoHighLevelRuntimeEnv;
+  core: GoHighLevelCoreRuntime;
+  path: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+const webhookTargets = new Map<string, WebhookTarget[]>();
+
+function logVerbose(core: GoHighLevelCoreRuntime, runtime: GoHighLevelRuntimeEnv, message: string) {
+  if (core.logging.shouldLogVerbose()) {
+    runtime.log?.(`[gohighlevel] ${message}`);
+  }
+}
+
+export function registerGoHighLevelWebhookTarget(target: WebhookTarget): () => void {
+  return registerWebhookTarget(webhookTargets, target).unregister;
+}
+
+export async function handleGoHighLevelWebhookRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const resolved = resolveWebhookTargets(req, webhookTargets);
+  if (!resolved) {
+    return false;
+  }
+  const { targets } = resolved;
+
+  if (rejectNonPostWebhookRequest(req, res)) {
+    return true;
+  }
+
+  // Read raw body for signature verification before JSON parsing
+  let rawBody: string;
+  try {
+    rawBody = await readRequestBodyWithLimit(req, {
+      maxBytes: 1024 * 1024,
+      timeoutMs: 30_000,
+    });
+  } catch (err) {
+    if (isRequestBodyLimitError(err)) {
+      res.statusCode = 413;
+      res.end(requestBodyErrorToText("PAYLOAD_TOO_LARGE"));
+      return true;
+    }
+    res.statusCode = 400;
+    res.end("invalid request body");
+    return true;
+  }
+
+  if (!rawBody.trim()) {
+    res.statusCode = 400;
+    res.end("empty body");
+    return true;
+  }
+
+  let payload: GHLWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody) as GHLWebhookPayload;
+  } catch {
+    res.statusCode = 400;
+    res.end("invalid JSON");
+    return true;
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    res.statusCode = 400;
+    res.end("invalid payload");
+    return true;
+  }
+
+  // Find matching target; verify signature if webhook secret is configured
+  const signatureHeader = String(req.headers["x-ghl-signature"] ?? "");
+  let matchedTarget: WebhookTarget | null = null;
+
+  for (const target of targets) {
+    const secret = target.account.config.webhookSecret?.trim();
+    if (secret) {
+      if (!verifyGHLSignature({ signature: signatureHeader, body: rawBody, secret })) {
+        continue;
+      }
+    }
+    matchedTarget = target;
+    break;
+  }
+
+  if (!matchedTarget) {
+    res.statusCode = 401;
+    res.end("unauthorized");
+    return true;
+  }
+
+  matchedTarget.statusSink?.({ lastInboundAt: Date.now() });
+  processGHLWebhook(payload, matchedTarget).catch((err) => {
+    matchedTarget.runtime.error?.(
+      `[${matchedTarget.account.accountId}] GHL webhook failed: ${String(err)}`,
+    );
+  });
+
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json");
+  res.end("{}");
+  return true;
+}
+
+async function processGHLWebhook(payload: GHLWebhookPayload, target: WebhookTarget) {
+  // Only process inbound messages
+  if (payload.direction !== "inbound") {
+    return;
+  }
+
+  const body = payload.body?.trim();
+  const hasAttachments = (payload.attachments?.length ?? 0) > 0;
+  const rawBody = body || (hasAttachments ? "<media:attachment>" : "");
+  if (!rawBody) {
+    return;
+  }
+
+  const contactId = payload.contactId ?? "";
+  const conversationId = payload.conversationId ?? "";
+  if (!contactId || !conversationId) {
+    return;
+  }
+
+  await processMessageWithPipeline({
+    payload,
+    rawBody,
+    account: target.account,
+    config: target.config,
+    runtime: target.runtime,
+    core: target.core,
+    statusSink: target.statusSink,
+  });
+}
+
+async function processMessageWithPipeline(params: {
+  payload: GHLWebhookPayload;
+  rawBody: string;
+  account: ResolvedGoHighLevelAccount;
+  config: OpenClawConfig;
+  runtime: GoHighLevelRuntimeEnv;
+  core: GoHighLevelCoreRuntime;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+}): Promise<void> {
+  const { payload, rawBody, account, config, runtime, core, statusSink } = params;
+
+  const contactId = payload.contactId ?? "";
+  const conversationId = payload.conversationId ?? "";
+  const messageType = payload.messageType ?? "SMS";
+  const senderPhone = payload.from ?? contactId;
+  const senderName = payload.from ?? "";
+
+  const pairing = createScopedPairingAccess({
+    core,
+    channel: "gohighlevel",
+    accountId: account.accountId,
+  });
+
+  // GHL is always DM-like (CRM conversations are 1:1 with contacts)
+  const dmPolicy = account.config.dm?.policy ?? account.config.dmPolicy ?? "open";
+
+  if (dmPolicy === "allowlist") {
+    const allowFrom = (account.config.dm?.allowFrom ?? account.config.allowFrom ?? []).map(
+      (v: string | number) => String(v),
+    );
+    const allowed = allowFrom.includes("*") || allowFrom.includes(contactId);
+    if (!allowed) {
+      logVerbose(core, runtime, `blocked GHL message from ${contactId} (allowlist)`);
+      return;
+    }
+  } else if (dmPolicy === "pairing") {
+    const storeAllowFrom: string[] = await pairing.readAllowFromStore().catch(() => []);
+    const allowed =
+      storeAllowFrom.includes("*") ||
+      storeAllowFrom.includes(contactId) ||
+      storeAllowFrom.includes(senderPhone);
+    if (!allowed) {
+      const { code, created } = await pairing.upsertPairingRequest({
+        id: contactId,
+        meta: { name: senderName || undefined, phone: senderPhone },
+      });
+      if (created) {
+        logVerbose(core, runtime, `GHL pairing request contact=${contactId}`);
+        try {
+          await sendGHLMessage({
+            account,
+            conversationId: contactId,
+            message: core.channel.pairing.buildPairingReply({
+              channel: "gohighlevel",
+              idLine: `Your GHL contact id: ${contactId}`,
+              code,
+            }),
+            messageType,
+          });
+          statusSink?.({ lastOutboundAt: Date.now() });
+        } catch (err) {
+          logVerbose(core, runtime, `pairing reply failed for ${contactId}: ${String(err)}`);
+        }
+      }
+      return;
+    }
+  }
+  // dmPolicy === "open" — allow all
+
+  const route = core.channel.routing.resolveAgentRoute({
+    cfg: config,
+    channel: "gohighlevel",
+    accountId: account.accountId,
+    peer: { kind: "direct", id: contactId },
+  });
+
+  // Handle media attachments
+  let mediaPath: string | undefined;
+  let mediaType: string | undefined;
+  if (payload.attachments && payload.attachments.length > 0) {
+    const first = payload.attachments[0];
+    if (first.url) {
+      try {
+        const maxBytes = (account.config.mediaMaxMb ?? 20) * 1024 * 1024;
+        const loaded = await core.channel.media.fetchRemoteMedia({
+          url: first.url,
+          maxBytes,
+        });
+        const saved = await core.channel.media.saveMediaBuffer(
+          loaded.buffer,
+          loaded.contentType ?? first.contentType,
+          "inbound",
+          maxBytes,
+          first.fileName,
+        );
+        mediaPath = saved.path;
+        mediaType = saved.contentType;
+      } catch (err) {
+        runtime.error?.(`GHL attachment download failed: ${String(err)}`);
+      }
+    }
+  }
+
+  const fromLabel = senderName || `contact:${contactId}`;
+  const storePath = core.channel.session.resolveStorePath(config.session?.store, {
+    agentId: route.agentId,
+  });
+  const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(config);
+  const previousTimestamp = core.channel.session.readSessionUpdatedAt({
+    storePath,
+    sessionKey: route.sessionKey,
+  });
+  const bodyFormatted = core.channel.reply.formatAgentEnvelope({
+    channel: `GoHighLevel (${messageType})`,
+    from: fromLabel,
+    timestamp: payload.dateAdded ? Date.parse(payload.dateAdded) : undefined,
+    previousTimestamp,
+    envelope: envelopeOptions,
+    body: rawBody,
+  });
+
+  const ctxPayload = core.channel.reply.finalizeInboundContext({
+    Body: bodyFormatted,
+    BodyForAgent: rawBody,
+    RawBody: rawBody,
+    CommandBody: rawBody,
+    From: `gohighlevel:${contactId}`,
+    To: `gohighlevel:${conversationId}`,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId,
+    ChatType: "direct",
+    ConversationLabel: fromLabel,
+    SenderName: senderName || undefined,
+    SenderId: contactId,
+    Provider: "gohighlevel",
+    Surface: "gohighlevel",
+    MessageSid: payload.messageId,
+    MessageSidFull: payload.messageId,
+    MediaPath: mediaPath,
+    MediaType: mediaType,
+    MediaUrl: mediaPath,
+    OriginatingChannel: "gohighlevel",
+    OriginatingTo: `gohighlevel:${conversationId}`,
+  });
+
+  void core.channel.session
+    .recordSessionMetaFromInbound({
+      storePath,
+      sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+      ctx: ctxPayload,
+    })
+    .catch((err) => {
+      runtime.error?.(`gohighlevel: failed updating session meta: ${String(err)}`);
+    });
+
+  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+    cfg: config,
+    agentId: route.agentId,
+    channel: "gohighlevel",
+    accountId: route.accountId,
+  });
+
+  await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+    ctx: ctxPayload,
+    cfg: config,
+    dispatcherOptions: {
+      ...prefixOptions,
+      deliver: async (replyPayload) => {
+        await deliverGHLReply({
+          payload: replyPayload,
+          account,
+          contactId,
+          conversationId,
+          messageType,
+          runtime,
+          core,
+          config,
+          statusSink,
+        });
+      },
+      onError: (err, info) => {
+        runtime.error?.(`[${account.accountId}] GHL ${info.kind} reply failed: ${String(err)}`);
+      },
+    },
+    replyOptions: { onModelSelected },
+  });
+}
+
+async function deliverGHLReply(params: {
+  payload: { text?: string; mediaUrls?: string[]; mediaUrl?: string };
+  account: ResolvedGoHighLevelAccount;
+  contactId: string;
+  conversationId: string;
+  messageType: string;
+  runtime: GoHighLevelRuntimeEnv;
+  core: GoHighLevelCoreRuntime;
+  config: OpenClawConfig;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+}): Promise<void> {
+  const { payload, account, contactId, messageType, runtime, core, config, statusSink } = params;
+
+  if (payload.text) {
+    const chunkLimit = account.config.textChunkLimit ?? 1600;
+    const chunkMode = core.channel.text.resolveChunkMode(config, "gohighlevel", account.accountId);
+    const chunks = core.channel.text.chunkMarkdownTextWithMode(payload.text, chunkLimit, chunkMode);
+    for (const chunk of chunks) {
+      try {
+        await sendGHLMessage({
+          account,
+          conversationId: contactId,
+          message: chunk,
+          messageType,
+        });
+        statusSink?.({ lastOutboundAt: Date.now() });
+      } catch (err) {
+        runtime.error?.(`GHL message send failed: ${String(err)}`);
+      }
+    }
+  }
+}
+
+export function monitorGoHighLevelProvider(options: GoHighLevelMonitorOptions): () => void {
+  const core = getGoHighLevelRuntime();
+  const webhookPath = resolveWebhookPath({
+    webhookPath: options.webhookPath,
+    webhookUrl: options.webhookUrl,
+    defaultPath: "/gohighlevel",
+  });
+  if (!webhookPath) {
+    options.runtime.error?.(`[${options.account.accountId}] invalid webhook path`);
+    return () => {};
+  }
+
+  const unregister = registerGoHighLevelWebhookTarget({
+    account: options.account,
+    config: options.config,
+    runtime: options.runtime,
+    core,
+    path: webhookPath,
+    statusSink: options.statusSink,
+  });
+
+  return unregister;
+}
+
+export async function startGoHighLevelMonitor(
+  params: GoHighLevelMonitorOptions,
+): Promise<() => void> {
+  return monitorGoHighLevelProvider(params);
+}
+
+export function resolveGoHighLevelWebhookPath(params: {
+  account: ResolvedGoHighLevelAccount;
+}): string {
+  return (
+    resolveWebhookPath({
+      webhookPath: params.account.config.webhookPath,
+      webhookUrl: params.account.config.webhookUrl,
+      defaultPath: "/gohighlevel",
+    }) ?? "/gohighlevel"
+  );
+}

--- a/extensions/gohighlevel/src/monitor.ts
+++ b/extensions/gohighlevel/src/monitor.ts
@@ -146,22 +146,43 @@ export async function handleGoHighLevelWebhookRequest(
  * Normalize a GHL Workflow "Customer Replied" payload into the standard
  * InboundMessage shape so the rest of the pipeline can handle it uniformly.
  *
- * Workflow payloads are contact-centric (snake_case fields, no `direction`,
- * no `conversationId`). We map them to the canonical format and default
- * `direction` to `"inbound"` when the event_type signals a customer reply.
+ * Real GHL Workflow payloads nest the message under `message.body` and
+ * the configured custom data under `customData`. The top-level `body` field
+ * is NOT populated by GHL — we must extract it from the nested objects.
+ *
+ * Typical Workflow payload shape:
+ * {
+ *   contact_id, first_name, last_name, phone, email, tags, location: {...},
+ *   message: { type: 2, body: "actual text" },
+ *   workflow: { id, name },
+ *   customData: { event_type: "customer.replied", body: "actual text" }
+ * }
  */
 function normalizeWorkflowPayload(payload: GHLWebhookPayload): void {
-  // Already in standard format
+  // Already in standard format (direct API webhook, not Workflow)
   if (payload.type === "InboundMessage" || payload.direction === "inbound") {
     return;
   }
 
-  // Detect Workflow payload by presence of snake_case fields or event_type
+  // Detect Workflow payload: has workflow metadata, customData, or snake_case contact fields
   const isWorkflow =
-    payload.event_type === "customer.replied" || (payload.contact_id && !payload.contactId);
+    payload.workflow != null ||
+    payload.customData != null ||
+    payload.event_type === "customer.replied" ||
+    (payload.contact_id && !payload.contactId);
 
   if (!isWorkflow) {
     return;
+  }
+
+  // Extract body from nested message object or customData (GHL doesn't populate top-level body)
+  if (!payload.body) {
+    payload.body = payload.message?.body ?? payload.customData?.body ?? undefined;
+  }
+
+  // Extract event_type from customData if not at top level
+  if (!payload.event_type && payload.customData?.event_type) {
+    payload.event_type = payload.customData.event_type;
   }
 
   // Map snake_case → camelCase

--- a/extensions/gohighlevel/src/monitor.ts
+++ b/extensions/gohighlevel/src/monitor.ts
@@ -1,16 +1,16 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/gohighlevel";
 import {
   createScopedPairingAccess,
   createReplyPrefixOptions,
   readRequestBodyWithLimit,
-  registerWebhookTarget,
+  registerWebhookTargetWithPluginRoute,
   rejectNonPostWebhookRequest,
   resolveWebhookPath,
   resolveWebhookTargets,
   requestBodyErrorToText,
   isRequestBodyLimitError,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/gohighlevel";
 import type { ResolvedGoHighLevelAccount } from "./accounts.js";
 import { addGHLContactTag, sendGHLMessage } from "./api.js";
 import { verifyGHLSignature } from "./auth.js";
@@ -52,7 +52,14 @@ function logVerbose(core: GoHighLevelCoreRuntime, runtime: GoHighLevelRuntimeEnv
 }
 
 export function registerGoHighLevelWebhookTarget(target: WebhookTarget): () => void {
-  return registerWebhookTarget(webhookTargets, target).unregister;
+  return registerWebhookTargetWithPluginRoute({
+    targetsByPath: webhookTargets,
+    target,
+    route: {
+      handler: handleGoHighLevelWebhookRequest,
+      auth: "plugin",
+    },
+  }).unregister;
 }
 
 export async function handleGoHighLevelWebhookRequest(

--- a/extensions/gohighlevel/src/monitor.ts
+++ b/extensions/gohighlevel/src/monitor.ts
@@ -142,9 +142,66 @@ export async function handleGoHighLevelWebhookRequest(
   return true;
 }
 
+/**
+ * Normalize a GHL Workflow "Customer Replied" payload into the standard
+ * InboundMessage shape so the rest of the pipeline can handle it uniformly.
+ *
+ * Workflow payloads are contact-centric (snake_case fields, no `direction`,
+ * no `conversationId`). We map them to the canonical format and default
+ * `direction` to `"inbound"` when the event_type signals a customer reply.
+ */
+function normalizeWorkflowPayload(payload: GHLWebhookPayload): void {
+  // Already in standard format
+  if (payload.type === "InboundMessage" || payload.direction === "inbound") {
+    return;
+  }
+
+  // Detect Workflow payload by presence of snake_case fields or event_type
+  const isWorkflow =
+    payload.event_type === "customer.replied" || (payload.contact_id && !payload.contactId);
+
+  if (!isWorkflow) {
+    return;
+  }
+
+  // Map snake_case → camelCase
+  if (!payload.contactId && payload.contact_id) {
+    payload.contactId = payload.contact_id;
+  }
+  // Workflow payloads lack conversationId; use contactId as fallback
+  // (GHL Conversations API accepts contactId for sending)
+  if (!payload.conversationId && payload.contactId) {
+    payload.conversationId = payload.contactId;
+  }
+  if (!payload.from) {
+    payload.from =
+      payload.phone ||
+      payload.full_name ||
+      [payload.first_name, payload.last_name].filter(Boolean).join(" ") ||
+      "";
+  }
+  if (!payload.direction) {
+    payload.direction = "inbound";
+  }
+  if (!payload.messageType) {
+    payload.messageType = "SMS";
+  }
+  if (!payload.locationId && payload.location?.id) {
+    payload.locationId = payload.location.id;
+  }
+}
+
 async function processGHLWebhook(payload: GHLWebhookPayload, target: WebhookTarget) {
+  // Normalize Workflow payloads into the standard InboundMessage shape
+  normalizeWorkflowPayload(payload);
+
   // Only process inbound messages
   if (payload.direction !== "inbound") {
+    logVerbose(
+      target.core,
+      target.runtime,
+      `ignoring non-inbound GHL payload (direction=${payload.direction ?? "undefined"})`,
+    );
     return;
   }
 
@@ -152,12 +209,18 @@ async function processGHLWebhook(payload: GHLWebhookPayload, target: WebhookTarg
   const hasAttachments = (payload.attachments?.length ?? 0) > 0;
   const rawBody = body || (hasAttachments ? "<media:attachment>" : "");
   if (!rawBody) {
+    logVerbose(target.core, target.runtime, `ignoring GHL payload with empty body`);
     return;
   }
 
   const contactId = payload.contactId ?? "";
   const conversationId = payload.conversationId ?? "";
   if (!contactId || !conversationId) {
+    logVerbose(
+      target.core,
+      target.runtime,
+      `ignoring GHL payload without contactId/conversationId`,
+    );
     return;
   }
 
@@ -360,18 +423,31 @@ async function processMessageWithPipeline(params: {
   });
 }
 
-const ESCALATION_PATTERNS = [
+const DEFAULT_ESCALATION_PATTERNS = [
   "let me look into that for you",
   "i'll get back to you shortly",
   "let me check on that",
-  // Legacy patterns in case prompt changes
-  "connect you with robert",
-  "reach him at (619) 602-9713",
 ];
 
-function isEscalationReply(text: string): boolean {
+function resolveEscalationPatterns(account: ResolvedGoHighLevelAccount): string[] {
+  const configured = account.config.escalation?.patterns;
+  if (configured && configured.length > 0) {
+    return configured.map((p) => p.toLowerCase().trim()).filter(Boolean);
+  }
+  return DEFAULT_ESCALATION_PATTERNS;
+}
+
+function resolveEscalationTag(account: ResolvedGoHighLevelAccount): string {
+  return account.config.escalation?.tag?.trim() || "escalation";
+}
+
+function isEscalationEnabled(account: ResolvedGoHighLevelAccount): boolean {
+  return account.config.escalation?.enabled !== false;
+}
+
+function isEscalationReply(text: string, patterns: string[]): boolean {
   const lower = text.toLowerCase();
-  return ESCALATION_PATTERNS.some((p) => lower.includes(p));
+  return patterns.some((p) => lower.includes(p));
 }
 
 async function deliverGHLReply(params: {
@@ -405,11 +481,15 @@ async function deliverGHLReply(params: {
       }
     }
 
-    // Tag contact for escalation when the bot defers to Robert
-    if (isEscalationReply(payload.text)) {
-      addGHLContactTag({ account, contactId, tag: "escalation" }).catch((err) => {
-        runtime.error?.(`GHL escalation tag failed: ${String(err)}`);
-      });
+    // Tag contact for escalation when the reply matches configured trigger phrases
+    if (isEscalationEnabled(account)) {
+      const patterns = resolveEscalationPatterns(account);
+      if (isEscalationReply(payload.text, patterns)) {
+        const tag = resolveEscalationTag(account);
+        addGHLContactTag({ account, contactId, tag }).catch((err) => {
+          runtime.error?.(`GHL escalation tag failed: ${String(err)}`);
+        });
+      }
     }
   }
 }

--- a/extensions/gohighlevel/src/onboarding.ts
+++ b/extensions/gohighlevel/src/onboarding.ts
@@ -1,0 +1,230 @@
+import type { OpenClawConfig, DmPolicy } from "openclaw/plugin-sdk";
+import {
+  addWildcardAllowFrom,
+  formatDocsLink,
+  mergeAllowFromEntries,
+  promptAccountId,
+  type ChannelOnboardingAdapter,
+  type ChannelOnboardingDmPolicy,
+  type WizardPrompter,
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+} from "openclaw/plugin-sdk";
+import {
+  listGoHighLevelAccountIds,
+  resolveDefaultGoHighLevelAccountId,
+  resolveGoHighLevelAccount,
+} from "./accounts.js";
+
+const channel = "gohighlevel" as const;
+
+const ENV_API_KEY = "GHL_API_KEY";
+
+function setGoHighLevelDmPolicy(cfg: OpenClawConfig, policy: DmPolicy) {
+  const allowFrom =
+    policy === "open"
+      ? addWildcardAllowFrom(cfg.channels?.["gohighlevel"]?.dm?.allowFrom)
+      : undefined;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      gohighlevel: {
+        ...cfg.channels?.["gohighlevel"],
+        dm: {
+          ...cfg.channels?.["gohighlevel"]?.dm,
+          policy,
+          ...(allowFrom ? { allowFrom } : {}),
+        },
+      },
+    },
+  };
+}
+
+function parseAllowFromInput(raw: string): string[] {
+  return raw
+    .split(/[\n,;]+/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+async function promptAllowFrom(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+}): Promise<OpenClawConfig> {
+  const current = params.cfg.channels?.["gohighlevel"]?.dm?.allowFrom ?? [];
+  const entry = await params.prompter.text({
+    message: "GoHighLevel allowFrom (contact IDs or phone numbers)",
+    placeholder: "contactId1, +15551234567",
+    initialValue: current[0] ? String(current[0]) : undefined,
+    validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+  });
+  const parts = parseAllowFromInput(String(entry));
+  const unique = mergeAllowFromEntries(undefined, parts);
+  return {
+    ...params.cfg,
+    channels: {
+      ...params.cfg.channels,
+      gohighlevel: {
+        ...params.cfg.channels?.["gohighlevel"],
+        enabled: true,
+        dm: {
+          ...params.cfg.channels?.["gohighlevel"]?.dm,
+          policy: "allowlist",
+          allowFrom: unique,
+        },
+      },
+    },
+  };
+}
+
+const dmPolicy: ChannelOnboardingDmPolicy = {
+  label: "GoHighLevel",
+  channel,
+  policyKey: "channels.gohighlevel.dm.policy",
+  allowFromKey: "channels.gohighlevel.dm.allowFrom",
+  getCurrent: (cfg) => cfg.channels?.["gohighlevel"]?.dm?.policy ?? "open",
+  setPolicy: (cfg, policy) => setGoHighLevelDmPolicy(cfg, policy),
+  promptAllowFrom,
+};
+
+function applyAccountConfig(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  patch: Record<string, unknown>;
+}): OpenClawConfig {
+  const { cfg, accountId, patch } = params;
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        gohighlevel: {
+          ...cfg.channels?.["gohighlevel"],
+          enabled: true,
+          ...patch,
+        },
+      },
+    };
+  }
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      gohighlevel: {
+        ...cfg.channels?.["gohighlevel"],
+        enabled: true,
+        accounts: {
+          ...cfg.channels?.["gohighlevel"]?.accounts,
+          [accountId]: {
+            ...cfg.channels?.["gohighlevel"]?.accounts?.[accountId],
+            enabled: true,
+            ...patch,
+          },
+        },
+      },
+    },
+  };
+}
+
+async function promptCredentials(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  accountId: string;
+}): Promise<OpenClawConfig> {
+  const { cfg, prompter, accountId } = params;
+  const envReady = accountId === DEFAULT_ACCOUNT_ID && Boolean(process.env[ENV_API_KEY]);
+  if (envReady) {
+    const useEnv = await prompter.confirm({
+      message: "Use GHL_API_KEY env var?",
+      initialValue: true,
+    });
+    if (useEnv) {
+      return applyAccountConfig({ cfg, accountId, patch: {} });
+    }
+  }
+
+  const apiKey = await prompter.text({
+    message: "GoHighLevel API key (Private Integration Token)",
+    placeholder: "pit-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+  });
+  return applyAccountConfig({
+    cfg,
+    accountId,
+    patch: { apiKey: String(apiKey).trim() },
+  });
+}
+
+async function promptLocationId(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  accountId: string;
+}): Promise<OpenClawConfig> {
+  const account = resolveGoHighLevelAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const currentLocation = account.locationId ?? "";
+  const locationId = await params.prompter.text({
+    message: "GoHighLevel Location ID",
+    placeholder: "xxxxxxxxxxxxxxxxxxxxxxxx",
+    initialValue: currentLocation || undefined,
+    validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+  });
+  return applyAccountConfig({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    patch: { locationId: String(locationId).trim() },
+  });
+}
+
+async function noteGoHighLevelSetup(prompter: WizardPrompter) {
+  await prompter.note(
+    [
+      "GoHighLevel uses a Private Integration Token for API access.",
+      "Create one in Settings > Integrations > Private Integrations.",
+      "Configure a GHL Workflow with 'Customer Replied' trigger to send webhooks.",
+      `Docs: ${formatDocsLink("/channels/gohighlevel", "channels/gohighlevel")}`,
+    ].join("\n"),
+    "GoHighLevel setup",
+  );
+}
+
+export const gohighlevelOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  dmPolicy,
+  getStatus: async ({ cfg }) => {
+    const configured = listGoHighLevelAccountIds(cfg).some(
+      (accountId) => resolveGoHighLevelAccount({ cfg, accountId }).credentialSource !== "none",
+    );
+    return {
+      channel,
+      configured,
+      statusLines: [`GoHighLevel: ${configured ? "configured" : "needs API key"}`],
+      selectionHint: configured ? "configured" : "needs auth",
+    };
+  },
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const override = accountOverrides["gohighlevel"]?.trim();
+    const defaultAccountId = resolveDefaultGoHighLevelAccountId(cfg);
+    let accountId = override ? normalizeAccountId(override) : defaultAccountId;
+    if (shouldPromptAccountIds && !override) {
+      accountId = await promptAccountId({
+        cfg,
+        prompter,
+        label: "GoHighLevel",
+        currentId: accountId,
+        listAccountIds: listGoHighLevelAccountIds,
+        defaultAccountId,
+      });
+    }
+
+    let next = cfg;
+    await noteGoHighLevelSetup(prompter);
+    next = await promptCredentials({ cfg: next, prompter, accountId });
+    next = await promptLocationId({ cfg: next, prompter, accountId });
+
+    return { cfg: next, accountId };
+  },
+};

--- a/extensions/gohighlevel/src/onboarding.ts
+++ b/extensions/gohighlevel/src/onboarding.ts
@@ -18,7 +18,7 @@ import {
 
 const channel = "gohighlevel" as const;
 
-const ENV_API_KEY = "GHL_API_KEY";
+const ENV_API_KEY_NAMES = ["GHL_API_KEY", "GHL_TOKEN"] as const;
 
 function setGoHighLevelDmPolicy(cfg: OpenClawConfig, policy: DmPolicy) {
   const allowFrom =
@@ -133,10 +133,11 @@ async function promptCredentials(params: {
   accountId: string;
 }): Promise<OpenClawConfig> {
   const { cfg, prompter, accountId } = params;
-  const envReady = accountId === DEFAULT_ACCOUNT_ID && Boolean(process.env[ENV_API_KEY]);
+  const envKeyName = ENV_API_KEY_NAMES.find((n) => process.env[n]?.trim());
+  const envReady = accountId === DEFAULT_ACCOUNT_ID && Boolean(envKeyName);
   if (envReady) {
     const useEnv = await prompter.confirm({
-      message: "Use GHL_API_KEY env var?",
+      message: `Use ${envKeyName} env var?`,
       initialValue: true,
     });
     if (useEnv) {

--- a/extensions/gohighlevel/src/onboarding.ts
+++ b/extensions/gohighlevel/src/onboarding.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig, DmPolicy } from "openclaw/plugin-sdk";
+import type { OpenClawConfig, DmPolicy } from "openclaw/plugin-sdk/gohighlevel";
 import {
   addWildcardAllowFrom,
   formatDocsLink,
@@ -9,7 +9,7 @@ import {
   type WizardPrompter,
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/gohighlevel";
 import {
   listGoHighLevelAccountIds,
   resolveDefaultGoHighLevelAccountId,

--- a/extensions/gohighlevel/src/runtime.ts
+++ b/extensions/gohighlevel/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setGoHighLevelRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getGoHighLevelRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("GoHighLevel runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/gohighlevel/src/runtime.ts
+++ b/extensions/gohighlevel/src/runtime.ts
@@ -1,4 +1,4 @@
-import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk/gohighlevel";
 
 let runtime: PluginRuntime | null = null;
 

--- a/extensions/gohighlevel/src/types.ts
+++ b/extensions/gohighlevel/src/types.ts
@@ -1,0 +1,54 @@
+/** GHL webhook payload for inbound messages (InboundMessage event). */
+export type GHLWebhookPayload = {
+  type?: string;
+  locationId?: string;
+  contactId?: string;
+  conversationId?: string;
+  messageId?: string;
+  body?: string;
+  dateAdded?: string;
+  messageType?: string;
+  direction?: string;
+  status?: string;
+  contentType?: string;
+  attachments?: GHLAttachment[];
+  from?: string;
+  to?: string;
+};
+
+export type GHLAttachment = {
+  url?: string;
+  contentType?: string;
+  fileName?: string;
+};
+
+/** GHL Conversations API: send message response. */
+export type GHLSendMessageResponse = {
+  conversationId?: string;
+  messageId?: string;
+  message?: string;
+  msg?: string;
+};
+
+/** GHL contact record. */
+export type GHLContact = {
+  id?: string;
+  contactName?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  locationId?: string;
+  tags?: string[];
+};
+
+/** GHL conversation record. */
+export type GHLConversation = {
+  id?: string;
+  contactId?: string;
+  locationId?: string;
+  lastMessageBody?: string;
+  lastMessageDate?: string;
+  type?: string;
+  unreadCount?: number;
+};

--- a/extensions/gohighlevel/src/types.ts
+++ b/extensions/gohighlevel/src/types.ts
@@ -22,7 +22,18 @@ export type GHLWebhookPayload = {
   email?: string;
   phone?: string;
   event_type?: string;
-  location?: { id?: string; name?: string };
+  tags?: string;
+  country?: string;
+  date_created?: string;
+  contact_source?: string;
+  contact_type?: string;
+  location?: { id?: string; name?: string; address?: string; city?: string; state?: string };
+  /** Nested message object from GHL Workflow triggers. */
+  message?: { type?: number; body?: string };
+  /** Workflow metadata injected by GHL. */
+  workflow?: { id?: string; name?: string };
+  /** Custom data fields configured in the GHL Workflow webhook action. */
+  customData?: { event_type?: string; body?: string; [key: string]: unknown };
 };
 
 export type GHLAttachment = {

--- a/extensions/gohighlevel/src/types.ts
+++ b/extensions/gohighlevel/src/types.ts
@@ -14,6 +14,15 @@ export type GHLWebhookPayload = {
   attachments?: GHLAttachment[];
   from?: string;
   to?: string;
+  // GHL Workflow "Customer Replied" webhook fields (snake_case, contact-centric)
+  contact_id?: string;
+  first_name?: string;
+  last_name?: string;
+  full_name?: string;
+  email?: string;
+  phone?: string;
+  event_type?: string;
+  location?: { id?: string; name?: string };
 };
 
 export type GHLAttachment = {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,10 @@
       "types": "./dist/plugin-sdk/google-gemini-cli-auth.d.ts",
       "default": "./dist/plugin-sdk/google-gemini-cli-auth.js"
     },
+    "./plugin-sdk/gohighlevel": {
+      "types": "./dist/plugin-sdk/gohighlevel.d.ts",
+      "default": "./dist/plugin-sdk/gohighlevel.js"
+    },
     "./plugin-sdk/googlechat": {
       "types": "./dist/plugin-sdk/googlechat.d.ts",
       "default": "./dist/plugin-sdk/googlechat.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 3.1004.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
-        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)
+        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
       '@clack/prompts':
         specifier: ^1.1.0
         version: 1.1.0
@@ -330,6 +330,12 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  extensions/gohighlevel:
+    dependencies:
+      openclaw:
+        specifier: '>=2026.1.26'
+        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+
   extensions/google-gemini-cli-auth: {}
 
   extensions/googlechat:
@@ -339,7 +345,7 @@ importers:
         version: 10.6.1
       openclaw:
         specifier: '>=2026.3.2'
-        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.5)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/imessage: {}
 
@@ -400,7 +406,7 @@ importers:
     dependencies:
       openclaw:
         specifier: '>=2026.3.2'
-        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.5)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/memory-lancedb:
     dependencies:
@@ -618,240 +624,216 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-bedrock-runtime@3.1000.0':
-    resolution: {integrity: sha512-GA96wgTFB4Z5vhysm+hErbgiEWZ9JqAl09BxARajL7Oanpf0KvdIjxuLp2rD/XqEIks9yG/5Rh9XIAoCUUTZXw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/client-bedrock-runtime@3.1004.0':
-    resolution: {integrity: sha512-t8cl+bPLlHZQD2Sw1a4hSLUybqJZU71+m8znkyeU8CHntFqEp2mMbuLKdHKaAYQ1fAApXMsvzenCAkDzNeeJlw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/client-bedrock@3.1000.0':
-    resolution: {integrity: sha512-wGU8uJXrPW/hZuHdPNVe1kAFIBiKcslBcoDBN0eYBzS13um8p5jJiQJ9WsD1nSpKCmyx7qZXc6xjcbIQPyOrrA==}
+  '@aws-sdk/client-bedrock-runtime@3.998.0':
+    resolution: {integrity: sha512-orRgpdNmdRLik+en3xDxlGuT5AxQU+GFUTMn97ZdRuPLnAiY7Y6/8VTsod6y97/3NB8xuTZbH9wNXzW97IWNMA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-bedrock@3.1004.0':
     resolution: {integrity: sha512-JbfZSV85IL+43S7rPBmeMbvoOYXs1wmrfbEpHkDBjkvbukRQWtoetiPAXNSKDfFq1qVsoq8sWPdoerDQwlUO8w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-s3@3.1000.0':
-    resolution: {integrity: sha512-7kPy33qNGq3NfwHC0412T6LDK1bp4+eiPzetX0sVd9cpTSXuQDKpoOFnB0Njj6uZjJDcLS3n2OeyarwwgkQ0Ow==}
+  '@aws-sdk/client-s3@3.1004.0':
+    resolution: {integrity: sha512-m0zNfpsona9jQdX1cHtHArOiuvSGZPsgp/KRZS2YjJhKah96G2UN3UNGZQ6aVjXIQjCY6UanCJo0uW9Xf2U41w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.15':
-    resolution: {integrity: sha512-AlC0oQ1/mdJ8vCIqu524j5RB7M8i8E24bbkZmya1CuiQxkY7SdIZAyw7NDNMGaNINQFq/8oGRMX0HeOfCVsl/A==}
+  '@aws-sdk/core@3.973.14':
+    resolution: {integrity: sha512-iAQ1jIGESTVjoqNNY9VlsE9FnCz+Hc8s+dgurF6WrgFyVIw+uggH+V102RFhwjRv4dLSSLfzjDwvQnLszov7TQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.973.18':
     resolution: {integrity: sha512-GUIlegfcK2LO1J2Y98sCJy63rQSiLiDOgVw7HiHPRqfI2vb3XozTVqemwO0VSGXp54ngCnAQz0Lf0YPCBINNxA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/crc64-nvme@3.972.3':
-    resolution: {integrity: sha512-UExeK+EFiq5LAcbHm96CQLSia+5pvpUVSAsVApscBzayb7/6dJBJKwV4/onsk4VbWSmqxDMcfuTD+pC4RxgZHg==}
+  '@aws-sdk/crc64-nvme@3.972.4':
+    resolution: {integrity: sha512-HKZIZLbRyvzo/bXZU7Zmk6XqU+1C9DjI56xd02vwuDIxedxBEqP17t9ExhbP9QFeNq/a3l9GOcyirFXxmbDhmw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.13':
-    resolution: {integrity: sha512-6ljXKIQ22WFKyIs1jbORIkGanySBHaPPTOI4OxACP5WXgbcR0nDYfqNJfXEGwCK7IzHdNbCSFsNKKs0qCexR8Q==}
+  '@aws-sdk/credential-provider-env@3.972.12':
+    resolution: {integrity: sha512-WPtj/iAYHHd+NDM6AZoilZwUz0nMaPxbTPGLA7nhyIYRZN2L8trqfbNvm7g/Jr3gzfKp1LpO6AtBTnrhz9WW2g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.16':
     resolution: {integrity: sha512-HrdtnadvTGAQUr18sPzGlE5El3ICphnH6SU7UQOMOWFgRKbTRNN8msTxM4emzguUso9CzaHU2xy5ctSrmK5YNA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.15':
-    resolution: {integrity: sha512-dJuSTreu/T8f24SHDNTjd7eQ4rabr0TzPh2UTCwYexQtzG3nTDKm1e5eIdhiroTMDkPEJeY+WPkA6F9wod/20A==}
+  '@aws-sdk/credential-provider-http@3.972.14':
+    resolution: {integrity: sha512-umtjCicH2o/Fcc8Fu1562UkDyt6gql4czTYVlUfHfAM8S4QEKggzmtHYYYpPfQcjFj1ajyy68ahYSuF67x4ptQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.18':
     resolution: {integrity: sha512-NyB6smuZAixND5jZumkpkunQ0voc4Mwgkd+SZ6cvAzIB7gK8HV8Zd4rS8Kn5MmoGgusyNfVGG+RLoYc4yFiw+A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.13':
-    resolution: {integrity: sha512-JKSoGb7XeabZLBJptpqoZIFbROUIS65NuQnEHGOpuT9GuuZwag2qciKANiDLFiYk4u8nSrJC9JIOnWKVvPVjeA==}
+  '@aws-sdk/credential-provider-ini@3.972.12':
+    resolution: {integrity: sha512-qjzgnMl6GIBbVeK74jBqSF07+s6kyeZl5R88qjMs302JlqkxE57jkvflDmZ9I017ffEWqIUa9/M4Hfp28qyu1g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.17':
     resolution: {integrity: sha512-dFqh7nfX43B8dO1aPQHOcjC0SnCJ83H3F+1LoCh3X1P7E7N09I+0/taID0asU6GCddfDExqnEvQtDdkuMe5tKQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.13':
-    resolution: {integrity: sha512-RtYcrxdnJHKY8MFQGLltCURcjuMjnaQpAxPE6+/QEdDHHItMKZgabRe/KScX737F9vJMQsmJy9EmMOkCnoC1JQ==}
+  '@aws-sdk/credential-provider-login@3.972.12':
+    resolution: {integrity: sha512-AO57y46PzG24bJzxWLk+FYJG6MzxvXoFXnOKnmKUGV43ub4/FS/4Rz7zCC6ThqUotgqEFd30l5LTAd65RP65pg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.17':
     resolution: {integrity: sha512-gf2E5b7LpKb+JX2oQsRIDxdRZjBFZt2olCGlWCdb3vBERbXIPgm2t1R5mEnwd4j0UEO/Tbg5zN2KJbHXttJqwA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.14':
-    resolution: {integrity: sha512-WqoC2aliIjQM/L3oFf6j+op/enT2i9Cc4UTxxMEKrJNECkq4/PlKE5BOjSYFcq6G9mz65EFbXJh7zOU4CvjSKQ==}
+  '@aws-sdk/credential-provider-node@3.972.13':
+    resolution: {integrity: sha512-ME2sgus+gFRtiudy5Xqj9iT/tj8lHOIGrFgktuO5skJU4EngOvTZ1Hpj8mknrW4FgWXmpWhc88NtEscUuuDpKw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.18':
     resolution: {integrity: sha512-ZDJa2gd1xiPg/nBDGhUlat02O8obaDEnICBAVS8qieZ0+nDfaB0Z3ec6gjZj27OqFTjnB/Q5a0GwQwb7rMVViw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.13':
-    resolution: {integrity: sha512-rsRG0LQA4VR+jnDyuqtXi2CePYSmfm5GNL9KxiW8DSe25YwJSr06W8TdUfONAC+rjsTI+aIH2rBGG5FjMeANrw==}
+  '@aws-sdk/credential-provider-process@3.972.12':
+    resolution: {integrity: sha512-msxrHBpVP5AOIDohNPCINUtL47f7XI1TEru3N13uM3nWUMvIRA1vFa8Tlxbxm1EntPPvLAxRmvE5EbjDjOZkbw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.16':
     resolution: {integrity: sha512-n89ibATwnLEg0ZdZmUds5bq8AfBAdoYEDpqP3uzPLaRuGelsKlIvCYSNNvfgGLi8NaHPNNhs1HjJZYbqkW9b+g==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.13':
-    resolution: {integrity: sha512-fr0UU1wx8kNHDhTQBXioc/YviSW8iXuAxHvnH7eQUtn8F8o/FU3uu6EUMvAQgyvn7Ne5QFnC0Cj0BFlwCk+RFw==}
+  '@aws-sdk/credential-provider-sso@3.972.12':
+    resolution: {integrity: sha512-D5iC5546hJyhobJN0szOT4KVeJQ8z/meZq2B3lEDZFcvHONKw+tzq36DAJUy3qLTueeB2geSxiHXngQlA11eoA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.17':
     resolution: {integrity: sha512-wGtte+48xnhnhHMl/MsxzacBPs5A+7JJedjiP452IkHY7vsbYKcvQBqFye8LwdTJVeHtBHv+JFeTscnwepoWGg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.13':
-    resolution: {integrity: sha512-a6iFMh1pgUH0TdcouBppLJUfPM7Yd3R9S1xFodPtCRoLqCz2RQFA3qjA8x4112PVYXEd4/pHX2eihapq39w0rA==}
+  '@aws-sdk/credential-provider-web-identity@3.972.12':
+    resolution: {integrity: sha512-yluBahBVsduoA/zgV0NAXtwwXvQ6tNn95dNA3Hg+vISdiPWA46QY0d9PLO2KpNbjtm+1oGcWxemS4fYTwJ0W1w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.17':
     resolution: {integrity: sha512-8aiVJh6fTdl8gcyL+sVNcNwTtWpmoFa1Sh7xlj6Z7L/cZ/tYMEBHq44wTYG8Kt0z/PpGNopD89nbj3FHl9QmTA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/eventstream-handler-node@3.972.10':
-    resolution: {integrity: sha512-g2Z9s6Y4iNh0wICaEqutgYgt/Pmhv5Ev9G3eKGFe2w9VuZDhc76vYdop6I5OocmpHV79d4TuLG+JWg5rQIVDVA==}
+  '@aws-sdk/eventstream-handler-node@3.972.8':
+    resolution: {integrity: sha512-tVrf8X7hKnqv3HyVraUbsQW5mfHlD++S5NSIbfQEx0sCRvIwUbTPDl/lJCxhNmZ2zjgUyBIXIKrWilFWBxzv+w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/eventstream-handler-node@3.972.9':
-    resolution: {integrity: sha512-mKPiiVssgFDWkAXdEDh8+wpr2pFSX/fBn2onXXnrfIAYbdZhYb4WilKbZ3SJMUnQi+Y48jZMam5J0RrgARluaA==}
+  '@aws-sdk/middleware-bucket-endpoint@3.972.7':
+    resolution: {integrity: sha512-goX+axlJ6PQlRnzE2bQisZ8wVrlm6dXJfBzMJhd8LhAIBan/w1Kl73fJnalM/S+18VnpzIHumyV6DtgmvqG5IA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-bucket-endpoint@3.972.6':
-    resolution: {integrity: sha512-3H2bhvb7Cb/S6WFsBy/Dy9q2aegC9JmGH1inO8Lb2sWirSqpLJlZmvQHPE29h2tIxzv6el/14X/tLCQ8BQU6ZQ==}
+  '@aws-sdk/middleware-eventstream@3.972.5':
+    resolution: {integrity: sha512-j8sFerTrzS9tEJhiW2k+T9hsELE+13D5H+mqMjTRyPSgAOebkiK9d4t8vjbLOXuk7yi5lop40x15MubgcjpLmQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-eventstream@3.972.6':
-    resolution: {integrity: sha512-mB2+3G/oxRC+y9WRk0KCdradE2rSfxxJpcOSmAm+vDh3ex3WQHVLZ1catNIe1j5NQ+3FLBsNMRPVGkZ43PRpjw==}
+  '@aws-sdk/middleware-expect-continue@3.972.7':
+    resolution: {integrity: sha512-mvWqvm61bmZUKmmrtl2uWbokqpenY3Mc3Jf4nXB/Hse6gWxLPaCQThmhPBDzsPSV8/Odn8V6ovWt3pZ7vy4BFQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-eventstream@3.972.7':
-    resolution: {integrity: sha512-VWndapHYCfwLgPpCb/xwlMKG4imhFzKJzZcKOEioGn7OHY+6gdr0K7oqy1HZgbLa3ACznZ9fku+DzmAi8fUC0g==}
+  '@aws-sdk/middleware-flexible-checksums@3.973.4':
+    resolution: {integrity: sha512-7CH2jcGmkvkHc5Buz9IGbdjq1729AAlgYJiAvGq7qhCHqYleCsriWdSnmsqWTwdAfXHMT+pkxX3w6v5tJNcSug==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-expect-continue@3.972.6':
-    resolution: {integrity: sha512-QMdffpU+GkSGC+bz6WdqlclqIeCsOfgX8JFZ5xvwDtX+UTj4mIXm3uXu7Ko6dBseRcJz1FA6T9OmlAAY6JgJUg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-flexible-checksums@3.973.1':
-    resolution: {integrity: sha512-QLXsxsI6VW8LuGK+/yx699wzqP/NMCGk/hSGP+qtB+Lcff+23UlbahyouLlk+nfT7Iu021SkXBhnAuVd6IZcPw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-host-header@3.972.6':
-    resolution: {integrity: sha512-5XHwjPH1lHB+1q4bfC7T8Z5zZrZXfaLcjSMwTd1HPSPrCmPFMbg3UQ5vgNWcVj0xoX4HWqTGkSf2byrjlnRg5w==}
+  '@aws-sdk/middleware-host-header@3.972.5':
+    resolution: {integrity: sha512-dVA0m1cEQ2iA6yB19aHvWNeUVTuvTt3AXzT0aiIu2uxk0S7AcmwDCDaRgYa/v+eFHcJVxEnpYTozqA7X62xinw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-host-header@3.972.7':
     resolution: {integrity: sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-location-constraint@3.972.6':
-    resolution: {integrity: sha512-XdZ2TLwyj3Am6kvUc67vquQvs6+D8npXvXgyEUJAdkUDx5oMFJKOqpK+UpJhVDsEL068WAJl2NEGzbSik7dGJQ==}
+  '@aws-sdk/middleware-location-constraint@3.972.7':
+    resolution: {integrity: sha512-vdK1LJfffBp87Lj0Bw3WdK1rJk9OLDYdQpqoKgmpIZPe+4+HawZ6THTbvjhJt4C4MNnRrHTKHQjkwBiIpDBoig==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-logger@3.972.6':
-    resolution: {integrity: sha512-iFnaMFMQdljAPrvsCVKYltPt2j40LQqukAbXvW7v0aL5I+1GO7bZ/W8m12WxW3gwyK5p5u1WlHg8TSAizC5cZw==}
+  '@aws-sdk/middleware-logger@3.972.5':
+    resolution: {integrity: sha512-03RqplLZjUTkYi0dDPR/bbOLnDLFNdaVvNENgA3XK7Ph1MhEBhUYlgoGfOyRAKApDZ+WG4ykOoA8jI8J04jmFA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-logger@3.972.7':
     resolution: {integrity: sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-recursion-detection@3.972.6':
-    resolution: {integrity: sha512-dY4v3of5EEMvik6+UDwQ96KfUFDk8m1oZDdkSc5lwi4o7rFrjnv0A+yTV+gu230iybQZnKgDLg/rt2P3H+Vscw==}
+  '@aws-sdk/middleware-recursion-detection@3.972.5':
+    resolution: {integrity: sha512-2QSuuVkpHTe84+mDdnFjHX8rAP3g0yYwLVAhS3lQN1rW5Z/zNsf8/pYQrLjLO4n4sPCsUAkTa0Vrod0lk+o1Tg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-recursion-detection@3.972.7':
     resolution: {integrity: sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.15':
-    resolution: {integrity: sha512-WDLgssevOU5BFx1s8jA7jj6cE5HuImz28sy9jKOaVtz0AW1lYqSzotzdyiybFaBcQTs5zxXOb2pUfyMxgEKY3Q==}
+  '@aws-sdk/middleware-sdk-s3@3.972.18':
+    resolution: {integrity: sha512-5E3XxaElrdyk6ZJ0TjH7Qm6ios4b/qQCiLr6oQ8NK7e4Kn6JBTJCaYioQCQ65BpZ1+l1mK5wTAac2+pEz0Smpw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-ssec@3.972.6':
-    resolution: {integrity: sha512-acvMUX9jF4I2Ew+Z/EA6gfaFaz9ehci5wxBmXCZeulLuv8m+iGf6pY9uKz8TPjg39bdAz3hxoE0eLP8Qz+IYlA==}
+  '@aws-sdk/middleware-ssec@3.972.7':
+    resolution: {integrity: sha512-G9clGVuAml7d8DYzY6DnRi7TIIDRvZ3YpqJPz/8wnWS5fYx/FNWNmkO6iJVlVkQg9BfeMzd+bVPtPJOvC4B+nQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.15':
-    resolution: {integrity: sha512-ABlFVcIMmuRAwBT+8q5abAxOr7WmaINirDJBnqGY5b5jSDo00UMlg/G4a0xoAgwm6oAECeJcwkvDlxDwKf58fQ==}
+  '@aws-sdk/middleware-user-agent@3.972.14':
+    resolution: {integrity: sha512-PzDz+yRAQuIzd+4ZY3s6/TYRzlNKAn4Gae3E5uLV7NnYHqrZHFoAfKE4beXcu3C51pA2/FQ3X2qOGSYqUoN1WQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-user-agent@3.972.19':
     resolution: {integrity: sha512-Km90fcXt3W/iqujHzuM6IaDkYCj73gsYufcuWXApWdzoTy6KGk8fnchAjePMARU0xegIR3K4N3yIo1vy7OVe8A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-websocket@3.972.10':
-    resolution: {integrity: sha512-uNqRpbL6djE+XXO4cQ+P8ra37cxNNBP+2IfkVOXu1xFdGMfW+uOTxBQuDPpP43i40PBRBXK5un79l/oYpbzYkA==}
+  '@aws-sdk/middleware-websocket@3.972.9':
+    resolution: {integrity: sha512-O+FSwU9UvKd+QNuGLHqvmP33kkH4jh8pAgdMo3wbFLf+u30fS9/2gbSSWWtNCcWkSNFyG6RUlKU7jPSLApFfGw==}
     engines: {node: '>= 14.0.0'}
 
-  '@aws-sdk/middleware-websocket@3.972.12':
-    resolution: {integrity: sha512-iyPP6FVDKe/5wy5ojC0akpDFG1vX3FeCUU47JuwN8xfvT66xlEI8qUJZPtN55TJVFzzWZJpWL78eqUE31md08Q==}
-    engines: {node: '>= 14.0.0'}
-
-  '@aws-sdk/nested-clients@3.996.3':
-    resolution: {integrity: sha512-AU5TY1V29xqwg/MxmA2odwysTez+ccFAhmfRJk+QZT5HNv90UTA9qKd1J9THlsQkvmH7HWTEV1lDNxkQO5PzNw==}
+  '@aws-sdk/nested-clients@3.996.2':
+    resolution: {integrity: sha512-W+u6EM8WRxOIhAhR2mXMHSaUygqItpTehkgxLwJngXqr9RlAR4t6CtECH7o7QK0ct3oyi5Z8ViDHtPbel+D2Rg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.996.7':
     resolution: {integrity: sha512-MlGWA8uPaOs5AiTZ5JLM4uuWDm9EEAnm9cqwvqQIc6kEgel/8s1BaOWm9QgUcfc9K8qd7KkC3n43yDbeXOA2tg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.6':
-    resolution: {integrity: sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==}
+  '@aws-sdk/region-config-resolver@3.972.5':
+    resolution: {integrity: sha512-AOitrygDwfTNCLCW7L+GScDy1p49FZ6WutTUFWROouoPetfVNmpL4q8TWD3MhfY/ynhoGhleUQENrBH374EU8w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.7':
     resolution: {integrity: sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/s3-request-presigner@3.1000.0':
-    resolution: {integrity: sha512-DP6EbwCD0CKzBwBnT1X6STB5i+bY765CxjMbWCATDhCgOB343Q6AHM9c1S/300Uc5waXWtI/Wdeak9Ru56JOvg==}
+  '@aws-sdk/s3-request-presigner@3.1004.0':
+    resolution: {integrity: sha512-JlYj2tDr14czOkXtsK8x27xein8MgHtYzI1d2V3uswlh/ngZncrRhbWXnqW35DsRUSVj8cmvabKxilVitRJ0rw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.996.3':
-    resolution: {integrity: sha512-gQYI/Buwp0CAGQxY7mR5VzkP56rkWq2Y1ROkFuXh5XY94DsSjJw62B3I0N0lysQmtwiL2ht2KHI9NylM/RP4FA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1000.0':
-    resolution: {integrity: sha512-eOI+8WPtWpLdlYBGs8OCK3k5uIMUHVsNG3AFO4kaRaZcKReJ/2OO6+2O2Dd/3vTzM56kRjSKe7mBOCwa4PdYqg==}
+  '@aws-sdk/signature-v4-multi-region@3.996.6':
+    resolution: {integrity: sha512-NnsOQsVmJXy4+IdPFUjRCWPn9qNH1TzS/f7MiWgXeoHs903tJpAWQWQtoFvLccyPoBgomKP9L89RRr2YsT/L0g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1004.0':
     resolution: {integrity: sha512-j9BwZZId9sFp+4GPhf6KrwO8Tben2sXibZA8D1vv2I1zBdvkUHcBA2g4pkqIpTRalMTLC0NPkBPX0gERxfy/iA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.999.0':
-    resolution: {integrity: sha512-cx0hHUlgXULfykx4rdu/ciNAJaa3AL5xz3rieCz7NKJ68MJwlj3664Y8WR5MGgxfyYJBdamnkjNSx5Kekuc0cg==}
+  '@aws-sdk/token-providers@3.998.0':
+    resolution: {integrity: sha512-JFzi44tQnENZQ+1DYcHfoa/wTRKkccz0VsNMow0rvsxZtqUEkeV2pYFbir35mHTyUKju9995ay1MAGxLt1dpRA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.4':
-    resolution: {integrity: sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==}
+  '@aws-sdk/types@3.973.3':
+    resolution: {integrity: sha512-tma6D8/xHZHJEUqmr6ksZjZ0onyIUqKDQLyp50ttZJmS0IwFYzxBgp5CxFvpYAnah52V3UtgrqGA6E83gtT7NQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.5':
     resolution: {integrity: sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-arn-parser@3.972.2':
-    resolution: {integrity: sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==}
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-endpoints@3.996.3':
-    resolution: {integrity: sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==}
+  '@aws-sdk/util-endpoints@3.996.2':
+    resolution: {integrity: sha512-83E6T1CKi0/IozPzqRBKqduW0mS4UQdI3soBH6CG7UgupTADWunqEMOTuPWCs9XGjpJJ4ujj+yu7pn8svhp5yg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.996.4':
     resolution: {integrity: sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-format-url@3.972.6':
-    resolution: {integrity: sha512-0YNVNgFyziCejXJx0rzxPiD2rkxTWco4c9wiMF6n37Tb9aQvIF8+t7GyEyIFCwQHZ0VMQaAl+nCZHOYz5I5EKw==}
+  '@aws-sdk/util-format-url@3.972.5':
+    resolution: {integrity: sha512-PccfrPQVOEQSL8xaSvu988ESMlqdH1Qfk3AWPZksCOYPHyzYeUV988E+DBachXNV7tBVTUvK85cZYEZu7JtPxQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-format-url@3.972.7':
@@ -862,14 +844,14 @@ packages:
     resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-user-agent-browser@3.972.6':
-    resolution: {integrity: sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==}
+  '@aws-sdk/util-user-agent-browser@3.972.5':
+    resolution: {integrity: sha512-2ja1WqtuBaEAMgVoHYuWx393DF6ULqdt3OozeO7BosqouYaoU47Adtp9vEF+GImSG/Q8A+dqfwDULTTdMkHGUQ==}
 
   '@aws-sdk/util-user-agent-browser@3.972.7':
     resolution: {integrity: sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==}
 
-  '@aws-sdk/util-user-agent-node@3.973.0':
-    resolution: {integrity: sha512-A9J2G4Nf236e9GpaC1JnA8wRn6u6GjnOXiTwBLA6NUJhlBTIGfrTy+K1IazmF8y+4OFdW3O5TZlhyspJMqiqjA==}
+  '@aws-sdk/util-user-agent-node@3.972.13':
+    resolution: {integrity: sha512-PHErmuu+v6iAST48zcsB2cYwDKW45gk6qCp49t1p0NGZ4EaFPr/tA5jl0X/ekDwvWbuT0LTj++fjjdVQAbuh0Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -890,8 +872,8 @@ packages:
     resolution: {integrity: sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/xml-builder@3.972.8':
-    resolution: {integrity: sha512-Ql8elcUdYCha83Ol7NznBsgN5GVZnv3vUd86fEc6waU6oUdY0T1O9NODkEEOS/Uaogr87avDrUC6DSeM4oXjZg==}
+  '@aws-sdk/xml-builder@3.972.7':
+    resolution: {integrity: sha512-9GF86s6mHuc1TYCbuKatMDWl2PyK3KIkpRaI7ul2/gYZPfaLzKZ+ISHhxzVb9KVeakf75tUQe6CXW2gugSCXNw==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.3':
@@ -980,14 +962,8 @@ packages:
   '@cacheable/utils@2.3.4':
     resolution: {integrity: sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA==}
 
-  '@clack/core@1.0.1':
-    resolution: {integrity: sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==}
-
   '@clack/core@1.1.0':
     resolution: {integrity: sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==}
-
-  '@clack/prompts@1.0.1':
-    resolution: {integrity: sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==}
 
   '@clack/prompts@1.1.0':
     resolution: {integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==}
@@ -1224,15 +1200,6 @@ packages:
 
   '@google/genai@1.43.0':
     resolution: {integrity: sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-
-  '@google/genai@1.44.0':
-    resolution: {integrity: sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -1644,6 +1611,10 @@ packages:
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
+  '@mariozechner/pi-agent-core@0.55.0':
+    resolution: {integrity: sha512-8RLaOpmESBSqTSpA/6E9ihxYybhrkNa5LOYNdJst57LuDSDytfvkiTXlKA4DjsHua4PKopG9p0Wgqaem+kKvCA==}
+    engines: {node: '>=20.0.0'}
+
   '@mariozechner/pi-agent-core@0.55.3':
     resolution: {integrity: sha512-rqbfpQ9BrP6BDiW+Ps3A8Z/p9+Md/pAfc/ECq8JP6cwnZL/jQgU355KWZKtF8zM9az1p0Q9hIWi9cQygVo6Auw==}
     engines: {node: '>=20.0.0'}
@@ -1652,6 +1623,11 @@ packages:
     resolution: {integrity: sha512-WXsBbkNWOObFGHkhixaT8GXJpHDd3+fn8QntYF+4R8Sa9WB90ENXWidO6b7vcKX+JX0jjO5dIsQxmzosARJKlg==}
     engines: {node: '>=20.0.0'}
 
+  '@mariozechner/pi-ai@0.55.0':
+    resolution: {integrity: sha512-G5rutF5h1hFZgU1W2yYktZJegKUZVDhdGCxvl7zPOonrGBczuNBKmM87VXvl1m+t9718rYMsgTSBseGN0RhYug==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
   '@mariozechner/pi-ai@0.55.3':
     resolution: {integrity: sha512-f9jWoDzJR9Wy/H8JPMbjoM4WvVUeFZ65QdYA9UHIfoOopDfwWE8F8JHQOj5mmmILMacXuzsqA3J7MYqNWZRvvQ==}
     engines: {node: '>=20.0.0'}
@@ -1659,6 +1635,11 @@ packages:
 
   '@mariozechner/pi-ai@0.57.1':
     resolution: {integrity: sha512-Bd/J4a3YpdzJVyHLih0vDSdB0QPL4ti0XsAwtHOK/8eVhB0fHM1CpcgIrcBFJ23TMcKXMi0qamz18ERfp8tmgg==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@mariozechner/pi-coding-agent@0.55.0':
+    resolution: {integrity: sha512-neflZvWsbFDph3RG+b3/ItfFtGaQnOFJO+N+fsnIC3BG/FEUu1IK1lcMwrM1FGGSMfJnCv7Q3Zk5MSBiRj4azQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -1671,6 +1652,10 @@ packages:
     resolution: {integrity: sha512-u5MQEduj68rwVIsRsqrWkJYiJCyPph/a6bMoJAQKo1sb+Pc17Y/ojwa+wGssnUMjEB38AQKofWTVe8NFEpSWNw==}
     engines: {node: '>=20.6.0'}
     hasBin: true
+
+  '@mariozechner/pi-tui@0.55.0':
+    resolution: {integrity: sha512-qFdBsA0CTIQbUlN5hp1yJOSgJJiuTegx+oNPzpHxaMMBPjwMuh3Y8szBqE/2HxroA6mGSQfp/fzuPinTK1+Iyg==}
+    engines: {node: '>=20.0.0'}
 
   '@mariozechner/pi-tui@0.55.3':
     resolution: {integrity: sha512-Gh4wkYgiSPCJJaB/4wEWSL7Ga8bxSq1Crp1RPRT4vKybE/DG0W/MQr5VJDvktarxtJrD16ixScwE4dzdox/PIA==}
@@ -2814,12 +2799,12 @@ packages:
     resolution: {integrity: sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/chunked-blob-reader-native@4.2.2':
-    resolution: {integrity: sha512-QzzYIlf4yg0w5TQaC9VId3B3ugSk1MI/wb7tgcHtd7CBV9gNRKZrhc2EPSxSZuDy10zUZ0lomNMgkc6/VVe8xg==}
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/chunked-blob-reader@5.2.1':
-    resolution: {integrity: sha512-y5d4xRiD6TzeP5BWlb+Ig/VFqF+t9oANNhGeMqyzU7obw7FYgTgVi50i5JqBTeKp+TABeDIeeXFZdz65RipNtA==}
+  '@smithy/chunked-blob-reader@5.2.2':
+    resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/config-resolver@4.4.10':
@@ -2894,8 +2879,8 @@ packages:
     resolution: {integrity: sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/hash-blob-browser@4.2.11':
-    resolution: {integrity: sha512-DrcAx3PM6AEbWZxsKl6CWAGnVwiz28Wp1ZhNu+Hi4uI/6C1PIZBIaPM2VoqBDAsOWbM6ZVzOEQMxFLLdmb4eBQ==}
+  '@smithy/hash-blob-browser@4.2.12':
+    resolution: {integrity: sha512-1wQE33DsxkM/waftAhCH9VtJbUGyt1PJ9YRDpOu+q9FUi73LLFUZ2fD8A61g2mT1UY9k7b99+V1xZ41Rz4SHRQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-node@4.2.10':
@@ -2906,8 +2891,8 @@ packages:
     resolution: {integrity: sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/hash-stream-node@4.2.10':
-    resolution: {integrity: sha512-w78xsYrOlwXKwN5tv1GnKIRbHb1HygSpeZMP6xDxCPGf1U/xDHjCpJu64c5T35UKyEPwa0bPeIcvU69VY3khUA==}
+  '@smithy/hash-stream-node@4.2.11':
+    resolution: {integrity: sha512-hQsTjwPCRY8w9GK07w1RqJi3e+myh0UaOWBBhZ1UMSDgofH/Q1fEYzU1teaX6HkpX/eWDdm7tAGR0jBPlz9QEQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/invalid-dependency@4.2.10':
@@ -2930,8 +2915,8 @@ packages:
     resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/md5-js@4.2.10':
-    resolution: {integrity: sha512-Op+Dh6dPLWTjWITChFayDllIaCXRofOed8ecpggTC5fkh8yXes0vAEX7gRUfjGK+TlyxoCAA05gHbZW/zB9JwQ==}
+  '@smithy/md5-js@4.2.11':
+    resolution: {integrity: sha512-350X4kGIrty0Snx2OWv7rPM6p6vM7RzryvFs6B/56Cux3w3sChOb3bymo5oidXJlPcP9fIRxGUCk7GqpiSOtng==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-content-length@4.2.10':
@@ -3186,8 +3171,8 @@ packages:
     resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-waiter@4.2.10':
-    resolution: {integrity: sha512-4eTWph/Lkg1wZEDAyObwme0kmhEb7J/JjibY2znJdrYRgKbKqB7YoEhhJVJ4R1g/SYih4zuwX7LpJaM8RsnTVg==}
+  '@smithy/util-waiter@4.2.11':
+    resolution: {integrity: sha512-x7Rh2azQPs3XxbvCzcttRErKKvLnbZfqRf/gOjw2pb+ZscX88e5UkRPCB67bVnsFHxayvMvmePfKTqsRb+is1A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/uuid@1.1.1':
@@ -3291,12 +3276,12 @@ packages:
   '@swc/helpers@0.5.19':
     resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
 
-  '@thi.ng/bitstream@2.4.43':
-    resolution: {integrity: sha512-tObOEr+osboa0kqQPk7Ny0E3vVfBRch13YJO5RpaDDSkMQmoXK/pw3yW/6kKJIObt27YQol6pGlOZBvB8MsghQ==}
+  '@thi.ng/bitstream@2.4.41':
+    resolution: {integrity: sha512-treRzw3+7I1YCuilFtznwT3SGtceS9spUXhyBqeuKNTm4nIfMuvg4fNqx4GgpuS6cGPQNPMUJm0OyzKnSe2Emw==}
     engines: {node: '>=18'}
 
-  '@thi.ng/errors@2.6.5':
-    resolution: {integrity: sha512-XKfcJzxikMI1+MKSiABcLzI2WIsm4SxGEdLIIQjYqew3q3CoypGe+w5W/DMvMWF6eFWT6ONINbiJ6QMHFTfVzA==}
+  '@thi.ng/errors@2.6.3':
+    resolution: {integrity: sha512-owkOOKHf7MrAPN2jNpKWDdY/vjtPFiJf6oxZ3jkkhV6ICTu2iY1fXIR2wQ7kVEeybdtb0w24k2PtrU43OYCWdg==}
     engines: {node: '>=18'}
 
   '@tinyhttp/content-disposition@2.2.4':
@@ -3367,8 +3352,8 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@types/aws-lambda@8.10.161':
-    resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
+  '@types/aws-lambda@8.10.160':
+    resolution: {integrity: sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -3448,11 +3433,11 @@ packages:
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
-  '@types/node@20.19.37':
-    resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
+  '@types/node@20.19.34':
+    resolution: {integrity: sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==}
 
-  '@types/node@24.11.0':
-    resolution: {integrity: sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==}
+  '@types/node@24.10.14':
+    resolution: {integrity: sha512-OowOUbD1lBCOFIPOZ8xnMIhgqA4sCutMiYOmPHL1PTLt5+y1XA+g2+yC9OOyz8p+deMZqPZLxfMjYIfrKsPeFg==}
 
   '@types/node@25.3.5':
     resolution: {integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==}
@@ -3895,8 +3880,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.3:
+    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -4051,8 +4036,8 @@ packages:
     resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
     engines: {node: '>=4.0.0'}
 
-  command-line-usage@7.0.4:
-    resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
+  command-line-usage@7.0.3:
+    resolution: {integrity: sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==}
     engines: {node: '>=12.20.0'}
 
   commander@10.0.1:
@@ -4209,9 +4194,6 @@ packages:
 
   discord-api-types@0.38.37:
     resolution: {integrity: sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==}
-
-  discord-api-types@0.38.40:
-    resolution: {integrity: sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ==}
 
   discord-api-types@0.38.41:
     resolution: {integrity: sha512-yMECyR8j9c2fVTvCQ+Qc24pweYFIZk/XoxDOmt1UvPeSw5tK6gXBd/2hhP+FEAe9Y6ny8pRMaf618XDK4U53OQ==}
@@ -4512,10 +4494,6 @@ packages:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
-  fs-extra@11.3.4:
-    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
-    engines: {node: '>=14.14'}
-
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -4536,6 +4514,10 @@ packages:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
     deprecated: This package is no longer supported.
+
+  gaxios@7.1.2:
+    resolution: {integrity: sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==}
+    engines: {node: '>=18'}
 
   gaxios@7.1.3:
     resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
@@ -4614,10 +4596,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  grammy@1.41.0:
-    resolution: {integrity: sha512-CAAu74SLT+/QCg40FBhUuYJalVsxxCN3D0c31TzhFBsWWTdXrMXYjGsKngBdfvN6hQ/VzHczluj/ugZVetFNCQ==}
-    engines: {node: ^12.20.0 || >=14.13.1}
-
   grammy@1.41.1:
     resolution: {integrity: sha512-wcHAQ1e7svL3fJMpDchcQVcWUmywhuepOOjHUHmMmWAwUJEIyK5ea5sbSjZd+Gy1aMpZeP8VYJa+4tP+j1YptQ==}
     engines: {node: ^12.20.0 || >=14.13.1}
@@ -4661,8 +4639,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.12.5:
-    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
+  hono@4.11.10:
+    resolution: {integrity: sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.0.1:
@@ -4912,8 +4890,8 @@ packages:
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
-  json-with-bigint@3.5.7:
-    resolution: {integrity: sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==}
+  json-with-bigint@3.5.3:
+    resolution: {integrity: sha512-QObKu6nxy7NsxqR0VK4rkXnsNr5L9ElJaGEg+ucJ6J7/suoKZ0n+p76cu9aCqowytxEbwYNzvrMerfMkXneF5A==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -5334,8 +5312,8 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
-  node-addon-api@8.6.0:
-    resolution: {integrity: sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==}
+  node-addon-api@8.5.0:
+    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
     engines: {node: ^18 || ^20 || >= 21}
 
   node-api-headers@1.8.0:
@@ -5501,6 +5479,14 @@ packages:
         optional: true
       zod:
         optional: true
+
+  openclaw@2026.2.24:
+    resolution: {integrity: sha512-a6zrcS6v5tUWqzsFh5cNtyu5+Tra1UW5yvPtYhRYCKSS/q6lXrLu+dj0ylJPOHRPAho2alZZL1gw1Qd2hAd2sQ==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.89
+      node-llama-cpp: 3.15.1
 
   openclaw@2026.3.2:
     resolution: {integrity: sha512-Gkqx24m7PF1DUXPI968DuC9n52lTZ5hI3X5PIi0HosC7J7d6RLkgVppj1mxvgiQAWMp41E41elvoi/h4KBjFcQ==}
@@ -5808,8 +5794,8 @@ packages:
   pug@3.0.3:
     resolution: {integrity: sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==}
 
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -6274,8 +6260,8 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
-  strnum@2.2.0:
-    resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
@@ -6774,20 +6760,20 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.5
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.5
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-locate-window': 3.965.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -6818,25 +6804,25 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-bedrock-runtime@3.1000.0':
+  '@aws-sdk/client-bedrock-runtime@3.998.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/credential-provider-node': 3.972.14
-      '@aws-sdk/eventstream-handler-node': 3.972.9
-      '@aws-sdk/middleware-eventstream': 3.972.6
-      '@aws-sdk/middleware-host-header': 3.972.6
-      '@aws-sdk/middleware-logger': 3.972.6
-      '@aws-sdk/middleware-recursion-detection': 3.972.6
-      '@aws-sdk/middleware-user-agent': 3.972.15
-      '@aws-sdk/middleware-websocket': 3.972.10
-      '@aws-sdk/region-config-resolver': 3.972.6
-      '@aws-sdk/token-providers': 3.1000.0
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/util-endpoints': 3.996.3
-      '@aws-sdk/util-user-agent-browser': 3.972.6
-      '@aws-sdk/util-user-agent-node': 3.973.0
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/credential-provider-node': 3.972.13
+      '@aws-sdk/eventstream-handler-node': 3.972.8
+      '@aws-sdk/middleware-eventstream': 3.972.5
+      '@aws-sdk/middleware-host-header': 3.972.5
+      '@aws-sdk/middleware-logger': 3.972.5
+      '@aws-sdk/middleware-recursion-detection': 3.972.5
+      '@aws-sdk/middleware-user-agent': 3.972.14
+      '@aws-sdk/middleware-websocket': 3.972.9
+      '@aws-sdk/region-config-resolver': 3.972.5
+      '@aws-sdk/token-providers': 3.998.0
+      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/util-endpoints': 3.996.2
+      '@aws-sdk/util-user-agent-browser': 3.972.5
+      '@aws-sdk/util-user-agent-node': 3.972.13
       '@smithy/config-resolver': 4.4.9
       '@smithy/core': 3.23.6
       '@smithy/eventstream-serde-browser': 4.2.10
@@ -6865,103 +6851,6 @@ snapshots:
       '@smithy/util-middleware': 4.2.10
       '@smithy/util-retry': 4.2.10
       '@smithy/util-stream': 4.5.15
-      '@smithy/util-utf8': 4.2.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-bedrock-runtime@3.1004.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/credential-provider-node': 3.972.18
-      '@aws-sdk/eventstream-handler-node': 3.972.10
-      '@aws-sdk/middleware-eventstream': 3.972.7
-      '@aws-sdk/middleware-host-header': 3.972.7
-      '@aws-sdk/middleware-logger': 3.972.7
-      '@aws-sdk/middleware-recursion-detection': 3.972.7
-      '@aws-sdk/middleware-user-agent': 3.972.19
-      '@aws-sdk/middleware-websocket': 3.972.12
-      '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/token-providers': 3.1004.0
-      '@aws-sdk/types': 3.973.5
-      '@aws-sdk/util-endpoints': 3.996.4
-      '@aws-sdk/util-user-agent-browser': 3.972.7
-      '@aws-sdk/util-user-agent-node': 3.973.4
-      '@smithy/config-resolver': 4.4.10
-      '@smithy/core': 3.23.9
-      '@smithy/eventstream-serde-browser': 4.2.11
-      '@smithy/eventstream-serde-config-resolver': 4.3.11
-      '@smithy/eventstream-serde-node': 4.2.11
-      '@smithy/fetch-http-handler': 5.3.13
-      '@smithy/hash-node': 4.2.11
-      '@smithy/invalid-dependency': 4.2.11
-      '@smithy/middleware-content-length': 4.2.11
-      '@smithy/middleware-endpoint': 4.4.23
-      '@smithy/middleware-retry': 4.4.40
-      '@smithy/middleware-serde': 4.2.12
-      '@smithy/middleware-stack': 4.2.11
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/node-http-handler': 4.4.14
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.13.0
-      '@smithy/url-parser': 4.2.11
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.39
-      '@smithy/util-defaults-mode-node': 4.2.42
-      '@smithy/util-endpoints': 3.3.2
-      '@smithy/util-middleware': 4.2.11
-      '@smithy/util-retry': 4.2.11
-      '@smithy/util-stream': 4.5.17
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-bedrock@3.1000.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/credential-provider-node': 3.972.14
-      '@aws-sdk/middleware-host-header': 3.972.6
-      '@aws-sdk/middleware-logger': 3.972.6
-      '@aws-sdk/middleware-recursion-detection': 3.972.6
-      '@aws-sdk/middleware-user-agent': 3.972.15
-      '@aws-sdk/region-config-resolver': 3.972.6
-      '@aws-sdk/token-providers': 3.1000.0
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/util-endpoints': 3.996.3
-      '@aws-sdk/util-user-agent-browser': 3.972.6
-      '@aws-sdk/util-user-agent-node': 3.973.0
-      '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.23.6
-      '@smithy/fetch-http-handler': 5.3.11
-      '@smithy/hash-node': 4.2.10
-      '@smithy/invalid-dependency': 4.2.10
-      '@smithy/middleware-content-length': 4.2.10
-      '@smithy/middleware-endpoint': 4.4.20
-      '@smithy/middleware-retry': 4.4.37
-      '@smithy/middleware-serde': 4.2.11
-      '@smithy/middleware-stack': 4.2.10
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.4.12
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.13.0
-      '@smithy/url-parser': 4.2.10
-      '@smithy/util-base64': 4.3.1
-      '@smithy/util-body-length-browser': 4.2.1
-      '@smithy/util-body-length-node': 4.2.2
-      '@smithy/util-defaults-mode-browser': 4.3.36
-      '@smithy/util-defaults-mode-node': 4.2.39
-      '@smithy/util-endpoints': 3.3.1
-      '@smithy/util-middleware': 4.2.10
-      '@smithy/util-retry': 4.2.10
       '@smithy/util-utf8': 4.2.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7012,70 +6901,70 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-s3@3.1000.0':
+  '@aws-sdk/client-s3@3.1004.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/credential-provider-node': 3.972.14
-      '@aws-sdk/middleware-bucket-endpoint': 3.972.6
-      '@aws-sdk/middleware-expect-continue': 3.972.6
-      '@aws-sdk/middleware-flexible-checksums': 3.973.1
-      '@aws-sdk/middleware-host-header': 3.972.6
-      '@aws-sdk/middleware-location-constraint': 3.972.6
-      '@aws-sdk/middleware-logger': 3.972.6
-      '@aws-sdk/middleware-recursion-detection': 3.972.6
-      '@aws-sdk/middleware-sdk-s3': 3.972.15
-      '@aws-sdk/middleware-ssec': 3.972.6
-      '@aws-sdk/middleware-user-agent': 3.972.15
-      '@aws-sdk/region-config-resolver': 3.972.6
-      '@aws-sdk/signature-v4-multi-region': 3.996.3
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/util-endpoints': 3.996.3
-      '@aws-sdk/util-user-agent-browser': 3.972.6
-      '@aws-sdk/util-user-agent-node': 3.973.0
-      '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.23.6
-      '@smithy/eventstream-serde-browser': 4.2.10
-      '@smithy/eventstream-serde-config-resolver': 4.3.10
-      '@smithy/eventstream-serde-node': 4.2.10
-      '@smithy/fetch-http-handler': 5.3.11
-      '@smithy/hash-blob-browser': 4.2.11
-      '@smithy/hash-node': 4.2.10
-      '@smithy/hash-stream-node': 4.2.10
-      '@smithy/invalid-dependency': 4.2.10
-      '@smithy/md5-js': 4.2.10
-      '@smithy/middleware-content-length': 4.2.10
-      '@smithy/middleware-endpoint': 4.4.20
-      '@smithy/middleware-retry': 4.4.37
-      '@smithy/middleware-serde': 4.2.11
-      '@smithy/middleware-stack': 4.2.10
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.4.12
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/smithy-client': 4.12.0
+      '@aws-sdk/core': 3.973.18
+      '@aws-sdk/credential-provider-node': 3.972.18
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.7
+      '@aws-sdk/middleware-expect-continue': 3.972.7
+      '@aws-sdk/middleware-flexible-checksums': 3.973.4
+      '@aws-sdk/middleware-host-header': 3.972.7
+      '@aws-sdk/middleware-location-constraint': 3.972.7
+      '@aws-sdk/middleware-logger': 3.972.7
+      '@aws-sdk/middleware-recursion-detection': 3.972.7
+      '@aws-sdk/middleware-sdk-s3': 3.972.18
+      '@aws-sdk/middleware-ssec': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.19
+      '@aws-sdk/region-config-resolver': 3.972.7
+      '@aws-sdk/signature-v4-multi-region': 3.996.6
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-endpoints': 3.996.4
+      '@aws-sdk/util-user-agent-browser': 3.972.7
+      '@aws-sdk/util-user-agent-node': 3.973.4
+      '@smithy/config-resolver': 4.4.10
+      '@smithy/core': 3.23.9
+      '@smithy/eventstream-serde-browser': 4.2.11
+      '@smithy/eventstream-serde-config-resolver': 4.3.11
+      '@smithy/eventstream-serde-node': 4.2.11
+      '@smithy/fetch-http-handler': 5.3.13
+      '@smithy/hash-blob-browser': 4.2.12
+      '@smithy/hash-node': 4.2.11
+      '@smithy/hash-stream-node': 4.2.11
+      '@smithy/invalid-dependency': 4.2.11
+      '@smithy/md5-js': 4.2.11
+      '@smithy/middleware-content-length': 4.2.11
+      '@smithy/middleware-endpoint': 4.4.23
+      '@smithy/middleware-retry': 4.4.40
+      '@smithy/middleware-serde': 4.2.12
+      '@smithy/middleware-stack': 4.2.11
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.3
       '@smithy/types': 4.13.0
-      '@smithy/url-parser': 4.2.10
-      '@smithy/util-base64': 4.3.1
-      '@smithy/util-body-length-browser': 4.2.1
-      '@smithy/util-body-length-node': 4.2.2
-      '@smithy/util-defaults-mode-browser': 4.3.36
-      '@smithy/util-defaults-mode-node': 4.2.39
-      '@smithy/util-endpoints': 3.3.1
-      '@smithy/util-middleware': 4.2.10
-      '@smithy/util-retry': 4.2.10
-      '@smithy/util-stream': 4.5.15
-      '@smithy/util-utf8': 4.2.1
-      '@smithy/util-waiter': 4.2.10
+      '@smithy/url-parser': 4.2.11
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.39
+      '@smithy/util-defaults-mode-node': 4.2.42
+      '@smithy/util-endpoints': 3.3.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-retry': 4.2.11
+      '@smithy/util-stream': 4.5.17
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.2.11
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.973.15':
+  '@aws-sdk/core@3.973.14':
     dependencies:
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/xml-builder': 3.972.8
+      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/xml-builder': 3.972.7
       '@smithy/core': 3.23.6
       '@smithy/node-config-provider': 4.3.10
       '@smithy/property-provider': 4.2.10
@@ -7104,15 +6993,15 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/crc64-nvme@3.972.3':
+  '@aws-sdk/crc64-nvme@3.972.4':
     dependencies:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.13':
+  '@aws-sdk/credential-provider-env@3.972.12':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/types': 3.973.3
       '@smithy/property-provider': 4.2.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
@@ -7125,10 +7014,10 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.15':
+  '@aws-sdk/credential-provider-http@3.972.14':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/types': 3.973.3
       '@smithy/fetch-http-handler': 5.3.11
       '@smithy/node-http-handler': 4.4.12
       '@smithy/property-provider': 4.2.10
@@ -7151,17 +7040,17 @@ snapshots:
       '@smithy/util-stream': 4.5.17
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.13':
+  '@aws-sdk/credential-provider-ini@3.972.12':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/credential-provider-env': 3.972.13
-      '@aws-sdk/credential-provider-http': 3.972.15
-      '@aws-sdk/credential-provider-login': 3.972.13
-      '@aws-sdk/credential-provider-process': 3.972.13
-      '@aws-sdk/credential-provider-sso': 3.972.13
-      '@aws-sdk/credential-provider-web-identity': 3.972.13
-      '@aws-sdk/nested-clients': 3.996.3
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/credential-provider-env': 3.972.12
+      '@aws-sdk/credential-provider-http': 3.972.14
+      '@aws-sdk/credential-provider-login': 3.972.12
+      '@aws-sdk/credential-provider-process': 3.972.12
+      '@aws-sdk/credential-provider-sso': 3.972.12
+      '@aws-sdk/credential-provider-web-identity': 3.972.12
+      '@aws-sdk/nested-clients': 3.996.2
+      '@aws-sdk/types': 3.973.3
       '@smithy/credential-provider-imds': 4.2.10
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
@@ -7189,11 +7078,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.13':
+  '@aws-sdk/credential-provider-login@3.972.12':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/nested-clients': 3.996.3
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/nested-clients': 3.996.2
+      '@aws-sdk/types': 3.973.3
       '@smithy/property-provider': 4.2.10
       '@smithy/protocol-http': 5.3.10
       '@smithy/shared-ini-file-loader': 4.4.5
@@ -7215,15 +7104,15 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.14':
+  '@aws-sdk/credential-provider-node@3.972.13':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.13
-      '@aws-sdk/credential-provider-http': 3.972.15
-      '@aws-sdk/credential-provider-ini': 3.972.13
-      '@aws-sdk/credential-provider-process': 3.972.13
-      '@aws-sdk/credential-provider-sso': 3.972.13
-      '@aws-sdk/credential-provider-web-identity': 3.972.13
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/credential-provider-env': 3.972.12
+      '@aws-sdk/credential-provider-http': 3.972.14
+      '@aws-sdk/credential-provider-ini': 3.972.12
+      '@aws-sdk/credential-provider-process': 3.972.12
+      '@aws-sdk/credential-provider-sso': 3.972.12
+      '@aws-sdk/credential-provider-web-identity': 3.972.12
+      '@aws-sdk/types': 3.973.3
       '@smithy/credential-provider-imds': 4.2.10
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
@@ -7249,10 +7138,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.13':
+  '@aws-sdk/credential-provider-process@3.972.12':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/types': 3.973.3
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.13.0
@@ -7267,12 +7156,12 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.13':
+  '@aws-sdk/credential-provider-sso@3.972.12':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/nested-clients': 3.996.3
-      '@aws-sdk/token-providers': 3.999.0
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/nested-clients': 3.996.2
+      '@aws-sdk/token-providers': 3.998.0
+      '@aws-sdk/types': 3.973.3
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.13.0
@@ -7293,11 +7182,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.13':
+  '@aws-sdk/credential-provider-web-identity@3.972.12':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/nested-clients': 3.996.3
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/nested-clients': 3.996.2
+      '@aws-sdk/types': 3.973.3
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.13.0
@@ -7317,71 +7206,57 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/eventstream-handler-node@3.972.10':
+  '@aws-sdk/eventstream-handler-node@3.972.8':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/eventstream-codec': 4.2.11
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@aws-sdk/eventstream-handler-node@3.972.9':
-    dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.3
       '@smithy/eventstream-codec': 4.2.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-bucket-endpoint@3.972.6':
+  '@aws-sdk/middleware-bucket-endpoint@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/util-arn-parser': 3.972.2
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/protocol-http': 5.3.10
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/protocol-http': 5.3.11
       '@smithy/types': 4.13.0
-      '@smithy/util-config-provider': 4.2.1
+      '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-eventstream@3.972.6':
+  '@aws-sdk/middleware-eventstream@3.972.5':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.3
       '@smithy/protocol-http': 5.3.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-eventstream@3.972.7':
+  '@aws-sdk/middleware-expect-continue@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.5
       '@smithy/protocol-http': 5.3.11
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-expect-continue@3.972.6':
-    dependencies:
-      '@aws-sdk/types': 3.973.4
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-flexible-checksums@3.973.1':
+  '@aws-sdk/middleware-flexible-checksums@3.973.4':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/crc64-nvme': 3.972.3
-      '@aws-sdk/types': 3.973.4
-      '@smithy/is-array-buffer': 4.2.1
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/protocol-http': 5.3.10
+      '@aws-sdk/core': 3.973.18
+      '@aws-sdk/crc64-nvme': 3.972.4
+      '@aws-sdk/types': 3.973.5
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/protocol-http': 5.3.11
       '@smithy/types': 4.13.0
-      '@smithy/util-middleware': 4.2.10
-      '@smithy/util-stream': 4.5.15
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-stream': 4.5.17
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-host-header@3.972.6':
+  '@aws-sdk/middleware-host-header@3.972.5':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.3
       '@smithy/protocol-http': 5.3.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
@@ -7393,15 +7268,15 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-location-constraint@3.972.6':
+  '@aws-sdk/middleware-location-constraint@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.5
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-logger@3.972.6':
+  '@aws-sdk/middleware-logger@3.972.5':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.3
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
@@ -7411,9 +7286,9 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.6':
+  '@aws-sdk/middleware-recursion-detection@3.972.5':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.3
       '@aws/lambda-invoke-store': 0.2.3
       '@smithy/protocol-http': 5.3.10
       '@smithy/types': 4.13.0
@@ -7427,34 +7302,34 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.15':
+  '@aws-sdk/middleware-sdk-s3@3.972.18':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/util-arn-parser': 3.972.2
-      '@smithy/core': 3.23.6
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/signature-v4': 5.3.10
-      '@smithy/smithy-client': 4.12.0
+      '@aws-sdk/core': 3.973.18
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.9
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/signature-v4': 5.3.11
+      '@smithy/smithy-client': 4.12.3
       '@smithy/types': 4.13.0
-      '@smithy/util-config-provider': 4.2.1
-      '@smithy/util-middleware': 4.2.10
-      '@smithy/util-stream': 4.5.15
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-stream': 4.5.17
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-ssec@3.972.6':
+  '@aws-sdk/middleware-ssec@3.972.7':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.5
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.15':
+  '@aws-sdk/middleware-user-agent@3.972.14':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/util-endpoints': 3.996.3
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/util-endpoints': 3.996.2
       '@smithy/core': 3.23.6
       '@smithy/protocol-http': 5.3.10
       '@smithy/types': 4.13.0
@@ -7471,10 +7346,10 @@ snapshots:
       '@smithy/util-retry': 4.2.11
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-websocket@3.972.10':
+  '@aws-sdk/middleware-websocket@3.972.9':
     dependencies:
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/util-format-url': 3.972.6
+      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/util-format-url': 3.972.5
       '@smithy/eventstream-codec': 4.2.10
       '@smithy/eventstream-serde-browser': 4.2.10
       '@smithy/fetch-http-handler': 5.3.11
@@ -7486,35 +7361,20 @@ snapshots:
       '@smithy/util-utf8': 4.2.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-websocket@3.972.12':
-    dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@aws-sdk/util-format-url': 3.972.7
-      '@smithy/eventstream-codec': 4.2.11
-      '@smithy/eventstream-serde-browser': 4.2.11
-      '@smithy/fetch-http-handler': 5.3.13
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/signature-v4': 5.3.11
-      '@smithy/types': 4.13.0
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.996.3':
+  '@aws-sdk/nested-clients@3.996.2':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/middleware-host-header': 3.972.6
-      '@aws-sdk/middleware-logger': 3.972.6
-      '@aws-sdk/middleware-recursion-detection': 3.972.6
-      '@aws-sdk/middleware-user-agent': 3.972.15
-      '@aws-sdk/region-config-resolver': 3.972.6
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/util-endpoints': 3.996.3
-      '@aws-sdk/util-user-agent-browser': 3.972.6
-      '@aws-sdk/util-user-agent-node': 3.973.0
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/middleware-host-header': 3.972.5
+      '@aws-sdk/middleware-logger': 3.972.5
+      '@aws-sdk/middleware-recursion-detection': 3.972.5
+      '@aws-sdk/middleware-user-agent': 3.972.14
+      '@aws-sdk/region-config-resolver': 3.972.5
+      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/util-endpoints': 3.996.2
+      '@aws-sdk/util-user-agent-browser': 3.972.5
+      '@aws-sdk/util-user-agent-node': 3.972.13
       '@smithy/config-resolver': 4.4.9
       '@smithy/core': 3.23.6
       '@smithy/fetch-http-handler': 5.3.11
@@ -7587,9 +7447,9 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.6':
+  '@aws-sdk/region-config-resolver@3.972.5':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.3
       '@smithy/config-resolver': 4.4.9
       '@smithy/node-config-provider': 4.3.10
       '@smithy/types': 4.13.0
@@ -7603,37 +7463,25 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/s3-request-presigner@3.1000.0':
+  '@aws-sdk/s3-request-presigner@3.1004.0':
     dependencies:
-      '@aws-sdk/signature-v4-multi-region': 3.996.3
-      '@aws-sdk/types': 3.973.4
-      '@aws-sdk/util-format-url': 3.972.6
-      '@smithy/middleware-endpoint': 4.4.20
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/smithy-client': 4.12.0
+      '@aws-sdk/signature-v4-multi-region': 3.996.6
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-format-url': 3.972.7
+      '@smithy/middleware-endpoint': 4.4.23
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.3
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.3':
+  '@aws-sdk/signature-v4-multi-region@3.996.6':
     dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.15
-      '@aws-sdk/types': 3.973.4
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/signature-v4': 5.3.10
+      '@aws-sdk/middleware-sdk-s3': 3.972.18
+      '@aws-sdk/types': 3.973.5
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/signature-v4': 5.3.11
       '@smithy/types': 4.13.0
       tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1000.0':
-    dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/nested-clients': 3.996.3
-      '@aws-sdk/types': 3.973.4
-      '@smithy/property-provider': 4.2.10
-      '@smithy/shared-ini-file-loader': 4.4.5
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/token-providers@3.1004.0':
     dependencies:
@@ -7647,11 +7495,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/token-providers@3.999.0':
+  '@aws-sdk/token-providers@3.998.0':
     dependencies:
-      '@aws-sdk/core': 3.973.15
-      '@aws-sdk/nested-clients': 3.996.3
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/core': 3.973.14
+      '@aws-sdk/nested-clients': 3.996.2
+      '@aws-sdk/types': 3.973.3
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.13.0
@@ -7659,7 +7507,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/types@3.973.4':
+  '@aws-sdk/types@3.973.3':
     dependencies:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
@@ -7669,13 +7517,13 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-arn-parser@3.972.2':
+  '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-endpoints@3.996.3':
+  '@aws-sdk/util-endpoints@3.996.2':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.3
       '@smithy/types': 4.13.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-endpoints': 3.3.1
@@ -7689,9 +7537,9 @@ snapshots:
       '@smithy/util-endpoints': 3.3.2
       tslib: 2.8.1
 
-  '@aws-sdk/util-format-url@3.972.6':
+  '@aws-sdk/util-format-url@3.972.5':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.3
       '@smithy/querystring-builder': 4.2.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
@@ -7707,9 +7555,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-browser@3.972.6':
+  '@aws-sdk/util-user-agent-browser@3.972.5':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.3
       '@smithy/types': 4.13.0
       bowser: 2.14.1
       tslib: 2.8.1
@@ -7721,10 +7569,10 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.0':
+  '@aws-sdk/util-user-agent-node@3.972.13':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.15
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/middleware-user-agent': 3.972.14
+      '@aws-sdk/types': 3.973.3
       '@smithy/node-config-provider': 4.3.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
@@ -7743,7 +7591,7 @@ snapshots:
       fast-xml-parser: 5.3.8
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.8':
+  '@aws-sdk/xml-builder@3.972.7':
     dependencies:
       '@smithy/types': 4.13.0
       fast-xml-parser: 5.3.8
@@ -7820,14 +7668,14 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)':
+  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)':
     dependencies:
       '@types/node': 25.3.5
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
       '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
-      '@hono/node-server': 1.19.10(hono@4.12.5)
+      '@hono/node-server': 1.19.10(hono@4.11.10)
       '@types/bun': 1.3.9
       '@types/ws': 8.18.1
       ws: 8.19.0
@@ -7858,19 +7706,8 @@ snapshots:
       hashery: 1.5.0
       keyv: 5.6.0
 
-  '@clack/core@1.0.1':
-    dependencies:
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
   '@clack/core@1.1.0':
     dependencies:
-      sisteransi: 1.0.5
-
-  '@clack/prompts@1.0.1':
-    dependencies:
-      '@clack/core': 1.0.1
-      picocolors: 1.1.1
       sisteransi: 1.0.5
 
   '@clack/prompts@1.1.0':
@@ -7982,7 +7819,7 @@ snapshots:
   '@discordjs/opus@0.10.0':
     dependencies:
       '@discordjs/node-pre-gyp': 0.4.5
-      node-addon-api: 8.6.0
+      node-addon-api: 8.5.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8111,31 +7948,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@google/genai@1.44.0':
-    dependencies:
-      google-auth-library: 10.6.1
-      p-retry: 4.6.2
-      protobufjs: 7.5.4
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@grammyjs/runner@2.0.3(grammy@1.41.0)':
-    dependencies:
-      abort-controller: 3.0.0
-      grammy: 1.41.0
-
   '@grammyjs/runner@2.0.3(grammy@1.41.1)':
     dependencies:
       abort-controller: 3.0.0
       grammy: 1.41.1
-
-  '@grammyjs/transformer-throttler@1.2.1(grammy@1.41.0)':
-    dependencies:
-      bottleneck: 2.19.5
-      grammy: 1.41.0
 
   '@grammyjs/transformer-throttler@1.2.1(grammy@1.41.1)':
     dependencies:
@@ -8171,9 +7987,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@1.19.10(hono@4.12.5)':
+  '@hono/node-server@1.19.10(hono@4.11.10)':
     dependencies:
-      hono: 4.12.5
+      hono: 4.11.10
     optional: true
 
   '@huggingface/jinja@0.5.5': {}
@@ -8404,7 +8220,7 @@ snapshots:
 
   '@line/bot-sdk@10.6.0':
     dependencies:
-      '@types/node': 24.11.0
+      '@types/node': 24.10.14
     optionalDependencies:
       axios: 1.13.5
     transitivePeerDependencies:
@@ -8501,6 +8317,18 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
+  '@mariozechner/pi-agent-core@0.55.0(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@mariozechner/pi-agent-core@0.55.3(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
@@ -8525,10 +8353,34 @@ snapshots:
       - ws
       - zod
 
+  '@mariozechner/pi-ai@0.55.0(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.998.0
+      '@google/genai': 1.43.0
+      '@mistralai/mistralai': 1.10.0
+      '@sinclair/typebox': 0.34.48
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      chalk: 5.6.2
+      openai: 6.10.0(ws@8.19.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.22.0
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@mariozechner/pi-ai@0.55.3(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.1000.0
+      '@aws-sdk/client-bedrock-runtime': 3.998.0
       '@google/genai': 1.43.0
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
@@ -8552,8 +8404,8 @@ snapshots:
   '@mariozechner/pi-ai@0.57.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.1004.0
-      '@google/genai': 1.44.0
+      '@aws-sdk/client-bedrock-runtime': 3.998.0
+      '@google/genai': 1.43.0
       '@mistralai/mistralai': 1.14.1
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
@@ -8564,6 +8416,36 @@ snapshots:
       proxy-agent: 6.5.0
       undici: 7.22.0
       zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-coding-agent@0.55.0(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/jiti': 2.6.5
+      '@mariozechner/pi-agent-core': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.55.3
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.3
+      file-type: 21.3.0
+      glob: 13.0.6
+      hosted-git-info: 9.0.2
+      ignore: 7.0.5
+      marked: 15.0.12
+      minimatch: 10.2.4
+      proper-lockfile: 4.1.2
+      strip-ansi: 7.2.0
+      yaml: 2.8.2
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.2
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -8635,6 +8517,15 @@ snapshots:
       - utf-8-validate
       - ws
       - zod
+
+  '@mariozechner/pi-tui@0.55.0':
+    dependencies:
+      '@types/mime-types': 2.1.4
+      chalk: 5.6.2
+      get-east-asian-width: 1.5.0
+      koffi: 2.15.1
+      marked: 15.0.12
+      mime-types: 3.0.2
 
   '@mariozechner/pi-tui@0.55.3':
     dependencies:
@@ -8897,7 +8788,7 @@ snapshots:
       '@octokit/core': 7.0.6
       '@octokit/oauth-authorization-url': 8.0.0
       '@octokit/oauth-methods': 6.0.2
-      '@types/aws-lambda': 8.10.161
+      '@types/aws-lambda': 8.10.160
       universal-user-agent: 7.0.3
 
   '@octokit/oauth-authorization-url@8.0.0': {}
@@ -8950,7 +8841,7 @@ snapshots:
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
       fast-content-type-parse: 3.0.0
-      json-with-bigint: 3.5.7
+      json-with-bigint: 3.5.3
       universal-user-agent: 7.0.3
 
   '@octokit/types@16.0.0':
@@ -9677,12 +9568,12 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@smithy/chunked-blob-reader-native@4.2.2':
+  '@smithy/chunked-blob-reader-native@4.2.3':
     dependencies:
-      '@smithy/util-base64': 4.3.1
+      '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
-  '@smithy/chunked-blob-reader@5.2.1':
+  '@smithy/chunked-blob-reader@5.2.2':
     dependencies:
       tslib: 2.8.1
 
@@ -9822,10 +9713,10 @@ snapshots:
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
-  '@smithy/hash-blob-browser@4.2.11':
+  '@smithy/hash-blob-browser@4.2.12':
     dependencies:
-      '@smithy/chunked-blob-reader': 5.2.1
-      '@smithy/chunked-blob-reader-native': 4.2.2
+      '@smithy/chunked-blob-reader': 5.2.2
+      '@smithy/chunked-blob-reader-native': 4.2.3
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
@@ -9843,10 +9734,10 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/hash-stream-node@4.2.10':
+  '@smithy/hash-stream-node@4.2.11':
     dependencies:
       '@smithy/types': 4.13.0
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.10':
@@ -9871,10 +9762,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/md5-js@4.2.10':
+  '@smithy/md5-js@4.2.11':
     dependencies:
       '@smithy/types': 4.13.0
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.2.10':
@@ -10277,9 +10168,9 @@ snapshots:
       '@smithy/util-buffer-from': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/util-waiter@4.2.10':
+  '@smithy/util-waiter@4.2.11':
     dependencies:
-      '@smithy/abort-controller': 4.2.10
+      '@smithy/abort-controller': 4.2.11
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
@@ -10358,20 +10249,20 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@thi.ng/bitstream@2.4.43':
+  '@thi.ng/bitstream@2.4.41':
     dependencies:
-      '@thi.ng/errors': 2.6.5
+      '@thi.ng/errors': 2.6.3
     optional: true
 
-  '@thi.ng/errors@2.6.5':
+  '@thi.ng/errors@2.6.3':
     optional: true
 
   '@tinyhttp/content-disposition@2.2.4': {}
 
   '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
     dependencies:
-      '@aws-sdk/client-s3': 3.1000.0
-      '@aws-sdk/s3-request-presigner': 3.1000.0
+      '@aws-sdk/client-s3': 3.1004.0
+      '@aws-sdk/s3-request-presigner': 3.1004.0
       '@urbit/aura': 3.0.0
       '@urbit/nockjs': 1.6.0
       any-ascii: 0.3.3
@@ -10474,7 +10365,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/aws-lambda@8.10.161': {}
+  '@types/aws-lambda@8.10.160': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -10568,11 +10459,11 @@ snapshots:
 
   '@types/node@10.17.60': {}
 
-  '@types/node@20.19.37':
+  '@types/node@20.19.34':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.11.0':
+  '@types/node@24.10.14':
     dependencies:
       undici-types: 7.16.0
 
@@ -10915,9 +10806,9 @@ snapshots:
       '@swc/helpers': 0.5.19
       '@types/command-line-args': 5.2.3
       '@types/command-line-usage': 5.0.4
-      '@types/node': 20.19.37
+      '@types/node': 20.19.34
       command-line-args: 5.2.1
-      command-line-usage: 7.0.4
+      command-line-usage: 7.0.3
       flatbuffers: 24.12.23
       json-bignum: 0.0.3
       tslib: 2.8.1
@@ -11087,7 +10978,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.3:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11210,7 +11101,7 @@ snapshots:
   cmake-js@8.0.0:
     dependencies:
       debug: 4.4.3
-      fs-extra: 11.3.4
+      fs-extra: 11.3.3
       node-api-headers: 1.8.0
       rc: 1.2.8
       semver: 7.7.4
@@ -11248,7 +11139,7 @@ snapshots:
       lodash.camelcase: 4.3.0
       typical: 4.0.0
 
-  command-line-usage@7.0.4:
+  command-line-usage@7.0.3:
     dependencies:
       array-back: 6.2.2
       chalk-template: 0.4.0
@@ -11363,8 +11254,6 @@ snapshots:
   diff@8.0.3: {}
 
   discord-api-types@0.38.37: {}
-
-  discord-api-types@0.38.40: {}
 
   discord-api-types@0.38.41: {}
 
@@ -11636,7 +11525,7 @@ snapshots:
 
   fast-xml-parser@5.3.8:
     dependencies:
-      strnum: 2.2.0
+      strnum: 2.1.2
 
   fastq@1.20.1:
     dependencies:
@@ -11737,12 +11626,6 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-extra@11.3.4:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
-
   fs.realpath@1.0.0:
     optional: true
 
@@ -11767,6 +11650,14 @@ snapshots:
       wide-align: 1.1.5
     optional: true
 
+  gaxios@7.1.2:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   gaxios@7.1.3:
     dependencies:
       extend: 3.0.2
@@ -11778,7 +11669,7 @@ snapshots:
 
   gcp-metadata@8.1.2:
     dependencies:
-      gaxios: 7.1.3
+      gaxios: 7.1.2
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -11808,7 +11699,7 @@ snapshots:
 
   get-stream@5.2.0:
     dependencies:
-      pump: 3.0.4
+      pump: 3.0.3
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -11876,16 +11767,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  grammy@1.41.0:
-    dependencies:
-      '@grammyjs/types': 3.25.0
-      abort-controller: 3.0.0
-      debug: 4.4.3
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   grammy@1.41.1:
     dependencies:
       '@grammyjs/types': 3.25.0
@@ -11942,7 +11823,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.12.5:
+  hono@4.11.10:
     optional: true
 
   hookable@6.0.1: {}
@@ -12070,7 +11951,7 @@ snapshots:
       commander: 10.0.1
       eventemitter3: 5.0.4
       filenamify: 6.0.0
-      fs-extra: 11.3.4
+      fs-extra: 11.3.3
       is-unicode-supported: 2.1.0
       lifecycle-utils: 2.1.0
       lodash.debounce: 4.0.8
@@ -12218,7 +12099,7 @@ snapshots:
 
   json-stringify-safe@5.0.1: {}
 
-  json-with-bigint@3.5.7: {}
+  json-with-bigint@3.5.3: {}
 
   json5@2.2.3: {}
 
@@ -12557,7 +12438,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.3
 
   minimist@1.2.8: {}
 
@@ -12623,7 +12504,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  node-addon-api@8.6.0: {}
+  node-addon-api@8.5.0: {}
 
   node-api-headers@1.8.0: {}
 
@@ -12660,14 +12541,14 @@ snapshots:
       cross-spawn: 7.0.6
       env-var: 7.5.0
       filenamify: 6.0.0
-      fs-extra: 11.3.4
+      fs-extra: 11.3.3
       ignore: 7.0.5
       ipull: 3.9.5
       is-unicode-supported: 2.1.0
       lifecycle-utils: 3.1.1
       log-symbols: 7.0.1
       nanoid: 5.1.6
-      node-addon-api: 8.6.0
+      node-addon-api: 8.5.0
       octokit: 5.0.5
       ora: 9.3.0
       pretty-ms: 9.3.0
@@ -12821,15 +12702,92 @@ snapshots:
       ws: 8.19.0
       zod: 4.3.6
 
-  openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.5)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+  openclaw@2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
-      '@aws-sdk/client-bedrock': 3.1000.0
-      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)
-      '@clack/prompts': 1.0.1
+      '@aws-sdk/client-bedrock': 3.1004.0
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
+      '@clack/prompts': 1.1.0
       '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
-      '@grammyjs/runner': 2.0.3(grammy@1.41.0)
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.0)
+      '@grammyjs/runner': 2.0.3(grammy@1.41.1)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.1)
+      '@homebridge/ciao': 1.3.5
+      '@larksuiteoapi/node-sdk': 1.59.0
+      '@line/bot-sdk': 10.6.0
+      '@lydell/node-pty': 1.2.0-beta.3
+      '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.55.0
+      '@mozilla/readability': 0.6.0
+      '@napi-rs/canvas': 0.1.95
+      '@sinclair/typebox': 0.34.48
+      '@slack/bolt': 4.6.0(@types/express@5.0.6)
+      '@slack/web-api': 7.14.1
+      '@snazzah/davey': 0.1.9
+      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      ajv: 8.18.0
+      chalk: 5.6.2
+      chokidar: 5.0.0
+      cli-highlight: 2.1.11
+      commander: 14.0.3
+      croner: 10.0.1
+      discord-api-types: 0.38.41
+      dotenv: 17.3.1
+      express: 5.2.1
+      file-type: 21.3.0
+      grammy: 1.41.1
+      https-proxy-agent: 7.0.6
+      ipaddr.js: 2.3.0
+      jiti: 2.6.1
+      json5: 2.2.3
+      jszip: 3.10.1
+      linkedom: 0.18.12
+      long: 5.3.2
+      markdown-it: 14.1.1
+      node-edge-tts: 1.2.10
+      node-llama-cpp: 3.16.2(typescript@5.9.3)
+      opusscript: 0.1.1
+      osc-progress: 0.3.0
+      pdfjs-dist: 5.5.207
+      playwright-core: 1.58.2
+      qrcode-terminal: 0.12.0
+      sharp: 0.34.5
+      sqlite-vec: 0.1.7-alpha.2
+      tar: 7.5.10
+      tslog: 4.10.2
+      undici: 7.22.0
+      ws: 8.19.0
+      yaml: 2.8.2
+      zod: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus': 0.10.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@types/express'
+      - audio-decode
+      - aws-crt
+      - bufferutil
+      - canvas
+      - debug
+      - encoding
+      - ffmpeg-static
+      - hono
+      - jimp
+      - link-preview-js
+      - node-opus
+      - supports-color
+      - utf-8-validate
+
+  openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock': 3.1004.0
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
+      '@clack/prompts': 1.1.0
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@grammyjs/runner': 2.0.3(grammy@1.41.1)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.1)
       '@homebridge/ciao': 1.3.5
       '@larksuiteoapi/node-sdk': 1.59.0
       '@line/bot-sdk': 10.6.0
@@ -12851,13 +12809,13 @@ snapshots:
       cli-highlight: 2.1.11
       commander: 14.0.3
       croner: 10.0.1
-      discord-api-types: 0.38.40
+      discord-api-types: 0.38.41
       dotenv: 17.3.1
       express: 5.2.1
       file-type: 21.3.0
       gaxios: 7.1.3
       google-auth-library: 10.6.1
-      grammy: 1.41.0
+      grammy: 1.41.1
       https-proxy-agent: 7.0.6
       ipaddr.js: 2.3.0
       jiti: 2.6.1
@@ -13285,7 +13243,7 @@ snapshots:
       pug-runtime: 3.0.1
       pug-strip-comments: 2.0.0
 
-  pump@3.0.4:
+  pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
@@ -13300,7 +13258,7 @@ snapshots:
 
   qoa-format@1.0.1:
     dependencies:
-      '@thi.ng/bitstream': 2.4.43
+      '@thi.ng/bitstream': 2.4.41
     optional: true
 
   qrcode-terminal@0.12.0: {}
@@ -13880,7 +13838,7 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
-  strnum@2.2.0: {}
+  strnum@2.1.2: {}
 
   strtok3@10.3.4:
     dependencies:

--- a/skills/gohighlevel/SKILL.md
+++ b/skills/gohighlevel/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: gohighlevel
+description: Use when you need to interact with GoHighLevel CRM — look up contacts, manage conversations, book appointments, and manage pipeline opportunities.
+metadata: { "openclaw": { "emoji": "📊", "requires": { "config": ["channels.gohighlevel"] } } }
+---
+
+# GoHighLevel CRM
+
+## Overview
+
+Use curl-based API calls to interact with GoHighLevel's REST API for CRM operations: contact lookup, conversation management, calendar/appointment booking, and pipeline/opportunity management.
+
+## Authentication
+
+All requests require:
+
+- `Authorization: Bearer <GHL_API_KEY>` header
+- `Version: 2021-07-28` header
+- Base URL: `https://services.leadconnectorhq.com`
+
+The API key is the Private Integration Token configured in GHL Settings > Integrations.
+
+## Contact Management
+
+### Get a contact
+
+```bash
+curl -s "https://services.leadconnectorhq.com/contacts/{contactId}" \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28"
+```
+
+### Search contacts
+
+```bash
+curl -s "https://services.leadconnectorhq.com/contacts/search" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{"locationId": "LOCATION_ID", "query": "John Doe", "limit": 10}'
+```
+
+### Create a contact
+
+```bash
+curl -s "https://services.leadconnectorhq.com/contacts/" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "locationId": "LOCATION_ID",
+    "firstName": "John",
+    "lastName": "Doe",
+    "email": "john@example.com",
+    "phone": "+15551234567",
+    "tags": ["new-lead"]
+  }'
+```
+
+### Update a contact
+
+```bash
+curl -s "https://services.leadconnectorhq.com/contacts/{contactId}" \
+  -X PUT \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{"firstName": "Jane", "tags": ["updated"]}'
+```
+
+### Add tags to a contact
+
+```bash
+curl -s "https://services.leadconnectorhq.com/contacts/{contactId}/tags" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{"tags": ["hot-lead", "follow-up"]}'
+```
+
+## Conversations
+
+### Send a message
+
+```bash
+curl -s "https://services.leadconnectorhq.com/conversations/messages" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "SMS",
+    "contactId": "CONTACT_ID",
+    "message": "Hello from OpenClaw!"
+  }'
+```
+
+Message types: `SMS`, `Email`, `WhatsApp`, `GMB`, `IG`, `FB`, `Custom`, `Live_Chat`.
+
+### Get conversation messages
+
+```bash
+curl -s "https://services.leadconnectorhq.com/conversations/{conversationId}/messages" \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28"
+```
+
+## Calendar & Appointments
+
+### List calendars
+
+```bash
+curl -s "https://services.leadconnectorhq.com/calendars/?locationId=LOCATION_ID" \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28"
+```
+
+### Get free slots
+
+```bash
+curl -s "https://services.leadconnectorhq.com/calendars/{calendarId}/free-slots?startDate=2026-03-01&endDate=2026-03-07" \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28"
+```
+
+### Book an appointment
+
+```bash
+curl -s "https://services.leadconnectorhq.com/calendars/events/appointments" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "calendarId": "CALENDAR_ID",
+    "locationId": "LOCATION_ID",
+    "contactId": "CONTACT_ID",
+    "startTime": "2026-03-05T10:00:00-08:00",
+    "endTime": "2026-03-05T11:00:00-08:00",
+    "title": "Consultation",
+    "appointmentStatus": "confirmed"
+  }'
+```
+
+## Pipeline & Opportunities
+
+### List pipelines
+
+```bash
+curl -s "https://services.leadconnectorhq.com/opportunities/pipelines?locationId=LOCATION_ID" \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28"
+```
+
+### Create an opportunity
+
+```bash
+curl -s "https://services.leadconnectorhq.com/opportunities/" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pipelineId": "PIPELINE_ID",
+    "locationId": "LOCATION_ID",
+    "name": "New Deal",
+    "pipelineStageId": "STAGE_ID",
+    "contactId": "CONTACT_ID",
+    "monetaryValue": 5000,
+    "status": "open"
+  }'
+```
+
+### Update an opportunity
+
+```bash
+curl -s "https://services.leadconnectorhq.com/opportunities/{opportunityId}" \
+  -X PUT \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{"pipelineStageId": "NEW_STAGE_ID", "status": "won", "monetaryValue": 7500}'
+```
+
+## Important Notes
+
+- All IDs (locationId, contactId, calendarId, pipelineId) are GHL-internal identifiers.
+- The `contactId` from an inbound webhook payload maps directly to the GHL contact record.
+- SMS character limit is ~1600 characters; longer messages may be split.
+- Rate limits apply; space bulk operations with reasonable delays.

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -511,4 +511,71 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     const result = validateAnthropicTurns(msgs);
     expect(result).toHaveLength(3);
   });
+
+  it("strips dangling toolCall blocks (pi-agent-core format)", () => {
+    // pi-agent-core stores tool calls as type "toolCall", not "toolUse".
+    // stripDanglingAnthropicToolUses must handle both representations.
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "tc-1", name: "read_file", input: {} },
+          { type: "text", text: "Let me check" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([{ type: "text", text: "Let me check" }]);
+  });
+
+  it("preserves toolCall blocks with matching tool_result", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "tc-1", name: "read_file", input: {} },
+          { type: "text", text: "Result" },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "toolResult", toolUseId: "tc-1", content: [{ type: "text", text: "file data" }] },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([
+      { type: "toolCall", id: "tc-1", name: "read_file", input: {} },
+      { type: "text", text: "Result" },
+    ]);
+  });
+
+  it("inserts fallback text when all toolCall content would be removed", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "tc-1", name: "exec", input: {} }],
+      },
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([{ type: "text", text: "[tool calls omitted]" }]);
+  });
 });

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 type AnthropicContentBlock = {
-  type: "text" | "toolUse" | "toolResult";
+  type: "text" | "toolUse" | "toolCall" | "toolResult";
   text?: string;
   id?: string;
   name?: string;
@@ -59,16 +59,19 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       }
     }
 
-    // Filter out tool_use blocks that don't have matching tool_result
+    // Filter out tool_use / tool_call blocks that don't have matching tool_result.
+    // pi-agent-core stores tool calls as type "toolCall"; Anthropic's native format
+    // uses "toolUse".  Accept both so the function works regardless of which
+    // representation is active in the transcript.
     const originalContent = Array.isArray(assistantMsg.content) ? assistantMsg.content : [];
     const filteredContent = originalContent.filter((block) => {
       if (!block) {
         return false;
       }
-      if (block.type !== "toolUse") {
+      if (block.type !== "toolUse" && block.type !== "toolCall") {
         return true;
       }
-      // Keep tool_use if its id is in the valid set
+      // Keep tool_use/tool_call if its id is in the valid set
       return validToolUseIds.has(block.id || "");
     });
 

--- a/src/agents/pi-embedded-runner/google.strip-error-state.test.ts
+++ b/src/agents/pi-embedded-runner/google.strip-error-state.test.ts
@@ -1,0 +1,144 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { stripErrorStateAssistantMessages } from "./google.js";
+
+function asMessages(raw: unknown[]): AgentMessage[] {
+  return raw as AgentMessage[];
+}
+
+describe("stripErrorStateAssistantMessages", () => {
+  it("removes assistant messages with stopReason error", () => {
+    const messages = asMessages([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "response" }],
+        stopReason: "stop",
+      },
+      { role: "user", content: [{ type: "text", text: "retry" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+        stopReason: "error",
+        errorMessage: "LLM request rejected",
+      },
+      { role: "user", content: [{ type: "text", text: "try again" }] },
+    ]);
+
+    const result = stripErrorStateAssistantMessages(messages);
+
+    expect(result).toHaveLength(4);
+    expect(result.map((m) => (m as { role: string }).role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "user",
+    ]);
+    // The remaining assistant should be the good one
+    expect((result[1] as { stopReason?: string }).stopReason).toBe("stop");
+  });
+
+  it("removes multiple consecutive error-state assistant messages", () => {
+    const messages = asMessages([
+      { role: "user", content: [{ type: "text", text: "ask" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "..." },
+          { type: "text", text: "good" },
+        ],
+        stopReason: "stop",
+      },
+      { role: "user", content: [{ type: "text", text: "follow up" }] },
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        errorMessage: "overloaded",
+      },
+      { role: "user", content: [{ type: "text", text: "retry 1" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+        stopReason: "error",
+        errorMessage: "overloaded",
+      },
+      { role: "user", content: [{ type: "text", text: "retry 2" }] },
+    ]);
+
+    const result = stripErrorStateAssistantMessages(messages);
+
+    expect(result).toHaveLength(5);
+    const roles = result.map((m) => (m as { role: string }).role);
+    expect(roles).toEqual(["user", "assistant", "user", "user", "user"]);
+  });
+
+  it("returns the same array reference when no error-state messages exist", () => {
+    const messages = asMessages([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "hi" }],
+        stopReason: "stop",
+      },
+    ]);
+
+    const result = stripErrorStateAssistantMessages(messages);
+
+    expect(result).toBe(messages);
+  });
+
+  it("preserves assistant messages with stopReason aborted", () => {
+    // "aborted" is a different stop reason, handled elsewhere; only "error" should be stripped
+    const messages = asMessages([
+      { role: "user", content: [{ type: "text", text: "do something" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "tc-1", name: "exec" }],
+        stopReason: "aborted",
+      },
+    ]);
+
+    const result = stripErrorStateAssistantMessages(messages);
+
+    expect(result).toBe(messages);
+    expect(result).toHaveLength(2);
+  });
+
+  it("preserves toolResult messages unaffected", () => {
+    const messages = asMessages([
+      { role: "user", content: [{ type: "text", text: "run" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "tc-1", name: "exec" }],
+        stopReason: "toolUse",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        content: [{ type: "text", text: "done" }],
+      },
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        errorMessage: "failed",
+      },
+    ]);
+
+    const result = stripErrorStateAssistantMessages(messages);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((m) => (m as { role: string }).role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
+  });
+
+  it("handles empty message array", () => {
+    const result = stripErrorStateAssistantMessages([]);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -517,6 +517,38 @@ export function applyGoogleTurnOrderingFix(params: {
   return { messages: sanitized, didPrepend };
 }
 
+/**
+ * Strips assistant messages that were persisted after a failed LLM request.
+ *
+ * pi-agent-core writes an assistant entry with `stopReason: "error"` (and
+ * typically empty or near-empty content) each time the API rejects a request.
+ * When retries pile up, these create structural imbalances (consecutive user
+ * turns, orphaned thinking blocks) that are difficult to self-heal.
+ *
+ * Removing them at sanitize-time is safe because:
+ * - The original error info is still in the JSONL file (we only filter the
+ *   in-memory transcript sent to the LLM).
+ * - `repairToolUseResultPairing` already skips tool call extraction for
+ *   error/aborted messages, so they serve no structural purpose.
+ */
+export function stripErrorStateAssistantMessages(messages: AgentMessage[]): AgentMessage[] {
+  let changed = false;
+  const result: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (
+      msg &&
+      typeof msg === "object" &&
+      (msg as { role?: unknown }).role === "assistant" &&
+      (msg as { stopReason?: unknown }).stopReason === "error"
+    ) {
+      changed = true;
+      continue;
+    }
+    result.push(msg);
+  }
+  return changed ? result : messages;
+}
+
 export async function sanitizeSessionHistory(params: {
   messages: AgentMessage[];
   modelApi?: string | null;
@@ -537,8 +569,15 @@ export async function sanitizeSessionHistory(params: {
       modelId: params.modelId,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
+
+  // Strip error-state assistant messages (stopReason: "error") that accumulate
+  // when LLM requests fail repeatedly.  These empty/near-empty messages break
+  // user/assistant alternation and can corrupt thinking-block transcripts.
+  // See: https://github.com/openclaw/openclaw/issues/41571
+  const withoutErrorAssistants = stripErrorStateAssistantMessages(withInterSessionMarkers);
+
   const sanitizedImages = await sanitizeSessionMessagesImages(
-    withInterSessionMarkers,
+    withoutErrorAssistants,
     "session:history",
     {
       sanitizeMode: policy.sanitizeMode,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -572,6 +572,38 @@ export function filterBootstrapFilesForSession(
   return files.filter((file) => MINIMAL_BOOTSTRAP_ALLOWLIST.has(file.name));
 }
 
+/**
+ * Minimal glob matcher for the Node < 22 fallback (no fs.glob).
+ * Supports `*` (single-segment wildcard) and `**` (multi-segment wildcard).
+ * Brace expansion and `?` are NOT supported — patterns using those features
+ * require Node 22+ `fs.glob`.
+ */
+function simpleGlobMatch(pattern: string, filePath: string): boolean {
+  // Convert glob pattern to regex
+  const parts = pattern.replace(/\\/g, "/").split("/");
+  let regexStr = "^";
+  for (let i = 0; i < parts.length; i++) {
+    if (i > 0) {
+      regexStr += "/";
+    }
+    const part = parts[i];
+    if (part === "**") {
+      // Match zero or more path segments
+      regexStr += "(?:.+/)?";
+      // Peek at next part; if it exists, the ** consumes up to it
+      if (i + 1 < parts.length) {
+        continue;
+      }
+      regexStr += ".*";
+    } else {
+      // Escape regex special chars except * which maps to [^/]*
+      regexStr += part.replace(/[.*+?^${}()|[\]\\]/g, (ch) => (ch === "*" ? "[^/]*" : `\\${ch}`));
+    }
+  }
+  regexStr += "$";
+  return new RegExp(regexStr).test(filePath);
+}
+
 export async function loadExtraBootstrapFiles(
   dir: string,
   extraPatterns: string[],
@@ -592,17 +624,31 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
   }
   const resolvedDir = resolveUserPath(dir);
 
-  // Resolve glob patterns into concrete file paths
+  // Resolve glob patterns into concrete file paths.
+  // fs.glob is available in Node 22+; fall back to recursive readdir + minimatch
+  // on older runtimes so the feature degrades gracefully.
   const resolvedPaths = new Set<string>();
   for (const pattern of extraPatterns) {
     if (pattern.includes("*") || pattern.includes("?") || pattern.includes("{")) {
       try {
-        const matches = fs.glob(pattern, { cwd: resolvedDir });
-        for await (const m of matches) {
-          resolvedPaths.add(m);
+        if (typeof fs.glob === "function") {
+          const matches = fs.glob(pattern, { cwd: resolvedDir });
+          for await (const m of matches) {
+            resolvedPaths.add(m);
+          }
+        } else {
+          // Node < 22 fallback: enumerate files recursively and test against the
+          // pattern using a simple path.sep-aware matcher.
+          const entries = await fs.readdir(resolvedDir, { recursive: true });
+          for (const entry of entries) {
+            const normalized = entry.replace(/\\/g, "/");
+            if (simpleGlobMatch(pattern, normalized)) {
+              resolvedPaths.add(normalized);
+            }
+          }
         }
       } catch {
-        // glob not available or pattern error — fall back to literal
+        // readdir or pattern error — fall back to literal
         resolvedPaths.add(pattern);
       }
     } else {

--- a/src/plugin-sdk/gohighlevel.ts
+++ b/src/plugin-sdk/gohighlevel.ts
@@ -1,0 +1,56 @@
+// Narrow plugin-sdk surface for the bundled gohighlevel plugin.
+// Keep this list additive and scoped to symbols used under extensions/gohighlevel.
+
+export type { ChannelDock } from "../channels/dock.js";
+export {
+  deleteAccountFromConfigSection,
+  setAccountEnabledInConfigSection,
+} from "../channels/plugins/config-helpers.js";
+export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
+export { formatPairingApproveHint } from "../channels/plugins/helpers.js";
+export type {
+  ChannelOnboardingAdapter,
+  ChannelOnboardingDmPolicy,
+} from "../channels/plugins/onboarding-types.js";
+export {
+  addWildcardAllowFrom,
+  mergeAllowFromEntries,
+  promptAccountId,
+} from "../channels/plugins/onboarding/helpers.js";
+export { PAIRING_APPROVED_MESSAGE } from "../channels/plugins/pairing-message.js";
+export {
+  applyAccountNameToChannelSection,
+  migrateBaseNameToDefaultAccount,
+} from "../channels/plugins/setup-helpers.js";
+export type { ChannelStatusIssue } from "../channels/plugins/types.js";
+export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+export { createReplyPrefixOptions } from "../channels/reply-prefix.js";
+export type { OpenClawConfig } from "../config/config.js";
+export type { DmPolicy } from "../config/types.js";
+export {
+  DmPolicySchema,
+  GroupPolicySchema,
+  MarkdownConfigSchema,
+  ReplyRuntimeConfigSchemaShape,
+  requireOpenAllowFrom,
+} from "../config/zod-schema.core.js";
+export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+export {
+  isRequestBodyLimitError,
+  readRequestBodyWithLimit,
+  requestBodyErrorToText,
+} from "../infra/http-body.js";
+export { missingTargetError } from "../infra/outbound/target-errors.js";
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export type { PluginRuntime } from "../plugins/runtime/types.js";
+export type { OpenClawPluginApi } from "../plugins/types.js";
+export { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
+export { createScopedPairingAccess } from "./pairing-access.js";
+export { formatDocsLink } from "../terminal/links.js";
+export { resolveWebhookPath } from "./webhook-path.js";
+export {
+  registerWebhookTargetWithPluginRoute,
+  rejectNonPostWebhookRequest,
+  resolveWebhookTargets,
+} from "./webhook-targets.js";
+export type { WizardPrompter } from "../wizard/prompts.js";

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -22,6 +22,7 @@ import {
 } from "../config/sessions.js";
 import type { OpenClawConfig, ReplyToMode, TelegramAccountConfig } from "../config/types.js";
 import { danger, logVerbose } from "../globals.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
@@ -44,6 +45,8 @@ import {
 } from "./reasoning-lane-coordinator.js";
 import { editMessageTelegram } from "./send.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
+
+const log = createSubsystemLogger("telegram/dispatch");
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 
@@ -624,6 +627,9 @@ export const dispatchTelegramMessage = async ({
         },
         onError: (err, info) => {
           deliveryState.markNonSilentFailure();
+          // Always log delivery failures to the structured subsystem log so they
+          // appear in gateway logs even when runtime.error is unavailable.  See #41567.
+          log.warn(`${info.kind} reply delivery failed`, { error: String(err) });
           runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
         },
       },
@@ -685,6 +691,7 @@ export const dispatchTelegramMessage = async ({
     }));
   } catch (err) {
     dispatchError = err;
+    log.warn("dispatch failed", { error: String(err) });
     runtime.error?.(danger(`telegram dispatch failed: ${String(err)}`));
   } finally {
     // Upstream assistant callbacks are fire-and-forget; drain queued lane work

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,7 @@ const pluginSdkSubpaths = [
   "diagnostics-otel",
   "diffs",
   "feishu",
+  "gohighlevel",
   "google-gemini-cli-auth",
   "googlechat",
   "irc",


### PR DESCRIPTION
## Summary

- Add GoHighLevel CRM channel extension (`extensions/gohighlevel/`) with webhook-based inbound message handling, GHL Conversations API outbound replies, escalation tagging, multi-account support, and HMAC-SHA256 signature verification
- Add GHL agent skill (`skills/gohighlevel/SKILL.md`) providing CRM/calendar/pipeline tools via GHL REST API
- Add scoped plugin-sdk subpath (`openclaw/plugin-sdk/gohighlevel`) following the no-monolithic-imports lint rule
- Add docs page, labeler config, and changelog entry

### Also includes (ancillary fixes discovered during development)

- fix(turns): strip dangling toolCall blocks (pi-agent-core format) in validateAnthropicTurns
- fix(sanitize): strip error-state assistant messages from session transcript
- fix(telegram): log delivery failures to subsystem logger for reliable visibility
- fix(workspace): add Node 20 fallback for fs.glob in extra bootstrap file loading

## Test plan

- [x] `pnpm test extensions/gohighlevel` — 32 tests pass (accounts, auth, monitor/webhook)
- [x] `pnpm check` — lint/format clean
- [x] `pnpm tsgo` — type-check passes
- [x] End-to-end webhook test: curl to `/gohighlevel` returns 200, agent processes and generates reply
- [ ] Live test with real GHL "Customer Replied" workflow event

🤖 Generated with [Claude Code](https://claude.com/claude-code)