### PR TITLE
feat(slack): add configurable typing status messages per agent

### DIFF
--- a/src/agents/identity.ts
+++ b/src/agents/identity.ts
@@ -169,3 +169,19 @@ export function resolveHumanDelayConfig(
     maxMs: overrides?.maxMs ?? defaults?.maxMs,
   };
 }
+
+const DEFAULT_TYPING_STATUS = "is typing...";
+
+/**
+ * Resolve typing status for Slack assistant threads.
+ * If the agent has custom typingStatuses configured, picks one at random.
+ * Otherwise falls back to "is typing...".
+ */
+export function resolveTypingStatus(cfg: OpenClawConfig, agentId: string): string {
+  const identity = resolveAgentIdentity(cfg, agentId);
+  const statuses = identity?.typingStatuses;
+  if (!statuses || statuses.length === 0) {
+    return DEFAULT_TYPING_STATUS;
+  }
+  return statuses[Math.floor(Math.random() * statuses.length)] ?? DEFAULT_TYPING_STATUS;
+}

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -235,4 +235,6 @@ export type IdentityConfig = {
   emoji?: string;
   /** Avatar image: workspace-relative path, http(s) URL, or data URI. */
   avatar?: string;
+  /** Custom typing status messages for Slack (picks random). Defaults to "is typing...". */
+  typingStatuses?: string[];
 };

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -280,6 +280,7 @@ export const IdentitySchema = z
     theme: z.string().optional(),
     emoji: z.string().optional(),
     avatar: z.string().optional(),
+    typingStatuses: z.array(z.string()).optional(),
   })
   .strict()
   .optional();

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -1,4 +1,4 @@
-import { resolveHumanDelayConfig } from "../../../agents/identity.js";
+import { resolveHumanDelayConfig, resolveTypingStatus } from "../../../agents/identity.js";
 import { dispatchInboundMessage } from "../../../auto-reply/dispatch.js";
 import { clearHistoryEntriesIfEnabled } from "../../../auto-reply/reply/history.js";
 import { createReplyDispatcherWithTyping } from "../../../auto-reply/reply/reply-dispatcher.js";
@@ -141,13 +141,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   const typingTarget = statusThreadTs ? `${message.channel}/${statusThreadTs}` : message.channel;
   const typingReaction = ctx.typingReaction;
+  const typingStatus = resolveTypingStatus(cfg, route.agentId);
   const typingCallbacks = createTypingCallbacks({
     start: async () => {
       didSetStatus = true;
       await ctx.setSlackThreadStatus({
         channelId: message.channel,
         threadTs: statusThreadTs,
-        status: "is typing...",
+        status: typingStatus,
       });
       if (typingReaction && message.ts) {
         await reactSlackMessage(message.channel, message.ts, typingReaction, {


### PR DESCRIPTION
## Summary

Adds `identity.typingStatuses` config option to allow custom typing indicator messages in Slack assistant threads. When configured, the agent picks a random status from the array each time it starts typing. Falls back to "is typing..." if not set.

## Motivation

This enables per-agent personality in the Slack typing indicator. For example, a Rick Sanchez-themed agent can show messages like "*burp* Processing..." or "Wubba lubba dub dub!" instead of the generic "is typing...".

## Example Config

```json
{
  "agents": {
    "list": [{
      "id": "rick",
      "identity": {
        "name": "Pickle Rick",
        "emoji": "🥒",
        "typingStatuses": [
          "Wubba lubba dub dub!",
          "*burp* Processing...",
          "Science-ing your request...",
          "Consulting the multiverse...",
          "This'll just take a sec, Morty..."
        ]
      }
    }]
  }
}
```

## Changes

- Added `typingStatuses?: string[]` to `IdentitySchema` (zod) and `IdentityConfig` (types)
- Added `resolveTypingStatus()` helper in `src/agents/identity.ts`
- Updated Slack dispatch handler to use the resolved typing status

## Testing

- [ ] Manual testing with custom typingStatuses config
- [ ] Verified random selection works across multiple requests