### PR TITLE
docs: add cursor-agent-api-proxy provider

### DIFF
--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -260,6 +260,7 @@
             "zh-CN/providers/anthropic",
             "zh-CN/providers/bedrock",
             "zh-CN/providers/claude-max-api-proxy",
+            "zh-CN/providers/cursor-agent-api-proxy",
             "zh-CN/providers/deepgram",
             "zh-CN/providers/github-copilot",
             "zh-CN/providers/glm",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1243,6 +1243,7 @@
                   "providers/comfy",
                   "providers/claude-max-api-proxy",
                   "providers/cloudflare-ai-gateway",
+                  "providers/cursor-agent-api-proxy",
                   "providers/deepgram",
                   "providers/deepseek",
                   "providers/fal",

--- a/docs/providers/cursor-agent-api-proxy.md
+++ b/docs/providers/cursor-agent-api-proxy.md
@@ -1,0 +1,158 @@
+---
+summary: "Community proxy that wraps the Cursor CLI as an OpenAI-compatible API server"
+read_when:
+  - You want to use your Cursor subscription with OpenAI-compatible tools
+  - You want a local API server that wraps the Cursor CLI (agent)
+  - You want to use Cursor models from OpenClaw without per-token billing
+title: "Cursor Agent API Proxy"
+---
+
+# Cursor Agent API Proxy
+
+**cursor-agent-api-proxy** is a community tool that wraps the [Cursor CLI](https://cursor.com/cn/docs/cli/headless) (`agent` command) as an OpenAI-compatible API server. Use your Cursor subscription (Pro / Business) with any tool that speaks the OpenAI API format.
+
+<Warning>
+This path is technical compatibility only. Using the Cursor CLI in automated/proxy
+workflows may conflict with Cursor's Terms of Service. Verify Cursor's current terms
+before relying on this approach in production.
+</Warning>
+
+Works on macOS, Linux, and Windows.
+
+## How It Works
+
+```
+Your App → cursor-agent-api-proxy → Cursor CLI (agent) → Cursor (via subscription)
+  (OpenAI format)                     (stream-json)         (uses your login)
+```
+
+## Installation
+
+Requires Node.js 20+ and an active Cursor subscription.
+
+```bash
+# 1. Install and authenticate the Cursor CLI
+# macOS / Linux / WSL:
+curl https://cursor.com/install -fsS | bash
+
+# Windows PowerShell:
+irm 'https://cursor.com/install?win32=true' | iex
+
+# Then authenticate:
+agent login
+agent --list-models   # verify it works
+
+# 2. Install and start the proxy
+npm install -g cursor-agent-api-proxy
+cursor-agent-api      # starts in background on http://localhost:4646
+
+# 3. Verify
+curl http://localhost:4646/health
+```
+
+<Tip>
+**Headless environments:** skip `agent login` and set `CURSOR_API_KEY` instead.
+Generate a key at [cursor.com/settings](https://cursor.com/settings).
+</Tip>
+
+## With OpenClaw
+
+### During onboarding
+
+When running `openclaw onboard`, at the **Model/Auth** step:
+
+1. Provider type → **Custom Provider** (OpenAI-compatible)
+2. Base URL → `http://localhost:4646/v1`
+3. API Key → type `not-needed`
+4. Default model → `auto`
+
+### Existing setup
+
+Edit the config file to add a custom provider:
+
+```json5
+{
+  models: {
+    providers: {
+      cursor: {
+        api: "openai-completions",
+        baseUrl: "http://localhost:4646/v1",
+        apiKey: "not-needed",
+        models: [
+          { id: "auto", name: "Auto" },
+          { id: "opus-4.6", name: "Claude Opus 4.6" },
+          { id: "sonnet-4.5", name: "Claude Sonnet 4.5" },
+          { id: "composer-1.5", name: "Composer 1.5" },
+        ],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "cursor/auto" },
+    },
+  },
+}
+```
+
+<Note>
+Set `apiKey` to `"not-needed"` when authentication is handled by `agent login`.
+To forward a specific Cursor API Key per-request, set it here instead.
+The `models` array lists available models. Run `agent --list-models` to see all options.
+</Note>
+
+## Models
+
+Model IDs match `agent --list-models` output directly:
+
+| Model ID              | Description                    |
+| --------------------- | ------------------------------ |
+| `auto`                | Auto-select                    |
+| `gpt-5.2`            | GPT-5.2                        |
+| `gpt-5.3-codex`      | GPT-5.3 Codex                  |
+| `opus-4.6-thinking`  | Claude Opus 4.6 (thinking)     |
+| `sonnet-4.5-thinking`| Claude Sonnet 4.5 (thinking)   |
+| `gemini-3-pro`       | Gemini 3 Pro                   |
+
+Full list: `curl http://localhost:4646/v1/models` or `agent --list-models`.
+
+## Process Management
+
+```bash
+cursor-agent-api              # start (background)
+cursor-agent-api stop         # stop
+cursor-agent-api restart      # restart
+cursor-agent-api status       # check if running
+cursor-agent-api run          # foreground (for debugging)
+```
+
+## Auto-start (Boot)
+
+Register as a system service (cross-platform):
+
+```bash
+cursor-agent-api install      # register and start
+cursor-agent-api uninstall    # remove
+```
+
+- macOS → LaunchAgent
+- Windows → Task Scheduler
+- Linux → systemd user service
+
+## Links
+
+- **npm:** [https://www.npmjs.com/package/cursor-agent-api-proxy](https://www.npmjs.com/package/cursor-agent-api-proxy)
+- **GitHub:** [https://github.com/tageecc/cursor-agent-api-proxy](https://github.com/tageecc/cursor-agent-api-proxy)
+- **Issues:** [https://github.com/tageecc/cursor-agent-api-proxy/issues](https://github.com/tageecc/cursor-agent-api-proxy/issues)
+
+## Notes
+
+- This is a **community tool**, not officially supported by Cursor or OpenClaw
+- Requires an active Cursor subscription (Pro / Business) with the CLI authenticated
+- The proxy runs locally, but requests are forwarded to Cursor's servers via the `agent` CLI (same as using Cursor IDE)
+- Streaming responses are fully supported
+
+## See Also
+
+- [Claude Max API Proxy](/providers/claude-max-api-proxy) - Similar proxy for Claude subscriptions
+- [OpenAI provider](/providers/openai) - For OpenAI/Codex subscriptions

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -83,6 +83,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 ## Community tools
 
 - [Claude Max API Proxy](/providers/claude-max-api-proxy) - Community proxy for Claude subscription credentials (verify Anthropic policy/terms before use)
+- [Cursor Agent API Proxy](/providers/cursor-agent-api-proxy) - Community proxy that wraps the Cursor CLI as an OpenAI-compatible API server
 
 For the full provider catalog (xAI, Groq, Mistral, etc.) and advanced configuration,
 see [Model providers](/concepts/model-providers).

--- a/docs/zh-CN/providers/cursor-agent-api-proxy.md
+++ b/docs/zh-CN/providers/cursor-agent-api-proxy.md
@@ -1,0 +1,157 @@
+---
+summary: "将 Cursor CLI 包装为 OpenAI 兼容 API 服务的社区工具"
+read_when:
+  - 你想将 Cursor 订阅与 OpenAI 兼容工具配合使用
+  - 你想要一个封装 Cursor CLI (agent) 的本地 API 服务器
+  - 你想通过订阅而非按量计费来使用 Cursor 模型
+title: "Cursor Agent API 代理"
+---
+
+# Cursor Agent API 代理
+
+**cursor-agent-api-proxy** 是一个社区工具，将 [Cursor CLI](https://cursor.com/cn/docs/cli/headless)（`agent` 命令）包装为 OpenAI 兼容的 API 服务。让你的 Cursor 订阅（Pro / Business）可以被任何支持 OpenAI 格式的工具直接调用。
+
+<Warning>
+这是一个技术兼容方案。通过自动化/代理方式使用 Cursor CLI 可能与 Cursor 的服务条款冲突。
+在生产环境使用前，请自行确认 Cursor 的当前条款。
+</Warning>
+
+支持 macOS、Linux、Windows。
+
+## 工作原理
+
+```
+你的应用 → cursor-agent-api-proxy → Cursor CLI (agent) → Cursor（通过订阅）
+  （OpenAI 格式）                     （stream-json）        （使用你的登录凭据）
+```
+
+## 安装
+
+需要 Node.js 20+ 和有效的 Cursor 订阅。
+
+```bash
+# 1. 安装并认证 Cursor CLI
+# macOS / Linux / WSL:
+curl https://cursor.com/install -fsS | bash
+
+# Windows PowerShell:
+irm 'https://cursor.com/install?win32=true' | iex
+
+# 然后认证：
+agent login
+agent --list-models   # 确认 CLI 可用
+
+# 2. 安装并启动代理
+npm install -g cursor-agent-api-proxy
+cursor-agent-api      # 后台启动，默认 http://localhost:4646
+
+# 3. 验证
+curl http://localhost:4646/health
+```
+
+<Tip>
+**无头环境：** 跳过 `agent login`，改为设置 `CURSOR_API_KEY` 环境变量。
+到 [cursor.com/settings](https://cursor.com/settings) 生成 API Key。
+</Tip>
+
+## 配合 OpenClaw 使用
+
+### onboard 向导
+
+运行 `openclaw onboard` 时，在 **Model/Auth** 步骤：
+
+1. Provider 类型 → **Custom Provider**（OpenAI-compatible）
+2. Base URL → `http://localhost:4646/v1`
+3. API Key → 输入 `not-needed`
+4. Default model → `auto`
+
+### 编辑配置文件
+
+添加自定义 provider 配置：
+
+```json5
+{
+  models: {
+    providers: {
+      cursor: {
+        api: "openai-completions",
+        baseUrl: "http://localhost:4646/v1",
+        apiKey: "not-needed",
+        models: [
+          { id: "auto", name: "Auto" },
+          { id: "opus-4.6", name: "Claude Opus 4.6" },
+          { id: "sonnet-4.5", name: "Claude Sonnet 4.5" },
+          { id: "composer-1.5", name: "Composer 1.5" },
+        ],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "cursor/auto" },
+    },
+  },
+}
+```
+
+<Note>
+已通过 `agent login` 认证时，`apiKey` 设为 `"not-needed"` 即可。
+如需按请求转发特定的 Cursor API Key，填在这里。
+`models` 数组列出可用模型。运行 `agent --list-models` 查看所有选项。
+</Note>
+
+## 模型
+
+模型 ID 和 `agent --list-models` 输出一致：
+
+| Model ID              | 说明                           |
+| --------------------- | ------------------------------ |
+| `auto`                | 自动选择                       |
+| `gpt-5.2`            | GPT-5.2                        |
+| `gpt-5.3-codex`      | GPT-5.3 Codex                  |
+| `opus-4.6-thinking`  | Claude Opus 4.6 (thinking)     |
+| `sonnet-4.5-thinking`| Claude Sonnet 4.5 (thinking)   |
+| `gemini-3-pro`       | Gemini 3 Pro                   |
+
+完整列表：`curl http://localhost:4646/v1/models` 或 `agent --list-models`。
+
+## 进程管理
+
+```bash
+cursor-agent-api              # 启动（后台）
+cursor-agent-api stop         # 停止
+cursor-agent-api restart      # 重启
+cursor-agent-api status       # 查看状态
+cursor-agent-api run          # 前台运行（调试用）
+```
+
+## 开机自启
+
+注册为系统服务（跨平台）：
+
+```bash
+cursor-agent-api install      # 注册并启动
+cursor-agent-api uninstall    # 移除
+```
+
+- macOS → LaunchAgent
+- Windows → Task Scheduler
+- Linux → systemd user service
+
+## 链接
+
+- **npm:** [https://www.npmjs.com/package/cursor-agent-api-proxy](https://www.npmjs.com/package/cursor-agent-api-proxy)
+- **GitHub:** [https://github.com/tageecc/cursor-agent-api-proxy](https://github.com/tageecc/cursor-agent-api-proxy)
+- **Issues:** [https://github.com/tageecc/cursor-agent-api-proxy/issues](https://github.com/tageecc/cursor-agent-api-proxy/issues)
+
+## 注意事项
+
+- 这是一个**社区工具**，并非由 Cursor 或 OpenClaw 官方支持
+- 需要有效的 Cursor 订阅（Pro / Business）并已认证 CLI
+- 代理在本地运行，但请求会通过 `agent` CLI 转发到 Cursor 服务器（与使用 Cursor IDE 相同）
+- 完全支持流式响应
+
+## 另请参阅
+
+- [Claude Max API 代理](/providers/claude-max-api-proxy) - 类似的 Claude 订阅代理
+- [OpenAI 提供商](/providers/openai) - 适用于 OpenAI/Codex 订阅


### PR DESCRIPTION
## Summary

Add documentation for [cursor-agent-api-proxy](https://github.com/tageecc/cursor-agent-api-proxy), a community tool that wraps the Cursor CLI (`agent` command) as an OpenAI-compatible API server. This allows Cursor subscription users (Pro / Business) to use their subscription with OpenClaw and other OpenAI-compatible clients.

Similar to the existing [claude-max-api-proxy](/providers/claude-max-api-proxy) provider doc.

## Changes

- `docs/providers/cursor-agent-api-proxy.md` — English provider doc
- `docs/zh-CN/providers/cursor-agent-api-proxy.md` — Chinese provider doc
- `docs/docs.json` — Add navigation entries (EN + zh-CN)
- `docs/providers/index.md` — Add to Community tools section
- `docs/zh-CN/providers/index.md` — Add to Community tools section (zh-CN)

## What the tool does

- Wraps the Cursor CLI as a local HTTP server speaking OpenAI API format
- Supports streaming responses, process management (`start`/`stop`/`restart`), and cross-platform auto-start service registration
- Works on macOS, Linux, and Windows
- Published on npm: [`cursor-agent-api-proxy`](https://www.npmjs.com/package/cursor-agent-api-proxy)

## Test plan

- [ ] Verify English doc renders correctly at `/providers/cursor-agent-api-proxy`
- [ ] Verify Chinese doc renders correctly at `/zh-CN/providers/cursor-agent-api-proxy`
- [ ] Verify sidebar navigation shows the new entry in both languages
- [ ] Verify cross-references (See Also links) resolve correctly
- [ ] Verify Community tools section in providers/index.md displays properly


Made with [Cursor](https://cursor.com)