### PR TITLE
fix(memory-lancedb): preserve dimensions for baseUrl embeddings

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -218,6 +218,104 @@ describe("memory plugin e2e", () => {
     }
   });
 
+  test("uses direct fetch for baseUrl embeddings and preserves configured dimensions", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [{ embedding: [0.1, 0.2, 0.3, 0.4] }],
+      }),
+    }));
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const openAiEmbeddingsCreate = vi.fn();
+
+    vi.resetModules();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: openAiEmbeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          countRows: vi.fn(async () => 0),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+            dimensions: 1024,
+            baseUrl: "http://localhost:4000/v1",
+          },
+          dbPath,
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+        registerTool: (tool: any, opts: any) => {
+          registeredTools.push({ tool, opts });
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+        registerCli: vi.fn(),
+        // oxlint-disable-next-line typescript/no-explicit-any
+        registerService: vi.fn(),
+        // oxlint-disable-next-line typescript/no-explicit-any
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+      const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+      expect(recallTool).toBeDefined();
+      await recallTool.execute("test-call-baseurl-fetch", { query: "hello fetch dimensions" });
+
+      expect(fetchMock).toHaveBeenCalledWith("http://localhost:4000/v1/embeddings", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: "text-embedding-3-small",
+          input: "hello fetch dimensions",
+          dimensions: 1024,
+        }),
+      });
+      expect(openAiEmbeddingsCreate).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
   test("shouldCapture applies real capture rules", async () => {
     const { shouldCapture } = await import("./index.js");
 

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -162,6 +162,8 @@ class MemoryDB {
 
 class Embeddings {
   private client: OpenAI;
+  private apiKey: string;
+  private baseUrl?: string;
 
   constructor(
     apiKey: string,
@@ -169,10 +171,48 @@ class Embeddings {
     baseUrl?: string,
     private dimensions?: number,
   ) {
+    this.apiKey = apiKey;
+    this.baseUrl = baseUrl;
     this.client = new OpenAI({ apiKey, baseURL: baseUrl });
   }
 
+  private async embedViaFetch(text: string): Promise<number[]> {
+    if (!this.baseUrl) {
+      throw new Error("Direct fetch embedding path requires baseUrl");
+    }
+
+    const response = await fetch(`${this.baseUrl.replace(/\/$/, "")}/embeddings`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        input: text,
+        ...(this.dimensions ? { dimensions: this.dimensions } : {}),
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Embedding request failed: HTTP ${response.status}`);
+    }
+
+    const payload = (await response.json()) as {
+      data?: Array<{ embedding?: number[] }>;
+    };
+    const embedding = payload.data?.[0]?.embedding;
+    if (!Array.isArray(embedding)) {
+      throw new Error("Embedding response missing vector payload");
+    }
+    return embedding;
+  }
+
   async embed(text: string): Promise<number[]> {
+    if (this.baseUrl) {
+      return this.embedViaFetch(text);
+    }
+
     const params: { model: string; input: string; dimensions?: number } = {
       model: this.model,
       input: text,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `memory-lancedb` can receive the wrong embedding dimensionality when configured against an OpenAI-compatible `baseUrl` provider, even when `embedding.dimensions` is set explicitly.
- Why it matters: recall/search can fail at runtime with LanceDB errors like `No vector column found to match with the query vector dimension: 192`, which breaks memory recall despite correct config and correct on-disk schema.
- What changed: when `memory-lancedb` is configured with `embedding.baseUrl`, the plugin now uses a direct HTTP `POST /embeddings` call instead of the Node OpenAI SDK path; a regression test covers this path and asserts the configured dimensions are preserved.
- What did NOT change (scope boundary): native OpenAI embedding calls without `baseUrl` still use the existing OpenAI SDK path, and no table schema or storage behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `memory-lancedb` recall/search now works reliably when embeddings are routed through an OpenAI-compatible `baseUrl` provider such as LiteLLM.
- No config or migration changes are required.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - The plugin already made outbound embedding requests to the configured provider. This change keeps the same destination and auth material, but replaces the client implementation with a direct HTTP call only for `baseUrl` providers. Risk is limited to that code path and is covered by a regression test.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 / linux 6.12
- Runtime/container: OpenClaw `2026.3.8`, Node `24.13.1`
- Model/provider: `episodic-embedding` via LiteLLM -> Ollama (`embeddinggemma`)
- Integration/channel (if any): none required
- Relevant config (redacted):
  - `memory-lancedb.embedding.model = episodic-embedding`
  - `memory-lancedb.embedding.baseUrl = http://localhost:4000/v1`
  - `memory-lancedb.embedding.dimensions = 768`

### Steps

1. Configure `memory-lancedb` with a custom `embedding.baseUrl` and explicit `embedding.dimensions`.
2. Run memory recall/search (`openclaw ltm search ...` or trigger auto-recall via the gateway).
3. Observe the embedding vector length returned through the SDK path and LanceDB query behavior.

### Expected

- The configured dimensions are preserved end to end and LanceDB recall succeeds.

### Actual

- The SDK/baseUrl path returned a `192`-dimensional vector even when `dimensions=768` was requested, causing LanceDB recall/query failures.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - reproduced the failure on a live Clavicus OpenClaw install with `memory-lancedb`
  - confirmed direct raw HTTP to LiteLLM returned the correct `768` dimensions
  - confirmed the Node OpenAI SDK path returned `192` for the same endpoint/config
  - applied the fix and verified `openclaw ltm search` succeeded instead of failing
  - ran `pnpm exec vitest run --config vitest.extensions.config.ts extensions/memory-lancedb/index.test.ts`
- Edge cases checked:
  - explicit `dimensions` preserved in the `baseUrl` path
  - native OpenAI path left untouched
- What you did **not** verify:
  - full repo test suite
  - non-LiteLLM OpenAI-compatible providers beyond the local LiteLLM repro

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert the patch in `extensions/memory-lancedb/index.ts`
- Files/config to restore:
  - `extensions/memory-lancedb/index.ts`
  - `extensions/memory-lancedb/index.test.ts`
- Known bad symptoms reviewers should watch for:
  - embedding request failures on `baseUrl` providers
  - missing/invalid JSON from `/embeddings`

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Some OpenAI-compatible providers may behave differently from LiteLLM and return a nonstandard embeddings payload.
  - Mitigation:
    - the change is only enabled for the `baseUrl` path, validates the response shape explicitly, and preserves the native OpenAI SDK path otherwise.
