### PR TITLE
docs: add MCP Bridge to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -59,6 +59,18 @@ while reducing token usage.
 openclaw plugins install @martian-engineering/lossless-claw
 ```
 
+### MCP Bridge
+
+Connect any MCP server to OpenClaw. Supports stdio, SSE, and streamable-http
+transports with a built-in server catalog for one-command setup.
+
+- **npm:** `@aiwerk/openclaw-mcp-bridge`
+- **repo:** [github.com/AIWerk/openclaw-mcp-bridge](https://github.com/AIWerk/openclaw-mcp-bridge)
+
+```bash
+openclaw plugins install @aiwerk/openclaw-mcp-bridge
+```
+
 ### Opik
 
 Official plugin that exports agent traces to Opik. Monitor agent behavior,


### PR DESCRIPTION
Adds @aiwerk/openclaw-mcp-bridge to the community plugins page.

- Published on npm: @aiwerk/openclaw-mcp-bridge
- GitHub: https://github.com/AIWerk/openclaw-mcp-bridge
- MIT license, CI on Node 20+22

## Summary

- Adds MCP Bridge entry to the community plugins listing
- Follows the existing page format (heading, description, npm/repo links, install command)
- Docs-only change, no code affected