### PR TITLE
fix(cron): add missing CommandLane import

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -13,6 +13,7 @@ import { lookupContextTokens } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { resolveNestedAgentLane } from "../../agents/lanes.js";
+import { CommandLane } from "../../process/lanes.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import {


### PR DESCRIPTION
Fixes TypeScript compilation error in `src/cron/isolated-agent/run.ts` where `CommandLane.Nested` was used without importing the `CommandLane` enum.

**Error fixed**:
```
src/cron/isolated-agent/run.ts(207,12): error TS2304: Cannot find name 'CommandLane'.
```

**Changes**:
- Added import: `import { CommandLane } from "../../process/lanes.js";`