### PR TITLE
fix(discord): fail fast when bot user id cannot be resolved

### DIFF
--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -530,4 +530,36 @@ describe("monitorDiscordProvider", () => {
     const messages = vi.mocked(runtime.log).mock.calls.map((call) => String(call[0]));
     expect(messages.some((msg) => msg.includes("discord startup ["))).toBe(false);
   });
+
+  it("throws when fetchUser('@me') rejects during startup", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    clientFetchUserMock.mockRejectedValueOnce(new Error("Discord API unavailable"));
+
+    await expect(
+      monitorDiscordProvider({
+        config: baseConfig(),
+        runtime: baseRuntime(),
+      }),
+    ).rejects.toThrow("Failed to fetch bot identity");
+
+    expect(monitorLifecycleMock).not.toHaveBeenCalled();
+    expect(createdBindingManagers).toHaveLength(1);
+    expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when fetchUser('@me') returns undefined or empty object", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    clientFetchUserMock.mockResolvedValueOnce({});
+
+    await expect(
+      monitorDiscordProvider({
+        config: baseConfig(),
+        runtime: baseRuntime(),
+      }),
+    ).rejects.toThrow("Failed to resolve Discord bot user id");
+
+    expect(monitorLifecycleMock).not.toHaveBeenCalled();
+    expect(createdBindingManagers).toHaveLength(1);
+    expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -549,7 +549,7 @@ describe("monitorDiscordProvider", () => {
 
   it("throws when fetchUser('@me') returns undefined or empty object", async () => {
     const { monitorDiscordProvider } = await import("./provider.js");
-    clientFetchUserMock.mockResolvedValueOnce({});
+    clientFetchUserMock.mockResolvedValueOnce({} as { id: string });
 
     await expect(
       monitorDiscordProvider({

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -882,6 +882,15 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       throw new Error(`Failed to fetch bot identity: ${String(err)}`, { cause: err });
     }
     if (!botUserId) {
+      runtime.error?.(danger("discord: bot user id missing after successful identity fetch"));
+      logDiscordStartupPhase({
+        runtime,
+        accountId: account.accountId,
+        phase: "fetch-bot-identity:error",
+        startAt: startupStartedAt,
+        gateway: lifecycleGateway,
+        details: "botUserId resolved to undefined",
+      });
       throw new Error("Failed to resolve Discord bot user id");
     }
 

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -879,6 +879,10 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         gateway: lifecycleGateway,
         details: String(err),
       });
+      throw new Error(`Failed to fetch bot identity: ${String(err)}`, { cause: err });
+    }
+    if (!botUserId) {
+      throw new Error("Failed to resolve Discord bot user id");
     }
 
     if (voiceEnabled) {


### PR DESCRIPTION
## Summary

When `fetchUser("@me")` fails or returns undefined during Discord provider startup, the bot now throws an error to trigger a restart instead of continuing with `botUserId = undefined`.

## Problem

When `botUserId` is undefined, multiple security and routing failures occur:

1. **Mention gating bypassed**: The guard `if (botId && mentionGate.shouldSkip)` short-circuits when `botId` is undefined, letting all guild messages bypass `requireMention: true`
2. **Self-message filtering disabled**: `author.id === botUserId` never matches, risking self-reply loops
3. **Reply detection broken**: Replying to the bot's message isn't recognized as an implicit mention

## Solution

Add fail-fast behavior matching the existing pattern for `fetchDiscordApplicationId`:
- Throw on `fetchUser("@me")` catch block instead of just logging
- Add explicit check for undefined `botUserId` after successful fetch

This ensures the provider restarts cleanly instead of running in a degraded state.

## Testing

- Existing Discord tests pass
- `message-handler.preflight.test.ts`: 18 tests pass
- `provider.proxy.test.ts`: 3 tests pass

Fixes #42219