### PR TITLE
Media: prevent caching of temporary downloads

### DIFF
--- a/src/media/server.test.ts
+++ b/src/media/server.test.ts
@@ -62,6 +62,9 @@ describe("media server", () => {
     const res = await fetch(mediaUrl("file1"));
     expect(res.status).toBe(200);
     expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("cache-control")).toBe("no-store, private, max-age=0, must-revalidate");
+    expect(res.headers.get("pragma")).toBe("no-cache");
+    expect(res.headers.get("expires")).toBe("0");
     expect(await res.text()).toBe("hello");
     await waitForFileRemoval(file);
   });
@@ -115,6 +118,7 @@ describe("media server", () => {
     const res = await fetch(mediaUrl("missing-file"));
     expect(res.status).toBe(404);
     expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("cache-control")).toBe("no-store, private, max-age=0, must-revalidate");
     expect(await res.text()).toBe("not found");
   });
 

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -34,6 +34,10 @@ export function attachMediaRoutes(
 
   app.get("/media/:id", async (req, res) => {
     res.setHeader("X-Content-Type-Options", "nosniff");
+    // Temporary media URLs are capability-style secrets; prevent browser/proxy caching.
+    res.setHeader("Cache-Control", "no-store, private, max-age=0, must-revalidate");
+    res.setHeader("Pragma", "no-cache");
+    res.setHeader("Expires", "0");
     const id = req.params.id;
     if (!isValidMediaId(id)) {
       res.status(400).send("invalid path");


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: temporary `/media/:id` responses relied on TTL + post-send deletion but did not explicitly disable browser/proxy caching.
- Why it matters: these URLs act like short-lived capability links, so cache retention can preserve access past the intended lifetime.
- What changed: add `Cache-Control: no-store, private, max-age=0, must-revalidate`, `Pragma: no-cache`, and `Expires: 0` on the media endpoint, and assert the headers in tests.
- What did NOT change (scope boundary): media path validation, TTL expiry, deletion timing, and file serving behavior.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Temporary media downloads now send explicit no-store/no-cache headers. No config or workflow changes.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): local media server
- Relevant config (redacted): default media server test harness

### Steps

1. Start the media server test harness and fetch a temporary `/media/:id` URL.
2. Inspect response headers before this patch.
3. Observe the body served normally and cleanup still occurring after send.

### Expected

- Temporary media responses include explicit anti-cache headers.

### Actual

- Before this patch, only `X-Content-Type-Options: nosniff` was set.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: fetched an existing temp media file and a missing media id through the test suite, confirming the new headers are present and existing behavior still passes.
- Edge cases checked: outside-workspace rejection test still passes unchanged.
- What you did **not** verify: real browser cache behavior outside the automated test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `688eb5d96a1a5a37a811e3c49969ee192a5031e7`.
- Files/config to restore: `src/media/server.ts`, `src/media/server.test.ts`
- Known bad symptoms reviewers should watch for: none expected beyond tests asserting cache headers.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some consumer unexpectedly relied on absent cache headers for debugging or replay.
  - Mitigation: body/status behavior is unchanged; only cache directives were tightened, and tests cover normal/missing media responses.
