### PR TITLE
fix(security): use correct shellPayload property in interpreter approval hardening

### DIFF
--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -746,7 +746,7 @@ export function buildSystemRunApprovalPlan(params: {
   const mutableFileOperand = resolveMutableFileOperandSnapshotSync({
     argv: hardening.argv,
     cwd: hardening.cwd,
-    shellCommand: command.shellCommand,
+    shellCommand: command.shellPayload,
   });
   if (!mutableFileOperand.ok) {
     return { ok: false, message: mutableFileOperand.message };


### PR DESCRIPTION
## Summary

- Fix a property name typo in `invoke-system-run-plan.ts` where `command.shellCommand` (non-existent) was used instead of `command.shellPayload`, causing `undefined` to be passed to `resolveMutableFileOperandSnapshotSync()`
- This caused `requiresStableInterpreterApprovalBindingWithShellCommand()` to skip the safety check (`undefined !== null` evaluates to `true`), allowing unbound interpreter commands like `bun run dev` and `deno eval ...` to be incorrectly approved

## Root Cause

In `src/node-host/invoke-system-run-plan.ts:749`, the resolved command object uses `shellPayload` (as defined in `ResolvedSystemRunCommand` from `src/infra/system-run-command.ts`), but the code referenced the non-existent `shellCommand` property:

```typescript
// Before (bug): command.shellCommand is undefined
shellCommand: command.shellCommand,

// After (fix): use the correct property name
shellCommand: command.shellPayload,
```

## Impact

Two existing tests were failing:
- `rejects bun package script names that do not bind a concrete file`
- `rejects deno eval invocations that do not bind a concrete file`

## Test plan

- [x] `pnpm vitest run src/node-host/invoke-system-run-plan.test.ts` — 18/18 passed
- [x] `pnpm test` — 892 files, 7287 tests all passed