### PR TITLE
feat(tracing): add agent execution tracing plugin

### DIFF
--- a/docs/plans/2026-03-09-agent-tracing-design.md
+++ b/docs/plans/2026-03-09-agent-tracing-design.md
@@ -1,0 +1,184 @@
+# Agent Tracing System Design
+
+## Goal
+
+Let any OpenClaw instance trace tool calls, LLM invocations, and sub-agent relationships with zero external dependencies. Users install a plugin and immediately get tree-view visibility into agent execution.
+
+## Architecture: Two Layers
+
+### Layer 1: Default (zero-dependency)
+
+Plugin `extensions/tracing` — JSONL + CLI/Web viewer.
+
+```
+OpenClaw hooks ──► TraceSpan ──► ~/.openclaw/traces/<date>.jsonl
+                                        │
+                          ┌──────────────┼──────────────┐
+                          ▼              ▼              ▼
+                   CLI tree view   Web UI /traces   Waterfall
+```
+
+User experience:
+
+- `openclaw plugins install tracing` — done
+- `openclaw traces` — CLI tree view
+- Web UI at `/traces` — interactive viewer
+
+### Layer 2: Optional advanced (PuppyGraph)
+
+For users who want arbitrary graph queries and advanced visualization.
+
+```
+TraceSpan ──► SQLite/DuckDB (same data, tabular format)
+                    │
+              PuppyGraph (Docker, free Developer Edition)
+                    │
+              Cypher/Gremlin queries + built-in graph UI
+```
+
+User experience:
+
+- `openclaw config set tracing.storage sqlite` — switch to SQLite output
+- `docker run puppygraph` + point at SQLite file
+- Query: `MATCH (a:Agent)-[:SPAWNED]->(b:Agent) RETURN a, b`
+
+## Data Model
+
+```typescript
+type TraceSpan = {
+  traceId: string; // shared across entire top-level session
+  spanId: string; // unique per span
+  parentSpanId?: string; // links to parent (null = root)
+  kind: "session" | "llm_call" | "tool_call" | "subagent";
+  name: string;
+  agentId?: string;
+  sessionKey?: string;
+  startMs: number;
+  endMs?: number;
+  durationMs?: number;
+  attributes: Record<string, string | number | boolean>;
+  // tool_call
+  toolName?: string;
+  toolParams?: Record<string, unknown>;
+  // subagent
+  childSessionKey?: string;
+  childAgentId?: string;
+  // llm_call
+  provider?: string;
+  model?: string;
+  tokensIn?: number;
+  tokensOut?: number;
+};
+```
+
+Two trees derived from one data model:
+
+- **Call tree**: nest by `parentSpanId`, sort by `startMs`
+- **Entity relationship tree**: filter `kind === "subagent"`, build `agentId → childAgentId` graph
+
+## Hook Registration
+
+| Hook                | Span kind           | Action                               |
+| ------------------- | ------------------- | ------------------------------------ |
+| `session_start`     | `session` (open)    | Create root span, assign traceId     |
+| `session_end`       | `session` (close)   | Set endMs, durationMs                |
+| `llm_input`         | `llm_call` (open)   | Record provider, model, tokensIn     |
+| `llm_output`        | `llm_call` (close)  | Set tokensOut, durationMs            |
+| `before_tool_call`  | `tool_call` (open)  | Record toolName, toolParams          |
+| `after_tool_call`   | `tool_call` (close) | Set result summary, durationMs       |
+| `subagent_spawning` | `subagent` (open)   | Record childAgentId, childSessionKey |
+| `subagent_ended`    | `subagent` (close)  | Set durationMs                       |
+
+### Parent chain logic
+
+- session span: root (no parent)
+- llm_call parent = current session span
+- tool_call parent = triggering llm_call span
+- subagent parent = triggering tool_call span (sessions_spawn)
+- child agent's session span parent = parent agent's subagent span
+- traceId propagates from top-level session through all descendants
+
+## CLI Viewer: `openclaw traces`
+
+Three view modes:
+
+### Call tree (default: `openclaw traces --mode call`)
+
+```
+└─ research-bot (session:main-abc) 12.0s
+   ├─ llm [anthropic/claude-sonnet-4-20250514] 1.4s [in:2800 out:350]
+   │  ├─ web_search (query=...) 1.3s
+   │  └─ read_url (url=...) 400ms
+   ├─ llm [anthropic/claude-sonnet-4-20250514] 1.3s
+   │  └─ → translator-bot (session:translator-def) 5.0s
+   │     └─ translator-bot (session:translator-def) 4.8s
+   │        ├─ llm [openai/gpt-4o] 1.1s
+   │        │  ├─ translate (from=en, to=zh) 400ms
+   │        │  └─ → summarizer-bot 2.0s
+   ...
+```
+
+### Entity tree (`openclaw traces --mode entity`)
+
+```
+└─ research-bot (session:main-abc) 12.0s
+   │ 3 LLM calls  3 tool calls  tokens: 14500→1430
+   │ models: claude-sonnet-4-20250514
+   │ tools: web_search, read_url, send_message
+   └─ translator-bot 4.8s
+      │ 2 LLM calls  1 tool calls  tokens: 8000→770
+      └─ summarizer-bot 1.8s
+```
+
+### Waterfall (`openclaw traces --mode waterfall`)
+
+Timeline bar chart showing parallel/sequential execution.
+
+### Both (`openclaw traces` with no flag)
+
+Shows all three views.
+
+## Storage
+
+### Layer 1: JSONL (default)
+
+- Path: `~/.openclaw/traces/YYYY-MM-DD.jsonl`
+- One JSON object per line
+- Auto-rotate daily, configurable retention (`tracing.retentionDays`, default 7)
+
+### Layer 2: SQLite/DuckDB (opt-in)
+
+- Path: `~/.openclaw/traces/traces.db`
+- Single `spans` table matching TraceSpan schema
+- Enables PuppyGraph connection
+
+## Configuration
+
+```yaml
+tracing:
+  enabled: true # default: false
+  storage: jsonl # jsonl | sqlite
+  retentionDays: 7
+  redactToolParams: false # strip tool params from output
+```
+
+## Plugin Structure
+
+```
+extensions/tracing/
+  package.json
+  index.ts              # plugin registration
+  src/
+    collector.ts        # hook handlers, span lifecycle
+    storage-jsonl.ts    # JSONL writer
+    storage-sqlite.ts   # SQLite writer (optional)
+    viewer-cli.ts       # CLI tree renderer
+    types.ts            # TraceSpan type
+```
+
+## Non-Goals (for now)
+
+- Real-time streaming UI
+- Distributed tracing across multiple OpenClaw instances
+- Integration with existing APM tools (covered by diagnostics-otel)
+- Token cost analytics (covered by diagnostics-otel metrics)

