### PR TITLE
fix: canonicalize local implicit session key for session_status

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -115,6 +115,22 @@ describe("session_status tool", () => {
     expect(details.statusText).not.toContain("OAuth/token status");
   });
 
+  it("canonicalizes non-key implicit session refs to the agent main key", async () => {
+    resetSessionStore({
+      "agent:main:main": {
+        sessionId: "s-main",
+        updatedAt: 10,
+      },
+    });
+
+    const tool = getSessionStatusTool("local-status-probe");
+
+    const result = await tool.execute("call2", {});
+    const details = result.details as { ok?: boolean; sessionKey?: string };
+    expect(details.ok).toBe(true);
+    expect(details.sessionKey).toBe("agent:main:main");
+  });
+
   it("errors for unknown session keys", async () => {
     resetSessionStore({
       main: { sessionId: "s1", updatedAt: 10 },

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -40,6 +40,7 @@ import {
   resolveInternalSessionKey,
   resolveMainSessionAlias,
   createAgentToAgentPolicy,
+  looksLikeSessionKey,
 } from "./sessions-helpers.js";
 
 const SessionStatusToolSchema = Type.Object({
@@ -189,14 +190,25 @@ export function createSessionStatusTool(opts?: {
       const a2aPolicy = createAgentToAgentPolicy(cfg);
 
       const requestedKeyParam = readStringParam(params, "sessionKey");
-      let requestedKeyRaw = requestedKeyParam ?? opts?.agentSessionKey;
+      const fallbackAgentSessionKey = opts?.agentSessionKey?.trim();
+      let requestedKeyRaw = requestedKeyParam ?? fallbackAgentSessionKey;
       if (!requestedKeyRaw?.trim()) {
         throw new Error("sessionKey required");
       }
 
       const requesterAgentId = resolveAgentIdFromSessionKey(
-        opts?.agentSessionKey ?? requestedKeyRaw,
+        fallbackAgentSessionKey ?? requestedKeyRaw,
       );
+      if (
+        !requestedKeyParam &&
+        fallbackAgentSessionKey &&
+        !looksLikeSessionKey(fallbackAgentSessionKey)
+      ) {
+        requestedKeyRaw = buildAgentMainSessionKey({
+          agentId: requesterAgentId,
+          mainKey,
+        });
+      }
       const ensureAgentAccess = (targetAgentId: string) => {
         if (targetAgentId === requesterAgentId) {
           return;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -81,7 +81,7 @@ import {
 } from "../infra/agent-events.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
-import { normalizeAgentId } from "../routing/session-key.js";
+import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
@@ -706,6 +706,12 @@ async function agentCommandInternal(
     acpResolution,
   } = prepared;
   let sessionEntry = prepared.sessionEntry;
+  const embeddedSessionKey =
+    sessionKey ??
+    buildAgentMainSessionKey({
+      agentId: sessionAgentId,
+      mainKey: cfg.session?.mainKey,
+    });
 
   try {
     if (opts.deliver === true) {
@@ -1066,7 +1072,7 @@ async function agentCommandInternal(
     if (!sessionFile) {
       const resolvedSessionFile = await resolveSessionTranscriptFile({
         sessionId,
-        sessionKey: sessionKey ?? sessionId,
+        sessionKey: embeddedSessionKey,
         sessionEntry,
         agentId: sessionAgentId,
         threadId: opts.threadId,
@@ -1115,7 +1121,7 @@ async function agentCommandInternal(
             cfg,
             sessionEntry,
             sessionId,
-            sessionKey,
+            sessionKey: embeddedSessionKey,
             sessionAgentId,
             sessionFile,
             workspaceDir,


### PR DESCRIPTION
## Summary

- canonicalize local embedded fallback session references to the agent main session key instead of reusing bare CLI transcript ids
- pass the canonicalized key into transcript resolution and embedded tool/runtime handoff
- make session_status canonicalize non-key implicit fallback values (while preserving explicit sessionKey arguments)
- add regression coverage for non-key implicit fallback handling

## Validation
- pnpm vitest src/agents/openclaw-tools.session-status.test.ts
- pnpm vitest src/commands/agent/session.test.ts

Closes #42692