### PR TITLE
fix(models): guard missing input in custom provider rows

### DIFF
--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -372,4 +372,22 @@ describe("models list/status", () => {
     expect(row.missing).toBe(false);
     expect(row.available).toBe(false);
   });
+
+  it("toModelRow defaults missing input to text for custom providers", async () => {
+    const row = toModelRow({
+      model: {
+        provider: "custom-openai",
+        id: "custom-model",
+        name: "Custom Model",
+        baseUrl: "https://example.com/v1",
+        contextWindow: 128000,
+      } as never,
+      key: "custom-openai/custom-model",
+      tags: [],
+      availableKeys: undefined,
+    });
+
+    expect(row.missing).toBe(false);
+    expect(row.input).toBe("text");
+  });
 });

--- a/src/commands/models/list.registry.ts
+++ b/src/commands/models/list.registry.ts
@@ -155,7 +155,7 @@ export function toModelRow(params: {
     };
   }
 
-  const input = model.input.join("+") || "text";
+  const input = model.input?.join("+") || "text";
   const local = isLocalBaseUrl(model.baseUrl);
   const modelIsAvailable = availableKeys?.has(modelKey(model.provider, model.id)) ?? false;
   // Prefer model-level registry availability when present.


### PR DESCRIPTION
## Summary
- guard `toModelRow()` against custom provider models that omit `input`
- treat missing input as text-only instead of dereferencing `undefined`
- add a targeted regression test for `models list` row rendering with a custom provider model missing `input`

Fixes #42068

## Testing
- corepack pnpm test src/commands/models.list.e2e.test.ts