### PR TITLE
Tests/docs: clarify profile and subagent allow semantics for browser and web tools

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1521,6 +1521,7 @@ Environment alternatives:
 Notes:
 
 - If you use allowlists, add `web_search`/`web_fetch` or `group:web`.
+- `tools.profile` runs before later allowlists. If a profile excluded web tools, use `tools.alsoAllow` to add them; `tools.allow` and `tools.subagents.tools.allow` do not restore tools filtered out earlier by the profile.
 - `web_fetch` is enabled by default (unless explicitly disabled).
 - Daemons read env vars from `~/.openclaw/.env` (or the service environment).
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -272,6 +272,13 @@ Override via config:
 }
 ```
 
+Notes:
+
+- `tools.profile` runs before `tools.subagents.tools`. If a profile already removed a tool, a later `tools.subagents.tools.allow` entry does not restore it.
+- `tools.subagents.tools.allow` is allow-only. Use it when you want a tight sub-agent subset.
+- To add tools on top of a profile, use `tools.alsoAllow` or `agents.list[].tools.alsoAllow`.
+- To re-enable tools from the default sub-agent denylist without switching to allow-only mode, use `tools.subagents.tools.alsoAllow`.
+
 ## Concurrency
 
 Sub-agents use a dedicated in-process queue lane:

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -385,4 +385,5 @@ Notes:
 - See [Firecrawl](/tools/firecrawl) for key setup and service details.
 - Responses are cached (default 15 minutes) to reduce repeated fetches.
 - If you use tool profiles/allowlists, add `web_search`/`web_fetch` or `group:web`.
+- `tools.profile` runs before later allowlists. If a profile filtered out `web_search`/`web_fetch`, add them with `tools.alsoAllow` instead of expecting `tools.allow` or `tools.subagents.tools.allow` to restore them later.
 - If the API key is missing, `web_search` returns a short setup hint with a docs link.

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import "./test-helpers/fast-coding-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import { findUnsupportedSchemaKeywords } from "./pi-embedded-runner/google.js";
@@ -395,6 +396,53 @@ describe("createOpenClawCodingTools", () => {
       },
     });
     expect(tools.map((tool) => tool.name)).toEqual(["read"]);
+  });
+
+  it("does not let subagent allow restore browser removed by the coding profile", () => {
+    const tools = createOpenClawCodingTools({
+      sessionKey: "agent:main:subagent:issue-41577",
+      config: {
+        tools: {
+          profile: "coding",
+          subagents: {
+            tools: {
+              allow: ["read", "write", "edit", "browser", "web_search", "web_fetch"],
+            },
+          },
+        },
+      },
+    });
+    const names = new Set(tools.map((tool) => tool.name));
+    expect(names.has("read")).toBe(true);
+    expect(names.has("write")).toBe(true);
+    expect(names.has("edit")).toBe(true);
+    expect(names.has("browser")).toBe(false);
+  });
+
+  it("uses tools.alsoAllow to add browser on top of the coding profile", () => {
+    const config = {
+      tools: {
+        profile: "coding",
+        alsoAllow: ["browser", "web_search", "web_fetch"],
+      },
+    } as const satisfies OpenClawConfig;
+    const mainNames = new Set(
+      createOpenClawCodingTools({
+        sessionKey: "agent:main:main",
+        config,
+      }).map((tool) => tool.name),
+    );
+    const subagentNames = new Set(
+      createOpenClawCodingTools({
+        sessionKey: "agent:main:subagent:issue-41577-also-allow",
+        config,
+      }).map((tool) => tool.name),
+    );
+
+    for (const names of [mainNames, subagentNames]) {
+      expect(names.has("read")).toBe(true);
+      expect(names.has("browser")).toBe(true);
+    }
   });
 
   it("applies tool profiles before allow/deny policies", () => {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -3,10 +3,12 @@ import type { OpenClawConfig } from "../config/config.js";
 import {
   filterToolsByPolicy,
   isToolAllowedByPolicyName,
+  isToolAllowedByPolicies,
   resolveEffectiveToolPolicy,
   resolveSubagentToolPolicy,
 } from "./pi-tools.policy.js";
 import { createStubTool } from "./test-helpers/pi-tool-stubs.js";
+import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js";
 
 describe("pi-tools.policy", () => {
   it("treats * in allow as allow-all", () => {
@@ -89,6 +91,57 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     } as unknown as OpenClawConfig;
     const policy = resolveSubagentToolPolicy(cfg, 1);
     expect(isToolAllowedByPolicyName("sessions_send", policy)).toBe(false);
+  });
+
+  it("does not let subagent allow restore browser or web tools removed by the coding profile", () => {
+    const cfg = {
+      agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },
+      tools: {
+        profile: "coding",
+        subagents: {
+          tools: {
+            allow: ["read", "write", "edit", "browser", "web_search", "web_fetch"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const profilePolicy = resolveToolProfilePolicy("coding");
+    const subagentPolicy = resolveSubagentToolPolicy(cfg, 1);
+    expect(isToolAllowedByPolicies("read", [profilePolicy, subagentPolicy])).toBe(true);
+    expect(isToolAllowedByPolicies("browser", [profilePolicy, subagentPolicy])).toBe(false);
+    expect(isToolAllowedByPolicies("web_search", [profilePolicy, subagentPolicy])).toBe(false);
+    expect(isToolAllowedByPolicies("web_fetch", [profilePolicy, subagentPolicy])).toBe(false);
+  });
+
+  it("uses alsoAllow to add browser and web tools on top of the coding profile", () => {
+    const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy("coding"), [
+      "browser",
+      "web_search",
+      "web_fetch",
+    ]);
+    const subagentPolicy = resolveSubagentToolPolicy(baseCfg, 1);
+    expect(isToolAllowedByPolicies("browser", [profilePolicy, subagentPolicy])).toBe(true);
+    expect(isToolAllowedByPolicies("web_search", [profilePolicy, subagentPolicy])).toBe(true);
+    expect(isToolAllowedByPolicies("web_fetch", [profilePolicy, subagentPolicy])).toBe(true);
+  });
+
+  it("keeps deny precedence for browser and web tools even when allow and alsoAllow match", () => {
+    const cfg = {
+      agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },
+      tools: {
+        subagents: {
+          tools: {
+            allow: ["browser", "web_search"],
+            alsoAllow: ["browser", "web_fetch"],
+            deny: ["browser", "web_fetch"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const policy = resolveSubagentToolPolicy(cfg, 1);
+    expect(isToolAllowedByPolicyName("browser", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("web_fetch", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("web_search", policy)).toBe(true);
   });
 
   it("does not create a restrictive allowlist when only alsoAllow is configured", () => {


### PR DESCRIPTION
## Summary

This PR adds characterization tests and small docs clarifications for the current tool-policy behavior behind #41577.

It does not change runtime semantics.

## What changed

- added final tool-surface tests around `createOpenClawCodingTools()`
- added policy-level tests covering:
  - `tools.profile` filtering first
  - `coding` not including `browser`, `web_search`, or `web_fetch`
  - `tools.subagents.tools.allow` being allow-only
  - additive behavior using `alsoAllow`
  - `deny` still winning over `allow` / `alsoAllow`
- clarified the same semantics in:
  - `docs/tools/subagents.md`
  - `docs/tools/web.md`
  - `docs/help/faq.md`

## Why

#41577 initially looks like a subagent runtime/tool-registration bug, but the current behavior is better explained by tool-policy semantics and filter order:

- `tools.profile` runs first
- `coding` does not include `browser`, `web_search`, or `web_fetch`
- `tools.subagents.tools.allow` is allow-only, not additive
- additive expansion should use `alsoAllow`
- `deny` remains highest priority

This PR makes that behavior explicit in tests and docs so it is easier to understand and less likely to be misread from config shape alone.

## Validation

```bash
pnpm vitest run src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts src/agents/pi-tools.policy.test.ts
pnpm check