### PR TITLE
fix(feishu): replace raw media JSON with placeholder in agent body

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1740,6 +1740,48 @@ describe("handleFeishuMessage command authorization", () => {
     await Promise.all([dispatchMessage({ cfg, event }), dispatchMessage({ cfg, event })]);
     expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
+
+  it("replaces raw image_key JSON with placeholder in body for image messages", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-image-placeholder",
+        },
+      },
+      message: {
+        message_id: "msg-image-placeholder",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "image",
+        content: JSON.stringify({
+          image_key: "img_placeholder_payload",
+        }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("<media:image>"),
+        RawBody: "<media:image>",
+      }),
+    );
+    // Ensure raw image_key JSON does not leak into the body
+    const ctx = mockFinalizeInboundContext.mock.calls[0][0] as Record<string, string>;
+    expect(ctx.BodyForAgent).not.toContain("image_key");
+    expect(ctx.RawBody).not.toContain("image_key");
+  });
 });
 
 describe("toMessageResourceType", () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1229,6 +1229,12 @@ export async function handleFeishuMessage(params: {
     });
     const mediaPayload = buildAgentMediaPayload(mediaList);
 
+    // Replace raw media JSON (e.g. {"image_key":"..."}) with human-readable
+    // placeholder so the LLM does not see confusing API-internal keys.
+    if (mediaList.length > 0) {
+      ctx.content = mediaList.map((m) => m.placeholder).join(" ");
+    }
+
     // Fetch quoted/replied message content if parentId exists
     let quotedContent: string | undefined;
     if (ctx.parentId) {


### PR DESCRIPTION
## Summary

- When Feishu sends an image/video/audio message, `ctx.content` contains raw API JSON (e.g. `{"image_key":"img_v3_xxx"}`). This gets embedded in the agent body as `Speaker: {"image_key":"..."}`.
- Even though the media understanding pipeline correctly downloads the image and appends a description, the LLM sees the raw `image_key` JSON and responds with "I can't see images" instead of using the appended description.
- After `resolveFeishuMediaList()` successfully downloads media, replace `ctx.content` with the human-readable placeholder (e.g. `<media:image>`) so the LLM sees clean context instead of confusing API-internal keys.

## Test plan

- [x] Added test: "replaces raw image_key JSON with placeholder in body for image messages"
- [x] All 53 existing tests pass
- [x] Manual verification: send image via Lark DM → bot describes image content instead of claiming it can't see images

🤖 Generated with [Claude Code](https://claude.com/claude-code)