### PR TITLE
fix(discord): stream live ACP thread replies via draft preview [AI-assisted]

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1248,6 +1248,56 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("bridges live ACP Discord blocks into partial draft updates and synthesizes a final text reply", async () => {
+    setNoAbort();
+    const runtime = createAcpRuntime([
+      { type: "text_delta", text: "Hello" },
+      { type: "text_delta", text: " world" },
+      { type: "done" },
+    ]);
+    acpMocks.readAcpSessionEntry.mockReturnValue({
+      sessionKey: "agent:codex-acp:session-1",
+      storeSessionKey: "agent:codex-acp:session-1",
+      cfg: {},
+      storePath: "/tmp/mock-sessions.json",
+      entry: {},
+      acp: {
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: "runtime:1",
+        mode: "persistent",
+        state: "idle",
+        lastActivityAt: Date.now(),
+      },
+    });
+    acpMocks.requireAcpRuntimeBackend.mockReturnValue({
+      id: "acpx",
+      runtime,
+    });
+
+    const cfg = {
+      acp: {
+        enabled: true,
+        dispatch: { enabled: true },
+        stream: { deliveryMode: "live", coalesceIdleMs: 0, maxChunkChars: 256 },
+      },
+    } as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const onPartialReply = vi.fn();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:codex-acp:session-1",
+      BodyForAgent: "stream this live",
+    });
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyOptions: { onPartialReply } });
+
+    expect(onPartialReply).toHaveBeenCalledWith({ text: "Hello world" });
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Hello world" });
+  });
+
   it("generates final-mode TTS audio after ACP block streaming completes", async () => {
     setNoAbort();
     ttsMocks.state.synthesizeFinalAudio = true;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1298,6 +1298,63 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Hello world" });
   });
 
