### PR TITLE
fix(cron): per-attempt AbortControllers and deferred execution timeout

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -563,31 +563,84 @@ export async function runCronIsolatedAgentTurn(params: {
           if (abortSignal?.aborted) {
             throw new Error(abortReason());
           }
-          const bootstrapPromptWarningSignature =
-            bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
-          if (isCliProvider(providerOverride, cfgWithAgentDefaults)) {
-            // Fresh isolated cron sessions must not reuse a stored CLI session ID.
-            // Passing an existing ID activates the resume watchdog profile
-            // (noOutputTimeoutRatio 0.3, maxMs 180 s) instead of the fresh profile
-            // (ratio 0.8, maxMs 600 s), causing jobs to time out at roughly 1/3 of
-            // the configured timeoutSeconds. See: https://github.com/openclaw/openclaw/issues/29774
-            const cliSessionId = cronSession.isNewSession
-              ? undefined
-              : getCliSessionId(cronSession.sessionEntry, providerOverride);
-            const result = await runCliAgent({
+          // Create a per-attempt AbortController so the model fallback chain
+          // survives when a single attempt is aborted by the cron timeout.
+          // The parent signal propagates to the attempt controller, but each
+          // new attempt gets a fresh (non-aborted) controller.  (#37505)
+          const attemptAbort = new AbortController();
+          const onParentAbort = () => attemptAbort.abort(abortSignal?.reason);
+          abortSignal?.addEventListener("abort", onParentAbort, { once: true });
+          try {
+            const bootstrapPromptWarningSignature =
+              bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
+            if (isCliProvider(providerOverride, cfgWithAgentDefaults)) {
+              // Fresh isolated cron sessions must not reuse a stored CLI session ID.
+              // Passing an existing ID activates the resume watchdog profile
+              // (noOutputTimeoutRatio 0.3, maxMs 180 s) instead of the fresh profile
+              // (ratio 0.8, maxMs 600 s), causing jobs to time out at roughly 1/3 of
+              // the configured timeoutSeconds. See: https://github.com/openclaw/openclaw/issues/29774
+              const cliSessionId = cronSession.isNewSession
+                ? undefined
+                : getCliSessionId(cronSession.sessionEntry, providerOverride);
+              const result = await runCliAgent({
+                sessionId: cronSession.sessionEntry.sessionId,
+                sessionKey: agentSessionKey,
+                agentId,
+                sessionFile,
+                workspaceDir,
+                config: cfgWithAgentDefaults,
+                prompt: promptText,
+                provider: providerOverride,
+                model: modelOverride,
+                thinkLevel,
+                timeoutMs,
+                runId: cronSession.sessionEntry.sessionId,
+                cliSessionId,
+                bootstrapPromptWarningSignaturesSeen,
+                bootstrapPromptWarningSignature,
+              });
+              bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+                result.meta?.systemPromptReport,
+              );
+              return result;
+            }
+            const result = await runEmbeddedPiAgent({
               sessionId: cronSession.sessionEntry.sessionId,
               sessionKey: agentSessionKey,
               agentId,
+              trigger: "cron",
+              // Cron jobs are trusted local automation, so isolated runs should
+              // inherit owner-only tooling like local `openclaw agent` runs.
+              senderIsOwner: true,
+              messageChannel,
+              agentAccountId: resolvedDelivery.accountId,
               sessionFile,
+              agentDir,
               workspaceDir,
               config: cfgWithAgentDefaults,
+              skillsSnapshot,
               prompt: promptText,
+              lane: resolveNestedAgentLane(params.lane),
               provider: providerOverride,
               model: modelOverride,
+              authProfileId,
+              authProfileIdSource,
               thinkLevel,
+              fastMode: resolveFastModeState({
+                cfg: cfgWithAgentDefaults,
+                provider: providerOverride,
+                model: modelOverride,
+                sessionEntry: cronSession.sessionEntry,
+              }).enabled,
+              verboseLevel: resolvedVerboseLevel,
               timeoutMs,
+              bootstrapContextMode: agentPayload?.lightContext ? "lightweight" : undefined,
+              bootstrapContextRunKind: "cron",
               runId: cronSession.sessionEntry.sessionId,
-              cliSessionId,
+              requireExplicitMessageTarget: toolPolicy.requireExplicitMessageTarget,
+              disableMessageTool: toolPolicy.disableMessageTool,
+              allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+              abortSignal: attemptAbort.signal,
               bootstrapPromptWarningSignaturesSeen,
               bootstrapPromptWarningSignature,
             });
@@ -595,51 +648,10 @@ export async function runCronIsolatedAgentTurn(params: {
               result.meta?.systemPromptReport,
             );
             return result;
+          } finally {
+            abortSignal?.removeEventListener("abort", onParentAbort);
           }
-          const result = await runEmbeddedPiAgent({
-            sessionId: cronSession.sessionEntry.sessionId,
-            sessionKey: agentSessionKey,
-            agentId,
-            trigger: "cron",
-            // Cron jobs are trusted local automation, so isolated runs should
-            // inherit owner-only tooling like local `openclaw agent` runs.
-            senderIsOwner: true,
-            messageChannel,
-            agentAccountId: resolvedDelivery.accountId,
-            sessionFile,
-            agentDir,
-            workspaceDir,
-            config: cfgWithAgentDefaults,
-            skillsSnapshot,
-            prompt: promptText,
-            lane: resolveNestedAgentLane(params.lane),
-            provider: providerOverride,
-            model: modelOverride,
-            authProfileId,
-            authProfileIdSource,
-            thinkLevel,
-            fastMode: resolveFastModeState({
-              cfg: cfgWithAgentDefaults,
-              provider: providerOverride,
-              model: modelOverride,
-              sessionEntry: cronSession.sessionEntry,
-            }).enabled,
-            verboseLevel: resolvedVerboseLevel,
-            timeoutMs,
-            bootstrapContextMode: agentPayload?.lightContext ? "lightweight" : undefined,
-            bootstrapContextRunKind: "cron",
-            runId: cronSession.sessionEntry.sessionId,
-            requireExplicitMessageTarget: toolPolicy.requireExplicitMessageTarget,
-            disableMessageTool: toolPolicy.disableMessageTool,
-            allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
-            abortSignal,
-            bootstrapPromptWarningSignaturesSeen,
-            bootstrapPromptWarningSignature,
-          });
-          bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-            result.meta?.systemPromptReport,
-          );
-          return result;
+
         },
       });
       runResult = fallbackResult.result;

--- a/src/cron/service.cron-timeout-abort.test.ts
+++ b/src/cron/service.cron-timeout-abort.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createAbortAwareIsolatedRunner,
+  createIsolatedRegressionJob,
+  noopLogger,
+  setupCronIssueRegressionFixtures,
+  writeCronJobs,
+} from "./service.issue-regressions.test-helpers.js";
+import { createCronServiceState } from "./service/state.js";
+import { executeJobCore, executeJobCoreWithTimeout, onTimer } from "./service/timer.js";
+
+describe("Cron timeout and abort fixes", () => {
+  const { makeStorePath } = setupCronIssueRegressionFixtures();
+
+  describe("#41783 — deferred execution timeout", () => {
+    it("does not fire the timeout during queue wait (onExecutionStart defers the clock)", async () => {
+      vi.useRealTimers();
+      const store = makeStorePath();
+      const scheduledAt = Date.parse("2026-03-10T12:00:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "deferred-timeout",
+        name: "deferred timeout",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        // Very short timeout (2.5ms) — if the safety backstop fires at
+        // the old moment (before deferred arm), the job would time out
+        // during the simulated queue wait.
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 0.05 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      let resolveWork: ((v: { status: "ok"; summary: string }) => void) | undefined;
+      const workPromise = new Promise<{ status: "ok"; summary: string }>((resolve) => {
+        resolveWork = resolve;
+      });
+
+      let now = scheduledAt;
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeatNow: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => {
+          // Simulate completing quickly once actually running.
+          // The deferred timeout gives us the full 50ms budget
+          // from when execution starts, not from enqueue.
+          resolveWork!({ status: "ok", summary: "done" });
+          return workPromise;
+        }),
+      });
+
+      const timerPromise = onTimer(state);
+
+      // Resolve the work immediately.
+      resolveWork!({ status: "ok", summary: "done" });
+      await timerPromise;
+
+      const job = state.store?.jobs.find((j) => j.id === "deferred-timeout");
+      expect(job?.state.lastStatus).toBe("ok");
+      expect(job?.state.lastError).toBeUndefined();
+    });
+
+    it("executeJobCore calls onExecutionStart before running isolated jobs", async () => {
+      vi.useRealTimers();
+      const store = makeStorePath();
+      const scheduledAt = Date.parse("2026-03-10T12:00:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "arm-callback-test",
+        name: "arm callback",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "test" },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      const onExecutionStart = vi.fn();
+      let now = scheduledAt;
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeatNow: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => {
+          // Verify onExecutionStart was called before we run.
+          expect(onExecutionStart).toHaveBeenCalledTimes(1);
+          return { status: "ok" as const, summary: "done" };
+        }),
+      });
+
+      state.running = true;
+      state.store = { version: 1, jobs: [cronJob] };
+
+      await executeJobCore(state, cronJob, undefined, onExecutionStart);
+
+      expect(onExecutionStart).toHaveBeenCalledTimes(1);
+    });
+
+    it("executeJobCore calls onExecutionStart for main session jobs", async () => {
+      vi.useRealTimers();
+      const store = makeStorePath();
+      const scheduledAt = Date.parse("2026-03-10T12:00:00.000Z");
+      const mainJob = {
+        id: "main-arm-test",
+        name: "main arm",
+        enabled: true,
+        createdAtMs: scheduledAt,
+        updatedAtMs: scheduledAt,
+        schedule: { kind: "at" as const, at: new Date(scheduledAt).toISOString() },
+        sessionTarget: "main" as const,
+        wakeMode: "next-heartbeat" as const,
+        payload: { kind: "systemEvent" as const, text: "ping" },
+        state: { nextRunAtMs: scheduledAt },
+      };
+
+      const onExecutionStart = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => scheduledAt,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeatNow: vi.fn(),
+        runIsolatedAgentJob: vi.fn().mockResolvedValue({ status: "ok" }),
+      });
+      state.running = true;
+      state.store = { version: 1, jobs: [mainJob] };
+
+      await executeJobCore(state, mainJob, undefined, onExecutionStart);
+
+      expect(onExecutionStart).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("#37505 — shared AbortController kills fallback chain", () => {
+    it("abort signal is passed to runIsolatedAgentJob and fires on timeout", async () => {
+      vi.useRealTimers();
+      const store = makeStorePath();
+      const scheduledAt = Date.parse("2026-03-10T12:00:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "abort-signal-test",
+        name: "abort signal",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 0.005 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      const abortAwareRunner = createAbortAwareIsolatedRunner();
+      let now = scheduledAt;
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeatNow: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async (params) => {
+          const result = await abortAwareRunner.runIsolatedAgentJob(params);
+          now += 5;
+          return result;
+        }),
+      });
+
+      await onTimer(state);
+
+      expect(abortAwareRunner.getObservedAbortSignal()).toBeDefined();
+      expect(abortAwareRunner.getObservedAbortSignal()?.aborted).toBe(true);
+
+      const job = state.store?.jobs.find((j) => j.id === "abort-signal-test");
+      expect(job?.state.lastStatus).toBe("error");
+      expect(job?.state.lastError).toContain("timed out");
+    });
+
+    it("executeJobCoreWithTimeout still times out correctly with deferred start", async () => {
+      vi.useRealTimers();
+      const store = makeStorePath();
+      const scheduledAt = Date.parse("2026-03-10T12:00:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "timeout-still-works",
+        name: "timeout works",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "slow", timeoutSeconds: 0.005 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      const abortAwareRunner = createAbortAwareIsolatedRunner();
+      let now = scheduledAt;
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeatNow: vi.fn(),
+        runIsolatedAgentJob: abortAwareRunner.runIsolatedAgentJob,
+      });
+      state.running = true;
+      state.store = { version: 1, jobs: [cronJob] };
+
+      // executeJobCoreWithTimeout rejects the Promise.race when timeout
+      // fires, which surfaces as a thrown error. The caller (executeJob/
+      // ops.ts) catches this and records it as an error status.
+      await expect(executeJobCoreWithTimeout(state, cronJob)).rejects.toThrow("timed out");
+      expect(abortAwareRunner.getObservedAbortSignal()?.aborted).toBe(true);
+    });
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -72,20 +72,47 @@ export async function executeJobCoreWithTimeout(
   }
 
   const runAbortController = new AbortController();
