### PR TITLE
feat(auth): add openai-codex device-code login

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -52,14 +52,14 @@ openclaw onboard --auth-choice openai-codex
 openclaw models auth login --provider openai-codex
 ```
 
-### CLI setup (Codex device code)
+### CLI setup (Codex CLI login)
 
 ```bash
-# Run Codex device login in the wizard
-openclaw onboard --auth-choice openai-device-code
+# Run Codex CLI login in the wizard
+openclaw onboard --auth-choice openai-codex-cli
 
 # Or import credentials after Codex CLI login
-openclaw models auth login --provider openai-codex --method device-code
+openclaw models auth login --provider openai-codex --method cli
 ```
 
 ### Config snippet (Codex subscription)

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -58,7 +58,7 @@ openclaw models auth login --provider openai-codex
 # Run Codex CLI login in the wizard
 openclaw onboard --auth-choice openai-codex-cli
 
-# Or import credentials after Codex CLI login
+# Or import credentials after Codex CLI device-auth login
 openclaw models auth login --provider openai-codex --method cli
 ```
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -52,6 +52,16 @@ openclaw onboard --auth-choice openai-codex
 openclaw models auth login --provider openai-codex
 ```
 
+### CLI setup (Codex device code)
+
+```bash
+# Run Codex device login in the wizard
+openclaw onboard --auth-choice openai-device-code
+
+# Or import credentials after Codex CLI login
+openclaw models auth login --provider openai-codex --method device-code
+```
+
 ### Config snippet (Codex subscription)
 
 ```json5

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -33,7 +33,7 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
     - **Anthropic API key**: uses `ANTHROPIC_API_KEY` if present or prompts for a key, then saves it for daemon use.
     - **Anthropic OAuth (Claude Code CLI)**: on macOS the wizard checks Keychain item "Claude Code-credentials" (choose "Always Allow" so launchd starts don't block); on Linux/Windows it reuses `~/.claude/.credentials.json` if present.
     - **Anthropic token (paste setup-token)**: run `claude setup-token` on any machine, then paste the token (you can name it; blank = default).
-    - **OpenAI Code (Codex) subscription (device code)**: runs `codex login`, shows the device-code instructions in the terminal, then imports the resulting credentials into OpenClaw.
+    - **OpenAI Code (Codex) subscription (Codex CLI login)**: runs `codex login`, then imports the resulting credentials into OpenClaw.
     - **OpenAI Code (Codex) subscription (OAuth)**: browser flow; paste the `code#state`.
       - Sets `agents.defaults.model` to `openai-codex/gpt-5.2` when model is unset or `openai/*`.
     - **OpenAI API key**: uses `OPENAI_API_KEY` if present or prompts for a key, then stores it in auth profiles.

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -33,7 +33,7 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
     - **Anthropic API key**: uses `ANTHROPIC_API_KEY` if present or prompts for a key, then saves it for daemon use.
     - **Anthropic OAuth (Claude Code CLI)**: on macOS the wizard checks Keychain item "Claude Code-credentials" (choose "Always Allow" so launchd starts don't block); on Linux/Windows it reuses `~/.claude/.credentials.json` if present.
     - **Anthropic token (paste setup-token)**: run `claude setup-token` on any machine, then paste the token (you can name it; blank = default).
-    - **OpenAI Code (Codex) subscription (Codex CLI login)**: runs `codex login`, then imports the resulting credentials into OpenClaw.
+    - **OpenAI Code (Codex) subscription (Codex CLI login)**: runs `codex login --device-auth`, then imports the resulting credentials into OpenClaw.
     - **OpenAI Code (Codex) subscription (OAuth)**: browser flow; paste the `code#state`.
       - Sets `agents.defaults.model` to `openai-codex/gpt-5.2` when model is unset or `openai/*`.
     - **OpenAI API key**: uses `OPENAI_API_KEY` if present or prompts for a key, then stores it in auth profiles.

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -33,7 +33,7 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
     - **Anthropic API key**: uses `ANTHROPIC_API_KEY` if present or prompts for a key, then saves it for daemon use.
     - **Anthropic OAuth (Claude Code CLI)**: on macOS the wizard checks Keychain item "Claude Code-credentials" (choose "Always Allow" so launchd starts don't block); on Linux/Windows it reuses `~/.claude/.credentials.json` if present.
     - **Anthropic token (paste setup-token)**: run `claude setup-token` on any machine, then paste the token (you can name it; blank = default).
-    - **OpenAI Code (Codex) subscription (Codex CLI)**: if `~/.codex/auth.json` exists, the wizard can reuse it.
+    - **OpenAI Code (Codex) subscription (device code)**: runs `codex login`, shows the device-code instructions in the terminal, then imports the resulting credentials into OpenClaw.
     - **OpenAI Code (Codex) subscription (OAuth)**: browser flow; paste the `code#state`.
       - Sets `agents.defaults.model` to `openai-codex/gpt-5.2` when model is unset or `openai/*`.
     - **OpenAI API key**: uses `OPENAI_API_KEY` if present or prompts for a key, then stores it in auth profiles.

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -137,8 +137,8 @@ What you set:
     Run `claude setup-token` on any machine, then paste the token.
     You can name it; blank uses default.
   </Accordion>
-  <Accordion title="OpenAI Code subscription (Codex CLI reuse)">
-    If `~/.codex/auth.json` exists, the wizard can reuse it.
+  <Accordion title="OpenAI Code subscription (Codex CLI device code)">
+    Runs `codex login`, shows the device-code instructions in the terminal, then imports the resulting credentials into OpenClaw.
   </Accordion>
   <Accordion title="OpenAI Code subscription (OAuth)">
     Browser flow; paste `code#state`.

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -137,8 +137,8 @@ What you set:
     Run `claude setup-token` on any machine, then paste the token.
     You can name it; blank uses default.
   </Accordion>
-  <Accordion title="OpenAI Code subscription (Codex CLI device code)">
-    Runs `codex login`, shows the device-code instructions in the terminal, then imports the resulting credentials into OpenClaw.
+  <Accordion title="OpenAI Code subscription (Codex CLI login)">
+    Runs `codex login`, then imports the resulting credentials into OpenClaw.
   </Accordion>
   <Accordion title="OpenAI Code subscription (OAuth)">
     Browser flow; paste `code#state`.

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -138,7 +138,7 @@ What you set:
     You can name it; blank uses default.
   </Accordion>
   <Accordion title="OpenAI Code subscription (Codex CLI login)">
-    Runs `codex login`, then imports the resulting credentials into OpenClaw.
+    Runs `codex login --device-auth`, then imports the resulting credentials into OpenClaw.
   </Accordion>
   <Accordion title="OpenAI Code subscription (OAuth)">
     Browser flow; paste `code#state`.

--- a/src/commands/auth-choice-legacy.ts
+++ b/src/commands/auth-choice-legacy.ts
@@ -5,6 +5,7 @@ export const AUTH_CHOICE_LEGACY_ALIASES_FOR_CLI: ReadonlyArray<AuthChoice> = [
   "oauth",
   "claude-cli",
   "codex-cli",
+  "openai-device-code",
   "minimax-cloud",
   "minimax",
 ];
@@ -15,8 +16,8 @@ export function normalizeLegacyOnboardAuthChoice(
   if (authChoice === "oauth" || authChoice === "claude-cli") {
     return "setup-token";
   }
-  if (authChoice === "codex-cli") {
-    return "openai-device-code";
+  if (authChoice === "codex-cli" || authChoice === "openai-device-code") {
+    return "openai-codex-cli";
   }
   return authChoice;
 }

--- a/src/commands/auth-choice-legacy.ts
+++ b/src/commands/auth-choice-legacy.ts
@@ -16,7 +16,10 @@ export function normalizeLegacyOnboardAuthChoice(
   if (authChoice === "oauth" || authChoice === "claude-cli") {
     return "setup-token";
   }
-  if (authChoice === "codex-cli" || authChoice === "openai-device-code") {
+  if (authChoice === "codex-cli") {
+    return "openai-codex";
+  }
+  if (authChoice === "openai-device-code") {
     return "openai-codex-cli";
   }
   return authChoice;

--- a/src/commands/auth-choice-legacy.ts
+++ b/src/commands/auth-choice-legacy.ts
@@ -16,7 +16,7 @@ export function normalizeLegacyOnboardAuthChoice(
     return "setup-token";
   }
   if (authChoice === "codex-cli") {
-    return "openai-codex";
+    return "openai-device-code";
   }
   return authChoice;
 }

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -83,6 +83,16 @@ describe("buildAuthChoiceOptions", () => {
     expect(chutesGroup?.options.some((opt) => opt.value === "chutes")).toBe(true);
   });
 
+  it("shows OpenAI device code in the OpenAI group", () => {
+    const { groups } = buildAuthChoiceGroups({
+      store: EMPTY_STORE,
+      includeSkip: false,
+    });
+    const openAiGroup = groups.find((group) => group.value === "openai");
+
+    expect(openAiGroup?.options.some((opt) => opt.value === "openai-device-code")).toBe(true);
+  });
+
   it("groups OpenCode Zen and Go under one OpenCode entry", () => {
     const { groups } = buildAuthChoiceGroups({
       store: EMPTY_STORE,

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -70,6 +70,7 @@ describe("buildAuthChoiceOptions", () => {
     expect(cliChoices).toContain("oauth");
     expect(cliChoices).toContain("claude-cli");
     expect(cliChoices).toContain("codex-cli");
+    expect(cliChoices).toContain("openai-device-code");
   });
 
   it("shows Chutes in grouped provider selection", () => {
@@ -83,14 +84,14 @@ describe("buildAuthChoiceOptions", () => {
     expect(chutesGroup?.options.some((opt) => opt.value === "chutes")).toBe(true);
   });
 
-  it("shows OpenAI device code in the OpenAI group", () => {
+  it("shows OpenAI Codex CLI login in the OpenAI group", () => {
     const { groups } = buildAuthChoiceGroups({
       store: EMPTY_STORE,
       includeSkip: false,
     });
     const openAiGroup = groups.find((group) => group.value === "openai");
 
-    expect(openAiGroup?.options.some((opt) => opt.value === "openai-device-code")).toBe(true);
+    expect(openAiGroup?.options.some((opt) => opt.value === "openai-codex-cli")).toBe(true);
   });
 
   it("groups OpenCode Zen and Go under one OpenCode entry", () => {

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -241,7 +241,7 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
   {
     value: "openai-codex-cli",
     label: "OpenAI Codex CLI login",
-    hint: "Runs `codex login` and imports the resulting credentials",
+    hint: "Runs `codex login --device-auth` and imports the resulting credentials",
   },
   { value: "chutes", label: "Chutes (OAuth)" },
   {

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -26,8 +26,8 @@ const AUTH_CHOICE_GROUP_DEFS: {
   {
     value: "openai",
     label: "OpenAI",
-    hint: "Codex OAuth + device code + API key",
-    choices: ["openai-codex", "openai-device-code", "openai-api-key"],
+    hint: "Codex OAuth + CLI login + API key",
+    choices: ["openai-codex", "openai-codex-cli", "openai-api-key"],
   },
   {
     value: "anthropic",
@@ -239,9 +239,9 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     label: "OpenAI Codex (ChatGPT OAuth)",
   },
   {
-    value: "openai-device-code",
-    label: "OpenAI device code (Codex CLI)",
-    hint: "Headless-friendly login via `codex login`",
+    value: "openai-codex-cli",
+    label: "OpenAI Codex CLI login",
+    hint: "Runs `codex login` and imports the resulting credentials",
   },
   { value: "chutes", label: "Chutes (OAuth)" },
   {

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -26,8 +26,8 @@ const AUTH_CHOICE_GROUP_DEFS: {
   {
     value: "openai",
     label: "OpenAI",
-    hint: "Codex OAuth + API key",
-    choices: ["openai-codex", "openai-api-key"],
+    hint: "Codex OAuth + device code + API key",
+    choices: ["openai-codex", "openai-device-code", "openai-api-key"],
   },
   {
     value: "anthropic",
@@ -237,6 +237,11 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
   {
     value: "openai-codex",
     label: "OpenAI Codex (ChatGPT OAuth)",
+  },
+  {
+    value: "openai-device-code",
+    label: "OpenAI device code (Codex CLI)",
+    hint: "Headless-friendly login via `codex login`",
   },
   { value: "chutes", label: "Chutes (OAuth)" },
   {

--- a/src/commands/auth-choice.apply.openai.ts
+++ b/src/commands/auth-choice.apply.openai.ts
@@ -75,7 +75,10 @@ export async function applyAuthChoiceOpenAI(
     return await applyOpenAiDefaultModelChoice();
   }
 
-  if (params.authChoice === "openai-codex" || params.authChoice === "openai-device-code") {
+  const isOpenAICodexCliChoice =
+    params.authChoice === "openai-codex-cli" || params.authChoice === "openai-device-code";
+
+  if (params.authChoice === "openai-codex" || isOpenAICodexCliChoice) {
     let nextConfig = params.config;
     let agentModelOverride: string | undefined;
     let creds: OAuthCredentials | null = null;
@@ -108,17 +111,20 @@ export async function applyAuthChoiceOpenAI(
       }
     };
 
-    try {
-      if (params.authChoice === "openai-device-code") {
-        await params.prompter.note(
-          [
-            "Starting Codex CLI login.",
-            "Follow the device-code instructions printed in this terminal.",
-          ].join("\n"),
-          "OpenAI device code",
-        );
-        creds = await loginOpenAICodexDeviceCode();
-      } else {
+    if (isOpenAICodexCliChoice) {
+      await params.prompter.note(
+        [
+          "Starting Codex CLI login.",
+          "Complete the Codex CLI sign-in flow shown in this terminal.",
+        ].join("\n"),
+        "OpenAI Codex CLI",
+      );
+      creds = await loginOpenAICodexDeviceCode();
+      if (!creds) {
+        throw new Error("Codex CLI login did not return credentials.");
+      }
+    } else {
+      try {
         creds = await loginOpenAICodexOAuth({
           prompter: params.prompter,
           runtime: params.runtime,
@@ -128,12 +134,9 @@ export async function applyAuthChoiceOpenAI(
           },
           localBrowserMessage: "Complete sign-in in browser…",
         });
+      } catch {
+        return { config: nextConfig, agentModelOverride };
       }
-    } catch (error) {
-      if (params.authChoice === "openai-device-code") {
-        params.runtime.error(error instanceof Error ? error.message : String(error));
-      }
-      return { config: nextConfig, agentModelOverride };
     }
     await persistCodexCredentials(creds);
     return { config: nextConfig, agentModelOverride };

--- a/src/commands/auth-choice.apply.openai.ts
+++ b/src/commands/auth-choice.apply.openai.ts
@@ -114,14 +114,14 @@ export async function applyAuthChoiceOpenAI(
     if (isOpenAICodexCliChoice) {
       await params.prompter.note(
         [
-          "Starting Codex CLI login.",
-          "Complete the Codex CLI sign-in flow shown in this terminal.",
+          "Starting Codex CLI device-auth login.",
+          "Complete the device-auth flow shown in this terminal.",
         ].join("\n"),
         "OpenAI Codex CLI",
       );
       creds = await loginOpenAICodexDeviceCode();
       if (!creds) {
-        throw new Error("Codex CLI login did not return credentials.");
+        throw new Error("Codex CLI device-auth login did not return credentials.");
       }
     } else {
       try {

--- a/src/commands/auth-choice.apply.openai.ts
+++ b/src/commands/auth-choice.apply.openai.ts
@@ -1,3 +1,4 @@
+import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import { normalizeApiKeyInput, validateApiKeyInput } from "./auth-choice.api-key.js";
 import {
   createAuthChoiceAgentModelNoter,
@@ -9,6 +10,7 @@ import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
 import { isRemoteEnvironment } from "./oauth-env.js";
 import { applyAuthProfileConfig, setOpenaiApiKey, writeOAuthCredentials } from "./onboard-auth.js";
 import { openUrl } from "./onboard-helpers.js";
+import { loginOpenAICodexDeviceCode } from "./openai-codex-device-code.js";
 import {
   applyOpenAICodexModelDefault,
   OPENAI_CODEX_DEFAULT_MODEL,
@@ -73,27 +75,15 @@ export async function applyAuthChoiceOpenAI(
     return await applyOpenAiDefaultModelChoice();
   }
 
-  if (params.authChoice === "openai-codex") {
+  if (params.authChoice === "openai-codex" || params.authChoice === "openai-device-code") {
     let nextConfig = params.config;
     let agentModelOverride: string | undefined;
 
-    let creds;
-    try {
-      creds = await loginOpenAICodexOAuth({
-        prompter: params.prompter,
-        runtime: params.runtime,
-        isRemote: isRemoteEnvironment(),
-        openUrl: async (url) => {
-          await openUrl(url);
-        },
-        localBrowserMessage: "Complete sign-in in browser…",
-      });
-    } catch {
-      // The helper already surfaces the error to the user.
-      // Keep onboarding flow alive and return unchanged config.
-      return { config: nextConfig, agentModelOverride };
-    }
-    if (creds) {
+    const persistCodexCredentials = async (creds: OAuthCredentials | null) => {
+      if (!creds) {
+        return;
+      }
+
       const profileId = await writeOAuthCredentials("openai-codex", creds, params.agentDir, {
         syncSiblingAgents: true,
       });
@@ -115,6 +105,34 @@ export async function applyAuthChoiceOpenAI(
         agentModelOverride = OPENAI_CODEX_DEFAULT_MODEL;
         await noteAgentModel(OPENAI_CODEX_DEFAULT_MODEL);
       }
+    };
+
+    try {
+      if (params.authChoice === "openai-device-code") {
+        await params.prompter.note(
+          [
+            "Starting Codex CLI login.",
+            "Follow the device-code instructions printed in this terminal.",
+          ].join("\n"),
+          "OpenAI device code",
+        );
+        await persistCodexCredentials(await loginOpenAICodexDeviceCode());
+      } else {
+        await persistCodexCredentials(
+          await loginOpenAICodexOAuth({
+            prompter: params.prompter,
+            runtime: params.runtime,
+            isRemote: isRemoteEnvironment(),
+            openUrl: async (url) => {
+              await openUrl(url);
+            },
+            localBrowserMessage: "Complete sign-in in browser…",
+          }),
+        );
+      }
+    } catch (error) {
+      params.runtime.error(error instanceof Error ? error.message : String(error));
+      return { config: nextConfig, agentModelOverride };
     }
     return { config: nextConfig, agentModelOverride };
   }

--- a/src/commands/auth-choice.apply.openai.ts
+++ b/src/commands/auth-choice.apply.openai.ts
@@ -78,6 +78,7 @@ export async function applyAuthChoiceOpenAI(
   if (params.authChoice === "openai-codex" || params.authChoice === "openai-device-code") {
     let nextConfig = params.config;
     let agentModelOverride: string | undefined;
+    let creds: OAuthCredentials | null = null;
 
     const persistCodexCredentials = async (creds: OAuthCredentials | null) => {
       if (!creds) {
@@ -116,24 +117,25 @@ export async function applyAuthChoiceOpenAI(
           ].join("\n"),
           "OpenAI device code",
         );
-        await persistCodexCredentials(await loginOpenAICodexDeviceCode());
+        creds = await loginOpenAICodexDeviceCode();
       } else {
-        await persistCodexCredentials(
-          await loginOpenAICodexOAuth({
-            prompter: params.prompter,
-            runtime: params.runtime,
-            isRemote: isRemoteEnvironment(),
-            openUrl: async (url) => {
-              await openUrl(url);
-            },
-            localBrowserMessage: "Complete sign-in in browser…",
-          }),
-        );
+        creds = await loginOpenAICodexOAuth({
+          prompter: params.prompter,
+          runtime: params.runtime,
+          isRemote: isRemoteEnvironment(),
+          openUrl: async (url) => {
+            await openUrl(url);
+          },
+          localBrowserMessage: "Complete sign-in in browser…",
+        });
       }
     } catch (error) {
-      params.runtime.error(error instanceof Error ? error.message : String(error));
+      if (params.authChoice === "openai-device-code") {
+        params.runtime.error(error instanceof Error ? error.message : String(error));
+      }
       return { config: nextConfig, agentModelOverride };
     }
+    await persistCodexCredentials(creds);
     return { config: nextConfig, agentModelOverride };
   }
 

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -9,6 +9,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   vllm: "vllm",
   ollama: "ollama",
   "openai-codex": "openai-codex",
+  "openai-device-code": "openai-codex",
   "codex-cli": "openai-codex",
   chutes: "chutes",
   "openai-api-key": "openai",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -9,6 +9,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   vllm: "vllm",
   ollama: "ollama",
   "openai-codex": "openai-codex",
+  "openai-codex-cli": "openai-codex",
   "openai-device-code": "openai-codex",
   "codex-cli": "openai-codex",
   chutes: "chutes",

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -258,7 +258,7 @@ describe("applyAuthChoice", () => {
     });
   });
 
-  it("stores openai-device-code credentials into the openai-codex auth store", async () => {
+  it("stores openai-codex-cli credentials into the openai-codex auth store", async () => {
     await setupTempState();
 
     loginOpenAICodexDeviceCode.mockResolvedValueOnce({
@@ -272,7 +272,7 @@ describe("applyAuthChoice", () => {
     const runtime = createExitThrowingRuntime();
 
     const result = await applyAuthChoice({
-      authChoice: "openai-device-code",
+      authChoice: "openai-codex-cli",
       config: {},
       prompter,
       runtime,
@@ -291,6 +291,26 @@ describe("applyAuthChoice", () => {
       access: "access-token",
       email: "device@example.com",
     });
+  });
+
+  it("rethrows openai-codex CLI login failures", async () => {
+    await setupTempState();
+
+    loginOpenAICodexDeviceCode.mockRejectedValueOnce(new Error("cli failed"));
+
+    const prompter = createPrompter({});
+    const runtime = createExitThrowingRuntime();
+
+    await expect(
+      applyAuthChoice({
+        authChoice: "openai-codex-cli",
+        config: {},
+        prompter,
+        runtime,
+        setDefaultModel: false,
+      }),
+    ).rejects.toThrow("cli failed");
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 
   it("prompts and writes provider API key for common providers", async () => {

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -23,15 +23,14 @@ import {
 } from "./test-wizard-helpers.js";
 
 type DetectZaiEndpoint = typeof import("./zai-endpoint-detect.js").detectZaiEndpoint;
+type LoginOpenAICodexOAuth = typeof import("./openai-codex-oauth.js").loginOpenAICodexOAuth;
 type PromptAndConfigureOllama = typeof import("./ollama-setup.js").promptAndConfigureOllama;
 
 vi.mock("../providers/github-copilot-auth.js", () => ({
   githubCopilotLoginCommand: vi.fn(async () => {}),
 }));
 
-const loginOpenAICodexOAuth = vi.hoisted(() =>
-  vi.fn<() => Promise<OAuthCredentials | null>>(async () => null),
-);
+const loginOpenAICodexOAuth = vi.hoisted(() => vi.fn<LoginOpenAICodexOAuth>(async () => null));
 vi.mock("./openai-codex-oauth.js", () => ({
   loginOpenAICodexOAuth,
 }));

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -34,6 +34,16 @@ const loginOpenAICodexOAuth = vi.hoisted(() =>
 vi.mock("./openai-codex-oauth.js", () => ({
   loginOpenAICodexOAuth,
 }));
+const loginOpenAICodexDeviceCode = vi.hoisted(() =>
+  vi.fn<() => Promise<OAuthCredentials>>(async () => ({
+    access: "access-token",
+    refresh: "refresh-token",
+    expires: Date.now() + 60_000,
+  })),
+);
+vi.mock("./openai-codex-device-code.js", () => ({
+  loginOpenAICodexDeviceCode,
+}));
 
 const resolvePluginProviders = vi.hoisted(() => vi.fn(() => []));
 vi.mock("../plugins/providers.js", () => ({
@@ -147,6 +157,12 @@ describe("applyAuthChoice", () => {
       config: cfg,
       defaultModelId: "qwen3.5:35b",
     }));
+    loginOpenAICodexDeviceCode.mockReset();
+    loginOpenAICodexDeviceCode.mockResolvedValue({
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+    });
     await lifecycle.cleanup();
     activeStateDir = null;
   });
@@ -202,6 +218,41 @@ describe("applyAuthChoice", () => {
       refresh: "refresh-token",
       access: "access-token",
       email: "user@example.com",
+    });
+  });
+
+  it("stores openai-device-code credentials into the openai-codex auth store", async () => {
+    await setupTempState();
+
+    loginOpenAICodexDeviceCode.mockResolvedValueOnce({
+      email: "device@example.com",
+      refresh: "refresh-token",
+      access: "access-token",
+      expires: Date.now() + 60_000,
+    });
+
+    const prompter = createPrompter({});
+    const runtime = createExitThrowingRuntime();
+
+    const result = await applyAuthChoice({
+      authChoice: "openai-device-code",
+      config: {},
+      prompter,
+      runtime,
+      setDefaultModel: false,
+    });
+
+    expect(loginOpenAICodexDeviceCode).toHaveBeenCalledOnce();
+    expect(result.config.auth?.profiles?.["openai-codex:device@example.com"]).toMatchObject({
+      provider: "openai-codex",
+      mode: "oauth",
+    });
+    expect(await readAuthProfile("openai-codex:device@example.com")).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      refresh: "refresh-token",
+      access: "access-token",
+      email: "device@example.com",
     });
   });
 

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -5,6 +5,7 @@ import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { applyAuthChoice, resolvePreferredProviderForAuthChoice } from "./auth-choice.js";
 import { GOOGLE_GEMINI_DEFAULT_MODEL } from "./google-gemini-model-default.js";
+import * as onboardAuth from "./onboard-auth.js";
 import {
   MINIMAX_CN_API_BASE_URL,
   ZAI_CODING_CN_BASE_URL,
@@ -170,10 +171,12 @@ describe("applyAuthChoice", () => {
   it("does not throw when openai-codex oauth fails", async () => {
     await setupTempState();
 
-    loginOpenAICodexOAuth.mockRejectedValueOnce(new Error("oauth failed"));
-
     const prompter = createPrompter({});
     const runtime = createExitThrowingRuntime();
+    loginOpenAICodexOAuth.mockImplementationOnce(async ({ runtime: loginRuntime }) => {
+      loginRuntime.error("oauth failed");
+      throw new Error("oauth failed");
+    });
 
     await expect(
       applyAuthChoice({
@@ -184,6 +187,41 @@ describe("applyAuthChoice", () => {
         setDefaultModel: false,
       }),
     ).resolves.toEqual({ config: {} });
+    expect(runtime.error).toHaveBeenCalledTimes(1);
+    expect(runtime.error).toHaveBeenCalledWith("oauth failed");
+  });
+
+  it("rethrows openai-codex credential persistence failures", async () => {
+    await setupTempState();
+
+    loginOpenAICodexOAuth.mockResolvedValueOnce({
+      email: "user@example.com",
+      refresh: "refresh-token",
+      access: "access-token",
+      expires: Date.now() + 60_000,
+    });
+
+    const writeOAuthCredentialsSpy = vi
+      .spyOn(onboardAuth, "writeOAuthCredentials")
+      .mockRejectedValueOnce(new Error("disk full"));
+
+    const prompter = createPrompter({});
+    const runtime = createExitThrowingRuntime();
+
+    try {
+      await expect(
+        applyAuthChoice({
+          authChoice: "openai-codex",
+          config: {},
+          prompter,
+          runtime,
+          setDefaultModel: false,
+        }),
+      ).rejects.toThrow("disk full");
+      expect(runtime.error).not.toHaveBeenCalled();
+    } finally {
+      writeOAuthCredentialsSpy.mockRestore();
+    }
   });
 
   it("stores openai-codex OAuth with email profile id", async () => {

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -236,7 +236,7 @@ describe("modelsAuthLoginCommand", () => {
 
     await expect(
       modelsAuthLoginCommand({ provider: "openai-codex", method: "cli" }, runtime),
-    ).rejects.toThrow("Codex CLI login did not return credentials.");
+    ).rejects.toThrow("Codex CLI device-auth login did not return credentials.");
   });
 
   it("rejects unknown built-in openai-codex auth methods", async () => {

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -115,6 +115,24 @@ function withInteractiveStdin() {
   };
 }
 
+function withNonInteractiveStdin() {
+  const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
+  const hadOwnIsTTY = Object.prototype.hasOwnProperty.call(stdin, "isTTY");
+  const previousIsTTYDescriptor = Object.getOwnPropertyDescriptor(stdin, "isTTY");
+  Object.defineProperty(stdin, "isTTY", {
+    configurable: true,
+    enumerable: true,
+    get: () => false,
+  });
+  return () => {
+    if (previousIsTTYDescriptor) {
+      Object.defineProperty(stdin, "isTTY", previousIsTTYDescriptor);
+    } else if (!hadOwnIsTTY) {
+      delete (stdin as { isTTY?: boolean }).isTTY;
+    }
+  };
+}
+
 describe("modelsAuthLoginCommand", () => {
   let restoreStdin: (() => void) | null = null;
   let currentConfig: OpenClawConfig;
@@ -227,6 +245,28 @@ describe("modelsAuthLoginCommand", () => {
     );
     expect(runtime.log).toHaveBeenCalledWith(
       "Auth profile: openai-codex:device@example.com (openai-codex/oauth)",
+    );
+  });
+
+  it("allows built-in openai-codex CLI login without an interactive TTY", async () => {
+    restoreStdin?.();
+    restoreStdin = withNonInteractiveStdin();
+    const runtime = createRuntime();
+    mocks.writeOAuthCredentials.mockResolvedValueOnce("openai-codex:device@example.com");
+
+    await modelsAuthLoginCommand({ provider: "openai-codex", method: "device-code" }, runtime);
+
+    expect(mocks.loginOpenAICodexDeviceCode).toHaveBeenCalledOnce();
+    expect(mocks.loginOpenAICodexOAuth).not.toHaveBeenCalled();
+  });
+
+  it("still requires an interactive TTY for built-in openai-codex OAuth login", async () => {
+    restoreStdin?.();
+    restoreStdin = withNonInteractiveStdin();
+    const runtime = createRuntime();
+
+    await expect(modelsAuthLoginCommand({ provider: "openai-codex" }, runtime)).rejects.toThrow(
+      "models auth login requires an interactive TTY.",
     );
   });
 

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -211,11 +211,11 @@ describe("modelsAuthLoginCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith("Default model set to openai-codex/gpt-5.4");
   });
 
-  it("supports built-in openai-codex device-code login", async () => {
+  it("supports built-in openai-codex CLI login", async () => {
     const runtime = createRuntime();
     mocks.writeOAuthCredentials.mockResolvedValueOnce("openai-codex:device@example.com");
 
-    await modelsAuthLoginCommand({ provider: "openai-codex", method: "device-code" }, runtime);
+    await modelsAuthLoginCommand({ provider: "openai-codex", method: "cli" }, runtime);
 
     expect(mocks.loginOpenAICodexDeviceCode).toHaveBeenCalledOnce();
     expect(mocks.loginOpenAICodexOAuth).not.toHaveBeenCalled();
@@ -230,13 +230,13 @@ describe("modelsAuthLoginCommand", () => {
     );
   });
 
-  it("uses a device-code-specific missing credentials error", async () => {
+  it("uses a CLI-specific missing credentials error", async () => {
     const runtime = createRuntime();
     mocks.loginOpenAICodexDeviceCode.mockResolvedValueOnce(null);
 
     await expect(
-      modelsAuthLoginCommand({ provider: "openai-codex", method: "device-code" }, runtime),
-    ).rejects.toThrow("Codex CLI device-code login did not return credentials.");
+      modelsAuthLoginCommand({ provider: "openai-codex", method: "cli" }, runtime),
+    ).rejects.toThrow("Codex CLI login did not return credentials.");
   });
 
   it("rejects unknown built-in openai-codex auth methods", async () => {
@@ -244,9 +244,7 @@ describe("modelsAuthLoginCommand", () => {
 
     await expect(
       modelsAuthLoginCommand({ provider: "openai-codex", method: "sso" }, runtime),
-    ).rejects.toThrow(
-      "Unknown auth method for openai-codex. Use --method oauth or --method device-code.",
-    );
+    ).rejects.toThrow("Unknown auth method for openai-codex. Use --method oauth or --method cli.");
   });
 
   it("keeps existing plugin error behavior for non built-in providers", async () => {

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -230,6 +230,15 @@ describe("modelsAuthLoginCommand", () => {
     );
   });
 
+  it("uses a device-code-specific missing credentials error", async () => {
+    const runtime = createRuntime();
+    mocks.loginOpenAICodexDeviceCode.mockResolvedValueOnce(null);
+
+    await expect(
+      modelsAuthLoginCommand({ provider: "openai-codex", method: "device-code" }, runtime),
+    ).rejects.toThrow("Codex CLI device-code login did not return credentials.");
+  });
+
   it("rejects unknown built-in openai-codex auth methods", async () => {
     const runtime = createRuntime();
 

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   resolvePluginProviders: vi.fn(),
   createClackPrompter: vi.fn(),
   loginOpenAICodexOAuth: vi.fn(),
+  loginOpenAICodexDeviceCode: vi.fn(),
   writeOAuthCredentials: vi.fn(),
   loadValidConfigOrThrow: vi.fn(),
   updateConfig: vi.fn(),
@@ -55,6 +56,10 @@ vi.mock("../../wizard/clack-prompter.js", () => ({
 
 vi.mock("../openai-codex-oauth.js", () => ({
   loginOpenAICodexOAuth: mocks.loginOpenAICodexOAuth,
+}));
+
+vi.mock("../openai-codex-device-code.js", () => ({
+  loginOpenAICodexDeviceCode: mocks.loginOpenAICodexDeviceCode,
 }));
 
 vi.mock("../onboard-auth.js", async (importActual) => {
@@ -153,6 +158,14 @@ describe("modelsAuthLoginCommand", () => {
       expires: Date.now() + 60_000,
       email: "user@example.com",
     });
+    mocks.loginOpenAICodexDeviceCode.mockResolvedValue({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+      email: "device@example.com",
+    });
     mocks.writeOAuthCredentials.mockResolvedValue("openai-codex:user@example.com");
     mocks.resolvePluginProviders.mockReturnValue([]);
   });
@@ -183,7 +196,7 @@ describe("modelsAuthLoginCommand", () => {
       "Auth profile: openai-codex:user@example.com (openai-codex/oauth)",
     );
     expect(runtime.log).toHaveBeenCalledWith(
-      "Default model available: openai-codex/gpt-5.3-codex (use --set-default to apply)",
+      "Default model available: openai-codex/gpt-5.4 (use --set-default to apply)",
     );
   });
 
@@ -193,9 +206,38 @@ describe("modelsAuthLoginCommand", () => {
     await modelsAuthLoginCommand({ provider: "openai-codex", setDefault: true }, runtime);
 
     expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
-      primary: "openai-codex/gpt-5.3-codex",
+      primary: "openai-codex/gpt-5.4",
     });
-    expect(runtime.log).toHaveBeenCalledWith("Default model set to openai-codex/gpt-5.3-codex");
+    expect(runtime.log).toHaveBeenCalledWith("Default model set to openai-codex/gpt-5.4");
+  });
+
+  it("supports built-in openai-codex device-code login", async () => {
+    const runtime = createRuntime();
+    mocks.writeOAuthCredentials.mockResolvedValueOnce("openai-codex:device@example.com");
+
+    await modelsAuthLoginCommand({ provider: "openai-codex", method: "device-code" }, runtime);
+
+    expect(mocks.loginOpenAICodexDeviceCode).toHaveBeenCalledOnce();
+    expect(mocks.loginOpenAICodexOAuth).not.toHaveBeenCalled();
+    expect(mocks.writeOAuthCredentials).toHaveBeenCalledWith(
+      "openai-codex",
+      expect.objectContaining({ email: "device@example.com" }),
+      "/tmp/openclaw/agents/main",
+      { syncSiblingAgents: true },
+    );
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Auth profile: openai-codex:device@example.com (openai-codex/oauth)",
+    );
+  });
+
+  it("rejects unknown built-in openai-codex auth methods", async () => {
+    const runtime = createRuntime();
+
+    await expect(
+      modelsAuthLoginCommand({ provider: "openai-codex", method: "sso" }, runtime),
+    ).rejects.toThrow(
+      "Unknown auth method for openai-codex. Use --method oauth or --method device-code.",
+    );
   });
 
   it("keeps existing plugin error behavior for non built-in providers", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -382,7 +382,12 @@ async function runBuiltInOpenAICodexLogin(params: {
 }
 
 export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: RuntimeEnv) {
-  if (!process.stdin.isTTY) {
+  const requestedProviderId = normalizeProviderId(String(opts.provider ?? ""));
+  const allowsNonInteractiveTty =
+    requestedProviderId === "openai-codex" &&
+    resolveBuiltInOpenAICodexMethodOrThrow(opts.method) === "cli";
+
+  if (!process.stdin.isTTY && !allowsNonInteractiveTty) {
     throw new Error("models auth login requires an interactive TTY.");
   }
 
@@ -391,7 +396,6 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
   const agentDir = resolveAgentDir(config, defaultAgentId);
   const workspaceDir =
     resolveAgentWorkspaceDir(config, defaultAgentId) ?? resolveDefaultAgentWorkspaceDir();
-  const requestedProviderId = normalizeProviderId(String(opts.provider ?? ""));
   const prompter = createClackPrompter();
 
   if (requestedProviderId === "openai-codex") {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -331,8 +331,8 @@ async function runBuiltInOpenAICodexLogin(params: {
       ? await (async () => {
           await params.prompter.note(
             [
-              "Starting Codex CLI login.",
-              "Complete the Codex CLI sign-in flow shown in this terminal.",
+              "Starting Codex CLI device-auth login.",
+              "Complete the device-auth flow shown in this terminal.",
             ].join("\n"),
             "OpenAI Codex CLI",
           );
@@ -350,7 +350,7 @@ async function runBuiltInOpenAICodexLogin(params: {
   if (!creds) {
     throw new Error(
       method === "cli"
-        ? "Codex CLI login did not return credentials."
+        ? "Codex CLI device-auth login did not return credentials."
         : "OpenAI Codex OAuth did not return credentials.",
     );
   }

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -266,7 +266,7 @@ type LoginOptions = {
   setDefault?: boolean;
 };
 
-type BuiltInOpenAICodexMethod = "oauth" | "device-code";
+type BuiltInOpenAICodexMethod = "oauth" | "cli";
 
 function resolveBuiltInOpenAICodexMethodOrThrow(rawMethod?: string): BuiltInOpenAICodexMethod {
   const normalized = String(rawMethod ?? "")
@@ -275,12 +275,16 @@ function resolveBuiltInOpenAICodexMethodOrThrow(rawMethod?: string): BuiltInOpen
   if (!normalized || normalized === "oauth") {
     return "oauth";
   }
-  if (normalized === "device-code" || normalized === "device_code" || normalized === "device") {
-    return "device-code";
+  if (
+    normalized === "cli" ||
+    normalized === "codex-cli" ||
+    normalized === "device-code" ||
+    normalized === "device_code" ||
+    normalized === "device"
+  ) {
+    return "cli";
   }
-  throw new Error(
-    "Unknown auth method for openai-codex. Use --method oauth or --method device-code.",
-  );
+  throw new Error("Unknown auth method for openai-codex. Use --method oauth or --method cli.");
 }
 
 export function resolveRequestedLoginProviderOrThrow(
@@ -323,14 +327,14 @@ async function runBuiltInOpenAICodexLogin(params: {
 }) {
   const method = resolveBuiltInOpenAICodexMethodOrThrow(params.opts.method);
   const creds =
-    method === "device-code"
+    method === "cli"
       ? await (async () => {
           await params.prompter.note(
             [
               "Starting Codex CLI login.",
-              "Follow the device-code instructions printed in this terminal.",
+              "Complete the Codex CLI sign-in flow shown in this terminal.",
             ].join("\n"),
-            "OpenAI device code",
+            "OpenAI Codex CLI",
           );
           return await loginOpenAICodexDeviceCode();
         })()
@@ -345,8 +349,8 @@ async function runBuiltInOpenAICodexLogin(params: {
         });
   if (!creds) {
     throw new Error(
-      method === "device-code"
-        ? "Codex CLI device-code login did not return credentials."
+      method === "cli"
+        ? "Codex CLI login did not return credentials."
         : "OpenAI Codex OAuth did not return credentials.",
     );
   }

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -344,7 +344,11 @@ async function runBuiltInOpenAICodexLogin(params: {
           localBrowserMessage: "Complete sign-in in browser…",
         });
   if (!creds) {
-    throw new Error("OpenAI Codex OAuth did not return credentials.");
+    throw new Error(
+      method === "device-code"
+        ? "Codex CLI device-code login did not return credentials."
+        : "OpenAI Codex OAuth did not return credentials.",
+    );
   }
 
   const profileId = await writeOAuthCredentials("openai-codex", creds, params.agentDir, {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -27,6 +27,7 @@ import { isRemoteEnvironment } from "../oauth-env.js";
 import { createVpsAwareOAuthHandlers } from "../oauth-flow.js";
 import { applyAuthProfileConfig, writeOAuthCredentials } from "../onboard-auth.js";
 import { openUrl } from "../onboard-helpers.js";
+import { loginOpenAICodexDeviceCode } from "../openai-codex-device-code.js";
 import {
   applyOpenAICodexModelDefault,
   OPENAI_CODEX_DEFAULT_MODEL,
@@ -265,6 +266,23 @@ type LoginOptions = {
   setDefault?: boolean;
 };
 
+type BuiltInOpenAICodexMethod = "oauth" | "device-code";
+
+function resolveBuiltInOpenAICodexMethodOrThrow(rawMethod?: string): BuiltInOpenAICodexMethod {
+  const normalized = String(rawMethod ?? "")
+    .trim()
+    .toLowerCase();
+  if (!normalized || normalized === "oauth") {
+    return "oauth";
+  }
+  if (normalized === "device-code" || normalized === "device_code" || normalized === "device") {
+    return "device-code";
+  }
+  throw new Error(
+    "Unknown auth method for openai-codex. Use --method oauth or --method device-code.",
+  );
+}
+
 export function resolveRequestedLoginProviderOrThrow(
   providers: ProviderPlugin[],
   rawProvider?: string,
@@ -303,15 +321,28 @@ async function runBuiltInOpenAICodexLogin(params: {
   prompter: ReturnType<typeof createClackPrompter>;
   agentDir: string;
 }) {
-  const creds = await loginOpenAICodexOAuth({
-    prompter: params.prompter,
-    runtime: params.runtime,
-    isRemote: isRemoteEnvironment(),
-    openUrl: async (url) => {
-      await openUrl(url);
-    },
-    localBrowserMessage: "Complete sign-in in browser…",
-  });
+  const method = resolveBuiltInOpenAICodexMethodOrThrow(params.opts.method);
+  const creds =
+    method === "device-code"
+      ? await (async () => {
+          await params.prompter.note(
+            [
+              "Starting Codex CLI login.",
+              "Follow the device-code instructions printed in this terminal.",
+            ].join("\n"),
+            "OpenAI device code",
+          );
+          return await loginOpenAICodexDeviceCode();
+        })()
+      : await loginOpenAICodexOAuth({
+          prompter: params.prompter,
+          runtime: params.runtime,
+          isRemote: isRemoteEnvironment(),
+          openUrl: async (url) => {
+            await openUrl(url);
+          },
+          localBrowserMessage: "Complete sign-in in browser…",
+        });
   if (!creds) {
     throw new Error("OpenAI Codex OAuth did not return credentials.");
   }

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -485,6 +485,20 @@ describe("onboard (non-interactive): provider auth", () => {
     });
   });
 
+  it("rejects OpenAI device code auth choice in non-interactive mode", async () => {
+    await withOnboardEnv(
+      "openclaw-onboard-openai-device-code-non-interactive-",
+      async ({ runtime }) => {
+        await expect(
+          runNonInteractiveOnboardingWithDefaults(runtime, {
+            authChoice: "openai-device-code",
+            skipSkills: true,
+          }),
+        ).rejects.toThrow('Run "openclaw onboard" and select OpenAI device code (Codex CLI).');
+      },
+    );
+  });
+
   it("stores LiteLLM API key and sets default model", async () => {
     await withOnboardEnv("openclaw-onboard-litellm-", async (env) => {
       const cfg = await runOnboardingAndReadConfig(env, {

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -485,16 +485,16 @@ describe("onboard (non-interactive): provider auth", () => {
     });
   });
 
-  it("rejects OpenAI device code auth choice in non-interactive mode", async () => {
+  it("rejects OpenAI Codex CLI auth choice in non-interactive mode", async () => {
     await withOnboardEnv(
-      "openclaw-onboard-openai-device-code-non-interactive-",
+      "openclaw-onboard-openai-codex-cli-non-interactive-",
       async ({ runtime }) => {
         await expect(
           runNonInteractiveOnboardingWithDefaults(runtime, {
-            authChoice: "openai-device-code",
+            authChoice: "openai-codex-cli",
             skipSkills: true,
           }),
-        ).rejects.toThrow('Run "openclaw onboard" and select OpenAI device code (Codex CLI).');
+        ).rejects.toThrow('Run "openclaw onboard" and select OpenAI Codex CLI login.');
       },
     );
   });

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -157,7 +157,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     runtime.error(
       [
         'Auth choice "codex-cli" is deprecated.',
-        'Run "openclaw onboard" and choose OpenAI Codex CLI login or OpenAI Codex (ChatGPT OAuth).',
+        'Use "--auth-choice openai-codex" for OpenAI Codex (ChatGPT OAuth).',
       ].join("\n"),
     );
     runtime.exit(1);

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -157,7 +157,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     runtime.error(
       [
         'Auth choice "codex-cli" is deprecated.',
-        'Run "openclaw onboard" and choose OpenAI device code (Codex CLI) or OpenAI Codex (ChatGPT OAuth).',
+        'Run "openclaw onboard" and choose OpenAI Codex CLI login or OpenAI Codex (ChatGPT OAuth).',
       ].join("\n"),
     );
     runtime.exit(1);
@@ -190,11 +190,11 @@ export async function applyNonInteractiveAuthChoice(params: {
     return configureOllamaNonInteractive({ nextConfig, opts, runtime });
   }
 
-  if (authChoice === "openai-device-code") {
+  if (authChoice === "openai-codex-cli" || authChoice === "openai-device-code") {
     runtime.error(
       [
-        'Auth choice "openai-device-code" requires interactive mode.',
-        'Run "openclaw onboard" and select OpenAI device code (Codex CLI).',
+        `Auth choice "${authChoice}" requires interactive mode.`,
+        'Run "openclaw onboard" and select OpenAI Codex CLI login.',
       ].join("\n"),
     );
     runtime.exit(1);

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -142,11 +142,22 @@ export async function applyNonInteractiveAuthChoice(params: {
     return true;
   };
 
-  if (authChoice === "claude-cli" || authChoice === "codex-cli") {
+  if (authChoice === "claude-cli") {
     runtime.error(
       [
-        `Auth choice "${authChoice}" is deprecated.`,
-        'Use "--auth-choice token" (Anthropic setup-token) or "--auth-choice openai-codex".',
+        'Auth choice "claude-cli" is deprecated.',
+        'Use "--auth-choice token" (Anthropic setup-token).',
+      ].join("\n"),
+    );
+    runtime.exit(1);
+    return null;
+  }
+
+  if (authChoice === "codex-cli") {
+    runtime.error(
+      [
+        'Auth choice "codex-cli" is deprecated.',
+        'Run "openclaw onboard" and choose OpenAI device code (Codex CLI) or OpenAI Codex (ChatGPT OAuth).',
       ].join("\n"),
     );
     runtime.exit(1);
@@ -177,6 +188,17 @@ export async function applyNonInteractiveAuthChoice(params: {
 
   if (authChoice === "ollama") {
     return configureOllamaNonInteractive({ nextConfig, opts, runtime });
+  }
+
+  if (authChoice === "openai-device-code") {
+    runtime.error(
+      [
+        'Auth choice "openai-device-code" requires interactive mode.',
+        'Run "openclaw onboard" and select OpenAI device code (Codex CLI).',
+      ].join("\n"),
+    );
+    runtime.exit(1);
+    return null;
   }
 
   if (authChoice === "apiKey") {
@@ -1090,6 +1112,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     authChoice === "oauth" ||
     authChoice === "chutes" ||
     authChoice === "openai-codex" ||
+    authChoice === "openai-device-code" ||
     authChoice === "qwen-portal" ||
     authChoice === "minimax-portal"
   ) {

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -1112,7 +1112,6 @@ export async function applyNonInteractiveAuthChoice(params: {
     authChoice === "oauth" ||
     authChoice === "chutes" ||
     authChoice === "openai-codex" ||
-    authChoice === "openai-device-code" ||
     authChoice === "qwen-portal" ||
     authChoice === "minimax-portal"
   ) {

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -12,6 +12,7 @@ export type AuthChoice =
   | "vllm"
   | "ollama"
   | "openai-codex"
+  | "openai-device-code"
   | "openai-api-key"
   | "openrouter-api-key"
   | "kilocode-api-key"

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -12,6 +12,8 @@ export type AuthChoice =
   | "vllm"
   | "ollama"
   | "openai-codex"
+  | "openai-codex-cli"
+  // Deprecated alias kept for backwards CLI compatibility.
   | "openai-device-code"
   | "openai-api-key"
   | "openrouter-api-key"

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -175,7 +175,7 @@ describe("onboardCommand", () => {
     expect(runtime.error).toHaveBeenCalledWith(
       [
         'Auth choice "codex-cli" is deprecated.',
-        'Run "openclaw onboard" and choose OpenAI device code (Codex CLI) or OpenAI Codex (ChatGPT OAuth).',
+        'Run "openclaw onboard" and choose OpenAI Codex CLI login or OpenAI Codex (ChatGPT OAuth).',
       ].join("\n"),
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -175,11 +175,33 @@ describe("onboardCommand", () => {
     expect(runtime.error).toHaveBeenCalledWith(
       [
         'Auth choice "codex-cli" is deprecated.',
-        'Run "openclaw onboard" and choose OpenAI Codex CLI login or OpenAI Codex (ChatGPT OAuth).',
+        'Use "--auth-choice openai-codex" for OpenAI Codex (ChatGPT OAuth).',
       ].join("\n"),
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(mocks.runInteractiveOnboarding).not.toHaveBeenCalled();
+    expect(mocks.runNonInteractiveOnboarding).not.toHaveBeenCalled();
+  });
+
+  it("maps interactive codex-cli to OpenAI Codex OAuth", async () => {
+    const runtime = makeRuntime();
+
+    await onboardCommand(
+      {
+        authChoice: "codex-cli",
+      },
+      runtime,
+    );
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      'Auth choice "codex-cli" is deprecated; using OpenAI Codex OAuth instead.',
+    );
+    expect(mocks.runInteractiveOnboarding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authChoice: "openai-codex",
+      }),
+      runtime,
+    );
     expect(mocks.runNonInteractiveOnboarding).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -138,4 +138,48 @@ describe("onboardCommand", () => {
     expect(mocks.runInteractiveOnboarding).not.toHaveBeenCalled();
     expect(mocks.runNonInteractiveOnboarding).not.toHaveBeenCalled();
   });
+
+  it("rejects non-interactive claude-cli with setup-token guidance", async () => {
+    const runtime = makeRuntime();
+
+    await onboardCommand(
+      {
+        nonInteractive: true,
+        authChoice: "claude-cli",
+      },
+      runtime,
+    );
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      [
+        'Auth choice "claude-cli" is deprecated.',
+        'Use "--auth-choice token" (Anthropic setup-token).',
+      ].join("\n"),
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.runInteractiveOnboarding).not.toHaveBeenCalled();
+    expect(mocks.runNonInteractiveOnboarding).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-interactive codex-cli with interactive OpenAI guidance", async () => {
+    const runtime = makeRuntime();
+
+    await onboardCommand(
+      {
+        nonInteractive: true,
+        authChoice: "codex-cli",
+      },
+      runtime,
+    );
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      [
+        'Auth choice "codex-cli" is deprecated.',
+        'Run "openclaw onboard" and choose OpenAI device code (Codex CLI) or OpenAI Codex (ChatGPT OAuth).',
+      ].join("\n"),
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.runInteractiveOnboarding).not.toHaveBeenCalled();
+    expect(mocks.runNonInteractiveOnboarding).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -30,7 +30,7 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
     runtime.error(
       [
         'Auth choice "codex-cli" is deprecated.',
-        'Run "openclaw onboard" and choose OpenAI Codex CLI login or OpenAI Codex (ChatGPT OAuth).',
+        'Use "--auth-choice openai-codex" for OpenAI Codex (ChatGPT OAuth).',
       ].join("\n"),
     );
     runtime.exit(1);
@@ -40,7 +40,7 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
     runtime.log('Auth choice "claude-cli" is deprecated; using setup-token flow instead.');
   }
   if (originalAuthChoice === "codex-cli") {
-    runtime.log('Auth choice "codex-cli" is deprecated; using OpenAI Codex CLI login instead.');
+    runtime.log('Auth choice "codex-cli" is deprecated; using OpenAI Codex OAuth instead.');
   }
   const flow = opts.flow === "manual" ? ("advanced" as const) : opts.flow;
   const normalizedOpts =

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -30,7 +30,7 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
     runtime.error(
       [
         'Auth choice "codex-cli" is deprecated.',
-        'Run "openclaw onboard" and choose OpenAI device code (Codex CLI) or OpenAI Codex (ChatGPT OAuth).',
+        'Run "openclaw onboard" and choose OpenAI Codex CLI login or OpenAI Codex (ChatGPT OAuth).',
       ].join("\n"),
     );
     runtime.exit(1);
@@ -40,7 +40,7 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
     runtime.log('Auth choice "claude-cli" is deprecated; using setup-token flow instead.');
   }
   if (originalAuthChoice === "codex-cli") {
-    runtime.log('Auth choice "codex-cli" is deprecated; using OpenAI device code instead.');
+    runtime.log('Auth choice "codex-cli" is deprecated; using OpenAI Codex CLI login instead.');
   }
   const flow = opts.flow === "manual" ? ("advanced" as const) : opts.flow;
   const normalizedOpts =

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -30,7 +30,7 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
     runtime.log('Auth choice "claude-cli" is deprecated; using setup-token flow instead.');
   }
   if (originalAuthChoice === "codex-cli") {
-    runtime.log('Auth choice "codex-cli" is deprecated; using OpenAI Codex OAuth instead.');
+    runtime.log('Auth choice "codex-cli" is deprecated; using OpenAI device code instead.');
   }
   const flow = opts.flow === "manual" ? ("advanced" as const) : opts.flow;
   const normalizedOpts =

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -4,7 +4,7 @@ import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
-import { isDeprecatedAuthChoice, normalizeLegacyOnboardAuthChoice } from "./auth-choice-legacy.js";
+import { normalizeLegacyOnboardAuthChoice } from "./auth-choice-legacy.js";
 import { DEFAULT_WORKSPACE, handleReset } from "./onboard-helpers.js";
 import { runInteractiveOnboarding } from "./onboard-interactive.js";
 import { runNonInteractiveOnboarding } from "./onboard-non-interactive.js";
@@ -16,11 +16,21 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
   assertSupportedRuntime(runtime);
   const originalAuthChoice = opts.authChoice;
   const normalizedAuthChoice = normalizeLegacyOnboardAuthChoice(originalAuthChoice);
-  if (opts.nonInteractive && isDeprecatedAuthChoice(originalAuthChoice)) {
+  if (opts.nonInteractive && originalAuthChoice === "claude-cli") {
     runtime.error(
       [
-        `Auth choice "${String(originalAuthChoice)}" is deprecated.`,
-        'Use "--auth-choice token" (Anthropic setup-token) or "--auth-choice openai-codex".',
+        'Auth choice "claude-cli" is deprecated.',
+        'Use "--auth-choice token" (Anthropic setup-token).',
+      ].join("\n"),
+    );
+    runtime.exit(1);
+    return;
+  }
+  if (opts.nonInteractive && originalAuthChoice === "codex-cli") {
+    runtime.error(
+      [
+        'Auth choice "codex-cli" is deprecated.',
+        'Run "openclaw onboard" and choose OpenAI device code (Codex CLI) or OpenAI Codex (ChatGPT OAuth).',
       ].join("\n"),
     );
     runtime.exit(1);

--- a/src/commands/openai-codex-device-code.test.ts
+++ b/src/commands/openai-codex-device-code.test.ts
@@ -78,7 +78,7 @@ describe("loginOpenAICodexDeviceCode", () => {
 
     expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(["codex", "login"], {
       timeoutMs: 600_000,
-      env: { NODE_OPTIONS: "" },
+      env: { NODE_OPTIONS: "", OPENAI_API_KEY: undefined },
       mirrorStdout: true,
       mirrorStderr: true,
     });

--- a/src/commands/openai-codex-device-code.test.ts
+++ b/src/commands/openai-codex-device-code.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  detectBinary: vi.fn(),
+  runCommandWithTimeout: vi.fn(),
+  readCodexCliCredentials: vi.fn(),
+}));
+
+vi.mock("./onboard-helpers.js", () => ({
+  detectBinary: mocks.detectBinary,
+}));
+
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: mocks.runCommandWithTimeout,
+}));
+
+vi.mock("../agents/cli-credentials.js", () => ({
+  readCodexCliCredentials: mocks.readCodexCliCredentials,
+}));
+
+const { extractOpenAICodexEmailFromAccessToken, loginOpenAICodexDeviceCode } =
+  await import("./openai-codex-device-code.js");
+
+function encodeBase64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function buildJwt(payload: Record<string, unknown>): string {
+  return [
+    encodeBase64Url(JSON.stringify({ alg: "none", typ: "JWT" })),
+    encodeBase64Url(JSON.stringify(payload)),
+    "sig",
+  ].join(".");
+}
+
+describe("extractOpenAICodexEmailFromAccessToken", () => {
+  it("reads the OpenAI profile email claim from the access token", () => {
+    const accessToken = buildJwt({
+      "https://api.openai.com/profile.email": "user@example.com",
+    });
+
+    expect(extractOpenAICodexEmailFromAccessToken(accessToken)).toBe("user@example.com");
+  });
+
+  it("returns undefined for malformed tokens", () => {
+    expect(extractOpenAICodexEmailFromAccessToken("not-a-jwt")).toBeUndefined();
+  });
+});
+
+describe("loginOpenAICodexDeviceCode", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs codex login with mirrored output and imports the resulting credentials", async () => {
+    const accessToken = buildJwt({
+      "https://api.openai.com/profile.email": "user@example.com",
+    });
+    mocks.detectBinary.mockResolvedValue(true);
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      stdout: "device instructions",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+    mocks.readCodexCliCredentials.mockReturnValue({
+      type: "oauth",
+      provider: "openai-codex",
+      access: accessToken,
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+      accountId: "acct_123",
+    });
+
+    const result = await loginOpenAICodexDeviceCode();
+
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(["codex", "login"], {
+      timeoutMs: 600_000,
+      env: { NODE_OPTIONS: "" },
+      mirrorStdout: true,
+      mirrorStderr: true,
+    });
+    expect(result).toMatchObject({
+      access: accessToken,
+      refresh: "refresh-token",
+      email: "user@example.com",
+      accountId: "acct_123",
+    });
+  });
+
+  it("fails clearly when codex is not installed", async () => {
+    mocks.detectBinary.mockResolvedValue(false);
+
+    await expect(loginOpenAICodexDeviceCode()).rejects.toThrow(
+      "Codex CLI not found. Install with: npm install -g @openai/codex",
+    );
+  });
+
+  it("fails when codex login exits non-zero", async () => {
+    mocks.detectBinary.mockResolvedValue(true);
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      stdout: "",
+      stderr: "bad login",
+      code: 1,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+
+    await expect(loginOpenAICodexDeviceCode()).rejects.toThrow("Codex CLI login failed (exit 1).");
+  });
+});

--- a/src/commands/openai-codex-device-code.test.ts
+++ b/src/commands/openai-codex-device-code.test.ts
@@ -52,7 +52,7 @@ describe("loginOpenAICodexDeviceCode", () => {
     vi.clearAllMocks();
   });
 
-  it("runs codex login with mirrored output and imports the resulting credentials", async () => {
+  it("runs codex login --device-auth with mirrored output and imports the resulting credentials", async () => {
     const accessToken = buildJwt({
       "https://api.openai.com/profile.email": "user@example.com",
     });
@@ -76,7 +76,7 @@ describe("loginOpenAICodexDeviceCode", () => {
 
     const result = await loginOpenAICodexDeviceCode();
 
-    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(["codex", "login"], {
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(["codex", "login", "--device-auth"], {
       timeoutMs: 600_000,
       env: { NODE_OPTIONS: "", OPENAI_API_KEY: undefined },
       mirrorStdout: true,
@@ -98,7 +98,7 @@ describe("loginOpenAICodexDeviceCode", () => {
     );
   });
 
-  it("fails when codex login exits non-zero", async () => {
+  it("fails when codex device-auth login exits non-zero", async () => {
     mocks.detectBinary.mockResolvedValue(true);
     mocks.runCommandWithTimeout.mockResolvedValue({
       stdout: "",
@@ -109,6 +109,8 @@ describe("loginOpenAICodexDeviceCode", () => {
       termination: "exit",
     });
 
-    await expect(loginOpenAICodexDeviceCode()).rejects.toThrow("Codex CLI login failed (exit 1).");
+    await expect(loginOpenAICodexDeviceCode()).rejects.toThrow(
+      "Codex CLI device-auth login failed (exit 1).",
+    );
   });
 });

--- a/src/commands/openai-codex-device-code.ts
+++ b/src/commands/openai-codex-device-code.ts
@@ -43,7 +43,8 @@ export async function loginOpenAICodexDeviceCode(): Promise<OAuthCredentials> {
 
   const result = await runCommandWithTimeout(["codex", "login"], {
     timeoutMs: CODEX_LOGIN_TIMEOUT_MS,
-    env: { NODE_OPTIONS: "" },
+    // Prevent ambient API-key auth from short-circuiting the Codex CLI login flow.
+    env: { NODE_OPTIONS: "", OPENAI_API_KEY: undefined },
     mirrorStdout: true,
     mirrorStderr: true,
   });

--- a/src/commands/openai-codex-device-code.ts
+++ b/src/commands/openai-codex-device-code.ts
@@ -41,9 +41,9 @@ export async function loginOpenAICodexDeviceCode(): Promise<OAuthCredentials> {
     throw new Error("Codex CLI not found. Install with: npm install -g @openai/codex");
   }
 
-  const result = await runCommandWithTimeout(["codex", "login"], {
+  const result = await runCommandWithTimeout(["codex", "login", "--device-auth"], {
     timeoutMs: CODEX_LOGIN_TIMEOUT_MS,
-    // Prevent ambient API-key auth from short-circuiting the Codex CLI login flow.
+    // Prevent ambient API-key auth from short-circuiting the device-auth flow.
     env: { NODE_OPTIONS: "", OPENAI_API_KEY: undefined },
     mirrorStdout: true,
     mirrorStderr: true,
@@ -53,7 +53,7 @@ export async function loginOpenAICodexDeviceCode(): Promise<OAuthCredentials> {
     const details = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join("\n");
     throw new Error(
       [
-        `Codex CLI login failed (exit ${String(result.code)}).`,
+        `Codex CLI device-auth login failed (exit ${String(result.code)}).`,
         details ? `Output:\n${details}` : "No output captured.",
       ].join("\n"),
     );
@@ -62,7 +62,7 @@ export async function loginOpenAICodexDeviceCode(): Promise<OAuthCredentials> {
   const creds = readCodexCliCredentials();
   if (!creds) {
     throw new Error(
-      "Codex CLI login completed, but credentials were not found in ~/.codex/auth.json or keychain.",
+      "Codex CLI device-auth login completed, but credentials were not found in ~/.codex/auth.json or keychain.",
     );
   }
 

--- a/src/commands/openai-codex-device-code.ts
+++ b/src/commands/openai-codex-device-code.ts
@@ -1,0 +1,70 @@
+import type { OAuthCredentials } from "@mariozechner/pi-ai";
+import { readCodexCliCredentials } from "../agents/cli-credentials.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { detectBinary } from "./onboard-helpers.js";
+
+const CODEX_LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
+const OPENAI_PROFILE_EMAIL_CLAIM = "https://api.openai.com/profile.email";
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const segments = token.split(".");
+  const payload = segments[1];
+  if (!payload) {
+    return null;
+  }
+
+  try {
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const paddingLength = (4 - (normalized.length % 4)) % 4;
+    const padded = normalized.padEnd(normalized.length + paddingLength, "=");
+    const parsed = JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function extractOpenAICodexEmailFromAccessToken(accessToken: string): string | undefined {
+  const payload = decodeJwtPayload(accessToken);
+  const candidates = [payload?.[OPENAI_PROFILE_EMAIL_CLAIM], payload?.email];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
+export async function loginOpenAICodexDeviceCode(): Promise<OAuthCredentials> {
+  const hasCodex = await detectBinary("codex");
+  if (!hasCodex) {
+    throw new Error("Codex CLI not found. Install with: npm install -g @openai/codex");
+  }
+
+  const result = await runCommandWithTimeout(["codex", "login"], {
+    timeoutMs: CODEX_LOGIN_TIMEOUT_MS,
+    env: { NODE_OPTIONS: "" },
+    mirrorStdout: true,
+    mirrorStderr: true,
+  });
+
+  if (result.code !== 0) {
+    const details = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join("\n");
+    throw new Error(
+      [
+        `Codex CLI login failed (exit ${String(result.code)}).`,
+        details ? `Output:\n${details}` : "No output captured.",
+      ].join("\n"),
+    );
+  }
+
+  const creds = readCodexCliCredentials();
+  if (!creds) {
+    throw new Error(
+      "Codex CLI login completed, but credentials were not found in ~/.codex/auth.json or keychain.",
+    );
+  }
+
+  const email = extractOpenAICodexEmailFromAccessToken(creds.access);
+  return email ? { ...creds, email } : creds;
+}

--- a/src/process/exec.mirror.test.ts
+++ b/src/process/exec.mirror.test.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+import { runCommandWithTimeout } from "./exec.js";
+
+type MockChild = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+  kill: ReturnType<typeof vi.fn>;
+  pid?: number;
+  killed?: boolean;
+};
+
+function createMockChild(params?: { stdout?: string; stderr?: string; code?: number }): MockChild {
+  const child = new EventEmitter() as MockChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = {
+    write: vi.fn(),
+    end: vi.fn(),
+  };
+  child.kill = vi.fn(() => true);
+  child.pid = 1234;
+  child.killed = false;
+  queueMicrotask(() => {
+    if (params?.stdout) {
+      child.stdout.emit("data", Buffer.from(params.stdout));
+    }
+    if (params?.stderr) {
+      child.stderr.emit("data", Buffer.from(params.stderr));
+    }
+    child.emit("close", params?.code ?? 0, null);
+  });
+  return child;
+}
+
+describe("runCommandWithTimeout mirrored output", () => {
+  afterEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it("mirrors stdout while still capturing it", async () => {
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    const stdoutSpy = vi.fn(() => true);
+    process.stdout.write = stdoutSpy as typeof process.stdout.write;
+    spawnMock.mockImplementation(() => createMockChild({ stdout: "hello" }));
+
+    try {
+      const result = await runCommandWithTimeout(["codex", "login"], {
+        timeoutMs: 1_000,
+        mirrorStdout: true,
+      });
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toBe("hello");
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.any(Buffer));
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+  });
+
+  it("mirrors stderr while still capturing it", async () => {
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    const stderrSpy = vi.fn(() => true);
+    process.stderr.write = stderrSpy as typeof process.stderr.write;
+    spawnMock.mockImplementation(() => createMockChild({ stderr: "oops" }));
+
+    try {
+      const result = await runCommandWithTimeout(["codex", "login"], {
+        timeoutMs: 1_000,
+        mirrorStderr: true,
+      });
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe("oops");
+      expect(stderrSpy).toHaveBeenCalledWith(expect.any(Buffer));
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+  });
+});

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -72,44 +72,6 @@ describe("runCommandWithTimeout", () => {
     expect(result.code).not.toBe(0);
   });
 
-  it("mirrors stdout when requested", async () => {
-    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    try {
-      const result = await runCommandWithTimeout(
-        [process.execPath, "-e", 'process.stdout.write("hello")'],
-        {
-          timeoutMs: 5_000,
-          mirrorStdout: true,
-        },
-      );
-
-      expect(result.code).toBe(0);
-      expect(result.stdout).toBe("hello");
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.any(Buffer));
-    } finally {
-      stdoutSpy.mockRestore();
-    }
-  });
-
-  it("mirrors stderr when requested", async () => {
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    try {
-      const result = await runCommandWithTimeout(
-        [process.execPath, "-e", 'process.stderr.write("oops")'],
-        {
-          timeoutMs: 5_000,
-          mirrorStderr: true,
-        },
-      );
-
-      expect(result.code).toBe(0);
-      expect(result.stderr).toBe("oops");
-      expect(stderrSpy).toHaveBeenCalledWith(expect.any(Buffer));
-    } finally {
-      stderrSpy.mockRestore();
-    }
-  });
-
   it.runIf(process.platform === "win32")(
     "on Windows spawns node + npm-cli.js for npm argv to avoid spawn EINVAL",
     async () => {

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -72,6 +72,44 @@ describe("runCommandWithTimeout", () => {
     expect(result.code).not.toBe(0);
   });
 
+  it("mirrors stdout when requested", async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const result = await runCommandWithTimeout(
+        [process.execPath, "-e", 'process.stdout.write("hello")'],
+        {
+          timeoutMs: 5_000,
+          mirrorStdout: true,
+        },
+      );
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toBe("hello");
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.any(Buffer));
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
+
+  it("mirrors stderr when requested", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const result = await runCommandWithTimeout(
+        [process.execPath, "-e", 'process.stderr.write("oops")'],
+        {
+          timeoutMs: 5_000,
+          mirrorStderr: true,
+        },
+      );
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe("oops");
+      expect(stderrSpy).toHaveBeenCalledWith(expect.any(Buffer));
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
   it.runIf(process.platform === "win32")(
     "on Windows spawns node + npm-cli.js for npm argv to avoid spawn EINVAL",
     async () => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -7,38 +7,14 @@ import { danger, shouldLogVerbose } from "../globals.js";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
 import { logDebug, logError } from "../logger.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
-import { resolveWindowsCommandShim, WINDOWS_CMD_SHIM_COMMANDS } from "./windows-command.js";
+import {
+  buildCmdExeCommandLine,
+  isWindowsBatchCommand,
+  resolveWindowsCommandShim,
+  WINDOWS_CMD_SHIM_COMMANDS,
+} from "./windows-command.js";
 
 const execFileAsync = promisify(execFile);
-
-const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>^%\r\n]/;
-
-function isWindowsBatchCommand(resolvedCommand: string): boolean {
-  if (process.platform !== "win32") {
-    return false;
-  }
-  const ext = path.extname(resolvedCommand).toLowerCase();
-  return ext === ".cmd" || ext === ".bat";
-}
-
-function escapeForCmdExe(arg: string): string {
-  // Reject cmd metacharacters to avoid injection when we must pass a single command line.
-  if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
-    throw new Error(
-      `Unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}. ` +
-        "Pass an explicit shell-wrapper argv at the call site instead.",
-    );
-  }
-  // Quote when needed; double inner quotes for cmd parsing.
-  if (!arg.includes(" ") && !arg.includes('"')) {
-    return arg;
-  }
-  return `"${arg.replace(/"/g, '""')}"`;
-}
-
-function buildCmdExeCommandLine(resolvedCommand: string, args: string[]): string {
-  return [escapeForCmdExe(resolvedCommand), ...args.map(escapeForCmdExe)].join(" ");
-}
 
 /**
  * On Windows, Node 18.20.2+ (CVE-2024-27980) rejects spawning .cmd/.bat directly

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -73,7 +73,8 @@ function resolveNpmArgvForWindows(argv: string[]): string[] | null {
 
 /**
  * Resolves a command for Windows compatibility.
- * On Windows, npm-style shims (like pnpm, yarn, codex) are resolved to .cmd;
+ * On Windows, npm-style shims (like pnpm, yarn, codex) are resolved to the
+ * actual PATH match when present, with a .cmd fallback for npm-style installs;
  * npm/npx are handled by resolveNpmArgvForWindows to avoid spawn EINVAL
  * (no direct .cmd spawn).
  */

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -171,6 +171,8 @@ export type CommandOptions = {
   env?: NodeJS.ProcessEnv;
   windowsVerbatimArguments?: boolean;
   noOutputTimeoutMs?: number;
+  mirrorStdout?: boolean;
+  mirrorStderr?: boolean;
 };
 
 export function resolveCommandEnv(params: {
@@ -215,7 +217,7 @@ export async function runCommandWithTimeout(
 ): Promise<SpawnResult> {
   const options: CommandOptions =
     typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
-  const { timeoutMs, cwd, input, env, noOutputTimeoutMs } = options;
+  const { timeoutMs, cwd, input, env, noOutputTimeoutMs, mirrorStdout, mirrorStderr } = options;
   const { windowsVerbatimArguments } = options;
   const hasInput = input !== undefined;
   const resolvedEnv = resolveCommandEnv({ argv, env });
@@ -291,10 +293,16 @@ export async function runCommandWithTimeout(
 
     child.stdout?.on("data", (d) => {
       stdout += d.toString();
+      if (mirrorStdout) {
+        process.stdout.write(d);
+      }
       armNoOutputTimer();
     });
     child.stderr?.on("data", (d) => {
       stderr += d.toString();
+      if (mirrorStderr) {
+        process.stderr.write(d);
+      }
       armNoOutputTimer();
     });
     child.on("error", (err) => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -7,7 +7,7 @@ import { danger, shouldLogVerbose } from "../globals.js";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
 import { logDebug, logError } from "../logger.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
-import { resolveWindowsCommandShim } from "./windows-command.js";
+import { resolveWindowsCommandShim, WINDOWS_CMD_SHIM_COMMANDS } from "./windows-command.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -73,13 +73,14 @@ function resolveNpmArgvForWindows(argv: string[]): string[] | null {
 
 /**
  * Resolves a command for Windows compatibility.
- * On Windows, non-.exe commands (like pnpm, yarn) are resolved to .cmd; npm/npx
- * are handled by resolveNpmArgvForWindows to avoid spawn EINVAL (no direct .cmd).
+ * On Windows, npm-style shims (like pnpm, yarn, codex) are resolved to .cmd;
+ * npm/npx are handled by resolveNpmArgvForWindows to avoid spawn EINVAL
+ * (no direct .cmd spawn).
  */
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
     command,
-    cmdCommands: ["pnpm", "yarn"],
+    cmdCommands: WINDOWS_CMD_SHIM_COMMANDS,
   });
 }
 

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -53,13 +53,14 @@ type ExecCall = [
 function expectCmdWrappedInvocation(params: {
   captured: SpawnCall | ExecCall | undefined;
   expectedComSpec: string;
+  expectedCommandLine: string;
 }) {
   if (!params.captured) {
     throw new Error("expected command wrapper to be called");
   }
   expect(params.captured[0]).toBe(params.expectedComSpec);
   expect(params.captured[1].slice(0, 3)).toEqual(["/d", "/s", "/c"]);
-  expect(params.captured[1][3]).toContain("pnpm.cmd --version");
+  expect(params.captured[1][3]).toContain(params.expectedCommandLine);
   expect(params.captured[2].windowsVerbatimArguments).toBe(true);
 }
 
@@ -82,7 +83,33 @@ describe("windows command wrapper behavior", () => {
       const result = await runCommandWithTimeout(["pnpm", "--version"], { timeoutMs: 1000 });
       expect(result.code).toBe(0);
       const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
-      expectCmdWrappedInvocation({ captured, expectedComSpec });
+      expectCmdWrappedInvocation({
+        captured,
+        expectedComSpec,
+        expectedCommandLine: "pnpm.cmd --version",
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("wraps codex.cmd via cmd.exe in runCommandWithTimeout", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+
+    spawnMock.mockImplementation(
+      (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
+    );
+
+    try {
+      const result = await runCommandWithTimeout(["codex", "login"], { timeoutMs: 1000 });
+      expect(result.code).toBe(0);
+      const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
+      expectCmdWrappedInvocation({
+        captured,
+        expectedComSpec,
+        expectedCommandLine: "codex.cmd login",
+      });
     } finally {
       platformSpy.mockRestore();
     }
@@ -106,7 +133,11 @@ describe("windows command wrapper behavior", () => {
     try {
       await runExec("pnpm", ["--version"], 1000);
       const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
-      expectCmdWrappedInvocation({ captured, expectedComSpec });
+      expectCmdWrappedInvocation({
+        captured,
+        expectedComSpec,
+        expectedCommandLine: "pnpm.cmd --version",
+      });
     } finally {
       platformSpy.mockRestore();
     }

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -93,7 +93,7 @@ describe("windows command wrapper behavior", () => {
     }
   });
 
-  it("wraps codex.cmd via cmd.exe in runCommandWithTimeout", async () => {
+  it("wraps codex.cmd device-auth login via cmd.exe in runCommandWithTimeout", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
 
@@ -102,13 +102,15 @@ describe("windows command wrapper behavior", () => {
     );
 
     try {
-      const result = await runCommandWithTimeout(["codex", "login"], { timeoutMs: 1000 });
+      const result = await runCommandWithTimeout(["codex", "login", "--device-auth"], {
+        timeoutMs: 1000,
+      });
       expect(result.code).toBe(0);
       const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
       expectCmdWrappedInvocation({
         captured,
         expectedComSpec,
-        expectedCommandLine: "codex.cmd login",
+        expectedCommandLine: "codex.cmd login --device-auth",
       });
     } finally {
       platformSpy.mockRestore();

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
@@ -114,6 +115,39 @@ describe("windows command wrapper behavior", () => {
       });
     } finally {
       platformSpy.mockRestore();
+    }
+  });
+
+  it("spawns a standalone codex.exe directly when that PATH match exists", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const pathSpy = vi.spyOn(process, "env", "get").mockReturnValue({
+      ...process.env,
+      PATH: 'C:\\Tools;C:\\Other',
+      PATHEXT: ".EXE;.CMD",
+    });
+    vi.spyOn(fs, "existsSync").mockImplementation(
+      (candidate) => String(candidate) === "C:\\Tools\\codex.exe",
+    );
+
+    spawnMock.mockImplementation(
+      (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
+    );
+
+    try {
+      const result = await runCommandWithTimeout(["codex", "login", "--device-auth"], {
+        timeoutMs: 1000,
+      });
+      expect(result.code).toBe(0);
+      const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
+      if (!captured) {
+        throw new Error("expected spawn to be called");
+      }
+      expect(captured[0]).toBe("C:\\Tools\\codex.exe");
+      expect(captured[1]).toEqual(["login", "--device-auth"]);
+      expect(captured[2].windowsVerbatimArguments).toBeUndefined();
+    } finally {
+      platformSpy.mockRestore();
+      pathSpy.mockRestore();
     }
   });
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
@@ -137,5 +138,71 @@ describe("createChildAdapter", () => {
       options?: { env?: Record<string, string> };
     };
     expect(spawnArgs.options?.env).toEqual({ FOO: "bar", COUNT: "12" });
+  });
+
+  it("wraps codex.cmd via cmd.exe on Windows", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const envSpy = vi.spyOn(process, "env", "get").mockReturnValue({
+      ...process.env,
+      PATH: 'C:\\Tools;C:\\Other',
+      PATHEXT: ".EXE;.CMD",
+      ComSpec: "cmd.exe",
+    });
+    vi.spyOn(fs, "existsSync").mockImplementation(
+      (candidate) => String(candidate) === "C:\\Other\\codex.cmd",
+    );
+
+    try {
+      await createAdapterHarness({
+        pid: 5555,
+        argv: ["codex", "login", "--device-auth"],
+      });
+
+      const spawnArgs = spawnWithFallbackMock.mock.calls[0]?.[0] as {
+        argv?: string[];
+        options?: { windowsVerbatimArguments?: boolean };
+      };
+      expect(spawnArgs.argv).toEqual([
+        "cmd.exe",
+        "/d",
+        "/s",
+        "/c",
+        "C:\\Other\\codex.cmd login --device-auth",
+      ]);
+      expect(spawnArgs.options?.windowsVerbatimArguments).toBe(true);
+    } finally {
+      platformSpy.mockRestore();
+      envSpy.mockRestore();
+    }
+  });
+
+  it("spawns codex.exe directly on Windows when it is the PATH match", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const envSpy = vi.spyOn(process, "env", "get").mockReturnValue({
+      ...process.env,
+      PATH: 'C:\\Tools;C:\\Other',
+      PATHEXT: ".EXE;.CMD",
+      ComSpec: "cmd.exe",
+    });
+    vi.spyOn(fs, "existsSync").mockImplementation(
+      (candidate) => String(candidate) === "C:\\Tools\\codex.exe",
+    );
+
+    try {
+      await createAdapterHarness({
+        pid: 6666,
+        argv: ["codex", "login", "--device-auth"],
+      });
+
+      const spawnArgs = spawnWithFallbackMock.mock.calls[0]?.[0] as {
+        argv?: string[];
+        options?: { windowsVerbatimArguments?: boolean };
+      };
+      expect(spawnArgs.argv).toEqual(["C:\\Tools\\codex.exe", "login", "--device-auth"]);
+      expect(spawnArgs.options?.windowsVerbatimArguments).toBeUndefined();
+    } finally {
+      platformSpy.mockRestore();
+      envSpy.mockRestore();
+    }
   });
 });

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -1,7 +1,12 @@
 import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_process";
 import { killProcessTree } from "../../kill-tree.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
-import { resolveWindowsCommandShim, WINDOWS_CMD_SHIM_COMMANDS } from "../../windows-command.js";
+import {
+  buildCmdExeCommandLine,
+  isWindowsBatchCommand,
+  resolveWindowsCommandShim,
+  WINDOWS_CMD_SHIM_COMMANDS,
+} from "../../windows-command.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
 
@@ -28,6 +33,16 @@ export async function createChildAdapter(params: {
 }): Promise<ChildAdapter> {
   const resolvedArgv = [...params.argv];
   resolvedArgv[0] = resolveCommand(resolvedArgv[0] ?? "");
+  const useCmdWrapper = isWindowsBatchCommand(resolvedArgv[0] ?? "");
+  const spawnArgv = useCmdWrapper
+    ? [
+        process.env.ComSpec ?? "cmd.exe",
+        "/d",
+        "/s",
+        "/c",
+        buildCmdExeCommandLine(resolvedArgv[0] ?? "", resolvedArgv.slice(1)),
+      ]
+    : resolvedArgv;
 
   const stdinMode = params.stdinMode ?? (params.input !== undefined ? "pipe-closed" : "inherit");
 
@@ -42,7 +57,7 @@ export async function createChildAdapter(params: {
     stdio: ["pipe", "pipe", "pipe"],
     detached: useDetached,
     windowsHide: true,
-    windowsVerbatimArguments: params.windowsVerbatimArguments,
+    windowsVerbatimArguments: useCmdWrapper ? true : params.windowsVerbatimArguments,
   };
   if (stdinMode === "inherit") {
     options.stdio = ["inherit", "pipe", "pipe"];
@@ -51,7 +66,7 @@ export async function createChildAdapter(params: {
   }
 
   const spawned = await spawnWithFallback({
-    argv: resolvedArgv,
+    argv: spawnArgv,
     options,
     fallbacks: useDetached
       ? [

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -1,14 +1,14 @@
 import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_process";
 import { killProcessTree } from "../../kill-tree.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
-import { resolveWindowsCommandShim } from "../../windows-command.js";
+import { resolveWindowsCommandShim, WINDOWS_CMD_SHIM_COMMANDS } from "../../windows-command.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
 
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
     command,
-    cmdCommands: ["npm", "pnpm", "yarn", "npx"],
+    cmdCommands: WINDOWS_CMD_SHIM_COMMANDS,
   });
 }
 

--- a/src/process/windows-command.test.ts
+++ b/src/process/windows-command.test.ts
@@ -22,14 +22,30 @@ describe("resolveWindowsCommandShim", () => {
     ).toBe("pnpm.cmd");
   });
 
-  it("appends .cmd for codex on Windows", () => {
+  it("resolves a codex.exe PATH match on Windows", () => {
     expect(
       resolveWindowsCommandShim({
         command: "codex",
         cmdCommands: ["codex"],
         platform: "win32",
+        pathEnv: 'C:\\Tools;C:\\Other',
+        pathExt: ".EXE;.CMD",
+        fileExists: (candidate) => candidate === "C:\\Tools\\codex.exe",
       }),
-    ).toBe("codex.cmd");
+    ).toBe("C:\\Tools\\codex.exe");
+  });
+
+  it("resolves a codex.cmd PATH match on Windows when no exe exists", () => {
+    expect(
+      resolveWindowsCommandShim({
+        command: "codex",
+        cmdCommands: ["codex"],
+        platform: "win32",
+        pathEnv: 'C:\\Tools;C:\\Other',
+        pathExt: ".EXE;.CMD",
+        fileExists: (candidate) => candidate === "C:\\Other\\codex.cmd",
+      }),
+    ).toBe("C:\\Other\\codex.cmd");
   });
 
   it("keeps explicit extensions on Windows", () => {
@@ -40,5 +56,18 @@ describe("resolveWindowsCommandShim", () => {
         platform: "win32",
       }),
     ).toBe("npm.cmd");
+  });
+
+  it("falls back to .cmd when no PATH match is found", () => {
+    expect(
+      resolveWindowsCommandShim({
+        command: "codex",
+        cmdCommands: ["codex"],
+        platform: "win32",
+        pathEnv: 'C:\\Tools',
+        pathExt: ".EXE;.CMD",
+        fileExists: () => false,
+      }),
+    ).toBe("codex.cmd");
   });
 });

--- a/src/process/windows-command.test.ts
+++ b/src/process/windows-command.test.ts
@@ -16,10 +16,20 @@ describe("resolveWindowsCommandShim", () => {
     expect(
       resolveWindowsCommandShim({
         command: "pnpm",
-        cmdCommands: ["pnpm", "yarn"],
+        cmdCommands: ["pnpm", "yarn", "codex"],
         platform: "win32",
       }),
     ).toBe("pnpm.cmd");
+  });
+
+  it("appends .cmd for codex on Windows", () => {
+    expect(
+      resolveWindowsCommandShim({
+        command: "codex",
+        cmdCommands: ["codex"],
+        platform: "win32",
+      }),
+    ).toBe("codex.cmd");
   });
 
   it("keeps explicit extensions on Windows", () => {

--- a/src/process/windows-command.ts
+++ b/src/process/windows-command.ts
@@ -1,21 +1,75 @@
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
 export const WINDOWS_CMD_SHIM_COMMANDS = ["npm", "npx", "pnpm", "yarn", "codex"] as const;
+const DEFAULT_WINDOWS_PATHEXT = [".com", ".exe", ".bat", ".cmd"] as const;
+
+function parseWindowsPathExt(pathExt: string | undefined): string[] {
+  const parsed = String(pathExt ?? "")
+    .split(";")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean)
+    .map((value) => (value.startsWith(".") ? value : `.${value}`));
+  return parsed.length > 0 ? parsed : [...DEFAULT_WINDOWS_PATHEXT];
+}
+
+function findWindowsCommandMatch(params: {
+  command: string;
+  pathEnv?: string;
+  pathExt?: string;
+  fileExists?: (candidate: string) => boolean;
+}): string | undefined {
+  const fileExists = params.fileExists ?? fs.existsSync;
+  const pathExts = parseWindowsPathExt(params.pathExt ?? process.env.PATHEXT);
+  const isExplicitPath =
+    path.win32.isAbsolute(params.command) || /[\\/]/.test(params.command);
+  const candidateBases = isExplicitPath
+    ? [params.command]
+    : String(params.pathEnv ?? process.env.PATH ?? "")
+        .split(";")
+        .map((entry) => entry.trim().replace(/^"(.*)"$/, "$1"))
+        .filter(Boolean)
+        .map((entry) => path.win32.join(entry, params.command));
+
+  for (const base of candidateBases) {
+    for (const ext of pathExts) {
+      const candidate = `${base}${ext}`;
+      if (fileExists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return undefined;
+}
 
 export function resolveWindowsCommandShim(params: {
   command: string;
   cmdCommands: readonly string[];
   platform?: NodeJS.Platform;
+  pathEnv?: string;
+  pathExt?: string;
+  fileExists?: (candidate: string) => boolean;
 }): string {
-  if ((params.platform ?? process.platform) !== "win32") {
+  const platform = params.platform ?? process.platform;
+  if (platform !== "win32") {
     return params.command;
   }
-  const basename = path.basename(params.command).toLowerCase();
-  if (path.extname(basename)) {
+  const basename = path.win32.basename(params.command).toLowerCase();
+  if (path.win32.extname(basename)) {
     return params.command;
   }
   if (params.cmdCommands.includes(basename)) {
+    const resolved = findWindowsCommandMatch({
+      command: params.command,
+      pathEnv: params.pathEnv,
+      pathExt: params.pathExt,
+      fileExists: params.fileExists,
+    });
+    if (resolved) {
+      return resolved;
+    }
     return `${params.command}.cmd`;
   }
   return params.command;

--- a/src/process/windows-command.ts
+++ b/src/process/windows-command.ts
@@ -4,6 +4,7 @@ import process from "node:process";
 
 export const WINDOWS_CMD_SHIM_COMMANDS = ["npm", "npx", "pnpm", "yarn", "codex"] as const;
 const DEFAULT_WINDOWS_PATHEXT = [".com", ".exe", ".bat", ".cmd"] as const;
+const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>^%\r\n]/;
 
 function parseWindowsPathExt(pathExt: string | undefined): string[] {
   const parsed = String(pathExt ?? "")
@@ -42,6 +43,34 @@ function findWindowsCommandMatch(params: {
   }
 
   return undefined;
+}
+
+export function isWindowsBatchCommand(
+  resolvedCommand: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform !== "win32") {
+    return false;
+  }
+  const ext = path.win32.extname(resolvedCommand).toLowerCase();
+  return ext === ".cmd" || ext === ".bat";
+}
+
+function escapeForCmdExe(arg: string): string {
+  if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
+    throw new Error(
+      `Unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}. ` +
+        "Pass an explicit shell-wrapper argv at the call site instead.",
+    );
+  }
+  if (!arg.includes(" ") && !arg.includes('"')) {
+    return arg;
+  }
+  return `"${arg.replace(/"/g, '""')}"`;
+}
+
+export function buildCmdExeCommandLine(resolvedCommand: string, args: string[]): string {
+  return [escapeForCmdExe(resolvedCommand), ...args.map(escapeForCmdExe)].join(" ");
 }
 
 export function resolveWindowsCommandShim(params: {

--- a/src/process/windows-command.ts
+++ b/src/process/windows-command.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 import process from "node:process";
 
+export const WINDOWS_CMD_SHIM_COMMANDS = ["npm", "npx", "pnpm", "yarn", "codex"] as const;
+
 export function resolveWindowsCommandShim(params: {
   command: string;
   cmdCommands: readonly string[];


### PR DESCRIPTION
## Summary
Add a built-in Codex CLI device-code login path for `openai-codex`.

This adds:
- a new interactive onboard auth choice: `openai-device-code`
- a built-in `openclaw models auth login --provider openai-codex --method device-code`
- a shared helper that runs `codex login`, mirrors the device-code instructions to the terminal, and imports the resulting credentials into OpenClaw
- docs updates for the new device-code flow

## Why
OpenClaw already supports `openai-codex` via browser OAuth, but headless and remote environments are better served by the Codex CLI device-code flow now supported upstream.

There was an earlier attempt in #7796, but it only covered onboarding and went stale. This patch carries the same direction forward on current `main`, and also wires the flow into `models auth login`.

## Implementation notes
- keep stdout and stderr captured while mirroring child output to the terminal so device-code prompts remain visible without losing debuggability
- import Codex CLI credentials into the existing `openai-codex` auth store
- derive the OpenAI profile email from the access token when available so the stored profile id is stable
- map legacy `codex-cli` onboarding alias to the new device-code path instead of browser OAuth

## Tests
Passed:
- `pnpm test src/process/exec.test.ts src/commands/openai-codex-device-code.test.ts src/commands/models/auth.test.ts src/commands/auth-choice.test.ts src/commands/auth-choice-options.test.ts`
- `pnpm test src/commands/auth-choice.apply.openai.test.ts`

## Follow-up
I only updated the English docs in this patch; `zh-CN` doc copies still need the same wording update.
