### PR TITLE
Gateway: align nested lane concurrency with cron.maxConcurrentRuns

### DIFF
--- a/src/agents/lanes.test.ts
+++ b/src/agents/lanes.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { AGENT_LANE_NESTED, resolveNestedAgentLane } from "./lanes.js";
+import {
+  AGENT_LANE_CRON_NESTED,
+  AGENT_LANE_NESTED,
+  resolveCronEmbeddedAgentLane,
+  resolveNestedAgentLane,
+} from "./lanes.js";
+
+describe("resolveCronEmbeddedAgentLane", () => {
+  it("defaults to the dedicated cron nested lane when no lane is provided", () => {
+    expect(resolveCronEmbeddedAgentLane()).toBe(AGENT_LANE_CRON_NESTED);
+  });
+
+  it("moves cron lane callers onto the dedicated cron nested lane", () => {
+    expect(resolveCronEmbeddedAgentLane("cron")).toBe(AGENT_LANE_CRON_NESTED);
+    expect(resolveCronEmbeddedAgentLane("  cron  ")).toBe(AGENT_LANE_CRON_NESTED);
+  });
+
+  it("preserves non-cron lanes", () => {
+    expect(resolveCronEmbeddedAgentLane("subagent")).toBe("subagent");
+    expect(resolveCronEmbeddedAgentLane(" custom-lane ")).toBe("custom-lane");
+  });
+});
 
 describe("resolveNestedAgentLane", () => {
   it("defaults to the nested lane when no lane is provided", () => {

--- a/src/agents/lanes.ts
+++ b/src/agents/lanes.ts
@@ -1,7 +1,19 @@
 import { CommandLane } from "../process/lanes.js";
 
+export const AGENT_LANE_CRON_NESTED = CommandLane.CronNested;
 export const AGENT_LANE_NESTED = CommandLane.Nested;
 export const AGENT_LANE_SUBAGENT = CommandLane.Subagent;
+
+export function resolveCronEmbeddedAgentLane(lane?: string): string {
+  const trimmed = lane?.trim();
+  // Cron jobs already occupy the cron lane while they dispatch embedded work.
+  // Route inner runs onto a dedicated cron-nested lane instead of the shared
+  // interactive nested lane.
+  if (!trimmed || trimmed === "cron") {
+    return AGENT_LANE_CRON_NESTED;
+  }
+  return trimmed;
+}
 
 export function resolveNestedAgentLane(lane?: string): string {
   const trimmed = lane?.trim();

--- a/src/cron/isolated-agent.lane.test.ts
+++ b/src/cron/isolated-agent.lane.test.ts
@@ -46,13 +46,13 @@ describe("runCronIsolatedAgentTurn lane selection", () => {
 
   it("moves the cron lane to nested for embedded runs", async () => {
     await withTempCronHome(async (home) => {
-      expect(await runLaneCase(home, "cron")).toBe("nested");
+      expect(await runLaneCase(home, "cron")).toBe("cron-nested");
     });
   });
 
   it("defaults missing lanes to nested for embedded runs", async () => {
     await withTempCronHome(async (home) => {
-      expect(await runLaneCase(home)).toBe("nested");
+      expect(await runLaneCase(home)).toBe("cron-nested");
     });
   });
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -198,7 +198,6 @@ function appendCronDeliveryInstruction(params: {
   }
   return `${params.commandBody}\n\nReturn your summary as plain text; it will be delivered automatically. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`.trim();
 }
-
 export async function runCronIsolatedAgentTurn(params: {
   cfg: OpenClawConfig;
   deps: CliDeps;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -13,7 +13,7 @@ import { lookupContextTokens } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
-import { resolveNestedAgentLane } from "../../agents/lanes.js";
+import { resolveCronEmbeddedAgentLane } from "../../agents/lanes.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import {
@@ -198,6 +198,7 @@ function appendCronDeliveryInstruction(params: {
   }
   return `${params.commandBody}\n\nReturn your summary as plain text; it will be delivered automatically. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`.trim();
 }
+
 export async function runCronIsolatedAgentTurn(params: {
   cfg: OpenClawConfig;
   deps: CliDeps;
@@ -611,7 +612,7 @@ export async function runCronIsolatedAgentTurn(params: {
             config: cfgWithAgentDefaults,
             skillsSnapshot,
             prompt: promptText,
-            lane: resolveNestedAgentLane(params.lane),
+            lane: resolveCronEmbeddedAgentLane(params.lane),
             provider: providerOverride,
             model: modelOverride,
             authProfileId,

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -16,7 +16,34 @@ describe("applyGatewayLaneConcurrency", () => {
     resetAllLanes();
   });
 
-  it("keeps nested lane concurrency aligned with cron.maxConcurrentRuns", async () => {
+  it("keeps the cron nested lane concurrency aligned with cron.maxConcurrentRuns", async () => {
+    applyGatewayLaneConcurrency({
+      cron: { maxConcurrentRuns: 2 },
+    } as unknown as ReturnType<typeof import("../config/config.js").loadConfig>);
+
+    const blocker = createDeferred();
+    let started = 0;
+
+    const runTask = () =>
+      enqueueCommandInLane(CommandLane.CronNested, async () => {
+        started += 1;
+        await blocker.promise;
+      });
+
+    const first = runTask();
+    const second = runTask();
+
+    try {
+      await vi.waitFor(() => {
+        expect(started).toBe(2);
+      });
+    } finally {
+      blocker.resolve();
+      await Promise.allSettled([first, second]);
+    }
+  });
+
+  it("keeps the shared interactive nested lane at its default concurrency", async () => {
     applyGatewayLaneConcurrency({
       cron: { maxConcurrentRuns: 2 },
     } as unknown as ReturnType<typeof import("../config/config.js").loadConfig>);
@@ -35,7 +62,7 @@ describe("applyGatewayLaneConcurrency", () => {
 
     try {
       await vi.waitFor(() => {
-        expect(started).toBe(2);
+        expect(started).toBe(1);
       });
     } finally {
       blocker.resolve();

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { enqueueCommandInLane, resetAllLanes } from "../process/command-queue.js";
+import { CommandLane } from "../process/lanes.js";
+import { applyGatewayLaneConcurrency } from "./server-lanes.js";
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("applyGatewayLaneConcurrency", () => {
+  beforeEach(() => {
+    resetAllLanes();
+  });
+
+  it("keeps nested lane concurrency aligned with cron.maxConcurrentRuns", async () => {
+    applyGatewayLaneConcurrency({
+      cron: { maxConcurrentRuns: 2 },
+    } as unknown as ReturnType<typeof import("../config/config.js").loadConfig>);
+
+    const blocker = createDeferred();
+    let started = 0;
+
+    const runTask = () =>
+      enqueueCommandInLane(CommandLane.Nested, async () => {
+        started += 1;
+        await blocker.promise;
+      });
+
+    const first = runTask();
+    const second = runTask();
+
+    try {
+      await vi.waitFor(() => {
+        expect(started).toBe(2);
+      });
+    } finally {
+      blocker.resolve();
+      await Promise.allSettled([first, second]);
+    }
+  });
+});

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -4,7 +4,13 @@ import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 
 export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) {
-  setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
+  const cronConcurrency = cfg.cron?.maxConcurrentRuns ?? 1;
+  setCommandLaneConcurrency(CommandLane.Cron, cronConcurrency);
+  // Cron embedded runs execute in the nested lane to avoid re-entering the cron
+  // lane (which deadlocks when cron.run itself is enqueued behind that lane).
+  // Keep nested concurrency aligned with cron.maxConcurrentRuns so the config
+  // remains the effective limit for isolated cron jobs.
+  setCommandLaneConcurrency(CommandLane.Nested, cronConcurrency);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
 }

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -6,11 +6,10 @@ import { CommandLane } from "../process/lanes.js";
 export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) {
   const cronConcurrency = cfg.cron?.maxConcurrentRuns ?? 1;
   setCommandLaneConcurrency(CommandLane.Cron, cronConcurrency);
-  // Cron embedded runs execute in the nested lane to avoid re-entering the cron
-  // lane (which deadlocks when cron.run itself is enqueued behind that lane).
-  // Keep nested concurrency aligned with cron.maxConcurrentRuns so the config
-  // remains the effective limit for isolated cron jobs.
-  setCommandLaneConcurrency(CommandLane.Nested, cronConcurrency);
+  // Cron embedded runs use a dedicated cron-nested lane so scheduled jobs can
+  // honor cron.maxConcurrentRuns without widening interactive nested-agent
+  // throughput.
+  setCommandLaneConcurrency(CommandLane.CronNested, cronConcurrency);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
 }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -135,7 +135,9 @@ export function createGatewayReloadHandlers(params: {
       }
     }
 
-    setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
+    const cronConcurrency = nextConfig.cron?.maxConcurrentRuns ?? 1;
+    setCommandLaneConcurrency(CommandLane.Cron, cronConcurrency);
+    setCommandLaneConcurrency(CommandLane.Nested, cronConcurrency);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -137,7 +137,7 @@ export function createGatewayReloadHandlers(params: {
 
     const cronConcurrency = nextConfig.cron?.maxConcurrentRuns ?? 1;
     setCommandLaneConcurrency(CommandLane.Cron, cronConcurrency);
-    setCommandLaneConcurrency(CommandLane.Nested, cronConcurrency);
+    setCommandLaneConcurrency(CommandLane.CronNested, cronConcurrency);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
 

--- a/src/process/lanes.ts
+++ b/src/process/lanes.ts
@@ -1,6 +1,7 @@
 export const enum CommandLane {
   Main = "main",
   Cron = "cron",
+  CronNested = "cron-nested",
   Subagent = "subagent",
   Nested = "nested",
 }


### PR DESCRIPTION
## What
- Keep `CommandLane.Nested` concurrency aligned with `cron.maxConcurrentRuns` (startup + hot reload).
- Fix `pnpm tsgo` break from an unused helper referencing `CommandLane` without importing it.
- Align gateway remote credential planning with the current `gateway.remote` schema (no `enabled` field).
- Formatting-only: apply oxfmt to a test file that was failing `pnpm format:check`.

## Why
Isolated cron runs execute embedded agent work in the `nested` lane to avoid re-entering the `cron` lane (which deadlocks when `cron.run` is itself queued behind that lane; see reports like #41266 / #41798).

Because the gateway currently only applies concurrency limits to `cron`, `main`, and `subagent` lanes, moving cron embedded runs to `nested` silently forces isolated cron concurrency back to 1 regardless of `cron.maxConcurrentRuns`.

## Changes
- `src/gateway/server-lanes.ts`: set `CommandLane.Nested` concurrency to `cron.maxConcurrentRuns`.
- `src/gateway/server-reload-handlers.ts`: keep `nested` lane concurrency in sync on config hot reload.
- `src/gateway/server-lanes.test.ts`: regression test asserting nested lane runs 2 tasks concurrently when `cron.maxConcurrentRuns=2`.
- `src/cron/isolated-agent/run.ts`: delete unused `resolveCronEmbeddedAgentLane` (was referencing `CommandLane` without import).
- `src/gateway/credential-planner.ts`: treat `remoteEnabled` as always true (schema no longer supports disabling remote via `gateway.remote.enabled`).
- `src/cli/daemon-cli/lifecycle.test.ts`: oxfmt-only.

## Verification
- `pnpm check`
- `pnpm exec vitest run src/gateway/server-lanes.test.ts`
- `pnpm exec vitest run src/cron/isolated-agent.lane.test.ts`