-  let timeoutId: NodeJS.Timeout | undefined;
+  let executionTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  let safetyTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  // Defer the execution timeout timer until executeJobCore signals that
+  // actual execution has begun.  This prevents queue wait time (lane
+  // acquisition inside the embedded runner) from consuming the execution
+  // timeout budget.  (#41783)
+  let rejectRace: ((err: Error) => void) | undefined;
+  let armed = false;
+  const fireTimeout = () => {
+    runAbortController.abort(timeoutErrorMessage());
+    rejectRace?.(new Error(timeoutErrorMessage()));
+  };
+  const armExecutionTimeout = () => {
+    if (armed) {
+      return;
+    }
+    armed = true;
+    // Cancel the safety backstop and start the real execution timer.
+    if (safetyTimeoutId) {
+      clearTimeout(safetyTimeoutId);
+      safetyTimeoutId = undefined;
+    }
+    executionTimeoutId = setTimeout(fireTimeout, jobTimeoutMs);
+  };
   try {
     return await Promise.race([
-      executeJobCore(state, job, runAbortController.signal),
+      executeJobCore(state, job, runAbortController.signal, armExecutionTimeout),
       new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          runAbortController.abort(timeoutErrorMessage());
-          reject(new Error(timeoutErrorMessage()));
-        }, jobTimeoutMs);
+        rejectRace = reject;
+        // Safety backstop: if executeJobCore returns early without arming
+        // (e.g. skipped/error before real work), this generous ceiling
+        // ensures we never hang forever.  2× the configured timeout.
+        safetyTimeoutId = setTimeout(fireTimeout, jobTimeoutMs * 2);
       }),
     ]);
   } finally {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
+    if (executionTimeoutId) {
+      clearTimeout(executionTimeoutId);
+    }
+    if (safetyTimeoutId) {
+      clearTimeout(safetyTimeoutId);
     }
   }
 }
