### PR TITLE
fix(auth): show actual expiry status for OAuth profiles with refresh tokens

### DIFF
--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -9,6 +9,10 @@ describe("buildAuthHealthSummary", () => {
   const now = 1_700_000_000_000;
   const profileStatuses = (summary: ReturnType<typeof buildAuthHealthSummary>) =>
     Object.fromEntries(summary.profiles.map((profile) => [profile.profileId, profile.status]));
+  const profileRefreshable = (summary: ReturnType<typeof buildAuthHealthSummary>) =>
+    Object.fromEntries(
+      summary.profiles.map((profile) => [profile.profileId, profile.refreshable ?? false]),
+    );
   const profileReasonCodes = (summary: ReturnType<typeof buildAuthHealthSummary>) =>
     Object.fromEntries(summary.profiles.map((profile) => [profile.profileId, profile.reasonCode]));
 
@@ -58,11 +62,18 @@ describe("buildAuthHealthSummary", () => {
     const statuses = profileStatuses(summary);
 
     expect(statuses["anthropic:ok"]).toBe("ok");
-    // OAuth credentials with refresh tokens are auto-renewable, so they report "ok"
-    expect(statuses["anthropic:expiring"]).toBe("ok");
-    expect(statuses["anthropic:expired"]).toBe("ok");
+    // OAuth credentials with refresh tokens report true status with refreshable flag
+    expect(statuses["anthropic:expiring"]).toBe("expiring");
+    expect(statuses["anthropic:expired"]).toBe("expired");
     expect(statuses["anthropic:api"]).toBe("static");
 
+    const refreshableFlags = profileRefreshable(summary);
+    expect(refreshableFlags["anthropic:ok"]).toBe(true);
+    expect(refreshableFlags["anthropic:expiring"]).toBe(true);
+    expect(refreshableFlags["anthropic:expired"]).toBe(true);
+    expect(refreshableFlags["anthropic:api"]).toBe(false);
+
+    // Provider-level rollup treats refreshable expired/expiring profiles as ok
     const provider = summary.providers.find((entry) => entry.provider === "anthropic");
     expect(provider?.status).toBe("ok");
   });

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -19,6 +19,7 @@ export type AuthProfileHealth = {
   provider: string;
   type: "oauth" | "token" | "api_key";
   status: AuthProfileHealthStatus;
+  refreshable?: boolean;
   reasonCode?: AuthCredentialReasonCode;
   expiresAt?: number;
   remainingMs?: number;
@@ -163,20 +164,13 @@ function buildProfileHealth(params: {
   }
 
   const hasRefreshToken = typeof credential.refresh === "string" && credential.refresh.length > 0;
-  const { status: rawStatus, remainingMs } = resolveOAuthStatus(
-    credential.expires,
-    now,
-    warnAfterMs,
-  );
-  // OAuth credentials with a valid refresh token auto-renew on first API call,
-  // so don't warn about access token expiration.
-  const status =
-    hasRefreshToken && (rawStatus === "expired" || rawStatus === "expiring") ? "ok" : rawStatus;
+  const { status, remainingMs } = resolveOAuthStatus(credential.expires, now, warnAfterMs);
   return {
     profileId,
     provider: credential.provider,
     type: "oauth",
     status,
+    refreshable: hasRefreshToken || undefined,
     expiresAt: credential.expires,
     remainingMs,
     source,
@@ -265,7 +259,10 @@ export function buildAuthHealthSummary(params: {
       provider.remainingMs = provider.expiresAt - now;
     }
 
-    const statuses = new Set(expirable.map((p) => p.status));
+    const nonRefreshableOrMissing = expirable.filter(
+      (p) => !p.refreshable || p.status === "missing",
+    );
+    const statuses = new Set(nonRefreshableOrMissing.map((p) => p.status));
     if (statuses.has("expired") || statuses.has("missing")) {
       provider.status = "expired";
     } else if (statuses.has("expiring")) {

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -311,9 +311,13 @@ export async function modelsStatusCommand(
 
   const checkStatus = (() => {
     const hasExpiredOrMissing =
-      oauthProfiles.some((profile) => ["expired", "missing"].includes(profile.status)) ||
-      missingProvidersInUse.length > 0;
-    const hasExpiring = oauthProfiles.some((profile) => profile.status === "expiring");
+      oauthProfiles.some(
+        (profile) =>
+          profile.status === "missing" || (profile.status === "expired" && !profile.refreshable),
+      ) || missingProvidersInUse.length > 0;
+    const hasExpiring = oauthProfiles.some(
+      (profile) => profile.status === "expiring" && !profile.refreshable,
+    );
     if (hasExpiredOrMissing) {
       return 1;
     }
@@ -614,13 +618,17 @@ export async function modelsStatusCommand(
         const labelText = profile.label || profile.profileId;
         const label = colorize(rich, theme.accent, labelText);
         const status = formatStatus(profile.status);
+        const refreshable =
+          profile.refreshable && (profile.status === "expired" || profile.status === "expiring")
+            ? colorize(rich, theme.muted, " (refreshable)")
+            : "";
         const expiry =
           profile.status === "static"
             ? ""
             : profile.expiresAt
               ? ` expires in ${formatRemainingShort(profile.remainingMs)}`
               : " expires unknown";
-        runtime.log(`  - ${label} ${status}${expiry}`);
+        runtime.log(`  - ${label} ${status}${refreshable}${expiry}`);
       }
     }
   }


### PR DESCRIPTION
## Summary

- `models status` reports "ok" for expired OAuth tokens when a refresh token is present, which makes it look like everything's fine when credentials have actually lapsed.
- Changed it to show the real status (expired/expiring) and added a "(refreshable)" label so you can still tell the token will auto-renew on next use.

## Test plan

- [x] Updated existing test to expect true expiry status instead of masked "ok"
- [x] Added assertions for the new `refreshable` flag
- [x] `pnpm vitest run src/agents/auth-health.test.ts` passes
- [x] Related test `directive-handling.auth.test.ts` still passes

Fixes #42721