+  it("preserves leading whitespace across separate ACP blocks in live draft stream", async () => {
+    setNoAbort();
+    const runtime = createAcpRuntime([
+      { type: "text_delta", text: "Hello" },
+      { type: "text_delta", text: " world" },
+      { type: "done" },
+    ]);
+    acpMocks.readAcpSessionEntry.mockReturnValue({
+      sessionKey: "agent:codex-acp:session-1",
+      storeSessionKey: "agent:codex-acp:session-1",
+      cfg: {},
+      storePath: "/tmp/mock-sessions.json",
+      entry: {},
+      acp: {
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: "runtime:1",
+        mode: "persistent",
+        state: "idle",
+        lastActivityAt: Date.now(),
+      },
+    });
+    acpMocks.requireAcpRuntimeBackend.mockReturnValue({
+      id: "acpx",
+      runtime,
+    });
+
+    const cfg = {
+      acp: {
+        enabled: true,
+        dispatch: { enabled: true },
+        // coalesceIdleMs: 0 forces blocks to arrive separately without coalescing
+        stream: { deliveryMode: "live", coalesceIdleMs: 0, maxChunkChars: 4 },
+      },
+    } as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const accumulated: string[] = [];
+    const onPartialReply = vi.fn((p: ReplyPayload) => {
+      if (p.text) {
+        accumulated.push(p.text);
+      }
+    });
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:codex-acp:session-1",
+      BodyForAgent: "stream this live",
+    });
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyOptions: { onPartialReply } });
+
+    // Final accumulated text must preserve the leading space from the second block
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Hello world" });
+    // No block should be swallowed or trimmed
+    expect(accumulated[accumulated.length - 1]).toBe("Hello world");
+  });
+
   it("generates final-mode TTS audio after ACP block streaming completes", async () => {
     setNoAbort();
     ttsMocks.state.synthesizeFinalAudio = true;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -349,12 +349,18 @@ export async function dispatchReplyFromConfig(params: {
       ? {
           ...dispatcher,
           sendBlockReply: (payload) => {
-            const text = payload.text?.trim();
-            if (!text) {
+            const text = payload.text;
+            if (!text?.trim()) {
               return dispatcher.sendBlockReply(payload);
             }
-            acpDraftText = acpDraftText ? `${acpDraftText}\n${text}` : text;
-            void params.replyOptions?.onPartialReply?.({ ...payload, text: acpDraftText });
+            acpDraftText += text;
+            params.replyOptions
+              ?.onPartialReply?.({ ...payload, text: acpDraftText })
+              ?.catch((err: unknown) => {
+                logVerbose(
+                  `dispatch-from-config: onPartialReply error during ACP draft stream: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              });
             return true;
           },
         }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -29,6 +29,7 @@ import { getReplyFromConfig } from "../reply.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
+import { resolveAcpProjectionSettings } from "./acp-stream-settings.js";
 import { shouldBypassAcpDispatchForCommand, tryDispatchAcpReply } from "./dispatch-acp.js";
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
@@ -337,10 +338,31 @@ export async function dispatchReplyFromConfig(params: {
     }
 
     const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
+    const shouldUseAcpDiscordDraftStream = Boolean(
+      !shouldRouteToOriginating &&
+      currentSurface === "discord" &&
+      params.replyOptions?.onPartialReply &&
+      resolveAcpProjectionSettings(cfg).deliveryMode === "live",
+    );
+    let acpDraftText = "";
+    const acpDraftDispatcher: ReplyDispatcher = shouldUseAcpDiscordDraftStream
+      ? {
+          ...dispatcher,
+          sendBlockReply: (payload) => {
+            const text = payload.text?.trim();
+            if (!text) {
+              return dispatcher.sendBlockReply(payload);
+            }
+            acpDraftText = acpDraftText ? `${acpDraftText}\n${text}` : text;
+            void params.replyOptions?.onPartialReply?.({ ...payload, text: acpDraftText });
+            return true;
+          },
+        }
+      : dispatcher;
     const acpDispatch = await tryDispatchAcpReply({
       ctx,
       cfg,
-      dispatcher,
+      dispatcher: acpDraftDispatcher,
       sessionKey: acpDispatchSessionKey,
       inboundAudio,
       sessionTtsAuto,
@@ -355,6 +377,15 @@ export async function dispatchReplyFromConfig(params: {
       markIdle,
     });
     if (acpDispatch) {
+      if (
+        shouldUseAcpDiscordDraftStream &&
+        !acpDispatch.queuedFinal &&
+        acpDraftText.trim() &&
+        dispatcher.sendFinalReply({ text: acpDraftText })
+      ) {
+        acpDispatch.queuedFinal = true;
+        acpDispatch.counts.final += 1;
+      }
       return acpDispatch;
     }
 
@@ -454,7 +485,7 @@ export async function dispatchReplyFromConfig(params: {
       const acpTailDispatch = await tryDispatchAcpReply({
         ctx,
         cfg,
-        dispatcher,
+        dispatcher: acpDraftDispatcher,
         sessionKey: acpDispatchSessionKey,
         inboundAudio,
         sessionTtsAuto,
@@ -469,6 +500,15 @@ export async function dispatchReplyFromConfig(params: {
         markIdle,
       });
       if (acpTailDispatch) {
+        if (
+          shouldUseAcpDiscordDraftStream &&
+          !acpTailDispatch.queuedFinal &&
+          acpDraftText.trim() &&
+          dispatcher.sendFinalReply({ text: acpDraftText })
+        ) {
+          acpTailDispatch.queuedFinal = true;
+          acpTailDispatch.counts.final += 1;
+        }
         return acpTailDispatch;
       }
     }


### PR DESCRIPTION
## Summary

- Problem: ACP sessions bound to Discord threads did not show live streaming/progress updates; users only saw output after the turn completed.
- Why it matters: Discord thread UX regressed compared with main-channel draft streaming, making long ACP turns look stalled.
- What changed: Live ACP block output on same-surface Discord dispatches now feeds the existing Discord draft preview path, and block-only ACP turns synthesize a final text reply so the preview persists in-thread.
- What did NOT change (scope boundary): ACP projector settings, routing policy, non-Discord channels, and non-live ACP delivery modes.
- AI-assisted: implemented with an LLM coding agent; I reviewed the resulting code and test coverage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- ACP turns in Discord threads now show edit-in-place live draft streaming when ACP `deliveryMode` is `live` and the reply stays on Discord.
- ACP turns that only emitted streamed blocks now leave a final visible reply in the thread instead of clearing the preview at cleanup.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (dev workspace)
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: ACP session path (runtime mocked in unit tests)
- Integration/channel (if any): Discord threads
- Relevant config (redacted): `acp.enabled=true`, `acp.dispatch.enabled=true`, `acp.stream.deliveryMode="live"`, Discord preview stream enabled

### Steps

1. Configure an ACP-backed session bound to a Discord thread with `acp.stream.deliveryMode: "live"`.
2. Send a prompt that yields incremental ACP text deltas.
3. Observe Discord thread behavior during the turn.

### Expected

- Incremental ACP output appears as edit-in-place draft streaming in the Discord thread.
- When the ACP turn finishes with streamed blocks only, the final thread message remains visible.

### Actual

- Before this fix, Discord ACP threads stayed silent until turn completion.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added a unit test covering live ACP Discord block output being bridged into partial draft updates and finalized as a text reply.
  - Re-ran ACP dispatch unit tests and Discord message-handler draft-stream tests.
  - Ran full project quality gates: `pnpm install`, `pnpm build`, `pnpm check`, `pnpm test`.
- Edge cases checked:
  - Non-live ACP modes remain unchanged.
  - Cross-channel/origin-routed ACP dispatch remains unchanged.
  - Empty/non-text ACP block payloads still fall back to normal dispatcher behavior.
- What you did **not** verify:
  - I did not manually exercise a live Discord/OpenClaw instance, so I do not have before/after screenshots yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `c9d6089be`, or set ACP delivery back to non-live / disable Discord preview streaming.
- Files/config to restore: `src/auto-reply/reply/dispatch-from-config.ts`
- Known bad symptoms reviewers should watch for: duplicated ACP text in Discord threads, missing final persisted reply after live preview, or unintended preview behavior outside Discord live ACP turns.

## Risks and Mitigations

- Risk: ACP live Discord turns could duplicate streamed content if both draft preview and normal block delivery fire.
  - Mitigation: same-surface live Discord ACP blocks are intercepted into the draft partial path and do not queue normal block replies.
- Risk: block-only ACP turns could still disappear after draft cleanup.
  - Mitigation: synthesize a final text reply from accumulated ACP block text when no final reply was otherwise queued.
