### PR TITLE
Fix/nodes run timeout propagation

### DIFF
--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -642,13 +642,14 @@ export function createNodesTool(options?: {
             // invokeTimeoutMs takes priority; fall back to commandTimeoutMs + 15s buffer.
             // Without this, callGatewayTool uses gatewayOpts.timeoutMs (default 30s),
             // which kills any node command that takes longer than 30 seconds.
-            const derivedTimeout =
-              invokeTimeoutMs ?? (commandTimeoutMs ? commandTimeoutMs + 15_000 : undefined);
-            // Clamp to at least the default gateway timeout floor (30s) so that
-            // small commandTimeoutMs values don't shrink below the time needed
-            // for node wake/reconnect flows.
-            const runGatewayTimeout =
-              derivedTimeout !== undefined ? Math.max(derivedTimeout, 30_000) : undefined;
+            // When invokeTimeoutMs is explicitly set, honor it as-is (callers may
+            // want short timeouts for fast failure/retry). Only apply the 30s floor
+            // to the commandTimeoutMs-derived fallback, where shrinking below the
+            // default could break node wake/reconnect flows.
+            const runGatewayTimeout = invokeTimeoutMs
+              ?? (commandTimeoutMs
+                ? Math.max(commandTimeoutMs + 15_000, 30_000)
+                : undefined);
             const runGatewayOpts = runGatewayTimeout
               ? { ...gatewayOpts, timeoutMs: runGatewayTimeout }
               : gatewayOpts;

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -638,6 +638,15 @@ export function createNodesTool(options?: {
             const env = parseEnvPairs(params.env);
             const commandTimeoutMs = parseTimeoutMs(params.commandTimeoutMs);
             const invokeTimeoutMs = parseTimeoutMs(params.invokeTimeoutMs);
+            // Compute the effective gateway timeout for long-running node commands.
+            // invokeTimeoutMs takes priority; fall back to commandTimeoutMs + 15s buffer.
+            // Without this, callGatewayTool uses gatewayOpts.timeoutMs (default 30s),
+            // which kills any node command that takes longer than 30 seconds.
+            const runGatewayTimeout =
+              invokeTimeoutMs ?? (commandTimeoutMs ? commandTimeoutMs + 15_000 : undefined);
+            const runGatewayOpts = runGatewayTimeout
+              ? { ...gatewayOpts, timeoutMs: runGatewayTimeout }
+              : gatewayOpts;
             const needsScreenRecording =
               typeof params.needsScreenRecording === "boolean"
                 ? params.needsScreenRecording
@@ -675,11 +684,11 @@ export function createNodesTool(options?: {
 
             // First attempt without approval flags.
             try {
-              const raw = await callGatewayTool<{ payload?: unknown }>("node.invoke", gatewayOpts, {
+              const raw = await callGatewayTool<{ payload?: unknown }>("node.invoke", runGatewayOpts, {
                 nodeId,
                 command: "system.run",
                 params: runParams,
-                timeoutMs: invokeTimeoutMs,
+                timeoutMs: runGatewayTimeout,
                 idempotencyKey: crypto.randomUUID(),
               });
               return jsonResult(raw?.payload ?? {});
@@ -732,7 +741,7 @@ export function createNodesTool(options?: {
             }
 
             // Retry with the approval decision.
-            const raw = await callGatewayTool<{ payload?: unknown }>("node.invoke", gatewayOpts, {
+            const raw = await callGatewayTool<{ payload?: unknown }>("node.invoke", runGatewayOpts, {
               nodeId,
               command: "system.run",
               params: {
@@ -741,7 +750,7 @@ export function createNodesTool(options?: {
                 approved: true,
                 approvalDecision,
               },
-              timeoutMs: invokeTimeoutMs,
+              timeoutMs: runGatewayTimeout,
               idempotencyKey: crypto.randomUUID(),
             });
             return jsonResult(raw?.payload ?? {});

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -642,8 +642,13 @@ export function createNodesTool(options?: {
             // invokeTimeoutMs takes priority; fall back to commandTimeoutMs + 15s buffer.
             // Without this, callGatewayTool uses gatewayOpts.timeoutMs (default 30s),
             // which kills any node command that takes longer than 30 seconds.
-            const runGatewayTimeout =
+            const derivedTimeout =
               invokeTimeoutMs ?? (commandTimeoutMs ? commandTimeoutMs + 15_000 : undefined);
+            // Clamp to at least the default gateway timeout floor (30s) so that
+            // small commandTimeoutMs values don't shrink below the time needed
+            // for node wake/reconnect flows.
+            const runGatewayTimeout =
+              derivedTimeout !== undefined ? Math.max(derivedTimeout, 30_000) : undefined;
             const runGatewayOpts = runGatewayTimeout
               ? { ...gatewayOpts, timeoutMs: runGatewayTimeout }
               : gatewayOpts;

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -642,14 +642,16 @@ export function createNodesTool(options?: {
             // invokeTimeoutMs takes priority; fall back to commandTimeoutMs + 15s buffer.
             // Without this, callGatewayTool uses gatewayOpts.timeoutMs (default 30s),
             // which kills any node command that takes longer than 30 seconds.
-            // When invokeTimeoutMs is explicitly set, honor it as-is (callers may
-            // want short timeouts for fast failure/retry). Only apply the 30s floor
-            // to the commandTimeoutMs-derived fallback, where shrinking below the
-            // default could break node wake/reconnect flows.
-            const runGatewayTimeout = invokeTimeoutMs
-              ?? (commandTimeoutMs
-                ? Math.max(commandTimeoutMs + 15_000, 30_000)
-                : undefined);
+            const derivedTimeout =
+              invokeTimeoutMs ?? (commandTimeoutMs ? commandTimeoutMs + 15_000 : undefined);
+            // Ensure the gateway timeout always covers commandTimeoutMs even when
+            // invokeTimeoutMs is set to an explicit (but shorter) value, and never
+            // drops below the 30s default needed for node wake/reconnect flows.
+            const commandBuffer = commandTimeoutMs ? commandTimeoutMs + 15_000 : 0;
+            const runGatewayTimeout =
+              derivedTimeout !== undefined
+                ? Math.max(derivedTimeout, commandBuffer, 30_000)
+                : undefined;
             const runGatewayOpts = runGatewayTimeout
               ? { ...gatewayOpts, timeoutMs: runGatewayTimeout }
               : gatewayOpts;


### PR DESCRIPTION
Summary

• Problem: nodes run (system.run) kills any node command taking >30s because callGatewayTool uses gatewayOpts.timeoutMs (default 30s) regardless of commandTimeoutMs or invokeTimeoutMs values.
• Why it matters: Makes nodes run unusable for any real workload (builds, coding agents, long scripts) on paired nodes.
• What changed: Compute runGatewayTimeout from invokeTimeoutMs or commandTimeoutMs + 15s, propagate it to both the websocket call options and the message-level timeoutMs.
• What did NOT change (scope boundary): No schema changes, no gateway-side changes, no new parameters. Only the agent-side timeout propagation logic in nodes-tool.ts.

Change Type (select all)

• [x] Bug fix
• [ ] Feature
• [ ] Refactor
• [ ] Docs
• [ ] Security hardening
• [ ] Chore/infra

Scope (select all touched areas)

• [ ] Gateway / orchestration
• [x] Skills / tool execution
• [ ] Auth / tokens
• [ ] Memory / storage
• [ ] Integrations
• [ ] API / contracts
• [ ] UI / DX
• [ ] CI/CD / infra

Linked Issue/PR

• Closes #
• Related #

User-visible / Behavior Changes

• nodes run commands with commandTimeoutMs or invokeTimeoutMs set will now correctly wait for the node to complete instead of timing out at 30s.
• No new parameters or config changes. Existing behavior for commands <30s is unchanged.

Security Impact (required)

• New permissions/capabilities? No
• Secrets/tokens handling changed? No
• New/changed network calls? No
• Command/tool execution surface changed? No
• Data access scope changed? No

Repro + Verification

Environment

• OS: WSL2 (Ubuntu) + Windows 11 paired node
• Runtime/container: Node v22.22.0, OpenClaw v2026.3.8
• Model/provider: github-copilot/claude-opus-4.6
• Integration/channel: Telegram
• Relevant config: Default gateway config, Windows companion node paired via LAN

Steps

Pair a Windows node with OpenClaw gateway
Run nodes run with a command that takes >30s (e.g., ping -n 35 127.0.0.1) and commandTimeoutMs: 60000
Observe timeout behavior
Expected

• Command completes after ~35s and returns stdout with all 35 ping replies

Actual

• Before fix: gateway timeout after 30000ms error at 30s
• After fix: Command completes successfully (34.6s), returns full output

Evidence

• [x] Trace/log snippets

Before fix:

{"status":"error","error":"gateway timeout after 30000ms"}

After fix (monkey-patched dist):

{"stdout":"...35 pings...","exitCode":0,"timedOut":false,"durationMs":34605}

Also tested GitHub Copilot CLI (74s run) successfully via Windows node after fix.

Human Verification (required)

• Verified scenarios: 35-ping test (34.6s), Copilot CLI codebase analysis (74s), both via Windows node
• Edge cases checked: No invokeTimeoutMs set (falls back to commandTimeoutMs + 15s); neither set (preserves default 30s behavior)
• What you did not verify: Approval retry path (tested only the first-attempt path); nodes invoke action (separate code path with same issue, not addressed here)

Review Conversations

• [x] I replied to or resolved every bot review conversation I addressed in this PR.
• [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Compatibility / Migration

• Backward compatible? Yes
• Config/env changes? No
• Migration needed? No

Failure Recovery (if this breaks)

• How to disable/revert this change quickly: Revert the single commit; timeout falls back to default 30s behavior.
• Files/config to restore: src/agents/tools/nodes-tool.ts
• Known bad symptoms reviewers should watch for:

If runGatewayTimeout computes an unexpectedly large value, gateway websocket connections could stay open longer than intended. Mitigated by only deriving from user-provided timeout params.

Risks and Mitigations

• Risk: Gateway websocket connections held open longer when large commandTimeoutMs values are passed.

• Mitigation: Timeout is derived directly from user-specified params — no unbounded defaults. If neither commandTimeoutMs nor invokeTimeoutMs is set, behavior is unchanged (30s default).