### PR TITLE
fix(daemon,cron): harden systemd user fallback and stop cron payload false-positive

### DIFF
--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -75,4 +75,45 @@ describe("normalizeStoredCronJobs", () => {
       channel: "slack",
     });
   });
+
+  it("does not report already-canonical payload kinds as legacy", () => {
+    const jobs = [
+      {
+        id: "agent-turn",
+        name: "agent turn",
+        enabled: true,
+        createdAtMs: 1773144000000,
+        updatedAtMs: 1773144000000,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1773144000000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: {
+          kind: "agentTurn",
+          message: "ping",
+        },
+        delivery: { mode: "announce" },
+        state: {},
+      },
+      {
+        id: "system-event",
+        name: "system event",
+        enabled: true,
+        createdAtMs: 1773144000000,
+        updatedAtMs: 1773144000000,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1773144000000 },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: {
+          kind: "systemEvent",
+          text: "pong",
+        },
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(false);
+    expect(result.issues).toEqual({});
+  });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,12 +28,13 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
-  if (raw === "agentturn") {
+  const raw = typeof payload.kind === "string" ? payload.kind.trim() : "";
+  const normalized = raw.toLowerCase();
+  if (normalized === "agentturn" && raw !== "agentTurn") {
     payload.kind = "agentTurn";
     return true;
   }
-  if (raw === "systemevent") {
+  if (normalized === "systemevent" && raw !== "systemEvent") {
     payload.kind = "systemEvent";
     return true;
   }

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -58,6 +58,12 @@ function pathLikeToString(pathname: unknown): string {
   return "";
 }
 
+function expectInferredUserBusEnv(opts: unknown) {
+  const env = (opts as { env?: NodeJS.ProcessEnv } | undefined)?.env;
+  expect(env?.XDG_RUNTIME_DIR).toMatch(/^\/run\/user\/\d+$/);
+  expect(env?.DBUS_SESSION_BUS_ADDRESS).toBe(`unix:path=${env?.XDG_RUNTIME_DIR}/bus`);
+}
+
 const assertRestartSuccess = async (env: NodeJS.ProcessEnv) => {
   const { write, stdout } = createWritableStreamMock();
   await restartSystemdService({ stdout, env });
@@ -98,7 +104,7 @@ describe("systemd availability", () => {
     await expect(isSystemdUserServiceAvailable()).resolves.toBe(true);
   });
 
-  it("falls back to machine user scope when --user bus is unavailable", async () => {
+  it("retries --user with an inferred bus env when the shell env is missing", async () => {
     execFileMock
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--user", "status"]);
@@ -107,6 +113,37 @@ describe("systemd availability", () => {
             "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
         });
         cb(err, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, opts, cb) => {
+        expect(args).toEqual(["--user", "status"]);
+        expectInferredUserBusEnv(opts);
+        cb(null, "", "");
+      });
+
+    await expect(isSystemdUserServiceAvailable({ USER: "debian" })).resolves.toBe(true);
+  });
+
+  it("falls back to machine user scope after inferred bus env retry fails", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "status"]);
+        cb(
+          createExecFileError("Failed to connect to user scope bus via local transport", {
+            stderr:
+              "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, opts, cb) => {
+        expect(args).toEqual(["--user", "status"]);
+        expectInferredUserBusEnv(opts);
+        cb(
+          createExecFileError("still unavailable", { stderr: "Failed to connect to bus" }),
+          "",
+          "",
+        );
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--machine", "debian@", "--user", "status"]);
@@ -199,14 +236,24 @@ describe("isSystemdServiceEnabled", () => {
     vi.spyOn(os, "userInfo").mockImplementationOnce(() => {
       throw new Error("no user info");
     });
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
-      cb(
-        createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
-        "",
-        "",
-      );
-    });
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+        cb(
+          createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
+          "",
+          "Failed to connect to bus",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, opts, cb) => {
+        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+        expectInferredUserBusEnv(opts);
+        cb(
+          createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
+          "",
+          "Failed to connect to bus",
+        );
+      });
 
     await expect(
       isSystemdServiceEnabled({
@@ -224,7 +271,16 @@ describe("isSystemdServiceEnabled", () => {
         cb(
           createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
           "",
+          "Failed to connect to bus",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, opts, cb) => {
+        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+        expectInferredUserBusEnv(opts);
+        cb(
+          createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
           "",
+          "Failed to connect to bus",
         );
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
@@ -241,7 +297,7 @@ describe("isSystemdServiceEnabled", () => {
               "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
           }),
           "",
-          "",
+          "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
         );
       });
 
@@ -279,10 +335,9 @@ describe("isSystemdServiceEnabled", () => {
         err.code = 1;
         cb(err, "", "Failed to connect to bus");
       })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args[0]).toBe("--machine");
-        expect(String(args[1])).toMatch(/^[^@]+@$/);
-        expect(args.slice(2)).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+      .mockImplementationOnce((_cmd, args, opts, cb) => {
+        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+        expectInferredUserBusEnv(opts);
         const err = new Error("permission denied") as Error & { code?: number };
         err.code = 1;
         cb(err, "", "permission denied");
@@ -705,13 +760,24 @@ describe("systemd service control", () => {
     vi.spyOn(os, "userInfo").mockImplementationOnce(() => {
       throw new Error("no user info");
     });
-    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
-      cb(
-        createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
-        "",
-        "",
-      );
-    });
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "status"]);
+        cb(
+          createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
+          "",
+          "Failed to connect to bus",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, opts, cb) => {
+        expect(args).toEqual(["--user", "status"]);
+        expectInferredUserBusEnv(opts);
+        cb(
+          createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
+          "",
+          "Failed to connect to bus",
+        );
+      });
 
     await expect(
       stopSystemdService({
@@ -747,7 +813,7 @@ describe("systemd service control", () => {
     await assertRestartSuccess({ SUDO_USER: "root", USER: "root" });
   });
 
-  it("falls back to machine user scope for restart when user bus env is missing", async () => {
+  it("retries restart in direct user scope with an inferred bus env when shell env is missing", async () => {
     execFileMock
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--user", "status"]);
@@ -757,16 +823,72 @@ describe("systemd service control", () => {
         });
         cb(err, "", "");
       })
+      .mockImplementationOnce((_cmd, args, opts, cb) => {
+        expect(args).toEqual(["--user", "status"]);
+        expectInferredUserBusEnv(opts);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "restart", "openclaw-gateway.service"]);
+        const err = createExecFileError("Failed to connect to user scope bus", {
+          stderr:
+            "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
+        });
+        cb(err, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, opts, cb) => {
+        expect(args).toEqual(["--user", "restart", "openclaw-gateway.service"]);
+        expectInferredUserBusEnv(opts);
+        cb(null, "", "");
+      });
+    await assertRestartSuccess({ USER: "debian" });
+  });
+
+  it("falls back to machine user scope for restart after inferred bus env retry fails", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "status"]);
+        cb(
+          createExecFileError("Failed to connect to user scope bus", {
+            stderr:
+              "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, opts, cb) => {
+        expect(args).toEqual(["--user", "status"]);
+        expectInferredUserBusEnv(opts);
+        cb(
+          createExecFileError("still unavailable", { stderr: "Failed to connect to bus" }),
+          "",
+          "Failed to connect to bus",
+        );
+      })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--machine", "debian@", "--user", "status"]);
         cb(null, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--user", "restart", "openclaw-gateway.service"]);
-        const err = createExecFileError("Failed to connect to user scope bus", {
-          stderr: "Failed to connect to user scope bus",
-        });
-        cb(err, "", "");
+        cb(
+          createExecFileError("Failed to connect to user scope bus", {
+            stderr:
+              "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, opts, cb) => {
+        expect(args).toEqual(["--user", "restart", "openclaw-gateway.service"]);
+        expectInferredUserBusEnv(opts);
+        cb(
+          createExecFileError("still unavailable", { stderr: "Failed to connect to bus" }),
+          "",
+          "Failed to connect to bus",
+        );
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertMachineRestartArgs(args);

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -253,8 +253,9 @@ export function parseSystemdShow(output: string): SystemdServiceInfo {
 
 async function execSystemctl(
   args: string[],
+  env?: GatewayServiceEnv,
 ): Promise<{ stdout: string; stderr: string; code: number }> {
-  return await execFileUtf8("systemctl", args);
+  return await execFileUtf8("systemctl", args, env ? { env: { ...process.env, ...env } } : {});
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
@@ -384,6 +385,35 @@ function shouldFallbackToMachineUserScope(detail: string): boolean {
   );
 }
 
+function resolveInferredUserBusEnv(env: GatewayServiceEnv): GatewayServiceEnv | null {
+  const runtimeDir = env.XDG_RUNTIME_DIR?.trim();
+  const busAddress = env.DBUS_SESSION_BUS_ADDRESS?.trim();
+  if (runtimeDir && busAddress) {
+    return null;
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (typeof uid !== "number" || !Number.isInteger(uid) || uid < 0) {
+    return null;
+  }
+  const nextRuntimeDir = runtimeDir || `/run/user/${uid}`;
+  const nextBusAddress = busAddress || `unix:path=${path.posix.join(nextRuntimeDir, "bus")}`;
+  return {
+    ...env,
+    XDG_RUNTIME_DIR: nextRuntimeDir,
+    DBUS_SESSION_BUS_ADDRESS: nextBusAddress,
+  };
+}
+
+function shouldRetryDirectUserScopeWithInferredBus(
+  detail: string,
+  env: GatewayServiceEnv,
+): GatewayServiceEnv | null {
+  if (!shouldFallbackToMachineUserScope(detail)) {
+    return null;
+  }
+  return resolveInferredUserBusEnv(env);
+}
+
 async function execSystemctlUser(
   env: GatewayServiceEnv,
   args: string[],
@@ -395,25 +425,37 @@ async function execSystemctlUser(
   if (sudoUser && sudoUser !== "root" && machineUser) {
     const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
     if (machineScopeArgs.length > 0) {
-      return await execSystemctl([...machineScopeArgs, ...args]);
+      return await execSystemctl([...machineScopeArgs, ...args], env);
     }
   }
 
-  const directResult = await execSystemctl([...resolveSystemctlDirectUserScopeArgs(), ...args]);
+  const directArgs = [...resolveSystemctlDirectUserScopeArgs(), ...args];
+  const directResult = await execSystemctl(directArgs, env);
   if (directResult.code === 0) {
     return directResult;
   }
 
   const detail = `${directResult.stderr} ${directResult.stdout}`.trim();
-  if (!machineUser || !shouldFallbackToMachineUserScope(detail)) {
-    return directResult;
+  const inferredUserBusEnv = shouldRetryDirectUserScopeWithInferredBus(detail, env);
+  if (inferredUserBusEnv) {
+    const inferredUserBusResult = await execSystemctl(directArgs, inferredUserBusEnv);
+    if (inferredUserBusResult.code === 0) {
+      return inferredUserBusResult;
+    }
+    const inferredDetail = `${inferredUserBusResult.stderr} ${inferredUserBusResult.stdout}`.trim();
+    if (!machineUser || !shouldFallbackToMachineUserScope(inferredDetail)) {
+      return inferredUserBusResult;
+    }
   }
 
   const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
   if (machineScopeArgs.length === 0) {
     return directResult;
   }
-  return await execSystemctl([...machineScopeArgs, ...args]);
+  if (!machineUser || !shouldFallbackToMachineUserScope(detail)) {
+    return directResult;
+  }
+  return await execSystemctl([...machineScopeArgs, ...args], env);
 }
 
 export async function isSystemdUserServiceAvailable(


### PR DESCRIPTION
## Summary
This PR ships two reliability fixes and tests:

1. **Daemon/systemd fallback hardening**
   - When `systemctl --user` fails, infer and set `DBUS_SESSION_BUS_ADDRESS=/run/user/<uid>/bus` first.
   - Retry `systemctl --user` with that environment **before** falling back to `--machine`.
   - Improves stability on hosts where `--machine` is unavailable but user bus is valid.

2. **Cron store migration false-positive fix**
   - Migration no longer repeatedly re-flags payloads where `payload.kind` is already canonical.
   - Prevents persistent noise/false warnings on subsequent runs.

## Tests included
- `src/daemon/systemd.test.ts`
- `src/cron/store-migration.test.ts`

## Changed files
- `src/daemon/systemd.ts`
- `src/daemon/systemd.test.ts`
- `src/cron/store-migration.ts`
- `src/cron/store-migration.test.ts`