### PR TITLE
fix(agents): strip tool_call/tool_result XML leaking into channel messages

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -5,6 +5,7 @@ import {
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
+  stripToolCallXml,
 } from "./pi-embedded-utils.js";
 
 function makeAssistantMessage(
@@ -594,6 +595,81 @@ describe("promoteThinkingTagsToBlocks", () => {
     });
     promoteThinkingTagsToBlocks(msg);
     expect(msg.content).toEqual([{ type: "text", text: "hello world" }]);
+  });
+});
+
+describe("stripToolCallXml", () => {
+  it("strips <tool_call> blocks", () => {
+    const text = `Before<tool_call>
+{"name": "search", "arguments": {"query": "test"}}
+</tool_call>After`;
+    expect(stripToolCallXml(text)).toBe("BeforeAfter");
+  });
+
+  it("strips <tool_result> blocks", () => {
+    const text = `Before<tool_result>
+Spawned sub-agent coding (id: sa_01jt3cwwqb5rz7hqp6ghh5qc12)
+</tool_result>After`;
+    expect(stripToolCallXml(text)).toBe("BeforeAfter");
+  });
+
+  it("strips both tool_call and tool_result blocks", () => {
+    const text = `I'll help with that.
+<tool_call>
+{"name": "subagents", "arguments": {"action": "spawn"}}
+</tool_call>
+<tool_result>
+Spawned sub-agent coding
+</tool_result>
+Here is the result.`;
+    expect(stripToolCallXml(text)).toBe("I'll help with that.\n\n\nHere is the result.");
+  });
+
+  it("handles tags with attributes", () => {
+    const text = `Start<tool_call id="123" type="function">content</tool_call>End`;
+    expect(stripToolCallXml(text)).toBe("StartEnd");
+  });
+
+  it("handles stray unclosed tags", () => {
+    const text = "Some text<tool_call>more text";
+    expect(stripToolCallXml(text)).toBe("Some textmore text");
+  });
+
+  it("returns text unchanged when no tool tags present", () => {
+    const text = "Normal response without any tool markup.";
+    expect(stripToolCallXml(text)).toBe(text);
+  });
+
+  it("returns empty/falsy input unchanged", () => {
+    expect(stripToolCallXml("")).toBe("");
+  });
+});
+
+describe("extractAssistantText strips tool_call XML (#40879)", () => {
+  it("strips tool_call XML from assistant messages", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `I'll search for that.
+<tool_call>
+{"name": "search", "arguments": {"query": "test"}}
+</tool_call>
+<tool_result>
+Found 3 results.
+</tool_result>
+Here are the results.`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).not.toContain("<tool_call>");
+    expect(result).not.toContain("<tool_result>");
+    expect(result).toContain("I'll search for that.");
+    expect(result).toContain("Here are the results.");
   });
 });
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -10,6 +10,30 @@ export function isAssistantMessage(msg: AgentMessage | undefined): msg is Assist
 }
 
 /**
+ * Strip raw `<tool_call>` / `<tool_result>` XML blocks that some models
+ * emit as plain text instead of structured tool-use events.
+ * Without this, the markup leaks into user-facing channel messages
+ * (Discord, Telegram, etc.).
+ */
+export function stripToolCallXml(text: string): string {
+  if (!text) {
+    return text;
+  }
+  if (!/<\/?tool_(?:call|result)/i.test(text)) {
+    return text;
+  }
+
+  // Remove <tool_call ...>...</tool_call> and <tool_result ...>...</tool_result> blocks.
+  let cleaned = text.replace(/<tool_call\b[^>]*>[\s\S]*?<\/tool_call>/gi, "");
+  cleaned = cleaned.replace(/<tool_result\b[^>]*>[\s\S]*?<\/tool_result>/gi, "");
+
+  // Remove stray opening/closing tags left behind.
+  cleaned = cleaned.replace(/<\/?tool_(?:call|result)\b[^>]*>/gi, "");
+
+  return cleaned;
+}
+
+/**
  * Strip malformed Minimax tool invocations that leak into text content.
  * Minimax sometimes embeds tool calls as XML in text blocks instead of
  * proper structured tool calls. This removes:
@@ -238,7 +262,9 @@ export function extractAssistantText(msg: AssistantMessage): string {
     extractTextFromChatContent(msg.content, {
       sanitizeText: (text) =>
         stripThinkingTagsFromText(
-          stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
+          stripDowngradedToolCallText(
+            stripToolCallXml(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
+          ),
         ).trim(),
       joinWith: "\n",
       normalizeText: (text) => text.trim(),


### PR DESCRIPTION
## Summary
- Add `stripToolCallXml()` to strip raw `<tool_call>` / `<tool_result>` XML blocks that some models emit as plain text
- Integrate into the `extractAssistantText()` sanitization chain alongside existing `stripMinimaxToolCallXml()` and `stripModelSpecialTokens()`

## Problem
When a model outputs raw XML tool markup (e.g. `<tool_call>{"name": "subagents", ...}</tool_call>`), these blocks leak into user-facing channel messages (Discord, Telegram, etc.) because no sanitization function targets them.

Existing strippers handle:
- `stripMinimaxToolCallXml()`: MiniMax-specific `<invoke>` / `</minimax:tool_call>` tags
- `stripDowngradedToolCallText()`: text-based `[Tool Call: ...]` markers
- `stripModelSpecialTokens()`: model special tokens

But generic `<tool_call>` / `<tool_result>` XML is not covered.

## Fix
New `stripToolCallXml()` function with:
- Fast-path regex guard (skips text without tool tags)
- Non-greedy block removal for paired `<tool_call>...</tool_call>` and `<tool_result>...</tool_result>`
- Stray tag cleanup for unclosed/orphaned tags

## Test plan
- [x] Unit tests for `stripToolCallXml()` (7 cases: paired blocks, attributes, stray tags, empty input, no-op)
- [x] Integration test for `extractAssistantText()` with tool_call XML

Closes #40879