### PR TITLE
fix(imessage): prevent self-echo message loop

### DIFF
--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -21,6 +21,8 @@ export async function deliverReplies(params: {
   const { replies, target, client, runtime, maxBytes, textLimit, accountId, sentMessageCache } =
     params;
   const scope = `${accountId ?? ""}:${target}`;
+  // Account-global scope catches self-echoes even when sender handle differs from target
+  const globalScope = `${accountId ?? ""}:_outbound_`;
   const cfg = loadConfig();
   const tableMode = resolveMarkdownTableMode({
     cfg,
@@ -37,6 +39,7 @@ export async function deliverReplies(params: {
     }
     if (mediaList.length === 0) {
       sentMessageCache?.remember(scope, { text });
+      sentMessageCache?.remember(globalScope, { text });
       for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
         const sent = await sendMessageIMessage(target, chunk, {
           maxBytes,
@@ -45,6 +48,7 @@ export async function deliverReplies(params: {
           replyToId: payload.replyToId,
         });
         sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
+        sentMessageCache?.remember(globalScope, { text: chunk, messageId: sent.messageId });
       }
     } else {
       let first = true;
@@ -59,6 +63,10 @@ export async function deliverReplies(params: {
           replyToId: payload.replyToId,
         });
         sentMessageCache?.remember(scope, {
+          text: caption || undefined,
+          messageId: sent.messageId,
+        });
+        sentMessageCache?.remember(globalScope, {
           text: caption || undefined,
           messageId: sent.messageId,
         });

--- a/src/imessage/monitor/echo-cache.ts
+++ b/src/imessage/monitor/echo-cache.ts
@@ -8,7 +8,10 @@ export type SentMessageCache = {
   has: (scope: string, lookup: SentMessageLookup) => boolean;
 };
 
-const SENT_MESSAGE_TEXT_TTL_MS = 5000;
+// Text TTL must be long enough to catch delayed self-echoes (the imsg daemon
+// can re-emit sent messages as inbound notifications several seconds later,
+// especially when multiple handles/devices are involved).
+const SENT_MESSAGE_TEXT_TTL_MS = 60_000;
 const SENT_MESSAGE_ID_TTL_MS = 60_000;
 
 function normalizeEchoTextKey(text: string | undefined): string | null {

--- a/src/imessage/monitor/inbound-processing.test.ts
+++ b/src/imessage/monitor/inbound-processing.test.ts
@@ -5,6 +5,38 @@ import {
   resolveIMessageInboundDecision,
 } from "./inbound-processing.js";
 
+describe("resolveIMessageInboundDecision is_from_me", () => {
+  const cfg = {} as OpenClawConfig;
+
+  it("drops messages with is_from_me=true", () => {
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 1,
+        sender: "+15555550123",
+        text: "Hello",
+        is_from_me: true,
+        is_group: false,
+      },
+      opts: undefined,
+      messageText: "Hello",
+      bodyText: "Hello",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      logVerbose: undefined,
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "from me" });
+  });
+});
+
 describe("resolveIMessageInboundDecision echo detection", () => {
   const cfg = {} as OpenClawConfig;
 
@@ -44,6 +76,57 @@ describe("resolveIMessageInboundDecision echo detection", () => {
         text: "Reasoning:\n_step_",
         messageId: "42",
       }),
+    );
+  });
+
+  it("drops self-echo via account-global outbound scope when conversation scope mismatches", () => {
+    // Simulates: bot sent "Hi there" to alice, but echo comes back with sender=bot_handle.
+    // Conversation scope won't match, but the global _outbound_ scope catches it.
+    const echoHas = vi.fn((scope: string, lookup: { text?: string; messageId?: string }) => {
+      // Conversation scope uses bot's own handle — doesn't match the original target scope
+      if (scope === "default:imessage:bot@icloud.com") {
+        return false;
+      }
+      // Account-global outbound scope matches
+      if (scope === "default:_outbound_" && lookup.text === "Hi there") {
+        return true;
+      }
+      return false;
+    });
+
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 99,
+        sender: "bot@icloud.com",
+        text: "Hi there",
+        is_from_me: false, // not set by daemon in this scenario
+        is_group: false,
+      },
+      opts: undefined,
+      messageText: "Hi there",
+      bodyText: "Hi there",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: { has: echoHas },
+      logVerbose: undefined,
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "echo" });
+    // Should have checked both conversation scope and global scope
+    expect(echoHas).toHaveBeenCalledWith(
+      "default:imessage:bot@icloud.com",
+      expect.objectContaining({ text: "Hi there" }),
+    );
+    expect(echoHas).toHaveBeenCalledWith(
+      "default:_outbound_",
+      expect.objectContaining({ text: "Hi there" }),
     );
   });
 });

--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -216,6 +216,8 @@ export function resolveIMessageInboundDecision(params: {
 
   // Echo detection: check if the received message matches a recently sent message (within 5 seconds).
   // Scope by conversation so same text in different chats is not conflated.
+  // Also check account-global outbound scope to catch self-echoes where the sender handle
+  // differs from the original target (e.g., bot's own handle vs recipient handle).
   const inboundMessageId = params.message.id != null ? String(params.message.id) : undefined;
   if (params.echoCache && (messageText || inboundMessageId)) {
     const echoScope = buildIMessageEchoScope({
@@ -224,8 +226,13 @@ export function resolveIMessageInboundDecision(params: {
       chatId,
       sender,
     });
+    const globalEchoScope = `${params.accountId}:_outbound_`;
     if (
       params.echoCache.has(echoScope, {
+        text: messageText || undefined,
+        messageId: inboundMessageId,
+      }) ||
+      params.echoCache.has(globalEchoScope, {
         text: messageText || undefined,
         messageId: inboundMessageId,
       })

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -436,6 +436,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       logVerbose("imessage: dropping malformed RPC message payload");
       return;
     }
+    // Early self-echo guard: drop before debouncer to prevent coalescing with real messages
+    if (message.is_from_me) {
+      logVerbose("imessage: dropping own message (is_from_me)");
+      return;
+    }
     await inboundDebouncer.enqueue({ message });
   };
 


### PR DESCRIPTION
## Summary
- Fixes #41330 — iMessage channel duplicate message loop where the bot's own replies are re-ingested as inbound messages, causing an infinite feedback loop
- Adds pre-debouncer `is_from_me` check to drop self-messages before they enter the debounce queue
- Adds account-global echo cache scope so self-echoes are caught even when the sender handle (bot) differs from the original target (recipient)

## Root Cause
The echo cache had a scope mismatch for DMs: outbound messages were remembered with scope `accountId:imessage:recipient` but echoed inbound messages arrived with scope `accountId:imessage:bot_handle`. These never matched, so the secondary echo filter was completely broken for self-echoes. Combined with `is_from_me` not being reliably set by the imsg daemon, self-messages passed through all filters.

## Test plan
- [x] Unit tests for `is_from_me=true` drop
- [x] Unit test for global echo scope fallback when conversation scope mismatches
- [x] All 47 iMessage tests pass (`pnpm test -- src/imessage/`)
- [x] Lint/format clean (`pnpm check`)
- [ ] Manual: restart gateway, send iMessage, verify no loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)