### PR TITLE
fix: default OpenAI transport to SSE for non-OpenAI baseUrl

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1075,6 +1075,7 @@ describe("applyExtraParamsToAgent", () => {
       api: "openai-responses",
       provider: "openai",
       id: "gpt-5",
+      baseUrl: "https://api.openai.com/v1",
     } as Model<"openai-responses">;
     const context: Context = { messages: [] };
     void agent.streamFn?.(model, context, {});
@@ -1082,6 +1083,25 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.transport).toBe("auto");
     expect(calls[0]?.openaiWsWarmup).toBe(true);
+  });
+
+  it("defaults OpenAI transport to SSE for non-OpenAI baseUrl", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5");
+
+    const model = {
+      api: "openai-responses",
+      provider: "openai",
+      id: "gpt-5",
+      baseUrl: "http://localhost:1234/v1",
+    } as Model<"openai-responses">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.transport).toBe("sse");
+    expect(calls[0]?.openaiWsWarmup).toBe(false);
   });
 
   it("lets runtime options override OpenAI default transport", () => {

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -247,10 +247,12 @@ export function createOpenAIDefaultTransportWrapper(baseStreamFn: StreamFn | und
     const typedOptions = options as
       | (SimpleStreamOptions & { openaiWsWarmup?: boolean })
       | undefined;
+    const inferredTransport =
+      options?.transport ?? (isDirectOpenAIBaseUrl(model.baseUrl) ? "auto" : "sse");
     const mergedOptions = {
       ...options,
-      transport: options?.transport ?? "auto",
-      openaiWsWarmup: typedOptions?.openaiWsWarmup ?? true,
+      transport: inferredTransport,
+      openaiWsWarmup: typedOptions?.openaiWsWarmup ?? inferredTransport === "auto",
     } as SimpleStreamOptions;
     return underlying(model, context, mergedOptions);
   };


### PR DESCRIPTION
## Summary
- default OpenAI transport to SSE when baseUrl is not OpenAI (prevents WS mode against local OpenAI-compatible backends)
- keep WS auto + warmup for direct OpenAI baseUrl
- add test coverage for local baseUrl

## Testing
- npx -y pnpm@latest vitest run src/agents/pi-embedded-runner-extraparams.test.ts (67/67 passed)
