### PR TITLE
fix(ui): reduce initial Control UI chat hydration window for heavy sessions

### DIFF
--- a/ui/src/ui/chat/constants.ts
+++ b/ui/src/ui/chat/constants.ts
@@ -2,6 +2,9 @@
  * Chat-related constants for the UI layer.
  */
 
+/** Initial Control UI chat history hydration/render window */
+export const INITIAL_CHAT_HISTORY_WINDOW = 80;
+
 /** Character threshold for showing tool output inline vs collapsed */
 export const TOOL_INLINE_THRESHOLD = 80;
 

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -555,7 +555,7 @@ describe("loadChatHistory", () => {
 
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
-      limit: 200,
+      limit: 80,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "visible answer" }] },

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { INITIAL_CHAT_HISTORY_WINDOW } from "../chat/constants.ts";
 import { handleChatEvent, loadChatHistory, type ChatEventPayload, type ChatState } from "./chat.ts";
 
 function createState(overrides: Partial<ChatState> = {}): ChatState {
@@ -555,7 +556,7 @@ describe("loadChatHistory", () => {
 
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
-      limit: 80,
+      limit: INITIAL_CHAT_HISTORY_WINDOW,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "visible answer" }] },

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -74,7 +74,10 @@ export async function loadChatHistory(state: ChatState) {
       "chat.history",
       {
         sessionKey: state.sessionKey,
-        limit: 200,
+        // Keep initial WebUI chat hydration intentionally smaller than the
+        // server-side default to avoid tab freezes on sessions with many large
+        // toolResult payloads.
+        limit: 80,
       },
     );
     const messages = Array.isArray(res.messages) ? res.messages : [];

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,4 +1,5 @@
 import { resetToolStream } from "../app-tool-stream.ts";
+import { INITIAL_CHAT_HISTORY_WINDOW } from "../chat/constants.ts";
 import { extractText } from "../chat/message-extract.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ChatAttachment } from "../ui-types.ts";
@@ -77,7 +78,7 @@ export async function loadChatHistory(state: ChatState) {
         // Keep initial WebUI chat hydration intentionally smaller than the
         // server-side default to avoid tab freezes on sessions with many large
         // toolResult payloads.
-        limit: 80,
+        limit: INITIAL_CHAT_HISTORY_WINDOW,
       },
     );
     const messages = Array.isArray(res.messages) ? res.messages : [];

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1,5 +1,6 @@
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+import { INITIAL_CHAT_HISTORY_WINDOW } from "../chat/constants.ts";
 import type { SessionsListResult } from "../types.ts";
 import { renderChat, type ChatProps } from "./chat.ts";
 
@@ -282,5 +283,29 @@ describe("chat view", () => {
     );
     expect(senderLabels).toContain("Iris");
     expect(senderLabels).toContain("Joaquin De Rojas");
+  });
+
+  it("truncates rendered history to the initial hydration window and shows a notice", () => {
+    const container = document.createElement("div");
+    const messages = Array.from({ length: INITIAL_CHAT_HISTORY_WINDOW + 5 }, (_, index) => ({
+      role: "assistant",
+      content: [{ type: "text", text: `message-${index}` }],
+      timestamp: index + 1,
+    }));
+
+    render(
+      renderChat(
+        createProps({
+          messages,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain(
+      `Showing last ${INITIAL_CHAT_HISTORY_WINDOW} messages (5 hidden).`,
+    );
+    expect(container.textContent).not.toContain("message-0");
+    expect(container.textContent).toContain(`message-${INITIAL_CHAT_HISTORY_WINDOW + 4}`);
   });
 });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -480,7 +480,10 @@ export function renderChat(props: ChatProps) {
   `;
 }
 
-const CHAT_HISTORY_RENDER_LIMIT = 200;
+// The chat page is an intervention surface, not a full transcript viewer.
+// Keep the render window conservative so oversized session histories do not
+// freeze the page during initial load.
+const CHAT_HISTORY_RENDER_LIMIT = 80;
 
 function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
+import { INITIAL_CHAT_HISTORY_WINDOW } from "../chat/constants.ts";
 import {
   renderMessageGroup,
   renderReadingIndicatorGroup,
@@ -483,8 +484,6 @@ export function renderChat(props: ChatProps) {
 // The chat page is an intervention surface, not a full transcript viewer.
 // Keep the render window conservative so oversized session histories do not
 // freeze the page during initial load.
-const CHAT_HISTORY_RENDER_LIMIT = 80;
-
 function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];
   let currentGroup: MessageGroup | null = null;
@@ -536,14 +535,14 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   const items: ChatItem[] = [];
   const history = Array.isArray(props.messages) ? props.messages : [];
   const tools = Array.isArray(props.toolMessages) ? props.toolMessages : [];
-  const historyStart = Math.max(0, history.length - CHAT_HISTORY_RENDER_LIMIT);
+  const historyStart = Math.max(0, history.length - INITIAL_CHAT_HISTORY_WINDOW);
   if (historyStart > 0) {
     items.push({
       kind: "message",
       key: "chat:history:notice",
       message: {
         role: "system",
-        content: `Showing last ${CHAT_HISTORY_RENDER_LIMIT} messages (${historyStart} hidden).`,
+        content: `Showing last ${INITIAL_CHAT_HISTORY_WINDOW} messages (${historyStart} hidden).`,
         timestamp: Date.now(),
       },
     });


### PR DESCRIPTION
## Summary
Reduce the initial Control UI chat hydration/render window from 200 to 80 messages.

This lowers first-load cost for heavy sessions with many large `toolResult` / config-output messages and helps prevent the chat page from freezing during initial render.

## Problem
The Control UI chat page can become unresponsive when opening sessions with a large number of heavy history entries, especially sessions containing oversized `toolResult` payloads or large config / audit outputs.

Although the gateway already caps oversized `chat.history` payloads, the browser still does a relatively expensive first hydration/render pass when the initial history window is too large.

## Root cause
The initial client-side `chat.history` request and render window were both set to 200 messages.

For intervention-style Control UI usage, this is often more history than needed on first load, and it increases the chance of browser stalls on sessions with many large structured messages.

## Changes
- reduce initial `chat.history` request limit:
  - `200 -> 80`
- reduce initial chat render window:
  - `200 -> 80`

Files changed:
- `ui/src/ui/controllers/chat.ts`
- `ui/src/ui/views/chat.ts`
- `ui/src/ui/controllers/chat.test.ts`

## Why this is safe
The Control UI chat surface is primarily an intervention surface, not a full transcript viewer.

Reducing the initial hydration window is a conservative UI-side performance guard:
- no protocol changes
- no transcript mutation
- no server-side behavior changes
- low regression risk

## Validation
Ran:
- `pnpm --dir ui test src/ui/controllers/chat.test.ts`
- `pnpm --dir ui test src/ui/storage.node.test.ts src/ui/navigation.browser.test.ts src/ui/app-lifecycle-connect.node.test.ts`
- `pnpm ui:build`

All passed locally.
