### PR TITLE
fix: only kill stale gateway if not responding

### DIFF
--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { Command } from "commander";
@@ -223,11 +224,53 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.exit(1);
     return;
   }
+  /**
+   * Check if gateway is responding on the given port.
+   * Returns true if gateway is healthy and responding.
+   */
+  async function isGatewayResponding(port: number, timeoutMs = 2000): Promise<boolean> {
+    return new Promise((resolve) => {
+      try {
+        const req = spawn(
+          "curl",
+          ["-s", "-o", "/dev/null", "-w", "%{http_code}", `http://127.0.0.1:${port}/health`],
+          { timeout: timeoutMs },
+        );
+        let output = "";
+        req.stdout?.on("data", (data) => {
+          output += data.toString();
+        });
+        req.on("close", (code) => {
+          if (code === 0 && output.includes("200")) {
+            resolve(true);
+          } else {
+            resolve(false);
+          }
+        });
+        req.on("error", () => resolve(false));
+        setTimeout(() => {
+          resolve(false);
+        }, timeoutMs);
+      } catch {
+        resolve(false);
+      }
+    });
+  }
+
   if (process.env.OPENCLAW_SERVICE_MARKER?.trim()) {
-    const stale = cleanStaleGatewayProcessesSync(port);
-    if (stale.length > 0) {
+    // Only kill "stale" gateways that are not responding
+    // This prevents killing healthy gateways that happen to be on the port
+    const isHealthy = await isGatewayResponding(port);
+    if (!isHealthy) {
+      const stale = cleanStaleGatewayProcessesSync(port);
+      if (stale.length > 0) {
+        gatewayLog.info(
+          `service-mode: cleared ${stale.length} stale gateway pid(s) before bind on port ${port}`,
+        );
+      }
+    } else {
       gatewayLog.info(
-        `service-mode: cleared ${stale.length} stale gateway pid(s) before bind on port ${port}`,
+        `service-mode: gateway already running and responding on port ${port}, skipping stale cleanup`,
       );
     }
   }


### PR DESCRIPTION
## Summary

This fix addresses a bug where the OpenCLAW CLI would kill any gateway process on the port when `OPENCLAW_SERVICE_MARKER` was set, without checking if the gateway was healthy.

## Root Cause

When running any `openclaw` command (like `health`), the CLI checks if `OPENCLAW_SERVICE_MARKER` is set. If set, it calls `cleanStaleGatewayProcessesSync()` which finds ANY gateway on the port and kills it - regardless of whether the gateway is healthy or responding.

## Fix

Before killing "stale" gateway processes, we now check if the gateway is responding via HTTP health check (`GET /health`). Only if the gateway is not responding do we proceed with killing it.

```typescript
const isHealthy = await isGatewayResponding(port);
if (!isHealthy) {
  // kill stale gateway
} else {
  // skip - gateway is healthy
}
```

## Test Plan

- [ ] Run gateway manually
- [ ] Run `openclaw health` - gateway should NOT be killed
- [ ] Verify gateway continues running
- [ ] Run `openclaw gateway` - should detect healthy gateway and skip cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>