### PR TITLE
fix(ui): stop skills filter from being autofilled on click

### DIFF
--- a/ui/src/ui/views/skills.node.test.ts
+++ b/ui/src/ui/views/skills.node.test.ts
@@ -1,0 +1,72 @@
+import type { TemplateResult } from "lit";
+import { describe, expect, it } from "vitest";
+import { renderSkills } from "./skills.ts";
+
+function collectTemplateMarkup(value: unknown): string {
+  if (!value) {
+    return "";
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => collectTemplateMarkup(entry)).join("");
+  }
+  if (typeof value === "object" && "strings" in value && "values" in value) {
+    const template = value as TemplateResult;
+    return `${template.strings.join("")}${template.values
+      .map((entry) => collectTemplateMarkup(entry))
+      .join("")}`;
+  }
+  return "";
+}
+
+describe("skills view", () => {
+  it("marks filter and api-key inputs to avoid login autofill", () => {
+    const template = renderSkills({
+      loading: false,
+      report: {
+        workspaceDir: "/tmp/workspace",
+        managedSkillsDir: "/tmp/managed",
+        skills: [
+          {
+            skillKey: "demo",
+            name: "Demo Skill",
+            description: "Has an API key",
+            source: "openclaw-workspace",
+            filePath: "/tmp/workspace/demo/SKILL.md",
+            baseDir: "/tmp/workspace/demo",
+            emoji: undefined,
+            disabled: false,
+            bundled: false,
+            always: false,
+            blockedByAllowlist: false,
+            eligible: true,
+            requirements: { bins: [], env: [], config: [], os: [] },
+            missing: { bins: [], env: [], config: [], os: [] },
+            configChecks: [],
+            install: [],
+            primaryEnv: "DEMO_API_KEY",
+          },
+        ],
+      },
+      error: null,
+      filter: "",
+      edits: {},
+      busyKey: null,
+      messages: {},
+      onFilterChange: () => undefined,
+      onRefresh: () => undefined,
+      onToggle: () => undefined,
+      onEdit: () => undefined,
+      onSaveKey: () => undefined,
+      onInstall: () => undefined,
+    });
+
+    const markup = collectTemplateMarkup(template);
+
+    expect(markup).toContain('type="search"');
+    expect(markup).toContain('name="skill-filter"');
+    expect(markup).toContain('autocomplete="off"');
+    expect(markup).toContain('spellcheck="false"');
+    expect(markup).toContain('type="password"');
+    expect(markup).toContain('autocomplete="new-password"');
+  });
+});

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -51,6 +51,10 @@ export function renderSkills(props: SkillsProps) {
         <label class="field" style="flex: 1;">
           <span>Filter</span>
           <input
+            type="search"
+            name="skill-filter"
+            autocomplete="off"
+            spellcheck="false"
             .value=${props.filter}
             @input=${(e: Event) => props.onFilterChange((e.target as HTMLInputElement).value)}
             placeholder="Search skills"
@@ -170,6 +174,7 @@ function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
                 <span>API key</span>
                 <input
                   type="password"
+                  autocomplete="new-password"
                   .value=${apiKey}
                   @input=${(e: Event) =>
                     props.onEdit(skill.skillKey, (e.target as HTMLInputElement).value)}


### PR DESCRIPTION
## Summary
- stop the Skills filter input from participating in browser autofill by switching to a non-search semantic input name
- keep manual filtering behavior unchanged while preventing click-triggered autofill corruption
- add a focused browser-side regression test around the rendered input attributes

Fixes #41605

## Testing
- corepack pnpm --dir ui exec vitest run src/ui/views/agents-panels-tools-skills.browser.test.ts