### PR TITLE
fix(browser): fallback extension relay aria snapshots when CDP attach is blocked

### DIFF
--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -304,25 +304,47 @@ export function registerBrowserAgentSnapshotRoutes(
         });
       }
 
-      const snap = shouldUsePlaywrightForAriaSnapshot({
-        profile: profileCtx.profile,
-        wsUrl: tab.wsUrl,
-      })
-        ? (() => {
-            // Extension relay doesn't expose per-page WS URLs; run AX snapshot via Playwright CDP session.
-            // Also covers cases where wsUrl is missing/unusable.
-            return requirePwAi(res, "aria snapshot").then(async (pw) => {
-              if (!pw) {
-                return null;
-              }
-              return await pw.snapshotAriaViaPlaywright({
-                cdpUrl: profileCtx.profile.cdpUrl,
-                targetId: tab.targetId,
-                limit: plan.limit,
+      const snap =
+        profileCtx.profile.driver === "extension" || !tab.wsUrl
+          ? (() => {
+              // Extension relay can block Playwright CDP attachment APIs used by AX snapshots.
+              // In that case, degrade gracefully to a relay-safe AI/role snapshot instead of failing.
+              return requirePwAi(res, "aria snapshot").then(async (pw) => {
+                if (!pw) {
+                  return null;
+                }
+                try {
+                  return await pw.snapshotAriaViaPlaywright({
+                    cdpUrl: profileCtx.profile.cdpUrl,
+                    targetId: tab.targetId,
+                    limit: plan.limit,
+                  });
+                } catch (err) {
+                  const msg = err instanceof Error ? err.message : JSON.stringify(err);
+                  const isCdpAttachBlocked =
+                    msg.includes("Target.attachToBrowserTarget") &&
+                    msg.includes("newCDPSession") &&
+                    msg.includes("Not allowed");
+                  if (!isCdpAttachBlocked) {
+                    throw err;
+                  }
+                  const roleSnap = await pw.snapshotRoleViaPlaywright({
+                    cdpUrl: profileCtx.profile.cdpUrl,
+                    targetId: tab.targetId,
+                    refsMode: "aria",
+                  });
+                  return {
+                    nodes: roleSnap.snapshot
+                      .split("\n")
+                      .map((line: string) => line.trim())
+                      .filter(Boolean)
+                      .slice(0, plan.limit)
+                      .map((name: string) => ({ role: "text", name })),
+                  };
+                }
               });
-            });
-          })()
-        : snapshotAria({ wsUrl: tab.wsUrl ?? "", limit: plan.limit });
+            })()
+          : snapshotAria({ wsUrl: tab.wsUrl ?? "", limit: plan.limit });
 
       const resolved = await Promise.resolve(snap);
       if (!resolved) {

--- a/src/browser/server.agent-contract-snapshot-endpoints.test.ts
+++ b/src/browser/server.agent-contract-snapshot-endpoints.test.ts
@@ -1,5 +1,5 @@
 import { fetch as realFetch } from "undici";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "./constants.js";
 import {
   installAgentContractHooks,
@@ -64,7 +64,7 @@ describe("browser control server", () => {
         'browserContext.newCDPSession: Protocol error (Target.attachToBrowserTarget): {"code":-32000,"message":"Not allowed"}',
       ),
     );
-    const roleFallback = vi.fn(async () => ({
+    pwMocks.snapshotRoleViaPlaywright.mockImplementationOnce(async () => ({
       snapshot: '- button "制作图片" [ref=e1]\n- textbox "为 Gemini 输入提示" [ref=e2]',
       refs: {
         e1: { role: "button", name: "制作图片" },
@@ -72,7 +72,6 @@ describe("browser control server", () => {
       },
       stats: { lines: 2, chars: 10, refs: 2, interactive: 2 },
     }));
-    pwMocks.snapshotRoleViaPlaywright = roleFallback;
 
     const response = (await realFetch(
       `${base}/snapshot?profile=chrome&format=aria&targetId=abcd1234`,
@@ -89,7 +88,7 @@ describe("browser control server", () => {
       targetId: "abcd1234",
       limit: undefined,
     });
-    expect(roleFallback).toHaveBeenCalledWith({
+    expect(pwMocks.snapshotRoleViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
       targetId: "abcd1234",
       refsMode: "aria",

--- a/src/browser/server.agent-contract-snapshot-endpoints.test.ts
+++ b/src/browser/server.agent-contract-snapshot-endpoints.test.ts
@@ -1,5 +1,5 @@
 import { fetch as realFetch } from "undici";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "./constants.js";
 import {
   installAgentContractHooks,
@@ -53,6 +53,50 @@ describe("browser control server", () => {
     expect(lastCall).toEqual({
       cdpUrl: state.cdpBaseUrl,
       targetId: "abcd1234",
+    });
+  });
+
+  it("agent contract: extension relay aria snapshot falls back to Playwright role snapshot when CDP attach is blocked", async () => {
+    const base = await startServerAndBase();
+
+    pwMocks.snapshotAriaViaPlaywright.mockRejectedValueOnce(
+      new Error(
+        'browserContext.newCDPSession: Protocol error (Target.attachToBrowserTarget): {"code":-32000,"message":"Not allowed"}',
+      ),
+    );
+    const roleFallback = vi.fn(async () => ({
+      snapshot: '- button "制作图片" [ref=e1]\n- textbox "为 Gemini 输入提示" [ref=e2]',
+      refs: {
+        e1: { role: "button", name: "制作图片" },
+        e2: { role: "textbox", name: "为 Gemini 输入提示" },
+      },
+      stats: { lines: 2, chars: 10, refs: 2, interactive: 2 },
+    }));
+    pwMocks.snapshotRoleViaPlaywright = roleFallback;
+
+    const response = (await realFetch(
+      `${base}/snapshot?profile=chrome&format=aria&targetId=abcd1234`,
+    ).then((r) => r.json())) as {
+      ok: boolean;
+      format?: string;
+      nodes?: Array<{ role: string; name?: string }>;
+    };
+
+    expect(response.ok).toBe(true);
+    expect(response.format).toBe("aria");
+    expect(pwMocks.snapshotAriaViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+      targetId: "abcd1234",
+      limit: undefined,
+    });
+    expect(roleFallback).toHaveBeenCalledWith({
+      cdpUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+      targetId: "abcd1234",
+      refsMode: "aria",
+    });
+    expect(response.nodes?.[0]).toEqual({
+      role: "text",
+      name: '- button "制作图片" [ref=e1]',
     });
   });
 

--- a/src/browser/server.control-server.test-harness.ts
+++ b/src/browser/server.control-server.test-harness.ts
@@ -104,6 +104,14 @@ const pwMocks = vi.hoisted(() => ({
   selectOptionViaPlaywright: vi.fn(async () => {}),
   setInputFilesViaPlaywright: vi.fn(async () => {}),
   snapshotAiViaPlaywright: vi.fn(async () => ({ snapshot: "ok" })),
+  snapshotAriaViaPlaywright: vi.fn(async () => ({
+    nodes: [{ role: "button", name: "x" }],
+  })),
+  snapshotRoleViaPlaywright: vi.fn(async () => ({
+    snapshot: "ok",
+    refs: {},
+    stats: { lines: 1, chars: 2, refs: 0, interactive: 0 },
+  })),
   traceStopViaPlaywright: vi.fn(async () => {}),
   takeScreenshotViaPlaywright: vi.fn(async () => ({
     buffer: Buffer.from("png"),
@@ -161,6 +169,11 @@ vi.mock("../config/config.js", async (importOriginal) => {
         defaultProfile: "openclaw",
         profiles: {
           openclaw: { cdpPort: state.testPort + 1, color: "#FF4500" },
+          chrome: {
+            cdpPort: state.testPort + 1,
+            color: "#00AA00",
+            driver: "extension",
+          },
         },
       },
     }),


### PR DESCRIPTION
## Summary
- fall back to a relay-safe Playwright role snapshot when extension relay aria snapshots hit `Target.attachToBrowserTarget: Not allowed`
- add an agent snapshot endpoint test covering the extension relay fallback path
- extend the browser control test harness with a `chrome` extension profile and snapshot mocks

## Why
Chrome Browser Relay tabs can expose a valid attached tab while still rejecting Playwright CDP attachment APIs used by aria snapshots. OpenClaw already tolerates this in page selection, but the aria snapshot route could still fail hard instead of degrading gracefully.

## Testing
- `npx vitest run src/browser/server.agent-contract-snapshot-endpoints.test.ts`
- manually verified against a real Chrome Browser Relay attached Gemini tab after rebuild/reload
