### PR TITLE
feat(feishu): resolve media from quoted/replied messages

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -571,6 +571,9 @@ function inferPlaceholder(messageType: string): string {
   }
 }
 
+/** Message types that carry downloadable media (images, files, etc.) */
+const FEISHU_MEDIA_MESSAGE_TYPES = ["image", "file", "audio", "video", "media", "sticker", "post"];
+
 /**
  * Resolve media from a Feishu message, downloading and saving to disk.
  * Similar to Discord's resolveMediaList().
@@ -587,8 +590,7 @@ async function resolveFeishuMediaList(params: {
   const { cfg, messageId, messageType, content, maxBytes, log, accountId } = params;
 
   // Only process media message types (including post for embedded images)
-  const mediaTypes = ["image", "file", "audio", "video", "media", "sticker", "post"];
-  if (!mediaTypes.includes(messageType)) {
+  if (!FEISHU_MEDIA_MESSAGE_TYPES.includes(messageType)) {
     return [];
   }
 
@@ -1227,8 +1229,6 @@ export async function handleFeishuMessage(params: {
       log,
       accountId: account.accountId,
     });
-    const mediaPayload = buildAgentMediaPayload(mediaList);
-
     // Fetch quoted/replied message content if parentId exists
     let quotedContent: string | undefined;
     if (ctx.parentId) {
@@ -1243,11 +1243,38 @@ export async function handleFeishuMessage(params: {
           log(
             `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
           );
+
+          // Also resolve media from quoted message (images, files, etc.)
+          if (FEISHU_MEDIA_MESSAGE_TYPES.includes(quotedMsg.contentType)) {
+            try {
+              const quotedMediaList = await resolveFeishuMediaList({
+                cfg,
+                messageId: quotedMsg.messageId,
+                messageType: quotedMsg.contentType,
+                content: quotedMsg.rawContent,
+                maxBytes: mediaMaxBytes,
+                log,
+                accountId: account.accountId,
+              });
+              if (quotedMediaList.length > 0) {
+                mediaList.push(...quotedMediaList);
+                log(
+                  `feishu[${account.accountId}]: resolved ${quotedMediaList.length} media from quoted message`,
+                );
+              }
+            } catch (quotedMediaErr) {
+              log(
+                `feishu[${account.accountId}]: failed to resolve quoted message media: ${String(quotedMediaErr)}`,
+              );
+            }
+          }
         }
       } catch (err) {
         log(`feishu[${account.accountId}]: failed to fetch quoted message: ${String(err)}`);
       }
     }
+
+    const mediaPayload = buildAgentMediaPayload(mediaList);
 
     const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
     const messageBody = buildFeishuAgentBody({

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -58,6 +58,7 @@ function createFetchedReactionMessage(chatId: string) {
     senderOpenId: "ou_bot",
     content: "hello",
     contentType: "text",
+    rawContent: '{"text":"hello"}',
   };
 }
 
@@ -253,6 +254,7 @@ describe("resolveReactionSyntheticEvent", () => {
         senderType: "app",
         content: "hello",
         contentType: "text",
+        rawContent: '{"text":"hello"}',
       }),
     });
     expect(result).toBeNull();
@@ -272,6 +274,7 @@ describe("resolveReactionSyntheticEvent", () => {
         senderType: "user",
         content: "hello",
         contentType: "text",
+        rawContent: '{"text":"hello"}',
       }),
     });
     expect(result).toBeNull();
@@ -297,6 +300,7 @@ describe("resolveReactionSyntheticEvent", () => {
         senderType: "user",
         content: "hello",
         contentType: "text",
+        rawContent: '{"text":"hello"}',
       }),
       uuid: () => "fixed-uuid",
     });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -82,6 +82,7 @@ export type FeishuMessageInfo = {
   senderType?: string;
   content: string;
   contentType: string;
+  rawContent: string;
   createTime?: number;
 };
 
@@ -233,6 +234,7 @@ export async function getMessageFeishu(params: {
       senderType: item.sender?.sender_type,
       content,
       contentType: msgType,
+      rawContent,
       createTime: item.create_time ? parseInt(String(item.create_time), 10) : undefined,
     };
   } catch {


### PR DESCRIPTION
## Summary

- When a user replies to an image/file/media message in Feishu, the quoted message's media was not downloaded — only a text placeholder like `[image message]` or `[file message]` was passed to the agent
- This PR adds media resolution for quoted messages, so images, PDFs, audio, video, and other attachments from replied-to messages are now downloaded and included in the agent context
- This is a frequently encountered issue — previously reported in #22957 and #29501 (both closed without merge)

## Changes

- **`send.ts`**: Add `rawContent` field to `FeishuMessageInfo` to preserve the original JSON content (containing `image_key`/`file_key`)
- **`bot.ts`**: After fetching a quoted message, call `resolveFeishuMediaList` to download its media and merge into the main media list. Extract `FEISHU_MEDIA_MESSAGE_TYPES` as shared constant to avoid duplication. Move `buildAgentMediaPayload` after quoted media resolution.
- **`monitor.reaction.test.ts`**: Add `rawContent` to test mocks to match updated `FeishuMessageInfo` type

## Test plan

- [x] Reply to an **image message** with text → image is downloaded and passed to agent
- [x] Reply to a **PDF file message** with text → PDF is downloaded and passed to agent
- [x] Direct image messages (no quote) still work as before
- [x] Text-only quoted messages still work as before (no regression)
- [x] All existing tests pass (`vitest run monitor.reaction.test.ts` — 17/17)

## AI Disclosure

- [x] AI-assisted (Claude Code)
- [x] Fully tested on a live Feishu group chat
- [x] I understand what the code does

🤖 Generated with [Claude Code](https://claude.com/claude-code)