### PR TITLE
docs(zh-CN): 添加 CI 流水线文档翻译

### DIFF
--- a/docs/zh-CN/ci.md
+++ b/docs/zh-CN/ci.md
@@ -1,0 +1,56 @@
+---
+title: CI 流水线
+description: OpenClaw CI 流水线的工作原理
+summary: "CI 任务图、范围检测和本地命令等效"
+read_when:
+  - 你需要了解为什么某个 CI 任务没有运行
+  - 你正在调试失败的 GitHub Actions 检查
+---
+
+# CI 流水线
+
+CI 在每次推送到 `main` 分支和每个 Pull Request 时运行。它使用智能范围检测来跳过仅有文档或原生代码变更时的昂贵任务。
+
+## 任务概览
+
+| 任务               | 用途                                                 | 运行时机                                      |
+| ----------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| `docs-scope`      | 检测仅文档变更                                | 始终                                            |
+| `changed-scope`   | 检测哪些区域发生了变更 (node/macos/android/windows) | 非文档 PR                                    |
+| `check`           | TypeScript 类型检查、lint、格式化                          | 推送到 `main`，或有 Node 相关变更的 PR |
+| `check-docs`      | Markdown lint + 检查坏链接                       | 文档变更                                  |
+| `code-analysis`   | 代码行数阈值检查 (1000 行)                        | 仅 PR                                |
+| `secrets`         | 检测泄露的密钥                                   | 始终                                            |
+| `build-artifacts` | 构建一次 dist，共享给其他任务                  | 非文档，node 变更                            |
+| `release-check`   | 验证 npm pack 内容                              | 构建后                                       |
+| `checks`          | Node/Bun 测试 + 协议检查                         | 非文档，node 变更                            |
+| `checks-windows`  | Windows 特定测试                                  | 非文档，windows 相关变更                |
+| `macos`           | Swift lint/build/test + TS 测试                        | 有 macos 变更的 PR                            |
+| `android`         | Gradle 构建 + 测试                                    | 非文档，android 变更                         |
+
+## 快速失败顺序
+
+任务按顺序排列，使便宜的检查在昂贵的检查之前失败：
+
+1. `docs-scope` + `code-analysis` + `check` (并行, ~1-2 分钟)
+2. `build-artifacts` (等待上述完成)
+3. `checks`, `checks-windows`, `macos`, `android` (等待构建完成)
+
+范围检测逻辑位于 `scripts/ci-changed-scope.mjs`，单元测试位于 `src/scripts/ci-changed-scope.test.ts`。
+
+## 运行器
+
+| 运行器                           | 任务                                       |
+| -------------------------------- | ------------------------------------------ |
+| `blacksmith-16vcpu-ubuntu-2404`  | 大多数 Linux 任务，包括范围检测 |
+| `blacksmith-32vcpu-windows-2025` | `checks-windows`                           |
+| `macos-latest`                   | `macos`, `ios`                             |
+
+## 本地等效命令
+
+```bash
+pnpm check          # 类型 + lint + 格式化
+pnpm test           # vitest 测试
+pnpm check:docs     # 文档格式化 + lint + 坏链接检查
+pnpm release:check  # 验证 npm pack
+```


### PR DESCRIPTION
## 概述

将 `docs/ci.md` 翻译为中文，补全中文文档的缺失内容。

## 变更内容

- 新增 `docs/zh-CN/ci.md`：CI 流水线文档中文翻译

## 翻译说明

1. 保持原有的 frontmatter 格式不变
2. 表格内容完整翻译，保持格式一致
3. 代码块命令保持英文（这些是实际的命令行指令）
4. 技术术语如 CI、lint、PR、npm pack 等保留英文，符合中文技术文档习惯

## 检查清单

- [x] 文档格式与原文一致
- [x] 专有名词处理得当
- [x] 代码块命令未改动

---

这是我的第一个 OpenClaw 贡献，希望对社区有帮助！🦞