### PR TITLE
feat: add Langfuse tracing on fresh main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1269,6 +1269,9 @@
     "@matrix-org/matrix-sdk-crypto-nodejs": "^0.4.0",
     "openshell": "0.1.0"
   },
+  "optionalDependencies": {
+    "langfuse": "^3.38.6"
+  },
   "engines": {
     "node": ">=22.14.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,12 +239,9 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/browser-playwright@4.1.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@matrix-org/matrix-sdk-crypto-nodejs':
-        specifier: ^0.4.0
-        version: 0.4.0
-      openshell:
-        specifier: 0.1.0
-        version: 0.1.0
+      langfuse:
+        specifier: ^3.38.6
+        version: 3.38.6
 
   extensions/acpx:
     dependencies:
@@ -3373,9 +3370,6 @@ packages:
   '@swc/helpers@0.5.20':
     resolution: {integrity: sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==}
 
-  '@telegraf/types@7.1.0':
-    resolution: {integrity: sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==}
-
   '@thi.ng/bitstream@2.4.44':
     resolution: {integrity: sha512-SN5GtdycUC8J9kRn4+GAcAJ93F9vKtaiI/SjpOyLl911bWNlF8gANFFCdgBkzbF2DHcpKflHxrVVfrYB6aCdsw==}
     engines: {node: '>=18'}
@@ -3960,20 +3954,11 @@ packages:
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
-  buffer-alloc-unsafe@1.1.0:
-    resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
-
-  buffer-alloc@1.2.0:
-    resolution: {integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==}
-
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
-  buffer-fill@1.0.0:
-    resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -4273,10 +4258,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -4991,6 +4972,14 @@ packages:
   koffi@2.15.2:
     resolution: {integrity: sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==}
 
+  langfuse-core@3.38.6:
+    resolution: {integrity: sha512-EcZXa+DK9FJdi1I30+u19eKjuBJ04du6j2Nybk19KKCuraLczg/ppkTQcGvc4QOk//OAi3qUHrajUuV74RXsBQ==}
+    engines: {node: '>=18'}
+
+  langfuse@3.38.6:
+    resolution: {integrity: sha512-mtwfsNGIYvObRh+NYNGlJQJDiBN+Wr3Hnr++wN25mxuOpSTdXX+JQqVCyAqGL5GD2TAXRZ7COsN42Vmp9krYmg==}
+    engines: {node: '>=18'}
+
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
@@ -5315,10 +5304,6 @@ packages:
   mpg123-decoder@1.0.3:
     resolution: {integrity: sha512-+fjxnWigodWJm3+4pndi+KUg9TBojgn31DPk85zEsim7C6s0X5Ztc/hQYdytXkwuGXH+aB0/aEkG40Emukv6oQ==}
 
-  mri@1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -5329,6 +5314,10 @@ packages:
   music-metadata@11.12.3:
     resolution: {integrity: sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ==}
     engines: {node: '>=18'}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -5502,11 +5491,6 @@ packages:
       zod:
         optional: true
 
-  openshell@0.1.0:
-    resolution: {integrity: sha512-B7jLewH+d73hraWcrSFgNOjvd+frW5JPejkTpqgj2EJBjX/Yk1Y4blgP5pDl4FwrBxfmwsTKR08Uwgrdo+xpSg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
 
@@ -5563,10 +5547,6 @@ packages:
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
-
-  p-timeout@4.1.0:
-    resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
-    engines: {node: '>=10'}
 
   p-timeout@7.0.1:
     resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
@@ -5986,19 +5966,12 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  safe-compare@1.1.4:
-    resolution: {integrity: sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==}
-
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  sandwich-stream@2.0.2:
-    resolution: {integrity: sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==}
-    engines: {node: '>= 0.10'}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -6287,11 +6260,6 @@ packages:
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
-
-  telegraf@4.16.3:
-    resolution: {integrity: sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==}
-    engines: {node: ^12.20.0 || >=14.13.1}
-    hasBin: true
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -9899,9 +9867,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@telegraf/types@7.1.0':
-    optional: true
-
   '@thi.ng/bitstream@2.4.44':
     dependencies:
       '@thi.ng/errors': 2.6.6
@@ -10557,21 +10522,9 @@ snapshots:
     dependencies:
       base-x: 5.0.1
 
-  buffer-alloc-unsafe@1.1.0:
-    optional: true
-
-  buffer-alloc@1.2.0:
-    dependencies:
-      buffer-alloc-unsafe: 1.1.0
-      buffer-fill: 1.0.0
-    optional: true
-
   buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
-
-  buffer-fill@1.0.0:
-    optional: true
 
   buffer-from@1.1.2: {}
 
@@ -10853,9 +10806,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  dotenv@16.6.1:
-    optional: true
 
   dotenv@17.3.1: {}
 
@@ -11754,6 +11704,16 @@ snapshots:
   koffi@2.15.2:
     optional: true
 
+  langfuse-core@3.38.6:
+    dependencies:
+      mustache: 4.2.0
+    optional: true
+
+  langfuse@3.38.6:
+    dependencies:
+      langfuse-core: 3.38.6
+    optional: true
+
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
@@ -12044,9 +12004,6 @@ snapshots:
       '@wasm-audio-decoders/common': 9.0.7
     optional: true
 
-  mri@1.2.0:
-    optional: true
-
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -12065,6 +12022,9 @@ snapshots:
       win-guid: 0.2.1
     transitivePeerDependencies:
       - supports-color
+
+  mustache@4.2.0:
+    optional: true
 
   mz@2.7.0:
     dependencies:
@@ -12259,15 +12219,6 @@ snapshots:
       ws: 8.20.0
       zod: 4.3.6
 
-  openshell@0.1.0:
-    dependencies:
-      dotenv: 16.6.1
-      telegraf: 4.16.3
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    optional: true
-
   opus-decoder@0.7.11:
     dependencies:
       '@wasm-audio-decoders/common': 9.0.7
@@ -12368,9 +12319,6 @@ snapshots:
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
-
-  p-timeout@4.1.0:
-    optional: true
 
   p-timeout@7.0.1: {}
 
@@ -12860,17 +12808,9 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  safe-compare@1.1.4:
-    dependencies:
-      buffer-alloc: 1.2.0
-    optional: true
-
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
-
-  sandwich-stream@2.0.2:
-    optional: true
 
   sax@1.6.0: {}
 
@@ -13225,21 +13165,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-
-  telegraf@4.16.3:
-    dependencies:
-      '@telegraf/types': 7.1.0
-      abort-controller: 3.0.0
-      debug: 4.4.3
-      mri: 1.2.0
-      node-fetch: 2.7.0
-      p-timeout: 4.1.0
-      safe-compare: 1.1.4
-      sandwich-stream: 2.0.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    optional: true
 
   text-decoder@1.2.7:
     dependencies:

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { endSubagentSpan, startSubagentSpan } from "../../observability/langfuse-agent-hooks.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { ACP_SPAWN_MODES, ACP_SPAWN_STREAM_TARGETS, spawnAcpDirect } from "../acp-spawn.js";
 import { optionalStringEnum } from "../schema/typebox.js";
@@ -149,17 +150,74 @@ export function createSessionsSpawnTool(
               "attachments are currently unsupported for runtime=acp; use runtime=subagent or remove attachments",
           });
         }
-        const result = await spawnAcpDirect(
+        const acpSpanHandle = startSubagentSpan({
+          agentId: requestedAgentId,
+          task,
+          model: modelOverride,
+        });
+        let acpResult: Awaited<ReturnType<typeof spawnAcpDirect>>;
+        try {
+          acpResult = await spawnAcpDirect(
+            {
+              task,
+              label: label || undefined,
+              agentId: requestedAgentId,
+              resumeSessionId,
+              cwd,
+              mode: mode && ACP_SPAWN_MODES.includes(mode) ? mode : undefined,
+              thread,
+              sandbox,
+              streamTo,
+            },
+            {
+              agentSessionKey: opts?.agentSessionKey,
+              agentChannel: opts?.agentChannel,
+              agentAccountId: opts?.agentAccountId,
+              agentTo: opts?.agentTo,
+              agentThreadId: opts?.agentThreadId,
+              sandboxed: opts?.sandboxed,
+            },
+          );
+        } catch (err) {
+          endSubagentSpan(acpSpanHandle, {
+            status: "error",
+            error: err instanceof Error ? err.message : String(err),
+          });
+          throw err;
+        }
+        endSubagentSpan(acpSpanHandle, {
+          status: acpResult.status,
+          childSessionKey: acpResult.childSessionKey,
+          runId: acpResult.runId,
+        });
+        return jsonResult(acpResult);
+      }
+
+      const subagentSpanHandle = startSubagentSpan({
+        agentId: requestedAgentId,
+        task,
+        model: modelOverride,
+      });
+      let spawnResult: Awaited<ReturnType<typeof spawnSubagentDirect>>;
+      try {
+        spawnResult = await spawnSubagentDirect(
           {
             task,
             label: label || undefined,
             agentId: requestedAgentId,
-            resumeSessionId,
-            cwd,
-            mode: mode && ACP_SPAWN_MODES.includes(mode) ? mode : undefined,
+            model: modelOverride,
+            thinking: thinkingOverrideRaw,
+            runTimeoutSeconds,
             thread,
+            mode,
+            cleanup,
             sandbox,
-            streamTo,
+            expectsCompletionMessage: true,
+            attachments,
+            attachMountPath:
+              params.attachAs && typeof params.attachAs === "object"
+                ? readStringParam(params.attachAs as Record<string, unknown>, "mountPath")
+                : undefined,
           },
           {
             agentSessionKey: opts?.agentSessionKey,
@@ -167,46 +225,27 @@ export function createSessionsSpawnTool(
             agentAccountId: opts?.agentAccountId,
             agentTo: opts?.agentTo,
             agentThreadId: opts?.agentThreadId,
-            sandboxed: opts?.sandboxed,
+            agentGroupId: opts?.agentGroupId,
+            agentGroupChannel: opts?.agentGroupChannel,
+            agentGroupSpace: opts?.agentGroupSpace,
+            requesterAgentIdOverride: opts?.requesterAgentIdOverride,
+            workspaceDir: opts?.workspaceDir,
           },
         );
-        return jsonResult(result);
+      } catch (err) {
+        endSubagentSpan(subagentSpanHandle, {
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
       }
+      endSubagentSpan(subagentSpanHandle, {
+        status: spawnResult.status,
+        childSessionKey: spawnResult.childSessionKey,
+        runId: spawnResult.runId,
+      });
 
-      const result = await spawnSubagentDirect(
-        {
-          task,
-          label: label || undefined,
-          agentId: requestedAgentId,
-          model: modelOverride,
-          thinking: thinkingOverrideRaw,
-          runTimeoutSeconds,
-          thread,
-          mode,
-          cleanup,
-          sandbox,
-          expectsCompletionMessage: true,
-          attachments,
-          attachMountPath:
-            params.attachAs && typeof params.attachAs === "object"
-              ? readStringParam(params.attachAs as Record<string, unknown>, "mountPath")
-              : undefined,
-        },
-        {
-          agentSessionKey: opts?.agentSessionKey,
-          agentChannel: opts?.agentChannel,
-          agentAccountId: opts?.agentAccountId,
-          agentTo: opts?.agentTo,
-          agentThreadId: opts?.agentThreadId,
-          agentGroupId: opts?.agentGroupId,
-          agentGroupChannel: opts?.agentGroupChannel,
-          agentGroupSpace: opts?.agentGroupSpace,
-          requesterAgentIdOverride: opts?.requesterAgentIdOverride,
-          workspaceDir: opts?.workspaceDir,
-        },
-      );
-
-      return jsonResult(result);
+      return jsonResult(spawnResult);
     },
   };
 }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
@@ -19,6 +20,12 @@ import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import {
+  clearRunToolSpans,
+  endModelGeneration,
+  errorModelGeneration,
+  startModelGeneration,
+} from "../../observability/langfuse-agent-hooks.js";
 import { defaultRuntime } from "../../runtime.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import {
@@ -399,13 +406,26 @@ export async function runReplyAgent(params: {
         `Role ordering conflict (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
       cleanupTranscripts: true,
     });
+  // Pre-generate runId so we can clean up tool spans in the finally block even
+  // if runAgentTurnWithFallback throws before returning it.
+  const preGeneratedRunId = opts?.runId ?? crypto.randomUUID();
+  const optsWithRunId = opts ? { ...opts, runId: preGeneratedRunId } : { runId: preGeneratedRunId };
+
+  // Start a Langfuse model generation span before the agent turn.
+  const generationStartedAt = Date.now();
+  const generationHandle = startModelGeneration({
+    provider: followupRun.run.provider,
+    model: followupRun.run.model,
+    prompt: commandBody,
+  });
+
   try {
     const runStartedAt = Date.now();
     const runOutcome = await runAgentTurnWithFallback({
       commandBody,
       followupRun,
       sessionCtx,
-      opts,
+      opts: optsWithRunId,
       typingSignals,
       blockReplyPipeline,
       blockStreamingEnabled,
@@ -426,6 +446,13 @@ export async function runReplyAgent(params: {
     });
 
     if (runOutcome.kind === "final") {
+      // Short-circuit path (e.g. context overflow recovered). End generation with no usage.
+      endModelGeneration(generationHandle, {
+        outputText: runOutcome.payload.text,
+        provider: followupRun.run.provider,
+        model: followupRun.run.model,
+        durationMs: Date.now() - generationStartedAt,
+      });
       return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn);
     }
 
@@ -777,6 +804,20 @@ export async function runReplyAgent(params: {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
     }
 
+    // Close the Langfuse generation span with output and usage data.
+    const outputText = finalPayloads
+      .map((p) => (typeof p.text === "string" ? p.text : ""))
+      .filter(Boolean)
+      .join("\n");
+    endModelGeneration(generationHandle, {
+      outputText: outputText || undefined,
+      provider: providerUsed,
+      model: modelUsed,
+      durationMs: Date.now() - generationStartedAt,
+      usage,
+      fallbackAttemptCount: fallbackAttempts.length,
+    });
+
     return finalizeWithFollowup(
       finalPayloads.length === 1 ? finalPayloads[0] : finalPayloads,
       queueKey,
@@ -786,8 +827,11 @@ export async function runReplyAgent(params: {
     // Keep the followup queue moving even when an unexpected exception escapes
     // the run path; the caller still receives the original error.
     finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+    errorModelGeneration(generationHandle, error);
     throw error;
   } finally {
+    // Clean up any open tool spans (handles exception paths where tool.result never fires).
+    clearRunToolSpans(preGeneratedRunId);
     blockReplyPipeline?.stop();
     typing.markRunComplete();
     // Safety net: the dispatcher's onIdle callback normally fires

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -10,6 +10,16 @@ import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
+import {
+  initializeLangfuseAgentHooks,
+  redactPayload,
+  truncateString,
+} from "../../observability/langfuse-agent-hooks.js";
+import {
+  withLangfuseRequestScope,
+  type LangfuseRequestScope,
+} from "../../observability/langfuse-request-scope.js";
+import { getLangfuseInstrumentation, type LangfuseHandle } from "../../observability/langfuse.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
@@ -43,6 +53,9 @@ function loadStageSandboxMediaRuntime() {
   stageSandboxMediaRuntimePromise ??= import("./stage-sandbox-media.runtime.js");
   return stageSandboxMediaRuntimePromise;
 }
+
+// Register global agent event listener for tool span tracking once at startup.
+initializeLangfuseAgentHooks();
 
 function mergeSkillFilters(channelFilter?: string[], agentFilter?: string[]): string[] | undefined {
   const normalize = (list?: string[]) => {
@@ -429,49 +442,161 @@ export async function getReplyFromConfig(
     });
   }
 
-  return runPreparedReply({
-    ctx,
-    sessionCtx,
-    cfg,
-    agentId,
-    agentDir,
-    agentCfg,
-    sessionCfg,
-    commandAuthorized,
-    command,
-    commandSource,
-    allowTextCommands,
-    directives,
-    defaultActivation,
-    resolvedThinkLevel,
-    resolvedVerboseLevel,
-    resolvedReasoningLevel,
-    resolvedElevatedLevel,
-    execOverrides,
-    elevatedEnabled,
-    elevatedAllowed,
-    blockStreamingEnabled,
-    blockReplyChunking,
-    resolvedBlockStreamingBreak,
-    modelState,
-    provider,
-    model,
-    perMessageQueueMode,
-    perMessageQueueOptions,
-    typing,
-    opts: resolvedOpts,
-    defaultProvider,
-    defaultModel,
-    timeoutMs,
-    isNewSession,
-    resetTriggered,
-    systemSent,
-    sessionEntry,
-    sessionStore,
+  // Build Langfuse root trace metadata from the available context.
+  const traceInput = redactPayload({
+    body: truncateString(ctx.Body ?? "", 2_000),
     sessionKey,
-    sessionId,
-    storePath,
-    workspaceDir,
-    abortedLastRun,
+    messageId: ctx.MessageSid,
+    senderId: ctx.From,
+    channel: ctx.Provider,
+    surface: ctx.Surface,
+    chatType: ctx.ChatType,
+    agentId,
+    accountId: ctx.AccountId,
+    to: ctx.To,
+    isHeartbeat: opts?.isHeartbeat ?? false,
   });
+
+  const instrumentation = await getLangfuseInstrumentation();
+  if (!instrumentation.enabled) {
+    // Langfuse disabled — skip trace, run normally.
+    return runPreparedReply({
+      ctx,
+      sessionCtx,
+      cfg,
+      agentId,
+      agentDir,
+      agentCfg,
+      sessionCfg,
+      commandAuthorized,
+      command,
+      commandSource,
+      allowTextCommands,
+      directives,
+      defaultActivation,
+      resolvedThinkLevel,
+      resolvedVerboseLevel,
+      resolvedReasoningLevel,
+      resolvedElevatedLevel,
+      execOverrides,
+      elevatedEnabled,
+      elevatedAllowed,
+      blockStreamingEnabled,
+      blockReplyChunking,
+      resolvedBlockStreamingBreak,
+      modelState,
+      provider,
+      model,
+      perMessageQueueMode,
+      perMessageQueueOptions,
+      typing,
+      opts: resolvedOpts,
+      defaultProvider,
+      defaultModel,
+      timeoutMs,
+      isNewSession,
+      resetTriggered,
+      systemSent,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      sessionId,
+      storePath,
+      workspaceDir,
+      abortedLastRun,
+    });
+  }
+
+  const traceHandle: LangfuseHandle = instrumentation.startTrace({
+    name: "request",
+    input: traceInput,
+    metadata: {
+      sessionKey,
+      agentId,
+      provider,
+      model,
+      isHeartbeat: opts?.isHeartbeat ?? false,
+    },
+  });
+
+  const scope: LangfuseRequestScope = {
+    trace: traceHandle,
+    requestName: "request",
+    metadata: { sessionKey, agentId },
+  };
+
+  let result: ReplyPayload | ReplyPayload[] | undefined;
+  try {
+    result = await withLangfuseRequestScope(scope, () =>
+      runPreparedReply({
+        ctx,
+        sessionCtx,
+        cfg,
+        agentId,
+        agentDir,
+        agentCfg,
+        sessionCfg,
+        commandAuthorized,
+        command,
+        commandSource,
+        allowTextCommands,
+        directives,
+        defaultActivation,
+        resolvedThinkLevel,
+        resolvedVerboseLevel,
+        resolvedReasoningLevel,
+        resolvedElevatedLevel,
+        execOverrides,
+        elevatedEnabled,
+        elevatedAllowed,
+        blockStreamingEnabled,
+        blockReplyChunking,
+        resolvedBlockStreamingBreak,
+        modelState,
+        provider,
+        model,
+        perMessageQueueMode,
+        perMessageQueueOptions,
+        typing,
+        opts: resolvedOpts,
+        defaultProvider,
+        defaultModel,
+        timeoutMs,
+        isNewSession,
+        resetTriggered,
+        systemSent,
+        sessionEntry,
+        sessionStore,
+        sessionKey,
+        sessionId,
+        storePath,
+        workspaceDir,
+        abortedLastRun,
+      }),
+    );
+
+    // Collect output text for trace.
+    const outputText = (() => {
+      if (!result) {
+        return undefined;
+      }
+      const payloads = Array.isArray(result) ? result : [result];
+      const texts = payloads
+        .map((p) => (typeof p.text === "string" ? p.text : ""))
+        .filter(Boolean)
+        .join("\n");
+      return texts ? truncateString(texts, 2_000) : undefined;
+    })();
+
+    traceHandle.end({
+      output: outputText,
+      metadata: {
+        replyKind: result ? (Array.isArray(result) ? "multi" : "single") : "none",
+      },
+    });
+    return result;
+  } catch (error) {
+    traceHandle.captureError(error, { phase: "runPreparedReply" });
+    throw error;
+  }
 }

--- a/src/observability/langfuse-agent-hooks.test.ts
+++ b/src/observability/langfuse-agent-hooks.test.ts
@@ -74,6 +74,39 @@ describe("langfuse agent hook payload safety", () => {
     expect(redactPayload({ nested: null })).toEqual({ nested: null });
   });
 
+  it("replaces over-depth payload branches with a safe sentinel", () => {
+    const payload = {
+      level0: {
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                level5: {
+                  token: "secret-token",
+                  long: "x".repeat(5_000),
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(redactPayload(payload)).toEqual({
+      level0: {
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                level5: "[max depth exceeded]",
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
   it("does not throw on circular-like or deeply nested values", () => {
     const deep: Record<string, unknown> = {};
     let cur = deep;
@@ -196,6 +229,53 @@ describe("langfuse agent hooks — tool span lifecycle via emitAgentEvent", () =
     expect(spanEndFn).toHaveBeenCalledWith(
       expect.objectContaining({ statusMessage: expect.stringContaining("run ended") }),
     );
+  });
+
+  it("captures tool errors even when result is unserializable", async () => {
+    initializeLangfuseAgentHooks();
+
+    const mockTrace = makeMockTrace();
+    const spanCaptureErrorFn = vi.fn();
+    const spanHandle = {
+      ...makeNoopHandle(),
+      captureError: spanCaptureErrorFn,
+    };
+    (mockTrace.span as ReturnType<typeof vi.fn>).mockReturnValueOnce(spanHandle);
+
+    const runId = "run-tool-error-789";
+    const toolCallId = "tc-003";
+
+    await withLangfuseRequestScope({ trace: mockTrace, requestName: "test" }, async () => {
+      emitAgentEvent({
+        runId,
+        stream: "tool",
+        data: { phase: "start", name: "exec", toolCallId, args: { command: "ls" } },
+      });
+    });
+
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    circular.big = 123n;
+
+    await withLangfuseRequestScope({ trace: mockTrace, requestName: "test" }, async () => {
+      emitAgentEvent({
+        runId,
+        stream: "tool",
+        data: {
+          phase: "result",
+          name: "exec",
+          toolCallId,
+          isError: true,
+          result: circular,
+        },
+      });
+    });
+
+    expect(spanCaptureErrorFn).toHaveBeenCalledWith(
+      "[unserializable tool error]",
+      expect.objectContaining({ toolCallId, runId, durationMs: expect.any(Number) }),
+    );
+    expect(() => clearRunToolSpans(runId)).not.toThrow();
   });
 
   it("tool span is not opened outside a request scope", () => {

--- a/src/observability/langfuse-agent-hooks.test.ts
+++ b/src/observability/langfuse-agent-hooks.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import { redactPayload, truncateString, clearRunToolSpans } from "./langfuse-agent-hooks.js";
+import { initializeLangfuseAgentHooks } from "./langfuse-agent-hooks.js";
+import { withLangfuseRequestScope, getLangfuseRequestScope } from "./langfuse-request-scope.js";
+import type { LangfuseHandle } from "./langfuse.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Payload redaction and safety
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("langfuse agent hook payload safety", () => {
+  it("redacts sensitive keys recursively", () => {
+    expect(
+      redactPayload({
+        token: "secret-token",
+        nested: {
+          password: "p@ss",
+          ok: "visible",
+        },
+      }),
+    ).toEqual({
+      token: "[REDACTED]",
+      nested: {
+        password: "[REDACTED]",
+        ok: "visible",
+      },
+    });
+  });
+
+  it("redacts all known sensitive key names", () => {
+    const keys = [
+      "token",
+      "secret",
+      "password",
+      "authorization",
+      "apikey",
+      "api_key",
+      "auth",
+      "credential",
+      "private_key",
+      "access_token",
+      "refresh_token",
+      "bearer",
+    ];
+    for (const key of keys) {
+      const result = redactPayload({ [key]: "value" }) as Record<string, unknown>;
+      expect(result[key]).toBe("[REDACTED]");
+    }
+  });
+
+  it("truncates oversized strings and arrays", () => {
+    const long = "x".repeat(2_100);
+    const result = redactPayload({
+      long,
+      items: Array.from({ length: 25 }, (_, i) => i + 1),
+    }) as { long: string; items: unknown[] };
+
+    expect(result.long).toContain("…[truncated]");
+    expect(result.long.length).toBeLessThan(long.length);
+    expect(result.items).toHaveLength(21);
+    expect(result.items.at(-1)).toBe("…[5 more items]");
+  });
+
+  it("truncateString adds truncation marker", () => {
+    expect(truncateString("abcdef", 4)).toBe("abcd…[truncated]");
+    expect(truncateString("abc", 4)).toBe("abc");
+    expect(truncateString("", 4)).toBe("");
+  });
+
+  it("handles null and undefined gracefully", () => {
+    expect(redactPayload(null)).toBeNull();
+    expect(redactPayload(undefined)).toBeUndefined();
+    expect(redactPayload({ nested: null })).toEqual({ nested: null });
+  });
+
+  it("does not throw on circular-like or deeply nested values", () => {
+    const deep: Record<string, unknown> = {};
+    let cur = deep;
+    for (let i = 0; i < 10; i++) {
+      cur.child = {};
+      cur = cur.child as Record<string, unknown>;
+    }
+    expect(() => redactPayload(deep)).not.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tool span bookkeeping and clearRunToolSpans
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeNoopHandle(): LangfuseHandle {
+  return {
+    enabled: true,
+    kind: "span",
+    update: vi.fn(),
+    end: vi.fn(),
+    captureError: vi.fn(),
+    span: vi.fn(() => makeNoopHandle()),
+    generation: vi.fn(() => makeNoopHandle()),
+  };
+}
+
+function makeMockTrace(): LangfuseHandle {
+  return {
+    enabled: true,
+    kind: "trace",
+    update: vi.fn(),
+    end: vi.fn(),
+    captureError: vi.fn(),
+    span: vi.fn(() => makeNoopHandle()),
+    generation: vi.fn(() => makeNoopHandle()),
+  };
+}
+
+describe("langfuse agent hooks — tool span lifecycle via emitAgentEvent", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens a tool span on start event and closes on result via emitAgentEvent", async () => {
+    // Ensure the global listener is registered.
+    initializeLangfuseAgentHooks();
+
+    const mockTrace = makeMockTrace();
+    const spanEndFn = vi.fn();
+    const spanHandle = {
+      ...makeNoopHandle(),
+      end: spanEndFn,
+    };
+    (mockTrace.span as ReturnType<typeof vi.fn>).mockReturnValueOnce(spanHandle);
+
+    const runId = "run-abc-123";
+    const toolCallId = "tc-001";
+
+    // Emit tool start from within a request scope.
+    await withLangfuseRequestScope({ trace: mockTrace, requestName: "test" }, async () => {
+      emitAgentEvent({
+        runId,
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "read",
+          toolCallId,
+          args: { path: "/tmp/test.txt" },
+        },
+      });
+    });
+
+    expect(mockTrace.span).toHaveBeenCalledWith(expect.objectContaining({ name: "tool.read" }));
+
+    // Emit tool result from within the same scope (simulates async resolution).
+    await withLangfuseRequestScope({ trace: mockTrace, requestName: "test" }, async () => {
+      emitAgentEvent({
+        runId,
+        stream: "tool",
+        data: {
+          phase: "result",
+          name: "read",
+          toolCallId,
+          isError: false,
+          result: { content: "file contents" },
+        },
+      });
+    });
+
+    expect(spanEndFn).toHaveBeenCalledWith(expect.objectContaining({ output: expect.anything() }));
+  });
+
+  it("clearRunToolSpans closes orphaned spans on exception paths", async () => {
+    initializeLangfuseAgentHooks();
+
+    const mockTrace = makeMockTrace();
+    const spanEndFn = vi.fn();
+    const spanHandle = { ...makeNoopHandle(), end: spanEndFn };
+    (mockTrace.span as ReturnType<typeof vi.fn>).mockReturnValueOnce(spanHandle);
+
+    const runId = "run-orphan-456";
+    const toolCallId = "tc-002";
+
+    // Open a tool span.
+    await withLangfuseRequestScope({ trace: mockTrace, requestName: "test" }, async () => {
+      emitAgentEvent({
+        runId,
+        stream: "tool",
+        data: { phase: "start", name: "exec", toolCallId, args: { command: "ls" } },
+      });
+    });
+
+    expect(mockTrace.span).toHaveBeenCalledOnce();
+    expect(spanEndFn).not.toHaveBeenCalled();
+
+    // Simulate exception path: result event never fires, clearRunToolSpans is called.
+    clearRunToolSpans(runId);
+
+    expect(spanEndFn).toHaveBeenCalledWith(
+      expect.objectContaining({ statusMessage: expect.stringContaining("run ended") }),
+    );
+  });
+
+  it("tool span is not opened outside a request scope", () => {
+    initializeLangfuseAgentHooks();
+
+    // Emit WITHOUT being inside withLangfuseRequestScope.
+    const unsubscribe = onAgentEvent((evt) => {
+      if (evt.stream === "tool") {
+        // Just verify scope is missing at this point.
+        const scope = getLangfuseRequestScope();
+        expect(scope).toBeUndefined();
+      }
+    });
+
+    emitAgentEvent({
+      runId: "run-no-scope",
+      stream: "tool",
+      data: { phase: "start", name: "read", toolCallId: "tc-noscope", args: {} },
+    });
+
+    unsubscribe();
+    // No span opened — clearRunToolSpans is a no-op.
+    expect(() => clearRunToolSpans("run-no-scope")).not.toThrow();
+  });
+});

--- a/src/observability/langfuse-agent-hooks.ts
+++ b/src/observability/langfuse-agent-hooks.ts
@@ -30,9 +30,15 @@ const SENSITIVE_KEY_RE =
 const MAX_STRING_LEN = 2_000;
 const MAX_ARRAY_ITEMS = 20;
 const MAX_OBJ_DEPTH = 5;
+const MAX_DEPTH_EXCEEDED = "[max depth exceeded]";
+const UNKNOWN_TOOL_ERROR = "unknown tool error";
+const UNSERIALIZABLE_TOOL_ERROR = "[unserializable tool error]";
 
 function redactValue(value: unknown, depth: number): unknown {
-  if (depth > MAX_OBJ_DEPTH || value === null || value === undefined) {
+  if (depth > MAX_OBJ_DEPTH) {
+    return MAX_DEPTH_EXCEEDED;
+  }
+  if (value === null || value === undefined) {
     return value;
   }
   if (typeof value === "string") {
@@ -72,6 +78,17 @@ export function truncateString(str: string, maxLen: number): string {
     return str;
   }
   return `${str.slice(0, maxLen)}…[truncated]`;
+}
+
+function formatToolError(result: unknown): string {
+  if (typeof result === "string") {
+    return truncateString(result, 500);
+  }
+  try {
+    return truncateString(JSON.stringify(redactPayload(result ?? UNKNOWN_TOOL_ERROR)), 500);
+  } catch {
+    return UNSERIALIZABLE_TOOL_ERROR;
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -221,24 +238,20 @@ export function initializeLangfuseAgentHooks(): void {
       if (!record) {
         return;
       }
-      spans.delete(toolCallId);
-      if (spans.size === 0) {
-        openToolSpansByRun.delete(runId);
-      }
       const durationMs = Date.now() - record.startedAt;
       const isError = evt.data.isError === true;
       const result = evt.data.result;
       if (isError) {
-        const errText =
-          typeof result === "string"
-            ? result
-            : JSON.stringify(result ?? "unknown tool error").slice(0, 500);
-        record.handle.captureError(errText, { toolCallId, runId, durationMs });
+        record.handle.captureError(formatToolError(result), { toolCallId, runId, durationMs });
       } else {
         record.handle.end({
           output: redactPayload(result),
           metadata: { toolCallId, durationMs },
         });
+      }
+      spans.delete(toolCallId);
+      if (spans.size === 0) {
+        openToolSpansByRun.delete(runId);
       }
     }
   });

--- a/src/observability/langfuse-agent-hooks.ts
+++ b/src/observability/langfuse-agent-hooks.ts
@@ -1,0 +1,319 @@
+/**
+ * Langfuse agent instrumentation hooks for OpenClaw.
+ *
+ * Provides helpers for:
+ *  - Model generation spans
+ *  - Tool-call spans (via full-fidelity global agent event stream)
+ *  - Subagent-spawn spans
+ *  - Payload redaction and truncation
+ *
+ * All functions are safe no-ops when called outside an active Langfuse
+ * request scope (i.e. when Langfuse is disabled or not configured).
+ *
+ * ## Tool span bookkeeping
+ * Tool spans are opened when a tool.start event fires and closed on tool.result.
+ * The agent runner must call clearRunToolSpans(runId) in its finally block to
+ * guarantee cleanup even when the run throws before tool.result fires.
+ */
+
+import { onAgentEvent } from "../infra/agent-events.js";
+import { getLangfuseRequestScope } from "./langfuse-request-scope.js";
+import type { LangfuseHandle } from "./langfuse.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Payload redaction and safety
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SENSITIVE_KEY_RE =
+  /^(token|secret|password|authorization|apikey|api_key|auth|credential|private_key|access_token|refresh_token|bearer)$/i;
+
+const MAX_STRING_LEN = 2_000;
+const MAX_ARRAY_ITEMS = 20;
+const MAX_OBJ_DEPTH = 5;
+
+function redactValue(value: unknown, depth: number): unknown {
+  if (depth > MAX_OBJ_DEPTH || value === null || value === undefined) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return value.length > MAX_STRING_LEN ? `${value.slice(0, MAX_STRING_LEN)}…[truncated]` : value;
+  }
+  if (typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const items = value.slice(0, MAX_ARRAY_ITEMS).map((item) => redactValue(item, depth + 1));
+    return value.length > MAX_ARRAY_ITEMS
+      ? [...items, `…[${value.length - MAX_ARRAY_ITEMS} more items]`]
+      : items;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = SENSITIVE_KEY_RE.test(k) ? "[REDACTED]" : redactValue(v, depth + 1);
+  }
+  return out;
+}
+
+/** Recursively redact known sensitive keys and truncate oversized strings. */
+export function redactPayload(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  try {
+    return redactValue(value, 0);
+  } catch {
+    return "[could not process payload]";
+  }
+}
+
+/** Truncate a string to at most `maxLen` characters, appending an ellipsis marker. */
+export function truncateString(str: string, maxLen: number): string {
+  if (!str || str.length <= maxLen) {
+    return str;
+  }
+  return `${str.slice(0, maxLen)}…[truncated]`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Model generation tracking
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Start a Langfuse generation child span from the current request scope. Returns null when Langfuse is not active. */
+export function startModelGeneration(params: {
+  provider: string;
+  model: string;
+  prompt: string;
+}): LangfuseHandle | null {
+  const scope = getLangfuseRequestScope();
+  if (!scope || !scope.trace.enabled) {
+    return null;
+  }
+  return scope.trace.generation({
+    name: "model.generation",
+    model: `${params.provider}/${params.model}`,
+    input: truncateString(params.prompt, 4_000),
+    metadata: { provider: params.provider, model: params.model },
+  });
+}
+
+/** Close a model generation handle with success data. No-op if handle is null. */
+export function endModelGeneration(
+  handle: LangfuseHandle | null,
+  params: {
+    outputText?: string;
+    provider: string;
+    model: string;
+    durationMs: number;
+    usage?: {
+      input?: number;
+      output?: number;
+      cacheRead?: number;
+      cacheWrite?: number;
+      total?: number;
+    };
+    fallbackAttemptCount?: number;
+  },
+): void {
+  if (!handle) {
+    return;
+  }
+  handle.end({
+    output: params.outputText ? truncateString(params.outputText, 4_000) : undefined,
+    model: `${params.provider}/${params.model}`,
+    usage: params.usage
+      ? {
+          input: params.usage.input ?? 0,
+          output: params.usage.output ?? 0,
+          total: params.usage.total,
+        }
+      : undefined,
+    metadata: {
+      provider: params.provider,
+      model: params.model,
+      durationMs: params.durationMs,
+      fallbackAttemptCount: params.fallbackAttemptCount ?? 0,
+    },
+  });
+}
+
+/** Capture an error on a model generation handle. No-op if handle is null. */
+export function errorModelGeneration(handle: LangfuseHandle | null, error: unknown): void {
+  if (!handle) {
+    return;
+  }
+  handle.captureError(error, { phase: "model.generation" });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tool span tracking (via full-fidelity global agent event stream)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type ToolSpanRecord = {
+  handle: LangfuseHandle;
+  startedAt: number;
+  name: string;
+};
+
+/**
+ * Per-runId map of currently-open tool spans.
+ * Keyed outer: runId; inner: toolCallId.
+ * Must be cleaned up via clearRunToolSpans() in the agent runner's finally block.
+ */
+const openToolSpansByRun = new Map<string, Map<string, ToolSpanRecord>>();
+
+function getRunToolSpanMap(runId: string): Map<string, ToolSpanRecord> {
+  let map = openToolSpansByRun.get(runId);
+  if (!map) {
+    map = new Map();
+    openToolSpansByRun.set(runId, map);
+  }
+  return map;
+}
+
+let agentEventListenerRegistered = false;
+
+/**
+ * Register the global agent event listener for tool span tracking.
+ * Idempotent — safe to call multiple times.
+ *
+ * Uses the full-fidelity emitAgentEvent stream (not the stripped UI-callback
+ * path passed to pi-embedded), so args and result are always present.
+ */
+export function initializeLangfuseAgentHooks(): void {
+  if (agentEventListenerRegistered) {
+    return;
+  }
+  agentEventListenerRegistered = true;
+  onAgentEvent((evt) => {
+    if (evt.stream !== "tool") {
+      return;
+    }
+    const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+    const runId = evt.runId;
+    const toolCallId = typeof evt.data.toolCallId === "string" ? evt.data.toolCallId : "";
+    const toolName = typeof evt.data.name === "string" ? evt.data.name : "unknown";
+
+    if (phase === "start") {
+      // Open a span for this tool call. Uses AsyncLocalStorage context from
+      // the agent runner, which runs inside withLangfuseRequestScope().
+      const scope = getLangfuseRequestScope();
+      if (!scope || !scope.trace.enabled) {
+        return;
+      }
+      const args = evt.data.args;
+      const handle = scope.trace.span({
+        name: `tool.${toolName}`,
+        input: redactPayload(args),
+        metadata: { toolCallId, runId, toolName },
+      });
+      getRunToolSpanMap(runId).set(toolCallId, {
+        handle,
+        startedAt: Date.now(),
+        name: toolName,
+      });
+    } else if (phase === "result") {
+      // Close the span opened at "start".
+      const spans = openToolSpansByRun.get(runId);
+      if (!spans) {
+        return;
+      }
+      const record = spans.get(toolCallId);
+      if (!record) {
+        return;
+      }
+      spans.delete(toolCallId);
+      if (spans.size === 0) {
+        openToolSpansByRun.delete(runId);
+      }
+      const durationMs = Date.now() - record.startedAt;
+      const isError = evt.data.isError === true;
+      const result = evt.data.result;
+      if (isError) {
+        const errText =
+          typeof result === "string"
+            ? result
+            : JSON.stringify(result ?? "unknown tool error").slice(0, 500);
+        record.handle.captureError(errText, { toolCallId, runId, durationMs });
+      } else {
+        record.handle.end({
+          output: redactPayload(result),
+          metadata: { toolCallId, durationMs },
+        });
+      }
+    }
+  });
+}
+
+/**
+ * Close and discard all open tool spans for a given run.
+ * Must be called in the finally block of the agent runner to prevent orphan spans
+ * when the run throws before all tool.result events fire.
+ */
+export function clearRunToolSpans(runId: string): void {
+  const spans = openToolSpansByRun.get(runId);
+  if (!spans) {
+    return;
+  }
+  for (const record of spans.values()) {
+    record.handle.end({ statusMessage: "run ended before tool completed" });
+  }
+  spans.clear();
+  openToolSpansByRun.delete(runId);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Subagent span tracking
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Start a subagent-spawn span under the current request scope.
+ * Returns null when Langfuse is not active.
+ */
+export function startSubagentSpan(params: {
+  agentId?: string;
+  task: string;
+  model?: string;
+}): LangfuseHandle | null {
+  const scope = getLangfuseRequestScope();
+  if (!scope) {
+    return null;
+  }
+  return scope.trace.span({
+    name: "subagent.spawn",
+    input: truncateString(params.task, 2_000),
+    metadata: { agentId: params.agentId, model: params.model },
+  });
+}
+
+/**
+ * End a subagent span with the spawn result.
+ * Captures an error span when the spawn failed or was forbidden.
+ */
+export function endSubagentSpan(
+  handle: LangfuseHandle | null,
+  result: {
+    status: string;
+    childSessionKey?: string;
+    runId?: string;
+    error?: string;
+  },
+): void {
+  if (!handle) {
+    return;
+  }
+  if (result.status === "error" || result.status === "forbidden") {
+    handle.captureError(result.error ?? `subagent spawn ${result.status}`, {
+      childSessionKey: result.childSessionKey,
+      status: result.status,
+    });
+  } else {
+    handle.end({
+      output: result.status,
+      metadata: {
+        childSessionKey: result.childSessionKey,
+        runId: result.runId,
+        status: result.status,
+      },
+    });
+  }
+}

--- a/src/observability/langfuse-request-scope.ts
+++ b/src/observability/langfuse-request-scope.ts
@@ -1,0 +1,34 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { LangfuseHandle } from "./langfuse.js";
+
+export type LangfuseRequestScope = {
+  trace: LangfuseHandle;
+  traceId?: string;
+  requestName: string;
+  metadata?: Record<string, unknown>;
+};
+
+const LANGFUSE_REQUEST_SCOPE_KEY: unique symbol = Symbol.for(
+  "openclaw.observability.langfuseRequestScope",
+);
+
+const langfuseRequestScope = (() => {
+  const globalState = globalThis as typeof globalThis & {
+    [LANGFUSE_REQUEST_SCOPE_KEY]?: AsyncLocalStorage<LangfuseRequestScope>;
+  };
+  const existing = globalState[LANGFUSE_REQUEST_SCOPE_KEY];
+  if (existing) {
+    return existing;
+  }
+  const created = new AsyncLocalStorage<LangfuseRequestScope>();
+  globalState[LANGFUSE_REQUEST_SCOPE_KEY] = created;
+  return created;
+})();
+
+export function withLangfuseRequestScope<T>(scope: LangfuseRequestScope, run: () => T): T {
+  return langfuseRequestScope.run(scope, run);
+}
+
+export function getLangfuseRequestScope(): LangfuseRequestScope | undefined {
+  return langfuseRequestScope.getStore();
+}

--- a/src/observability/langfuse.test.ts
+++ b/src/observability/langfuse.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  initializeLangfuse,
+  readLangfuseConfig,
+  resetLangfuseInstrumentationForTests,
+  startLangfuseTrace,
+} from "./langfuse.js";
+
+afterEach(() => {
+  resetLangfuseInstrumentationForTests();
+  vi.resetModules();
+  vi.unmock("langfuse");
+});
+
+describe("langfuse observability layer", () => {
+  it("parses disabled config and stays in no-op mode", async () => {
+    const instrumentation = await initializeLangfuse({ LANGFUSE_ENABLED: "0" });
+    const trace = await startLangfuseTrace({ name: "disabled-trace" });
+
+    expect(readLangfuseConfig({ LANGFUSE_ENABLED: "0" }).enabled).toBe(false);
+    expect(instrumentation.enabled).toBe(false);
+    expect(trace.enabled).toBe(false);
+    expect(() => trace.update({ ok: true })).not.toThrow();
+    expect(() => trace.end({ status: "ok" })).not.toThrow();
+    expect(() => trace.captureError(new Error("boom"))).not.toThrow();
+  });
+
+  it("falls back to no-op when enabled but config is incomplete", async () => {
+    const instrumentation = await initializeLangfuse({
+      LANGFUSE_ENABLED: "1",
+      LANGFUSE_HOST: "http://127.0.0.1:3300",
+      LANGFUSE_PUBLIC_KEY: "pk-test",
+    });
+
+    expect(instrumentation.enabled).toBe(false);
+    expect(instrumentation.config.enabled).toBe(true);
+    expect(instrumentation.config.configured).toBe(false);
+  });
+
+  it("does not expose secretKey in config object", async () => {
+    const cfg = readLangfuseConfig({
+      LANGFUSE_ENABLED: "1",
+      LANGFUSE_HOST: "http://127.0.0.1:3300",
+      LANGFUSE_PUBLIC_KEY: "pk-test",
+      LANGFUSE_SECRET_KEY: "sk-secret",
+    });
+
+    expect("secretKey" in cfg).toBe(false);
+    expect(JSON.stringify(cfg)).not.toContain("sk-secret");
+  });
+
+  it("creates callable handles when enabled and configured", async () => {
+    const end = vi.fn();
+    const update = vi.fn();
+    const span = vi.fn(() => ({ end, update, span, generation }));
+    const generation = vi.fn(() => ({ end, update, span, generation }));
+    const traceNode = { update, span, generation };
+    const trace = vi.fn(() => traceNode);
+
+    vi.doMock("langfuse", () => ({
+      Langfuse: class {
+        trace = trace;
+        flushAsync = vi.fn(async () => {});
+        shutdownAsync = vi.fn(async () => {});
+      },
+    }));
+
+    const instrumentation = await initializeLangfuse({
+      LANGFUSE_ENABLED: "1",
+      LANGFUSE_HOST: "http://127.0.0.1:3300",
+      LANGFUSE_PUBLIC_KEY: "pk-test",
+      LANGFUSE_SECRET_KEY: "sk-test",
+    });
+
+    const handle = instrumentation.startTrace({ name: "root" });
+    const childSpan = handle.span({ name: "tool" });
+    const childGeneration = handle.generation({ name: "model" });
+
+    expect(instrumentation.enabled).toBe(true);
+    expect(handle.enabled).toBe(true);
+    expect(() => handle.update({ output: "ok" })).not.toThrow();
+    expect(() => handle.captureError(new Error("trace-error"))).not.toThrow();
+    expect(() => childSpan.end({ output: "done" })).not.toThrow();
+    expect(() => childGeneration.captureError(new Error("gen-error"))).not.toThrow();
+    expect(trace).toHaveBeenCalledOnce();
+    expect(span).toHaveBeenCalledOnce();
+    expect(generation).toHaveBeenCalledOnce();
+    expect(update).toHaveBeenCalled();
+    expect(end).toHaveBeenCalled();
+  });
+
+  it("parses various truthy enabled values", () => {
+    for (const val of ["1", "true", "yes", "on"]) {
+      expect(readLangfuseConfig({ LANGFUSE_ENABLED: val }).enabled).toBe(true);
+    }
+    for (const val of ["0", "false", "no", "off", "", undefined]) {
+      expect(readLangfuseConfig({ LANGFUSE_ENABLED: val }).enabled).toBe(false);
+    }
+  });
+
+  it("no-op instrumentation handles do not throw on any operation", async () => {
+    const inst = await initializeLangfuse({ LANGFUSE_ENABLED: "0" });
+    const traceHandle = inst.startTrace({ name: "noop-test" });
+    const spanHandle = traceHandle.span({ name: "child-span" });
+    const genHandle = traceHandle.generation({ name: "child-gen" });
+
+    expect(() => traceHandle.update({ foo: "bar" })).not.toThrow();
+    expect(() => traceHandle.end({ output: "done" })).not.toThrow();
+    expect(() => traceHandle.captureError(new Error("x"))).not.toThrow();
+    expect(() => spanHandle.end({ output: "span done" })).not.toThrow();
+    expect(() => spanHandle.captureError(new Error("y"))).not.toThrow();
+    expect(() => genHandle.end({ output: "gen done" })).not.toThrow();
+    expect(() => genHandle.captureError(new Error("z"))).not.toThrow();
+  });
+});

--- a/src/observability/langfuse.ts
+++ b/src/observability/langfuse.ts
@@ -1,0 +1,203 @@
+import process from "node:process";
+import { createSubsystemLogger } from "../logging.js";
+
+const log = createSubsystemLogger("observability.langfuse");
+
+type EnvLike = NodeJS.ProcessEnv;
+
+type LangfuseClientLike = {
+  trace: (params?: Record<string, unknown>) => LangfuseTraceLike;
+  flushAsync?: () => Promise<void>;
+  shutdownAsync?: () => Promise<void>;
+};
+
+type LangfuseTraceLike = {
+  update?: (params?: Record<string, unknown>) => unknown;
+  span?: (params?: Record<string, unknown>) => LangfuseObservationLike;
+  generation?: (params?: Record<string, unknown>) => LangfuseObservationLike;
+};
+
+type LangfuseObservationLike = {
+  update?: (params?: Record<string, unknown>) => unknown;
+  end?: (params?: Record<string, unknown>) => unknown;
+  span?: (params?: Record<string, unknown>) => LangfuseObservationLike;
+  generation?: (params?: Record<string, unknown>) => LangfuseObservationLike;
+};
+
+export type LangfuseConfig = {
+  enabled: boolean;
+  host?: string;
+  publicKey?: string;
+  /** secretKey is intentionally omitted from the exported shape to avoid accidental exposure. */
+  configured: boolean;
+};
+
+export type LangfuseHandle = {
+  readonly enabled: boolean;
+  readonly kind: "trace" | "span" | "generation";
+  update: (params?: Record<string, unknown>) => void;
+  end: (params?: Record<string, unknown>) => void;
+  captureError: (error: unknown, extra?: Record<string, unknown>) => void;
+  span: (params?: Record<string, unknown>) => LangfuseHandle;
+  generation: (params?: Record<string, unknown>) => LangfuseHandle;
+};
+
+export type LangfuseInstrumentation = {
+  readonly enabled: boolean;
+  readonly config: LangfuseConfig;
+  startTrace: (params?: Record<string, unknown>) => LangfuseHandle;
+  captureError: (error: unknown, extra?: Record<string, unknown>) => void;
+  flush: () => Promise<void>;
+  shutdown: () => Promise<void>;
+};
+
+const noopHandle = (kind: LangfuseHandle["kind"]): LangfuseHandle => ({
+  enabled: false,
+  kind,
+  update: () => {},
+  end: () => {},
+  captureError: () => {},
+  span: () => noopHandle("span"),
+  generation: () => noopHandle("generation"),
+});
+
+const noopInstrumentation: LangfuseInstrumentation = {
+  enabled: false,
+  config: { enabled: false, configured: false },
+  startTrace: () => noopHandle("trace"),
+  captureError: () => {},
+  flush: async () => {},
+  shutdown: async () => {},
+};
+
+let instrumentationPromise: Promise<LangfuseInstrumentation> | null = null;
+
+function parseEnabled(raw: string | undefined): boolean {
+  const value = raw?.trim().toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
+export function readLangfuseConfig(env: EnvLike = process.env): LangfuseConfig {
+  const enabled = parseEnabled(env.LANGFUSE_ENABLED);
+  const host = env.LANGFUSE_HOST?.trim() || undefined;
+  const publicKey = env.LANGFUSE_PUBLIC_KEY?.trim() || undefined;
+  const secretKey = env.LANGFUSE_SECRET_KEY?.trim() || undefined;
+  const configured = Boolean(host && publicKey && secretKey);
+  return { enabled, host, publicKey, configured };
+}
+
+function toErrorString(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack || error.message;
+  }
+  return String(error);
+}
+
+function createHandle(
+  kind: LangfuseHandle["kind"],
+  node: LangfuseTraceLike | LangfuseObservationLike,
+): LangfuseHandle {
+  return {
+    enabled: true,
+    kind,
+    update: (params) => {
+      node.update?.(params);
+    },
+    end: (params) => {
+      if (kind === "trace") {
+        node.update?.(params);
+        return;
+      }
+      (node as LangfuseObservationLike).end?.(params);
+    },
+    captureError: (error, extra) => {
+      const payload = {
+        ...extra,
+        level: "ERROR",
+        statusMessage: toErrorString(error),
+      };
+      if (kind === "trace") {
+        node.update?.(payload);
+        return;
+      }
+      (node as LangfuseObservationLike).end?.(payload);
+    },
+    span: (params) => {
+      const child = node.span?.(params);
+      return child ? createHandle("span", child) : noopHandle("span");
+    },
+    generation: (params) => {
+      const child = node.generation?.(params);
+      return child ? createHandle("generation", child) : noopHandle("generation");
+    },
+  };
+}
+
+async function buildInstrumentation(env: EnvLike): Promise<LangfuseInstrumentation> {
+  const config = readLangfuseConfig(env);
+  if (!config.enabled) {
+    log.debug("Langfuse disabled via env; using no-op instrumentation");
+    return { ...noopInstrumentation, config };
+  }
+  if (!config.configured) {
+    log.warn("Langfuse enabled but configuration incomplete; falling back to no-op mode", {
+      hostConfigured: Boolean(config.host),
+      publicKeyConfigured: Boolean(config.publicKey),
+      secretKeyConfigured: Boolean(env.LANGFUSE_SECRET_KEY?.trim()),
+    });
+    return { ...noopInstrumentation, config };
+  }
+
+  try {
+    const { Langfuse } = await import("langfuse");
+    const client = new Langfuse({
+      enabled: true,
+      baseUrl: config.host,
+      publicKey: config.publicKey,
+      secretKey: env.LANGFUSE_SECRET_KEY?.trim(),
+    }) as LangfuseClientLike;
+    log.info("Langfuse client initialized", { host: config.host });
+    return {
+      enabled: true,
+      config,
+      startTrace: (params) => createHandle("trace", client.trace(params)),
+      captureError: (error, extra) => {
+        log.warn("Langfuse top-level error captured", {
+          error: toErrorString(error),
+          ...extra,
+        });
+      },
+      flush: async () => {
+        await client.flushAsync?.();
+      },
+      shutdown: async () => {
+        await client.shutdownAsync?.();
+      },
+    };
+  } catch (error) {
+    log.error("Langfuse initialization failed; falling back to no-op mode", {
+      error: toErrorString(error),
+    });
+    return { ...noopInstrumentation, config };
+  }
+}
+
+export function initializeLangfuse(env: EnvLike = process.env): Promise<LangfuseInstrumentation> {
+  instrumentationPromise ??= buildInstrumentation(env);
+  return instrumentationPromise;
+}
+
+export async function getLangfuseInstrumentation(): Promise<LangfuseInstrumentation> {
+  return initializeLangfuse(process.env);
+}
+
+export async function startLangfuseTrace(
+  params?: Record<string, unknown>,
+): Promise<LangfuseHandle> {
+  const instrumentation = await getLangfuseInstrumentation();
+  return instrumentation.startTrace(params);
+}
+
+export function resetLangfuseInstrumentationForTests(): void {
+  instrumentationPromise = null;
+}


### PR DESCRIPTION
## Summary

Adds Langfuse tracing on top of fresh `main` with:
- one root trace per inbound request
- request-local trace scope via `AsyncLocalStorage`
- generation tracing for model calls
- tool spans from the full-fidelity agent event stream
- dedicated `subagent.spawn` span
- payload redaction/truncation
- safe no-op behavior when Langfuse is disabled/misconfigured
- cleanup for open tool span bookkeeping on exception paths

## What changed

- added `src/observability/langfuse.ts`
- added `src/observability/langfuse-request-scope.ts`
- added `src/observability/langfuse-agent-hooks.ts`
- wired root trace lifecycle into `src/auto-reply/reply/get-reply.ts`
- wired generation tracing into `src/auto-reply/reply/agent-runner.ts`
- instrumented `sessions_spawn` / `subagent.spawn` in `src/agents/tools/sessions-spawn-tool.ts`
- added focused tests for Langfuse init/hooks behavior

## Verification

Passed locally:
- `pnpm test -- --run src/observability/langfuse.test.ts src/observability/langfuse-agent-hooks.test.ts`
- `pnpm build:strict-smoke`

Live verification status:
- confirmed that the Langfuse client initializes and traces flow in runtime
- historical traced verification for the same behavior existed before this fresh-main reimplementation
- fresh-main live verification on a separate Telegram-traced runtime was partially exercised, but isolation was noisy because of competing local runtimes / Telegram polling conflicts

## Notes

This implementation intentionally uses the full-fidelity agent event stream for tool spans to avoid the prior bad duplicate/empty `ERROR tool.sessions_spawn` span with `input: null` / `output: undefined`.
