### PR TITLE
Honor proxy env for runtime undici dispatcher

### DIFF
--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -169,6 +169,21 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     });
   });
 
+  it("reinstalls env proxy hardening if the dispatcher later reverts to Agent", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+    getDefaultAutoSelectFamily.mockReturnValue(true);
+
+    ensureGlobalUndiciStreamTimeouts();
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    expect(getCurrentDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+
+    setCurrentDispatcher(new Agent());
+    ensureGlobalUndiciStreamTimeouts();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
+    expect(getCurrentDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
   it("does not override unsupported custom proxy dispatcher types", () => {
     setCurrentDispatcher(new ProxyAgent("http://proxy.test:8080"));
 

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -15,7 +15,13 @@ const {
   }
 
   class EnvHttpProxyAgent {
-    constructor(public readonly options?: Record<string, unknown>) {}
+    static shouldThrow = false;
+
+    constructor(public readonly options?: Record<string, unknown>) {
+      if (EnvHttpProxyAgent.shouldThrow) {
+        throw new Error("invalid proxy env");
+      }
+    }
   }
 
   class ProxyAgent {
@@ -75,6 +81,7 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     setCurrentDispatcher(new Agent());
     getDefaultAutoSelectFamily.mockReturnValue(undefined);
     vi.mocked(hasProxyEnvConfigured).mockReturnValue(false);
+    EnvHttpProxyAgent.shouldThrow = false;
   });
 
   it("replaces default Agent dispatcher with extended stream timeouts", () => {
@@ -119,6 +126,24 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
     const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
     expect(next).toBeInstanceOf(EnvHttpProxyAgent);
+    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.connect).toEqual({
+      autoSelectFamily: true,
+      autoSelectFamilyAttemptTimeout: 300,
+    });
+  });
+
+  it("falls back to Agent hardening when env-proxy upgrade fails", () => {
+    vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+    getDefaultAutoSelectFamily.mockReturnValue(true);
+    EnvHttpProxyAgent.shouldThrow = true;
+
+    ensureGlobalUndiciStreamTimeouts();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(Agent);
     expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
     expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
     expect(next.options?.connect).toEqual({

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -57,6 +57,11 @@ vi.mock("node:net", () => ({
   getDefaultAutoSelectFamily,
 }));
 
+vi.mock("./proxy-env.js", () => ({
+  hasProxyEnvConfigured: vi.fn(() => false),
+}));
+
+import { hasProxyEnvConfigured } from "./proxy-env.js";
 import {
   DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
   ensureGlobalUndiciStreamTimeouts,
@@ -69,6 +74,7 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     resetGlobalUndiciStreamTimeoutsForTests();
     setCurrentDispatcher(new Agent());
     getDefaultAutoSelectFamily.mockReturnValue(undefined);
+    vi.mocked(hasProxyEnvConfigured).mockReturnValue(false);
   });
 
   it("replaces default Agent dispatcher with extended stream timeouts", () => {
@@ -100,6 +106,23 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
     expect(next.options?.connect).toEqual({
       autoSelectFamily: false,
+      autoSelectFamilyAttemptTimeout: 300,
+    });
+  });
+
+  it("upgrades default Agent dispatcher to EnvHttpProxyAgent when proxy env is configured", () => {
+    vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+    getDefaultAutoSelectFamily.mockReturnValue(true);
+
+    ensureGlobalUndiciStreamTimeouts();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(EnvHttpProxyAgent);
+    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.connect).toEqual({
+      autoSelectFamily: true,
       autoSelectFamilyAttemptTimeout: 300,
     });
   });

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -64,11 +64,10 @@ vi.mock("node:net", () => ({
 }));
 
 vi.mock("./proxy-env.js", () => ({
-  hasProxyEnvConfigured: vi.fn(() => false),
   hasEnvHttpProxyConfigured: vi.fn(() => false),
 }));
 
-import { hasEnvHttpProxyConfigured, hasProxyEnvConfigured } from "./proxy-env.js";
+import { hasEnvHttpProxyConfigured } from "./proxy-env.js";
 import {
   DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
   ensureGlobalUndiciEnvProxyDispatcher,
@@ -82,7 +81,6 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     resetGlobalUndiciStreamTimeoutsForTests();
     setCurrentDispatcher(new Agent());
     getDefaultAutoSelectFamily.mockReturnValue(undefined);
-    vi.mocked(hasProxyEnvConfigured).mockReturnValue(false);
     vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(false);
     EnvHttpProxyAgent.shouldThrow = false;
   });
@@ -120,8 +118,8 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     });
   });
 
