### PR TITLE
fix(openai-responses): strip prompt cache fields for non-OpenAI endpoints

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1692,6 +1692,49 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("store");
   });
 
+  it("strips prompt cache fields for non-OpenAI responses-compatible endpoints", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-ark-cn-beijing-volces-com",
+      applyModelId: "ep-20260310072239-f9rhn",
+      model: {
+        api: "openai-responses",
+        provider: "custom-ark-cn-beijing-volces-com",
+        id: "ep-20260310072239-f9rhn",
+        name: "doubao-seed-2-0-pro-260215",
+        baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-123",
+        prompt_cache_retention: "24h",
+      },
+    });
+
+    expect(payload).not.toHaveProperty("prompt_cache_key");
+    expect(payload).not.toHaveProperty("prompt_cache_retention");
+  });
+
+  it("keeps prompt cache fields for direct OpenAI responses endpoints", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5",
+        baseUrl: "https://api.openai.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-123",
+        prompt_cache_retention: "24h",
+      },
+    });
+
+    expect(payload.prompt_cache_key).toBe("session-123");
+    expect(payload.prompt_cache_retention).toBe("24h");
+  });
+
   it("keeps existing context_management when stripping store for supportsStore=false models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "custom-openai-responses",

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -120,15 +120,19 @@ function shouldStripResponsesStore(
 function shouldStripResponsesPromptCacheFields(model: {
   api?: unknown;
   baseUrl?: unknown;
-  compat?: { supportsPromptCacheKey?: boolean };
+  compat?: unknown;
 }): boolean {
   if (typeof model.api !== "string" || !OPENAI_RESPONSES_APIS.has(model.api)) {
     return false;
   }
-  if (model.compat?.supportsPromptCacheKey === true) {
+  const supportsPromptCacheKey =
+    model.compat && typeof model.compat === "object"
+      ? (model.compat as Record<string, unknown>).supportsPromptCacheKey
+      : undefined;
+  if (supportsPromptCacheKey === true) {
     return false;
   }
-  if (model.compat?.supportsPromptCacheKey === false) {
+  if (supportsPromptCacheKey === false) {
     return true;
   }
   return !isDirectOpenAIBaseUrl(model.baseUrl);

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -44,7 +44,7 @@ function shouldForceResponsesStore(model: {
   api?: unknown;
   provider?: unknown;
   baseUrl?: unknown;
-  compat?: { supportsStore?: boolean };
+  compat?: { supportsStore?: boolean; supportsPromptCacheKey?: boolean };
 }): boolean {
   if (model.compat?.supportsStore === false) {
     return false;
@@ -117,10 +117,28 @@ function shouldStripResponsesStore(
   return OPENAI_RESPONSES_APIS.has(model.api) && model.compat?.supportsStore === false;
 }
 
+function shouldStripResponsesPromptCacheFields(model: {
+  api?: unknown;
+  baseUrl?: unknown;
+  compat?: { supportsPromptCacheKey?: boolean };
+}): boolean {
+  if (typeof model.api !== "string" || !OPENAI_RESPONSES_APIS.has(model.api)) {
+    return false;
+  }
+  if (model.compat?.supportsPromptCacheKey === true) {
+    return false;
+  }
+  if (model.compat?.supportsPromptCacheKey === false) {
+    return true;
+  }
+  return !isDirectOpenAIBaseUrl(model.baseUrl);
+}
+
 function applyOpenAIResponsesPayloadOverrides(params: {
   payloadObj: Record<string, unknown>;
   forceStore: boolean;
   stripStore: boolean;
+  stripPromptCacheFields: boolean;
   useServerCompaction: boolean;
   compactThreshold: number;
 }): void {
@@ -129,6 +147,10 @@ function applyOpenAIResponsesPayloadOverrides(params: {
   }
   if (params.stripStore) {
     delete params.payloadObj.store;
+  }
+  if (params.stripPromptCacheFields) {
+    delete params.payloadObj.prompt_cache_key;
+    delete params.payloadObj.prompt_cache_retention;
   }
   if (params.useServerCompaction && params.payloadObj.context_management === undefined) {
     params.payloadObj.context_management = [
@@ -177,7 +199,8 @@ export function createOpenAIResponsesContextManagementWrapper(
     const forceStore = shouldForceResponsesStore(model);
     const useServerCompaction = shouldEnableOpenAIResponsesServerCompaction(model, extraParams);
     const stripStore = shouldStripResponsesStore(model, forceStore);
-    if (!forceStore && !useServerCompaction && !stripStore) {
+    const stripPromptCacheFields = shouldStripResponsesPromptCacheFields(model);
+    if (!forceStore && !useServerCompaction && !stripStore && !stripPromptCacheFields) {
       return underlying(model, context, options);
     }
 
@@ -193,6 +216,7 @@ export function createOpenAIResponsesContextManagementWrapper(
             payloadObj: payload as Record<string, unknown>,
             forceStore,
             stripStore,
+            stripPromptCacheFields,
             useServerCompaction,
             compactThreshold,
           });


### PR DESCRIPTION
## Summary
- strip `prompt_cache_key` and `prompt_cache_retention` from OpenAI Responses payloads when the target is not a direct OpenAI/Azure OpenAI endpoint
- keep existing behavior for direct OpenAI endpoints
- preserve existing `supportsPromptCacheKey` compatibility override hooks for future provider-specific opt-ins/outs

## Testing
- `pnpm -C tmp-openclaw-42576 exec vitest run src/agents/pi-embedded-runner-extraparams.test.ts`

Resubmitted after queue-cap auto-close.

Closes #42614
