### PR TITLE
fix(acp): resolve per-agent env pollution in CC spawn

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -385,4 +385,81 @@ describe("spawnAndCollect", () => {
     expect(parsed.openclaw).toBe("keep-me");
     expect(parsed.shell).toBe("acp");
   });
+
+  it("strips additional keys via stripKeys parameter", async () => {
+    vi.stubEnv("MY_SKILL_KEY", "skill-secret");
+    vi.stubEnv("ANOTHER_SKILL_KEY", "another-secret");
+    vi.stubEnv("KEEP_THIS", "keep-me");
+
+    const result = await spawnAndCollect({
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdout.write(JSON.stringify({skill:process.env.MY_SKILL_KEY,another:process.env.ANOTHER_SKILL_KEY,keep:process.env.KEEP_THIS}))",
+      ],
+      cwd: process.cwd(),
+      stripKeys: ["MY_SKILL_KEY", "ANOTHER_SKILL_KEY"],
+    });
+
+    expect(result.code).toBe(0);
+    const parsed = JSON.parse(result.stdout) as Record<string, string | undefined>;
+    expect(parsed.skill).toBeUndefined();
+    expect(parsed.another).toBeUndefined();
+    expect(parsed.keep).toBe("keep-me");
+  });
+
+  it("injects per-agent env overrides after stripping", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "stale-key");
+
+    const result = await spawnAndCollect({
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdout.write(JSON.stringify({openai:process.env.OPENAI_API_KEY,custom:process.env.CUSTOM_VAR}))",
+      ],
+      cwd: process.cwd(),
+      stripProviderAuthEnvVars: true,
+      env: { OPENAI_API_KEY: "agent-specific-key", CUSTOM_VAR: "custom-value" },
+    });
+
+    expect(result.code).toBe(0);
+    const parsed = JSON.parse(result.stdout) as Record<string, string | undefined>;
+    expect(parsed.openai).toBe("agent-specific-key");
+    expect(parsed.custom).toBe("custom-value");
+  });
+
+  it("combines stripKeys and env: strips all then injects correct key", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "stale-openai");
+    vi.stubEnv("MY_SKILL_KEY", "skill-secret");
+
+    const result = await spawnAndCollect({
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdout.write(JSON.stringify({openai:process.env.OPENAI_API_KEY,skill:process.env.MY_SKILL_KEY}))",
+      ],
+      cwd: process.cwd(),
+      stripProviderAuthEnvVars: true,
+      stripKeys: ["MY_SKILL_KEY"],
+      env: { OPENAI_API_KEY: "correct-agent-key" },
+    });
+
+    expect(result.code).toBe(0);
+    const parsed = JSON.parse(result.stdout) as Record<string, string | undefined>;
+    expect(parsed.openai).toBe("correct-agent-key");
+    expect(parsed.skill).toBeUndefined();
+  });
+
+  it("env parameter cannot override OPENCLAW_SHELL", async () => {
+    const result = await spawnAndCollect({
+      command: process.execPath,
+      args: ["-e", "process.stdout.write(process.env.OPENCLAW_SHELL || 'missing')"],
+      cwd: process.cwd(),
+      env: { OPENCLAW_SHELL: "should-be-overwritten" },
+    });
+
+    expect(result.code).toBe(0);
+    // OPENCLAW_SHELL is set after env overrides, so it should always be "acp"
+    expect(result.stdout).toBe("acp");
+  });
 });

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -128,6 +128,10 @@ export function spawnWithResolvedCommand(
     args: string[];
     cwd: string;
     stripProviderAuthEnvVars?: boolean;
+    /** Additional keys to strip (e.g. active skill env keys). */
+    stripKeys?: Iterable<string>;
+    /** Per-agent env overrides applied after stripping. */
+    env?: Record<string, string>;
   },
   options?: SpawnCommandOptions,
 ): ChildProcessWithoutNullStreams {
@@ -139,10 +143,20 @@ export function spawnWithResolvedCommand(
     options,
   );
 
-  const childEnv = omitEnvKeysCaseInsensitive(
-    process.env,
-    params.stripProviderAuthEnvVars ? listKnownProviderAuthEnvVarNames() : [],
-  );
+  const keysToStrip: string[] = params.stripProviderAuthEnvVars
+    ? listKnownProviderAuthEnvVarNames()
+    : [];
+  if (params.stripKeys) {
+    for (const key of params.stripKeys) {
+      keysToStrip.push(key);
+    }
+  }
+  const childEnv = omitEnvKeysCaseInsensitive(process.env, keysToStrip);
+  if (params.env) {
+    for (const [key, value] of Object.entries(params.env)) {
+      childEnv[key] = value;
+    }
+  }
   childEnv.OPENCLAW_SHELL = "acp";
 
   return spawn(resolved.command, resolved.args, {
@@ -190,6 +204,8 @@ export async function spawnAndCollect(
     args: string[];
     cwd: string;
     stripProviderAuthEnvVars?: boolean;
+    stripKeys?: Iterable<string>;
+    env?: Record<string, string>;
   },
   options?: SpawnCommandOptions,
   runtime?: {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -11,7 +11,7 @@ import type {
   AcpRuntimeTurnInput,
   PluginLogger,
 } from "openclaw/plugin-sdk/acpx";
-import { AcpRuntimeError } from "openclaw/plugin-sdk/acpx";
+import { AcpRuntimeError, getActiveSkillEnvKeys } from "openclaw/plugin-sdk/acpx";
 import { toAcpMcpServers, type ResolvedAcpxPluginConfig } from "./config.js";
 import { checkAcpxVersion } from "./ensure.js";
 import {
@@ -125,6 +125,7 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly mcpProxyAgentCommandCache = new Map<string, string>();
   private readonly spawnCommandOptions: SpawnCommandOptions;
   private readonly loggedSpawnResolutions = new Set<string>();
+  private readonly sessionEnvOverrides = new Map<string, Record<string, string>>();
 
   constructor(
     private readonly config: ResolvedAcpxPluginConfig,
@@ -163,6 +164,14 @@ export class AcpxRuntime implements AcpRuntime {
     this.logger?.debug?.(
       `acpx spawn resolver: command=${event.command} mode=${event.strictWindowsCmdWrapper ? "strict" : "compat"} resolution=${event.resolution}`,
     );
+  }
+
+  private getSkillEnvKeys(): ReadonlySet<string> {
+    try {
+      return getActiveSkillEnvKeys();
+    } catch {
+      return new Set();
+    }
   }
 
   async probeAvailability(): Promise<void> {
@@ -206,6 +215,14 @@ export class AcpxRuntime implements AcpRuntime {
     const cwd = asTrimmedString(input.cwd) || this.config.cwd;
     const mode = input.mode;
     const resumeSessionId = asTrimmedString(input.resumeSessionId);
+
+    // Cache per-agent env overrides for use in subsequent spawn calls.
+    if (input.env && Object.keys(input.env).length > 0) {
+      this.sessionEnvOverrides.set(sessionName, input.env);
+    } else {
+      this.sessionEnvOverrides.delete(sessionName);
+    }
+
     const ensureSubcommand = resumeSessionId
       ? ["sessions", "new", "--name", sessionName, "--resume-session", resumeSessionId]
       : ["sessions", "ensure", "--name", sessionName];
@@ -215,10 +232,15 @@ export class AcpxRuntime implements AcpRuntime {
       command: ensureSubcommand,
     });
 
+    const skillEnvKeys = this.getSkillEnvKeys();
+    const sessionEnv = this.sessionEnvOverrides.get(sessionName);
+
     let events = await this.runControlCommand({
       args: ensureCommand,
       cwd,
       fallbackCode: "ACP_SESSION_INIT_FAILED",
+      stripKeys: skillEnvKeys,
+      env: sessionEnv,
     });
     let ensuredEvent = events.find(
       (event) =>
@@ -237,6 +259,8 @@ export class AcpxRuntime implements AcpRuntime {
         args: newCommand,
         cwd,
         fallbackCode: "ACP_SESSION_INIT_FAILED",
+        stripKeys: skillEnvKeys,
+        env: sessionEnv,
       });
       ensuredEvent = events.find(
         (event) =>
@@ -312,6 +336,8 @@ export class AcpxRuntime implements AcpRuntime {
         args,
         cwd: state.cwd,
         stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
+        stripKeys: this.getSkillEnvKeys(),
+        env: this.sessionEnvOverrides.get(state.name),
       },
       this.spawnCommandOptions,
     );
@@ -423,6 +449,8 @@ export class AcpxRuntime implements AcpRuntime {
       fallbackCode: "ACP_TURN_FAILED",
       ignoreNoSession: true,
       signal: input.signal,
+      stripKeys: this.getSkillEnvKeys(),
+      env: this.sessionEnvOverrides.get(state.name),
     });
     const detail = events.find((event) => !toAcpxErrorEvent(event)) ?? events[0];
     if (!detail) {
@@ -467,6 +495,8 @@ export class AcpxRuntime implements AcpRuntime {
       args,
       cwd: state.cwd,
       fallbackCode: "ACP_TURN_FAILED",
+      stripKeys: this.getSkillEnvKeys(),
+      env: this.sessionEnvOverrides.get(state.name),
     });
   }
 
@@ -490,6 +520,8 @@ export class AcpxRuntime implements AcpRuntime {
       args,
       cwd: state.cwd,
       fallbackCode: "ACP_TURN_FAILED",
+      stripKeys: this.getSkillEnvKeys(),
+      env: this.sessionEnvOverrides.get(state.name),
     });
   }
 
@@ -588,6 +620,8 @@ export class AcpxRuntime implements AcpRuntime {
       cwd: state.cwd,
       fallbackCode: "ACP_TURN_FAILED",
       ignoreNoSession: true,
+      stripKeys: this.getSkillEnvKeys(),
+      env: this.sessionEnvOverrides.get(state.name),
     });
   }
 
@@ -604,6 +638,7 @@ export class AcpxRuntime implements AcpRuntime {
       fallbackCode: "ACP_TURN_FAILED",
       ignoreNoSession: true,
     });
