### PR TITLE
fix: prefer plugin manifest ids for package discovery

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -151,6 +151,36 @@ describe("discoverOpenClawPlugins", () => {
     expect(ids).toContain("pack/two");
   });
 
+  it("prefers plugin manifest ids over npm package names", async () => {
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions", "type-pack");
+    fs.mkdirSync(path.join(globalExt, "src"), { recursive: true });
+
+    writePluginPackageManifest({
+      packageDir: globalExt,
+      packageName: "@type-dot-com/type-openclaw-plugin",
+      extensions: ["./src/index.ts"],
+    });
+    fs.writeFileSync(
+      path.join(globalExt, "openclaw.plugin.json"),
+      JSON.stringify({ id: "type", configSchema: { type: "object" } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(globalExt, "src", "index.ts"),
+      "export default function () {}",
+      "utf-8",
+    );
+
+    const { candidates } = await withStateDir(stateDir, async () => {
+      return discoverOpenClawPlugins({});
+    });
+
+    const ids = candidates.map((c) => c.idHint);
+    expect(ids).toContain("type");
+    expect(ids).not.toContain("type-openclaw-plugin");
+  });
+
   it("derives unscoped ids for scoped packages", async () => {
     const stateDir = makeTempDir();
     const globalExt = path.join(stateDir, "extensions", "voice-call-pack");

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -6,6 +6,7 @@ import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import {
   DEFAULT_PLUGIN_ENTRY_CANDIDATES,
   getPackageManifestMetadata,
+  loadPluginManifest,
   resolvePackageExtensionEntries,
   type OpenClawPackageManifest,
   type PackageManifest,
@@ -298,10 +299,21 @@ function readPackageManifest(dir: string, rejectHardlinks = true): PackageManife
 
 function deriveIdHint(params: {
   filePath: string;
+  rootDir: string;
   packageName?: string;
   hasMultipleExtensions: boolean;
+  rejectHardlinks?: boolean;
 }): string {
   const base = path.basename(params.filePath, path.extname(params.filePath));
+  const manifestResult = loadPluginManifest(params.rootDir, params.rejectHardlinks ?? true);
+  const manifestId = manifestResult.ok ? manifestResult.manifest.id.trim() : "";
+  if (manifestId) {
+    if (!params.hasMultipleExtensions) {
+      return manifestId;
+    }
+    return `${manifestId}/${base}`;
+  }
+
   const rawPackageName = params.packageName?.trim();
   if (!rawPackageName) {
     return base;
@@ -463,8 +475,10 @@ function discoverInDirectory(params: {
           seen: params.seen,
           idHint: deriveIdHint({
             filePath: resolved,
+            rootDir: fullPath,
             packageName: manifest?.name,
             hasMultipleExtensions: extensions.length > 1,
+            rejectHardlinks,
           }),
           source: resolved,
           rootDir: fullPath,
@@ -566,8 +580,10 @@ function discoverFromPath(params: {
           seen: params.seen,
           idHint: deriveIdHint({
             filePath: source,
+            rootDir: resolved,
             packageName: manifest?.name,
             hasMultipleExtensions: extensions.length > 1,
+            rejectHardlinks,
           }),
           source,
           rootDir: resolved,

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -47,6 +47,13 @@ function countDuplicateWarnings(registry: ReturnType<typeof loadPluginManifestRe
   ).length;
 }
 
+function countIdMismatchWarnings(registry: ReturnType<typeof loadPluginManifestRegistry>): number {
+  return registry.diagnostics.filter(
+    (diagnostic) =>
+      diagnostic.level === "warn" && diagnostic.message?.includes("plugin id mismatch"),
+  ).length;
+}
+
 function prepareLinkedManifestFixture(params: { id: string; mode: "symlink" | "hardlink" }): {
   rootDir: string;
   linked: boolean;
@@ -130,6 +137,21 @@ afterEach(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
+  it("does not emit id mismatch warnings when candidate hint already matches manifest id", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "type", configSchema: { type: "object" } });
+
+    const registry = loadRegistry([
+      createPluginCandidate({
+        idHint: "type",
+        rootDir: dir,
+        origin: "global",
+      }),
+    ]);
+
+    expect(countIdMismatchWarnings(registry)).toBe(0);
+  });
+
   it("emits duplicate warning for truly distinct plugins with same id", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();


### PR DESCRIPTION
## Summary
- prefer `openclaw.plugin.json` manifest ids over npm package names when deriving package plugin discovery hints
- keep descriptive npm package names (for example `@type-dot-com/type-openclaw-plugin`) while allowing ergonomic plugin/channel ids like `type`
- add regression coverage for package discovery and manifest registry warning behavior

## Why
OpenClaw already treats the plugin manifest id as canonical during npm plugin install, but discovery still derived `idHint` from the npm package name. That caused warnings like:

```
plugin id mismatch (manifest uses "type", entry hints "type-openclaw-plugin")
```

for valid plugins whose npm package name is intentionally more descriptive than the plugin id.

## Changes
- update `src/plugins/discovery.ts` to prefer `loadPluginManifest(...).manifest.id` when present
- fall back to existing package-name/file-name behavior when no manifest id is available
- add tests covering a package named `@type-dot-com/type-openclaw-plugin` with manifest id `type`

## Verification
- `corepack pnpm exec vitest run --config vitest.unit.config.ts src/plugins/discovery.test.ts src/plugins/manifest-registry.test.ts`
- verified locally in a forked OpenClaw build that the Type plugin warning no longer appears while the plugin still loads normally
