### PR TITLE
fix: avoid manual isolated cron.run lane deadlock

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
-import { clearCommandLane, setCommandLaneConcurrency } from "../process/command-queue.js";
+import {
+  clearCommandLane,
+  enqueueCommandInLane,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import * as schedule from "./schedule.js";
 import {
@@ -23,7 +27,7 @@ import {
   createRunningCronServiceState,
 } from "./service.test-harness.js";
 import { computeJobNextRunAtMs } from "./service/jobs.js";
-import { enqueueRun, run } from "./service/ops.js";
+import { enqueueRun, MANUAL_CRON_RUN_LANE, run } from "./service/ops.js";
 import { createCronServiceState, type CronEvent } from "./service/state.js";
 import {
   DEFAULT_JOB_TIMEOUT_MS,
@@ -1495,6 +1499,7 @@ describe("Cron issue regressions", () => {
   it("queues manual cron.run requests behind the cron execution lane", async () => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(MANUAL_CRON_RUN_LANE);
     setCommandLaneConcurrency(CommandLane.Cron, 1);
 
     const store = makeStorePath();
@@ -1566,11 +1571,57 @@ describe("Cron issue regressions", () => {
     });
 
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(MANUAL_CRON_RUN_LANE);
+  });
+
+  it("manual isolated cron.run does not deadlock when inner execution uses the cron lane", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(MANUAL_CRON_RUN_LANE);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+
+    const store = makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:02.500Z");
+    const job = createDueIsolatedJob({ id: "manual-inner-cron", nowMs: dueAt, nextRunAtMs: dueAt });
+    await fs.writeFile(store.storePath, JSON.stringify({ version: 1, jobs: [job] }), "utf-8");
+
+    let now = dueAt;
+    const runIsolatedAgentJob = vi.fn(
+      async () =>
+        await enqueueCommandInLane(CommandLane.Cron, async () => {
+          now += 10;
+          return { status: "ok" as const, summary: "inner cron lane finished" };
+        }),
+    );
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      cronConfig: { maxConcurrentRuns: 1 },
+      log: createNoopLogger(),
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    const ack = await enqueueRun(state, job.id, "force");
+    expect(ack).toEqual({ ok: true, enqueued: true, runId: expect.any(String) });
+
+    await vi.waitFor(() => {
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      const stored = state.store?.jobs.find((entry) => entry.id === job.id);
+      expect(stored?.state.lastStatus).toBe("ok");
+      expect(stored?.state.runningAtMs).toBeUndefined();
+    });
+
+    clearCommandLane(CommandLane.Cron);
+    clearCommandLane(MANUAL_CRON_RUN_LANE);
   });
 
   it("logs unexpected queued manual run background failures once", async () => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(MANUAL_CRON_RUN_LANE);
     setCommandLaneConcurrency(CommandLane.Cron, 1);
 
     const dueAt = Date.parse("2026-02-06T10:05:03.000Z");
@@ -1594,6 +1645,7 @@ describe("Cron issue regressions", () => {
     );
 
     clearCommandLane(CommandLane.Cron);
+    clearCommandLane(MANUAL_CRON_RUN_LANE);
   });
 
   // Regression: isolated cron runs must not abort at 1/3 of configured timeoutSeconds.

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -47,6 +47,13 @@ export type CronListPageResult = {
   hasMore: boolean;
   nextOffset: number | null;
 };
+
+// Manual `cron.run` requests already reserve the job under the cron service lock
+// before dispatching the actual execution. Queue them on a dedicated outer lane
+// so isolated cron runs can still use the global `cron` lane internally without
+// recursively enqueuing onto the same lane and deadlocking.
+export const MANUAL_CRON_RUN_LANE = `${CommandLane.Cron}:manual`;
+
 function mergeManualRunSnapshotAfterReload(params: {
   state: CronServiceState;
   jobId: string;
@@ -532,7 +539,7 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
 
   const runId = `manual:${id}:${state.deps.nowMs()}:${nextManualRunId++}`;
   void enqueueCommandInLane(
-    CommandLane.Cron,
+    MANUAL_CRON_RUN_LANE,
     async () => {
       const result = await run(state, id, mode);
       if (result.ok && "ran" in result && !result.ran) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: manual `cron.run` for isolated cron jobs could get stuck in `running` forever while the same job still succeeded on normal scheduled execution.
- Why it matters: WebUI/CLI manual triggers became unreliable for isolated cron jobs even though the underlying job payload and provider connectivity were fine.
- What changed: manual `cron.run` requests now queue on a dedicated outer manual-cron lane instead of the inner global `cron` worker lane, so isolated runs can still enqueue their actual agent execution on the global `cron` lane without self-deadlocking.
- What did NOT change (scope boundary): scheduled cron execution, isolated cron worker lane behavior, delivery logic, and timeout policy remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Manual `cron.run` / WebUI “Run” for isolated cron jobs no longer wedges the job in `running` due to recursive self-enqueue on the `cron` lane.
- No config/default changes.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (reproduced on Darwin 25.x)
- Runtime/container: local Gateway / Control UI
- Model/provider: not provider-specific; reproduced before model execution completed
- Integration/channel (if any): WebUI manual run and CLI `cron.run`
- Relevant config (redacted): isolated cron job (`sessionTarget: "isolated"`), default `cron.maxConcurrentRuns=1`

### Steps

1. Create an isolated cron job (`payload.kind="agentTurn"`).
2. Trigger it manually via WebUI “Run” or `cron.run`.
3. Observe the job enter `running` and never finish, while the same job still succeeds when fired by the scheduler.

### Expected

- Manual `cron.run` should enqueue and complete the isolated job, clearing `runningAtMs`.

### Actual

- Manual `cron.run` could occupy the outer `cron` lane and then deadlock when the inner isolated agent execution also tried to enqueue onto the same `cron` lane.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added a regression test that simulates manual `cron.run` dispatching an isolated job whose inner execution also enqueues on `CommandLane.Cron`.
  - Verified the targeted cron regression suite passes.
  - Verified targeted gateway `cron.run` server tests still pass.
- Edge cases checked:
  - queued manual runs still serialize cleanly
  - busy job still returns `already-running`
  - non-due job still returns `not-due`
- What you did **not** verify:
  - live external channel delivery on a real messaging target
  - a full end-to-end repro through an actual browser session in this checkout

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit
- Files/config to restore: `src/cron/service/ops.ts`, `src/cron/service.issue-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
  - manual isolated `cron.run` requests no longer queue/serialize as expected
  - unexpected overlap between manual runs

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: manual `cron.run` now uses a dedicated outer lane instead of the shared inner `cron` worker lane.
  - Mitigation: the actual isolated execution still uses the existing `cron` worker lane; per-job `runningAtMs` guards remain intact; regression coverage now explicitly exercises both manual queueing and the former deadlock case.