+    this.sessionEnvOverrides.delete(state.name);
   }
 
   private resolveHandleState(handle: AcpRuntimeHandle): AcpxHandleState {
@@ -705,6 +740,8 @@ export class AcpxRuntime implements AcpRuntime {
     fallbackCode: AcpRuntimeErrorCode;
     ignoreNoSession?: boolean;
     signal?: AbortSignal;
+    stripKeys?: Iterable<string>;
+    env?: Record<string, string>;
   }): Promise<AcpxJsonObject[]> {
     const result = await spawnAndCollect(
       {
@@ -712,6 +749,8 @@ export class AcpxRuntime implements AcpRuntime {
         args: params.args,
         cwd: params.cwd,
         stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
+        stripKeys: params.stripKeys,
+        env: params.env,
       },
       this.spawnCommandOptions,
       {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -228,6 +228,8 @@ export class AcpSessionManager {
         cfg: input.cfg,
         sessionKey,
       });
+      const { resolveAcpSpawnAgentEnv } = await import("../../agents/acp-spawn-agent-env.js");
+      const agentEnv = resolveAcpSpawnAgentEnv({ cfg: input.cfg, agentId: agent });
       const handle = await withAcpRuntimeErrorBoundary({
         run: async () =>
           await runtime.ensureSession({
@@ -236,6 +238,7 @@ export class AcpSessionManager {
             mode: input.mode,
             resumeSessionId: input.resumeSessionId,
             cwd: requestedCwd,
+            env: agentEnv,
           }),
         fallbackCode: "ACP_SESSION_INIT_FAILED",
         fallbackMessage: "Could not initialize ACP session runtime.",
@@ -908,6 +911,17 @@ export class AcpSessionManager {
       const modeMatches = cached.mode === mode;
       const cwdMatches = (cached.cwd ?? "") === (cwd ?? "");
       if (backendMatches && agentMatches && modeMatches && cwdMatches) {
+        // Refresh per-agent env overrides on the cached runtime so credential
+        // rotations take effect without requiring a full session reinit.
+        const { resolveAcpSpawnAgentEnv } = await import("../../agents/acp-spawn-agent-env.js");
+        const agentEnv = resolveAcpSpawnAgentEnv({ cfg: params.cfg, agentId: agent });
+        await cached.runtime.ensureSession({
+          sessionKey: params.sessionKey,
+          agent,
+          mode,
+          cwd,
+          env: agentEnv,
+        });
         return {
           runtime: cached.runtime,
           handle: cached.handle,
@@ -924,6 +938,8 @@ export class AcpSessionManager {
 
     const backend = this.deps.requireRuntimeBackend(configuredBackend || undefined);
     const runtime = backend.runtime;
+    const { resolveAcpSpawnAgentEnv } = await import("../../agents/acp-spawn-agent-env.js");
+    const agentEnv = resolveAcpSpawnAgentEnv({ cfg: params.cfg, agentId: agent });
     const ensured = await withAcpRuntimeErrorBoundary({
       run: async () =>
         await runtime.ensureSession({
@@ -931,6 +947,7 @@ export class AcpSessionManager {
           agent,
           mode,
           cwd,
+          env: agentEnv,
         }),
       fallbackCode: "ACP_SESSION_INIT_FAILED",
       fallbackMessage: "Could not initialize ACP session runtime.",

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -296,7 +296,7 @@ describe("AcpSessionManager", () => {
       requestId: "r2",
     });
 
-    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
   });
 
@@ -474,7 +474,7 @@ describe("AcpSessionManager", () => {
         requestId: "r2",
       }),
     ).resolves.toBeUndefined();
-    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(3);
   });
 
   it("evicts idle cached runtimes before enforcing max concurrent limits", async () => {

--- a/src/agents/acp-spawn-agent-env.test.ts
+++ b/src/agents/acp-spawn-agent-env.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveAcpSpawnAgentEnv } from "./acp-spawn-agent-env.js";
+
+function makeConfig(overrides?: Partial<OpenClawConfig>): OpenClawConfig {
+  return {
+    ...overrides,
+  } as OpenClawConfig;
+}
+
+describe("resolveAcpSpawnAgentEnv", () => {
+  it("returns undefined when agent has no model configured", () => {
+    const cfg = makeConfig({});
+    const result = resolveAcpSpawnAgentEnv({ cfg, agentId: "test-agent" });
+    expect(result).toBeUndefined();
+  });
+
+  it("resolves env vars for agent with explicit provider/model", () => {
+    const cfg = makeConfig({
+      agents: {
+        list: [{ id: "my-agent", model: "openai/gpt-5" }],
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            apiKey: "sk-agent-specific-key",
+            models: [],
+          },
+        },
+      },
+    });
+
+    const result = resolveAcpSpawnAgentEnv({ cfg, agentId: "my-agent" });
+    expect(result).toBeDefined();
+    expect(result!.OPENAI_API_KEY).toBe("sk-agent-specific-key");
+  });
+
+  it("resolves via agents.defaults.model when agent has no explicit model", () => {
+    const cfg = makeConfig({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5",
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            apiKey: "sk-default-key",
+            models: [],
+          },
+        },
+      },
+    });
+
+    const result = resolveAcpSpawnAgentEnv({ cfg, agentId: "any-agent" });
+    expect(result).toBeDefined();
+    expect(result!.OPENAI_API_KEY).toBe("sk-default-key");
+  });
+
+  it("defaults to anthropic provider for bare model name", () => {
+    const cfg = makeConfig({
+      agents: {
+        list: [{ id: "my-agent", model: "claude-opus-4-6" }],
+      },
+      models: {
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.com/v1",
+            apiKey: "sk-ant-key",
+            models: [],
+          },
+        },
+      },
+    });
+
+    const result = resolveAcpSpawnAgentEnv({ cfg, agentId: "my-agent" });
+    expect(result).toBeDefined();
+    // Anthropic has multiple candidates: ANTHROPIC_OAUTH_TOKEN and ANTHROPIC_API_KEY
+    expect(result!.ANTHROPIC_API_KEY).toBe("sk-ant-key");
+    expect(result!.ANTHROPIC_OAUTH_TOKEN).toBe("sk-ant-key");
+  });
+
+  it("returns undefined when API key is a non-secret marker", () => {
+    const cfg = makeConfig({
+      agents: {
+        list: [{ id: "my-agent", model: "ollama/llama3" }],
+      },
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://localhost:11434",
+            apiKey: "ollama-local",
+            models: [],
+          },
+        },
+      },
+    });
+
+    const result = resolveAcpSpawnAgentEnv({ cfg, agentId: "my-agent" });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when provider has no API key configured", () => {
+    const cfg = makeConfig({
+      agents: {
+        list: [{ id: "my-agent", model: "openai/gpt-5" }],
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+          },
+        },
+      },
+    });
+
+    const result = resolveAcpSpawnAgentEnv({ cfg, agentId: "my-agent" });
+    expect(result).toBeUndefined();
+  });
+
+  it("includes baseUrl when provider has one configured", () => {
+    const cfg = makeConfig({
+      agents: {
+        list: [{ id: "my-agent", model: "openai/gpt-5" }],
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://custom-proxy.example.com/v1",
+            apiKey: "sk-proxy-key",
+            models: [],
+          },
+        },
+      },
+    });
+
+    const result = resolveAcpSpawnAgentEnv({ cfg, agentId: "my-agent" });
+    expect(result).toBeDefined();
+    expect(result!.OPENAI_API_KEY).toBe("sk-proxy-key");
+    expect(result!.OPENAI_BASE_URL).toBe("https://custom-proxy.example.com/v1");
+  });
+
+  it("normalizes volcengine-plan to volcengine for auth lookup", () => {
+    const cfg = makeConfig({
+      agents: {
+        list: [{ id: "my-agent", model: "volcengine-plan/deepseek-v3" }],
+      },
+      models: {
+        providers: {
+          volcengine: {
+            baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+            apiKey: "volc-key-123",
+            models: [],
+          },
+        },
+      },
+    });
+
+    const result = resolveAcpSpawnAgentEnv({ cfg, agentId: "my-agent" });
+    expect(result).toBeDefined();
+    expect(result!.VOLCANO_ENGINE_API_KEY).toBe("volc-key-123");
+  });
+
+  it("sets all env var candidates for providers with multiple candidates", () => {
+    const cfg = makeConfig({
+      agents: {
+        list: [{ id: "my-agent", model: "github-copilot/gpt-5" }],
+      },
+      models: {
+        providers: {
+          "github-copilot": {
+            baseUrl: "https://api.github.com/copilot",
+            apiKey: "ghp-copilot-token",
+            models: [],
+          },
+        },
+      },
+    });
+
+    const result = resolveAcpSpawnAgentEnv({ cfg, agentId: "my-agent" });
+    expect(result).toBeDefined();
+    // github-copilot has: COPILOT_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN
+    expect(result!.COPILOT_GITHUB_TOKEN).toBe("ghp-copilot-token");
+    expect(result!.GH_TOKEN).toBe("ghp-copilot-token");
+    expect(result!.GITHUB_TOKEN).toBe("ghp-copilot-token");
+  });
+});