--- a/docs/plans/2026-03-09-agent-tracing-plan.md
+++ b/docs/plans/2026-03-09-agent-tracing-plan.md
@@ -1,0 +1,880 @@
+# Agent Tracing Plugin Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build `extensions/tracing` plugin that captures tool calls, LLM invocations, and sub-agent relationships as JSONL trace spans, viewable via CLI tree views.
+
+**Architecture:** Plugin registers hooks (`session_start/end`, `llm_input/output`, `before/after_tool_call`, `subagent_spawning/ended`) that emit `TraceSpan` objects to a JSONL writer. A CLI command reads JSONL and renders call tree, entity tree, and waterfall views.
+
+**Tech Stack:** TypeScript ESM, OpenClaw plugin SDK (`api.on()` hooks, `api.registerCli()`), Node fs for JSONL I/O.
+
+---
+
+### Task 1: Scaffold plugin package
+
+**Files:**
+
+- Create: `extensions/tracing/package.json`
+- Create: `extensions/tracing/src/types.ts`
+
+**Step 1: Create package.json**
+
+```json
+{
+  "name": "@openclaw/tracing",
+  "version": "2026.3.9",
+  "description": "Agent execution tracing with tree-view CLI",
+  "type": "module",
+  "openclaw": {
+    "extensions": ["./index.ts"]
+  }
+}
+```
+
+**Step 2: Create types.ts**
+
+```typescript
+export type TraceSpan = {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  kind: "session" | "llm_call" | "tool_call" | "subagent";
+  name: string;
+  agentId?: string;
+  sessionKey?: string;
+  startMs: number;
+  endMs?: number;
+  durationMs?: number;
+  attributes: Record<string, string | number | boolean>;
+  toolName?: string;
+  toolParams?: Record<string, unknown>;
+  childSessionKey?: string;
+  childAgentId?: string;
+  provider?: string;
+  model?: string;
+  tokensIn?: number;
+  tokensOut?: number;
+};
+
+export type TracingConfig = {
+  enabled?: boolean;
+  retentionDays?: number;
+  redactToolParams?: boolean;
+};
+```
+
+**Step 3: Commit**
+
+```bash
+scripts/committer "feat(tracing): scaffold plugin package and types" extensions/tracing/package.json extensions/tracing/src/types.ts
+```
+
+---
+
+### Task 2: JSONL storage writer
+
+**Files:**
+
+- Create: `extensions/tracing/src/storage-jsonl.ts`
+- Create: `extensions/tracing/src/storage-jsonl.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { JsonlTraceWriter } from "./storage-jsonl.js";
+import type { TraceSpan } from "./types.js";
+
+describe("JsonlTraceWriter", () => {
+  let tmpDir: string;
+  let writer: JsonlTraceWriter;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trace-test-"));
+    writer = new JsonlTraceWriter(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes span to daily JSONL file", () => {
+    const span: TraceSpan = {
+      traceId: "t1",
+      spanId: "s1",
+      kind: "session",
+      name: "test",
+      startMs: Date.now(),
+      attributes: {},
+    };
+    writer.write(span);
+    const files = fs.readdirSync(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}\.jsonl$/);
+    const content = fs.readFileSync(path.join(tmpDir, files[0]!), "utf-8").trim();
+    expect(JSON.parse(content)).toMatchObject({ traceId: "t1", spanId: "s1" });
+  });
+
+  it("appends multiple spans to same file", () => {
+    const base = { kind: "session" as const, name: "test", startMs: Date.now(), attributes: {} };
+    writer.write({ ...base, traceId: "t1", spanId: "s1" });
+    writer.write({ ...base, traceId: "t1", spanId: "s2" });
+    const files = fs.readdirSync(tmpDir);
+    const lines = fs.readFileSync(path.join(tmpDir, files[0]!), "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+  });
+
+  it("reads spans back from file", () => {
+    const span: TraceSpan = {
+      traceId: "t1",
+      spanId: "s1",
+      kind: "session",
+      name: "test",
+      startMs: Date.now(),
+      attributes: {},
+    };
+    writer.write(span);
+    const spans = writer.readToday();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.spanId).toBe("s1");
+  });
+
+  it("reads spans by date", () => {
+    const span: TraceSpan = {
+      traceId: "t1",
+      spanId: "s1",
+      kind: "session",
+      name: "test",
+      startMs: Date.now(),
+      attributes: {},
+    };
+    writer.write(span);
+    const today = new Date().toISOString().slice(0, 10);
+    const spans = writer.readByDate(today);
+    expect(spans).toHaveLength(1);
+  });
+
+  it("lists available trace dates", () => {
+    writer.write({
+      traceId: "t1",
+      spanId: "s1",
+      kind: "session",
+      name: "test",
+      startMs: Date.now(),
+      attributes: {},
+    });
+    const dates = writer.listDates();
+    expect(dates.length).toBeGreaterThanOrEqual(1);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run extensions/tracing/src/storage-jsonl.test.ts`
+Expected: FAIL — module not found
+
+**Step 3: Write implementation**
+
+```typescript
+import fs from "node:fs";
+import path from "node:path";
+import type { TraceSpan } from "./types.js";
+
+export class JsonlTraceWriter {
+  constructor(private dir: string) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  private dateKey(date?: Date): string {
+    return (date ?? new Date()).toISOString().slice(0, 10);
+  }
+
+  private filePath(dateKey: string): string {
+    return path.join(this.dir, `${dateKey}.jsonl`);
+  }
+
+  write(span: TraceSpan): void {
+    const file = this.filePath(this.dateKey());
+    fs.appendFileSync(file, JSON.stringify(span) + "\n");
+  }
+
+  readByDate(dateKey: string): TraceSpan[] {
+    const file = this.filePath(dateKey);
+    if (!fs.existsSync(file)) return [];
+    return fs
+      .readFileSync(file, "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as TraceSpan);
+  }
+
+  readToday(): TraceSpan[] {
+    return this.readByDate(this.dateKey());
+  }
+
+  listDates(): string[] {
+    if (!fs.existsSync(this.dir)) return [];
+    return fs
+      .readdirSync(this.dir)
+      .filter((f) => f.endsWith(".jsonl"))
+      .map((f) => f.replace(".jsonl", ""))
+      .sort()
+      .reverse();
+  }
+
+  cleanup(retentionDays: number): void {
+    const cutoff = Date.now() - retentionDays * 86400000;
+    for (const dateKey of this.listDates()) {
+      if (new Date(dateKey).getTime() < cutoff) {
+        fs.unlinkSync(this.filePath(dateKey));
+      }
+    }
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run extensions/tracing/src/storage-jsonl.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+scripts/committer "feat(tracing): add JSONL storage writer with tests" extensions/tracing/src/storage-jsonl.ts extensions/tracing/src/storage-jsonl.test.ts
+```
+
+---
+
+### Task 3: Span collector (hook handlers)
+
+**Files:**
+
+- Create: `extensions/tracing/src/collector.ts`
+- Create: `extensions/tracing/src/collector.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect, beforeEach } from "vitest";
+import { TraceCollector } from "./collector.js";
+import type { TraceSpan } from "./types.js";
+
+describe("TraceCollector", () => {
+  let spans: TraceSpan[];
+  let collector: TraceCollector;
+
+  beforeEach(() => {
+    spans = [];
+    collector = new TraceCollector((span) => spans.push(span));
+  });
+
+  it("creates session root span on session_start", () => {
+    collector.onSessionStart(
+      { sessionId: "sid1", sessionKey: "sk1" },
+      { agentId: "bot1", sessionId: "sid1", sessionKey: "sk1" },
+    );
+    expect(spans).toHaveLength(1);
+    expect(spans[0]).toMatchObject({ kind: "session", agentId: "bot1" });
+    expect(spans[0]!.traceId).toBeTruthy();
+    expect(spans[0]!.endMs).toBeUndefined();
+  });
+
+  it("closes session span on session_end", () => {
+    collector.onSessionStart(
+      { sessionId: "sid1", sessionKey: "sk1" },
+      { agentId: "bot1", sessionId: "sid1", sessionKey: "sk1" },
+    );
+    collector.onSessionEnd(
+      { sessionId: "sid1", sessionKey: "sk1", messageCount: 5, durationMs: 3000 },
+      { agentId: "bot1", sessionId: "sid1", sessionKey: "sk1" },
+    );
+    expect(spans).toHaveLength(2);
+    expect(spans[1]).toMatchObject({
+      kind: "session",
+      endMs: expect.any(Number),
+      durationMs: 3000,
+    });
+  });
+
+  it("tracks llm_input → llm_output as llm_call span", () => {
+    collector.onSessionStart(
+      { sessionId: "sid1", sessionKey: "sk1" },
+      { agentId: "bot1", sessionId: "sid1", sessionKey: "sk1" },
+    );
+    collector.onLlmInput(
+      {
+        runId: "r1",
+        sessionId: "sid1",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        prompt: "hi",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      { agentId: "bot1", sessionId: "sid1", sessionKey: "sk1" },
+    );
+    collector.onLlmOutput(
+      {
+        runId: "r1",
+        sessionId: "sid1",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        assistantTexts: ["hello"],
+        usage: { input: 100, output: 50 },
+      },
+      { agentId: "bot1", sessionId: "sid1", sessionKey: "sk1" },
+    );
+    const llmSpans = spans.filter((s) => s.kind === "llm_call");
+    expect(llmSpans).toHaveLength(1);
+    expect(llmSpans[0]).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      tokensIn: 100,
+      tokensOut: 50,
+      endMs: expect.any(Number),
+    });
+    expect(llmSpans[0]!.parentSpanId).toBeTruthy();
+  });
+
+  it("tracks before/after tool_call as tool_call span", () => {
+    collector.onSessionStart(
+      { sessionId: "sid1", sessionKey: "sk1" },
+      { agentId: "bot1", sessionId: "sid1", sessionKey: "sk1" },
+    );
+    collector.onLlmInput(
+      {
+        runId: "r1",
+        sessionId: "sid1",
+        provider: "anthropic",
+        model: "sonnet",
+        prompt: "hi",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      { agentId: "bot1", sessionId: "sid1", sessionKey: "sk1" },
+    );
+    collector.onBeforeToolCall(
+      { toolName: "web_search", params: { query: "test" }, runId: "r1", toolCallId: "tc1" },
+      {
+        agentId: "bot1",
+        sessionKey: "sk1",
+        sessionId: "sid1",
+        runId: "r1",
+        toolName: "web_search",
+      },
+    );
+    collector.onAfterToolCall(
+      {
+        toolName: "web_search",
+        params: { query: "test" },
+        runId: "r1",
+        toolCallId: "tc1",
+        durationMs: 500,
+      },
+      {
+        agentId: "bot1",
+        sessionKey: "sk1",
+        sessionId: "sid1",
+        runId: "r1",
+        toolName: "web_search",
+      },
+    );
+    const toolSpans = spans.filter((s) => s.kind === "tool_call");
+    expect(toolSpans).toHaveLength(1);
+    expect(toolSpans[0]).toMatchObject({ toolName: "web_search", durationMs: 500 });
+  });
+
+  it("tracks subagent_spawning → subagent_ended", () => {
+    collector.onSessionStart(
+      { sessionId: "sid1", sessionKey: "sk1" },
+      { agentId: "bot1", sessionId: "sid1", sessionKey: "sk1" },
+    );
+    collector.onSubagentSpawning(
+      {
+        childSessionKey: "sk2",
+        agentId: "child-bot",
+        label: "translator",
+        mode: "run",
+        threadRequested: false,
+      },
+      { runId: "r1", childSessionKey: "sk2", requesterSessionKey: "sk1" },
+    );
+    collector.onSubagentEnded(
+      { targetSessionKey: "sk2", targetKind: "subagent", reason: "done", outcome: "ok" },
+      { runId: "r1", childSessionKey: "sk2", requesterSessionKey: "sk1" },
+    );
+    const subSpans = spans.filter((s) => s.kind === "subagent");
+    expect(subSpans).toHaveLength(1);
+    expect(subSpans[0]).toMatchObject({ childAgentId: "child-bot", childSessionKey: "sk2" });
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run extensions/tracing/src/collector.test.ts`
+Expected: FAIL
+
+**Step 3: Write implementation**
+
+```typescript
+import crypto from "node:crypto";
+import type { TraceSpan } from "./types.js";
+import type {
+  PluginHookSessionStartEvent,
+  PluginHookSessionEndEvent,
+  PluginHookSessionContext,
+  PluginHookLlmInputEvent,
+  PluginHookLlmOutputEvent,
+  PluginHookAgentContext,
+  PluginHookBeforeToolCallEvent,
+  PluginHookAfterToolCallEvent,
+  PluginHookToolContext,
+  PluginHookSubagentSpawningEvent,
+  PluginHookSubagentEndedEvent,
+  PluginHookSubagentContext,
+} from "openclaw/plugin-sdk";
+
+const id = () => crypto.randomUUID().slice(0, 16);
+
+export class TraceCollector {
+  // sessionKey → { traceId, sessionSpanId }
+  private sessions = new Map<string, { traceId: string; spanId: string }>();
+  // runId → llm spanId (for parent linking tool_call → llm_call)
+  private activeRuns = new Map<string, string>();
+  // toolCallId → spanId (for open tool spans)
+  private activeTools = new Map<string, string>();
+  // childSessionKey → spanId (for open subagent spans)
+  private activeSubagents = new Map<string, string>();
+
+  constructor(private emit: (span: TraceSpan) => void) {}
+
+  private sessionCtx(sessionKey?: string) {
+    return sessionKey ? this.sessions.get(sessionKey) : undefined;
+  }
+
+  onSessionStart(event: PluginHookSessionStartEvent, ctx: PluginHookSessionContext): void {
+    const sk = ctx.sessionKey ?? event.sessionKey;
+    if (!sk) return;
+    const spanId = id();
+    const traceId = id();
+    this.sessions.set(sk, { traceId, spanId });
+    this.emit({
+      traceId,
+      spanId,
+      kind: "session",
+      name: `${ctx.agentId ?? "agent"} session`,
+      agentId: ctx.agentId,
+      sessionKey: sk,
+      startMs: Date.now(),
+      attributes: {},
+    });
+  }
+
+  onSessionEnd(event: PluginHookSessionEndEvent, ctx: PluginHookSessionContext): void {
+    const sk = ctx.sessionKey ?? event.sessionKey;
+    if (!sk) return;
+    const session = this.sessions.get(sk);
+    if (!session) return;
+    this.emit({
+      traceId: session.traceId,
+      spanId: session.spanId,
+      kind: "session",
+      name: `${ctx.agentId ?? "agent"} session`,
+      agentId: ctx.agentId,
+      sessionKey: sk,
+      startMs: Date.now() - (event.durationMs ?? 0),
+      endMs: Date.now(),
+      durationMs: event.durationMs,
+      attributes: { messageCount: event.messageCount },
+    });
+    this.sessions.delete(sk);
+  }
+
+  onLlmInput(event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext): void {
+    const session = this.sessionCtx(ctx.sessionKey);
+    if (!session) return;
+    const spanId = id();
+    if (event.runId) this.activeRuns.set(event.runId, spanId);
+    this.emit({
+      traceId: session.traceId,
+      spanId,
+      parentSpanId: session.spanId,
+      kind: "llm_call",
+      name: "llm_call",
+      agentId: ctx.agentId,
+      sessionKey: ctx.sessionKey,
+      provider: event.provider,
+      model: event.model,
+      startMs: Date.now(),
+      attributes: {},
+    });
+  }
+
+  onLlmOutput(event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext): void {
+    const session = this.sessionCtx(ctx.sessionKey);
+    if (!session) return;
+    const spanId = event.runId ? this.activeRuns.get(event.runId) : undefined;
+    if (!spanId) return;
+    this.emit({
+      traceId: session.traceId,
+      spanId,
+      parentSpanId: session.spanId,
+      kind: "llm_call",
+      name: "llm_call",
+      agentId: ctx.agentId,
+      sessionKey: ctx.sessionKey,
+      provider: event.provider,
+      model: event.model,
+      tokensIn: event.usage?.input,
+      tokensOut: event.usage?.output,
+      startMs: Date.now(),
+      endMs: Date.now(),
+      attributes: {},
+    });
+  }
+
+  onBeforeToolCall(event: PluginHookBeforeToolCallEvent, ctx: PluginHookToolContext): void {
+    const session = this.sessionCtx(ctx.sessionKey);
+    if (!session) return;
+    const spanId = id();
+    const parentLlm = ctx.runId ? this.activeRuns.get(ctx.runId) : undefined;
+    if (event.toolCallId) this.activeTools.set(event.toolCallId, spanId);
+    this.emit({
+      traceId: session.traceId,
+      spanId,
+      parentSpanId: parentLlm ?? session.spanId,
+      kind: "tool_call",
+      name: event.toolName,
+      agentId: ctx.agentId,
+      sessionKey: ctx.sessionKey,
+      toolName: event.toolName,
+      toolParams: event.params,
+      startMs: Date.now(),
+      attributes: {},
+    });
+  }
+
+  onAfterToolCall(event: PluginHookAfterToolCallEvent, ctx: PluginHookToolContext): void {
+    const session = this.sessionCtx(ctx.sessionKey);
+    if (!session) return;
+    const spanId = event.toolCallId ? this.activeTools.get(event.toolCallId) : undefined;
+    if (!spanId) return;
+    const parentLlm = ctx.runId ? this.activeRuns.get(ctx.runId) : undefined;
+    this.emit({
+      traceId: session.traceId,
+      spanId,
+      parentSpanId: parentLlm ?? session.spanId,
+      kind: "tool_call",
+      name: event.toolName,
+      agentId: ctx.agentId,
+      sessionKey: ctx.sessionKey,
+      toolName: event.toolName,
+      toolParams: event.params,
+      startMs: Date.now() - (event.durationMs ?? 0),
+      endMs: Date.now(),
+      durationMs: event.durationMs,
+      attributes: event.error ? { error: event.error } : {},
+    });
+    if (event.toolCallId) this.activeTools.delete(event.toolCallId);
+  }
+
+  onSubagentSpawning(event: PluginHookSubagentSpawningEvent, ctx: PluginHookSubagentContext): void {
+    const session = this.sessionCtx(ctx.requesterSessionKey);
+    if (!session) return;
+    const spanId = id();
+    this.activeSubagents.set(event.childSessionKey, spanId);
+    this.emit({
+      traceId: session.traceId,
+      spanId,
+      parentSpanId: session.spanId,
+      kind: "subagent",
+      name: `spawn:${event.agentId}`,
+      agentId: undefined,
+      sessionKey: ctx.requesterSessionKey,
+      childSessionKey: event.childSessionKey,
+      childAgentId: event.agentId,
+      startMs: Date.now(),
+      attributes: { mode: event.mode },
+    });
+  }
+
+  onSubagentEnded(event: PluginHookSubagentEndedEvent, ctx: PluginHookSubagentContext): void {
+    const childSk = event.targetSessionKey ?? ctx.childSessionKey;
+    if (!childSk) return;
+    const spanId = this.activeSubagents.get(childSk);
+    if (!spanId) return;
+    const session = this.sessionCtx(ctx.requesterSessionKey);
+    const traceId = session?.traceId ?? "unknown";
+    this.emit({
+      traceId,
+      spanId,
+      parentSpanId: session?.spanId,
+      kind: "subagent",
+      name: `spawn:ended`,
+      childSessionKey: childSk,
+      startMs: Date.now(),
+      endMs: Date.now(),
+      durationMs: undefined,
+      attributes: { outcome: event.outcome ?? "unknown", reason: event.reason },
+    });
+    this.activeSubagents.delete(childSk);
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run extensions/tracing/src/collector.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+scripts/committer "feat(tracing): add span collector with hook handlers" extensions/tracing/src/collector.ts extensions/tracing/src/collector.test.ts
+```
+
+---
+
+### Task 4: CLI tree viewer
+
+**Files:**
+
+- Create: `extensions/tracing/src/viewer-cli.ts`
+- Create: `extensions/tracing/src/viewer-cli.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { renderCallTree, renderEntityTree } from "./viewer-cli.js";
+import type { TraceSpan } from "./types.js";
+
+const spans: TraceSpan[] = [
+  {
+    traceId: "t1",
+    spanId: "s1",
+    kind: "session",
+    name: "bot session",
+    agentId: "bot",
+    sessionKey: "sk1",
+    startMs: 0,
+    endMs: 5000,
+    durationMs: 5000,
+    attributes: {},
+  },
+  {
+    traceId: "t1",
+    spanId: "s2",
+    parentSpanId: "s1",
+    kind: "llm_call",
+    name: "llm_call",
+    agentId: "bot",
+    sessionKey: "sk1",
+    provider: "anthropic",
+    model: "claude-sonnet-4-20250514",
+    startMs: 100,
+    endMs: 1500,
+    durationMs: 1400,
+    tokensIn: 200,
+    tokensOut: 50,
+    attributes: {},
+  },
+  {
+    traceId: "t1",
+    spanId: "s3",
+    parentSpanId: "s2",
+    kind: "tool_call",
+    name: "web_search",
+    agentId: "bot",
+    sessionKey: "sk1",
+    toolName: "web_search",
+    startMs: 1500,
+    endMs: 2500,
+    durationMs: 1000,
+    attributes: {},
+  },
+];
+
+describe("renderCallTree", () => {
+  it("returns lines with tree connectors", () => {
+    const lines = renderCallTree(spans);
+    expect(lines.length).toBeGreaterThan(0);
+    const plain = lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, "")).join("\n");
+    expect(plain).toContain("bot");
+    expect(plain).toContain("llm");
+    expect(plain).toContain("web_search");
+  });
+});
+
+describe("renderEntityTree", () => {
+  it("returns agent summary lines", () => {
+    const lines = renderEntityTree(spans);
+    expect(lines.length).toBeGreaterThan(0);
+    const plain = lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, "")).join("\n");
+    expect(plain).toContain("bot");
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run extensions/tracing/src/viewer-cli.test.ts`
+Expected: FAIL
+
+**Step 3: Write implementation**
+
+Port the rendering logic from `demo-tracing/viewer.ts` into two pure functions that return `string[]` lines (testable, no direct `console.log`). Keep ANSI colors, icons, duration formatting.
+
+Key functions:
+
+- `renderCallTree(spans: TraceSpan[]): string[]`
+- `renderEntityTree(spans: TraceSpan[]): string[]`
+- `renderWaterfall(spans: TraceSpan[]): string[]`
+
+Each returns an array of formatted lines. The CLI command joins and prints them.
+
+**Step 4: Run test, verify pass**
+
+**Step 5: Commit**
+
+```bash
+scripts/committer "feat(tracing): add CLI tree viewer" extensions/tracing/src/viewer-cli.ts extensions/tracing/src/viewer-cli.test.ts
+```
+
+---
+
+### Task 5: Plugin entry point + CLI registration
+
+**Files:**
+
+- Create: `extensions/tracing/index.ts`
+
+**Step 1: Write plugin entry point**
+
+```typescript
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { TraceCollector } from "./src/collector.js";
+import { JsonlTraceWriter } from "./src/storage-jsonl.js";
+import { renderCallTree, renderEntityTree, renderWaterfall } from "./src/viewer-cli.js";
+import path from "node:path";
+import os from "node:os";
+
+const plugin = {
+  id: "tracing",
+  name: "Agent Tracing",
+  description: "Trace tool calls, LLM invocations, and sub-agent relationships",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    const traceDir = path.join(os.homedir(), ".openclaw", "traces");
+    const writer = new JsonlTraceWriter(traceDir);
+    const collector = new TraceCollector((span) => writer.write(span));
+
+    // Register hooks
+    api.on("session_start", (event, ctx) => collector.onSessionStart(event, ctx));
+    api.on("session_end", (event, ctx) => collector.onSessionEnd(event, ctx));
+    api.on("llm_input", (event, ctx) => collector.onLlmInput(event, ctx));
+    api.on("llm_output", (event, ctx) => collector.onLlmOutput(event, ctx));
+    api.on("before_tool_call", (event, ctx) => collector.onBeforeToolCall(event, ctx));
+    api.on("after_tool_call", (event, ctx) => collector.onAfterToolCall(event, ctx));
+    api.on("subagent_spawning", (event, ctx) => {
+      collector.onSubagentSpawning(event, ctx);
+    });
+    api.on("subagent_ended", (event, ctx) => collector.onSubagentEnded(event, ctx));
+
+    // Register CLI command
+    api.registerCli(
+      (program) => {
+        program
+          .command("traces")
+          .description("View agent execution traces")
+          .option("--mode <mode>", "View mode: call, entity, waterfall, both", "both")
+          .option("--date <date>", "Date to view (YYYY-MM-DD), defaults to today")
+          .option("--list", "List available trace dates")
+          .action((opts) => {
+            if (opts.list) {
+              const dates = writer.listDates();
+              if (!dates.length) {
+                console.log("No traces found.");
+                return;
+              }
+              for (const d of dates) console.log(d);
+              return;
+            }
+            const dateKey = opts.date ?? new Date().toISOString().slice(0, 10);
+            const spans = writer.readByDate(dateKey);
+            if (!spans.length) {
+              console.log(`No traces for ${dateKey}.`);
+              return;
+            }
+            const mode = opts.mode as string;
+            if (mode === "call" || mode === "both") {
+              for (const line of renderCallTree(spans)) console.log(line);
+            }
+            if (mode === "entity" || mode === "both") {
+              for (const line of renderEntityTree(spans)) console.log(line);
+            }
+            if (mode === "waterfall" || mode === "both") {
+              for (const line of renderWaterfall(spans)) console.log(line);
+            }
+          });
+      },
+      { commands: ["traces"] },
+    );
+  },
+};
+
+export default plugin;
+```
+
+**Step 2: Commit**
+
+```bash
+scripts/committer "feat(tracing): add plugin entry point with hook + CLI wiring" extensions/tracing/index.ts
+```
+
+---
+
+### Task 6: Integration test with fake data
+
+**Files:**
+
+- Create: `extensions/tracing/src/integration.test.ts`
+
+**Step 1: Write end-to-end test**
+
+Test the full flow: collector → JSONL writer → reader → viewer rendering. Use the same fake scenario from `demo-tracing/generate-fake-data.ts` but driven programmatically through the collector's hook methods.
+
+**Step 2: Run all tests**
+
+Run: `npx vitest run extensions/tracing/`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+scripts/committer "test(tracing): add integration test" extensions/tracing/src/integration.test.ts
+```
+
+---
+
+### Task 7: Cleanup demo, final verification
+
+**Step 1: Verify the full plugin works**
+
+Run: `npx vitest run extensions/tracing/`
+
+**Step 2: Remove demo-tracing directory** (it was just a prototype)
+
+**Step 3: Final commit**
+
+```bash
+scripts/committer "chore: remove demo-tracing prototype" -d demo-tracing/
+```

--- a/extensions/tracing/index.ts
+++ b/extensions/tracing/index.ts
@@ -1,0 +1,84 @@
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/tracing";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/tracing";
+import { TraceCollector } from "./src/collector.js";
+import { JsonlTraceWriter } from "./src/storage-jsonl.js";
+import { renderCallTree, renderEntityTree, renderWaterfall } from "./src/viewer-cli.js";
+import { createTracingHttpHandler } from "./src/web-viewer.js";
+
+const plugin = {
+  id: "tracing",
+  name: "Agent Tracing",
+  description: "Trace tool calls, LLM invocations, and sub-agent relationships",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    const traceDir = path.join(os.homedir(), ".openclaw", "traces");
+    const writer = new JsonlTraceWriter(traceDir);
+    const collector = new TraceCollector((span) => writer.write(span));
+
+    api.on("session_start", (event, ctx) => collector.onSessionStart(event, ctx));
+    api.on("session_end", (event, ctx) => collector.onSessionEnd(event, ctx));
+    api.on("llm_input", (event, ctx) => collector.onLlmInput(event, ctx));
+    api.on("llm_output", (event, ctx) => collector.onLlmOutput(event, ctx));
+    api.on("before_tool_call", (event, ctx) => {
+      collector.onBeforeToolCall(event, ctx);
+    });
+    api.on("after_tool_call", (event, ctx) => collector.onAfterToolCall(event, ctx));
+    api.on("subagent_spawning", (event, ctx) => {
+      collector.onSubagentSpawning(event, ctx);
+    });
+    api.on("subagent_ended", (event, ctx) => collector.onSubagentEnded(event, ctx));
+
+    // Web UI at /plugins/tracing
+    api.registerHttpRoute({
+      path: "/plugins/tracing",
+      auth: "plugin",
+      match: "prefix",
+      handler: createTracingHttpHandler(writer),
+    });
+
+    api.registerCli(
+      ({ program }) => {
+        program
+          .command("traces")
+          .description("View agent execution traces")
+          .option("--mode <mode>", "View mode: call, entity, waterfall, both", "both")
+          .option("--date <date>", "Date to view (YYYY-MM-DD), defaults to today")
+          .option("--list", "List available trace dates")
+          .action((opts: { mode?: string; date?: string; list?: boolean }) => {
+            if (opts.list) {
+              const dates = writer.listDates();
+              if (!dates.length) {
+                console.log("No traces found.");
+                return;
+              }
+              for (const d of dates) console.log(d);
+              return;
+            }
+
+            const dateKey = opts.date ?? new Date().toISOString().slice(0, 10);
+            const spans = writer.readByDate(dateKey);
+            if (!spans.length) {
+              console.log(`No traces for ${dateKey}.`);
+              return;
+            }
+
+            const mode = opts.mode ?? "both";
+            if (mode === "call" || mode === "both") {
+              for (const line of renderCallTree(spans)) console.log(line);
+            }
+            if (mode === "entity" || mode === "both") {
+              for (const line of renderEntityTree(spans)) console.log(line);
+            }
+            if (mode === "waterfall" || mode === "both") {
+              for (const line of renderWaterfall(spans)) console.log(line);
+            }
+          });
+      },
+      { commands: ["traces"] },
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/tracing/package.json
+++ b/extensions/tracing/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@openclaw/tracing",
+  "version": "2026.3.9",
+  "description": "Agent execution tracing with tree-view CLI",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/tracing/src/collector.test.ts
+++ b/extensions/tracing/src/collector.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { TraceCollector } from "./collector.js";
+import type { TraceSpan } from "./types.js";
+
+describe("TraceCollector", () => {
+  let emitted: TraceSpan[];
+  let emit: (span: TraceSpan) => void;
+  let collector: TraceCollector;
+
+  beforeEach(() => {
+    emitted = [];
+    emit = (span) => emitted.push(span);
+    collector = new TraceCollector(emit);
+  });
+
+  describe("onSessionStart", () => {
+    it("emits an open session span with a new traceId", () => {
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk1" },
+        { sessionId: "s1", sessionKey: "sk1", agentId: "agent-1" },
+      );
+
+      expect(emitted).toHaveLength(1);
+      const span = emitted[0]!;
+      expect(span.kind).toBe("session");
+      expect(span.name).toBe("session");
+      expect(span.sessionKey).toBe("sk1");
+      expect(span.agentId).toBe("agent-1");
+      expect(span.traceId).toBeTruthy();
+      expect(span.spanId).toBeTruthy();
+      expect(span.parentSpanId).toBeUndefined();
+      expect(span.startMs).toBeGreaterThan(0);
+      expect(span.endMs).toBeUndefined();
+      expect(span.durationMs).toBeUndefined();
+    });
+  });
+
+  describe("onSessionEnd", () => {
+    it("emits a closed session span with endMs and durationMs", () => {
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk1" },
+        { sessionId: "s1", sessionKey: "sk1" },
+      );
+      emitted.length = 0;
+
+      collector.onSessionEnd(
+        { sessionId: "s1", sessionKey: "sk1", messageCount: 5, durationMs: 1000 },
+        { sessionId: "s1", sessionKey: "sk1" },
+      );
+
+      expect(emitted).toHaveLength(1);
+      const span = emitted[0]!;
+      expect(span.kind).toBe("session");
+      expect(span.endMs).toBeGreaterThan(0);
+      expect(span.durationMs).toBeGreaterThanOrEqual(0);
+      expect(span.attributes.messageCount).toBe(5);
+    });
+
+    it("does nothing if no matching session was started", () => {
+      collector.onSessionEnd(
+        { sessionId: "s-unknown", sessionKey: "sk-unknown", messageCount: 0 },
+        { sessionId: "s-unknown", sessionKey: "sk-unknown" },
+      );
+      expect(emitted).toHaveLength(0);
+    });
+  });
+
+  describe("onLlmInput", () => {
+    it("emits an open llm_call span parented to the session", () => {
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk1" },
+        { sessionId: "s1", sessionKey: "sk1", agentId: "a1" },
+      );
+      emitted.length = 0;
+
+      collector.onLlmInput(
+        {
+          runId: "r1",
+          sessionId: "s1",
+          provider: "anthropic",
+          model: "claude-4",
+          prompt: "hello",
+          historyMessages: [],
+          imagesCount: 0,
+        },
+        { agentId: "a1", sessionKey: "sk1", sessionId: "s1" },
+      );
+
+      expect(emitted).toHaveLength(1);
+      const span = emitted[0]!;
+      expect(span.kind).toBe("llm_call");
+      expect(span.provider).toBe("anthropic");
+      expect(span.model).toBe("claude-4");
+      expect(span.parentSpanId).toBeTruthy();
+      expect(span.endMs).toBeUndefined();
+    });
+  });
+
+  describe("onLlmOutput", () => {
+    it("closes the llm_call span with token counts", () => {
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk1" },
+        { sessionId: "s1", sessionKey: "sk1" },
+      );
+
+      collector.onLlmInput(
+        {
+          runId: "r1",
+          sessionId: "s1",
+          provider: "anthropic",
+          model: "claude-4",
+          prompt: "hello",
+          historyMessages: [],
+          imagesCount: 0,
+        },
+        { sessionKey: "sk1", sessionId: "s1" },
+      );
+      emitted.length = 0;
+
+      collector.onLlmOutput(
+        {
+          runId: "r1",
+          sessionId: "s1",
+          provider: "anthropic",
+          model: "claude-4",
+          assistantTexts: ["world"],
+          usage: { input: 10, output: 20, total: 30 },
+        },
+        { sessionKey: "sk1", sessionId: "s1" },
+      );
+
+      expect(emitted).toHaveLength(1);
+      const span = emitted[0]!;
+      expect(span.kind).toBe("llm_call");
+      expect(span.endMs).toBeGreaterThan(0);
+      expect(span.durationMs).toBeGreaterThanOrEqual(0);
+      expect(span.tokensIn).toBe(10);
+      expect(span.tokensOut).toBe(20);
+    });
+
+    it("does nothing if no matching run was opened", () => {
+      collector.onLlmOutput(
+        {
+          runId: "r-unknown",
+          sessionId: "s1",
+          provider: "anthropic",
+          model: "claude-4",
+          assistantTexts: [],
+        },
+        { sessionKey: "sk1" },
+      );
+      expect(emitted).toHaveLength(0);
+    });
+  });
+
+  describe("onBeforeToolCall / onAfterToolCall", () => {
+    it("opens and closes a tool_call span parented to the llm run", () => {
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk1" },
+        { sessionId: "s1", sessionKey: "sk1" },
+      );
+      collector.onLlmInput(
+        {
+          runId: "r1",
+          sessionId: "s1",
+          provider: "anthropic",
+          model: "claude-4",
+          prompt: "hi",
+          historyMessages: [],
+          imagesCount: 0,
+        },
+        { sessionKey: "sk1", sessionId: "s1" },
+      );
+      emitted.length = 0;
+
+      collector.onBeforeToolCall(
+        { toolName: "bash", params: { cmd: "ls" }, runId: "r1", toolCallId: "tc1" },
+        { sessionKey: "sk1", sessionId: "s1", runId: "r1", toolName: "bash", toolCallId: "tc1" },
+      );
+
+      expect(emitted).toHaveLength(1);
+      const openSpan = emitted[0]!;
+      expect(openSpan.kind).toBe("tool_call");
+      expect(openSpan.toolName).toBe("bash");
+      expect(openSpan.toolParams).toEqual({ cmd: "ls" });
+      expect(openSpan.endMs).toBeUndefined();
+
+      emitted.length = 0;
+
+      collector.onAfterToolCall(
+        { toolName: "bash", params: { cmd: "ls" }, runId: "r1", toolCallId: "tc1", durationMs: 50 },
+        { sessionKey: "sk1", sessionId: "s1", runId: "r1", toolName: "bash", toolCallId: "tc1" },
+      );
+
+      expect(emitted).toHaveLength(1);
+      const closeSpan = emitted[0]!;
+      expect(closeSpan.kind).toBe("tool_call");
+      expect(closeSpan.endMs).toBeGreaterThan(0);
+      expect(closeSpan.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("parents to session span if no active llm run", () => {
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk1" },
+        { sessionId: "s1", sessionKey: "sk1" },
+      );
+      const sessionSpanId = emitted[0]!.spanId;
+      emitted.length = 0;
+
+      collector.onBeforeToolCall(
+        { toolName: "bash", params: {}, toolCallId: "tc2" },
+        { sessionKey: "sk1", sessionId: "s1", toolName: "bash", toolCallId: "tc2" },
+      );
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]!.parentSpanId).toBe(sessionSpanId);
+    });
+  });
+
+  describe("onSubagentSpawning / onSubagentEnded", () => {
+    it("opens and closes a subagent span", () => {
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk1" },
+        { sessionId: "s1", sessionKey: "sk1" },
+      );
+      const sessionSpanId = emitted[0]!.spanId;
+      emitted.length = 0;
+
+      collector.onSubagentSpawning(
+        {
+          childSessionKey: "child-sk1",
+          agentId: "sub-agent",
+          label: "helper",
+          mode: "run",
+          threadRequested: false,
+        },
+        { requesterSessionKey: "sk1", childSessionKey: "child-sk1" },
+      );
+
+      expect(emitted).toHaveLength(1);
+      const openSpan = emitted[0]!;
+      expect(openSpan.kind).toBe("subagent");
+      expect(openSpan.parentSpanId).toBe(sessionSpanId);
+      expect(openSpan.childSessionKey).toBe("child-sk1");
+      expect(openSpan.childAgentId).toBe("sub-agent");
+      expect(openSpan.endMs).toBeUndefined();
+
+      emitted.length = 0;
+
+      collector.onSubagentEnded(
+        {
+          targetSessionKey: "child-sk1",
+          targetKind: "subagent",
+          reason: "completed",
+          outcome: "ok",
+        },
+        { requesterSessionKey: "sk1", childSessionKey: "child-sk1" },
+      );
+
+      expect(emitted).toHaveLength(1);
+      const closeSpan = emitted[0]!;
+      expect(closeSpan.kind).toBe("subagent");
+      expect(closeSpan.endMs).toBeGreaterThan(0);
+      expect(closeSpan.durationMs).toBeGreaterThanOrEqual(0);
+      expect(closeSpan.attributes.outcome).toBe("ok");
+      expect(closeSpan.attributes.reason).toBe("completed");
+    });
+
+    it("does nothing on end if subagent was not tracked", () => {
+      collector.onSubagentEnded(
+        { targetSessionKey: "unknown", targetKind: "subagent", reason: "done" },
+        { requesterSessionKey: "sk1", childSessionKey: "unknown" },
+      );
+      expect(emitted).toHaveLength(0);
+    });
+  });
+
+  describe("parent chain", () => {
+    it("links tool spans to their triggering llm run", () => {
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk1" },
+        { sessionId: "s1", sessionKey: "sk1" },
+      );
+      collector.onLlmInput(
+        {
+          runId: "r1",
+          sessionId: "s1",
+          provider: "anthropic",
+          model: "claude-4",
+          prompt: "hi",
+          historyMessages: [],
+          imagesCount: 0,
+        },
+        { sessionKey: "sk1", sessionId: "s1" },
+      );
+      const llmSpanId = emitted[1]!.spanId;
+      emitted.length = 0;
+
+      collector.onBeforeToolCall(
+        { toolName: "read", params: {}, runId: "r1", toolCallId: "tc1" },
+        { sessionKey: "sk1", sessionId: "s1", runId: "r1", toolName: "read", toolCallId: "tc1" },
+      );
+
+      expect(emitted[0]!.parentSpanId).toBe(llmSpanId);
+    });
+  });
+
+  describe("sub-agent traceId propagation", () => {
+    it("child session inherits parent traceId and links to subagent span", () => {
+      // Parent session
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk-parent" },
+        { sessionId: "s1", sessionKey: "sk-parent", agentId: "parent-bot" },
+      );
+      const parentTraceId = emitted[0]!.traceId;
+
+      // Spawn sub-agent
+      collector.onSubagentSpawning(
+        { childSessionKey: "sk-child", agentId: "child-bot", mode: "run", threadRequested: false },
+        { requesterSessionKey: "sk-parent", childSessionKey: "sk-child" },
+      );
+      const subagentSpanId = emitted[1]!.spanId;
+
+      // Child session starts — should inherit parent traceId
+      collector.onSessionStart(
+        { sessionId: "s2", sessionKey: "sk-child" },
+        { sessionId: "s2", sessionKey: "sk-child", agentId: "child-bot" },
+      );
+      const childSessionSpan = emitted[2]!;
+      expect(childSessionSpan.traceId).toBe(parentTraceId);
+      expect(childSessionSpan.parentSpanId).toBe(subagentSpanId);
+    });
+
+    it("child tool calls share the same traceId as parent", () => {
+      // Parent session
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk-parent" },
+        { sessionId: "s1", sessionKey: "sk-parent" },
+      );
+      const parentTraceId = emitted[0]!.traceId;
+
+      // Spawn + child session
+      collector.onSubagentSpawning(
+        { childSessionKey: "sk-child", agentId: "child-bot", mode: "run", threadRequested: false },
+        { requesterSessionKey: "sk-parent", childSessionKey: "sk-child" },
+      );
+      collector.onSessionStart(
+        { sessionId: "s2", sessionKey: "sk-child" },
+        { sessionId: "s2", sessionKey: "sk-child" },
+      );
+
+      // Child LLM + tool call
+      collector.onLlmInput(
+        {
+          runId: "r2",
+          sessionId: "s2",
+          provider: "openai",
+          model: "gpt-4o",
+          prompt: "translate",
+          historyMessages: [],
+          imagesCount: 0,
+        },
+        { sessionKey: "sk-child", sessionId: "s2" },
+      );
+      collector.onBeforeToolCall(
+        { toolName: "translate", params: { text: "hello" }, runId: "r2", toolCallId: "tc-child" },
+        {
+          sessionKey: "sk-child",
+          sessionId: "s2",
+          runId: "r2",
+          toolName: "translate",
+          toolCallId: "tc-child",
+        },
+      );
+
+      // All spans should share parent traceId
+      const allTraceIds = emitted.map((s) => s.traceId);
+      expect(allTraceIds.every((id) => id === parentTraceId)).toBe(true);
+    });
+  });
+
+  describe("ID generation", () => {
+    it("generates unique trace and span IDs", () => {
+      collector.onSessionStart(
+        { sessionId: "s1", sessionKey: "sk1" },
+        { sessionId: "s1", sessionKey: "sk1" },
+      );
+      collector.onSessionStart(
+        { sessionId: "s2", sessionKey: "sk2" },
+        { sessionId: "s2", sessionKey: "sk2" },
+      );
+
+      expect(emitted[0]!.traceId).not.toBe(emitted[1]!.traceId);
+      expect(emitted[0]!.spanId).not.toBe(emitted[1]!.spanId);
+    });
+  });
+
+  describe("session key fallback", () => {
+    it("uses sessionId as key when sessionKey is missing", () => {
+      collector.onSessionStart({ sessionId: "s1" }, { sessionId: "s1" });
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]!.sessionKey).toBe("s1");
+
+      collector.onSessionEnd({ sessionId: "s1", messageCount: 1 }, { sessionId: "s1" });
+
+      expect(emitted).toHaveLength(2);
+      expect(emitted[1]!.endMs).toBeGreaterThan(0);
+    });
+  });
+});

--- a/extensions/tracing/src/collector.ts
+++ b/extensions/tracing/src/collector.ts
@@ -1,0 +1,350 @@
+import crypto from "node:crypto";
+import type { TraceSpan } from "./types.js";
+
+// Local type aliases for hook events/contexts so we don't depend on openclaw/plugin-sdk
+
+type SessionStartEvent = { sessionId: string; sessionKey?: string; resumedFrom?: string };
+type SessionEndEvent = {
+  sessionId: string;
+  sessionKey?: string;
+  messageCount: number;
+  durationMs?: number;
+};
+type SessionContext = { agentId?: string; sessionId: string; sessionKey?: string };
+
+type LlmInputEvent = {
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  prompt: string;
+  historyMessages: unknown[];
+  imagesCount: number;
+};
+type LlmOutputEvent = {
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  assistantTexts: string[];
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+};
+type AgentContext = {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  workspaceDir?: string;
+  messageProvider?: string;
+  trigger?: string;
+  channelId?: string;
+};
+
+type BeforeToolCallEvent = {
+  toolName: string;
+  params: Record<string, unknown>;
+  runId?: string;
+  toolCallId?: string;
+};
+type AfterToolCallEvent = {
+  toolName: string;
+  params: Record<string, unknown>;
+  runId?: string;
+  toolCallId?: string;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+};
+type ToolContext = {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+  toolName: string;
+  toolCallId?: string;
+};
+
+type SubagentSpawningEvent = {
+  childSessionKey: string;
+  agentId: string;
+  label?: string;
+  mode: "run" | "session";
+  threadRequested: boolean;
+  requester?: { channel?: string; accountId?: string; to?: string; threadId?: string | number };
+};
+type SubagentEndedEvent = {
+  targetSessionKey: string;
+  targetKind: "subagent" | "acp";
+  reason: string;
+  sendFarewell?: boolean;
+  accountId?: string;
+  runId?: string;
+  endedAt?: number;
+  outcome?: "ok" | "error" | "timeout" | "killed" | "reset" | "deleted";
+  error?: string;
+};
+type SubagentContext = {
+  runId?: string;
+  childSessionKey?: string;
+  requesterSessionKey?: string;
+};
+
+function genId(): string {
+  return crypto.randomUUID().slice(0, 16);
+}
+
+function nowMs(): number {
+  return Date.now();
+}
+
+type SessionEntry = { traceId: string; spanId: string; startMs: number };
+type RunEntry = { spanId: string; span: TraceSpan };
+type ToolEntry = { spanId: string; span: TraceSpan };
+type SubagentEntry = { spanId: string; span: TraceSpan };
+
+export class TraceCollector {
+  private emit: (span: TraceSpan) => void;
+  private sessions = new Map<string, SessionEntry>();
+  private activeRuns = new Map<string, RunEntry>();
+  private activeTools = new Map<string, ToolEntry>();
+  private activeSubagents = new Map<string, SubagentEntry>();
+
+  constructor(emit: (span: TraceSpan) => void) {
+    this.emit = emit;
+  }
+
+  private sessionKey(
+    event: { sessionKey?: string; sessionId?: string },
+    ctx: { sessionKey?: string; sessionId?: string },
+  ): string {
+    return event.sessionKey ?? ctx.sessionKey ?? event.sessionId ?? ctx.sessionId ?? "unknown";
+  }
+
+  onSessionStart(event: SessionStartEvent, ctx: SessionContext): void {
+    const key = this.sessionKey(event, ctx);
+    const spanId = genId();
+    const start = nowMs();
+
+    // If this session was spawned as a sub-agent, inherit the parent's traceId
+    // and link this session span to the subagent span as its parent.
+    const parentSubagent = this.activeSubagents.get(key);
+    const traceId = parentSubagent ? parentSubagent.span.traceId : genId();
+    const parentSpanId = parentSubagent?.spanId;
+
+    this.sessions.set(key, { traceId, spanId, startMs: start });
+
+    const span: TraceSpan = {
+      traceId,
+      spanId,
+      parentSpanId,
+      kind: "session",
+      name: "session",
+      agentId: ctx.agentId,
+      sessionKey: key,
+      startMs: start,
+      attributes: {},
+    };
+
+    if (event.resumedFrom) {
+      span.attributes.resumedFrom = event.resumedFrom;
+    }
+
+    this.emit(span);
+  }
+
+  onSessionEnd(event: SessionEndEvent, ctx: SessionContext): void {
+    const key = this.sessionKey(event, ctx);
+    const session = this.sessions.get(key);
+    if (!session) return;
+
+    const end = nowMs();
+    const span: TraceSpan = {
+      traceId: session.traceId,
+      spanId: session.spanId,
+      kind: "session",
+      name: "session",
+      agentId: ctx.agentId,
+      sessionKey: key,
+      startMs: session.startMs,
+      endMs: end,
+      durationMs: end - session.startMs,
+      attributes: {
+        messageCount: event.messageCount,
+      },
+    };
+
+    this.emit(span);
+    this.sessions.delete(key);
+  }
+
+  onLlmInput(event: LlmInputEvent, ctx: AgentContext): void {
+    const key = this.sessionKey({ sessionId: event.sessionId }, ctx);
+    const session = this.sessions.get(key);
+    if (!session) return;
+
+    const spanId = genId();
+    const start = nowMs();
+
+    const span: TraceSpan = {
+      traceId: session.traceId,
+      spanId,
+      parentSpanId: session.spanId,
+      kind: "llm_call",
+      name: "llm_call",
+      agentId: ctx.agentId,
+      sessionKey: key,
+      startMs: start,
+      provider: event.provider,
+      model: event.model,
+      attributes: {
+        imagesCount: event.imagesCount,
+      },
+    };
+
+    this.activeRuns.set(event.runId, { spanId, span });
+    this.emit(span);
+  }
+
+  onLlmOutput(event: LlmOutputEvent, ctx: AgentContext): void {
+    const entry = this.activeRuns.get(event.runId);
+    if (!entry) return;
+
+    const end = nowMs();
+    const span: TraceSpan = {
+      ...entry.span,
+      endMs: end,
+      durationMs: end - entry.span.startMs,
+      tokensIn: event.usage?.input,
+      tokensOut: event.usage?.output,
+      attributes: {
+        ...entry.span.attributes,
+      },
+    };
+
+    if (event.usage?.cacheRead != null) span.attributes.cacheRead = event.usage.cacheRead;
+    if (event.usage?.cacheWrite != null) span.attributes.cacheWrite = event.usage.cacheWrite;
+    if (event.usage?.total != null) span.attributes.totalTokens = event.usage.total;
+
+    this.emit(span);
+    this.activeRuns.delete(event.runId);
+  }
+
+  onBeforeToolCall(event: BeforeToolCallEvent, ctx: ToolContext): void {
+    const key = this.sessionKey({}, ctx);
+    const session = this.sessions.get(key);
+    if (!session) return;
+
+    const spanId = genId();
+    const start = nowMs();
+
+    // Parent is the active LLM run if available, otherwise the session
+    let parentSpanId = session.spanId;
+    if (event.runId) {
+      const run = this.activeRuns.get(event.runId);
+      if (run) parentSpanId = run.spanId;
+    }
+
+    const toolCallId = event.toolCallId ?? ctx.toolCallId ?? genId();
+
+    const span: TraceSpan = {
+      traceId: session.traceId,
+      spanId,
+      parentSpanId,
+      kind: "tool_call",
+      name: `tool:${event.toolName}`,
+      agentId: ctx.agentId,
+      sessionKey: key,
+      startMs: start,
+      toolName: event.toolName,
+      toolParams: event.params,
+      attributes: {},
+    };
+
+    this.activeTools.set(toolCallId, { spanId, span });
+    this.emit(span);
+  }
+
+  onAfterToolCall(event: AfterToolCallEvent, ctx: ToolContext): void {
+    const toolCallId = event.toolCallId ?? ctx.toolCallId;
+    if (!toolCallId) return;
+
+    const entry = this.activeTools.get(toolCallId);
+    if (!entry) return;
+
+    const end = nowMs();
+    const span: TraceSpan = {
+      ...entry.span,
+      endMs: end,
+      durationMs: end - entry.span.startMs,
+      attributes: {
+        ...entry.span.attributes,
+      },
+    };
+
+    if (event.error) span.attributes.error = event.error;
+    if (event.durationMs != null) span.attributes.reportedDurationMs = event.durationMs;
+
+    this.emit(span);
+    this.activeTools.delete(toolCallId);
+  }
+
+  onSubagentSpawning(event: SubagentSpawningEvent, ctx: SubagentContext): void {
+    const requesterKey = ctx.requesterSessionKey;
+    if (!requesterKey) return;
+
+    const session = this.sessions.get(requesterKey);
+    if (!session) return;
+
+    const spanId = genId();
+    const start = nowMs();
+
+    const span: TraceSpan = {
+      traceId: session.traceId,
+      spanId,
+      parentSpanId: session.spanId,
+      kind: "subagent",
+      name: `subagent:${event.agentId}`,
+      sessionKey: requesterKey,
+      childSessionKey: event.childSessionKey,
+      childAgentId: event.agentId,
+      startMs: start,
+      attributes: {
+        mode: event.mode,
+        threadRequested: event.threadRequested,
+      },
+    };
+
+    if (event.label) span.attributes.label = event.label;
+
+    this.activeSubagents.set(event.childSessionKey, { spanId, span });
+    this.emit(span);
+  }
+
+  onSubagentEnded(event: SubagentEndedEvent, ctx: SubagentContext): void {
+    const childKey = event.targetSessionKey;
+    const entry = this.activeSubagents.get(childKey);
+    if (!entry) return;
+
+    const end = nowMs();
+    const span: TraceSpan = {
+      ...entry.span,
+      endMs: end,
+      durationMs: end - entry.span.startMs,
+      attributes: {
+        ...entry.span.attributes,
+        reason: event.reason,
+      },
+    };
+
+    if (event.outcome) span.attributes.outcome = event.outcome;
+    if (event.error) span.attributes.error = event.error;
+
+    this.emit(span);
+    this.activeSubagents.delete(childKey);
+  }
+}

--- a/extensions/tracing/src/integration.test.ts
+++ b/extensions/tracing/src/integration.test.ts
@@ -1,0 +1,204 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { TraceCollector } from "./collector.js";
+import { JsonlTraceWriter } from "./storage-jsonl.js";
+import { renderCallTree, renderEntityTree, renderWaterfall } from "./viewer-cli.js";
+
+/**
+ * Integration test: collector → JSONL writer → reader → viewer.
+ * Simulates a multi-agent scenario: main bot → LLM → tool → spawn sub-agent → sub-agent LLM → tool.
+ */
+describe("tracing integration", () => {
+  let tmpDir: string;
+  let writer: JsonlTraceWriter;
+  let collector: TraceCollector;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trace-integration-"));
+    writer = new JsonlTraceWriter(tmpDir);
+    collector = new TraceCollector((span) => writer.write(span));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runScenario() {
+    // Main session starts
+    collector.onSessionStart(
+      { sessionId: "sid1", sessionKey: "sk-main" },
+      { agentId: "research-bot", sessionId: "sid1", sessionKey: "sk-main" },
+    );
+
+    // Main: LLM call
+    collector.onLlmInput(
+      {
+        runId: "r1",
+        sessionId: "sid1",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        prompt: "hi",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      { agentId: "research-bot", sessionId: "sid1", sessionKey: "sk-main" },
+    );
+
+    // Main: tool call during LLM
+    collector.onBeforeToolCall(
+      { toolName: "web_search", params: { query: "test" }, runId: "r1", toolCallId: "tc1" },
+      {
+        agentId: "research-bot",
+        sessionKey: "sk-main",
+        sessionId: "sid1",
+        runId: "r1",
+        toolName: "web_search",
+      },
+    );
+    collector.onAfterToolCall(
+      {
+        toolName: "web_search",
+        params: { query: "test" },
+        runId: "r1",
+        toolCallId: "tc1",
+        durationMs: 800,
+      },
+      {
+        agentId: "research-bot",
+        sessionKey: "sk-main",
+        sessionId: "sid1",
+        runId: "r1",
+        toolName: "web_search",
+      },
+    );
+
+    // Main: LLM output
+    collector.onLlmOutput(
+      {
+        runId: "r1",
+        sessionId: "sid1",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        assistantTexts: ["result"],
+        usage: { input: 500, output: 100 },
+      },
+      { agentId: "research-bot", sessionId: "sid1", sessionKey: "sk-main" },
+    );
+
+    // Main: spawn sub-agent
+    collector.onSubagentSpawning(
+      {
+        childSessionKey: "sk-child",
+        agentId: "translator-bot",
+        mode: "run",
+        threadRequested: false,
+      },
+      { runId: "r1", childSessionKey: "sk-child", requesterSessionKey: "sk-main" },
+    );
+
+    // Child session starts
+    collector.onSessionStart(
+      { sessionId: "sid2", sessionKey: "sk-child" },
+      { agentId: "translator-bot", sessionId: "sid2", sessionKey: "sk-child" },
+    );
+
+    // Child: LLM call
+    collector.onLlmInput(
+      {
+        runId: "r2",
+        sessionId: "sid2",
+        provider: "openai",
+        model: "gpt-4o",
+        prompt: "translate",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      { agentId: "translator-bot", sessionId: "sid2", sessionKey: "sk-child" },
+    );
+    collector.onLlmOutput(
+      {
+        runId: "r2",
+        sessionId: "sid2",
+        provider: "openai",
+        model: "gpt-4o",
+        assistantTexts: ["done"],
+        usage: { input: 200, output: 80 },
+      },
+      { agentId: "translator-bot", sessionId: "sid2", sessionKey: "sk-child" },
+    );
+
+    // Child session ends
+    collector.onSessionEnd(
+      { sessionId: "sid2", sessionKey: "sk-child", messageCount: 3, durationMs: 2000 },
+      { agentId: "translator-bot", sessionId: "sid2", sessionKey: "sk-child" },
+    );
+
+    // Sub-agent ends
+    collector.onSubagentEnded(
+      { targetSessionKey: "sk-child", targetKind: "subagent", reason: "done", outcome: "ok" },
+      { runId: "r1", childSessionKey: "sk-child", requesterSessionKey: "sk-main" },
+    );
+
+    // Main session ends
+    collector.onSessionEnd(
+      { sessionId: "sid1", sessionKey: "sk-main", messageCount: 5, durationMs: 5000 },
+      { agentId: "research-bot", sessionId: "sid1", sessionKey: "sk-main" },
+    );
+  }
+
+  it("writes spans to JSONL and reads them back", () => {
+    runScenario();
+    const today = new Date().toISOString().slice(0, 10);
+    const spans = writer.readByDate(today);
+    expect(spans.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("all spans share the same traceId for main session", () => {
+    runScenario();
+    const spans = writer.readToday();
+    const mainSpans = spans.filter((s) => s.sessionKey === "sk-main");
+    const traceIds = new Set(mainSpans.map((s) => s.traceId));
+    expect(traceIds.size).toBe(1);
+  });
+
+  it("renderCallTree produces tree output from stored spans", () => {
+    runScenario();
+    const spans = writer.readToday();
+    const lines = renderCallTree(spans);
+    const plain = lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, "")).join("\n");
+    expect(plain).toContain("research-bot");
+    expect(plain).toContain("web_search");
+  });
+
+  it("renderEntityTree shows both agents", () => {
+    runScenario();
+    const spans = writer.readToday();
+    const lines = renderEntityTree(spans);
+    const plain = lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, "")).join("\n");
+    expect(plain).toContain("research-bot");
+    expect(plain).toContain("translator-bot");
+  });
+
+  it("renderWaterfall produces timeline output", () => {
+    runScenario();
+    const spans = writer.readToday();
+    const lines = renderWaterfall(spans);
+    expect(lines.length).toBeGreaterThan(0);
+    const plain = lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, "")).join("\n");
+    expect(plain).toContain("█");
+  });
+
+  it("tool_call span has llm_call as parent", () => {
+    runScenario();
+    const spans = writer.readToday();
+    // Find closed tool span (has endMs set)
+    const toolSpan = spans.find((s) => s.kind === "tool_call" && s.endMs !== undefined);
+    expect(toolSpan).toBeDefined();
+    // Its parent should be an llm_call span
+    const parent = spans.find((s) => s.spanId === toolSpan!.parentSpanId);
+    expect(parent).toBeDefined();
+    expect(parent!.kind).toBe("llm_call");
+  });
+});

--- a/extensions/tracing/src/storage-jsonl.test.ts
+++ b/extensions/tracing/src/storage-jsonl.test.ts
@@ -1,0 +1,191 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { JsonlTraceWriter } from "./storage-jsonl.js";
+import type { TraceSpan } from "./types.js";
+
+function makeSpan(overrides: Partial<TraceSpan> = {}): TraceSpan {
+  return {
+    traceId: "trace-1",
+    spanId: "span-1",
+    kind: "llm_call",
+    name: "test-span",
+    startMs: Date.now(),
+    attributes: {},
+    ...overrides,
+  };
+}
+
+describe("JsonlTraceWriter", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jsonl-trace-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("constructor", () => {
+    it("creates the directory if it does not exist", () => {
+      const nested = path.join(tmpDir, "a", "b", "c");
+      new JsonlTraceWriter(nested);
+      expect(fs.existsSync(nested)).toBe(true);
+    });
+
+    it("works when directory already exists", () => {
+      // tmpDir already exists; should not throw
+      const writer = new JsonlTraceWriter(tmpDir);
+      expect(writer).toBeDefined();
+    });
+  });
+
+  describe("write", () => {
+    it("writes a span as a JSON line to a date-keyed file", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      const span = makeSpan({ startMs: new Date("2026-03-09T12:00:00Z").getTime() });
+      writer.write(span);
+
+      const filePath = path.join(tmpDir, "2026-03-09.jsonl");
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const content = fs.readFileSync(filePath, "utf-8").trim();
+      const parsed = JSON.parse(content);
+      expect(parsed.traceId).toBe("trace-1");
+      expect(parsed.spanId).toBe("span-1");
+    });
+
+    it("appends multiple spans to the same file", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      const ts = new Date("2026-03-09T12:00:00Z").getTime();
+      writer.write(makeSpan({ spanId: "s1", startMs: ts }));
+      writer.write(makeSpan({ spanId: "s2", startMs: ts }));
+
+      const filePath = path.join(tmpDir, "2026-03-09.jsonl");
+      const lines = fs.readFileSync(filePath, "utf-8").trim().split("\n");
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]).spanId).toBe("s1");
+      expect(JSON.parse(lines[1]).spanId).toBe("s2");
+    });
+
+    it("writes to different files for different dates", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      writer.write(makeSpan({ startMs: new Date("2026-03-08T23:00:00Z").getTime() }));
+      writer.write(makeSpan({ startMs: new Date("2026-03-09T01:00:00Z").getTime() }));
+
+      expect(fs.existsSync(path.join(tmpDir, "2026-03-08.jsonl"))).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, "2026-03-09.jsonl"))).toBe(true);
+    });
+  });
+
+  describe("readByDate", () => {
+    it("returns an empty array when the file does not exist", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      expect(writer.readByDate("2026-01-01")).toEqual([]);
+    });
+
+    it("returns all spans from a date file", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      const ts = new Date("2026-03-09T10:00:00Z").getTime();
+      writer.write(makeSpan({ spanId: "a", startMs: ts }));
+      writer.write(makeSpan({ spanId: "b", startMs: ts }));
+
+      const spans = writer.readByDate("2026-03-09");
+      expect(spans).toHaveLength(2);
+      expect(spans[0].spanId).toBe("a");
+      expect(spans[1].spanId).toBe("b");
+    });
+
+    it("skips empty or malformed lines gracefully", () => {
+      // Write a file with a bad line
+      const filePath = path.join(tmpDir, "2026-03-09.jsonl");
+      const good = JSON.stringify(makeSpan({ spanId: "ok" }));
+      fs.writeFileSync(filePath, `${good}\n{bad json\n\n${good}\n`);
+
+      const writer = new JsonlTraceWriter(tmpDir);
+      const spans = writer.readByDate("2026-03-09");
+      expect(spans).toHaveLength(2);
+      expect(spans[0].spanId).toBe("ok");
+    });
+  });
+
+  describe("readToday", () => {
+    it("reads spans written today", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      // Write a span with current time (defaults to today)
+      writer.write(makeSpan({ spanId: "today-span" }));
+
+      const spans = writer.readToday();
+      expect(spans.length).toBeGreaterThanOrEqual(1);
+      expect(spans.some((s) => s.spanId === "today-span")).toBe(true);
+    });
+  });
+
+  describe("listDates", () => {
+    it("returns an empty array when no files exist", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      expect(writer.listDates()).toEqual([]);
+    });
+
+    it("returns date keys sorted newest first", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      // Create files manually
+      fs.writeFileSync(path.join(tmpDir, "2026-03-07.jsonl"), "{}");
+      fs.writeFileSync(path.join(tmpDir, "2026-03-09.jsonl"), "{}");
+      fs.writeFileSync(path.join(tmpDir, "2026-03-08.jsonl"), "{}");
+
+      const dates = writer.listDates();
+      expect(dates).toEqual(["2026-03-09", "2026-03-08", "2026-03-07"]);
+    });
+
+    it("ignores non-jsonl files", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, "2026-03-09.jsonl"), "{}");
+      fs.writeFileSync(path.join(tmpDir, "notes.txt"), "hello");
+
+      const dates = writer.listDates();
+      expect(dates).toEqual(["2026-03-09"]);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("removes files older than the retention period", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+
+      // Use relative dates so the test doesn't rot
+      const toKey = (d: Date) => d.toISOString().slice(0, 10);
+      const now = new Date();
+      const todayDate = toKey(now);
+      const recentDate = toKey(new Date(now.getTime() - 2 * 86400000));
+      const oldDate = toKey(new Date(now.getTime() - 30 * 86400000));
+
+      fs.writeFileSync(path.join(tmpDir, `${oldDate}.jsonl`), "{}");
+      fs.writeFileSync(path.join(tmpDir, `${recentDate}.jsonl`), "{}");
+      fs.writeFileSync(path.join(tmpDir, `${todayDate}.jsonl`), "{}");
+
+      // Retain only 7 days — old file should be removed
+      writer.cleanup(7);
+
+      expect(fs.existsSync(path.join(tmpDir, `${oldDate}.jsonl`))).toBe(false);
+      expect(fs.existsSync(path.join(tmpDir, `${recentDate}.jsonl`))).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, `${todayDate}.jsonl`))).toBe(true);
+    });
+
+    it("does not remove anything when all files are within retention", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, "2026-03-09.jsonl"), "{}");
+
+      writer.cleanup(30);
+
+      expect(fs.existsSync(path.join(tmpDir, "2026-03-09.jsonl"))).toBe(true);
+    });
+
+    it("handles empty directory gracefully", () => {
+      const writer = new JsonlTraceWriter(tmpDir);
+      // Should not throw
+      expect(() => writer.cleanup(7)).not.toThrow();
+    });
+  });
+});

--- a/extensions/tracing/src/storage-jsonl.ts
+++ b/extensions/tracing/src/storage-jsonl.ts
@@ -1,0 +1,88 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { TraceSpan } from "./types.js";
+
+/**
+ * Writes and reads TraceSpan objects as JSONL files keyed by date.
+ * Each day gets its own file: `YYYY-MM-DD.jsonl`.
+ */
+export class JsonlTraceWriter {
+  private readonly dir: string;
+
+  constructor(dir: string) {
+    this.dir = dir;
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  /** Append a span as a JSON line to the date-keyed file based on span.startMs. */
+  write(span: TraceSpan): void {
+    const dateKey = this.dateKeyFromMs(span.startMs);
+    const filePath = path.join(this.dir, `${dateKey}.jsonl`);
+    fs.appendFileSync(filePath, JSON.stringify(span) + "\n");
+  }
+
+  private static readonly DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+  /** Read all spans from a specific date file. Skips malformed lines. */
+  readByDate(dateKey: string): TraceSpan[] {
+    if (!JsonlTraceWriter.DATE_KEY_RE.test(dateKey)) return [];
+    const filePath = path.join(this.dir, `${dateKey}.jsonl`);
+    if (!fs.existsSync(filePath)) return [];
+
+    const content = fs.readFileSync(filePath, "utf-8");
+    const spans: TraceSpan[] = [];
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        spans.push(JSON.parse(trimmed) as TraceSpan);
+      } catch {
+        // skip malformed lines
+      }
+    }
+    return spans;
+  }
+
+  /** Shorthand: read today's spans. */
+  readToday(): TraceSpan[] {
+    return this.readByDate(this.dateKeyFromMs(Date.now()));
+  }
+
+  /** List available trace dates, sorted newest first. */
+  listDates(): string[] {
+    if (!fs.existsSync(this.dir)) return [];
+
+    const files = fs.readdirSync(this.dir);
+    return files
+      .filter((f) => f.endsWith(".jsonl"))
+      .map((f) => f.replace(/\.jsonl$/, ""))
+      .sort()
+      .reverse();
+  }
+
+  /** Remove JSONL files older than `retentionDays` days from today. */
+  cleanup(retentionDays: number): void {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - retentionDays);
+    const cutoffKey = this.dateKeyFromMs(cutoff.getTime());
+
+    for (const dateKey of this.listDates()) {
+      if (dateKey < cutoffKey) {
+        try {
+          fs.unlinkSync(path.join(this.dir, `${dateKey}.jsonl`));
+        } catch {
+          // file may already be deleted or locked; skip
+        }
+      }
+    }
+  }
+
+  /** Convert epoch ms to YYYY-MM-DD using UTC. */
+  private dateKeyFromMs(ms: number): string {
+    const d = new Date(ms);
+    const year = d.getUTCFullYear();
+    const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(d.getUTCDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+}

--- a/extensions/tracing/src/types.ts
+++ b/extensions/tracing/src/types.ts
@@ -1,0 +1,27 @@
+export type TraceSpan = {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  kind: "session" | "llm_call" | "tool_call" | "subagent";
+  name: string;
+  agentId?: string;
+  sessionKey?: string;
+  startMs: number;
+  endMs?: number;
+  durationMs?: number;
+  attributes: Record<string, string | number | boolean>;
+  toolName?: string;
+  toolParams?: Record<string, unknown>;
+  childSessionKey?: string;
+  childAgentId?: string;
+  provider?: string;
+  model?: string;
+  tokensIn?: number;
+  tokensOut?: number;
+};
+
+export type TracingConfig = {
+  enabled?: boolean;
+  retentionDays?: number;
+  redactToolParams?: boolean;
+};

--- a/extensions/tracing/src/viewer-cli.test.ts
+++ b/extensions/tracing/src/viewer-cli.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import type { TraceSpan } from "./types.js";
+import { renderCallTree, renderEntityTree, renderWaterfall } from "./viewer-cli.js";
+
+/** Strip ANSI escape codes for content assertions. */
+function strip(line: string): string {
+  return line.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function makeSpan(
+  overrides: Partial<TraceSpan> & Pick<TraceSpan, "spanId" | "kind" | "name" | "startMs">,
+): TraceSpan {
+  return {
+    traceId: "trace-1",
+    attributes: {},
+    ...overrides,
+  };
+}
+
+const sessionSpan = makeSpan({
+  spanId: "s1",
+  kind: "session",
+  name: "root-session",
+  agentId: "orchestrator",
+  sessionKey: "sess-abc",
+  startMs: 0,
+  endMs: 5000,
+  durationMs: 5000,
+});
+
+const llmSpan = makeSpan({
+  spanId: "s2",
+  parentSpanId: "s1",
+  kind: "llm_call",
+  name: "llm",
+  agentId: "orchestrator",
+  startMs: 100,
+  endMs: 2000,
+  durationMs: 1900,
+  provider: "anthropic",
+  model: "claude-sonnet-4-20250514",
+  tokensIn: 500,
+  tokensOut: 200,
+});
+
+const toolSpan = makeSpan({
+  spanId: "s3",
+  parentSpanId: "s1",
+  kind: "tool_call",
+  name: "bash",
+  agentId: "orchestrator",
+  toolName: "bash",
+  toolParams: { command: "ls -la" },
+  startMs: 2100,
+  endMs: 2500,
+  durationMs: 400,
+});
+
+const subagentSpan = makeSpan({
+  spanId: "s4",
+  parentSpanId: "s1",
+  kind: "subagent",
+  name: "spawn-researcher",
+  agentId: "orchestrator",
+  childAgentId: "researcher",
+  childSessionKey: "sess-xyz",
+  startMs: 2600,
+  endMs: 4500,
+  durationMs: 1900,
+});
+
+const childSessionSpan = makeSpan({
+  spanId: "s5",
+  kind: "session",
+  name: "researcher-session",
+  agentId: "researcher",
+  sessionKey: "sess-xyz",
+  startMs: 2600,
+  endMs: 4500,
+  durationMs: 1900,
+});
+
+const childLlmSpan = makeSpan({
+  spanId: "s6",
+  parentSpanId: "s5",
+  kind: "llm_call",
+  name: "llm",
+  agentId: "researcher",
+  startMs: 2700,
+  endMs: 4000,
+  durationMs: 1300,
+  provider: "openai",
+  model: "gpt-4o",
+  tokensIn: 300,
+  tokensOut: 150,
+});
+
+const allSpans: TraceSpan[] = [
+  sessionSpan,
+  llmSpan,
+  toolSpan,
+  subagentSpan,
+  childSessionSpan,
+  childLlmSpan,
+];
+
+describe("renderCallTree", () => {
+  it("returns empty array for empty spans", () => {
+    expect(renderCallTree([])).toEqual([]);
+  });
+
+  it("returns lines containing tree connectors and span names", () => {
+    const lines = renderCallTree(allSpans);
+    expect(lines.length).toBeGreaterThan(0);
+
+    const plain = lines.map(strip);
+    const joined = plain.join("\n");
+
+    // Should contain tree connectors
+    expect(joined).toContain("├─");
+
+    // Should contain the root agent name
+    expect(plain.some((l) => l.includes("orchestrator"))).toBe(true);
+
+    // Should contain the tool name
+    expect(plain.some((l) => l.includes("bash"))).toBe(true);
+
+    // Should contain llm label
+    expect(plain.some((l) => l.includes("llm"))).toBe(true);
+
+    // Should contain subagent child reference
+    expect(plain.some((l) => l.includes("researcher"))).toBe(true);
+  });
+
+  it("includes duration information", () => {
+    const lines = renderCallTree(allSpans);
+    const plain = lines.map(strip);
+    // 5000ms = 5.0s
+    expect(plain.some((l) => l.includes("5.0s"))).toBe(true);
+    // 400ms stays as ms
+    expect(plain.some((l) => l.includes("400ms"))).toBe(true);
+  });
+
+  it("includes token info for llm spans", () => {
+    const lines = renderCallTree(allSpans);
+    const plain = lines.map(strip);
+    expect(plain.some((l) => l.includes("in:500") && l.includes("out:200"))).toBe(true);
+  });
+
+  it("sorts children by startMs", () => {
+    const lines = renderCallTree(allSpans);
+    const plain = lines.map(strip);
+    const llmIdx = plain.findIndex((l) => l.includes("llm") && l.includes("anthropic"));
+    const toolIdx = plain.findIndex((l) => l.includes("bash"));
+    const subagentIdx = plain.findIndex((l) => l.includes("researcher"));
+    expect(llmIdx).toBeLessThan(toolIdx);
+    expect(toolIdx).toBeLessThan(subagentIdx);
+  });
+});
+
+describe("renderEntityTree", () => {
+  it("returns empty array for empty spans", () => {
+    expect(renderEntityTree([])).toEqual([]);
+  });
+
+  it("returns agent summary lines with stats", () => {
+    const lines = renderEntityTree(allSpans);
+    expect(lines.length).toBeGreaterThan(0);
+
+    const plain = lines.map(strip);
+    const joined = plain.join("\n");
+
+    // Should contain agent names
+    expect(joined).toContain("orchestrator");
+    expect(joined).toContain("researcher");
+
+    // Should contain LLM call counts
+    expect(plain.some((l) => l.includes("LLM calls"))).toBe(true);
+
+    // Should contain tool call counts
+    expect(plain.some((l) => l.includes("tool calls"))).toBe(true);
+
+    // Should contain model info
+    expect(plain.some((l) => l.includes("claude-sonnet-4-20250514"))).toBe(true);
+
+    // Should contain tool names
+    expect(plain.some((l) => l.includes("tools:") && l.includes("bash"))).toBe(true);
+  });
+
+  it("includes summary section", () => {
+    const lines = renderEntityTree(allSpans);
+    const plain = lines.map(strip);
+    const joined = plain.join("\n");
+    expect(joined).toContain("Summary");
+    expect(joined).toContain("Agents:");
+  });
+
+  it("includes token stats", () => {
+    const lines = renderEntityTree(allSpans);
+    const plain = lines.map(strip);
+    expect(plain.some((l) => l.includes("tokens:"))).toBe(true);
+  });
+});
+
+describe("renderWaterfall", () => {
+  it("returns empty array for empty spans", () => {
+    expect(renderWaterfall([])).toEqual([]);
+  });
+
+  it("returns timeline bars", () => {
+    const lines = renderWaterfall(allSpans);
+    expect(lines.length).toBeGreaterThan(0);
+
+    const plain = lines.map(strip);
+
+    // Should contain bar characters
+    expect(plain.some((l) => l.includes("█"))).toBe(true);
+
+    // Should contain bar delimiters
+    expect(plain.some((l) => l.includes("│"))).toBe(true);
+  });
+
+  it("includes span labels", () => {
+    const lines = renderWaterfall(allSpans);
+    const plain = lines.map(strip);
+    // Session label = agentId
+    expect(plain.some((l) => l.includes("orchestrator"))).toBe(true);
+    // Tool label = toolName
+    expect(plain.some((l) => l.includes("bash"))).toBe(true);
+  });
+
+  it("includes duration for each span", () => {
+    const lines = renderWaterfall(allSpans);
+    const plain = lines.map(strip);
+    // Should show durations
+    expect(plain.some((l) => l.includes("5.0s"))).toBe(true);
+    expect(plain.some((l) => l.includes("400ms"))).toBe(true);
+  });
+
+  it("includes a footer with total duration", () => {
+    const lines = renderWaterfall(allSpans);
+    const plain = lines.map(strip);
+    // Last line should show total duration
+    const lastLine = plain[plain.length - 1]!;
+    expect(lastLine).toContain("5.0s");
+    expect(lastLine).toContain("0");
+  });
+});

--- a/extensions/tracing/src/viewer-cli.ts
+++ b/extensions/tracing/src/viewer-cli.ts
@@ -1,0 +1,319 @@
+/**
+ * CLI trace viewer — pure functions that return string[] lines.
+ *
+ * Ported from demo-tracing/viewer.ts.
+ */
+
+import type { TraceSpan } from "./types.js";
+
+// ── ANSI colors ──
+const c = {
+  reset: "\x1b[0m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+  cyan: "\x1b[36m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  magenta: "\x1b[35m",
+  blue: "\x1b[34m",
+  white: "\x1b[37m",
+  bgBlue: "\x1b[44m",
+  bgMagenta: "\x1b[45m",
+};
+
+const kindColor: Record<string, string> = {
+  session: c.cyan,
+  llm_call: c.yellow,
+  tool_call: c.green,
+  subagent: c.magenta,
+};
+
+const kindIcon: Record<string, string> = {
+  session: "\u{1f535}",
+  llm_call: "\u{1f9e0}",
+  tool_call: "\u{1f527}",
+  subagent: "\u{1f916}",
+};
+
+function fmtDuration(ms?: number): string {
+  if (ms === undefined) return "";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function fmtTokens(span: TraceSpan): string {
+  if (span.kind !== "llm_call") return "";
+  const parts: string[] = [];
+  if (span.tokensIn) parts.push(`in:${span.tokensIn}`);
+  if (span.tokensOut) parts.push(`out:${span.tokensOut}`);
+  return parts.length ? `${c.dim}[${parts.join(" ")}]${c.reset}` : "";
+}
+
+/**
+ * Render a nested call tree by parentSpanId, sorted by startMs.
+ */
+export function renderCallTree(spans: TraceSpan[]): string[] {
+  if (spans.length === 0) return [];
+
+  const lines: string[] = [];
+
+  const children = new Map<string, TraceSpan[]>();
+  for (const span of spans) {
+    if (span.parentSpanId) {
+      const list = children.get(span.parentSpanId) ?? [];
+      list.push(span);
+      children.set(span.parentSpanId, list);
+    }
+  }
+
+  // Sort children by startMs
+  for (const [, list] of children) {
+    list.sort((a, b) => a.startMs - b.startMs);
+  }
+
+  const roots = spans.filter((s) => !s.parentSpanId).sort((a, b) => a.startMs - b.startMs);
+
+  function printSpan(span: TraceSpan, prefix: string, isLast: boolean) {
+    const connector = isLast ? "\u2514\u2500" : "\u251c\u2500";
+    const icon = kindIcon[span.kind] ?? "\u25cf";
+    const color = kindColor[span.kind] ?? c.white;
+    const dur = fmtDuration(span.durationMs);
+    const tokens = fmtTokens(span);
+
+    let label = "";
+    switch (span.kind) {
+      case "session":
+        label = `${color}${span.agentId}${c.reset} ${c.dim}(${span.sessionKey})${c.reset}`;
+        break;
+      case "llm_call":
+        label = `${color}llm${c.reset} ${c.dim}[${span.provider}/${span.model}]${c.reset}`;
+        break;
+      case "tool_call":
+        label = `${color}${span.toolName ?? span.name}${c.reset}`;
+        if (span.toolParams) {
+          const preview = Object.entries(span.toolParams)
+            .map(([k, v]) => {
+              const str = typeof v === "string" ? v : JSON.stringify(v);
+              return `${k}=${str.length > 30 ? str.slice(0, 30) + "\u2026" : str}`;
+            })
+            .join(", ");
+          label += ` ${c.dim}(${preview})${c.reset}`;
+        }
+        break;
+      case "subagent":
+        label = `${color}\u2192 ${span.childAgentId}${c.reset} ${c.dim}(${span.childSessionKey})${c.reset}`;
+        break;
+    }
+
+    const durStr = dur ? ` ${c.blue}${dur}${c.reset}` : "";
+    const tokensStr = tokens ? ` ${tokens}` : "";
+    lines.push(`${prefix}${connector} ${icon} ${label}${durStr}${tokensStr}`);
+
+    const kids = children.get(span.spanId) ?? [];
+    const childPrefix = prefix + (isLast ? "   " : "\u2502  ");
+    kids.forEach((child, i) => {
+      printSpan(child, childPrefix, i === kids.length - 1);
+    });
+  }
+
+  roots.forEach((root, i) => {
+    printSpan(root, "", i === roots.length - 1);
+  });
+
+  return lines;
+}
+
+/**
+ * Render an agent relationship tree with aggregated stats.
+ */
+export function renderEntityTree(spans: TraceSpan[]): string[] {
+  if (spans.length === 0) return [];
+
+  const lines: string[] = [];
+
+  type AgentNode = {
+    agentId: string;
+    sessionKey?: string;
+    children: AgentNode[];
+    toolsUsed: string[];
+    models: string[];
+    totalDurationMs: number;
+    totalTokensIn: number;
+    totalTokensOut: number;
+    llmCallCount: number;
+    toolCallCount: number;
+  };
+
+  const agentNodes = new Map<string, AgentNode>();
+
+  for (const span of spans) {
+    if (!span.agentId) continue;
+    if (!agentNodes.has(span.agentId)) {
+      agentNodes.set(span.agentId, {
+        agentId: span.agentId,
+        sessionKey: span.kind === "session" ? span.sessionKey : undefined,
+        children: [],
+        toolsUsed: [],
+        models: [],
+        totalDurationMs: 0,
+        totalTokensIn: 0,
+        totalTokensOut: 0,
+        llmCallCount: 0,
+        toolCallCount: 0,
+      });
+    }
+    const node = agentNodes.get(span.agentId)!;
+    if (span.kind === "session") {
+      node.sessionKey = span.sessionKey;
+      node.totalDurationMs = span.durationMs ?? 0;
+    }
+    if (span.kind === "llm_call") {
+      node.llmCallCount++;
+      node.totalTokensIn += span.tokensIn ?? 0;
+      node.totalTokensOut += span.tokensOut ?? 0;
+      if (span.model && !node.models.includes(span.model)) {
+        node.models.push(span.model);
+      }
+    }
+    if (span.kind === "tool_call" && span.toolName) {
+      node.toolCallCount++;
+      if (!node.toolsUsed.includes(span.toolName)) {
+        node.toolsUsed.push(span.toolName);
+      }
+    }
+  }
+
+  // Build parent->child edges
+  const childAgents = new Set<string>();
+  for (const span of spans) {
+    if (span.kind === "subagent" && span.agentId && span.childAgentId) {
+      const parent = agentNodes.get(span.agentId);
+      const child = agentNodes.get(span.childAgentId);
+      if (parent && child) {
+        parent.children.push(child);
+        childAgents.add(span.childAgentId);
+      }
+    }
+  }
+
+  const rootAgents = [...agentNodes.values()].filter((n) => !childAgents.has(n.agentId));
+
+  function printAgent(node: AgentNode, prefix: string, isLast: boolean) {
+    const connector = isLast ? "\u2514\u2500" : "\u251c\u2500";
+    const name = `${c.bold}${c.cyan}${node.agentId}${c.reset}`;
+    const session = node.sessionKey ? ` ${c.dim}(${node.sessionKey})${c.reset}` : "";
+    const dur = node.totalDurationMs
+      ? ` ${c.blue}${fmtDuration(node.totalDurationMs)}${c.reset}`
+      : "";
+    lines.push(`${prefix}${connector} \u{1f916} ${name}${session}${dur}`);
+
+    const detailPrefix = prefix + (isLast ? "   " : "\u2502  ");
+
+    // Stats line
+    const stats: string[] = [];
+    if (node.llmCallCount) stats.push(`${c.yellow}${node.llmCallCount} LLM calls${c.reset}`);
+    if (node.toolCallCount) stats.push(`${c.green}${node.toolCallCount} tool calls${c.reset}`);
+    if (node.totalTokensIn || node.totalTokensOut) {
+      stats.push(`${c.dim}tokens: ${node.totalTokensIn}\u2192${node.totalTokensOut}${c.reset}`);
+    }
+    if (stats.length) {
+      lines.push(`${detailPrefix}${c.dim}\u2502${c.reset} ${stats.join("  ")}`);
+    }
+
+    // Models
+    if (node.models.length) {
+      lines.push(
+        `${detailPrefix}${c.dim}\u2502${c.reset} models: ${c.yellow}${node.models.join(", ")}${c.reset}`,
+      );
+    }
+
+    // Tools
+    if (node.toolsUsed.length) {
+      lines.push(
+        `${detailPrefix}${c.dim}\u2502${c.reset} tools: ${c.green}${node.toolsUsed.join(", ")}${c.reset}`,
+      );
+    }
+
+    // Children
+    if (node.children.length) {
+      lines.push(`${detailPrefix}${c.dim}\u2502${c.reset}`);
+      node.children.forEach((child, i) => {
+        printAgent(child, detailPrefix, i === node.children.length - 1);
+      });
+    }
+  }
+
+  rootAgents.forEach((root, i) => {
+    printAgent(root, "", i === rootAgents.length - 1);
+  });
+
+  // Summary
+  lines.push("");
+  const totalAgents = agentNodes.size;
+  const totalLlm = spans.filter((s) => s.kind === "llm_call").length;
+  const totalTools = spans.filter((s) => s.kind === "tool_call").length;
+  const totalTokens = spans.reduce((sum, s) => sum + (s.tokensIn ?? 0) + (s.tokensOut ?? 0), 0);
+  lines.push(`${c.dim}\u2500\u2500\u2500 Summary \u2500\u2500\u2500${c.reset}`);
+  lines.push(
+    `  Agents: ${c.bold}${totalAgents}${c.reset}  LLM calls: ${c.bold}${totalLlm}${c.reset}  Tool calls: ${c.bold}${totalTools}${c.reset}  Total tokens: ${c.bold}${totalTokens}${c.reset}`,
+  );
+
+  return lines;
+}
+
+/**
+ * Render a waterfall timeline bar chart.
+ */
+export function renderWaterfall(spans: TraceSpan[]): string[] {
+  if (spans.length === 0) return [];
+
+  const lines: string[] = [];
+  const barWidth = 60;
+
+  const minStart = Math.min(...spans.map((s) => s.startMs));
+  const maxEnd = Math.max(...spans.map((s) => s.endMs ?? s.startMs));
+  const totalDuration = maxEnd - minStart;
+
+  // Sort by startMs, then by kind priority
+  const kindOrder: Record<string, number> = { session: 0, llm_call: 1, tool_call: 2, subagent: 1 };
+  const sorted = [...spans].sort((a, b) => {
+    if (a.startMs !== b.startMs) return a.startMs - b.startMs;
+    return (kindOrder[a.kind] ?? 9) - (kindOrder[b.kind] ?? 9);
+  });
+
+  for (const span of sorted) {
+    const relStart = span.startMs - minStart;
+    const dur = (span.endMs ?? span.startMs) - span.startMs;
+    const barStart = Math.round((relStart / totalDuration) * barWidth);
+    const barLen = Math.max(1, Math.round((dur / totalDuration) * barWidth));
+
+    const color = kindColor[span.kind] ?? c.white;
+    const icon = kindIcon[span.kind] ?? "\u25cf";
+
+    const label =
+      span.kind === "llm_call"
+        ? `llm [${span.model?.split("-").slice(0, 2).join("-") ?? "?"}]`
+        : span.kind === "subagent"
+          ? `\u2192${span.childAgentId}`
+          : span.kind === "session"
+            ? (span.agentId ?? span.name)
+            : (span.toolName ?? span.name);
+
+    const paddedLabel = (label + "                         ").slice(0, 25);
+    const bar =
+      " ".repeat(barStart) +
+      "\u2588".repeat(barLen) +
+      " ".repeat(Math.max(0, barWidth - barStart - barLen));
+    const durStr = fmtDuration(span.durationMs);
+
+    lines.push(
+      `  ${icon} ${color}${paddedLabel}${c.reset} ${c.dim}\u2502${c.reset}${color}${bar}${c.reset}${c.dim}\u2502${c.reset} ${c.blue}${durStr}${c.reset}`,
+    );
+  }
+
+  lines.push(
+    `  ${"                            "}${c.dim}\u2502${"0".padEnd(barWidth / 2)}${fmtDuration(totalDuration)}\u2502${c.reset}`,
+  );
+
+  return lines;
+}

--- a/extensions/tracing/src/web-viewer.ts
+++ b/extensions/tracing/src/web-viewer.ts
@@ -1,0 +1,343 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { JsonlTraceWriter } from "./storage-jsonl.js";
+
+const TRACES_PREFIX = "/plugins/tracing";
+
+function parseUrl(raw?: string): URL | null {
+  try {
+    return new URL(raw ?? "", "http://localhost");
+  } catch {
+    return null;
+  }
+}
+
+function json(res: ServerResponse, data: unknown, status = 200) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(data));
+  return true;
+}
+
+function html(res: ServerResponse, body: string) {
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.end(body);
+  return true;
+}
+
+export function createTracingHttpHandler(writer: JsonlTraceWriter) {
+  return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
+    const url = parseUrl(req.url);
+    if (!url) return false;
+
+    const path = url.pathname;
+
+    // API: list dates
+    if (path === `${TRACES_PREFIX}/api/dates`) {
+      return json(res, { dates: writer.listDates() });
+    }
+
+    // API: get spans by date
+    if (path === `${TRACES_PREFIX}/api/spans`) {
+      const date = url.searchParams.get("date") ?? new Date().toISOString().slice(0, 10);
+      return json(res, { date, spans: writer.readByDate(date) });
+    }
+
+    // Serve the viewer HTML
+    if (path === TRACES_PREFIX || path === `${TRACES_PREFIX}/`) {
+      return html(res, VIEWER_HTML);
+    }
+
+    return false;
+  };
+}
+
+const VIEWER_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OpenClaw Traces</title>
+<style>
+  :root {
+    --bg: #0d1117; --fg: #e6edf3; --border: #30363d;
+    --accent: #58a6ff; --green: #3fb950; --yellow: #d29922;
+    --magenta: #bc8cff; --red: #f85149; --dim: #8b949e;
+    --surface: #161b22; --surface2: #21262d;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace; background: var(--bg); color: var(--fg); font-size: 13px; line-height: 1.5; }
+  .header { padding: 16px 24px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 16px; }
+  .header h1 { font-size: 16px; font-weight: 600; }
+  .header select { background: var(--surface); color: var(--fg); border: 1px solid var(--border); border-radius: 6px; padding: 6px 10px; font-family: inherit; font-size: 13px; }
+  .tabs { display: flex; gap: 2px; padding: 0 24px; border-bottom: 1px solid var(--border); background: var(--surface); }
+  .tab { padding: 10px 16px; cursor: pointer; color: var(--dim); border-bottom: 2px solid transparent; transition: all 0.15s; }
+  .tab:hover { color: var(--fg); }
+  .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+  .content { padding: 16px 24px; overflow-x: auto; }
+  .empty { color: var(--dim); padding: 40px; text-align: center; }
+
+  /* Call Tree */
+  .tree-node { padding: 2px 0; white-space: nowrap; }
+  .tree-indent { color: var(--border); user-select: none; }
+  .tree-connector { color: var(--border); user-select: none; }
+  .kind-session { color: var(--accent); }
+  .kind-llm_call { color: var(--yellow); }
+  .kind-tool_call { color: var(--green); }
+  .kind-subagent { color: var(--magenta); }
+  .duration { color: var(--accent); margin-left: 8px; }
+  .tokens { color: var(--dim); margin-left: 8px; }
+  .tool-params { color: var(--dim); margin-left: 4px; }
+  .dim { color: var(--dim); }
+
+  /* Entity Tree */
+  .entity-node { padding: 4px 0; }
+  .entity-stats { color: var(--dim); padding-left: 24px; }
+  .entity-stat { margin-right: 16px; }
+  .stat-llm { color: var(--yellow); }
+  .stat-tool { color: var(--green); }
+
+  /* Waterfall */
+  .waterfall { width: 100%; }
+  .wf-row { display: flex; align-items: center; padding: 2px 0; gap: 8px; }
+  .wf-label { width: 220px; flex-shrink: 0; overflow: hidden; text-overflow: ellipsis; }
+  .wf-bar-container { flex: 1; position: relative; height: 18px; }
+  .wf-bar { position: absolute; height: 100%; border-radius: 2px; min-width: 2px; opacity: 0.85; }
+  .wf-bar.kind-session { background: var(--accent); }
+  .wf-bar.kind-llm_call { background: var(--yellow); }
+  .wf-bar.kind-tool_call { background: var(--green); }
+  .wf-bar.kind-subagent { background: var(--magenta); }
+  .wf-dur { width: 60px; flex-shrink: 0; text-align: right; color: var(--accent); }
+
+  /* Summary */
+  .summary { margin-top: 16px; padding: 12px 16px; background: var(--surface); border-radius: 6px; border: 1px solid var(--border); color: var(--dim); }
+  .summary strong { color: var(--fg); }
+</style>
+</head>
+<body>
+<div class="header">
+  <h1>🦞 OpenClaw Traces</h1>
+  <select id="dateSelect"><option>Loading...</option></select>
+  <span id="spanCount" class="dim"></span>
+</div>
+<div class="tabs">
+  <div class="tab active" data-view="call">📊 Call Tree</div>
+  <div class="tab" data-view="entity">🌳 Entity Tree</div>
+  <div class="tab" data-view="waterfall">⏱️ Waterfall</div>
+</div>
+<div class="content" id="content"></div>
+
+<script>
+const $ = (s) => document.querySelector(s);
+const $$ = (s) => document.querySelectorAll(s);
+let spans = [];
+let currentView = 'call';
+
+// Fetch
+async function fetchDates() {
+  const r = await fetch('/plugins/tracing/api/dates');
+  return (await r.json()).dates;
+}
+async function fetchSpans(date) {
+  const r = await fetch('/plugins/tracing/api/spans?date=' + date);
+  const d = await r.json();
+  return d.spans;
+}
+
+// Init
+(async () => {
+  const dates = await fetchDates();
+  const sel = $('#dateSelect');
+  sel.innerHTML = dates.length
+    ? dates.map(d => '<option value="'+d+'">'+d+'</option>').join('')
+    : '<option>No traces</option>';
+  sel.onchange = () => load(sel.value);
+  if (dates.length) load(dates[0]);
+})();
+
+async function load(date) {
+  spans = await fetchSpans(date);
+  $('#spanCount').textContent = spans.length + ' spans';
+  render();
+}
+
+// Tabs
+$$('.tab').forEach(t => t.onclick = () => {
+  $$('.tab').forEach(x => x.classList.remove('active'));
+  t.classList.add('active');
+  currentView = t.dataset.view;
+  render();
+});
+
+function render() {
+  const c = $('#content');
+  if (!spans.length) { c.innerHTML = '<div class="empty">No traces for this date.</div>'; return; }
+  if (currentView === 'call') c.innerHTML = renderCallTree();
+  else if (currentView === 'entity') c.innerHTML = renderEntityTree();
+  else c.innerHTML = renderWaterfall();
+}
+
+// Utils
+function fmtDur(ms) {
+  if (ms == null) return '';
+  return ms < 1000 ? ms + 'ms' : (ms/1000).toFixed(1) + 's';
+}
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+const icons = { session: '🔵', llm_call: '🧠', tool_call: '🔧', subagent: '🤖' };
+
+// Call Tree
+function renderCallTree() {
+  const byId = new Map(spans.map(s => [s.spanId, s]));
+  const children = new Map();
+  for (const s of spans) {
+    if (!s.parentSpanId) continue;
+    if (!children.has(s.parentSpanId)) children.set(s.parentSpanId, []);
+    children.get(s.parentSpanId).push(s);
+  }
+  for (const [,list] of children) list.sort((a,b) => a.startMs - b.startMs);
+  // Dedupe: prefer closed spans (with endMs) over open ones
+  const closed = new Map();
+  for (const s of spans) {
+    const key = s.spanId;
+    if (!closed.has(key) || s.endMs != null) closed.set(key, s);
+  }
+  const deduped = [...closed.values()];
+  const dedupedChildren = new Map();
+  for (const s of deduped) {
+    if (!s.parentSpanId) continue;
+    if (!dedupedChildren.has(s.parentSpanId)) dedupedChildren.set(s.parentSpanId, []);
+    dedupedChildren.get(s.parentSpanId).push(s);
+  }
+  for (const [,list] of dedupedChildren) list.sort((a,b) => a.startMs - b.startMs);
+  const roots = deduped.filter(s => !s.parentSpanId).sort((a,b) => a.startMs - b.startMs);
+
+  let html = '';
+  function renderNode(span, prefix, isLast) {
+    const conn = isLast ? '└─ ' : '├─ ';
+    const icon = icons[span.kind] || '●';
+    let label = '';
+    if (span.kind === 'session') {
+      label = '<span class="kind-session">' + esc(span.agentId || 'agent') + '</span> <span class="dim">(' + esc(span.sessionKey || '') + ')</span>';
+    } else if (span.kind === 'llm_call') {
+      label = '<span class="kind-llm_call">llm</span> <span class="dim">[' + esc(span.provider||'') + '/' + esc(span.model||'') + ']</span>';
+    } else if (span.kind === 'tool_call') {
+      label = '<span class="kind-tool_call">' + esc(span.toolName || span.name) + '</span>';
+      if (span.toolParams) {
+        const preview = Object.entries(span.toolParams).map(([k,v]) => {
+          const s = typeof v === 'string' ? v : JSON.stringify(v);
+          return k + '=' + (s.length > 30 ? s.slice(0,30) + '…' : s);
+        }).join(', ');
+        label += '<span class="tool-params">(' + esc(preview) + ')</span>';
+      }
+    } else if (span.kind === 'subagent') {
+      label = '<span class="kind-subagent">→ ' + esc(span.childAgentId||'') + '</span> <span class="dim">(' + esc(span.childSessionKey||'') + ')</span>';
+    }
+    const dur = span.durationMs != null ? '<span class="duration">' + fmtDur(span.durationMs) + '</span>' : '';
+    let tok = '';
+    if (span.kind === 'llm_call' && (span.tokensIn || span.tokensOut)) {
+      tok = '<span class="tokens">[in:' + (span.tokensIn||0) + ' out:' + (span.tokensOut||0) + ']</span>';
+    }
+    html += '<div class="tree-node"><span class="tree-indent">' + esc(prefix) + '</span><span class="tree-connector">' + conn + '</span>' + icon + ' ' + label + dur + tok + '</div>';
+    const kids = dedupedChildren.get(span.spanId) || [];
+    const childPrefix = prefix + (isLast ? '   ' : '│  ');
+    kids.forEach((kid, i) => renderNode(kid, childPrefix, i === kids.length - 1));
+  }
+  roots.forEach((r, i) => renderNode(r, '', i === roots.length - 1));
+  return html;
+}
+
+// Entity Tree
+function renderEntityTree() {
+  const agents = new Map();
+  // Dedupe spans
+  const closed = new Map();
+  for (const s of spans) {
+    const key = s.spanId;
+    if (!closed.has(key) || s.endMs != null) closed.set(key, s);
+  }
+  const deduped = [...closed.values()];
+
+  for (const s of deduped) {
+    if (!s.agentId) continue;
+    if (!agents.has(s.agentId)) agents.set(s.agentId, { agentId: s.agentId, sessionKey: null, children: [], tools: new Set(), models: new Set(), llmCalls: 0, toolCalls: 0, tokensIn: 0, tokensOut: 0, durationMs: 0 });
+    const a = agents.get(s.agentId);
+    if (s.kind === 'session') { a.sessionKey = s.sessionKey; a.durationMs = s.durationMs || 0; }
+    if (s.kind === 'llm_call') { a.llmCalls++; a.tokensIn += s.tokensIn||0; a.tokensOut += s.tokensOut||0; if (s.model) a.models.add(s.model); }
+    if (s.kind === 'tool_call') { a.toolCalls++; if (s.toolName) a.tools.add(s.toolName); }
+  }
+  const childAgents = new Set();
+  for (const s of deduped) {
+    if (s.kind === 'subagent' && s.childAgentId) {
+      const parent = agents.get(s.agentId);
+      const child = agents.get(s.childAgentId);
+      if (parent && child) { parent.children.push(child); childAgents.add(s.childAgentId); }
+    }
+  }
+  const roots = [...agents.values()].filter(a => !childAgents.has(a.agentId));
+
+  let html = '';
+  function renderAgent(a, prefix, isLast) {
+    const conn = isLast ? '└─ ' : '├─ ';
+    const dur = a.durationMs ? '<span class="duration">' + fmtDur(a.durationMs) + '</span>' : '';
+    html += '<div class="entity-node"><span class="tree-indent">' + esc(prefix) + '</span><span class="tree-connector">' + conn + '</span>🤖 <strong class="kind-session">' + esc(a.agentId) + '</strong> ' + dur + '</div>';
+    const dp = prefix + (isLast ? '   ' : '│  ');
+    const stats = [];
+    if (a.llmCalls) stats.push('<span class="stat-llm">' + a.llmCalls + ' LLM calls</span>');
+    if (a.toolCalls) stats.push('<span class="stat-tool">' + a.toolCalls + ' tool calls</span>');
+    if (a.tokensIn || a.tokensOut) stats.push('<span class="dim">tokens: ' + a.tokensIn + '→' + a.tokensOut + '</span>');
+    if (stats.length) html += '<div class="entity-stats"><span class="tree-indent">' + esc(dp) + '</span>' + stats.join('  ') + '</div>';
+    if (a.models.size) html += '<div class="entity-stats"><span class="tree-indent">' + esc(dp) + '</span>models: <span class="kind-llm_call">' + [...a.models].map(esc).join(', ') + '</span></div>';
+    if (a.tools.size) html += '<div class="entity-stats"><span class="tree-indent">' + esc(dp) + '</span>tools: <span class="kind-tool_call">' + [...a.tools].map(esc).join(', ') + '</span></div>';
+    a.children.forEach((c, i) => renderAgent(c, dp, i === a.children.length - 1));
+  }
+  roots.forEach((r, i) => renderAgent(r, '', i === roots.length - 1));
+
+  // Summary
+  const totalAgents = agents.size;
+  const totalLlm = deduped.filter(s => s.kind === 'llm_call').length;
+  const totalTools = deduped.filter(s => s.kind === 'tool_call').length;
+  const totalTokens = deduped.reduce((sum, s) => sum + (s.tokensIn||0) + (s.tokensOut||0), 0);
+  html += '<div class="summary">Agents: <strong>' + totalAgents + '</strong> &nbsp; LLM calls: <strong>' + totalLlm + '</strong> &nbsp; Tool calls: <strong>' + totalTools + '</strong> &nbsp; Total tokens: <strong>' + totalTokens + '</strong></div>';
+  return html;
+}
+
+// Waterfall
+function renderWaterfall() {
+  // Dedupe
+  const closed = new Map();
+  for (const s of spans) {
+    if (!closed.has(s.spanId) || s.endMs != null) closed.set(s.spanId, s);
+  }
+  const deduped = [...closed.values()].filter(s => s.endMs != null);
+  if (!deduped.length) return '<div class="empty">No completed spans.</div>';
+
+  const minStart = Math.min(...deduped.map(s => s.startMs));
+  const maxEnd = Math.max(...deduped.map(s => s.endMs));
+  const total = maxEnd - minStart || 1;
+
+  const kindOrder = { session: 0, llm_call: 1, subagent: 1, tool_call: 2 };
+  deduped.sort((a,b) => (a.startMs - b.startMs) || ((kindOrder[a.kind]||9) - (kindOrder[b.kind]||9)));
+
+  let html = '<div class="waterfall">';
+  for (const s of deduped) {
+    const left = ((s.startMs - minStart) / total * 100).toFixed(2);
+    const width = Math.max(0.5, ((s.endMs - s.startMs) / total * 100));
+    const label = s.kind === 'session' ? (s.agentId||'session')
+      : s.kind === 'llm_call' ? 'llm [' + (s.model||'?').split('-').slice(0,2).join('-') + ']'
+      : s.kind === 'subagent' ? '→' + (s.childAgentId||'?')
+      : (s.toolName || s.name);
+    const icon = icons[s.kind] || '●';
+    html += '<div class="wf-row">'
+      + '<div class="wf-label"><span class="kind-' + s.kind + '">' + icon + ' ' + esc(label) + '</span></div>'
+      + '<div class="wf-bar-container"><div class="wf-bar kind-' + s.kind + '" style="left:' + left + '%;width:' + width.toFixed(2) + '%"></div></div>'
+      + '<div class="wf-dur">' + fmtDur(s.durationMs) + '</div>'
+      + '</div>';
+  }
+  html += '</div>';
+  html += '<div class="summary">Total duration: <strong>' + fmtDur(total) + '</strong></div>';
+  return html;
+}
+</script>
+</body>
+</html>`;

--- a/package.json
+++ b/package.json
@@ -184,6 +184,10 @@
       "types": "./dist/plugin-sdk/thread-ownership.d.ts",
       "default": "./dist/plugin-sdk/thread-ownership.js"
     },
