### PR TITLE
docs(vps): add corporate proxy and SSL inspection guide for systemd

### DIFF
--- a/docs/vps.md
+++ b/docs/vps.md
@@ -100,3 +100,79 @@ TimeoutStartSec=90
 
 How `Restart=` policies help automated recovery:
 [systemd can automate service recovery](https://www.redhat.com/en/blog/systemd-automate-recovery).
+
+## Corporate proxy and SSL inspection
+
+If your VPS runs behind a corporate proxy with SSL inspection (common in enterprise networks),
+you need to configure environment variables explicitly in your systemd service file.
+
+### Key issues
+
+1. **systemd services don't read `/etc/environment`** — environment variables must be set
+   explicitly in the service file using `Environment=` directives.
+
+2. **Proxy environment variable case sensitivity** — some Node.js libraries (like `undici`)
+   check only uppercase `HTTP_PROXY`/`HTTPS_PROXY`, while others check lowercase variants.
+   **Best practice: set both.**
+
+3. **SSL certificate trust** — corporate proxies often perform SSL inspection (MITM), which
+   causes Node.js to reject connections with `SELF_SIGNED_CERT_IN_CHAIN` errors. You must
+   point Node.js to your corporate CA certificate.
+
+### Configuration example
+
+Edit your systemd service override:
+
+```bash
+sudo systemctl edit openclaw
+```
+
+Add the following environment variables:
+
+```ini
+[Service]
+# Proxy configuration (set both uppercase and lowercase)
+Environment=HTTP_PROXY=http://proxy.example.com:3127
+Environment=HTTPS_PROXY=http://proxy.example.com:3127
+Environment=http_proxy=http://proxy.example.com:3127
+Environment=https_proxy=http://proxy.example.com:3127
+
+# Corporate CA certificate for SSL inspection
+Environment=NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem
+
+# Optional: bypass proxy for internal hosts
+Environment=no_proxy=127.0.0.1,localhost,.internal.example.com,10.0.0.0/8
+Environment=NO_PROXY=127.0.0.1,localhost,.internal.example.com,10.0.0.0/8
+```
+
+After editing, reload and restart:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart openclaw
+```
+
+### Troubleshooting
+
+If LLM requests still fail after configuration:
+
+1. **Verify proxy connectivity** with curl:
+   ```bash
+   curl -v --proxy http://proxy.example.com:3127 https://api.anthropic.com
+   ```
+
+2. **Check process environment** (verify vars are loaded):
+   ```bash
+   cat /proc/$(pgrep -f openclaw)/environ | tr '\0' '\n' | grep -i proxy
+   ```
+
+3. **Test Node.js fetch directly** to isolate SSL issues:
+   ```bash
+   node -e "const {EnvHttpProxyAgent, fetch} = require('undici'); \
+     fetch('https://api.anthropic.com', {dispatcher: new EnvHttpProxyAgent()}) \
+     .then(r => console.log('OK:', r.status)) \
+     .catch(e => console.error('Error:', e.cause || e))"
+   ```
+
+   - If you see `SELF_SIGNED_CERT_IN_CHAIN`, verify `NODE_EXTRA_CA_CERTS` points to the correct CA file.
+   - If you see connection timeout, verify the proxy URL and network reachability.

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -141,8 +141,8 @@ Environment=https_proxy=http://proxy.example.com:3127
 Environment=NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem
 
 # Optional: bypass proxy for internal hosts
-Environment=no_proxy=127.0.0.1,localhost,.internal.example.com,10.0.0.0/8
-Environment=NO_PROXY=127.0.0.1,localhost,.internal.example.com,10.0.0.0/8
+Environment=no_proxy=127.0.0.1,localhost,.internal.example.com
+Environment=NO_PROXY=127.0.0.1,localhost,.internal.example.com
 ```
 
 After editing, reload and restart:
@@ -157,16 +157,19 @@ sudo systemctl restart openclaw
 If LLM requests still fail after configuration:
 
 1. **Verify proxy connectivity** with curl:
+
    ```bash
    curl -v --proxy http://proxy.example.com:3127 https://api.anthropic.com
    ```
 
 2. **Check process environment** (verify vars are loaded):
+
    ```bash
-   cat /proc/$(pgrep -f openclaw)/environ | tr '\0' '\n' | grep -i proxy
+   cat /proc/$(pgrep -fn openclaw)/environ | tr '\0' '\n' | grep -i proxy
    ```
 
 3. **Test Node.js fetch directly** to isolate SSL issues:
+
    ```bash
    node -e "const {EnvHttpProxyAgent, fetch} = require('undici'); \
      fetch('https://api.anthropic.com', {dispatcher: new EnvHttpProxyAgent()}) \

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -168,14 +168,11 @@ If LLM requests still fail after configuration:
    cat /proc/$(pgrep -fn openclaw)/environ | tr '\0' '\n' | grep -i proxy
    ```
 
-3. **Test Node.js fetch directly** to isolate SSL issues:
+3. **Check OpenClaw logs for proxy/TLS errors** (no extra Node packages required):
 
    ```bash
-   node -e "const {EnvHttpProxyAgent, fetch} = require('undici'); \
-     fetch('https://api.anthropic.com', {dispatcher: new EnvHttpProxyAgent()}) \
-     .then(r => console.log('OK:', r.status)) \
-     .catch(e => console.error('Error:', e.cause || e))"
+   sudo journalctl -u openclaw -n 200 --no-pager | grep -Ei 'SELF_SIGNED_CERT_IN_CHAIN|CERT|ECONN|ETIMEDOUT|timeout|proxy'
    ```
 
    - If you see `SELF_SIGNED_CERT_IN_CHAIN`, verify `NODE_EXTRA_CA_CERTS` points to the correct CA file.
-   - If you see connection timeout, verify the proxy URL and network reachability.
+   - If you see timeout/connection errors, verify the proxy URL and network reachability.

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -165,7 +165,7 @@ If LLM requests still fail after configuration:
 2. **Check process environment** (verify vars are loaded):
 
    ```bash
-   cat /proc/$(pgrep -fn openclaw)/environ | tr '\0' '\n' | grep -i proxy
+   sudo cat /proc/$(pgrep -fn openclaw)/environ | tr '\0' '\n' | grep -i proxy
    ```
 
 3. **Check OpenClaw logs for proxy/TLS errors** (no extra Node packages required):

--- a/docs/zh-CN/vps.md
+++ b/docs/zh-CN/vps.md
@@ -160,14 +160,11 @@ sudo systemctl restart openclaw
    cat /proc/$(pgrep -fn openclaw)/environ | tr '\0' '\n' | grep -i proxy
    ```
 
-3. **直接测试 Node.js fetch** 以隔离 SSL 问题：
+3. **检查 OpenClaw 日志中的代理/TLS 错误**（不需要额外 Node 包）：
 
    ```bash
-   node -e "const {EnvHttpProxyAgent, fetch} = require('undici'); \
-     fetch('https://api.anthropic.com', {dispatcher: new EnvHttpProxyAgent()}) \
-     .then(r => console.log('OK:', r.status)) \
-     .catch(e => console.error('Error:', e.cause || e))"
+   sudo journalctl -u openclaw -n 200 --no-pager | grep -Ei 'SELF_SIGNED_CERT_IN_CHAIN|CERT|ECONN|ETIMEDOUT|timeout|proxy'
    ```
 
    - 如果看到 `SELF_SIGNED_CERT_IN_CHAIN`，验证 `NODE_EXTRA_CA_CERTS` 指向正确的 CA 文件。
-   - 如果看到连接超时，验证代理 URL 和网络可达性。
+   - 如果看到超时/连接错误，验证代理 URL 和网络可达性。

--- a/docs/zh-CN/vps.md
+++ b/docs/zh-CN/vps.md
@@ -5,10 +5,10 @@ read_when:
 summary: OpenClaw 的 VPS 托管中心（Oracle/Fly/Hetzner/GCP/exe.dev）
 title: VPS 托管
 x-i18n:
-  generated_at: "2026-02-03T10:12:57Z"
-  model: claude-opus-4-5
+  generated_at: "2026-03-11T01:10:00Z"
+  model: claude-opus-4-6
   provider: pi
-  source_hash: 7749b479b333aa5541e7ad8b0ff84e9f8f6bd10d7188285121975cb893acc037
+  source_hash: c25ec2492890da400d6011e0d25664ef0103af6c448c1ceb7a3fa33764895c20
   source_path: vps.md
   workflow: 15
 ---
@@ -133,8 +133,8 @@ Environment=https_proxy=http://proxy.example.com:3127
 Environment=NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem
 
 # 可选：绕过内部主机的代理
-Environment=no_proxy=127.0.0.1,localhost,.internal.example.com,10.0.0.0/8
-Environment=NO_PROXY=127.0.0.1,localhost,.internal.example.com,10.0.0.0/8
+Environment=no_proxy=127.0.0.1,localhost,.internal.example.com
+Environment=NO_PROXY=127.0.0.1,localhost,.internal.example.com
 ```
 
 编辑后，重新加载并重启：
@@ -149,16 +149,19 @@ sudo systemctl restart openclaw
 如果配置后 LLM 请求仍然失败：
 
 1. **验证代理连通性**，使用 curl：
+
    ```bash
    curl -v --proxy http://proxy.example.com:3127 https://api.anthropic.com
    ```
 
 2. **检查进程环境变量**（验证变量是否加载）：
+
    ```bash
-   cat /proc/$(pgrep -f openclaw)/environ | tr '\0' '\n' | grep -i proxy
+   cat /proc/$(pgrep -fn openclaw)/environ | tr '\0' '\n' | grep -i proxy
    ```
 
 3. **直接测试 Node.js fetch** 以隔离 SSL 问题：
+
    ```bash
    node -e "const {EnvHttpProxyAgent, fetch} = require('undici'); \
      fetch('https://api.anthropic.com', {dispatcher: new EnvHttpProxyAgent()}) \

--- a/docs/zh-CN/vps.md
+++ b/docs/zh-CN/vps.md
@@ -45,3 +45,126 @@ x-i18n:
 你可以将 Gateway 网关保持在云端，并在本地设备（Mac/iOS/Android/无头）上配对**节点**。节点提供本地屏幕/摄像头/canvas 和 `system.run` 功能，而 Gateway 网关保持在云端。
 
 文档：[节点](/nodes)，[节点 CLI](/cli/nodes)
+
+## 小型 VM 和 ARM 主机的启动调优
+
+如果在低功耗 VM（或 ARM 主机）上 CLI 命令感觉缓慢，可以启用 Node 的模块编译缓存：
+
+```bash
+grep -q 'NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache' ~/.bashrc || cat >> ~/.bashrc <<'EOF'
+export NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache
+mkdir -p /var/tmp/openclaw-compile-cache
+export OPENCLAW_NO_RESPAWN=1
+EOF
+source ~/.bashrc
+```
+
+- `NODE_COMPILE_CACHE` 改善重复命令的启动时间。
+- `OPENCLAW_NO_RESPAWN=1` 避免自重启路径带来的额外启动开销。
+- 首次运行会预热缓存；后续运行会更快。
+- Raspberry Pi 特定配置参见 [Raspberry Pi](/platforms/raspberry-pi)。
+
+### systemd 调优清单（可选）
+
+对于使用 `systemd` 的 VM 主机，建议：
+
+- 添加服务环境变量以获得稳定的启动路径：
+  - `OPENCLAW_NO_RESPAWN=1`
+  - `NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache`
+- 保持明确的重启行为：
+  - `Restart=always`
+  - `RestartSec=2`
+  - `TimeoutStartSec=90`
+- 优先使用 SSD 支持的磁盘存放状态/缓存路径，以减少随机 I/O 冷启动延迟。
+
+示例：
+
+```bash
+sudo systemctl edit openclaw
+```
+
+```ini
+[Service]
+Environment=OPENCLAW_NO_RESPAWN=1
+Environment=NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache
+Restart=always
+RestartSec=2
+TimeoutStartSec=90
+```
+
+`Restart=` 策略如何帮助自动恢复：
+[systemd 可以自动化服务恢复](https://www.redhat.com/en/blog/systemd-automate-recovery)。
+
+## 企业代理和 SSL 检查
+
+如果你的 VPS 运行在带有 SSL 检查的企业代理后面（在企业网络中很常见），
+你需要在 systemd 服务文件中显式配置环境变量。
+
+### 关键问题
+
+1. **systemd 服务不会读取 `/etc/environment`** — 环境变量必须通过 `Environment=` 指令
+   在服务文件中显式设置。
+
+2. **代理环境变量大小写敏感** — 部分 Node.js 库（如 `undici`）只检查大写的
+   `HTTP_PROXY`/`HTTPS_PROXY`，而其他库检查小写变体。**最佳实践：同时设置两者。**
+
+3. **SSL 证书信任** — 企业代理通常执行 SSL 检查（中间人），这会导致 Node.js
+   拒绝连接并报 `SELF_SIGNED_CERT_IN_CHAIN` 错误。你必须将 Node.js 指向企业 CA 证书。
+
+### 配置示例
+
+编辑 systemd 服务覆盖：
+
+```bash
+sudo systemctl edit openclaw
+```
+
+添加以下环境变量：
+
+```ini
+[Service]
+# 代理配置（同时设置大写和小写）
+Environment=HTTP_PROXY=http://proxy.example.com:3127
+Environment=HTTPS_PROXY=http://proxy.example.com:3127
+Environment=http_proxy=http://proxy.example.com:3127
+Environment=https_proxy=http://proxy.example.com:3127
+
+# 企业 CA 证书（用于 SSL 检查）
+Environment=NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem
+
+# 可选：绕过内部主机的代理
+Environment=no_proxy=127.0.0.1,localhost,.internal.example.com,10.0.0.0/8
+Environment=NO_PROXY=127.0.0.1,localhost,.internal.example.com,10.0.0.0/8
+```
+
+编辑后，重新加载并重启：
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart openclaw
+```
+
+### 故障排查
+
+如果配置后 LLM 请求仍然失败：
+
+1. **验证代理连通性**，使用 curl：
+   ```bash
+   curl -v --proxy http://proxy.example.com:3127 https://api.anthropic.com
+   ```
+
+2. **检查进程环境变量**（验证变量是否加载）：
+   ```bash
+   cat /proc/$(pgrep -f openclaw)/environ | tr '\0' '\n' | grep -i proxy
+   ```
+
+3. **直接测试 Node.js fetch** 以隔离 SSL 问题：
+   ```bash
+   node -e "const {EnvHttpProxyAgent, fetch} = require('undici'); \
+     fetch('https://api.anthropic.com', {dispatcher: new EnvHttpProxyAgent()}) \
+     .then(r => console.log('OK:', r.status)) \
+     .catch(e => console.error('Error:', e.cause || e))"
+   ```
+
+   - 如果看到 `SELF_SIGNED_CERT_IN_CHAIN`，验证 `NODE_EXTRA_CA_CERTS` 指向正确的 CA 文件。
+   - 如果看到连接超时，验证代理 URL 和网络可达性。

--- a/docs/zh-CN/vps.md
+++ b/docs/zh-CN/vps.md
@@ -157,7 +157,7 @@ sudo systemctl restart openclaw
 2. **检查进程环境变量**（验证变量是否加载）：
 
    ```bash
-   cat /proc/$(pgrep -fn openclaw)/environ | tr '\0' '\n' | grep -i proxy
+   sudo cat /proc/$(pgrep -fn openclaw)/environ | tr '\0' '\n' | grep -i proxy
    ```
 
 3. **检查 OpenClaw 日志中的代理/TLS 错误**（不需要额外 Node 包）：


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw deployments behind corporate proxies with SSL inspection often fail with connection timeouts or `SELF_SIGNED_CERT_IN_CHAIN` errors. Users lack guidance on configuring systemd services for enterprise network environments.
- **Why it matters:** Enterprise deployments are common but the troubleshooting path is non-obvious. systemd services don't inherit `/etc/environment`, and proxy environment variables have case-sensitivity issues across Node.js libraries.
- **What changed:** Added a new "Corporate proxy and SSL inspection" section to `docs/vps.md` and its Chinese translation `docs/zh-CN/vps.md` with:
  - Explanation of why systemd services don't read `/etc/environment`
  - Best practice for proxy env vars (set both uppercase and lowercase)
  - `NODE_EXTRA_CA_CERTS` configuration for corporate CA certificates
  - Troubleshooting steps using curl and undici
- **What did NOT change:** No code changes, documentation only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None — documentation only.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 (corporate network)
- Runtime/container: systemd user service
- Model/provider: Custom LLM endpoint
- Integration/channel: N/A
- Relevant config: Corporate proxy with SSL inspection

### Steps

1. Deploy OpenClaw as systemd service behind corporate proxy
2. Attempt LLM request without explicit proxy env vars in service file
3. Observe timeout or SSL certificate error
4. Add `HTTP_PROXY`, `HTTPS_PROXY`, `NODE_EXTRA_CA_CERTS` to service file
5. Restart service and verify LLM requests work

### Expected

- LLM requests succeed after proper environment variable configuration

### Actual

- Documented steps now guide users through the troubleshooting process

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Key error patterns documented:
- `SELF_SIGNED_CERT_IN_CHAIN` — resolved by `NODE_EXTRA_CA_CERTS`
- Connection timeout — resolved by explicit proxy env vars in systemd service

## Human Verification (required)

- Verified scenarios: Documentation reflects real-world troubleshooting experience
- Edge cases checked: Both uppercase and lowercase proxy vars documented
- What you did **not** verify: Actual deployment test (documentation based on production troubleshooting)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No` — users opt-in by following the guide)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: N/A

## Risks and Mitigations

None — documentation only.