-  it("upgrades default Agent dispatcher to EnvHttpProxyAgent when proxy env is configured", () => {
-    vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+  it("upgrades default Agent dispatcher to EnvHttpProxyAgent when env HTTP proxy is configured", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
     getDefaultAutoSelectFamily.mockReturnValue(true);
 
     ensureGlobalUndiciStreamTimeouts();
@@ -137,8 +135,24 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     });
   });
 
-  it("falls back to Agent hardening when env-proxy upgrade fails", () => {
-    vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+  it("does not upgrade default Agent dispatcher when only non-HTTP proxy env is configured", () => {
+    getDefaultAutoSelectFamily.mockReturnValue(true);
+
+    ensureGlobalUndiciStreamTimeouts();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(Agent);
+    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.connect).toEqual({
+      autoSelectFamily: true,
+      autoSelectFamilyAttemptTimeout: 300,
+    });
+  });
+
+  it("falls back to Agent hardening when env HTTP proxy upgrade fails", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
     getDefaultAutoSelectFamily.mockReturnValue(true);
     EnvHttpProxyAgent.shouldThrow = true;
 

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -65,11 +65,13 @@ vi.mock("node:net", () => ({
 
 vi.mock("./proxy-env.js", () => ({
   hasProxyEnvConfigured: vi.fn(() => false),
+  hasEnvHttpProxyConfigured: vi.fn(() => false),
 }));
 
-import { hasProxyEnvConfigured } from "./proxy-env.js";
+import { hasEnvHttpProxyConfigured, hasProxyEnvConfigured } from "./proxy-env.js";
 import {
   DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
+  ensureGlobalUndiciEnvProxyDispatcher,
   ensureGlobalUndiciStreamTimeouts,
   resetGlobalUndiciStreamTimeoutsForTests,
 } from "./undici-global-dispatcher.js";
@@ -81,6 +83,7 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     setCurrentDispatcher(new Agent());
     getDefaultAutoSelectFamily.mockReturnValue(undefined);
     vi.mocked(hasProxyEnvConfigured).mockReturnValue(false);
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(false);
     EnvHttpProxyAgent.shouldThrow = false;
   });
 
@@ -182,5 +185,68 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
       autoSelectFamily: false,
       autoSelectFamilyAttemptTimeout: 300,
     });
+  });
+});
+
+describe("ensureGlobalUndiciEnvProxyDispatcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetGlobalUndiciStreamTimeoutsForTests();
+    setCurrentDispatcher(new Agent());
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(false);
+  });
+
+  it("installs EnvHttpProxyAgent when env HTTP proxy is configured on a default Agent", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    expect(getCurrentDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  it("does not override unsupported custom proxy dispatcher types", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+    setCurrentDispatcher(new ProxyAgent("http://proxy.test:8080"));
+
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("retries proxy bootstrap after an unsupported dispatcher later becomes a default Agent", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+    setCurrentDispatcher(new ProxyAgent("http://proxy.test:8080"));
+
+    ensureGlobalUndiciEnvProxyDispatcher();
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+
+    setCurrentDispatcher(new Agent());
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    expect(getCurrentDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  it("is idempotent after proxy bootstrap succeeds", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+
+    ensureGlobalUndiciEnvProxyDispatcher();
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("reinstalls env proxy if an external change later reverts the dispatcher to Agent", () => {
+    vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+
+    ensureGlobalUndiciEnvProxyDispatcher();
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+
+    setCurrentDispatcher(new Agent());
+    ensureGlobalUndiciEnvProxyDispatcher();
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
+    expect(getCurrentDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
   });
 });

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -120,7 +120,8 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
     ? resolveDispatcherKey({ kind: "env-proxy", timeoutMs, autoSelectFamily })
     : null;
   const appliedKey = envProxyKey ?? agentKey;
-  if (lastAppliedTimeoutKey === appliedKey) {
+  const shouldReinstallEnvProxy = envProxyRequested && currentKind !== "env-proxy";
+  if (lastAppliedTimeoutKey === appliedKey && !shouldReinstallEnvProxy) {
     return;
   }
 

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -1,5 +1,6 @@
 import * as net from "node:net";
 import { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { hasProxyEnvConfigured } from "./proxy-env.js";
 
 export const DEFAULT_UNDICI_STREAM_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -73,7 +74,9 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
     return;
   }
 
-  const kind = resolveDispatcherKind(dispatcher);
+  const currentKind = resolveDispatcherKind(dispatcher);
+  const kind =
+    currentKind === "agent" && hasProxyEnvConfigured() ? ("env-proxy" as const) : currentKind;
   if (kind === "unsupported") {
     return;
   }

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -75,38 +75,70 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
   }
 
   const currentKind = resolveDispatcherKind(dispatcher);
-  const kind =
-    currentKind === "agent" && hasProxyEnvConfigured() ? ("env-proxy" as const) : currentKind;
-  if (kind === "unsupported") {
+  if (currentKind === "unsupported") {
     return;
   }
 
   const autoSelectFamily = resolveAutoSelectFamily();
-  const nextKey = resolveDispatcherKey({ kind, timeoutMs, autoSelectFamily });
-  if (lastAppliedDispatcherKey === nextKey) {
+  const connect = resolveConnectOptions(autoSelectFamily);
+  const agentKey = resolveDispatcherKey({ kind: currentKind, timeoutMs, autoSelectFamily });
+  const envProxyRequested = currentKind === "agent" && hasProxyEnvConfigured();
+  const envProxyKey = envProxyRequested
+    ? resolveDispatcherKey({ kind: "env-proxy", timeoutMs, autoSelectFamily })
+    : null;
+  const appliedKey = envProxyKey ?? agentKey;
+  if (lastAppliedDispatcherKey === appliedKey) {
     return;
   }
 
-  const connect = resolveConnectOptions(autoSelectFamily);
   try {
-    if (kind === "env-proxy") {
+    if (envProxyRequested) {
       const proxyOptions = {
         bodyTimeout: timeoutMs,
         headersTimeout: timeoutMs,
         ...(connect ? { connect } : {}),
       } as ConstructorParameters<typeof EnvHttpProxyAgent>[0];
       setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
-    } else {
-      setGlobalDispatcher(
-        new Agent({
-          bodyTimeout: timeoutMs,
-          headersTimeout: timeoutMs,
-          ...(connect ? { connect } : {}),
-        }),
-      );
+      lastAppliedDispatcherKey = envProxyKey;
+      return;
     }
-    lastAppliedDispatcherKey = nextKey;
+
+    if (currentKind === "env-proxy") {
+      const proxyOptions = {
+        bodyTimeout: timeoutMs,
+        headersTimeout: timeoutMs,
+        ...(connect ? { connect } : {}),
+      } as ConstructorParameters<typeof EnvHttpProxyAgent>[0];
+      setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
+      lastAppliedDispatcherKey = agentKey;
+      return;
+    }
+
+    setGlobalDispatcher(
+      new Agent({
+        bodyTimeout: timeoutMs,
+        headersTimeout: timeoutMs,
+        ...(connect ? { connect } : {}),
+      }),
+    );
+    lastAppliedDispatcherKey = agentKey;
   } catch {
+    if (envProxyRequested) {
+      try {
+        setGlobalDispatcher(
+          new Agent({
+            bodyTimeout: timeoutMs,
+            headersTimeout: timeoutMs,
+            ...(connect ? { connect } : {}),
+          }),
+        );
+        lastAppliedDispatcherKey = agentKey;
+      } catch {
+        // Best-effort hardening only.
+      }
+      return;
+    }
+
     // Best-effort hardening only.
   }
 }

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -1,6 +1,6 @@
 import * as net from "node:net";
 import { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
-import { hasProxyEnvConfigured, hasEnvHttpProxyConfigured } from "./proxy-env.js";
+import { hasEnvHttpProxyConfigured } from "./proxy-env.js";
 
 export const DEFAULT_UNDICI_STREAM_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -115,7 +115,7 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
   const autoSelectFamily = resolveAutoSelectFamily();
   const connect = resolveConnectOptions(autoSelectFamily);
   const agentKey = resolveDispatcherKey({ kind: currentKind, timeoutMs, autoSelectFamily });
-  const envProxyRequested = currentKind === "agent" && hasProxyEnvConfigured();
+  const envProxyRequested = currentKind === "agent" && hasEnvHttpProxyConfigured("https");
   const envProxyKey = envProxyRequested
     ? resolveDispatcherKey({ kind: "env-proxy", timeoutMs, autoSelectFamily })
     : null;

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -1,12 +1,13 @@
 import * as net from "node:net";
 import { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
-import { hasProxyEnvConfigured } from "./proxy-env.js";
+import { hasProxyEnvConfigured, hasEnvHttpProxyConfigured } from "./proxy-env.js";
 
 export const DEFAULT_UNDICI_STREAM_TIMEOUT_MS = 30 * 60 * 1000;
 
 const AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 300;
 
-let lastAppliedDispatcherKey: string | null = null;
+let lastAppliedTimeoutKey: string | null = null;
+let lastAppliedProxyBootstrap = false;
 
 type DispatcherKind = "agent" | "env-proxy" | "unsupported";
 
@@ -60,6 +61,45 @@ function resolveDispatcherKey(params: {
   return `${params.kind}:${params.timeoutMs}:${autoSelectToken}`;
 }
 
+function resolveCurrentDispatcherKind(): DispatcherKind | null {
+  let dispatcher: unknown;
+  try {
+    dispatcher = getGlobalDispatcher();
+  } catch {
+    return null;
+  }
+
+  const currentKind = resolveDispatcherKind(dispatcher);
+  return currentKind === "unsupported" ? null : currentKind;
+}
+
+export function ensureGlobalUndiciEnvProxyDispatcher(): void {
+  const shouldUseEnvProxy = hasEnvHttpProxyConfigured("https");
+  if (!shouldUseEnvProxy) {
+    return;
+  }
+  if (lastAppliedProxyBootstrap) {
+    if (resolveCurrentDispatcherKind() === "env-proxy") {
+      return;
+    }
+    lastAppliedProxyBootstrap = false;
+  }
+  const currentKind = resolveCurrentDispatcherKind();
+  if (currentKind === null) {
+    return;
+  }
+  if (currentKind === "env-proxy") {
+    lastAppliedProxyBootstrap = true;
+    return;
+  }
+  try {
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+    lastAppliedProxyBootstrap = true;
+  } catch {
+    // Best-effort bootstrap only.
+  }
+}
+
 export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }): void {
   const timeoutMsRaw = opts?.timeoutMs ?? DEFAULT_UNDICI_STREAM_TIMEOUT_MS;
   const timeoutMs = Math.max(1, Math.floor(timeoutMsRaw));
@@ -67,15 +107,8 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
     return;
   }
 
-  let dispatcher: unknown;
-  try {
-    dispatcher = getGlobalDispatcher();
-  } catch {
-    return;
-  }
-
-  const currentKind = resolveDispatcherKind(dispatcher);
-  if (currentKind === "unsupported") {
+  const currentKind = resolveCurrentDispatcherKind();
+  if (currentKind === null) {
     return;
   }
 
@@ -87,30 +120,19 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
     ? resolveDispatcherKey({ kind: "env-proxy", timeoutMs, autoSelectFamily })
     : null;
   const appliedKey = envProxyKey ?? agentKey;
-  if (lastAppliedDispatcherKey === appliedKey) {
+  if (lastAppliedTimeoutKey === appliedKey) {
     return;
   }
 
   try {
-    if (envProxyRequested) {
+    if (envProxyRequested || currentKind === "env-proxy") {
       const proxyOptions = {
         bodyTimeout: timeoutMs,
         headersTimeout: timeoutMs,
         ...(connect ? { connect } : {}),
       } as ConstructorParameters<typeof EnvHttpProxyAgent>[0];
       setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
-      lastAppliedDispatcherKey = envProxyKey;
-      return;
-    }
-
-    if (currentKind === "env-proxy") {
-      const proxyOptions = {
-        bodyTimeout: timeoutMs,
-        headersTimeout: timeoutMs,
-        ...(connect ? { connect } : {}),
-      } as ConstructorParameters<typeof EnvHttpProxyAgent>[0];
-      setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
-      lastAppliedDispatcherKey = agentKey;
+      lastAppliedTimeoutKey = appliedKey;
       return;
     }
 
@@ -121,7 +143,7 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
         ...(connect ? { connect } : {}),
       }),
     );
-    lastAppliedDispatcherKey = agentKey;
+    lastAppliedTimeoutKey = agentKey;
   } catch {
     if (envProxyRequested) {
       try {
@@ -132,7 +154,7 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
             ...(connect ? { connect } : {}),
           }),
         );
-        lastAppliedDispatcherKey = agentKey;
+        lastAppliedTimeoutKey = agentKey;
       } catch {
         // Best-effort hardening only.
       }
@@ -144,5 +166,6 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
 }
 
 export function resetGlobalUndiciStreamTimeoutsForTests(): void {
-  lastAppliedDispatcherKey = null;
+  lastAppliedTimeoutKey = null;
+  lastAppliedProxyBootstrap = false;
 }


### PR DESCRIPTION
## Summary

This PR makes the runtime undici dispatcher honor proxy env in the common `Agent` case.

In proxy-only environments, `openai-codex` runtime requests could fail even after OAuth succeeded, because the runtime dispatcher path stayed on a plain `Agent` instead of switching to env-proxy mode.

With this change, when proxy env vars are present and the current global dispatcher is the default `Agent`, OpenClaw upgrades it to `EnvHttpProxyAgent` before applying stream timeout tuning.

This keeps the existing behavior for:
- already-proxied `EnvHttpProxyAgent` dispatchers
- unsupported custom dispatcher types such as explicit `ProxyAgent`

Related:
- Closes #42311
- Related to #39035
- Related to #42020
- Related to #42176

## What changed

- import `hasProxyEnvConfigured()` into `src/infra/net/undici-global-dispatcher.ts`
- when the current dispatcher is `Agent` and proxy env is configured, treat the effective mode as `env-proxy`
- add a unit test covering Agent -> EnvHttpProxyAgent upgrade

## Why this is minimal

This PR intentionally does **not**:
- set `NODE_USE_ENV_PROXY=1` globally
- modify OpenAI Codex request headers
- change behavior for custom proxy dispatchers

It only makes the runtime dispatcher reuse OpenClaw's existing env-proxy capability when proxy env vars are already configured.

## Validation

Ran:

```bash
corepack pnpm -C /home/dong/openclaw exec vitest run src/infra/net/undici-global-dispatcher.test.ts
```

Result:
- 1 test file passed
- 6 tests passed
