### PR TITLE
Keep bundled session-memory behavior consistent across automatic session rollover

### DIFF
--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -171,6 +171,77 @@ describe("getReplyFromConfig message hooks", () => {
     expect(mocks.triggerInternalHook).not.toHaveBeenCalled();
   });
 
+  it("emits a session rollover hook for automatic stale-session rollover", async () => {
+    mocks.initSessionState.mockResolvedValueOnce({
+      sessionCtx: {},
+      sessionEntry: { sessionId: "new-session" },
+      previousSessionEntry: { sessionId: "old-session", sessionFile: "/tmp/old.jsonl" },
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:-100123",
+      sessionId: "new-session",
+      isNewSession: true,
+      resetTriggered: false,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-chat",
+      groupResolution: undefined,
+      isGroup: true,
+      triggerBodyNormalized: "",
+      bodyStripped: "",
+    });
+
+    await getReplyFromConfig(buildCtx(), undefined, {});
+
+    expect(mocks.createInternalHookEvent).toHaveBeenCalledWith(
+      "session",
+      "rollover",
+      "agent:main:telegram:-100123",
+      expect.objectContaining({
+        previousSessionEntry: expect.objectContaining({ sessionId: "old-session" }),
+        sessionEntry: expect.objectContaining({ sessionId: "new-session" }),
+        resetReason: "automatic",
+      }),
+    );
+    expect(mocks.triggerInternalHook).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session", action: "rollover" }),
+    );
+  });
+
+  it("does not emit a session rollover hook for explicit /new or /reset flows", async () => {
+    mocks.initSessionState.mockResolvedValueOnce({
+      sessionCtx: {},
+      sessionEntry: { sessionId: "new-session" },
+      previousSessionEntry: { sessionId: "old-session", sessionFile: "/tmp/old.jsonl" },
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:-100123",
+      sessionId: "new-session",
+      isNewSession: true,
+      resetTriggered: true,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-chat",
+      groupResolution: undefined,
+      isGroup: true,
+      triggerBodyNormalized: "/new",
+      bodyStripped: "",
+    });
+
+    await getReplyFromConfig(
+      buildCtx({ Body: "/new", RawBody: "/new", CommandBody: "/new" }),
+      undefined,
+      {},
+    );
+
+    expect(mocks.createInternalHookEvent).not.toHaveBeenCalledWith(
+      "session",
+      "rollover",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it("skips message hooks when SessionKey is unavailable", async () => {
     await getReplyFromConfig(buildCtx({ SessionKey: undefined }), undefined, {});
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -9,6 +9,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -172,6 +173,23 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
     bodyStripped,
   } = sessionState;
+
+  const shouldEmitAutomaticRolloverHook =
+    isNewSession &&
+    !resetTriggered &&
+    Boolean(previousSessionEntry?.sessionId) &&
+    previousSessionEntry?.sessionId !== sessionEntry.sessionId;
+
+  if (shouldEmitAutomaticRolloverHook) {
+    const hookEvent = createInternalHookEvent("session", "rollover", sessionKey, {
+      sessionEntry,
+      previousSessionEntry,
+      workspaceDir,
+      cfg,
+      resetReason: "automatic",
+    });
+    await triggerInternalHook(hookEvent);
+  }
 
   await applyResetModelOverride({
     cfg,

--- a/src/commands/onboard-hooks.test.ts
+++ b/src/commands/onboard-hooks.test.ts
@@ -92,7 +92,7 @@ describe("onboard-hooks", () => {
           handlerPath: "/mock/workspace/hooks/session-memory/handler.js",
           hookKey: "session-memory",
           emoji: "💾",
-          events: ["command:new", "command:reset"],
+          events: ["command:new", "command:reset", "session:rollover"],
         },
         eligible,
       ),

--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -6,9 +6,9 @@ This directory contains hooks that ship with OpenClaw. These hooks are automatic
 
 ### 💾 session-memory
 
-Automatically saves session context to memory when you issue `/new` or `/reset`.
+Automatically saves session context to memory when you issue `/new`, `/reset`, or when OpenClaw automatically rolls over a stale session.
 
-**Events**: `command:new`, `command:reset`
+**Events**: `command:new`, `command:reset`, `session:rollover`
 **What it does**: Creates a dated memory file with LLM-generated slug based on conversation content.
 **Output**: `<workspace>/memory/YYYY-MM-DD-slug.md` (defaults to `~/.openclaw/workspace`)
 

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -1,13 +1,13 @@
 ---
 name: session-memory
-description: "Save session context to memory when /new or /reset command is issued"
+description: "Save session context to memory when /new, /reset, or automatic session rollover occurs"
 homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new", "command:reset"],
+        "events": ["command:new", "command:reset", "session:rollover"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },
@@ -16,7 +16,7 @@ metadata:
 
 # Session Memory Hook
 
-Automatically saves session context to your workspace memory when you issue `/new` or `/reset`.
+Automatically saves session context to your workspace memory when you issue `/new`, `/reset`, or when OpenClaw automatically rolls a stale session into a new one.
 
 ## What It Does
 

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -276,6 +276,7 @@ describe("session-memory hook", () => {
       sessionEntry: {
         sessionId: "new-session",
       },
+      resetReason: "automatic",
     });
 
     await handler(event);
@@ -288,6 +289,7 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("user: Yesterday's context");
     expect(memoryContent).toContain("assistant: Recovered during automatic rollover");
     expect(memoryContent).toContain("- **Session ID**: stale-session");
+    expect(memoryContent).toContain("- **Source**: automatic");
   });
 
   it("prefers workspaceDir from hook context when sessionKey points at main", async () => {

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -250,6 +250,46 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Captured before reset");
   });
 
+  it("creates memory file with session content on automatic session rollover", async () => {
+    const tempDir = await createCaseWorkspace("workspace");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const sessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "stale-session.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "Yesterday's context" },
+        { role: "assistant", content: "Recovered during automatic rollover" },
+      ]),
+    });
+
+    const event = createHookEvent("session", "rollover", "agent:main:main", {
+      cfg: {
+        agents: { defaults: { workspace: tempDir } },
+      } satisfies OpenClawConfig,
+      workspaceDir: tempDir,
+      previousSessionEntry: {
+        sessionId: "stale-session",
+        sessionFile,
+      },
+      sessionEntry: {
+        sessionId: "new-session",
+      },
+    });
+
+    await handler(event);
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = await fs.readdir(memoryDir);
+    expect(files.length).toBe(1);
+
+    const memoryContent = await fs.readFile(path.join(memoryDir, files[0]), "utf-8");
+    expect(memoryContent).toContain("user: Yesterday's context");
+    expect(memoryContent).toContain("assistant: Recovered during automatic rollover");
+    expect(memoryContent).toContain("- **Session ID**: stale-session");
+  });
+
   it("prefers workspaceDir from hook context when sessionKey points at main", async () => {
     const mainWorkspace = await createCaseWorkspace("workspace-main");
     const naviWorkspace = await createCaseWorkspace("workspace-navi");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -1,8 +1,9 @@
 /**
  * Session memory hook handler
  *
- * Saves session context to memory when /new or /reset command is triggered
- * Creates a new dated memory file with LLM-generated slug
+ * Saves session context to memory when explicit reset commands or automatic
+ * session rollover events end a conversation boundary.
+ * Creates a new dated memory file with an LLM-generated slug.
  */
 
 import fs from "node:fs/promises";
@@ -24,6 +25,7 @@ import {
 import { hasInterSessionUserProvenance } from "../../../sessions/input-provenance.js";
 import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
+import { isSessionRolloverEvent } from "../../internal-hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
@@ -199,8 +201,8 @@ async function findPreviousSessionFile(params: {
 const saveSessionToMemory: HookHandler = async (event) => {
   const isResetCommand =
     event.type === "command" && (event.action === "new" || event.action === "reset");
-  const isAutomaticRollover = event.type === "session" && event.action === "rollover";
-  if (!isResetCommand && !isAutomaticRollover) {
+  const rolloverEvent = isSessionRolloverEvent(event) ? event : null;
+  if (!isResetCommand && !rolloverEvent) {
     return;
   }
 
@@ -210,7 +212,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
       action: event.action,
     });
 
-    const context = event.context || {};
+    const context = rolloverEvent ? rolloverEvent.context : event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;
     const contextWorkspaceDir =
       typeof context.workspaceDir === "string" && context.workspaceDir.trim().length > 0
@@ -328,7 +330,10 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Extract context details
     const sessionId = (sessionEntry.sessionId as string) || "unknown";
-    const source = (context.commandSource as string) || "unknown";
+    const source =
+      (typeof context.commandSource === "string" && context.commandSource) ||
+      (typeof context.resetReason === "string" && context.resetReason) ||
+      "unknown";
 
     // Build Markdown entry
     const entryParts = [

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -194,17 +194,21 @@ async function findPreviousSessionFile(params: {
 }
 
 /**
- * Save session context to memory when /new or /reset command is triggered
+ * Save session context to memory when an explicit reset or automatic session rollover happens.
  */
 const saveSessionToMemory: HookHandler = async (event) => {
-  // Only trigger on reset/new commands
-  const isResetCommand = event.action === "new" || event.action === "reset";
-  if (event.type !== "command" || !isResetCommand) {
+  const isResetCommand =
+    event.type === "command" && (event.action === "new" || event.action === "reset");
+  const isAutomaticRollover = event.type === "session" && event.action === "rollover";
+  if (!isResetCommand && !isAutomaticRollover) {
     return;
   }
 
   try {
-    log.debug("Hook triggered for reset/new command", { action: event.action });
+    log.debug("Hook triggered for session memory persistence", {
+      type: event.type,
+      action: event.action,
+    });
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;

--- a/src/hooks/frontmatter.test.ts
+++ b/src/hooks/frontmatter.test.ts
@@ -155,7 +155,7 @@ describe("resolveOpenClawMetadata", () => {
       metadata: JSON.stringify({
         openclaw: {
           emoji: "🔥",
-          events: ["command:new", "command:reset"],
+          events: ["command:new", "command:reset", "session:rollover"],
           requires: {
             config: ["workspace.dir"],
             bins: ["git"],
@@ -167,7 +167,7 @@ describe("resolveOpenClawMetadata", () => {
     const result = resolveOpenClawMetadata(frontmatter);
     expect(result).toBeDefined();
     expect(result?.emoji).toBe("🔥");
-    expect(result?.events).toEqual(["command:new", "command:reset"]);
+    expect(result?.events).toEqual(["command:new", "command:reset", "session:rollover"]);
     expect(result?.requires?.config).toEqual(["workspace.dir"]);
     expect(result?.requires?.bins).toEqual(["git"]);
   });
@@ -239,7 +239,7 @@ metadata:
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new", "command:reset"],
+        "events": ["command:new", "command:reset", "session:rollover"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },
@@ -256,7 +256,7 @@ metadata:
     const openclaw = resolveOpenClawMetadata(frontmatter);
     expect(openclaw).toBeDefined();
     expect(openclaw?.emoji).toBe("💾");
-    expect(openclaw?.events).toEqual(["command:new", "command:reset"]);
+    expect(openclaw?.events).toEqual(["command:new", "command:reset", "session:rollover"]);
     expect(openclaw?.requires?.config).toEqual(["workspace.dir"]);
     expect(openclaw?.install?.[0].kind).toBe("bundled");
   });

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -7,6 +7,7 @@ import {
   isGatewayStartupEvent,
   isMessageReceivedEvent,
   isMessageSentEvent,
+  isSessionRolloverEvent,
   registerInternalHook,
   triggerInternalHook,
   unregisterInternalHook,
@@ -14,6 +15,7 @@ import {
   type GatewayStartupHookContext,
   type MessageReceivedHookContext,
   type MessageSentHookContext,
+  type SessionRolloverHookContext,
 } from "./internal-hooks.js";
 
 describe("hooks", () => {
@@ -234,6 +236,43 @@ describe("hooks", () => {
     for (const testCase of cases) {
       it(testCase.name, () => {
         expect(isGatewayStartupEvent(testCase.event)).toBe(testCase.expected);
+      });
+    }
+  });
+
+  describe("isSessionRolloverEvent", () => {
+    const cases: Array<{
+      name: string;
+      event: ReturnType<typeof createInternalHookEvent>;
+      expected: boolean;
+    }> = [
+      {
+        name: "returns true for session:rollover events with expected context",
+        event: createInternalHookEvent("session", "rollover", "test-session", {
+          workspaceDir: "/tmp/workspace",
+          resetReason: "automatic",
+        } satisfies SessionRolloverHookContext),
+        expected: true,
+      },
+      {
+        name: "returns false when workspaceDir is missing",
+        event: createInternalHookEvent("session", "rollover", "test-session", {
+          resetReason: "automatic",
+        }),
+        expected: false,
+      },
+      {
+        name: "returns false for non-rollover session events",
+        event: createInternalHookEvent("session", "start", "test-session", {
+          workspaceDir: "/tmp/workspace",
+        }),
+        expected: false,
+      },
+    ];
+
+    for (const testCase of cases) {
+      it(testCase.name, () => {
+        expect(isSessionRolloverEvent(testCase.event)).toBe(testCase.expected);
       });
     }
   });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,6 +8,7 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
@@ -37,6 +38,20 @@ export type GatewayStartupHookEvent = InternalHookEvent & {
   type: "gateway";
   action: "startup";
   context: GatewayStartupHookContext;
+};
+
+export type SessionRolloverHookContext = {
+  cfg?: OpenClawConfig;
+  workspaceDir: string;
+  sessionEntry?: SessionEntry;
+  previousSessionEntry?: SessionEntry;
+  resetReason?: string;
+};
+
+export type SessionRolloverHookEvent = InternalHookEvent & {
+  type: "session";
+  action: "rollover";
+  context: SessionRolloverHookContext;
 };
 
 // ============================================================================
@@ -362,6 +377,19 @@ export function isGatewayStartupEvent(event: InternalHookEvent): event is Gatewa
     return false;
   }
   return Boolean(getHookContext<GatewayStartupHookContext>(event));
+}
+
+export function isSessionRolloverEvent(
+  event: InternalHookEvent,
+): event is SessionRolloverHookEvent {
+  if (!isHookEventTypeAndAction(event, "session", "rollover")) {
+    return false;
+  }
+  const context = getHookContext<SessionRolloverHookContext>(event);
+  if (!context) {
+    return false;
+  }
+  return hasStringContextField(context, "workspaceDir");
 }
 
 export function isMessageReceivedEvent(


### PR DESCRIPTION
## Summary

This fixes an inconsistency in bundled `session-memory` persistence across session boundaries.

Previously, `session-memory` persisted context when users explicitly triggered `/new` or `/reset`, but it did **not** persist context when a stale session was automatically rolled over due to the normal session freshness lifecycle (for example daily reset or idle expiry on the next inbound message).

With this change:

- explicit `/new` and `/reset` continue to work as before
- automatic stale-session rollover now emits an internal `session:rollover` hook event
- bundled `session-memory` listens to that event and persists the previous session context
- explicit reset flows do **not** double-write, because the new hook is emitted only for automatic rollover paths

## Why this matters

From the product perspective, both explicit reset and automatic rollover represent the same boundary:

- an old session ends
- a new `sessionId` begins

Before this patch, bundled memory persistence was only attached to the explicit command path, so resuming a conversation after the daily reset boundary could rotate to a new `sessionId` without producing a `workspace/memory/...` snapshot for the previous session.

This change makes bundled `session-memory` behavior consistent across both explicit and automatic session rollover.

## Implementation

- emit a `session:rollover` internal hook from `getReplyFromConfig()` when:
  - a new session is created
  - the rollover was **not** triggered by explicit `/new` or `/reset`
  - a previous session exists and differs from the new session
- extend bundled `session-memory` to handle:
  - `command:new`
  - `command:reset`
  - `session:rollover`
- update bundled hook docs / metadata to advertise the new event
- add tests for:
  - automatic rollover persistence
  - explicit reset still avoiding rollover-hook duplication
  - updated hook metadata parsing / onboarding expectations

## Tests

Passed locally:

- `src/auto-reply/reply/get-reply.message-hooks.test.ts`
- `src/commands/onboard-hooks.test.ts`
- `src/hooks/frontmatter.test.ts`
- `src/hooks/bundled/session-memory/handler.test.ts`
