### PR TITLE
fix(setup): enable named account when patching config

### DIFF
--- a/src/channels/plugins/setup-helpers.ts
+++ b/src/channels/plugins/setup-helpers.ts
@@ -284,12 +284,7 @@ export function patchScopedAccountConfig(params: {
           ...accounts,
           [accountId]: {
             ...existingAccount,
-            ...(ensureAccountEnabled
-              ? {
-                  enabled:
-                    typeof existingAccount.enabled === "boolean" ? existingAccount.enabled : true,
-                }
-              : {}),
+            ...(ensureAccountEnabled ? { enabled: true } : {}),
             ...accountPatch,
           },
         },

--- a/src/channels/plugins/setup-wizard-helpers.test.ts
+++ b/src/channels/plugins/setup-wizard-helpers.test.ts
@@ -865,7 +865,7 @@ describe("patchChannelConfigForAccount", () => {
     expect(next.channels?.telegram?.dmPolicy).toBe("allowlist");
   });
 
-  it("patches nested account config and preserves existing enabled flag", () => {
+  it("patches nested account config and enables the target account", () => {
     const cfg: OpenClawConfig = {
       channels: {
         slack: {
@@ -888,7 +888,7 @@ describe("patchChannelConfigForAccount", () => {
     });
 
     expect(next.channels?.slack?.enabled).toBe(true);
-    expect(next.channels?.slack?.accounts?.work?.enabled).toBe(false);
+    expect(next.channels?.slack?.accounts?.work?.enabled).toBe(true);
     expect(next.channels?.slack?.accounts?.work?.botToken).toBe("new-bot");
     expect(next.channels?.slack?.accounts?.work?.appToken).toBe("new-app");
   });


### PR DESCRIPTION
Fixes Windows CI failure in src/channels/plugins/setup-helpers.test.ts where patching a named account during setup should enable the account even if it was previously disabled.

Change:
- patchScopedAccountConfig: when ensureAccountEnabled=true, set account.enabled=true (do not preserve existing false)

Tests:
- pnpm exec vitest run src/channels/plugins/setup-helpers.test.ts