@@ -1006,6 +1033,9 @@ export async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
   abortSignal?: AbortSignal,
+  /** Called by the job just before starting real work (e.g. LLM call) so the
+   *  caller can defer the timeout timer until after lane/queue wait.  (#41783) */
+  onExecutionStart?: () => void,
 ): Promise<
   CronRunOutcome & CronRunTelemetry & { delivered?: boolean; deliveryAttempted?: boolean }
 > {
@@ -1039,6 +1069,8 @@ export async function executeJobCore(
     return resolveAbortError();
   }
   if (job.sessionTarget === "main") {
+    // Arm execution timeout for main session jobs too.
+    onExecutionStart?.();
     const text = resolveJobPayloadTextForMain(job);
     if (!text) {
       const kind = job.payload.kind;
@@ -1129,6 +1161,10 @@ export async function executeJobCore(
   if (abortSignal?.aborted) {
     return resolveAbortError();
   }
+
+  // Arm the execution timeout now — the job is about to start real work.
+  // This excludes lane queue wait time from the timeout budget.  (#41783)
+  onExecutionStart?.();
 
   const res = await state.deps.runIsolatedAgentJob({
     job,


### PR DESCRIPTION
## Summary

Fix two root causes of isolated cron `agentTurn` jobs hanging until timeout (#42464):

- **Per-attempt AbortControllers (#37505):** The cron timeout fires a shared `AbortController` signal that propagates to all subsequent model fallback attempts, killing them instantly (~100ms) without making a network request. Each fallback attempt in `runCronIsolatedAgentTurn` now gets its own `AbortController` linked to the parent signal, so when one attempt is aborted the next attempt starts with a fresh (non-aborted) controller.

- **Deferred execution timeout (#41783):** The timeout timer in `executeJobCoreWithTimeout` started immediately via `Promise.race`, but the job may wait in the lane queue (inside `runEmbeddedPiAgent`) before doing real work. `executeJobCore` now accepts an `onExecutionStart` callback and calls it right before `runIsolatedAgentJob`, deferring the timeout clock until actual execution begins. A 2× safety backstop prevents indefinite hangs if the callback is never called.

### Files changed
- `src/cron/isolated-agent/run.ts` — per-attempt `AbortController` in the `runWithModelFallback` run callback
- `src/cron/service/timer.ts` — deferred timeout arming via `onExecutionStart` callback
- `src/cron/service.cron-timeout-abort.test.ts` — 5 new tests covering both fixes

## Test plan

- [x] All 502 existing cron tests pass (64 test files)
- [x] All 60 model-fallback tests pass
- [x] 5 new tests covering:
  - Deferred timeout does not fire during queue wait
  - `executeJobCore` calls `onExecutionStart` before running isolated jobs
  - `executeJobCore` calls `onExecutionStart` for main session jobs
  - Abort signal fires correctly on timeout
  - `executeJobCoreWithTimeout` still times out correctly with deferred start

Closes #37505
Closes #41783
Fixes #42632
Refs #42464 #40237

## Related

- Supersedes PR #41796 (closed by author in favour of this PR — same deferred timeout fix but narrower scope)
- Independent repro in #42632 (6 confirmations from affected users)
- WS self-contention (#40237) addressed separately in PR #42497