### PR TITLE
docs: fix broken troubleshooting anchor in Anthropic provider page

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -200,7 +200,7 @@ openclaw onboard --auth-choice setup-token
 ## Notes
 
 - Generate the setup-token with `claude setup-token` and paste it, or run `openclaw models auth setup-token` on the gateway host.
-- If you see “OAuth token refresh failed …” on a Claude subscription, re-auth with a setup-token. See [/gateway/troubleshooting#oauth-token-refresh-failed-anthropic-claude-subscription](/gateway/troubleshooting#oauth-token-refresh-failed-anthropic-claude-subscription).
+- If you see “OAuth token refresh failed …” on a Claude subscription, re-auth with a setup-token. See [/gateway/troubleshooting](/gateway/troubleshooting).
 - Auth details + reuse rules are in [/concepts/oauth](/concepts/oauth).
 
 ## Troubleshooting

--- a/docs/zh-CN/providers/anthropic.md
+++ b/docs/zh-CN/providers/anthropic.md
@@ -128,7 +128,7 @@ openclaw onboard --auth-choice setup-token
 ## 注意事项
 
 - 使用 `claude setup-token` 生成 setup-token 并粘贴，或在 Gateway 网关主机上运行 `openclaw models auth setup-token`。
-- 如果你在 Claude 订阅上看到"OAuth token refresh failed …"，请使用 setup-token 重新认证。参见 [/gateway/troubleshooting#oauth-token-refresh-failed-anthropic-claude-subscription](/gateway/troubleshooting#oauth-token-refresh-failed-anthropic-claude-subscription)。
+- 如果你在 Claude 订阅上看到"OAuth token refresh failed …"，请使用 setup-token 重新认证。参见 [/gateway/troubleshooting](/gateway/troubleshooting)。
 - 认证详情 + 重用规则在 [/concepts/oauth](/concepts/oauth)。
 
 ## 故障排除


### PR DESCRIPTION
## Summary

- Problem: The Anthropic provider page links to `/gateway/troubleshooting#oauth-token-refresh-failed-anthropic-claude-subscription`, but that anchor does not exist in the restructured troubleshooting page.
- Why it matters: Readers clicking the link land at the top of the troubleshooting page with no matching section.
- What changed: Removed the stale anchor fragment from the troubleshooting link in both EN and zh-CN Anthropic provider docs.
- What did NOT change (scope boundary): No content removed — the inline fix advice ("re-auth with a setup-token") and the page's own Troubleshooting section are untouched.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

None — discovered during docs review.

## User-visible / Behavior Changes

Troubleshooting link in Anthropic provider docs now correctly navigates to the troubleshooting page instead of a non-existent anchor.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Open https://docs.openclaw.ai/providers/anthropic
2. Scroll to "Notes" section
3. Click the "Troubleshooting" link in the OAuth bullet
Before: lands on troubleshooting page top, anchor not found. 
 <img width="610" height="254" alt="image" src="https://github.com/user-attachments/assets/fc516d58-3d1e-4de1-bc22-d51eac2327fe" />
 
After: lands on troubleshooting page (intentional, section was removed in restructure).
<img width="620" height="225" alt="image" src="https://github.com/user-attachments/assets/cd4b5251-8ada-4206-8648-66f4746e3373" />

## Evidence

- [x] Trace/log snippets

Target page headings (no `oauth-token-refresh-failed` anchor exists):
`## Command ladder`, `## Anthropic 429 extra usage required for long context`, `## No replies`, `## Dashboard control ui connectivity`, `## Gateway service not running`, `## Channel connected messages not flowing`, ...

## Human Verification (required)

- Verified scenarios: Confirmed the anchor target does not exist in `docs/gateway/troubleshooting.md` by checking all headings. Confirmed the same page already has a working `/gateway/troubleshooting` link at line 231 without the anchor.
- Edge cases checked: ja-JP has no `providers/anthropic.md`, so only EN and zh-CN need fixing.
- What you did **not** verify: Did not run full docs site link checker.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit.
- Files/config to restore: `docs/providers/anthropic.md`, `docs/zh-CN/providers/anthropic.md`
- Known bad symptoms reviewers should watch for: None expected.

## Risks and Mitigations

None.