### PR TITLE
fix(bonjour): suppress ciao IPv4 address-change assertion crash

### DIFF
--- a/src/infra/bonjour-ciao.test.ts
+++ b/src/infra/bonjour-ciao.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  logWarn: mocks.logWarn,
+  logDebug: mocks.logDebug,
+}));
+
+const { ignoreCiaoCancellationRejection } = await import("./bonjour-ciao.js");
+
+describe("ignoreCiaoCancellationRejection", () => {
+  it("suppresses ciao announcement cancellation", () => {
+    const err = new Error("ciao announcement cancelled");
+    expect(ignoreCiaoCancellationRejection(err)).toBe(true);
+    expect(mocks.logDebug).toHaveBeenCalled();
+  });
+
+  it("suppresses IPv4 address change from defined to undefined assertion", () => {
+    const err = new assert.AssertionError({
+      message: "Reached illegal state! IPV4 address change from defined to undefined!",
+    });
+    expect(ignoreCiaoCancellationRejection(err)).toBe(true);
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("suppressed ciao network-change assertion"),
+    );
+  });
+
+  it("suppresses IPv4 address changed from undefined to defined assertion", () => {
+    const err = new assert.AssertionError({
+      message: "Reached illegal state! IPv4 address changed from undefined to defined!",
+    });
+    expect(ignoreCiaoCancellationRejection(err)).toBe(true);
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("suppressed ciao network-change assertion"),
+    );
+  });
+
+  it("does not suppress unrelated errors", () => {
+    expect(ignoreCiaoCancellationRejection(new Error("something else"))).toBe(false);
+    expect(ignoreCiaoCancellationRejection(new TypeError("boom"))).toBe(false);
+    expect(ignoreCiaoCancellationRejection("random string")).toBe(false);
+  });
+});

--- a/src/infra/bonjour-ciao.ts
+++ b/src/infra/bonjour-ciao.ts
@@ -1,11 +1,27 @@
-import { logDebug } from "../logger.js";
+import { logDebug, logWarn } from "../logger.js";
 import { formatBonjourError } from "./bonjour-errors.js";
+
+// ciao's MDNSServer.handleUpdatedNetworkInterfaces fires assert.fail when an
+// interface's IPv4 address transitions between defined⇄undefined (e.g. WiFi
+// drop, VPN toggle, sleep/wake). These are transient network events, not bugs
+// in OpenClaw - swallow them so the gateway stays alive.
+const CIAO_TRANSIENT_PATTERNS = [
+  "CIAO ANNOUNCEMENT CANCELLED",
+  "REACHED ILLEGAL STATE! IPV4 ADDRESS CHANGE",
+  "REACHED ILLEGAL STATE! IPV4 ADDRESS CHANGED",
+];
 
 export function ignoreCiaoCancellationRejection(reason: unknown): boolean {
   const message = formatBonjourError(reason).toUpperCase();
-  if (!message.includes("CIAO ANNOUNCEMENT CANCELLED")) {
+  const matched = CIAO_TRANSIENT_PATTERNS.some((pattern) => message.includes(pattern));
+  if (!matched) {
     return false;
   }
-  logDebug(`bonjour: ignoring unhandled ciao rejection: ${formatBonjourError(reason)}`);
+  const formatted = formatBonjourError(reason);
+  if (message.includes("REACHED ILLEGAL STATE")) {
+    logWarn(`bonjour: suppressed ciao network-change assertion (non-fatal): ${formatted}`);
+  } else {
+    logDebug(`bonjour: ignoring unhandled ciao rejection: ${formatted}`);
+  }
   return true;
 }


### PR DESCRIPTION
## Summary

- Problem: gateway exits on unhandled rejection when `@homebridge/ciao` throws an IPv4 transition assertion (`Reached illegal state! IPv4 address changed...`).
- Why it matters: transient network/interface churn (sleep/wake, VPN toggle, Wi-Fi changes) can kill a healthy gateway process.
- What changed: extended `ignoreCiaoCancellationRejection()` to also suppress ciao IPv4 assertion variants and added focused unit tests.
- What did NOT change (scope boundary): no behavior changes outside ciao unhandled-rejection filtering; no gateway restart/health-monitor policy changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38628
- Related #27359

## User-visible / Behavior Changes

- Gateway no longer exits when the known ciao IPv4 transition assertions are emitted as unhandled rejections; process continues and logs a warning.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.2 (arm64)
- Runtime/container: Node 24.x, local gateway mode
- Model/provider: gmn / gpt-5.3-codex
- Integration/channel (if any): DingTalk channel enabled
- Relevant config (redacted): default local gateway, bonjour enabled

### Steps

1. Start gateway with bonjour enabled.
2. Trigger interface churn (sleep/wake, VPN toggle, or network transition) causing ciao assertion.
3. Observe unhandled rejection behavior.

### Expected

- Gateway should not crash on known transient ciao IPv4 assertion transitions.

### Actual

- Before: process exits on unhandled rejection.
- After: rejection is suppressed and logged as non-fatal warning.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Crash trace observed before fix:

```text
Unhandled promise rejection: AssertionError [ERR_ASSERTION]: Reached illegal state! IPv4 address changed from undefined to defined!
    at MDNSServer.handleUpdatedNetworkInterfaces (.../@homebridge/ciao/src/MDNSServer.ts:691:18)
```

Validation run:

```bash
pnpm vitest run src/infra/bonjour-ciao.test.ts src/infra/bonjour.test.ts src/infra/unhandled-rejections.test.ts
# 3 files, 43 tests passed
```

Note: repository-wide `pnpm check` currently fails on upstream formatting in `src/cli/daemon-cli/lifecycle.test.ts` (unrelated to this PR).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Known ciao cancellation rejection remains suppressed.
  - Two IPv4 assertion message variants are suppressed.
  - Unrelated errors are not suppressed.
- Edge cases checked:
  - Both “address change” and “address changed” message forms.
  - Case-insensitive matching through existing uppercase normalization.
- What you did **not** verify:
  - Full end-to-end live network churn reproduction in this PR branch runtime.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit.
- Files/config to restore:
  - `src/infra/bonjour-ciao.ts`
  - `src/infra/bonjour-ciao.test.ts`
- Known bad symptoms reviewers should watch for:
  - Over-broad suppression accidentally swallowing unrelated unhandled rejections.

## Risks and Mitigations

- Risk:
  - Matching too broadly could mask non-ciao assertion failures with similar text.
  - Mitigation:
    - Pattern remains tightly scoped to ciao-specific illegal-state IPv4 assertion text; tests assert unrelated errors remain unsuppressed.
