### PR TITLE
fix(telegram): preserve audioAsVoice in outbound media sends

### DIFF
--- a/src/channels/plugins/outbound/telegram.test.ts
+++ b/src/channels/plugins/outbound/telegram.test.ts
@@ -139,4 +139,36 @@ describe("telegramOutbound", () => {
     expect(secondCallOpts?.buttons).toBeUndefined();
     expect(result).toEqual({ channel: "telegram", messageId: "tg-2", chatId: "123" });
   });
+
+  it("passes asVoice for audioAsVoice payload media", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-voice-1", chatId: "123" });
+    const sendPayload = telegramOutbound.sendPayload;
+    expect(sendPayload).toBeDefined();
+
+    const payload: ReplyPayload = {
+      text: "voice caption",
+      mediaUrl: "https://example.com/note.ogg",
+      audioAsVoice: true,
+    };
+
+    await sendPayload!({
+      cfg: {},
+      to: "123",
+      text: "",
+      payload,
+      mediaLocalRoots: ["/tmp/media"],
+      accountId: "default",
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledWith(
+      "123",
+      "voice caption",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/note.ogg",
+        mediaLocalRoots: ["/tmp/media"],
+        asVoice: true,
+      }),
+    );
+  });
 });

--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -114,6 +114,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       ...contextOpts,
       quoteText,
       mediaLocalRoots,
+      asVoice: payload.audioAsVoice === true,
     };
 
     if (mediaUrls.length === 0) {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -307,6 +307,30 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("routes telegram audioAsVoice media payloads through sendPayload", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
+
+    await deliverTelegramPayload({
+      sendTelegram,
+      payload: {
+        text: "voice caption",
+        mediaUrl: "https://example.com/note.ogg",
+        audioAsVoice: true,
+      },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledTimes(1);
+    expect(sendTelegram).toHaveBeenCalledWith(
+      "123",
+      "voice caption",
+      expect.objectContaining({
+        textMode: "html",
+        mediaUrl: "https://example.com/note.ogg",
+        asVoice: true,
+      }),
+    );
+  });
+
   it("scopes media local roots to the active agent workspace when agentId is provided", async () => {
     const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
 

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -713,7 +713,7 @@ async function deliverOutboundPayloadsCore(
         replyToId: effectivePayload.replyToId ?? params.replyToId ?? undefined,
         threadId: params.threadId ?? undefined,
       };
-      if (handler.sendPayload && effectivePayload.channelData) {
+      if (handler.sendPayload && (effectivePayload.channelData || effectivePayload.audioAsVoice)) {
         const delivery = await handler.sendPayload(effectivePayload, sendOverrides);
         results.push(delivery);
         emitMessageSent({


### PR DESCRIPTION
## Summary
- preserve `audioAsVoice` when normalized outbound payloads flow through the generic text/media send path
- thread the flag through direct outbound media helpers so Telegram can send native voice notes instead of file attachments
- add targeted regression coverage for the outbound adapter and delivery plumbing

Fixes #42060

## Testing
- corepack pnpm test src/channels/plugins/outbound/telegram.test.ts src/infra/outbound/deliver.test.ts