### PR TITLE
fix: separate Current time from Reference UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -642,6 +642,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/nodes: preserve the live node registry session and invoke ownership when an older same-node WebSocket closes after reconnecting. (#78351) Thanks @samzong.
 - Browser/downloads: route explicit and managed browser download output directories through `fs-safe` validation before staging final files, so symlinked output roots are rejected before writes. (#78780) Thanks @jesse-merhi.
 - Agents/PI: skip the idle wait during aborted embedded-run cleanup, so stopped or timed-out runs clear pending tool state and release the session lock promptly. (#74919) Thanks @medns.
+- Agents/current-time: split UTC into a separate `Reference UTC:` prompt line so local `Current time:` stays anchored to the user's timezone. (#42654) Thanks @chencheng-li.
 
 ## 2026.5.3-1
 

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -84,8 +84,9 @@ describe("buildMemoryFlushPlan", () => {
 
     expect(plan?.prompt).toContain("memory/2026-02-16.md");
     expect(plan?.prompt).toContain(
-      "Current time: Monday, February 16th, 2026 - 10:00 AM (America/New_York) / 2026-02-16 15:00 UTC",
+      "Current time: Monday, February 16th, 2026 - 10:00 AM (America/New_York)",
     );
+    expect(plan?.prompt).toContain("Reference UTC: 2026-02-16 15:00 UTC");
     expect(plan?.relativePath).toBe("memory/2026-02-16.md");
   });
 

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -1943,7 +1943,8 @@ describe("short-term dreaming trigger", () => {
     const result = await runShortTermDreamingPromotionIfTriggered({
       cleanedBody: [
         "[cron:e795558c-a273-4124-ba88-d4916688d977 Memory Dreaming Promotion] __openclaw_memory_core_short_term_promotion_dream__",
-        "Current time: Thursday, April 16th, 2026 - 3:10 PM (America/Los_Angeles) / 2026-04-16 22:10 UTC",
+        "Current time: Thursday, April 16th, 2026 - 3:10 PM (America/Los_Angeles)",
+        "Reference UTC: 2026-04-16 22:10 UTC",
       ].join("\n"),
       trigger: "cron",
       workspaceDir,

--- a/src/agents/current-time.ts
+++ b/src/agents/current-time.ts
@@ -26,7 +26,7 @@ export function resolveCronStyleNow(cfg: TimeConfigLike, nowMs: number): CronSty
   const formattedTime =
     formatUserTime(new Date(nowMs), userTimezone, userTimeFormat) ?? new Date(nowMs).toISOString();
   const utcTime = new Date(nowMs).toISOString().replace("T", " ").slice(0, 16) + " UTC";
-  const timeLine = `Current time: ${formattedTime} (${userTimezone}) / ${utcTime}`;
+  const timeLine = `Current time: ${formattedTime} (${userTimezone})\nReference UTC: ${utcTime}`;
   return { userTimezone, formattedTime, timeLine };
 }
 

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -262,9 +262,8 @@ Never modify memory/YYYY-MM-DD.md destructively.
     expect(result).not.toBeNull();
     expect(result).toContain("memory/2026-03-03.md");
     expect(result).not.toContain("memory/YYYY-MM-DD.md");
-    expect(result).toContain(
-      "Current time: Tuesday, March 3rd, 2026 - 9:00 AM (America/New_York) / 2026-03-03 14:00 UTC",
-    );
+    expect(result).toContain("Current time: Tuesday, March 3rd, 2026 - 9:00 AM (America/New_York)");
+    expect(result).toContain("Reference UTC: 2026-03-03 14:00 UTC");
   });
 
   it("appends current time line even when no YYYY-MM-DD placeholder is present", async () => {

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -50,9 +50,8 @@ describe("buildBareSessionResetPrompt", () => {
     // 2026-03-03 14:00 UTC = 2026-03-03 09:00 EST
     const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
     const prompt = buildBareSessionResetPrompt(cfg, nowMs);
-    expect(prompt).toContain(
-      "Current time: Tuesday, March 3rd, 2026 - 9:00 AM (America/New_York) / 2026-03-03 14:00 UTC",
-    );
+    expect(prompt).toContain("Current time: Tuesday, March 3rd, 2026 - 9:00 AM (America/New_York)");
+    expect(prompt).toContain("Reference UTC: 2026-03-03 14:00 UTC");
   });
 
   it("does not append a duplicate current time line", () => {

--- a/src/cron/isolated-agent.session-identity.test.ts
+++ b/src/cron/isolated-agent.session-identity.test.ts
@@ -55,7 +55,8 @@ describe("runCronIsolatedAgentTurn session identity", () => {
       const lines = call?.prompt?.split("\n") ?? [];
       expect(lines[0]).toContain("[cron:job-1");
       expect(lines[0]).toContain("do it");
-      expect(lines[1]).toMatch(/^Current time: .+ \(.+\) \/ \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC$/);
+      expect(lines[1]).toMatch(/^Current time: .+ \(.+\)$/);
+      expect(lines[2]).toMatch(/^Reference UTC: \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC$/);
     });
   });
 

--- a/test/helpers/agents/prompt-composition-scenarios.ts
+++ b/test/helpers/agents/prompt-composition-scenarios.ts
@@ -594,7 +594,8 @@ async function createMaintenanceScenario(workspaceDir: string): Promise<PromptSc
     "Store durable memories only in memory/2026-03-15.md (create memory/ if needed).",
     "Treat workspace bootstrap/reference files such as MEMORY.md, SOUL.md, TOOLS.md, and AGENTS.md as read-only during this flush; never overwrite, replace, or edit them.",
     "If nothing to store, reply with NO_REPLY.",
-    "Current time: Sunday, March 15th, 2026 - 9:30 PM (America/Los_Angeles) / 2026-03-16 04:30 UTC",
+    "Current time: Sunday, March 15th, 2026 - 9:30 PM (America/Los_Angeles)",
+    "Reference UTC: 2026-03-16 04:30 UTC",
   ].join("\n");
   const memoryFlushSystemPrompt = buildSystemPrompt({
     workspaceDir,
@@ -618,7 +619,8 @@ async function createMaintenanceScenario(workspaceDir: string): Promise<PromptSc
     "## Red Lines",
     "Do not delete production data.",
     "",
-    "Current time: Sunday, March 15th, 2026 - 9:30 PM (America/Los_Angeles) / 2026-03-16 04:30 UTC",
+    "Current time: Sunday, March 15th, 2026 - 9:30 PM (America/Los_Angeles)",
+    "Reference UTC: 2026-03-16 04:30 UTC",
   ].join("\n");
   const postCompactionSystemPrompt = buildSystemPrompt({
     workspaceDir,


### PR DESCRIPTION
## Summary
- keep `Current time:` anchored to the user-local timezone
- move UTC onto a separate `Reference UTC:` line
- avoid putting two competing calendar dates on the same primary time line

## Why
The previous format could present two competing calendar dates on the same line, for example:

`Current time: Tuesday, March 10th, 2026 — 5:49 PM (America/Los_Angeles) / 2026-03-11 00:49 UTC`

In evening hours for US timezones, models can latch onto the UTC date and treat it as "today", even though the user-facing local date is still March 10.

This PR keeps UTC available for log reconciliation, but demotes it to a clearly secondary line so the local-time anchor remains unambiguous.

## New format
`Current time: Tuesday, March 10th, 2026 — 5:49 PM (America/Los_Angeles)`
`Reference UTC: 2026-03-11 00:49 UTC`

## Real behavior proof

- Behavior or issue addressed: Local Current time should stay anchored to the user's configured timezone while UTC is shown only as secondary reference data.
- Real environment tested: macOS local maintainer checkout of OpenClaw PR #42654 at eaead0535faec81919c41142f3c12a5ec0a9e7cb, using Node with tsx to execute the patched production current-time helper.
- Exact steps or command run after this patch: Ran `node --import tsx --input-type=module -e <resolveCronStyleNow proof>` from the rebased PR worktree with userTimezone `America/Los_Angeles` and fixed instant `2026-03-11T00:49:00.000Z`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output:

```text
$ node --import tsx --input-type=module -e <resolveCronStyleNow proof>
Current time: Tuesday, March 10th, 2026 - 5:49 PM (America/Los_Angeles)
Reference UTC: 2026-03-11 00:49 UTC
```

- Observed result after fix: The local `Current time:` line keeps the March 10 America/Los_Angeles date, while the March 11 UTC value appears only on the separate `Reference UTC:` line.
- What was not tested: Full local test suite was not run in this maintainer checkout; GitHub CI remains the broader validation path.