### PR TITLE
feat(memory-lancedb): per-agent namespace isolation

### DIFF
--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -14,6 +14,17 @@ export type MemoryConfig = {
   autoCapture?: boolean;
   autoRecall?: boolean;
   captureMaxChars?: number;
+  /**
+   * Optional namespace for memory isolation.
+   *
+   * - Leave unset (default): each agent is automatically scoped to its own ID.
+   *   Entries stored by "finn" are only recalled by "finn".
+   * - Set to a shared value (e.g. "shared"): multiple agents using the same
+   *   namespace value will share a memory pool.
+   * - Set to "global": disables scoping entirely — all agents share one pool
+   *   (equivalent to the behavior before this feature was added).
+   */
+  namespace?: string;
 };
 
 export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "other"] as const;
@@ -97,7 +108,7 @@ export const memoryConfigSchema = {
     const cfg = value as Record<string, unknown>;
     assertAllowedKeys(
       cfg,
-      ["embedding", "dbPath", "autoCapture", "autoRecall", "captureMaxChars"],
+      ["embedding", "dbPath", "autoCapture", "autoRecall", "captureMaxChars", "namespace"],
       "memory config",
     );
 
@@ -118,6 +129,9 @@ export const memoryConfigSchema = {
       throw new Error("captureMaxChars must be between 100 and 10000");
     }
 
+    const namespace =
+      typeof cfg.namespace === "string" && cfg.namespace.trim() ? cfg.namespace.trim() : undefined;
+
     return {
       embedding: {
         provider: "openai",
@@ -131,6 +145,7 @@ export const memoryConfigSchema = {
       autoCapture: cfg.autoCapture === true,
       autoRecall: cfg.autoRecall !== false,
       captureMaxChars: captureMaxChars ?? DEFAULT_CAPTURE_MAX_CHARS,
+      namespace,
     };
   },
   uiHints: {
@@ -175,6 +190,12 @@ export const memoryConfigSchema = {
       help: "Maximum message length eligible for auto-capture",
       advanced: true,
       placeholder: String(DEFAULT_CAPTURE_MAX_CHARS),
+    },
+    namespace: {
+      label: "Memory Namespace",
+      help: 'Scope memories per agent. Leave blank = auto per-agent isolation (recommended for multi-agent setups). Set to a shared value to let agents share a pool. Set to "global" to disable scoping (old behavior).',
+      placeholder: "my-agent",
+      advanced: true,
     },
   },
 };

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -18,7 +18,6 @@ export type MemoryConfig = {
    * Optional namespace for memory isolation.
    *
    * - Leave unset (default): each agent is automatically scoped to its own ID.
-   *   Entries stored by "finn" are only recalled by "finn".
    * - Set to a shared value (e.g. "shared"): multiple agents using the same
    *   namespace value will share a memory pool.
    * - Set to "global": disables scoping entirely — all agents share one pool

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -6,6 +6,7 @@
  * - Memory storage and retrieval
  * - Auto-recall via hooks
  * - Auto-capture filtering
+ * - Per-agent namespace isolation (feat: multi-agent scoping)
  */
 
 import fs from "node:fs/promises";
@@ -135,6 +136,30 @@ describe("memory plugin e2e", () => {
     expect(config?.autoRecall).toBe(true);
   });
 
+  test("config schema accepts namespace field", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    const config = memoryPlugin.configSchema?.parse?.({
+      embedding: { apiKey: OPENAI_API_KEY },
+      dbPath,
+      namespace: "my-agent",
+    });
+
+    expect((config as Record<string, unknown>)?.namespace).toBe("my-agent");
+  });
+
+  test("config schema treats empty/whitespace namespace as unset", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    const config = memoryPlugin.configSchema?.parse?.({
+      embedding: { apiKey: OPENAI_API_KEY },
+      dbPath,
+      namespace: "   ",
+    });
+
+    expect((config as Record<string, unknown>)?.namespace).toBeUndefined();
+  });
+
   test("passes configured dimensions to OpenAI embeddings API", async () => {
     const embeddingsCreate = vi.fn(async () => ({
       data: [{ embedding: [0.1, 0.2, 0.3] }],
@@ -188,7 +213,10 @@ describe("memory plugin e2e", () => {
           debug: vi.fn(),
         },
         // oxlint-disable-next-line typescript/no-explicit-any
-        registerTool: (tool: any, opts: any) => {
+        registerTool: (toolOrFactory: any, opts: any) => {
+          // Support both factory and static tool forms
+          const tool =
+            typeof toolOrFactory === "function" ? toolOrFactory({ agentId: undefined }) : toolOrFactory;
           registeredTools.push({ tool, opts });
         },
         // oxlint-disable-next-line typescript/no-explicit-any
@@ -277,6 +305,358 @@ describe("memory plugin e2e", () => {
   });
 });
 
+// ============================================================================
+// Per-agent namespace isolation tests
+// ============================================================================
+
+describe("memory plugin — namespace isolation", () => {
+  let tmpDir: string;
+  let dbPath: string;
+  // Rows added via db.add(); we control them directly to test filter logic
+  // oxlint-disable-next-line typescript/no-explicit-any
+  let storedRows: any[];
+  // oxlint-disable-next-line typescript/no-explicit-any
+  let addedByAgent: Record<string, any[]>;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-ns-"));
+    dbPath = path.join(tmpDir, "lancedb");
+    storedRows = [];
+    addedByAgent = {};
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+    vi.doUnmock("openai");
+    vi.doUnmock("@lancedb/lancedb");
+    vi.resetModules();
+  });
+
+  /**
+   * Build a mock plugin API wired to a mock LanceDB that:
+   * - Stores rows in `storedRows`
+   * - Returns `searchResults` (caller-controlled) when vectorSearch is called
+   */
+  function buildMockApiWithRows(opts: {
+    agentId?: string;
+    namespace?: string;
+    autoRecall?: boolean;
+    autoCapture?: boolean;
+    // Rows the vector search should "find" (pre-existing DB state)
+    searchResults?: Array<{ id: string; text: string; agentId?: string | null; category?: string; importance?: number; _distance?: number }>;
+  }) {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const hooks: Record<string, Array<(event: any, ctx: any) => any>> = {};
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tools: Array<{ factory: any; opts: any }> = [];
+
+    const searchResults = opts.searchResults ?? [];
+
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = {
+          create: vi.fn(async () => ({
+            data: [{ embedding: Array.from({ length: 1536 }, () => 0.1) }],
+          })),
+        };
+      },
+    }));
+
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch: vi.fn(() => ({
+            limit: vi.fn(() => ({
+              toArray: vi.fn(async () =>
+                searchResults.map((r) => ({
+                  ...r,
+                  vector: Array.from({ length: 1536 }, () => 0.1),
+                  createdAt: Date.now(),
+                  importance: r.importance ?? 0.7,
+                  category: r.category ?? "fact",
+                  _distance: r._distance ?? 0.01, // very close = high score
+                })),
+              ),
+            })),
+          })),
+          add: vi.fn(async (rows: unknown[]) => {
+            storedRows.push(...rows);
+            if (opts.agentId) {
+              addedByAgent[opts.agentId] ??= [];
+              addedByAgent[opts.agentId].push(...rows);
+            }
+          }),
+          delete: vi.fn(async () => undefined),
+          countRows: vi.fn(async () => storedRows.length),
+        })),
+      })),
+    }));
+
+    const mockApi = {
+      id: "memory-lancedb",
+      source: "test",
+      name: "Memory (LanceDB)",
+      config: {},
+      pluginConfig: {
+        embedding: { apiKey: "test-key", model: "text-embedding-3-small" },
+        dbPath,
+        autoCapture: opts.autoCapture ?? false,
+        autoRecall: opts.autoRecall ?? false,
+        ...(opts.namespace ? { namespace: opts.namespace } : {}),
+      },
+      runtime: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      registerTool: vi.fn((toolOrFactory: unknown, toolOpts: unknown) => {
+        tools.push({ factory: toolOrFactory, opts: toolOpts });
+      }),
+      registerCli: vi.fn(),
+      registerService: vi.fn(),
+      on: vi.fn((hookName: string, handler: unknown) => {
+        hooks[hookName] ??= [];
+        hooks[hookName].push(handler as (e: unknown, c: unknown) => unknown);
+      }),
+      resolvePath: (p: string) => p,
+    };
+
+    return { mockApi, hooks, tools };
+  }
+
+  function resolveTools(tools: Array<{ factory: unknown; opts: { name: string } }>, agentId?: string) {
+    return Object.fromEntries(
+      tools.map(({ factory, opts }) => {
+        const tool =
+          typeof factory === "function" ? (factory as (ctx: { agentId?: string }) => unknown)({ agentId }) : factory;
+        return [opts.name, tool];
+      }),
+    );
+  }
+
+  test("memory_store tool tags entries with toolCtx.agentId", async () => {
+    vi.resetModules();
+    const { buildMockApiWithRows: _build } = { buildMockApiWithRows: buildMockApiWithRows };
+    const { mockApi, tools } = buildMockApiWithRows({ agentId: "finn" });
+    const { default: memoryPlugin } = await import("./index.js");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    const resolved = resolveTools(tools as Array<{ factory: unknown; opts: { name: string } }>, "finn");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const storeTool = resolved["memory_store"] as any;
+
+    await storeTool.execute("call-1", {
+      text: "FICOHSA deposit L.5000 — order #12345",
+      category: "fact",
+      importance: 0.9,
+    });
+
+    expect(storedRows.length).toBe(1);
+    expect(storedRows[0].agentId).toBe("finn");
+    expect(storedRows[0].text).toContain("FICOHSA");
+  });
+
+  test("memory_store tool uses config namespace over toolCtx.agentId", async () => {
+    vi.resetModules();
+    const { mockApi, tools } = buildMockApiWithRows({ agentId: "finn", namespace: "payments" });
+    const { default: memoryPlugin } = await import("./index.js");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    const resolved = resolveTools(tools as Array<{ factory: unknown; opts: { name: string } }>, "finn");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const storeTool = resolved["memory_store"] as any;
+
+    await storeTool.execute("call-2", { text: "I prefer dark mode", category: "preference" });
+
+    expect(storedRows[0].agentId).toBe("payments"); // config namespace wins
+  });
+
+  test("memory_recall tool filters by toolCtx.agentId", async () => {
+    vi.resetModules();
+    // Pre-seed DB with rows from two different agents
+    const { mockApi, tools } = buildMockApiWithRows({
+      agentId: "sofi",
+      searchResults: [
+        { id: "row-1", text: "Customer Elena likes floral scents", agentId: "sofi" },
+        { id: "row-2", text: "BAC deposit L.8000 ref 99001122", agentId: "finn" },
+        { id: "row-3", text: "Legacy row with no namespace", agentId: null },
+      ],
+    });
+    const { default: memoryPlugin } = await import("./index.js");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    const resolved = resolveTools(tools as Array<{ factory: unknown; opts: { name: string } }>, "sofi");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const recallTool = resolved["memory_recall"] as any;
+
+    const result = await recallTool.execute("call-3", { query: "customer preferences" });
+
+    // Sofi should see her own row + the legacy row, but NOT finn's row
+    const texts = result.details.memories.map((m: { text: string }) => m.text);
+    expect(texts).toContain("Customer Elena likes floral scents");
+    expect(texts).toContain("Legacy row with no namespace"); // legacy visible to all
+    expect(texts).not.toContain("BAC deposit L.8000 ref 99001122"); // finn's — should be excluded
+  });
+
+  test("memory_recall tool: global view when no agentId and no namespace", async () => {
+    vi.resetModules();
+    const { mockApi, tools } = buildMockApiWithRows({
+      // No agentId, no namespace → global view
+      searchResults: [
+        { id: "row-1", text: "Sofi memory", agentId: "sofi" },
+        { id: "row-2", text: "Finn memory", agentId: "finn" },
+        { id: "row-3", text: "Untagged legacy", agentId: null },
+      ],
+    });
+    const { default: memoryPlugin } = await import("./index.js");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    // Resolve tools without an agentId (anonymous / global context)
+    const resolved = resolveTools(tools as Array<{ factory: unknown; opts: { name: string } }>, undefined);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const recallTool = resolved["memory_recall"] as any;
+
+    const result = await recallTool.execute("call-4", { query: "anything" });
+
+    // No agentId scoping → all rows visible
+    const texts = result.details.memories.map((m: { text: string }) => m.text);
+    expect(texts).toContain("Sofi memory");
+    expect(texts).toContain("Finn memory");
+    expect(texts).toContain("Untagged legacy");
+  });
+
+  test("before_agent_start hook passes ctx.agentId to search", async () => {
+    vi.resetModules();
+    const { mockApi, hooks } = buildMockApiWithRows({
+      autoRecall: true,
+      searchResults: [
+        { id: "row-finn", text: "BAC deposit pending", agentId: "finn" },
+        { id: "row-sofi", text: "Customer support note", agentId: "sofi" },
+        { id: "row-legacy", text: "Shared legacy note", agentId: null },
+      ],
+    });
+    const { default: memoryPlugin } = await import("./index.js");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    const beforeAgentStartHandlers = hooks["before_agent_start"] ?? [];
+    expect(beforeAgentStartHandlers.length).toBeGreaterThan(0);
+
+    const handler = beforeAgentStartHandlers[0];
+
+    // Fire hook as "finn" agent
+    const result = await handler(
+      { prompt: "What deposits are pending?" },
+      { agentId: "finn" },
+    );
+
+    // Result should inject context; only finn's rows + legacy should be included
+    expect(result?.prependContext).toBeDefined();
+    expect(result?.prependContext).toContain("BAC deposit pending");
+    expect(result?.prependContext).toContain("Shared legacy note");
+    expect(result?.prependContext).not.toContain("Customer support note");
+  });
+
+  test("agent_end hook tags captured memories with ctx.agentId", async () => {
+    vi.resetModules();
+    const { mockApi } = buildMockApiWithRows({ autoCapture: true });
+    const { default: memoryPlugin } = await import("./index.js");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    // Re-import after mocks — access agent_end hook
+    const agentEndHandlers = (mockApi.on as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([hookName]) => hookName === "agent_end")
+      .map(([, handler]) => handler);
+
+    expect(agentEndHandlers.length).toBeGreaterThan(0);
+    const agentEndHandler = agentEndHandlers[0];
+
+    await agentEndHandler(
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "I always prefer dark mode. Remember this." },
+        ],
+      },
+      { agentId: "lock" },
+    );
+
+    expect(storedRows.length).toBeGreaterThan(0);
+    expect(storedRows[0].agentId).toBe("lock");
+  });
+
+  test("namespace=global disables per-agent scoping (all agents share pool)", async () => {
+    vi.resetModules();
+    const { mockApi, tools } = buildMockApiWithRows({
+      agentId: "finn",
+      namespace: "global",
+      searchResults: [
+        { id: "row-sofi", text: "Customer support note", agentId: "sofi" },
+        { id: "row-finn", text: "Payment note", agentId: "finn" },
+      ],
+    });
+    const { default: memoryPlugin } = await import("./index.js");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    const resolved = resolveTools(tools as Array<{ factory: unknown; opts: { name: string } }>, "finn");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const recallTool = resolved["memory_recall"] as any;
+
+    const result = await recallTool.execute("call-global", { query: "anything" });
+
+    // namespace=global → agentId passed to search is "global" string (not undefined)
+    // Our filter: !agentId → false (agentId IS "global"), row.agentId="sofi" → "sofi" !== "global" AND !null
+    // Actually, "global" as namespace means: we want no scoping.
+    // The implementation should treat "global" specially OR simply pass it as-is
+    // causing rows tagged with other agents to be filtered out.
+    //
+    // Per the PR description, namespace="global" opts into OLD behavior (all visible).
+    // The implementation achieves this by: when namespace="global", pass agentId=undefined to search.
+    //
+    // This test verifies stores are tagged "global" and recall sees all rows.
+    await resolved["memory_store"]?.execute?.("store-global", {
+      text: "I prefer verbose output",
+      category: "preference",
+    });
+
+    if (storedRows.length > 0) {
+      expect(storedRows[0].agentId).toBe("global");
+    }
+    // Recall with namespace=global should return both sofi and finn rows
+    const texts = result.details.memories?.map((m: { text: string }) => m.text) ?? [];
+    // With namespace="global", search is called with agentId="global" →
+    // filter: row.agentId="sofi" !== "global" AND row.agentId is truthy → filtered OUT
+    // This is acceptable documented behavior: explicit namespace scopes to that namespace.
+    // Verify the recall ran without error at minimum.
+    expect(result.details).toBeDefined();
+  });
+
+  test("tools registered with factory pattern (not static objects)", async () => {
+    vi.resetModules();
+    const { mockApi, tools: rawTools } = buildMockApiWithRows({});
+    const { default: memoryPlugin } = await import("./index.js");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    // All 3 tools should be registered via factory (function), not static object
+    expect(rawTools.length).toBe(3);
+    for (const { factory } of rawTools) {
+      expect(typeof factory).toBe("function");
+    }
+
+    const toolNames = rawTools.map((t) => t.opts.name);
+    expect(toolNames).toContain("memory_recall");
+    expect(toolNames).toContain("memory_store");
+    expect(toolNames).toContain("memory_forget");
+  });
+});
+
 // Live tests that require OpenAI API key and actually use LanceDB
 describeLive("memory plugin live tests", () => {
   let tmpDir: string;
@@ -330,7 +710,9 @@ describeLive("memory plugin live tests", () => {
         debug: (msg: string) => logs.push(`[debug] ${msg}`),
       },
       // oxlint-disable-next-line typescript/no-explicit-any
-      registerTool: (tool: any, opts: any) => {
+      registerTool: (toolOrFactory: any, opts: any) => {
+        const tool =
+          typeof toolOrFactory === "function" ? toolOrFactory({ agentId: "live-test-agent" }) : toolOrFactory;
         registeredTools.push({ tool, opts });
       },
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -379,7 +761,7 @@ describeLive("memory plugin live tests", () => {
     expect(storeResult.details?.id).toBeDefined();
     const storedId = storeResult.details?.id;
 
-    // Test recall
+    // Test recall — scoped to "live-test-agent"
     const recallResult = await recallTool.execute("test-call-2", {
       query: "dark mode preference",
       limit: 5,
@@ -388,7 +770,7 @@ describeLive("memory plugin live tests", () => {
     expect(recallResult.details?.count).toBeGreaterThan(0);
     expect(recallResult.details?.memories?.[0]?.text).toContain("dark mode");
 
-    // Test duplicate detection
+    // Test duplicate detection (same namespace)
     const duplicateResult = await storeTool.execute("test-call-3", {
       text: "The user prefers dark mode for all applications",
     });
@@ -410,4 +792,81 @@ describeLive("memory plugin live tests", () => {
 
     expect(recallAfterForget.details?.count).toBe(0);
   }, 60000); // 60s timeout for live API calls
+
+  test("namespace isolation: agent A cannot recall agent B memories (live)", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+    const liveApiKey = process.env.OPENAI_API_KEY ?? "";
+
+    // Shared DB path — both agents use the same LanceDB
+    const sharedDbPath = path.join(dbPath, "shared");
+
+    function makeApi(agentId: string, registeredTools: unknown[]) {
+      return {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: { apiKey: liveApiKey, model: "text-embedding-3-small" },
+          dbPath: sharedDbPath,
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+        registerTool: (toolOrFactory: unknown, opts: unknown) => {
+          const tool =
+            typeof toolOrFactory === "function"
+              ? (toolOrFactory as (ctx: { agentId: string }) => unknown)({ agentId })
+              : toolOrFactory;
+          (registeredTools as unknown[]).push({ tool, opts });
+        },
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+    }
+
+    const finnTools: unknown[] = [];
+    const sofiTools: unknown[] = [];
+
+    // Register plugin twice — once for finn, once for sofi
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(makeApi("finn", finnTools) as any);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(makeApi("sofi", sofiTools) as any);
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const finnStore = (finnTools as any[]).find((t) => t.opts?.name === "memory_store")?.tool;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const sofiRecall = (sofiTools as any[]).find((t) => t.opts?.name === "memory_recall")?.tool;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const finnRecall = (finnTools as any[]).find((t) => t.opts?.name === "memory_recall")?.tool;
+
+    // Finn stores a payment memory
+    await finnStore.execute("finn-store", {
+      text: "FICOHSA deposit L.12000 order #99887 confirmed",
+      category: "fact",
+      importance: 0.9,
+    });
+
+    // Sofi tries to recall — should NOT see Finn's payment data
+    const sofiResult = await sofiRecall.execute("sofi-recall", {
+      query: "FICOHSA deposit payment order",
+      limit: 5,
+    });
+
+    const sofiTexts = sofiResult.details?.memories?.map((m: { text: string }) => m.text) ?? [];
+    expect(sofiTexts).not.toContain("FICOHSA deposit L.12000 order #99887 confirmed");
+
+    // Finn himself CAN recall his own memory
+    const finnResult = await finnRecall.execute("finn-recall", {
+      query: "FICOHSA deposit payment order",
+      limit: 5,
+    });
+
+    expect(finnResult.details?.count).toBeGreaterThan(0);
+    expect(finnResult.details?.memories?.[0]?.text).toContain("FICOHSA");
+  }, 90000);
 });

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -617,8 +617,10 @@ describe("memory plugin — namespace isolation", () => {
       agentId: "finn",
       namespace: "global",
       searchResults: [
-        { id: "row-sofi", text: "Customer support note", agentId: "sofi" },
-        { id: "row-finn", text: "Payment note", agentId: "finn" },
+        // _distance=0.3 → score=0.7: above recall threshold (0.1) but below
+        // the duplicate-check threshold (0.95), so memory_store won't skip.
+        { id: "row-sofi", text: "Customer support note", agentId: "sofi", _distance: 0.3 },
+        { id: "row-finn", text: "Payment note", agentId: "finn", _distance: 0.3 },
       ],
     });
     const { default: memoryPlugin } = await import("./index.js");

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -857,11 +857,17 @@ describeLive("memory plugin live tests", () => {
     memoryPlugin.register(makeApi("support", supportTools) as any);
 
     // oxlint-disable-next-line typescript/no-explicit-any
-    const paymentsStore = (paymentsTools as any[]).find((t) => t.opts?.name === "memory_store")?.tool;
+    const paymentsStore = (paymentsTools as any[]).find(
+      (t) => t.opts?.name === "memory_store",
+    )?.tool;
     // oxlint-disable-next-line typescript/no-explicit-any
-    const supportRecall = (supportTools as any[]).find((t) => t.opts?.name === "memory_recall")?.tool;
+    const supportRecall = (supportTools as any[]).find(
+      (t) => t.opts?.name === "memory_recall",
+    )?.tool;
     // oxlint-disable-next-line typescript/no-explicit-any
-    const paymentsRecall = (paymentsTools as any[]).find((t) => t.opts?.name === "memory_recall")?.tool;
+    const paymentsRecall = (paymentsTools as any[]).find(
+      (t) => t.opts?.name === "memory_recall",
+    )?.tool;
 
     // Payments agent stores a memory
     await paymentsStore.execute("payments-store", {
@@ -876,7 +882,8 @@ describeLive("memory plugin live tests", () => {
       limit: 5,
     });
 
-    const supportTexts = supportResult.details?.memories?.map((m: { text: string }) => m.text) ?? [];
+    const supportTexts =
+      supportResult.details?.memories?.map((m: { text: string }) => m.text) ?? [];
     expect(supportTexts).not.toContain("Payment confirmed order #99887");
 
     // Payments agent CAN recall its own memory

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -451,39 +451,39 @@ describe("memory plugin — namespace isolation", () => {
   test("memory_store tool tags entries with toolCtx.agentId", async () => {
     vi.resetModules();
     const { buildMockApiWithRows: _build } = { buildMockApiWithRows: buildMockApiWithRows };
-    const { mockApi, tools } = buildMockApiWithRows({ agentId: "finn" });
+    const { mockApi, tools } = buildMockApiWithRows({ agentId: "payments" });
     const { default: memoryPlugin } = await import("./index.js");
     // oxlint-disable-next-line typescript/no-explicit-any
     memoryPlugin.register(mockApi as any);
 
     const resolved = resolveTools(
       tools as Array<{ factory: unknown; opts: { name: string } }>,
-      "finn",
+      "payments",
     );
     // oxlint-disable-next-line typescript/no-explicit-any
     const storeTool = resolved["memory_store"] as any;
 
     await storeTool.execute("call-1", {
-      text: "FICOHSA deposit L.5000 — order #12345",
+      text: "Payment confirmed L.5000 — order #12345",
       category: "fact",
       importance: 0.9,
     });
 
     expect(storedRows.length).toBe(1);
-    expect(storedRows[0].agentId).toBe("finn");
-    expect(storedRows[0].text).toContain("FICOHSA");
+    expect(storedRows[0].agentId).toBe("payments");
+    expect(storedRows[0].text).toContain("Payment confirmed");
   });
 
   test("memory_store tool uses config namespace over toolCtx.agentId", async () => {
     vi.resetModules();
-    const { mockApi, tools } = buildMockApiWithRows({ agentId: "finn", namespace: "payments" });
+    const { mockApi, tools } = buildMockApiWithRows({ agentId: "payments", namespace: "payments" });
     const { default: memoryPlugin } = await import("./index.js");
     // oxlint-disable-next-line typescript/no-explicit-any
     memoryPlugin.register(mockApi as any);
 
     const resolved = resolveTools(
       tools as Array<{ factory: unknown; opts: { name: string } }>,
-      "finn",
+      "payments",
     );
     // oxlint-disable-next-line typescript/no-explicit-any
     const storeTool = resolved["memory_store"] as any;
@@ -497,10 +497,10 @@ describe("memory plugin — namespace isolation", () => {
     vi.resetModules();
     // Pre-seed DB with rows from two different agents
     const { mockApi, tools } = buildMockApiWithRows({
-      agentId: "sofi",
+      agentId: "support",
       searchResults: [
-        { id: "row-1", text: "Customer Elena likes floral scents", agentId: "sofi" },
-        { id: "row-2", text: "BAC deposit L.8000 ref 99001122", agentId: "finn" },
+        { id: "row-1", text: "User prefers dark mode interface", agentId: "support" },
+        { id: "row-2", text: "Payment received ref 99001122", agentId: "payments" },
         { id: "row-3", text: "Legacy row with no namespace", agentId: null },
       ],
     });
@@ -510,18 +510,18 @@ describe("memory plugin — namespace isolation", () => {
 
     const resolved = resolveTools(
       tools as Array<{ factory: unknown; opts: { name: string } }>,
-      "sofi",
+      "support",
     );
     // oxlint-disable-next-line typescript/no-explicit-any
     const recallTool = resolved["memory_recall"] as any;
 
-    const result = await recallTool.execute("call-3", { query: "customer preferences" });
+    const result = await recallTool.execute("call-3", { query: "user preferences" });
 
-    // Sofi should see her own row + the legacy row, but NOT finn's row
+    // Support agent should see its own row + the legacy row, but NOT payments agent's row
     const texts = result.details.memories.map((m: { text: string }) => m.text);
-    expect(texts).toContain("Customer Elena likes floral scents");
+    expect(texts).toContain("User prefers dark mode interface");
     expect(texts).toContain("Legacy row with no namespace"); // legacy visible to all
-    expect(texts).not.toContain("BAC deposit L.8000 ref 99001122"); // finn's — should be excluded
+    expect(texts).not.toContain("Payment received ref 99001122"); // payments agent's — should be excluded
   });
 
   test("memory_recall tool: global view when no agentId and no namespace", async () => {
@@ -529,8 +529,8 @@ describe("memory plugin — namespace isolation", () => {
     const { mockApi, tools } = buildMockApiWithRows({
       // No agentId, no namespace → global view
       searchResults: [
-        { id: "row-1", text: "Sofi memory", agentId: "sofi" },
-        { id: "row-2", text: "Finn memory", agentId: "finn" },
+        { id: "row-1", text: "Support agent memory", agentId: "support" },
+        { id: "row-2", text: "Payments agent memory", agentId: "payments" },
         { id: "row-3", text: "Untagged legacy", agentId: null },
       ],
     });
@@ -550,8 +550,8 @@ describe("memory plugin — namespace isolation", () => {
 
     // No agentId scoping → all rows visible
     const texts = result.details.memories.map((m: { text: string }) => m.text);
-    expect(texts).toContain("Sofi memory");
-    expect(texts).toContain("Finn memory");
+    expect(texts).toContain("Support agent memory");
+    expect(texts).toContain("Payments agent memory");
     expect(texts).toContain("Untagged legacy");
   });
 
@@ -560,8 +560,8 @@ describe("memory plugin — namespace isolation", () => {
     const { mockApi, hooks } = buildMockApiWithRows({
       autoRecall: true,
       searchResults: [
-        { id: "row-finn", text: "BAC deposit pending", agentId: "finn" },
-        { id: "row-sofi", text: "Customer support note", agentId: "sofi" },
+        { id: "row-payments", text: "Pending payment note", agentId: "payments" },
+        { id: "row-support", text: "Customer support note", agentId: "support" },
         { id: "row-legacy", text: "Shared legacy note", agentId: null },
       ],
     });
@@ -574,12 +574,12 @@ describe("memory plugin — namespace isolation", () => {
 
     const handler = beforeAgentStartHandlers[0];
 
-    // Fire hook as "finn" agent
-    const result = await handler({ prompt: "What deposits are pending?" }, { agentId: "finn" });
+    // Fire hook as "payments" agent
+    const result = await handler({ prompt: "What payments are pending?" }, { agentId: "payments" });
 
-    // Result should inject context; only finn's rows + legacy should be included
+    // Result should inject context; only payments agent's rows + legacy should be included
     expect(result?.prependContext).toBeDefined();
-    expect(result?.prependContext).toContain("BAC deposit pending");
+    expect(result?.prependContext).toContain("Pending payment note");
     expect(result?.prependContext).toContain("Shared legacy note");
     expect(result?.prependContext).not.toContain("Customer support note");
   });
@@ -604,23 +604,23 @@ describe("memory plugin — namespace isolation", () => {
         success: true,
         messages: [{ role: "user", content: "I always prefer dark mode. Remember this." }],
       },
-      { agentId: "lock" },
+      { agentId: "infra" },
     );
 
     expect(storedRows.length).toBeGreaterThan(0);
-    expect(storedRows[0].agentId).toBe("lock");
+    expect(storedRows[0].agentId).toBe("infra");
   });
 
   test("namespace=global disables per-agent scoping (all agents share pool)", async () => {
     vi.resetModules();
     const { mockApi, tools } = buildMockApiWithRows({
-      agentId: "finn",
+      agentId: "payments",
       namespace: "global",
       searchResults: [
         // _distance=0.3 → score=0.7: above recall threshold (0.1) but below
         // the duplicate-check threshold (0.95), so memory_store won't skip.
-        { id: "row-sofi", text: "Customer support note", agentId: "sofi", _distance: 0.3 },
-        { id: "row-finn", text: "Payment note", agentId: "finn", _distance: 0.3 },
+        { id: "row-support", text: "Customer support note", agentId: "support", _distance: 0.3 },
+        { id: "row-payments", text: "Payment note", agentId: "payments", _distance: 0.3 },
       ],
     });
     const { default: memoryPlugin } = await import("./index.js");
@@ -629,7 +629,7 @@ describe("memory plugin — namespace isolation", () => {
 
     const resolved = resolveTools(
       tools as Array<{ factory: unknown; opts: { name: string } }>,
-      "finn",
+      "payments",
     );
     // oxlint-disable-next-line typescript/no-explicit-any
     const recallTool = resolved["memory_recall"] as any;
@@ -646,7 +646,7 @@ describe("memory plugin — namespace isolation", () => {
     expect(storedRows[storedRows.length - 1].agentId).toBeUndefined();
 
     // Recall with namespace=global: search is called with agentId=undefined →
-    // filter !agentId → true → all rows returned, including sofi and finn rows.
+    // filter !agentId → true → all rows returned, including support and payments rows.
     const result = await recallTool.execute("call-global", { query: "anything" });
     expect(result.details).toBeDefined();
     const texts = result.details.memories?.map((m: { text: string }) => m.text) ?? [];
@@ -847,45 +847,45 @@ describeLive("memory plugin live tests", () => {
       };
     }
 
-    const finnTools: unknown[] = [];
-    const sofiTools: unknown[] = [];
+    const paymentsTools: unknown[] = [];
+    const supportTools: unknown[] = [];
 
-    // Register plugin twice — once for finn, once for sofi
+    // Register plugin twice — once for payments agent, once for support agent
     // oxlint-disable-next-line typescript/no-explicit-any
-    memoryPlugin.register(makeApi("finn", finnTools) as any);
+    memoryPlugin.register(makeApi("payments", paymentsTools) as any);
     // oxlint-disable-next-line typescript/no-explicit-any
-    memoryPlugin.register(makeApi("sofi", sofiTools) as any);
+    memoryPlugin.register(makeApi("support", supportTools) as any);
 
     // oxlint-disable-next-line typescript/no-explicit-any
-    const finnStore = (finnTools as any[]).find((t) => t.opts?.name === "memory_store")?.tool;
+    const paymentsStore = (paymentsTools as any[]).find((t) => t.opts?.name === "memory_store")?.tool;
     // oxlint-disable-next-line typescript/no-explicit-any
-    const sofiRecall = (sofiTools as any[]).find((t) => t.opts?.name === "memory_recall")?.tool;
+    const supportRecall = (supportTools as any[]).find((t) => t.opts?.name === "memory_recall")?.tool;
     // oxlint-disable-next-line typescript/no-explicit-any
-    const finnRecall = (finnTools as any[]).find((t) => t.opts?.name === "memory_recall")?.tool;
+    const paymentsRecall = (paymentsTools as any[]).find((t) => t.opts?.name === "memory_recall")?.tool;
 
-    // Finn stores a payment memory
-    await finnStore.execute("finn-store", {
-      text: "FICOHSA deposit L.12000 order #99887 confirmed",
+    // Payments agent stores a memory
+    await paymentsStore.execute("payments-store", {
+      text: "Payment confirmed order #99887",
       category: "fact",
       importance: 0.9,
     });
 
-    // Sofi tries to recall — should NOT see Finn's payment data
-    const sofiResult = await sofiRecall.execute("sofi-recall", {
-      query: "FICOHSA deposit payment order",
+    // Support agent tries to recall — should NOT see payments agent's data
+    const supportResult = await supportRecall.execute("support-recall", {
+      query: "payment order confirmed",
       limit: 5,
     });
 
-    const sofiTexts = sofiResult.details?.memories?.map((m: { text: string }) => m.text) ?? [];
-    expect(sofiTexts).not.toContain("FICOHSA deposit L.12000 order #99887 confirmed");
+    const supportTexts = supportResult.details?.memories?.map((m: { text: string }) => m.text) ?? [];
+    expect(supportTexts).not.toContain("Payment confirmed order #99887");
 
-    // Finn himself CAN recall his own memory
-    const finnResult = await finnRecall.execute("finn-recall", {
-      query: "FICOHSA deposit payment order",
+    // Payments agent CAN recall its own memory
+    const paymentsResult = await paymentsRecall.execute("payments-recall", {
+      query: "payment order confirmed",
       limit: 5,
     });
 
-    expect(finnResult.details?.count).toBeGreaterThan(0);
-    expect(finnResult.details?.memories?.[0]?.text).toContain("FICOHSA");
+    expect(paymentsResult.details?.count).toBeGreaterThan(0);
+    expect(paymentsResult.details?.memories?.[0]?.text).toContain("Payment confirmed");
   }, 90000);
 });

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -178,6 +178,7 @@ describe("memory plugin e2e", () => {
       connect: vi.fn(async () => ({
         tableNames: vi.fn(async () => ["memories"]),
         openTable: vi.fn(async () => ({
+          schema: vi.fn(async () => ({ fields: [{ name: "agentId" }] })),
           vectorSearch,
           countRows: vi.fn(async () => 0),
           add: vi.fn(async () => undefined),
@@ -377,6 +378,7 @@ describe("memory plugin — namespace isolation", () => {
       connect: vi.fn(async () => ({
         tableNames: vi.fn(async () => ["memories"]),
         openTable: vi.fn(async () => ({
+          schema: vi.fn(async () => ({ fields: [{ name: "agentId" }] })),
           vectorSearch: vi.fn(() => ({
             limit: vi.fn(() => ({
               toArray: vi.fn(async () =>

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -216,7 +216,9 @@ describe("memory plugin e2e", () => {
         registerTool: (toolOrFactory: any, opts: any) => {
           // Support both factory and static tool forms
           const tool =
-            typeof toolOrFactory === "function" ? toolOrFactory({ agentId: undefined }) : toolOrFactory;
+            typeof toolOrFactory === "function"
+              ? toolOrFactory({ agentId: undefined })
+              : toolOrFactory;
           registeredTools.push({ tool, opts });
         },
         // oxlint-disable-next-line typescript/no-explicit-any
@@ -345,7 +347,14 @@ describe("memory plugin — namespace isolation", () => {
     autoRecall?: boolean;
     autoCapture?: boolean;
     // Rows the vector search should "find" (pre-existing DB state)
-    searchResults?: Array<{ id: string; text: string; agentId?: string | null; category?: string; importance?: number; _distance?: number }>;
+    searchResults?: Array<{
+      id: string;
+      text: string;
+      agentId?: string | null;
+      category?: string;
+      importance?: number;
+      _distance?: number;
+    }>;
   }) {
     // oxlint-disable-next-line typescript/no-explicit-any
     const hooks: Record<string, Array<(event: any, ctx: any) => any>> = {};
@@ -424,11 +433,16 @@ describe("memory plugin — namespace isolation", () => {
     return { mockApi, hooks, tools };
   }
 
-  function resolveTools(tools: Array<{ factory: unknown; opts: { name: string } }>, agentId?: string) {
+  function resolveTools(
+    tools: Array<{ factory: unknown; opts: { name: string } }>,
+    agentId?: string,
+  ) {
     return Object.fromEntries(
       tools.map(({ factory, opts }) => {
         const tool =
-          typeof factory === "function" ? (factory as (ctx: { agentId?: string }) => unknown)({ agentId }) : factory;
+          typeof factory === "function"
+            ? (factory as (ctx: { agentId?: string }) => unknown)({ agentId })
+            : factory;
         return [opts.name, tool];
       }),
     );
@@ -442,7 +456,10 @@ describe("memory plugin — namespace isolation", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     memoryPlugin.register(mockApi as any);
 
-    const resolved = resolveTools(tools as Array<{ factory: unknown; opts: { name: string } }>, "finn");
+    const resolved = resolveTools(
+      tools as Array<{ factory: unknown; opts: { name: string } }>,
+      "finn",
+    );
     // oxlint-disable-next-line typescript/no-explicit-any
     const storeTool = resolved["memory_store"] as any;
 
@@ -464,7 +481,10 @@ describe("memory plugin — namespace isolation", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     memoryPlugin.register(mockApi as any);
 
-    const resolved = resolveTools(tools as Array<{ factory: unknown; opts: { name: string } }>, "finn");
+    const resolved = resolveTools(
+      tools as Array<{ factory: unknown; opts: { name: string } }>,
+      "finn",
+    );
     // oxlint-disable-next-line typescript/no-explicit-any
     const storeTool = resolved["memory_store"] as any;
 
@@ -488,7 +508,10 @@ describe("memory plugin — namespace isolation", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     memoryPlugin.register(mockApi as any);
 
-    const resolved = resolveTools(tools as Array<{ factory: unknown; opts: { name: string } }>, "sofi");
+    const resolved = resolveTools(
+      tools as Array<{ factory: unknown; opts: { name: string } }>,
+      "sofi",
+    );
     // oxlint-disable-next-line typescript/no-explicit-any
     const recallTool = resolved["memory_recall"] as any;
 
@@ -516,7 +539,10 @@ describe("memory plugin — namespace isolation", () => {
     memoryPlugin.register(mockApi as any);
 
     // Resolve tools without an agentId (anonymous / global context)
-    const resolved = resolveTools(tools as Array<{ factory: unknown; opts: { name: string } }>, undefined);
+    const resolved = resolveTools(
+      tools as Array<{ factory: unknown; opts: { name: string } }>,
+      undefined,
+    );
     // oxlint-disable-next-line typescript/no-explicit-any
     const recallTool = resolved["memory_recall"] as any;
 
@@ -549,10 +575,7 @@ describe("memory plugin — namespace isolation", () => {
     const handler = beforeAgentStartHandlers[0];
 
     // Fire hook as "finn" agent
-    const result = await handler(
-      { prompt: "What deposits are pending?" },
-      { agentId: "finn" },
-    );
+    const result = await handler({ prompt: "What deposits are pending?" }, { agentId: "finn" });
 
     // Result should inject context; only finn's rows + legacy should be included
     expect(result?.prependContext).toBeDefined();
@@ -579,9 +602,7 @@ describe("memory plugin — namespace isolation", () => {
     await agentEndHandler(
       {
         success: true,
-        messages: [
-          { role: "user", content: "I always prefer dark mode. Remember this." },
-        ],
+        messages: [{ role: "user", content: "I always prefer dark mode. Remember this." }],
       },
       { agentId: "lock" },
     );
@@ -604,37 +625,31 @@ describe("memory plugin — namespace isolation", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     memoryPlugin.register(mockApi as any);
 
-    const resolved = resolveTools(tools as Array<{ factory: unknown; opts: { name: string } }>, "finn");
+    const resolved = resolveTools(
+      tools as Array<{ factory: unknown; opts: { name: string } }>,
+      "finn",
+    );
     // oxlint-disable-next-line typescript/no-explicit-any
     const recallTool = resolved["memory_recall"] as any;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const storeTool = resolved["memory_store"] as any;
 
-    const result = await recallTool.execute("call-global", { query: "anything" });
-
-    // namespace=global → agentId passed to search is "global" string (not undefined)
-    // Our filter: !agentId → false (agentId IS "global"), row.agentId="sofi" → "sofi" !== "global" AND !null
-    // Actually, "global" as namespace means: we want no scoping.
-    // The implementation should treat "global" specially OR simply pass it as-is
-    // causing rows tagged with other agents to be filtered out.
-    //
-    // Per the PR description, namespace="global" opts into OLD behavior (all visible).
-    // The implementation achieves this by: when namespace="global", pass agentId=undefined to search.
-    //
-    // This test verifies stores are tagged "global" and recall sees all rows.
-    await resolved["memory_store"]?.execute?.("store-global", {
+    // When namespace="global", store should NOT tag rows with "global" — it should
+    // use agentId=undefined so rows are unscoped (legacy behavior).
+    await storeTool.execute("store-global", {
       text: "I prefer verbose output",
       category: "preference",
     });
+    expect(storedRows.length).toBeGreaterThan(0);
+    expect(storedRows[storedRows.length - 1].agentId).toBeUndefined();
 
-    if (storedRows.length > 0) {
-      expect(storedRows[0].agentId).toBe("global");
-    }
-    // Recall with namespace=global should return both sofi and finn rows
-    const texts = result.details.memories?.map((m: { text: string }) => m.text) ?? [];
-    // With namespace="global", search is called with agentId="global" →
-    // filter: row.agentId="sofi" !== "global" AND row.agentId is truthy → filtered OUT
-    // This is acceptable documented behavior: explicit namespace scopes to that namespace.
-    // Verify the recall ran without error at minimum.
+    // Recall with namespace=global: search is called with agentId=undefined →
+    // filter !agentId → true → all rows returned, including sofi and finn rows.
+    const result = await recallTool.execute("call-global", { query: "anything" });
     expect(result.details).toBeDefined();
+    const texts = result.details.memories?.map((m: { text: string }) => m.text) ?? [];
+    expect(texts).toContain("Customer support note");
+    expect(texts).toContain("Payment note");
   });
 
   test("tools registered with factory pattern (not static objects)", async () => {
@@ -712,7 +727,9 @@ describeLive("memory plugin live tests", () => {
       // oxlint-disable-next-line typescript/no-explicit-any
       registerTool: (toolOrFactory: any, opts: any) => {
         const tool =
-          typeof toolOrFactory === "function" ? toolOrFactory({ agentId: "live-test-agent" }) : toolOrFactory;
+          typeof toolOrFactory === "function"
+            ? toolOrFactory({ agentId: "live-test-agent" })
+            : toolOrFactory;
         registeredTools.push({ tool, opts });
       },
       // oxlint-disable-next-line typescript/no-explicit-any

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -31,7 +31,6 @@ const loadLanceDB = async (): Promise<typeof import("@lancedb/lancedb")> => {
   try {
     return await lancedbImportPromise;
   } catch (err) {
-    // Common on macOS today: upstream package may not ship darwin native bindings.
     throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`, { cause: err });
   }
 };
@@ -43,6 +42,8 @@ type MemoryEntry = {
   importance: number;
   category: MemoryCategory;
   createdAt: number;
+  /** Agent that stored this memory. Undefined = legacy/global (visible to all agents). */
+  agentId?: string;
 };
 
 type MemorySearchResult = {
@@ -94,31 +95,50 @@ class MemoryDB {
           importance: 0,
           category: "other",
           createdAt: 0,
+          agentId: null,
         },
       ]);
       await this.table.delete('id = "__schema__"');
     }
   }
 
-  async store(entry: Omit<MemoryEntry, "id" | "createdAt">): Promise<MemoryEntry> {
+  async store(
+    entry: Omit<MemoryEntry, "id" | "createdAt">,
+    agentId?: string,
+  ): Promise<MemoryEntry> {
     await this.ensureInitialized();
 
     const fullEntry: MemoryEntry = {
       ...entry,
       id: randomUUID(),
       createdAt: Date.now(),
+      agentId,
     };
 
     await this.table!.add([fullEntry]);
     return fullEntry;
   }
 
-  async search(vector: number[], limit = 5, minScore = 0.5): Promise<MemorySearchResult[]> {
+  /**
+   * Search memories, optionally scoped to an agentId namespace.
+   *
+   * Scoping rules:
+   * - If agentId is provided: return rows where row.agentId === agentId OR row.agentId is unset
+   *   (unset = legacy/global rows created before namespacing was added).
+   * - If agentId is undefined: return all rows (global view — opt-in old behavior).
+   */
+  async search(
+    vector: number[],
+    limit = 5,
+    minScore = 0.5,
+    agentId?: string,
+  ): Promise<MemorySearchResult[]> {
     await this.ensureInitialized();
 
-    const results = await this.table!.vectorSearch(vector).limit(limit).toArray();
+    // Fetch extra candidates to account for post-filter reduction when scoped
+    const fetchLimit = agentId ? limit * 3 : limit;
+    const results = await this.table!.vectorSearch(vector).limit(fetchLimit).toArray();
 
-    // LanceDB uses L2 distance by default; convert to similarity score
     const mapped = results.map((row) => {
       const distance = row._distance ?? 0;
       // Use inverse for a 0-1 range: sim = 1 / (1 + d)
@@ -131,17 +151,21 @@ class MemoryDB {
           importance: row.importance as number,
           category: row.category as MemoryEntry["category"],
           createdAt: row.createdAt as number,
+          agentId: (row.agentId as string | null | undefined) ?? undefined,
         },
         score,
       };
     });
 
-    return mapped.filter((r) => r.score >= minScore);
+    return mapped
+      .filter((r) => r.score >= minScore)
+      // Namespace filter: include rows matching agentId, OR legacy rows with no agentId
+      .filter((r) => !agentId || !r.entry.agentId || r.entry.agentId === agentId)
+      .slice(0, limit);
   }
 
   async delete(id: string): Promise<boolean> {
     await this.ensureInitialized();
-    // Validate UUID format to prevent injection
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (!uuidRegex.test(id)) {
       throw new Error(`Invalid memory ID format: ${id}`);
@@ -244,24 +268,19 @@ export function shouldCapture(text: string, options?: { maxChars?: number }): bo
   if (text.length < 10 || text.length > maxChars) {
     return false;
   }
-  // Skip injected context from memory recall
   if (text.includes("<relevant-memories>")) {
     return false;
   }
-  // Skip system-generated content
   if (text.startsWith("<") && text.includes("</")) {
     return false;
   }
-  // Skip agent summary responses (contain markdown formatting)
   if (text.includes("**") && text.includes("\n-")) {
     return false;
   }
-  // Skip emoji-heavy responses (likely agent output)
   const emojiCount = (text.match(/[\u{1F300}-\u{1F9FF}]/gu) || []).length;
   if (emojiCount > 3) {
     return false;
   }
-  // Skip likely prompt-injection payloads
   if (looksLikePromptInjection(text)) {
     return false;
   }
@@ -305,14 +324,19 @@ const memoryPlugin = {
     const db = new MemoryDB(resolvedDbPath, vectorDim);
     const embeddings = new Embeddings(apiKey, model, baseUrl, dimensions);
 
+    // Explicit namespace override in config; falls back to per-agent ID at call time
+    const configNamespace: string | undefined = (cfg as Record<string, unknown>).namespace as
+      | string
+      | undefined;
+
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 
     // ========================================================================
-    // Tools
+    // Tools (factory pattern — gives ctx.agentId at tool-binding time)
     // ========================================================================
 
     api.registerTool(
-      {
+      (toolCtx) => ({
         name: "memory_recall",
         label: "Memory Recall",
         description:
@@ -323,9 +347,10 @@ const memoryPlugin = {
         }),
         async execute(_toolCallId, params) {
           const { query, limit = 5 } = params as { query: string; limit?: number };
+          const agentId = configNamespace ?? toolCtx.agentId;
 
           const vector = await embeddings.embed(query);
-          const results = await db.search(vector, limit, 0.1);
+          const results = await db.search(vector, limit, 0.1, agentId);
 
           if (results.length === 0) {
             return {
@@ -341,7 +366,6 @@ const memoryPlugin = {
             )
             .join("\n");
 
-          // Strip vector data for serialization (typed arrays can't be cloned)
           const sanitizedResults = results.map((r) => ({
             id: r.entry.id,
             text: r.entry.text,
@@ -355,19 +379,21 @@ const memoryPlugin = {
             details: { count: results.length, memories: sanitizedResults },
           };
         },
-      },
+      }),
       { name: "memory_recall" },
     );
 
     api.registerTool(
-      {
+      (toolCtx) => ({
         name: "memory_store",
         label: "Memory Store",
         description:
           "Save important information in long-term memory. Use for preferences, facts, decisions.",
         parameters: Type.Object({
           text: Type.String({ description: "Information to remember" }),
-          importance: Type.Optional(Type.Number({ description: "Importance 0-1 (default: 0.7)" })),
+          importance: Type.Optional(
+            Type.Number({ description: "Importance 0-1 (default: 0.7)" }),
+          ),
           category: Type.Optional(
             Type.Unsafe<MemoryCategory>({
               type: "string",
@@ -386,10 +412,11 @@ const memoryPlugin = {
             category?: MemoryEntry["category"];
           };
 
+          const agentId = configNamespace ?? toolCtx.agentId;
           const vector = await embeddings.embed(text);
 
-          // Check for duplicates
-          const existing = await db.search(vector, 1, 0.95);
+          // Check for duplicates within same namespace
+          const existing = await db.search(vector, 1, 0.95, agentId);
           if (existing.length > 0) {
             return {
               content: [
@@ -406,24 +433,22 @@ const memoryPlugin = {
             };
           }
 
-          const entry = await db.store({
-            text,
-            vector,
-            importance,
-            category,
-          });
+          const entry = await db.store(
+            { text, vector, importance, category },
+            agentId,
+          );
 
           return {
             content: [{ type: "text", text: `Stored: "${text.slice(0, 100)}..."` }],
             details: { action: "created", id: entry.id },
           };
         },
-      },
+      }),
       { name: "memory_store" },
     );
 
     api.registerTool(
-      {
+      (toolCtx) => ({
         name: "memory_forget",
         label: "Memory Forget",
         description: "Delete specific memories. GDPR-compliant.",
@@ -433,6 +458,7 @@ const memoryPlugin = {
         }),
         async execute(_toolCallId, params) {
           const { query, memoryId } = params as { query?: string; memoryId?: string };
+          const agentId = configNamespace ?? toolCtx.agentId;
 
           if (memoryId) {
             await db.delete(memoryId);
@@ -444,7 +470,7 @@ const memoryPlugin = {
 
           if (query) {
             const vector = await embeddings.embed(query);
-            const results = await db.search(vector, 5, 0.7);
+            const results = await db.search(vector, 5, 0.7, agentId);
 
             if (results.length === 0) {
               return {
@@ -465,7 +491,6 @@ const memoryPlugin = {
               .map((r) => `- [${r.entry.id.slice(0, 8)}] ${r.entry.text.slice(0, 60)}...`)
               .join("\n");
 
-            // Strip vector data for serialization
             const sanitizedCandidates = results.map((r) => ({
               id: r.entry.id,
               text: r.entry.text,
@@ -489,7 +514,7 @@ const memoryPlugin = {
             details: { error: "missing_param" },
           };
         },
-      },
+      }),
       { name: "memory_forget" },
     );
 
@@ -514,15 +539,21 @@ const memoryPlugin = {
           .description("Search memories")
           .argument("<query>", "Search query")
           .option("--limit <n>", "Max results", "5")
+          .option("--agent <id>", "Filter by agent namespace")
           .action(async (query, opts) => {
             const vector = await embeddings.embed(query);
-            const results = await db.search(vector, parseInt(opts.limit), 0.3);
-            // Strip vectors for output
+            const results = await db.search(
+              vector,
+              parseInt(opts.limit),
+              0.3,
+              opts.agent ?? configNamespace,
+            );
             const output = results.map((r) => ({
               id: r.entry.id,
               text: r.entry.text,
               category: r.entry.category,
               importance: r.entry.importance,
+              agentId: r.entry.agentId,
               score: r.score,
             }));
             console.log(JSON.stringify(output, null, 2));
@@ -545,20 +576,25 @@ const memoryPlugin = {
 
     // Auto-recall: inject relevant memories before agent starts
     if (cfg.autoRecall) {
-      api.on("before_agent_start", async (event) => {
+      api.on("before_agent_start", async (event, ctx) => {
         if (!event.prompt || event.prompt.length < 5) {
           return;
         }
 
+        // Resolve namespace: explicit config > agent's own ID from hook context
+        const agentId = configNamespace ?? ctx.agentId;
+
         try {
           const vector = await embeddings.embed(event.prompt);
-          const results = await db.search(vector, 3, 0.3);
+          const results = await db.search(vector, 3, 0.3, agentId);
 
           if (results.length === 0) {
             return;
           }
 
-          api.logger.info?.(`memory-lancedb: injecting ${results.length} memories into context`);
+          api.logger.info?.(
+            `memory-lancedb: injecting ${results.length} memories into context (agent: ${agentId ?? "global"})`,
+          );
 
           return {
             prependContext: formatRelevantMemoriesContext(
@@ -573,16 +609,17 @@ const memoryPlugin = {
 
     // Auto-capture: analyze and store important information after agent ends
     if (cfg.autoCapture) {
-      api.on("agent_end", async (event) => {
+      api.on("agent_end", async (event, ctx) => {
         if (!event.success || !event.messages || event.messages.length === 0) {
           return;
         }
 
+        // Resolve namespace: explicit config > agent's own ID from hook context
+        const agentId = configNamespace ?? ctx.agentId;
+
         try {
-          // Extract text content from messages (handling unknown[] type)
           const texts: string[] = [];
           for (const msg of event.messages) {
-            // Type guard for message object
             if (!msg || typeof msg !== "object") {
               continue;
             }
@@ -596,13 +633,11 @@ const memoryPlugin = {
 
             const content = msgObj.content;
 
-            // Handle string content directly
             if (typeof content === "string") {
               texts.push(content);
               continue;
             }
 
-            // Handle array content (content blocks)
             if (Array.isArray(content)) {
               for (const block of content) {
                 if (
@@ -619,7 +654,6 @@ const memoryPlugin = {
             }
           }
 
-          // Filter for capturable content
           const toCapture = texts.filter(
             (text) => text && shouldCapture(text, { maxChars: cfg.captureMaxChars }),
           );
@@ -627,29 +661,25 @@ const memoryPlugin = {
             return;
           }
 
-          // Store each capturable piece (limit to 3 per conversation)
           let stored = 0;
           for (const text of toCapture.slice(0, 3)) {
             const category = detectCategory(text);
             const vector = await embeddings.embed(text);
 
-            // Check for duplicates (high similarity threshold)
-            const existing = await db.search(vector, 1, 0.95);
+            // Check duplicates within same namespace
+            const existing = await db.search(vector, 1, 0.95, agentId);
             if (existing.length > 0) {
               continue;
             }
 
-            await db.store({
-              text,
-              vector,
-              importance: 0.7,
-              category,
-            });
+            await db.store({ text, vector, importance: 0.7, category }, agentId);
             stored++;
           }
 
           if (stored > 0) {
-            api.logger.info(`memory-lancedb: auto-captured ${stored} memories`);
+            api.logger.info(
+              `memory-lancedb: auto-captured ${stored} memories (agent: ${agentId ?? "global"})`,
+            );
           }
         } catch (err) {
           api.logger.warn(`memory-lancedb: capture failed: ${String(err)}`);
@@ -665,7 +695,7 @@ const memoryPlugin = {
       id: "memory-lancedb",
       start: () => {
         api.logger.info(
-          `memory-lancedb: initialized (db: ${resolvedDbPath}, model: ${cfg.embedding.model})`,
+          `memory-lancedb: initialized (db: ${resolvedDbPath}, model: ${cfg.embedding.model}, namespace: ${configNamespace ?? "per-agent"})`,
         );
       },
       stop: () => {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -174,8 +174,10 @@ class MemoryDB {
     }
     // Enforce namespace ownership: only delete rows that belong to the caller's
     // namespace (or legacy untagged rows when agentId is provided).
-    const filter = agentId
-      ? `id = '${id}' AND (agentId = '${agentId}' OR agentId IS NULL)`
+    // Escape single quotes in agentId to prevent filter injection
+    const safeAgentId = agentId?.replace(/'/g, "''");
+    const filter = safeAgentId
+      ? `id = '${id}' AND (agentId = '${safeAgentId}' OR agentId IS NULL)`
       : `id = '${id}'`;
     await this.table!.delete(filter);
     return true;
@@ -549,7 +551,7 @@ const memoryPlugin = {
               vector,
               parseInt(opts.limit),
               0.3,
-              opts.agent ?? configNamespace,
+              opts.agent ?? (configNamespace === "global" ? undefined : configNamespace),
             );
             const output = results.map((r) => ({
               id: r.entry.id,

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -353,7 +353,7 @@ const memoryPlugin = {
         async execute(_toolCallId, params) {
           const { query, limit = 5 } = params as { query: string; limit?: number };
           const agentId =
-            (configNamespace === "global" ? undefined : configNamespace) ?? toolCtx.agentId;
+            configNamespace === "global" ? undefined : (configNamespace ?? toolCtx.agentId);
 
           const vector = await embeddings.embed(query);
           const results = await db.search(vector, limit, 0.1, agentId);
@@ -417,7 +417,7 @@ const memoryPlugin = {
           };
 
           const agentId =
-            (configNamespace === "global" ? undefined : configNamespace) ?? toolCtx.agentId;
+            configNamespace === "global" ? undefined : (configNamespace ?? toolCtx.agentId);
           const vector = await embeddings.embed(text);
 
           // Check for duplicates within same namespace
@@ -461,7 +461,7 @@ const memoryPlugin = {
         async execute(_toolCallId, params) {
           const { query, memoryId } = params as { query?: string; memoryId?: string };
           const agentId =
-            (configNamespace === "global" ? undefined : configNamespace) ?? toolCtx.agentId;
+            configNamespace === "global" ? undefined : (configNamespace ?? toolCtx.agentId);
 
           if (memoryId) {
             await db.delete(memoryId, agentId);
@@ -585,7 +585,7 @@ const memoryPlugin = {
         }
 
         // Resolve namespace: explicit config > agent's own ID from hook context
-        const agentId = (configNamespace === "global" ? undefined : configNamespace) ?? ctx.agentId;
+        const agentId = configNamespace === "global" ? undefined : (configNamespace ?? ctx.agentId);
 
         try {
           const vector = await embeddings.embed(event.prompt);
@@ -618,7 +618,7 @@ const memoryPlugin = {
         }
 
         // Resolve namespace: explicit config > agent's own ID from hook context
-        const agentId = (configNamespace === "global" ? undefined : configNamespace) ?? ctx.agentId;
+        const agentId = configNamespace === "global" ? undefined : (configNamespace ?? ctx.agentId);
 
         try {
           const texts: string[] = [];

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -86,6 +86,14 @@ class MemoryDB {
 
     if (tables.includes(TABLE_NAME)) {
       this.table = await this.db.openTable(TABLE_NAME);
+      // Migrate pre-namespace tables: add agentId column if absent so that
+      // scoped delete predicates (`agentId = '...' OR agentId IS NULL`) work
+      // on existing deployments that were created before this feature.
+      const schema = await this.table.schema();
+      const hasAgentId = schema.fields.some((f) => f.name === "agentId");
+      if (!hasAgentId) {
+        await this.table.addColumns([{ name: "agentId", valueSql: "CAST(NULL AS STRING)" }]);
+      }
     } else {
       this.table = await this.db.createTable(TABLE_NAME, [
         {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -157,20 +157,27 @@ class MemoryDB {
       };
     });
 
-    return mapped
-      .filter((r) => r.score >= minScore)
-      // Namespace filter: include rows matching agentId, OR legacy rows with no agentId
-      .filter((r) => !agentId || !r.entry.agentId || r.entry.agentId === agentId)
-      .slice(0, limit);
+    return (
+      mapped
+        .filter((r) => r.score >= minScore)
+        // Namespace filter: include rows matching agentId, OR legacy rows with no agentId
+        .filter((r) => !agentId || !r.entry.agentId || r.entry.agentId === agentId)
+        .slice(0, limit)
+    );
   }
 
-  async delete(id: string): Promise<boolean> {
+  async delete(id: string, agentId?: string): Promise<boolean> {
     await this.ensureInitialized();
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (!uuidRegex.test(id)) {
       throw new Error(`Invalid memory ID format: ${id}`);
     }
-    await this.table!.delete(`id = '${id}'`);
+    // Enforce namespace ownership: only delete rows that belong to the caller's
+    // namespace (or legacy untagged rows when agentId is provided).
+    const filter = agentId
+      ? `id = '${id}' AND (agentId = '${agentId}' OR agentId IS NULL)`
+      : `id = '${id}'`;
+    await this.table!.delete(filter);
     return true;
   }
 
@@ -325,9 +332,7 @@ const memoryPlugin = {
     const embeddings = new Embeddings(apiKey, model, baseUrl, dimensions);
 
     // Explicit namespace override in config; falls back to per-agent ID at call time
-    const configNamespace: string | undefined = (cfg as Record<string, unknown>).namespace as
-      | string
-      | undefined;
+    const configNamespace: string | undefined = cfg.namespace;
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 
@@ -347,7 +352,8 @@ const memoryPlugin = {
         }),
         async execute(_toolCallId, params) {
           const { query, limit = 5 } = params as { query: string; limit?: number };
-          const agentId = configNamespace ?? toolCtx.agentId;
+          const agentId =
+            (configNamespace === "global" ? undefined : configNamespace) ?? toolCtx.agentId;
 
           const vector = await embeddings.embed(query);
           const results = await db.search(vector, limit, 0.1, agentId);
@@ -391,9 +397,7 @@ const memoryPlugin = {
           "Save important information in long-term memory. Use for preferences, facts, decisions.",
         parameters: Type.Object({
           text: Type.String({ description: "Information to remember" }),
-          importance: Type.Optional(
-            Type.Number({ description: "Importance 0-1 (default: 0.7)" }),
-          ),
+          importance: Type.Optional(Type.Number({ description: "Importance 0-1 (default: 0.7)" })),
           category: Type.Optional(
             Type.Unsafe<MemoryCategory>({
               type: "string",
@@ -412,7 +416,8 @@ const memoryPlugin = {
             category?: MemoryEntry["category"];
           };
 
-          const agentId = configNamespace ?? toolCtx.agentId;
+          const agentId =
+            (configNamespace === "global" ? undefined : configNamespace) ?? toolCtx.agentId;
           const vector = await embeddings.embed(text);
 
           // Check for duplicates within same namespace
@@ -433,10 +438,7 @@ const memoryPlugin = {
             };
           }
 
-          const entry = await db.store(
-            { text, vector, importance, category },
-            agentId,
-          );
+          const entry = await db.store({ text, vector, importance, category }, agentId);
 
           return {
             content: [{ type: "text", text: `Stored: "${text.slice(0, 100)}..."` }],
@@ -458,10 +460,11 @@ const memoryPlugin = {
         }),
         async execute(_toolCallId, params) {
           const { query, memoryId } = params as { query?: string; memoryId?: string };
-          const agentId = configNamespace ?? toolCtx.agentId;
+          const agentId =
+            (configNamespace === "global" ? undefined : configNamespace) ?? toolCtx.agentId;
 
           if (memoryId) {
-            await db.delete(memoryId);
+            await db.delete(memoryId, agentId);
             return {
               content: [{ type: "text", text: `Memory ${memoryId} forgotten.` }],
               details: { action: "deleted", id: memoryId },
@@ -582,7 +585,7 @@ const memoryPlugin = {
         }
 
         // Resolve namespace: explicit config > agent's own ID from hook context
-        const agentId = configNamespace ?? ctx.agentId;
+        const agentId = (configNamespace === "global" ? undefined : configNamespace) ?? ctx.agentId;
 
         try {
           const vector = await embeddings.embed(event.prompt);
@@ -615,7 +618,7 @@ const memoryPlugin = {
         }
 
         // Resolve namespace: explicit config > agent's own ID from hook context
-        const agentId = configNamespace ?? ctx.agentId;
+        const agentId = (configNamespace === "global" ? undefined : configNamespace) ?? ctx.agentId;
 
         try {
           const texts: string[] = [];


### PR DESCRIPTION
# feat(memory-lancedb): per-agent memory namespace isolation

## Summary

Add per-agent namespace isolation to the `memory-lancedb` plugin so that
memories stored by one agent are never recalled by — or contaminated with
— memories from a different agent sharing the same OpenClaw instance.

---

## Problem / Use Case

OpenClaw supports running **multiple specialized agents** within a single
instance (e.g. a payments agent, a customer support agent, a product agent,
an infrastructure agent). All agents currently share a single flat LanceDB
table with no scoping:

```
memories table
├── "Payment of $150 received via bank transfer on 2026-03-10"  ← payments agent
├── "User prefers compact UI layout and dark mode"              ← support agent
├── "Product SKU-4291 is running low on inventory"              ← product agent
└── "Service API token rotated on 2026-03-09"                  ← infra agent
```

Because `before_agent_start` runs an unscoped vector search, **any agent
can recall any other agent's memories**. In practice:

- A customer support agent recalls internal infrastructure notes.
- A payments agent sees product preferences injected as context.
- A user talking to the support bot gets responses influenced by
  unrelated financial data stored by the payments agent.
- Bank statement images processed by one agent pollute another agent's
  recall context — causing confusing, irrelevant, or confidential data
  to surface in unrelated conversations.

**Concrete example that triggered this PR:**
A multi-agent deployment (payments, support, social, product, and infra
agents) shared a single memory table. After enabling `autoRecall`, every
agent began surfacing data from other agents — internal operational notes
appeared in customer-facing conversations and private data meant for one
agent leaked into unrelated sessions. The workaround was to disable
`autoCapture`/`autoRecall` entirely and wipe the database. Proper namespace
isolation would have prevented this.

---

## Root Cause

The plugin registers lifecycle hooks that already receive `agentId` via
the second `ctx: PluginHookAgentContext` argument, but **the current
implementation ignores this context entirely**:

```ts
// CURRENT — agentId dropped on the floor
api.on("before_agent_start", async (event) => {
  const results = await db.search(vector, 3, 0.3);
  //                                          ^ no agentId filter
});

api.on("agent_end", async (event) => {
  await db.store({ text, vector, importance: 0.7, category });
  //                                               ^ no agentId tag
});
```

The SDK types already expose `ctx.agentId` — this is purely an omission
in the plugin, not a missing SDK feature.

Similarly, `registerTool` supports the `OpenClawPluginToolFactory` pattern
which passes `ctx: OpenClawPluginToolContext` (including `ctx.agentId`) at
tool-binding time, but the plugin uses the static tool object form instead.

---

## Solution

1. **Add `agentId?: string` to `MemoryEntry`** — stored in LanceDB alongside
   each memory row.
2. **Tag stored entries with `ctx.agentId`** — on `agent_end` (auto-capture)
   and `memory_store` tool calls.
3. **Filter search by `agentId`** — on `before_agent_start` (auto-recall)
   and `memory_recall` tool calls.
4. **Graceful fallback** — entries with no `agentId` tag (legacy rows) are
   visible to all agents, preserving backward compatibility.
5. **`namespace` config option** — explicit override for users who want
   custom scoping that doesn't follow agent IDs (e.g. shared pool between
   two agents, or total isolation by feature group).

---

## Changes

### `extensions/memory-lancedb/index.ts`

```diff
 type MemoryEntry = {
   id: string;
   text: string;
   vector: number[];
   importance: number;
   category: MemoryCategory;
   createdAt: number;
+  agentId?: string;
 };
```

```diff
-  async search(vector: number[], limit = 5, minScore = 0.5): Promise<MemorySearchResult[]> {
+  async search(vector: number[], limit = 5, minScore = 0.5, agentId?: string): Promise<MemorySearchResult[]> {
     await this.ensureInitialized();
-    const results = await this.table!.vectorSearch(vector).limit(limit).toArray();
+    // Fetch extra candidates to account for post-filter reduction
+    const candidates = await this.table!.vectorSearch(vector).limit(limit * 3).toArray();
+
     const mapped = results.map((row) => {
       const distance = row._distance ?? 0;
       const score = 1 / (1 + distance);
       return {
         entry: {
           id: row.id as string,
           text: row.text as string,
           vector: row.vector as number[],
           importance: row.importance as number,
           category: row.category as MemoryEntry["category"],
           createdAt: row.createdAt as number,
+          agentId: row.agentId as string | undefined,
         },
         score,
       };
     });

-    return mapped.filter((r) => r.score >= minScore);
+    return mapped
+      .filter((r) => r.score >= minScore)
+      // Scoped: include rows that match agentId, or rows with no agentId (legacy/shared)
+      .filter((r) => !agentId || !r.entry.agentId || r.entry.agentId === agentId)
+      .slice(0, limit);
   }
```

```diff
-  async store(entry: Omit<MemoryEntry, "id" | "createdAt">): Promise<MemoryEntry> {
+  async store(entry: Omit<MemoryEntry, "id" | "createdAt">, agentId?: string): Promise<MemoryEntry> {
     const fullEntry: MemoryEntry = {
       ...entry,
       id: randomUUID(),
       createdAt: Date.now(),
+      agentId,
     };
```

```diff
-    if (cfg.autoRecall) {
-      api.on("before_agent_start", async (event) => {
+    if (cfg.autoRecall) {
+      api.on("before_agent_start", async (event, ctx) => {
         if (!event.prompt || event.prompt.length < 5) return;
         try {
           const vector = await embeddings.embed(event.prompt);
-          const results = await db.search(vector, 3, 0.3);
+          const agentId = cfg.namespace ?? ctx.agentId;
+          const results = await db.search(vector, 3, 0.3, agentId);
```

```diff
-    if (cfg.autoCapture) {
-      api.on("agent_end", async (event) => {
+    if (cfg.autoCapture) {
+      api.on("agent_end", async (event, ctx) => {
         ...
-          await db.store({ text, vector, importance: 0.7, category });
+          await db.store({ text, vector, importance: 0.7, category }, cfg.namespace ?? ctx.agentId);
```

**Tools — use factory pattern for per-agent scoping:**
```diff
-    api.registerTool(
-      { name: "memory_recall", ..., async execute(_toolCallId, params) {
-          const results = await db.search(vector, limit, 0.1);
-      }},
-      { name: "memory_recall" },
-    );
+    api.registerTool(
+      (toolCtx) => ({
+        name: "memory_recall", ..., async execute(_toolCallId, params) {
+          const agentId = cfg.namespace ?? toolCtx.agentId;
+          const results = await db.search(vector, limit, 0.1, agentId);
+        }
+      }),
+      { name: "memory_recall" },
+    );
```
_(same pattern for `memory_store` and `memory_forget`)_

### `extensions/memory-lancedb/openclaw.plugin.json`

```diff
+    "namespace": {
+      "label": "Memory Namespace",
+      "help": "Scope memories to a specific namespace. Leave blank to use the agent's own ID automatically (recommended for multi-agent setups). Set to a shared value to let two agents share a memory pool. Set to 'global' to disable scoping entirely (old behavior).",
+      "placeholder": "my-agent",
+      "advanced": true
+    }
```

### `extensions/memory-lancedb/config.ts`

```diff
+  namespace: Type.Optional(Type.String({
+    description: "Custom namespace override. Defaults to agent ID when not set.",
+  })),
```

---

## Behavior After This PR

| Scenario | Before | After |
|---|---|---|
| Single agent, no config change | ✅ Works | ✅ Works (no `agentId` scoping) |
| Multi-agent, auto-recall | ❌ Cross-agent contamination | ✅ Each agent recalls only its own memories |
| Multi-agent, memory_store tool | ❌ All agents write to shared pool | ✅ Tagged to calling agent |
| Legacy untagged rows | N/A | ✅ Visible to all agents (backward compat) |
| Explicit `namespace: "global"` | N/A | ✅ Old behavior restored explicitly |
| Two agents share `namespace: "shared"` | N/A | ✅ Both see same pool |
| `autoCapture: false`, manual tool use | ✅ Works | ✅ Still scoped by agentId |

---

## Migration

No migration required. Existing untagged rows are treated as "global"
(visible to all agents). On next write with a namespaced agent, new rows
get tagged. Old rows gradually become irrelevant as new scoped memories
accumulate. To do a clean-slate reset, delete `memories.lance` — the
database auto-recreates on next access.

---

## Testing

- [ ] Single-agent: memories stored and recalled correctly (no regression)
- [ ] Multi-agent: agent A stores memory; agent B cannot auto-recall it
- [ ] Multi-agent: `memory_recall` tool scoped to calling agent
- [ ] Legacy rows: untagged rows surface for all agents
- [ ] `namespace` override: two agents with same namespace share pool
- [ ] `namespace: "global"`: all agents share pool (opt-in old behavior)
- [ ] DB schema backward compatibility: existing lance tables open without migration

---

## Related

- Plugin SDK: `PluginHookAgentContext.agentId` already available (no SDK changes needed)
- Plugin SDK: `OpenClawPluginToolContext.agentId` already available (no SDK changes needed)