### PR TITLE
fix(slack): prevent streaming preview from showing only final chunk

### DIFF
--- a/src/slack/draft-stream.test.ts
+++ b/src/slack/draft-stream.test.ts
@@ -122,6 +122,19 @@ describe("createSlackDraftStream", () => {
     expect(remove).not.toHaveBeenCalled();
   });
 
+  it("waitForInFlight resolves after in-flight send completes", async () => {
+    const { stream, send } = createDraftStreamHarness();
+
+    stream.update("hello");
+    await stream.flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+
+    // After flush, in-flight is settled — waitForInFlight should resolve immediately.
+    await stream.waitForInFlight();
+    expect(stream.messageId()).toBe("111.222");
+  });
+
   it("clear warns when cleanup fails", async () => {
     const remove = vi.fn<DraftRemoveFn>(async () => {
       throw new Error("cleanup failed");

--- a/src/slack/draft-stream.test.ts
+++ b/src/slack/draft-stream.test.ts
@@ -122,16 +122,34 @@ describe("createSlackDraftStream", () => {
     expect(remove).not.toHaveBeenCalled();
   });
 
-  it("waitForInFlight resolves after in-flight send completes", async () => {
-    const { stream, send } = createDraftStreamHarness();
+  it("waitForInFlight resolves only after a concurrent in-flight send completes", async () => {
+    let resolveSend!: () => void;
+    const slowSend = vi.fn<DraftSendFn>(
+      () =>
+        new Promise<{ channelId: string; messageId: string }>((resolve) => {
+          resolveSend = () => resolve({ channelId: "C123", messageId: "111.222" });
+        }),
+    );
+    const { stream } = createDraftStreamHarness({ send: slowSend });
 
     stream.update("hello");
-    await stream.flush();
+    void stream.flush(); // kick off the in-flight send without awaiting
 
-    expect(send).toHaveBeenCalledTimes(1);
+    stream.stop(); // stop the loop while the send is still pending
+    const waitPromise = stream.waitForInFlight();
 
-    // After flush, in-flight is settled — waitForInFlight should resolve immediately.
-    await stream.waitForInFlight();
+    let resolved = false;
+    void waitPromise.then(() => {
+      resolved = true;
+    });
+
+    // Not yet resolved — send is still in flight
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    resolveSend(); // complete the in-flight send
+    await waitPromise;
+    expect(resolved).toBe(true);
     expect(stream.messageId()).toBe("111.222");
   });
 

--- a/src/slack/draft-stream.ts
+++ b/src/slack/draft-stream.ts
@@ -11,6 +11,7 @@ export type SlackDraftStream = {
   clear: () => Promise<void>;
   stop: () => void;
   forceNewMessage: () => void;
+  waitForInFlight: () => Promise<void>;
   messageId: () => string | undefined;
   channelId: () => string | undefined;
 };
@@ -134,6 +135,7 @@ export function createSlackDraftStream(params: {
     clear,
     stop,
     forceNewMessage,
+    waitForInFlight: loop.waitForInFlight,
     messageId: () => streamMessageId,
     channelId: () => streamChannelId,
   };

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -306,6 +306,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       const draftChannelId = draftStream?.channelId();
       const finalText = payload.text;
       const canFinalizeViaPreviewEdit =
+        !previewEditDone &&
         previewStreamingEnabled &&
         streamMode !== "status_final" &&
         mediaCount === 0 &&
@@ -317,6 +318,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
       if (canFinalizeViaPreviewEdit) {
         draftStream?.stop();
+        await draftStream?.waitForInFlight();
         try {
           await ctx.app.client.chat.update({
             token: ctx.botToken,
@@ -324,6 +326,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             ts: draftMessageId,
             text: normalizeSlackOutboundText(finalText.trim()),
           });
+          previewEditDone = true;
+          replyPlan.markSent();
           return;
         } catch (err) {
           logVerbose(
@@ -375,6 +379,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     warn: logVerbose,
   });
   let hasStreamedMessage = false;
+  let previewEditDone = false;
   const streamMode = slackStreaming.draftMode;
   let appendRenderedText = "";
   let appendSourceText = "";


### PR DESCRIPTION
## Summary

- Problem: Slack streaming messages only show the last ~100-200 words instead of the complete response for long messages (500+ words). Refreshing Slack reveals the full content.
- Why it matters: 100% reproducible for long responses, making real-time Slack replies unreadable. Users must refresh every time.
- What changed: Fixed two bugs in the `canFinalizeViaPreviewEdit` path in `dispatch.ts`. Added `waitForInFlight` to `SlackDraftStream` so callers can drain in-flight requests before the final edit.
- What did NOT change: The draft stream loop, throttle mechanism, streaming modes, and normal delivery path are untouched.

### Root cause

Two issues in the preview-edit finalization path (`dispatch.ts:318-327`):

1. **Race condition**: `draftStream.stop()` cancels timers and rejects new updates but does NOT wait for any in-flight `chat.update` call from the draft stream loop. The final `chat.update` (with full text) could race with a partial update still in flight. If the partial update resolves last on the Slack client, the message renders with stale partial content.

2. **Block delivery overwrite**: When block streaming produces multiple `deliver` callbacks (one per block), each call passed the `canFinalizeViaPreviewEdit` check and edited the same draft message with only that block's text. Previous blocks were overwritten, leaving only the last block visible (~100-200 words).

### Fix

- Expose `waitForInFlight()` from `SlackDraftStream` (delegates to the existing `loop.waitForInFlight`).
- Await it before the final `chat.update` to ensure no partial update races.
- Add a `previewEditDone` guard so preview edit runs at most once per dispatch. Subsequent block deliveries fall through to `deliverNormally` which sends them as separate messages.
- Call `replyPlan.markSent()` after a successful preview edit for consistent delivery tracking.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42200

## User-visible / Behavior Changes

Slack streaming previews now show the complete response text instead of only the final chunk. No config changes needed.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same chat.update, just correctly ordered)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime/container: Node 22+
- Model/provider: Any model producing 500+ word responses
- Integration/channel: Slack (Socket Mode or Events API)

### Steps

1. Configure OpenClaw with Slack channel, streaming enabled (default)
2. Send a message that triggers a long response (500+ words)
3. Watch the streaming preview in Slack

### Expected

Full response text visible during and after streaming.

### Actual (before fix)

Only last ~100-200 words visible. Full content appears only after refreshing Slack.

## Evidence

- [x] Failing test/log before + passing after

All 8 tests in `draft-stream.test.ts` pass including the new `waitForInFlight` test. Build and format pass cleanly.

## Human Verification (required)

- Verified scenarios: `pnpm build` passes, `pnpm format` passes, `vitest run src/slack/draft-stream.test.ts` passes (8/8). Traced the full code path from `onPartialReply` through `updateDraftFromPartial`, draft stream loop, `sendOrEditStreamMessage`, and the `canFinalizeViaPreviewEdit` finalization path.
- Edge cases checked: Draft stream stopped from maxChars limit (messageId persists, final edit still works). Multiple block deliveries (second delivery falls through to deliverNormally). Empty final reply after block (skipped correctly).
- What I did **not** verify: Live Slack instance with real streaming. The changes are minimal and the control flow is clear, but end-to-end testing on a running gateway would confirm.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit. Streaming preview goes back to previous behavior.
- Files/config to restore: None
- Known bad symptoms: If `waitForInFlight` somehow hangs, the final delivery would stall. Unlikely since it awaits the same promise the draft stream loop already manages.

## Risks and Mitigations

- Risk: `waitForInFlight` adds a small delay before the final edit (waiting for the last draft update to complete).
  - Mitigation: This is at most one throttle window (~1s). The user experience improvement far outweighs the minor delay.

---

This PR was AI-assisted (Claude). I understand what the code does and have verified tests, build, and formatting pass.