### PR TITLE
fix(cron): start job timeout after execution begins, not at enqueue time

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -273,6 +273,7 @@ export async function runEmbeddedPiAgent(
 
   return enqueueSession(() =>
     enqueueGlobal(async () => {
+      params.onLaneAcquired?.();
       const started = Date.now();
       const workspaceResolution = resolveRunWorkspaceDir({
         workspaceDir: params.workspaceDir,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -124,4 +124,6 @@ export type RunEmbeddedPiAgentParams = {
    * where transient service pressure is often model-scoped.
    */
   allowTransientCooldownProbe?: boolean;
+  /** Called once both session and global lanes are acquired (before agent loop). */
+  onLaneAcquired?: () => void;
 };

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -219,6 +219,7 @@ export async function runCronIsolatedAgentTurn(params: {
   agentId?: string;
   lane?: string;
   deliveryContract?: IsolatedDeliveryContract;
+  onExecutionStart?: () => void;
 }): Promise<RunCronAgentTurnResult> {
   const abortSignal = params.abortSignal ?? params.signal;
   const isAborted = () => abortSignal?.aborted === true;
@@ -638,7 +639,10 @@ export async function runCronIsolatedAgentTurn(params: {
             abortSignal,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
+            onLaneAcquired: params.onExecutionStart,
           });
+          // Clear after first call so retry iterations don't re-fire the timer.
+          params.onExecutionStart = undefined;
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,
           );

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -84,6 +84,7 @@ export type CronServiceDeps = {
     job: CronJob;
     message: string;
     abortSignal?: AbortSignal;
+    onExecutionStart?: () => void;
   }) => Promise<
     {
       summary?: string;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1142,11 +1142,11 @@ export async function executeJobCore(
     return resolveAbortError();
   }
 
-  onExecutionStart?.();
   const res = await state.deps.runIsolatedAgentJob({
     job,
     message: job.payload.message,
     abortSignal,
+    onExecutionStart,
   });
 
   if (abortSignal?.aborted) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -73,14 +73,21 @@ export async function executeJobCoreWithTimeout(
 
   const runAbortController = new AbortController();
   let timeoutId: NodeJS.Timeout | undefined;
+  let rejectTimeout: ((reason?: unknown) => void) | undefined;
+  const startTimer = () => {
+    if (timeoutId) {
+      return;
+    }
+    timeoutId = setTimeout(() => {
+      runAbortController.abort(timeoutErrorMessage());
+      rejectTimeout?.(new Error(timeoutErrorMessage()));
+    }, jobTimeoutMs);
+  };
   try {
     return await Promise.race([
-      executeJobCore(state, job, runAbortController.signal),
+      executeJobCore(state, job, runAbortController.signal, startTimer),
       new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          runAbortController.abort(timeoutErrorMessage());
-          reject(new Error(timeoutErrorMessage()));
-        }, jobTimeoutMs);
+        rejectTimeout = reject;
       }),
     ]);
   } finally {
@@ -1006,6 +1013,7 @@ export async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
   abortSignal?: AbortSignal,
+  onExecutionStart?: () => void,
 ): Promise<
   CronRunOutcome & CronRunTelemetry & { delivered?: boolean; deliveryAttempted?: boolean }
 > {
@@ -1050,6 +1058,10 @@ export async function executeJobCore(
             : 'main job requires payload.kind="systemEvent"',
       };
     }
+    if (abortSignal?.aborted) {
+      return resolveAbortError();
+    }
+    onExecutionStart?.();
     // Preserve the job session namespace for main-target reminders so heartbeat
     // routing can deliver follow-through in the originating channel/thread.
     // Downstream gateway wiring canonicalizes/guards this key per agent.
@@ -1130,6 +1142,7 @@ export async function executeJobCore(
     return resolveAbortError();
   }
 
+  onExecutionStart?.();
   const res = await state.deps.runIsolatedAgentJob({
     job,
     message: job.payload.message,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -282,7 +282,7 @@ export function buildGatewayCronService(params: {
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },
-    runIsolatedAgentJob: async ({ job, message, abortSignal }) => {
+    runIsolatedAgentJob: async ({ job, message, abortSignal, onExecutionStart }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       return await runCronIsolatedAgentTurn({
         cfg: runtimeConfig,
@@ -293,6 +293,7 @@ export function buildGatewayCronService(params: {
         agentId,
         sessionKey: `cron:${job.id}`,
         lane: "cron",
+        onExecutionStart,
       });
     },
     sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) => {


### PR DESCRIPTION
## Summary

Cron job timeout was starting at enqueue time, which included queue wait time. This caused premature timeouts when the agent lane was busy.

## Changes

1. **timer.ts**: Move `onExecutionStart` callback through the execution pipeline
2. **run.ts (cron)**: Pass `onExecutionStart` to embedded runner
3. **run.ts (embedded)**: Forward callback to `enqueueGlobal`
4. **params.ts**: Fire `onExecutionStart` only after lane acquisition, then clear it to prevent duplicate calls on retry

## Testing

- Regression tests in `service.issue-regressions.test.ts` covering:
  - Timeout fires after execution begins (not at enqueue)
  - Suppresses follow-up side effects after timeout
  - Applies to manual `cron.run` and startup catch-up executions

Supersedes #41886 (rebased on latest main).