### PR TITLE
Discord: add thread parent inheritance config

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -632,6 +632,7 @@ Default slash command settings:
 
     - Discord threads are routed as channel sessions
     - parent thread metadata can be used for parent-session linkage
+    - `channels.discord.threadContext.parentInheritance` controls whether native Discord thread sessions fork the parent transcript (`"fork"`, default) or start fresh (`"fresh"`)
     - thread config inherits parent channel config unless a thread-specific entry exists
 
     Channel topics are injected as **untrusted** context (not as system prompt).

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -231,6 +231,64 @@ describe("initSessionState thread forking", () => {
     warn.mockRestore();
   });
 
+  it("skips fork and creates fresh session when explicit skip flag is set", async () => {
+    const root = await makeCaseDir("openclaw-thread-session-explicit-skip-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+
+    const parentSessionId = "parent-explicit-skip";
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    const header = {
+      type: "session",
+      version: 3,
+      id: parentSessionId,
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    };
+    const message = {
+      type: "message",
+      id: "m1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "Parent prompt" },
+    };
+    await fs.writeFile(
+      parentSessionFile,
+      `${JSON.stringify(header)}\n${JSON.stringify(message)}\n`,
+      "utf-8",
+    );
+
+    const storePath = path.join(root, "sessions.json");
+    const parentSessionKey = "agent:main:slack:channel:c1";
+    await writeSessionStoreFast(storePath, {
+      [parentSessionKey]: {
+        sessionId: parentSessionId,
+        sessionFile: parentSessionFile,
+        updatedAt: Date.now(),
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    const threadSessionKey = "agent:main:slack:channel:c1:thread:456";
+    const result = await initSessionState({
+      ctx: {
+        Body: "Thread reply",
+        SessionKey: threadSessionKey,
+        ParentSessionKey: parentSessionKey,
+        SkipParentSessionFork: true,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.forkedFromParent).toBe(true);
+    expect(result.sessionEntry.sessionId).not.toBe(parentSessionId);
+    expect(result.sessionEntry.sessionFile).not.toBe(parentSessionFile);
+  });
+
   it("skips fork and creates fresh session when parent tokens exceed threshold", async () => {
     const root = await makeCaseDir("openclaw-thread-session-overflow-");
     const sessionsDir = path.join(root, "sessions");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -479,38 +479,46 @@ export async function initSessionState(params: {
   }
   const parentSessionKey = ctx.ParentSessionKey?.trim();
   const alreadyForked = sessionEntry.forkedFromParent === true;
+  const skipParentSessionFork = ctx.SkipParentSessionFork === true;
   if (
     parentSessionKey &&
     parentSessionKey !== sessionKey &&
     sessionStore[parentSessionKey] &&
     !alreadyForked
   ) {
-    const parentTokens = sessionStore[parentSessionKey].totalTokens ?? 0;
-    if (parentForkMaxTokens > 0 && parentTokens > parentForkMaxTokens) {
-      // Parent context is too large — forking would create a thread session
-      // that immediately overflows the model's context window. Start fresh
-      // instead and mark as forked to prevent re-attempts. See #26905.
+    if (skipParentSessionFork) {
       log.warn(
-        `skipping parent fork (parent too large): parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-          `parentTokens=${parentTokens} maxTokens=${parentForkMaxTokens}`,
+        `skipping parent fork (explicit): parentKey=${parentSessionKey} → sessionKey=${sessionKey}`,
       );
       sessionEntry.forkedFromParent = true;
     } else {
-      log.warn(
-        `forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-          `parentTokens=${parentTokens}`,
-      );
-      const forked = forkSessionFromParent({
-        parentEntry: sessionStore[parentSessionKey],
-        agentId,
-        sessionsDir: path.dirname(storePath),
-      });
-      if (forked) {
-        sessionId = forked.sessionId;
-        sessionEntry.sessionId = forked.sessionId;
-        sessionEntry.sessionFile = forked.sessionFile;
+      const parentTokens = sessionStore[parentSessionKey].totalTokens ?? 0;
+      if (parentForkMaxTokens > 0 && parentTokens > parentForkMaxTokens) {
+        // Parent context is too large — forking would create a thread session
+        // that immediately overflows the model's context window. Start fresh
+        // instead and mark as forked to prevent re-attempts. See #26905.
+        log.warn(
+          `skipping parent fork (parent too large): parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
+            `parentTokens=${parentTokens} maxTokens=${parentForkMaxTokens}`,
+        );
         sessionEntry.forkedFromParent = true;
-        log.warn(`forked session created: file=${forked.sessionFile}`);
+      } else {
+        log.warn(
+          `forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
+            `parentTokens=${parentTokens}`,
+        );
+        const forked = forkSessionFromParent({
+          parentEntry: sessionStore[parentSessionKey],
+          agentId,
+          sessionsDir: path.dirname(storePath),
+        });
+        if (forked) {
+          sessionId = forked.sessionId;
+          sessionEntry.sessionId = forked.sessionId;
+          sessionEntry.sessionFile = forked.sessionFile;
+          sessionEntry.forkedFromParent = true;
+          log.warn(`forked session created: file=${forked.sessionFile}`);
+        }
       }
     }
   }

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -48,6 +48,8 @@ export type MsgContext = {
   /** Provider account id (multi-account). */
   AccountId?: string;
   ParentSessionKey?: string;
+  /** If true, preserve parent linkage metadata but do not fork the parent transcript into this session. */
+  SkipParentSessionFork?: boolean;
   MessageSid?: string;
   /** Provider-specific full message id when MessageSid is a shortened alias. */
   MessageSidFull?: string;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1521,6 +1521,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow subagent spawns with thread=true to auto-create and bind Discord threads (default: false; opt-in). Set true to enable thread-bound subagent spawns for this account/channel.",
   "channels.discord.threadBindings.spawnAcpSessions":
     "Allow /acp spawn to auto-create and bind Discord threads for ACP sessions (default: false; opt-in). Set true to enable thread-bound ACP spawns for this account/channel.",
+  "channels.discord.threadContext.parentInheritance":
+    'Controls whether native Discord thread sessions inherit the parent channel transcript. Use "fork" to keep current behavior or "fresh" to start a fresh thread session without parent transcript inheritance (default: "fork").',
   "channels.discord.ui.components.accentColor":
     "Accent color for Discord component containers (hex). Set per account via channels.discord.accounts.<id>.ui.components.accentColor.",
   "channels.discord.voice.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -760,6 +760,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.discord.threadBindings.maxAgeHours": "Discord Thread Binding Max Age (hours)",
   "channels.discord.threadBindings.spawnSubagentSessions": "Discord Thread-Bound Subagent Spawn",
   "channels.discord.threadBindings.spawnAcpSessions": "Discord Thread-Bound ACP Spawn",
+  "channels.discord.threadContext.parentInheritance": "Discord Thread Parent Inheritance",
   "channels.discord.ui.components.accentColor": "Discord Component Accent Color",
   "channels.discord.intents.presence": "Discord Presence Intent",
   "channels.discord.intents.guildMembers": "Discord Guild Members Intent",

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -56,6 +56,17 @@ export type DiscordGuildChannelConfig = {
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";
 
+export type DiscordThreadParentInheritanceMode = "fork" | "fresh";
+
+export type DiscordThreadContextConfig = {
+  /**
+   * Controls whether native Discord thread sessions inherit the parent channel transcript.
+   * - "fork": branch from the parent session transcript (default)
+   * - "fresh": start a fresh thread session without parent transcript inheritance
+   */
+  parentInheritance?: DiscordThreadParentInheritanceMode;
+};
+
 export type DiscordGuildEntry = {
   slug?: string;
   requireMention?: boolean;
@@ -305,6 +316,8 @@ export type DiscordAccountConfig = {
   slashCommand?: DiscordSlashCommandConfig;
   /** Thread binding lifecycle settings (focus/subagent thread sessions). */
   threadBindings?: DiscordThreadBindingsConfig;
+  /** Native Discord thread session bootstrap behavior. */
+  threadContext?: DiscordThreadContextConfig;
   /** Privileged Gateway Intents (must also be enabled in Discord Developer Portal). */
   intents?: DiscordIntentsConfig;
   /** Voice channel conversation settings. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -514,6 +514,12 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    threadContext: z
+      .object({
+        parentInheritance: z.enum(["fork", "fresh"]).optional(),
+      })
+      .strict()
+      .optional(),
     intents: z
       .object({
         presence: z.boolean().optional(),

--- a/src/discord/monitor/message-handler.process.auto-thread.test.ts
+++ b/src/discord/monitor/message-handler.process.auto-thread.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createBaseDiscordMessageContext } from "./message-handler.test-harness.js";
+
+const dispatchInboundMessage = vi.fn(async (_params?: unknown) => ({
+  queuedFinal: false,
+  counts: { final: 0, tool: 0, block: 0 },
+}));
+const recordInboundSession = vi.fn(async () => {});
+
+vi.mock("../../auto-reply/dispatch.js", () => ({ dispatchInboundMessage }));
+vi.mock("../../channels/session.js", () => ({ recordInboundSession }));
+vi.mock("../../config/sessions.js", () => ({
+  readSessionUpdatedAt: vi.fn(() => undefined),
+  resolveStorePath: vi.fn(() => "/tmp/openclaw-discord-process-test-sessions.json"),
+}));
+vi.mock("../send.js", () => ({
+  reactMessageDiscord: vi.fn(async () => {}),
+  removeReactionDiscord: vi.fn(async () => {}),
+}));
+vi.mock("../send.messages.js", () => ({ editMessageDiscord: vi.fn(async () => ({})) }));
+vi.mock("../draft-stream.js", () => ({
+  createDiscordDraftStream: vi.fn(() => ({
+    update: vi.fn(),
+    flush: vi.fn(async () => {}),
+    messageId: vi.fn(() => "preview-1"),
+    clear: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    forceNewMessage: vi.fn(),
+  })),
+}));
+vi.mock("./reply-delivery.js", () => ({ deliverDiscordReply: vi.fn(async () => {}) }));
+vi.mock("../../auto-reply/reply/reply-dispatcher.js", () => ({
+  createReplyDispatcherWithTyping: vi.fn(
+    (opts: { deliver: (payload: unknown, info: { kind: string }) => Promise<void> | void }) => ({
+      dispatcher: {
+        sendToolResult: vi.fn(() => true),
+        sendBlockReply: vi.fn((payload: unknown) => {
+          void opts.deliver(payload as never, { kind: "block" });
+          return true;
+        }),
+        sendFinalReply: vi.fn((payload: unknown) => {
+          void opts.deliver(payload as never, { kind: "final" });
+          return true;
+        }),
+        waitForIdle: vi.fn(async () => {}),
+        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        markComplete: vi.fn(),
+      },
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+    }),
+  ),
+}));
+vi.mock("./threading.js", async () => {
+  const actual = await vi.importActual<typeof import("./threading.js")>("./threading.js");
+  return {
+    ...actual,
+    resolveDiscordAutoThreadReplyPlan: vi.fn(async () => ({
+      deliverTarget: "channel:thread-99",
+      replyTarget: "channel:thread-99",
+      replyReference: null,
+      createdThreadId: "thread-99",
+      autoThreadContext: {
+        createdThreadId: "thread-99",
+        From: "discord:channel:thread-99",
+        To: "channel:thread-99",
+        OriginatingTo: "channel:thread-99",
+        SessionKey: "agent:main:discord:channel:thread-99",
+        ParentSessionKey: "agent:main:discord:channel:c1",
+      },
+    })),
+    resolveDiscordThreadStarter: vi.fn(async () => null),
+  };
+});
+
+const { processDiscordMessage } = await import("./message-handler.process.js");
+
+beforeEach(() => {
+  dispatchInboundMessage.mockClear();
+  recordInboundSession.mockClear();
+});
+
+function getLastDispatchCtx() {
+  const callArgs = dispatchInboundMessage.mock.calls.at(-1) as unknown[] | undefined;
+  const params = callArgs?.[0] as
+    | {
+        ctx?: {
+          SessionKey?: string;
+          ParentSessionKey?: string;
+          SkipParentSessionFork?: boolean;
+          MessageThreadId?: string | number;
+        };
+      }
+    | undefined;
+  return params?.ctx;
+}
+
+describe("processDiscordMessage auto-thread inheritance", () => {
+  it("marks auto-created thread sessions to skip parent fork in fresh mode", async () => {
+    const ctx = await createBaseDiscordMessageContext({
+      discordConfig: { threadContext: { parentInheritance: "fresh" } },
+      threadChannel: null,
+      threadParentId: undefined,
+      threadParentName: undefined,
+      messageChannelId: "c1",
+      route: {
+        agentId: "main",
+        channel: "discord",
+        accountId: "default",
+        sessionKey: "agent:main:discord:channel:c1",
+        mainSessionKey: "agent:main:main",
+      },
+      baseSessionKey: "agent:main:discord:channel:c1",
+    });
+
+    await processDiscordMessage(ctx as never);
+
+    expect(getLastDispatchCtx()).toMatchObject({
+      SessionKey: "agent:main:discord:channel:thread-99",
+      ParentSessionKey: "agent:main:discord:channel:c1",
+      SkipParentSessionFork: true,
+      MessageThreadId: "thread-99",
+    });
+  });
+});

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -185,6 +185,7 @@ function getLastDispatchCtx():
       SessionKey?: string;
       MessageThreadId?: string | number;
       ParentSessionKey?: string;
+      SkipParentSessionFork?: boolean;
     }
   | undefined {
   const callArgs = dispatchInboundMessage.mock.calls.at(-1) as unknown[] | undefined;
@@ -194,6 +195,7 @@ function getLastDispatchCtx():
           SessionKey?: string;
           MessageThreadId?: string | number;
           ParentSessionKey?: string;
+          SkipParentSessionFork?: boolean;
         };
       }
     | undefined;
@@ -484,7 +486,7 @@ describe("processDiscordMessage session routing", () => {
     });
   });
 
-  it("can start native Discord threads fresh without parent session linkage", async () => {
+  it("can start native Discord threads fresh without forking while preserving parent linkage", async () => {
     const ctx = await createBaseContext({
       discordConfig: { threadContext: { parentInheritance: "fresh" } },
       messageChannelId: "thread-1",
@@ -501,8 +503,9 @@ describe("processDiscordMessage session routing", () => {
     expect(getLastDispatchCtx()).toMatchObject({
       SessionKey: "agent:main:discord:channel:thread-1",
       MessageThreadId: "thread-1",
+      ParentSessionKey: "agent:main:discord:channel:c-parent",
+      SkipParentSessionFork: true,
     });
-    expect(getLastDispatchCtx()?.ParentSessionKey).toBeUndefined();
   });
 });
 

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -181,11 +181,21 @@ function getLastRouteUpdate():
 }
 
 function getLastDispatchCtx():
-  | { SessionKey?: string; MessageThreadId?: string | number }
+  | {
+      SessionKey?: string;
+      MessageThreadId?: string | number;
+      ParentSessionKey?: string;
+    }
   | undefined {
   const callArgs = dispatchInboundMessage.mock.calls.at(-1) as unknown[] | undefined;
   const params = callArgs?.[0] as
-    | { ctx?: { SessionKey?: string; MessageThreadId?: string | number } }
+    | {
+        ctx?: {
+          SessionKey?: string;
+          MessageThreadId?: string | number;
+          ParentSessionKey?: string;
+        };
+      }
     | undefined;
   return params?.ctx;
 }
@@ -452,6 +462,47 @@ describe("processDiscordMessage session routing", () => {
       to: "channel:thread-1",
       accountId: "default",
     });
+  });
+
+  it("keeps parent session linkage for native Discord threads by default", async () => {
+    const ctx = await createBaseContext({
+      messageChannelId: "thread-1",
+      threadChannel: { id: "thread-1", name: "topic" },
+      threadParentId: "c-parent",
+      threadParentName: "system",
+      baseSessionKey: "agent:main:discord:channel:thread-1",
+      route: BASE_CHANNEL_ROUTE,
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(getLastDispatchCtx()).toMatchObject({
+      SessionKey: "agent:main:discord:channel:thread-1",
+      MessageThreadId: "thread-1",
+      ParentSessionKey: "agent:main:discord:channel:c-parent",
+    });
+  });
+
+  it("can start native Discord threads fresh without parent session linkage", async () => {
+    const ctx = await createBaseContext({
+      discordConfig: { threadContext: { parentInheritance: "fresh" } },
+      messageChannelId: "thread-1",
+      threadChannel: { id: "thread-1", name: "topic" },
+      threadParentId: "c-parent",
+      threadParentName: "system",
+      baseSessionKey: "agent:main:discord:channel:thread-1",
+      route: BASE_CHANNEL_ROUTE,
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(getLastDispatchCtx()).toMatchObject({
+      SessionKey: "agent:main:discord:channel:thread-1",
+      MessageThreadId: "thread-1",
+    });
+    expect(getLastDispatchCtx()?.ParentSessionKey).toBeUndefined();
   });
 });
 

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -342,6 +342,13 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   const replyTarget = replyPlan.replyTarget;
   const replyReference = replyPlan.replyReference;
   const autoThreadContext = replyPlan.autoThreadContext;
+  if (
+    !skipParentSessionFork &&
+    autoThreadContext?.ParentSessionKey &&
+    resolveDiscordThreadParentInheritanceMode({ discordConfig }) === "fresh"
+  ) {
+    skipParentSessionFork = true;
+  }
 
   const effectiveFrom = isDirectMessage
     ? `discord:${author.id}`

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -25,6 +25,10 @@ import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matc
 import { resolveDiscordPreviewStreamMode } from "../../config/discord-preview-streaming.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js";
+import type {
+  DiscordConfig,
+  DiscordThreadParentInheritanceMode,
+} from "../../config/types.discord.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../globals.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
@@ -61,8 +65,8 @@ function sleep(ms: number): Promise<void> {
 const DISCORD_TYPING_MAX_DURATION_MS = 20 * 60_000;
 
 function resolveDiscordThreadParentInheritanceMode(params: {
-  discordConfig?: { threadContext?: { parentInheritance?: string } } | null;
-}): "fork" | "fresh" {
+  discordConfig?: DiscordConfig | null;
+}): DiscordThreadParentInheritanceMode {
   return params.discordConfig?.threadContext?.parentInheritance === "fresh" ? "fresh" : "fork";
 }
 
@@ -279,8 +283,10 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   let threadStarterBody: string | undefined;
   let threadLabel: string | undefined;
   let parentSessionKey: string | undefined;
-  const threadParentInheritanceMode = resolveDiscordThreadParentInheritanceMode({ discordConfig });
   if (threadChannel) {
+    const threadParentInheritanceMode = resolveDiscordThreadParentInheritanceMode({
+      discordConfig,
+    });
     const includeThreadStarter = channelConfig?.includeThreadStarter !== false;
     if (includeThreadStarter) {
       const starter = await resolveDiscordThreadStarter({

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -283,6 +283,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   let threadStarterBody: string | undefined;
   let threadLabel: string | undefined;
   let parentSessionKey: string | undefined;
+  let skipParentSessionFork: boolean | undefined;
   if (threadChannel) {
     const threadParentInheritanceMode = resolveDiscordThreadParentInheritanceMode({
       discordConfig,
@@ -305,12 +306,15 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     threadLabel = threadName
       ? `Discord thread #${normalizeDiscordSlug(parentName)} › ${threadName}`
       : `Discord thread #${normalizeDiscordSlug(parentName)}`;
-    if (threadParentId && threadParentInheritanceMode === "fork") {
+    if (threadParentId) {
       parentSessionKey = buildAgentSessionKey({
         agentId: route.agentId,
         channel: route.channel,
         peer: { kind: "channel", id: threadParentId },
       });
+      if (threadParentInheritanceMode === "fresh") {
+        skipParentSessionFork = true;
+      }
     }
   }
   const mediaPayload = buildDiscordMediaPayload(mediaList);
@@ -389,6 +393,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     ReplyToBody: replyContext?.body,
     ReplyToSender: replyContext?.sender,
     ParentSessionKey: autoThreadContext?.ParentSessionKey ?? threadKeys.parentSessionKey,
+    SkipParentSessionFork: skipParentSessionFork,
     MessageThreadId: threadChannel?.id ?? autoThreadContext?.createdThreadId ?? undefined,
     ThreadStarterBody: threadStarterBody,
     ThreadLabel: threadLabel,

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -60,6 +60,12 @@ function sleep(ms: number): Promise<void> {
 
 const DISCORD_TYPING_MAX_DURATION_MS = 20 * 60_000;
 
+function resolveDiscordThreadParentInheritanceMode(params: {
+  discordConfig?: { threadContext?: { parentInheritance?: string } } | null;
+}): "fork" | "fresh" {
+  return params.discordConfig?.threadContext?.parentInheritance === "fresh" ? "fresh" : "fork";
+}
+
 function isProcessAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
 }
@@ -273,6 +279,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   let threadStarterBody: string | undefined;
   let threadLabel: string | undefined;
   let parentSessionKey: string | undefined;
+  const threadParentInheritanceMode = resolveDiscordThreadParentInheritanceMode({ discordConfig });
   if (threadChannel) {
     const includeThreadStarter = channelConfig?.includeThreadStarter !== false;
     if (includeThreadStarter) {
@@ -292,7 +299,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     threadLabel = threadName
       ? `Discord thread #${normalizeDiscordSlug(parentName)} › ${threadName}`
       : `Discord thread #${normalizeDiscordSlug(parentName)}`;
-    if (threadParentId) {
+    if (threadParentId && threadParentInheritanceMode === "fork") {
       parentSessionKey = buildAgentSessionKey({
         agentId: route.agentId,
         channel: route.channel,


### PR DESCRIPTION
## Summary

Add `channels.discord.threadContext.parentInheritance` to control whether native Discord thread sessions inherit the parent channel transcript.

- `"fork"` keeps the current behavior
- `"fresh"` starts the native Discord thread session without parent-session linkage
- default remains `"fork"`

## Why

Discord thread/session inheritance is currently implicit. This adds an explicit Discord-side config knob for users who want fresh native thread sessions without relying on the generic `session.parentForkMaxTokens` guard.

Slack already exposes explicit parent-inheritance control for threads (`channels.slack.thread.inheritParent`); this adds the equivalent control for native Discord threads.

## Changes

- add Discord config types + schema for `channels.discord.threadContext.parentInheritance`
- gate `ParentSessionKey` assignment for native Discord threads in the Discord inbound handler
- add tests covering:
  - default parent linkage
  - explicit `\"fresh\"` behavior
- document the new config in Discord docs

## Testing

- `pnpm vitest run src/discord/monitor/message-handler.process.test.ts`
- `pnpm tsgo`