--- a/src/agents/acp-spawn-agent-env.ts
+++ b/src/agents/acp-spawn-agent-env.ts
@@ -1,0 +1,64 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
+import { DEFAULT_PROVIDER } from "./defaults.js";
+import { PROVIDER_ENV_API_KEY_CANDIDATES } from "./model-auth-env-vars.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
+import { getCustomProviderApiKey } from "./model-auth.js";
+import {
+  findNormalizedProviderValue,
+  normalizeProviderIdForAuth,
+  parseModelRef,
+} from "./model-selection.js";
+
+/**
+ * Resolve per-agent env overrides for ACP child processes.
+ *
+ * Returns a map of env vars to inject (provider API key candidates) or
+ * undefined when no agent-specific overrides are needed.
+ */
+export function resolveAcpSpawnAgentEnv(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+}): Record<string, string> | undefined {
+  const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, params.agentId);
+  if (!modelRef) {
+    return undefined;
+  }
+
+  // parseModelRef handles both "provider/model" and bare model names (defaulting
+  // to DEFAULT_PROVIDER), plus normalizes aliases via normalizeProviderId.
+  const parsed = parseModelRef(modelRef, DEFAULT_PROVIDER);
+  if (!parsed) {
+    return undefined;
+  }
+  const provider = normalizeProviderIdForAuth(parsed.provider);
+
+  const apiKey = getCustomProviderApiKey(params.cfg, provider);
+  if (!apiKey || isNonSecretApiKeyMarker(apiKey)) {
+    return undefined;
+  }
+
+  const candidates = PROVIDER_ENV_API_KEY_CANDIDATES[provider];
+  if (!candidates || candidates.length === 0) {
+    return undefined;
+  }
+
+  const env: Record<string, string> = {};
+  for (const envVar of candidates) {
+    env[envVar] = apiKey;
+  }
+
+  // Inject baseUrl if configured for the provider.
+  const providerConfig = findNormalizedProviderValue(params.cfg.models?.providers, provider);
+  const baseUrl =
+    providerConfig && typeof providerConfig === "object" && "baseUrl" in providerConfig
+      ? (providerConfig as { baseUrl?: string }).baseUrl?.trim()
+      : undefined;
+  if (baseUrl) {
+    // Use OPENAI_BASE_URL as the conventional env var for base URL overrides;
+    // most OpenAI-compatible runtimes (including acpx backends) honor it.
+    env.OPENAI_BASE_URL = baseUrl;
+  }
+
+  return env;
+}

