### PR TITLE
fix(telegram): normalize delivery-only group chat ids

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -470,6 +470,28 @@ describe("sendMessageTelegram", () => {
     ).rejects.toThrow(/could not be resolved to a numeric chat ID/i);
   });
 
+  it("sends bare group-prefixed numeric delivery targets without lookup", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 1,
+      chat: { id: "-100123" },
+    });
+    const getChat = vi.fn();
+    const api = { sendMessage, getChat } as unknown as {
+      sendMessage: typeof sendMessage;
+      getChat: typeof getChat;
+    };
+
+    await sendMessageTelegram("group:-100123", "hi", {
+      token: "tok",
+      api,
+    });
+
+    expect(getChat).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith("-100123", "hi", {
+      parse_mode: "HTML",
+    });
+  });
+
   it("includes thread params in media messages", async () => {
     const chatId = "-1001234567890";
     const sendPhoto = vi.fn().mockResolvedValue({

--- a/src/telegram/targets.test.ts
+++ b/src/telegram/targets.test.ts
@@ -93,6 +93,11 @@ describe("normalizeTelegramChatId", () => {
     expect(normalizeTelegramChatId("123456789")).toBe("123456789");
   });
 
+  it("normalizes bare delivery-only group prefixes for numeric chat ids", () => {
+    expect(normalizeTelegramChatId("group:-1001234567890")).toBe("-1001234567890");
+    expect(normalizeTelegramChatId("group:123456789")).toBe("123456789");
+  });
+
   it("returns undefined for empty input", () => {
     expect(normalizeTelegramChatId("  ")).toBeUndefined();
   });
@@ -109,6 +114,11 @@ describe("normalizeTelegramLookupTarget", () => {
   it("keeps numeric chat ids unchanged", () => {
     expect(normalizeTelegramLookupTarget("-1001234567890")).toBe("-1001234567890");
     expect(normalizeTelegramLookupTarget("123456789")).toBe("123456789");
+  });
+
+  it("normalizes bare delivery-only group prefixes for numeric chat ids", () => {
+    expect(normalizeTelegramLookupTarget("group:-1001234567890")).toBe("-1001234567890");
+    expect(normalizeTelegramLookupTarget("group:123456789")).toBe("123456789");
   });
 
   it("rejects invalid username forms", () => {

--- a/src/telegram/targets.ts
+++ b/src/telegram/targets.ts
@@ -7,6 +7,12 @@ export type TelegramTarget = {
 const TELEGRAM_NUMERIC_CHAT_ID_REGEX = /^-?\d+$/;
 const TELEGRAM_USERNAME_REGEX = /^[A-Za-z0-9_]{5,}$/i;
 
+function normalizeTelegramDeliveryGroupChatId(raw: string): string {
+  const trimmed = raw.trim();
+  const match = /^group:\s*(-?\d+)$/i.exec(trimmed);
+  return match?.[1] ?? trimmed;
+}
+
 export function stripTelegramInternalPrefixes(to: string): string {
   let trimmed = to.trim();
   let strippedTelegramPrefix = false;
@@ -30,7 +36,7 @@ export function stripTelegramInternalPrefixes(to: string): string {
 }
 
 export function normalizeTelegramChatId(raw: string): string | undefined {
-  const stripped = stripTelegramInternalPrefixes(raw);
+  const stripped = normalizeTelegramDeliveryGroupChatId(stripTelegramInternalPrefixes(raw));
   if (!stripped) {
     return undefined;
   }
@@ -45,7 +51,7 @@ export function isNumericTelegramChatId(raw: string): boolean {
 }
 
 export function normalizeTelegramLookupTarget(raw: string): string | undefined {
-  const stripped = stripTelegramInternalPrefixes(raw);
+  const stripped = normalizeTelegramDeliveryGroupChatId(stripTelegramInternalPrefixes(raw));
   if (!stripped) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- normalize bare `group:<numeric_chat_id>` targets in Telegram delivery helpers
- apply the delivery-only normalization in both chat-id and lookup-target paths
- add regression coverage for direct normalization and send-time delivery

## Testing
- pnpm exec vitest run src/telegram/targets.test.ts -t "normalizes bare delivery-only group prefixes for numeric chat ids"
- pnpm exec vitest run src/telegram/send.test.ts -t "sends bare group-prefixed numeric delivery targets without lookup"
- node --import tsx -e "import { normalizeTelegramChatId, normalizeTelegramLookupTarget } from './src/telegram/targets.ts'; console.log(JSON.stringify({ chatId: normalizeTelegramChatId('group:-1003786508776'), lookup: normalizeTelegramLookupTarget('group:-1003786508776') }));"