### PR TITLE
feat: add resemble deepfake detection command

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -77,6 +77,7 @@ Text + native (when enabled):
 - `/approve <id> allow-once|allow-always|deny` (resolve exec approval prompts)
 - `/context [list|detail|json]` (explain “context”; `detail` shows per-file + per-tool + per-skill + system prompt size)
 - `/export-session [path]` (alias: `/export`) (export current session to HTML with full system prompt)
+- `/detect <url>` (detect deepfakes in media URLs or attachments using Resemble AI)
 - `/whoami` (show your sender id; alias: `/id`)
 - `/session idle <duration|off>` (manage inactivity auto-unfocus for focused thread bindings)
 - `/session max-age <duration|off>` (manage hard max-age auto-unfocus for focused thread bindings)

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -734,6 +734,22 @@ function buildChatCommands(): ChatCommandDefinition[] {
         },
       ],
     }),
+    defineChatCommand({
+      key: "detect",
+      nativeName: "detect",
+      description: "Detect deepfakes in media URLs or attachments using Resemble AI.",
+      textAlias: "/detect",
+      category: "media",
+      acceptsArgs: true,
+      args: [
+        {
+          name: "url",
+          description: "Media URL",
+          type: "string",
+          captureRemaining: true,
+        },
+      ],
+    }),
     ...listChannelDocks()
       .filter((dock) => dock.capabilities.nativeCommands)
       .map((dock) => defineDockCommand(dock)),

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -737,7 +737,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
     defineChatCommand({
       key: "detect",
       nativeName: "detect",
-      description: "Detect deepfakes in media URLs using Resemble AI.",
+      description: "Detect deepfakes in media URLs or attachments using Resemble AI.",
       textAlias: "/detect",
       category: "media",
       acceptsArgs: true,

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -737,7 +737,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
     defineChatCommand({
       key: "detect",
       nativeName: "detect",
-      description: "Detect deepfakes in media URLs or attachments using Resemble AI.",
+      description: "Detect deepfakes in media URLs using Resemble AI.",
       textAlias: "/detect",
       category: "media",
       acceptsArgs: true,

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -13,6 +13,7 @@ import { handleApproveCommand } from "./commands-approve.js";
 import { handleBashCommand } from "./commands-bash.js";
 import { handleCompactCommand } from "./commands-compact.js";
 import { handleConfigCommand, handleDebugCommand } from "./commands-config.js";
+import { handleDetectCommand } from "./commands-detect.js";
 import {
   handleCommandsListCommand,
   handleContextCommand,
@@ -186,6 +187,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleAllowlistCommand,
       handleApproveCommand,
       handleContextCommand,
+      handleDetectCommand,
       handleExportSessionCommand,
       handleWhoamiCommand,
       handleSubagentsCommand,

--- a/src/auto-reply/reply/commands-detect.ts
+++ b/src/auto-reply/reply/commands-detect.ts
@@ -22,7 +22,7 @@ export const handleDetectCommand: CommandHandler = async (params, allowTextComma
   
   if (!url) {
     // Try to fall back to media attachments if no URL is provided in text
-    const mediaUrl = params.payload.mediaUrl || params.payload.mediaUrls?.[0];
+    const mediaUrl = params.ctx.MediaUrl || params.ctx.MediaUrls?.[0];
     if (mediaUrl) {
       url = mediaUrl;
     } else {

--- a/src/auto-reply/reply/commands-detect.ts
+++ b/src/auto-reply/reply/commands-detect.ts
@@ -1,0 +1,88 @@
+import { detectDeepfake } from "../../detect/resemble-detect.js";
+import type { CommandHandler } from "./commands-types.js";
+
+export const handleDetectCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+
+  const body = params.command.commandBodyNormalized;
+  if (!body.startsWith("/detect ") && body !== "/detect") {
+    return null;
+  }
+
+  if (!params.command.isAuthorizedSender) {
+    return {
+      shouldContinue: false,
+      reply: { text: "❌ You are not authorized to use the /detect command." },
+    };
+  }
+
+  let url = body.slice("/detect ".length).trim();
+  
+  if (!url) {
+    // Try to fall back to media attachments if no URL is provided in text
+    const mediaUrl = params.payload.mediaUrl || params.payload.mediaUrls?.[0];
+    if (mediaUrl) {
+      url = mediaUrl;
+    } else {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: "⚠️ Please provide a media URL or attach a file.\nUsage: /detect <url> or upload a file with the caption /detect",
+        },
+      };
+    }
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      throw new Error("Invalid protocol");
+    }
+  } catch {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: "⚠️ Please provide a valid HTTP or HTTPS media URL.\nUsage: /detect <url>",
+      },
+    };
+  }
+
+  const result = await detectDeepfake(url, params.cfg);
+
+  if (!result.success) {
+    return {
+      shouldContinue: false,
+      reply: { text: `❌ Detection failed: ${result.error}` },
+    };
+  }
+
+  const item = result.item;
+  if (!item) {
+    return {
+      shouldContinue: false,
+      reply: { text: "❌ Invalid response from Resemble API." },
+    };
+  }
+
+  let text = `🕵️‍♂️ **Media Verification Report**\nType: ${item.media_type}\n`;
+
+  if (item.media_type === "video" && item.video_metrics) {
+    const vm = item.video_metrics;
+    text += `Status: ${vm.label}\nConfidence: ${Math.round(vm.score * 100)}% (Certainty: ${Math.round(vm.certainty * 100)}%)\n`;
+  } else if (item.media_type === "audio" && item.metrics) {
+    const am = item.metrics;
+    text += `Status: ${am.label}\nAggregated Score: ${am.aggregated_score}\n`;
+  } else if (item.media_type === "image" && item.image_metrics) {
+    const im = item.image_metrics;
+    text += `Status: ${im.label}\nScore: ${Math.round(im.score * 100)}%\nType: ${im.type}\n`;
+  } else {
+    text += `Status: Analyzed\n`;
+  }
+
+  return {
+    shouldContinue: false,
+    reply: { text },
+  };
+};

--- a/src/auto-reply/reply/commands-detect.ts
+++ b/src/auto-reply/reply/commands-detect.ts
@@ -19,7 +19,7 @@ export const handleDetectCommand: CommandHandler = async (params, allowTextComma
   }
 
   let url = body.slice("/detect ".length).trim();
-  
+
   if (!url) {
     // Try to fall back to media attachments if no URL is provided in text
     const mediaUrl = params.ctx.MediaUrl || params.ctx.MediaUrls?.[0];

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -24,7 +24,7 @@ import type {
 import type { ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
 import type { PluginsConfig } from "./types.plugins.js";
-import type { SecretsConfig } from "./types.secrets.js";
+import type { SecretInput, SecretsConfig } from "./types.secrets.js";
 import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
@@ -120,6 +120,9 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  resemble?: {
+    apiKey?: SecretInput;
+  };
 };
 
 export type ConfigValidationIssue = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -809,6 +809,12 @@ export const OpenClawSchema = z
       .strict()
       .optional(),
     memory: MemorySchema,
+    resemble: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+      })
+      .strict()
+      .optional(),
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),

--- a/src/detect/resemble-detect.ts
+++ b/src/detect/resemble-detect.ts
@@ -1,0 +1,52 @@
+import type { OpenClawConfig } from "../config/types.js";
+import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
+
+export async function detectDeepfake(mediaUrl: string, cfg: OpenClawConfig) {
+  const apiKey =
+    normalizeResolvedSecretInputString({
+      value: cfg.resemble?.apiKey,
+      path: "resemble.apiKey",
+    }) || process.env.RESEMBLE_API_KEY;
+
+  if (!apiKey) {
+    return {
+      success: false,
+      error: "Resemble API key is not configured. Please add it to your configuration.",
+    };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 60_000);
+
+  try {
+    const response = await fetch("https://app.resemble.ai/api/v2/detect", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        Prefer: "wait",
+      },
+      body: JSON.stringify({ url: mediaUrl, visualize: true }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `Resemble Detect API error: ${response.status} ${response.statusText}`,
+      };
+    }
+
+    const data = await response.json();
+    return { success: true, item: data.item ?? data };
+  } catch (err: unknown) {
+    const error = err as Error;
+    if (error.name === "AbortError") {
+      return { success: false, error: "Resemble Detect API request timed out." };
+    }
+    const message = error.message ? error.message : String(err);
+    return { success: false, error: message };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}


### PR DESCRIPTION
This PR adds the core /detect chat command and the underlying utility for Resemble AI deepfake detection. 

Following feedback on PR #41498, I have removed the Skill component to keep the core lean. This focus is solely on the built-in slash command.