### PR TITLE
fix(heartbeat): preserve session displayName during heartbeat polls

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -708,6 +708,9 @@ export async function runHeartbeatOnce(opts: {
     MessageThreadId: delivery.threadId,
     Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",
     SessionKey: sessionKey,
+    // Preserve the existing session label so heartbeat polls don't overwrite
+    // the user-facing displayName with "heartbeat" (#42495).
+    ConversationLabel: entry?.origin?.label,
   };
   if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {
     emitHeartbeatEvent({


### PR DESCRIPTION
## Summary

- Problem: Heartbeat polls overwrite the session's `displayName` to "heartbeat", breaking the control UI session selector
- Why it matters: Users see generic "heartbeat" labels instead of descriptive session names set by actual messages
- What changed: Pass the existing session label (`entry.origin.label`) as `ConversationLabel` in the heartbeat context, so `deriveSessionOrigin` preserves the existing label instead of falling back to the `From` field ("heartbeat")
- What did NOT change (scope boundary): Heartbeat execution flow, sender resolution, delivery routing — only metadata derivation is affected

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42495

## User-visible / Behavior Changes

Session dropdown in the control UI now retains descriptive labels set by user messages instead of being overwritten to "heartbeat" every heartbeat interval.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Channel: webchat (control UI)
- Heartbeat config: `agents.defaults.heartbeat.every: "30m"`

### Steps

1. Configure an agent with heartbeat enabled
2. Send messages — session dropdown shows descriptive labels
3. Wait for heartbeat poll to fire
4. Check session dropdown label

### Expected

- Session dropdown retains the descriptive label from user messages

### Actual

- Before: displayName overwritten to "heartbeat" after each heartbeat poll
- After: displayName preserved from the existing session origin label

## Evidence

- [x] Trace/log snippets — issue #42495 describes the exact symptom

## Human Verification (required)

- Verified scenarios: Heartbeat context now includes `ConversationLabel: entry?.origin?.label` which preserves existing label through `resolveConversationLabel` → `deriveSessionOrigin` path
- Edge cases checked: New sessions without existing label (entry?.origin?.label is undefined, falls back to From as before)
- What you did **not** verify: End-to-end with live heartbeat polling

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: src/infra/heartbeat-runner.ts
- Known bad symptoms reviewers should watch for: Session labels not updating when they should (unlikely since this only preserves existing labels)

## Risks and Mitigations

None — only preserves existing label, does not change label derivation logic.