### PR TITLE
feat(skills): add skills.priority config for prompt ordering

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -78,8 +78,8 @@ type TranscriptResolveRuntime = typeof import("../config/sessions/transcript-res
 type CliDepsRuntime = typeof import("../cli/deps.js");
 type ExecDefaultsRuntime = typeof import("./exec-defaults.js");
 type SkillsRuntime = typeof import("./skills.js");
-type SkillsFilterRuntime = typeof import("./skills/filter.js");
 type SkillsRefreshStateRuntime = typeof import("./skills/refresh-state.js");
+type SkillsSnapshotCacheRuntime = typeof import("./skills/snapshot-cache.js");
 type SkillsRemoteRuntime = typeof import("../infra/skills-remote.js");
 
 let attemptExecutionRuntimePromise: Promise<AttemptExecutionRuntime> | undefined;
@@ -94,8 +94,8 @@ let transcriptResolveRuntimePromise: Promise<TranscriptResolveRuntime> | undefin
 let cliDepsRuntimePromise: Promise<CliDepsRuntime> | undefined;
 let execDefaultsRuntimePromise: Promise<ExecDefaultsRuntime> | undefined;
 let skillsRuntimePromise: Promise<SkillsRuntime> | undefined;
-let skillsFilterRuntimePromise: Promise<SkillsFilterRuntime> | undefined;
 let skillsRefreshStateRuntimePromise: Promise<SkillsRefreshStateRuntime> | undefined;
+let skillsSnapshotCacheRuntimePromise: Promise<SkillsSnapshotCacheRuntime> | undefined;
 let skillsRemoteRuntimePromise: Promise<SkillsRemoteRuntime> | undefined;
 
 function loadAttemptExecutionRuntime(): Promise<AttemptExecutionRuntime> {
@@ -158,14 +158,14 @@ function loadSkillsRuntime(): Promise<SkillsRuntime> {
   return skillsRuntimePromise;
 }
 
-function loadSkillsFilterRuntime(): Promise<SkillsFilterRuntime> {
-  skillsFilterRuntimePromise ??= import("./skills/filter.js");
-  return skillsFilterRuntimePromise;
-}
-
 function loadSkillsRefreshStateRuntime(): Promise<SkillsRefreshStateRuntime> {
   skillsRefreshStateRuntimePromise ??= import("./skills/refresh-state.js");
   return skillsRefreshStateRuntimePromise;
+}
+
+function loadSkillsSnapshotCacheRuntime(): Promise<SkillsSnapshotCacheRuntime> {
+  skillsSnapshotCacheRuntimePromise ??= import("./skills/snapshot-cache.js");
+  return skillsSnapshotCacheRuntimePromise;
 }
 
 function loadSkillsRemoteRuntime(): Promise<SkillsRemoteRuntime> {
@@ -588,16 +588,21 @@ async function agentCommandInternal(
       });
     }
 
-    const [{ getSkillsSnapshotVersion, shouldRefreshSnapshotForVersion }, { matchesSkillFilter }] =
-      await Promise.all([loadSkillsRefreshStateRuntime(), loadSkillsFilterRuntime()]);
+    const [{ getSkillsSnapshotVersion }, { canReuseSkillSnapshot }] = await Promise.all([
+      loadSkillsRefreshStateRuntime(),
+      loadSkillsSnapshotCacheRuntime(),
+    ]);
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const currentSkillsSnapshot = sessionEntry?.skillsSnapshot;
-    const shouldRefreshSkillsSnapshot =
-      !currentSkillsSnapshot ||
-      shouldRefreshSnapshotForVersion(currentSkillsSnapshot.version, skillsSnapshotVersion) ||
-      !matchesSkillFilter(currentSkillsSnapshot.skillFilter, skillFilter);
-    const needsSkillsSnapshot = isNewSession || shouldRefreshSkillsSnapshot;
+    const needsSkillsSnapshot =
+      isNewSession ||
+      !canReuseSkillSnapshot({
+        snapshot: currentSkillsSnapshot,
+        snapshotVersion: skillsSnapshotVersion,
+        config: cfg,
+        skillFilter,
+      });
     const skillsSnapshot = needsSkillsSnapshot
       ? await (async () => {
           const [

--- a/src/agents/skills.buildworkspaceskillsnapshot.test.ts
+++ b/src/agents/skills.buildworkspaceskillsnapshot.test.ts
@@ -5,11 +5,13 @@ import { withPathResolutionEnv } from "../test-utils/env.js";
 import { createFixtureSuite } from "../test-utils/fixture-suite.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 import { writeSkill, writeWorkspaceSkills } from "./skills.e2e-test-helpers.js";
+import { createCanonicalFixtureSkill } from "./skills.test-helpers.js";
 import {
   restoreMockSkillsHomeEnv,
   setMockSkillsHomeEnv,
   type SkillsHomeEnvSnapshot,
 } from "./skills/home-env.test-support.js";
+import type { SkillEntry } from "./skills/types.js";
 import { buildWorkspaceSkillSnapshot, buildWorkspaceSkillsPrompt } from "./skills/workspace.js";
 
 vi.mock("./skills/plugin-skills.js", () => ({
@@ -96,6 +98,41 @@ function expectSnapshotNamesAndPrompt(
     expect(snapshot.skills.map((skill) => skill.name)).not.toContain(name);
     expect(snapshot.prompt).not.toContain(name);
   }
+}
+
+function extractPromptSkillNames(prompt: string): string[] {
+  return Array.from(prompt.matchAll(/<name>([^<]+)<\/name>/g), (match) => match[1] ?? "");
+}
+
+function createEntry(
+  workspaceDir: string,
+  name: string,
+  options?: {
+    skillKey?: string;
+    primaryEnv?: string;
+    disableModelInvocation?: boolean;
+  },
+): SkillEntry {
+  const dir = path.join(workspaceDir, "skills", name);
+  return {
+    skill: createCanonicalFixtureSkill({
+      name,
+      description: `${name} description`,
+      filePath: path.join(dir, "SKILL.md"),
+      baseDir: dir,
+      source: "workspace",
+      disableModelInvocation: options?.disableModelInvocation,
+    }),
+    frontmatter: {},
+    ...(options?.skillKey || options?.primaryEnv
+      ? {
+          metadata: {
+            ...(options?.skillKey ? { skillKey: options.skillKey } : {}),
+            ...(options?.primaryEnv ? { primaryEnv: options.primaryEnv } : {}),
+          },
+        }
+      : {}),
+  };
 }
 
 describe("buildWorkspaceSkillSnapshot", () => {
@@ -222,6 +259,154 @@ describe("buildWorkspaceSkillSnapshot", () => {
       "github",
     ]);
     expect(snapshot.skillFilter).toEqual(["docs-search", "github"]);
+  });
+
+  it("puts priority skills first so they survive low maxSkillsInPrompt limits", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    for (const [name, description] of [
+      ["alpha-skill", "Alpha"],
+      ["beta-skill", "Beta"],
+      ["wechat-reader", "Read WeChat chats"],
+    ] as const) {
+      await writeSkill({
+        dir: path.join(workspaceDir, "skills", name),
+        name,
+        description,
+      });
+    }
+
+    const snapshot = withWorkspaceHome(workspaceDir, () =>
+      buildWorkspaceSkillSnapshot(workspaceDir, {
+        config: {
+          skills: {
+            priority: ["wechat-reader", "beta-skill"],
+            limits: {
+              maxSkillsInPrompt: 2,
+              maxSkillsPromptChars: 5_000,
+            },
+          },
+        },
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      }),
+    );
+
+    expect(extractPromptSkillNames(snapshot.prompt)).toEqual(["wechat-reader", "beta-skill"]);
+    expect(snapshot.prompt).not.toContain("<name>alpha-skill</name>");
+  });
+
+  it("preserves the existing entry order when skills.priority is unset", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    const snapshot = buildSnapshot(workspaceDir, {
+      entries: [
+        createEntry(workspaceDir, "zeta-skill"),
+        createEntry(workspaceDir, "alpha-skill"),
+        createEntry(workspaceDir, "beta-skill"),
+      ],
+      config: {
+        skills: {
+          limits: {
+            maxSkillsInPrompt: 10,
+            maxSkillsPromptChars: 5_000,
+          },
+        },
+      },
+    });
+
+    expect(extractPromptSkillNames(snapshot.prompt)).toEqual([
+      "zeta-skill",
+      "alpha-skill",
+      "beta-skill",
+    ]);
+  });
+
+  it("keeps non-priority skills alphabetized after the pinned skills", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    for (const [name, description] of [
+      ["delta-skill", "Delta"],
+      ["alpha-skill", "Alpha"],
+      ["wechat-reader", "Read WeChat chats"],
+      ["charlie-skill", "Charlie"],
+    ] as const) {
+      await writeSkill({
+        dir: path.join(workspaceDir, "skills", name),
+        name,
+        description,
+      });
+    }
+
+    const snapshot = withWorkspaceHome(workspaceDir, () =>
+      buildWorkspaceSkillSnapshot(workspaceDir, {
+        config: {
+          skills: {
+            priority: ["wechat-reader"],
+            limits: {
+              maxSkillsInPrompt: 10,
+              maxSkillsPromptChars: 5_000,
+            },
+          },
+        },
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      }),
+    );
+
+    expect(extractPromptSkillNames(snapshot.prompt)).toEqual([
+      "wechat-reader",
+      "alpha-skill",
+      "charlie-skill",
+      "delta-skill",
+    ]);
+  });
+
+  it("prefers exact skill names over colliding aliases", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    const snapshot = buildSnapshot(workspaceDir, {
+      entries: [
+        createEntry(workspaceDir, "github"),
+        createEntry(workspaceDir, "internal-helper", {
+          skillKey: "github",
+        }),
+      ],
+      config: {
+        skills: {
+          priority: ["github"],
+          limits: {
+            maxSkillsInPrompt: 10,
+            maxSkillsPromptChars: 5_000,
+          },
+        },
+      },
+    });
+
+    expect(extractPromptSkillNames(snapshot.prompt)).toEqual(["github", "internal-helper"]);
+    expect(snapshot.skills.map((skill) => skill.name)).toEqual(["github", "internal-helper"]);
+  });
+
+  it("keeps persisted snapshot skill order aligned with prompt priority", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    const snapshot = buildSnapshot(workspaceDir, {
+      entries: [
+        createEntry(workspaceDir, "alpha-skill", {
+          primaryEnv: "OPENAI_API_KEY",
+        }),
+        createEntry(workspaceDir, "beta-skill", {
+          primaryEnv: "OPENAI_API_KEY",
+        }),
+      ],
+      config: {
+        skills: {
+          priority: ["beta-skill"],
+          limits: {
+            maxSkillsInPrompt: 10,
+            maxSkillsPromptChars: 5_000,
+          },
+        },
+      },
+    });
+
+    expect(extractPromptSkillNames(snapshot.prompt)).toEqual(["beta-skill", "alpha-skill"]);
+    expect(snapshot.skills.map((skill) => skill.name)).toEqual(["beta-skill", "alpha-skill"]);
   });
 
   it("limits discovery for nested repo-style skills roots (dir/skills/*)", async () => {

--- a/src/agents/skills/snapshot-cache.ts
+++ b/src/agents/skills/snapshot-cache.ts
@@ -1,0 +1,37 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import { normalizeStringEntries } from "../../shared/string-normalization.js";
+import { matchesSkillFilter } from "./filter.js";
+import type { SkillSnapshot } from "./types.js";
+
+function normalizeSnapshotVersion(version?: number): number {
+  return version ?? 0;
+}
+
+export function resolveSkillsSnapshotConfigKey(config?: OpenClawConfig): string | undefined {
+  const normalizedPriority = normalizeStringEntries(config?.skills?.priority);
+  if (normalizedPriority.length === 0) {
+    return undefined;
+  }
+  return JSON.stringify({ priority: normalizedPriority });
+}
+
+export function canReuseSkillSnapshot(params: {
+  snapshot?: Pick<SkillSnapshot, "configKey" | "skillFilter" | "version">;
+  snapshotVersion: number;
+  config?: OpenClawConfig;
+  skillFilter?: ReadonlyArray<unknown>;
+}): boolean {
+  const snapshot = params.snapshot;
+  if (!snapshot) {
+    return false;
+  }
+  if (
+    normalizeSnapshotVersion(snapshot.version) !== normalizeSnapshotVersion(params.snapshotVersion)
+  ) {
+    return false;
+  }
+  if (!matchesSkillFilter(snapshot.skillFilter, params.skillFilter)) {
+    return false;
+  }
+  return snapshot.configKey === resolveSkillsSnapshotConfigKey(params.config);
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -93,6 +93,8 @@ export type SkillEligibilityContext = {
 export type SkillSnapshot = {
   prompt: string;
   skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[] }>;
+  /** Normalized snapshot-affecting skills config, used to invalidate persisted snapshots. */
+  configKey?: string;
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];
   resolvedSkills?: Skill[];

--- a/src/agents/skills/workspace.test.ts
+++ b/src/agents/skills/workspace.test.ts
@@ -1,0 +1,140 @@
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { withEnv } from "../../test-utils/env.js";
+import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
+import { writeSkill } from "../skills.e2e-test-helpers.js";
+import { canReuseSkillSnapshot } from "./snapshot-cache.js";
+import { buildWorkspaceSkillSnapshot } from "./workspace.js";
+
+const fixtureSuite = createFixtureSuite("openclaw-skills-workspace-suite-");
+
+function withWorkspaceHome<T>(workspaceDir: string, cb: () => T): T {
+  return withEnv({ HOME: workspaceDir, PATH: "" }, cb);
+}
+
+function extractPromptSkillNames(prompt: string): string[] {
+  return Array.from(prompt.matchAll(/<name>([^<]+)<\/name>/g), (match) => match[1] ?? "");
+}
+
+describe("skills workspace snapshot behavior", () => {
+  beforeAll(async () => {
+    await fixtureSuite.setup();
+  });
+
+  afterAll(async () => {
+    await fixtureSuite.cleanup();
+  });
+
+  it("prioritizes skills by skillKey aliases", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "alpha-skill"),
+      name: "alpha-skill",
+      description: "Alpha",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "zeta-skill"),
+      name: "zeta-skill",
+      description: "Zeta",
+      metadata: '{"openclaw":{"skillKey":"wechat-reader"}}',
+    });
+
+    const snapshot = withWorkspaceHome(workspaceDir, () =>
+      buildWorkspaceSkillSnapshot(workspaceDir, {
+        config: {
+          skills: {
+            priority: ["wechat-reader"],
+            limits: {
+              maxSkillsInPrompt: 10,
+              maxSkillsPromptChars: 5_000,
+            },
+          },
+        },
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      }),
+    );
+
+    expect(extractPromptSkillNames(snapshot.prompt)).toEqual(["zeta-skill", "alpha-skill"]);
+  });
+
+  it("keeps priority matching the original skill name when aliases are present", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "alpha-skill"),
+      name: "alpha-skill",
+      description: "Alpha",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "zeta-skill"),
+      name: "zeta-skill",
+      description: "Zeta",
+      metadata: '{"openclaw":{"skillKey":"wechat-reader"}}',
+    });
+
+    const snapshot = withWorkspaceHome(workspaceDir, () =>
+      buildWorkspaceSkillSnapshot(workspaceDir, {
+        config: {
+          skills: {
+            priority: ["zeta-skill"],
+            limits: {
+              maxSkillsInPrompt: 10,
+              maxSkillsPromptChars: 5_000,
+            },
+          },
+        },
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      }),
+    );
+
+    expect(extractPromptSkillNames(snapshot.prompt)).toEqual(["zeta-skill", "alpha-skill"]);
+  });
+
+  it("invalidates cached snapshots when skills.priority changes", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "alpha-skill"),
+      name: "alpha-skill",
+      description: "Alpha",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "beta-skill"),
+      name: "beta-skill",
+      description: "Beta",
+    });
+
+    const config = {
+      skills: {
+        priority: ["alpha-skill"],
+      },
+    };
+    const snapshot = withWorkspaceHome(workspaceDir, () =>
+      buildWorkspaceSkillSnapshot(workspaceDir, {
+        config,
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+        snapshotVersion: 7,
+      }),
+    );
+
+    expect(
+      canReuseSkillSnapshot({
+        snapshot,
+        snapshotVersion: 7,
+        config,
+      }),
+    ).toBe(true);
+    expect(
+      canReuseSkillSnapshot({
+        snapshot,
+        snapshotVersion: 7,
+        config: {
+          skills: {
+            priority: ["beta-skill"],
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -15,11 +15,17 @@ import {
 import { resolveBundledSkillsDir } from "./bundled-dir.js";
 import { shouldIncludeSkill } from "./config.js";
 import { normalizeSkillFilter } from "./filter.js";
-import { resolveOpenClawMetadata, resolveSkillInvocationPolicy } from "./frontmatter.js";
+import {
+  parseFrontmatter,
+  resolveOpenClawMetadata,
+  resolveSkillKey,
+  resolveSkillInvocationPolicy,
+} from "./frontmatter.js";
 import { loadSkillsFromDirSafe, readSkillFrontmatterSafe } from "./local-loader.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
 import { formatSkillsForPrompt, type Skill } from "./skill-contract.js";
+import { resolveSkillsSnapshotConfigKey } from "./snapshot-cache.js";
 import type {
   ParsedSkillFrontmatter,
   SkillEligibilityContext,
@@ -716,19 +722,66 @@ function applySkillsPromptLimits(params: {
   return { skillsForPrompt, truncated, compact };
 }
 
+function orderSkillEntriesForPrompt(entries: SkillEntry[], priority?: string[]): SkillEntry[] {
+  if (entries.length <= 1) {
+    return entries.slice();
+  }
+
+  const orderedPriority = (priority ?? []).map((name) => name.trim()).filter(Boolean);
+  if (orderedPriority.length === 0) {
+    return entries.slice();
+  }
+
+  const entriesByKey = new Map<string, SkillEntry>();
+  for (const entry of entries) {
+    entriesByKey.set(entry.skill.name, entry);
+  }
+  for (const entry of entries) {
+    // Allow alias-based pinning without letting aliases override another
+    // skill's exact name match when identifiers collide.
+    const skillKey = resolveSkillKey(entry.skill, entry);
+    if (!skillKey || skillKey === entry.skill.name || entriesByKey.has(skillKey)) {
+      continue;
+    }
+    entriesByKey.set(skillKey, entry);
+  }
+  const seen = new Set<string>();
+  const prioritized: SkillEntry[] = [];
+
+  for (const key of orderedPriority) {
+    const entry = entriesByKey.get(key);
+    if (!entry || seen.has(entry.skill.name)) {
+      continue;
+    }
+    prioritized.push(entry);
+    seen.add(entry.skill.name);
+  }
+
+  const remaining = entries
+    .filter((entry) => !seen.has(entry.skill.name))
+    .sort((a, b) => a.skill.name.localeCompare(b.skill.name));
+
+  return [...prioritized, ...remaining];
+}
+
 export function buildWorkspaceSkillSnapshot(
   workspaceDir: string,
   opts?: WorkspaceSkillBuildOptions & { snapshotVersion?: number },
 ): SkillSnapshot {
   const { eligible, prompt, resolvedSkills } = resolveWorkspaceSkillPromptState(workspaceDir, opts);
+  const orderedEligibleEntries = orderSkillEntriesForPrompt(
+    eligible,
+    opts?.config?.skills?.priority,
+  );
   const skillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
   return {
     prompt,
-    skills: eligible.map((entry) => ({
+    skills: orderedEligibleEntries.map((entry) => ({
       name: entry.skill.name,
       primaryEnv: entry.metadata?.primaryEnv,
       requiredEnv: entry.metadata?.requires?.env?.slice(),
     })),
+    configKey: resolveSkillsSnapshotConfigKey(opts?.config),
     ...(skillFilter === undefined ? {} : { skillFilter }),
     resolvedSkills,
     version: opts?.snapshotVersion,
@@ -781,7 +834,13 @@ function resolveWorkspaceSkillPromptState(
     effectiveSkillFilter,
     opts?.eligibility,
   );
-  const promptEntries = eligible.filter((entry) => isSkillVisibleInAvailableSkillsPrompt(entry));
+  const orderedEligibleEntries = orderSkillEntriesForPrompt(
+    eligible,
+    opts?.config?.skills?.priority,
+  );
+  const promptEntries = orderedEligibleEntries.filter((entry) =>
+    isSkillVisibleInAvailableSkillsPrompt(entry),
+  );
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const resolvedSkills = promptEntries.map((entry) => entry.skill);
   // Derive prompt-facing skills with compacted paths (e.g. ~/...) once.

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -4,12 +4,9 @@ import path from "node:path";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { canExecRequestNode } from "../../agents/exec-defaults.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
-import { matchesSkillFilter } from "../../agents/skills/filter.js";
-import {
-  getSkillsSnapshotVersion,
-  shouldRefreshSnapshotForVersion,
-} from "../../agents/skills/refresh-state.js";
+import { getSkillsSnapshotVersion } from "../../agents/skills/refresh-state.js";
 import { ensureSkillsWatcher } from "../../agents/skills/refresh.js";
+import { canReuseSkillSnapshot } from "../../agents/skills/snapshot-cache.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
@@ -145,9 +142,12 @@ export async function ensureSkillSnapshot(params: {
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   const existingSnapshot = nextEntry?.skillsSnapshot;
   ensureSkillsWatcher({ workspaceDir, config: cfg });
-  const shouldRefreshSnapshot =
-    shouldRefreshSnapshotForVersion(existingSnapshot?.version, snapshotVersion) ||
-    !matchesSkillFilter(existingSnapshot?.skillFilter, skillFilter);
+  const shouldRefreshSnapshot = !canReuseSkillSnapshot({
+    snapshot: existingSnapshot,
+    snapshotVersion,
+    config: cfg,
+    skillFilter,
+  });
   const buildSnapshot = () =>
     buildWorkspaceSkillSnapshot(workspaceDir, {
       config: cfg,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -23297,6 +23297,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
               type: "string",
             },
           },
+          priority: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
           load: {
             type: "object",
             properties: {

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -475,6 +475,8 @@ export type GroupKeyResolution = {
 export type SessionSkillSnapshot = {
   prompt: string;
   skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[] }>;
+  /** Normalized snapshot-affecting skills config, used to invalidate persisted snapshots. */
+  configKey?: string;
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];
   resolvedSkills?: Skill[];

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -40,6 +40,8 @@ export type SkillsLimitsConfig = {
 export type SkillsConfig = {
   /** Optional bundled-skill allowlist (only affects bundled skills). */
   allowBundled?: string[];
+  /** Skills pinned to the front of the model-facing prompt, in priority order. */
+  priority?: string[];
   load?: SkillsLoadConfig;
   install?: SkillsInstallConfig;
   limits?: SkillsLimitsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -953,6 +953,7 @@ export const OpenClawSchema = z
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),
+        priority: z.array(z.string()).optional(),
         load: z
           .object({
             extraDirs: z.array(z.string()).optional(),

--- a/src/cron/isolated-agent/skills-snapshot.ts
+++ b/src/cron/isolated-agent/skills-snapshot.ts
@@ -1,5 +1,5 @@
 import type { SkillSnapshot } from "../../agents/skills.js";
-import { matchesSkillFilter } from "../../agents/skills/filter.js";
+import { canReuseSkillSnapshot } from "../../agents/skills/snapshot-cache.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 let skillsSnapshotRuntimePromise:
@@ -27,11 +27,13 @@ export async function resolveCronSkillsSnapshot(params: {
   const snapshotVersion = runtime.getSkillsSnapshotVersion(params.workspaceDir);
   const skillFilter = runtime.resolveAgentSkillsFilter(params.config, params.agentId);
   const existingSnapshot = params.existingSnapshot;
-  const shouldRefresh =
-    !existingSnapshot ||
-    existingSnapshot.version !== snapshotVersion ||
-    !matchesSkillFilter(existingSnapshot.skillFilter, skillFilter);
-  if (!shouldRefresh) {
+  const shouldRefresh = !canReuseSkillSnapshot({
+    snapshot: existingSnapshot,
+    snapshotVersion,
+    config: params.config,
+    skillFilter,
+  });
+  if (!shouldRefresh && existingSnapshot) {
     return existingSnapshot;
   }
 


### PR DESCRIPTION
## Problem

When many skills are installed and the prompt exceeds `maxSkillsPromptChars`, skills are included alphabetically. Important skills with names late in the alphabet (e.g. `wechat-reader`, `web-search-plus`) get truncated.

## Solution

Add `skills.priority` config — an ordered list of skill names that are pinned to the front of the model-facing prompt:

```yaml
skills:
  priority: [wechat-reader, supabase, github]
```

Priority skills are included first (in the specified order), then remaining skills follow in alphabetical order. This ensures critical skills survive truncation.

## Changes

- `types.skills.ts`: Add `priority?: string[]` to `SkillsConfig`
- `zod-schema.ts`: Add validation for the new field
- `workspace.ts`: New `orderSkillsForPrompt()` function that reorders skills before the existing count/chars limits are applied
- Tests: 2 new test cases covering priority ordering and truncation survival

## Test

```
npx vitest run src/agents/skills
```

All existing + new tests pass.