+    "./plugin-sdk/tracing": {
+      "types": "./dist/plugin-sdk/tracing.d.ts",
+      "default": "./dist/plugin-sdk/tracing.js"
+    },
     "./plugin-sdk/tlon": {
       "types": "./dist/plugin-sdk/tlon.d.ts",
       "default": "./dist/plugin-sdk/tlon.js"

--- a/src/plugin-sdk/tracing.ts
+++ b/src/plugin-sdk/tracing.ts
@@ -1,0 +1,5 @@
+// Narrow plugin-sdk surface for the bundled tracing plugin.
+// Keep this list additive and scoped to symbols used under extensions/tracing.
+
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export type { OpenClawPluginApi } from "../plugins/types.js";


### PR DESCRIPTION
## Summary

- Add `extensions/tracing` plugin that traces tool calls, LLM invocations, and sub-agent relationships with zero external dependencies
- Writes TraceSpan objects to daily JSONL files (`~/.openclaw/traces/`) via plugin hooks (session_start/end, llm_input/output, before/after_tool_call, subagent_spawning/ended)
- CLI viewer: `openclaw traces` with three view modes (call tree, entity relationship tree, waterfall timeline)
- Web UI at `/plugins/tracing` with interactive dark-theme viewer (call tree, entity tree, waterfall tabs)
- Sub-agent traceId propagation: child agent sessions inherit parent traceId for cross-agent nested call trees
- Path traversal protection on JSONL reader
- 50 tests across 4 test files (storage, collector, viewer, integration)

## Usage

```bash
# Install
openclaw plugins install @openclaw/tracing

# CLI
openclaw traces                    # all three views
openclaw traces --mode call        # call tree only
openclaw traces --mode entity      # agent relationship tree
openclaw traces --mode waterfall   # timeline
openclaw traces --list             # list available dates
openclaw traces --date 2026-03-09  # specific date

# Web UI
# Visit /plugins/tracing in the OpenClaw web interface
```

## Test plan

- [x] `npx vitest run extensions/tracing/` — 50 tests pass
- [ ] Manual test: install plugin locally, trigger agent run, verify traces appear
- [ ] Manual test: verify web UI renders at `/plugins/tracing`
- [ ] Verify sub-agent tool calls appear nested under parent agent in call tree

🤖 Generated with [Claude Code](https://claude.ai/code)