### PR TITLE
fix(feishu): apply dedup check to single-entry flush path (#42681)

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -240,10 +240,16 @@ function registerEventHandlers(
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
   const enqueue = createChatQueue();
-  const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
+  const dispatchFeishuMessage = async (
+    event: FeishuMessageEvent,
+    opts?: { checkDedup?: boolean },
+  ) => {
     const chatId = event.message.chat_id?.trim() || "unknown";
-    const task = () =>
-      handleFeishuMessage({
+    const task = async () => {
+      if (opts?.checkDedup && (await isMessageAlreadyProcessed(event))) {
+        return;
+      }
+      await handleFeishuMessage({
         cfg,
         event,
         botOpenId: botOpenIds.get(accountId),
@@ -252,6 +258,7 @@ function registerEventHandlers(
         chatHistories,
         accountId,
       });
+    };
     await enqueue(chatId, task);
   };
   const resolveSenderDebounceId = (event: FeishuMessageEvent): string | undefined => {
@@ -328,10 +335,7 @@ function registerEventHandlers(
         return;
       }
       if (entries.length === 1) {
-        if (await isMessageAlreadyProcessed(last)) {
-          return;
-        }
-        await dispatchFeishuMessage(last);
+        await dispatchFeishuMessage(last, { checkDedup: true });
         return;
       }
       const dedupedEntries = dedupeFeishuDebounceEntriesByMessageId(entries);

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -328,6 +328,9 @@ function registerEventHandlers(
         return;
       }
       if (entries.length === 1) {
+        if (await isMessageAlreadyProcessed(last)) {
+          return;
+        }
         await dispatchFeishuMessage(last);
         return;
       }

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -468,6 +468,35 @@ describe("Feishu inbound debounce regressions", () => {
     expect(firstParams?.botName).toBe("OpenClaw Bot");
   });
 
+  it("skips single-entry debounce flush when the message was already persistently deduped", async () => {
+    vi.spyOn(dedup, "tryRecordMessage").mockReturnValue(true);
+    const tryRecordPersistentSpy = vi
+      .spyOn(dedup, "tryRecordMessagePersistent")
+      .mockResolvedValue(true);
+    vi.spyOn(dedup, "hasRecordedMessage").mockReturnValue(false);
+    const hasRecordedPersistentSpy = vi
+      .spyOn(dedup, "hasRecordedMessagePersistent")
+      .mockImplementation(async (messageId: string) => messageId === "om_single_dup");
+    const onMessage = await setupDebounceMonitor();
+
+    await enqueueDebouncedMessage(
+      onMessage,
+      createTextEvent({
+        messageId: "om_single_dup",
+        text: "duplicate",
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(handleFeishuMessageMock).not.toHaveBeenCalled();
+    expect(hasRecordedPersistentSpy).toHaveBeenCalledWith(
+      "om_single_dup",
+      "default",
+      expect.any(Function),
+    );
+    expect(tryRecordPersistentSpy).not.toHaveBeenCalled();
+  });
+
   it("does not synthesize mention-forward intent across separate messages", async () => {
     setDedupPassThroughMocks();
     const onMessage = await setupDebounceMonitor();


### PR DESCRIPTION
Fixes #42681

## Summary

Feishu channel sent duplicate replies because the single-entry debounce flush path skipped `isMessageAlreadyProcessed()` dedup check, allowing already-processed messages to trigger `deliver()` again.

## Changes

- Add `isMessageAlreadyProcessed()` guard to the `entries.length === 1` path in `monitor.account.ts` `onFlush`
- Add regression test for single-entry dedup scenario

## Testing

- 349 tests pass across feishu extension