### PR TITLE
fix(discord): throw error when fetchUser(@me) fails to prevent security bypass

### DIFF
--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -660,6 +660,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       botUserName = botUser?.username?.trim() || botUser?.globalName?.trim() || undefined;
     } catch (err) {
       runtime.error?.(danger(`discord: failed to fetch bot identity: ${String(err)}`));
+      throw new Error(`Discord bot identity fetch failed: ${String(err)}. Cannot start Discord provider without botUserId.`);
     }
 
     if (voiceEnabled) {


### PR DESCRIPTION
## Problem

When `fetchUser("@me")` fails during Discord provider startup (e.g., due to transient network issues after a proxy reconnect), the bot continues running with `botUserId = undefined`. This causes multiple security and routing failures:

1. **Mention gating bypassed**: The guard `if (botId && mentionGate.shouldSkip)` in `message-handler.preflight.ts:686` short-circuits when `botId` is undefined, letting **all** guild messages bypass `requireMention: true`.
2. **Self-message filtering disabled**: `author.id === botUserId` never matches, risking self-reply loops.
3. **Reply detection broken**: Replying to the bot's message isn't recognized as a valid trigger.

## Fix

Throw an error when `fetchUser("@me")` fails, preventing the Discord provider from starting without a valid `botUserId`. This ensures security controls remain intact.

## Testing

- Manual testing: Simulated network failure during startup
- Existing tests should continue to pass
- No behavioral change for successful startups

Fixes #42219