### PR TITLE
fix(config): guard non-string values in env.vars to prevent TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Channels/Telegram: persist native command metadata on target sessions so topic, helper, and ACP-bound slash commands keep their session metadata attached to the routed conversation. (#57548) Thanks @GaosCode.
 - Channels/native commands: keep validated native slash command replies visible in group chats while preserving explicit owner allowlists for command authorization. (#73672) Thanks @obviyus.
 - Auto-reply/session: carry the tail of user/assistant turns into the freshly-rotated transcript on silent in-reply session resets (compaction failure, role-ordering conflict) so direct-chat continuity survives the rebind. Fixes #70853. (#70898) Thanks @neeravmakwana.
+- Config: skip malformed non-string `env.vars` entries before env-reference checks, so config loading no longer crashes on JSON values like numbers or booleans. (#42402) Thanks @MiltonHeYan.
 
 ## 2026.4.27
 

--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -20,7 +20,7 @@ function collectConfigEnvVarsByTarget(cfg?: OpenClawConfig): Record<string, stri
 
   if (envConfig.vars) {
     for (const [rawKey, value] of Object.entries(envConfig.vars)) {
-      if (!value) {
+      if (typeof value !== "string" || !value.trim()) {
         continue;
       }
       const key = normalizeEnvVarKey(rawKey, { portable: true });

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -35,6 +35,25 @@ describe("config env vars", () => {
     });
   });
 
+  it("skips non-string env.vars values from runtime JSON configs", async () => {
+    await withEnvOverride({ API_TOKEN: undefined, PORT: undefined, DEBUG: undefined }, async () => {
+      const cfg = JSON.parse(`{
+        "env": {
+          "vars": {
+            "API_TOKEN": "sk-test-123",
+            "PORT": 8080,
+            "DEBUG": true
+          }
+        }
+      }`);
+
+      expect(() => applyConfigEnvVars(cfg)).not.toThrow();
+      expect(process.env.API_TOKEN).toBe("sk-test-123");
+      expect(process.env.PORT).toBeUndefined();
+      expect(process.env.DEBUG).toBeUndefined();
+    });
+  });
+
   it("can build a merged runtime env without mutating process.env", async () => {
     await withEnvOverride({ OPENROUTER_API_KEY: undefined }, async () => {
       const merged = createConfigRuntimeEnv({


### PR DESCRIPTION
## Summary

Fixes #42363

`collectConfigEnvVarsByTarget` iterates `env.vars` entries without a type guard, so numeric/boolean JSON values (e.g. `"PORT": 8080`) reach `containsEnvVarReference` and crash on `.includes()`.

Added `typeof value !== "string"` check to match the existing guard on line 41 for top-level env entries.

## Test plan

- Added regression test that passes mixed-type `env.vars` to `applyConfigEnvVars`
- `pnpm test -- --run src/config/env-vars.test.ts src/config/env-substitution.test.ts` passes