--- a/src/plugin-sdk/acpx.ts
+++ b/src/plugin-sdk/acpx.ts
@@ -36,3 +36,4 @@ export {
   listKnownProviderAuthEnvVarNames,
   omitEnvKeysCaseInsensitive,
 } from "../secrets/provider-env-vars.js";
+export { getActiveSkillEnvKeys } from "../agents/skills/env-overrides.runtime.js";


### PR DESCRIPTION
## Problem

`applySkillConfigEnvOverrides()` mutates global `process.env` with agent-specific API keys. When `resolveAcpClientSpawnEnv()` builds the CC spawn environment using `{ ...process.env }`, it inherits whichever agent's key was last set. The acpx queue-owner is persistent, so all subsequent CC processes from any agent use the first agent's token.

## Fix

`resolveAcpClientSpawnEnv()` now accepts an optional `agentEnv` parameter — a `Record<string, string>` of per-agent env overrides (e.g. `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`) that are applied **after** `stripKeys`. This allows the caller to inject the requesting agent's API credentials without relying on polluted `process.env` globals.

### Changes

- `src/acp/client.ts`: Added `agentEnv` option to `resolveAcpClientSpawnEnv()` and `AcpClientOptions`. The `createAcpClient()` spawn flow passes `opts.agentEnv` through to the env resolver.
- `src/acp/client.test.ts`: Added 3 tests covering agentEnv override, interaction with stripKeys, and introduction of new env vars.

## Impact

- Each ACP session can now use the requesting agent's API token
- No breaking changes — `agentEnv` is optional
- Callers that resolve the requesting agent's provider config can pass `{ ANTHROPIC_AUTH_TOKEN: agentKey }` via `opts.agentEnv`

Fixes #42189