### PR TITLE
Gateway: add missing remote enabled config type

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -186,6 +186,8 @@ export type GatewayTailscaleConfig = {
 };
 
 export type GatewayRemoteConfig = {
+  /** Set false to disable remote auth fallback surfaces. */
+  enabled?: boolean;
   /** Remote Gateway WebSocket URL (ws:// or wss://). */
   url?: string;
   /** Transport for macOS remote connections (ssh tunnel or direct WS). */


### PR DESCRIPTION
## Summary

- Problem: `pnpm build` on `main` fails because `src/gateway/credential-planner.ts` reads `gateway.remote.enabled`, but `GatewayRemoteConfig` does not declare that field.
- Why it matters: this breaks local builds and blocks restarting the gateway from a fresh pull of `main`.
- What changed: add the missing optional `enabled?: boolean` field to `GatewayRemoteConfig`.
- What did NOT change (scope boundary): no runtime behavior, config defaults, or auth logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v24.13.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): local gateway service
- Relevant config (redacted): default local profile

### Steps

1. Pull current `main`.
2. Run `pnpm build`.
3. Observe TypeScript compilation fail in `src/gateway/credential-planner.ts` on `remote?.enabled`.

### Expected

- `pnpm build` completes successfully.

### Actual

- Build fails because `GatewayRemoteConfig` is missing the `enabled` property used by gateway credential planning.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the build failure before the patch; reran `pnpm build` successfully after the patch; restarted the local gateway successfully from the rebuilt output.
- Edge cases checked: confirmed the change is type-only and does not alter generated launchd service behavior.
- What you did **not** verify: no additional automated tests beyond the successful build.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/config/types.gateway.ts`
- Known bad symptoms reviewers should watch for: none beyond build/typecheck behavior.

## Risks and Mitigations

- Risk: the type declaration could diverge from intended config schema.
  - Mitigation: the field is already consumed in gateway code and referenced in docs/runtime messages; this change aligns the type with existing usage.
