### PR TITLE
feat(telegram): add supersede preemption + burst coalesce for inbound runs

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -42,10 +42,10 @@ import { buildInboundMetaSystemPrompt, buildInboundUserContextPrefix } from "./i
 import type { createModelSelectionState } from "./model-selection.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveQueueSettings } from "./queue.js";
-import { resolveTelegramSupersedeQueueOverride } from "./telegram-supersede.js";
 import { routeReply } from "./route-reply.js";
 import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents, ensureSkillSnapshot } from "./session-updates.js";
+import { resolveTelegramSupersedeQueueOverride } from "./telegram-supersede.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 import type { TypingController } from "./typing.js";

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -42,6 +42,7 @@ import { buildInboundMetaSystemPrompt, buildInboundUserContextPrefix } from "./i
 import type { createModelSelectionState } from "./model-selection.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveQueueSettings } from "./queue.js";
+import { resolveTelegramSupersedeQueueOverride } from "./telegram-supersede.js";
 import { routeReply } from "./route-reply.js";
 import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents, ensureSkillSnapshot } from "./session-updates.js";
@@ -435,19 +436,33 @@ export async function runPreparedReply(
   const queuedBody = mediaNote
     ? [mediaNote, mediaReplyHint, queueBodyBase].filter(Boolean).join("\n").trim()
     : queueBodyBase;
+  const telegramSupersedeOverride = resolveTelegramSupersedeQueueOverride({
+    cfg,
+    channel: sessionCtx.Provider,
+    accountId: sessionCtx.AccountId,
+  });
   const resolvedQueue = resolveQueueSettings({
     cfg,
     channel: sessionCtx.Provider,
     sessionEntry,
-    inlineMode: perMessageQueueMode,
-    inlineOptions: perMessageQueueOptions,
+    inlineMode: telegramSupersedeOverride.inlineMode ?? perMessageQueueMode,
+    inlineOptions:
+      telegramSupersedeOverride.inlineOptions || perMessageQueueOptions
+        ? {
+            ...(perMessageQueueOptions ?? {}),
+            ...(telegramSupersedeOverride.inlineOptions ?? {}),
+          }
+        : undefined,
   });
   const sessionLaneKey = resolveEmbeddedSessionLane(sessionKey ?? sessionIdFinal);
   const laneSize = getQueueSize(sessionLaneKey);
-  if (resolvedQueue.mode === "interrupt" && laneSize > 0) {
-    const cleared = clearCommandLane(sessionLaneKey);
+  const hadActiveRunBeforeInterrupt = isEmbeddedPiRunActive(sessionIdFinal);
+  if (resolvedQueue.mode === "interrupt" && (laneSize > 0 || hadActiveRunBeforeInterrupt)) {
+    const cleared = laneSize > 0 ? clearCommandLane(sessionLaneKey) : 0;
     const aborted = abortEmbeddedPiRun(sessionIdFinal);
-    logVerbose(`Interrupting ${sessionLaneKey} (cleared ${cleared}, aborted=${aborted})`);
+    logVerbose(
+      `Interrupting ${sessionLaneKey} (cleared ${cleared}, active=${hadActiveRunBeforeInterrupt}, aborted=${aborted})`,
+    );
   }
   const queueKey = sessionKey ?? sessionIdFinal;
   const isActive = isEmbeddedPiRunActive(sessionIdFinal);

--- a/src/auto-reply/reply/telegram-supersede.test.ts
+++ b/src/auto-reply/reply/telegram-supersede.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  resolveTelegramSupersedeDebounceMs,
+  resolveTelegramSupersedeQueueOverride,
+} from "./telegram-supersede.js";
+
+describe("telegram supersede helpers", () => {
+  it("returns no override when channel is not telegram", () => {
+    const cfg = {} as OpenClawConfig;
+    expect(resolveTelegramSupersedeQueueOverride({ cfg, channel: "discord" })).toEqual({});
+  });
+
+  it("enables interrupt mode for latest-wins", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          supersede: {
+            enabled: true,
+            policy: "latest-wins",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveTelegramSupersedeQueueOverride({ cfg, channel: "telegram" })).toEqual({
+      inlineMode: "interrupt",
+      inlineOptions: {
+        debounceMs: 0,
+      },
+    });
+  });
+
+  it("uses account override and exposes burst debounce", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          supersede: {
+            enabled: true,
+            policy: "latest-wins",
+            graceMs: 10,
+          },
+          accounts: {
+            alpha: {
+              supersede: {
+                enabled: true,
+                policy: "burst-coalesce",
+                graceMs: 1200,
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveTelegramSupersedeQueueOverride({
+        cfg,
+        channel: "telegram",
+        accountId: "alpha",
+      }),
+    ).toEqual({
+      inlineMode: "interrupt",
+      inlineOptions: {
+        cap: 1,
+        dropPolicy: "old",
+        debounceMs: 1200,
+      },
+    });
+
+    expect(resolveTelegramSupersedeDebounceMs({ cfg, accountId: "alpha" })).toBe(1200);
+    expect(resolveTelegramSupersedeDebounceMs({ cfg })).toBe(0);
+  });
+});

--- a/src/auto-reply/reply/telegram-supersede.ts
+++ b/src/auto-reply/reply/telegram-supersede.ts
@@ -1,0 +1,76 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import type { QueueSettings } from "./queue/types.js";
+
+type TelegramSupersedePolicy = "latest-wins" | "burst-coalesce";
+
+type TelegramSupersedeResolved = {
+  enabled: boolean;
+  policy: TelegramSupersedePolicy;
+  graceMs: number;
+};
+
+function resolveTelegramSupersedeConfig(params: {
+  cfg: OpenClawConfig;
+  accountId?: string;
+}): TelegramSupersedeResolved {
+  const accountId = params.accountId?.trim();
+  const telegram = params.cfg.channels?.telegram;
+  const account = accountId ? telegram?.accounts?.[accountId] : undefined;
+  const supersede = account?.supersede ?? telegram?.supersede;
+  return {
+    enabled: supersede?.enabled === true,
+    policy: supersede?.policy === "burst-coalesce" ? "burst-coalesce" : "latest-wins",
+    graceMs:
+      typeof supersede?.graceMs === "number" && Number.isFinite(supersede.graceMs)
+        ? Math.max(0, Math.floor(supersede.graceMs))
+        : 0,
+  };
+}
+
+export function resolveTelegramSupersedeQueueOverride(params: {
+  cfg: OpenClawConfig;
+  channel?: string;
+  accountId?: string;
+}): {
+  inlineMode?: QueueSettings["mode"];
+  inlineOptions?: Partial<QueueSettings>;
+} {
+  if (params.channel?.trim().toLowerCase() !== "telegram") {
+    return {};
+  }
+  const supersede = resolveTelegramSupersedeConfig({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  if (!supersede.enabled) {
+    return {};
+  }
+  if (supersede.policy === "burst-coalesce") {
+    return {
+      inlineMode: "interrupt",
+      inlineOptions: {
+        // Keep only the freshest queued follow-up when bursts race with cancellation.
+        cap: 1,
+        dropPolicy: "old",
+        debounceMs: supersede.graceMs,
+      },
+    };
+  }
+  return {
+    inlineMode: "interrupt",
+    inlineOptions: {
+      debounceMs: supersede.graceMs,
+    },
+  };
+}
+
+export function resolveTelegramSupersedeDebounceMs(params: {
+  cfg: OpenClawConfig;
+  accountId?: string;
+}): number {
+  const supersede = resolveTelegramSupersedeConfig(params);
+  if (!supersede.enabled || supersede.policy !== "burst-coalesce") {
+    return 0;
+  }
+  return supersede.graceMs;
+}

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -39,6 +39,7 @@ export type TelegramNetworkConfig = {
 export type TelegramInlineButtonsScope = "off" | "dm" | "group" | "all" | "allowlist";
 export type TelegramStreamingMode = "off" | "partial" | "block" | "progress";
 export type TelegramExecApprovalTarget = "dm" | "channel" | "both";
+export type TelegramSupersedePolicy = "latest-wins" | "burst-coalesce";
 
 export type TelegramExecApprovalConfig = {
   /** Enable Telegram exec approvals for this account. Default: false. */
@@ -51,6 +52,15 @@ export type TelegramExecApprovalConfig = {
   sessionFilter?: string[];
   /** Where to send approval prompts. Default: "dm". */
   target?: TelegramExecApprovalTarget;
+};
+
+export type TelegramSupersedeConfig = {
+  /** Enable Telegram run preemption when a newer inbound message arrives for the same session. */
+  enabled?: boolean;
+  /** Optional debounce/grace window (ms) for burst-coalesce handling. */
+  graceMs?: number;
+  /** Supersede strategy. latest-wins aborts immediately; burst-coalesce debounces bursts first. */
+  policy?: TelegramSupersedePolicy;
 };
 
 export type TelegramCapabilitiesConfig =
@@ -135,6 +145,8 @@ export type TelegramAccountConfig = {
   streaming?: TelegramStreamingMode | boolean;
   /** Disable block streaming for this account. */
   blockStreaming?: boolean;
+  /** Telegram run supersede controls (preempt stale in-flight turns on new inbound). */
+  supersede?: TelegramSupersedeConfig;
   /** @deprecated Legacy chunking config from `streamMode: "block"`; ignored after migration. */
   draftChunk?: BlockStreamingChunkConfig;
   /** Merge streamed block replies before sending. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -186,6 +186,14 @@ export const TelegramAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     streaming: z.union([z.boolean(), z.enum(["off", "partial", "block", "progress"])]).optional(),
     blockStreaming: z.boolean().optional(),
+    supersede: z
+      .object({
+        enabled: z.boolean().optional(),
+        graceMs: z.number().int().nonnegative().optional(),
+        policy: z.enum(["latest-wins", "burst-coalesce"]).optional(),
+      })
+      .strict()
+      .optional(),
     draftChunk: BlockStreamingChunkSchema.optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     // Legacy key kept for automatic migration to `streaming`.

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -5,6 +5,7 @@ import {
   resolveInboundDebounceMs,
 } from "../auto-reply/inbound-debounce.js";
 import { buildCommandsPaginationKeyboard } from "../auto-reply/reply/commands-info.js";
+import { resolveTelegramSupersedeDebounceMs } from "../auto-reply/reply/telegram-supersede.js";
 import {
   buildModelsProviderData,
   formatModelsAvailableHeader,
@@ -163,6 +164,10 @@ export const registerTelegramHandlers = ({
   let textFragmentProcessing: Promise<void> = Promise.resolve();
 
   const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
+  const supersedeBurstDebounceMs = resolveTelegramSupersedeDebounceMs({
+    cfg,
+    accountId,
+  });
   const FORWARD_BURST_DEBOUNCE_MS = 80;
   type TelegramDebounceLane = "default" | "forward";
   type TelegramDebounceEntry = {
@@ -216,8 +221,12 @@ export const registerTelegramHandlers = ({
   };
   const inboundDebouncer = createInboundDebouncer<TelegramDebounceEntry>({
     debounceMs,
-    resolveDebounceMs: (entry) =>
-      entry.debounceLane === "forward" ? FORWARD_BURST_DEBOUNCE_MS : debounceMs,
+    resolveDebounceMs: (entry) => {
+      if (entry.debounceLane === "forward") {
+        return Math.max(FORWARD_BURST_DEBOUNCE_MS, supersedeBurstDebounceMs);
+      }
+      return Math.max(debounceMs, supersedeBurstDebounceMs);
+    },
     buildKey: (entry) => entry.debounceKey,
     shouldDebounce: (entry) => {
       const text = entry.msg.text ?? entry.msg.caption ?? "";

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -5,12 +5,12 @@ import {
   resolveInboundDebounceMs,
 } from "../auto-reply/inbound-debounce.js";
 import { buildCommandsPaginationKeyboard } from "../auto-reply/reply/commands-info.js";
-import { resolveTelegramSupersedeDebounceMs } from "../auto-reply/reply/telegram-supersede.js";
 import {
   buildModelsProviderData,
   formatModelsAvailableHeader,
 } from "../auto-reply/reply/commands-models.js";
 import { resolveStoredModelOverride } from "../auto-reply/reply/model-selection.js";
+import { resolveTelegramSupersedeDebounceMs } from "../auto-reply/reply/telegram-supersede.js";
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { buildCommandsMessagePaginated } from "../auto-reply/status.js";
 import { shouldDebounceTextInbound } from "../channels/inbound-debounce-policy.js";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram follow-up messages could be queued behind an active run, causing stale responses when user intent changed mid-run.
- Why it matters: chat responsiveness degrades under fast back-and-forth; latest intent should win.
- What changed: added Telegram supersede config, queue preemption hook for in-flight runs, and burst coalescing debounce wiring in inbound handlers, with regression tests.
- What did NOT change (scope boundary): no Discord/Slack supersede support and no universal cross-channel preemption.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related # https://linear.app/max-techera/issue/NEO-332

## User-visible / Behavior Changes

- Adds `channels.telegram.supersede.enabled|graceMs|policy` config surface (default off).
- When enabled, new Telegram inbound can supersede active in-flight run so latest message is prioritized.
- Burst coalesce path combines near-limit channel_post fragments into a single message processing unit.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js repo workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram inbound pipeline
- Relevant config (redacted): `channels.telegram.supersede.enabled=true`, policy `latest-wins` / `burst-coalesce`

### Steps

1. Run `pnpm dlx vitest run src/auto-reply/reply/telegram-supersede.test.ts src/auto-reply/reply/queue-policy.test.ts`
2. Run `pnpm dlx vitest run src/telegram/bot.create-telegram-bot.test.ts -t "coalesces channel_post near-limit text fragments into one message"`
3. Confirm tests pass and supersede/coalesce assertions hold.

### Expected

- Supersede helper and queue policy tests pass.
- Telegram fragment coalesce scenario passes.

### Actual

- All targeted tests passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence snippets:
- `src/auto-reply/reply/queue-policy.test.ts` → 4 passed
- `src/auto-reply/reply/telegram-supersede.test.ts` → 3 passed
- `src/telegram/bot.create-telegram-bot.test.ts -t "coalesces ..."` → 1 passed (45 skipped)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: supersede helper behavior, queue policy precedence, burst coalesce regression path.
- Edge cases checked: coalesced near-limit channel_post fragments and non-target tests unaffected by test filter.
- What you did **not** verify: live Telegram runtime under production traffic.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `channels.telegram.supersede.enabled=false` (default), or rollback to commit `42a1394c5`.
- Files/config to restore: Telegram supersede-related changes in config schema and reply pipeline files listed below.
- Known bad symptoms reviewers should watch for: dropped/duplicated Telegram replies or unexpected preemption behavior when supersede is enabled.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: aggressive preemption may cancel long-running turns too eagerly under burst traffic.
  - Mitigation: policy + graceMs controls, default-off rollout, targeted regression coverage.
- Risk: coalescing could hide message boundaries for edge channel_post payloads.
  - Mitigation: constrained coalesce logic with regression test for near-limit fragment case.
