### PR TITLE
Canvas: add baseline security headers

### DIFF
--- a/src/canvas-host/a2ui.ts
+++ b/src/canvas-host/a2ui.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { setDefaultSecurityHeaders } from "../gateway/http-common.js";
 import { detectMime } from "../media/mime.js";
 import { resolveFileWithinRoot } from "./file-resolver.js";
 
@@ -154,6 +155,8 @@ export async function handleA2uiHttpRequest(
   if (!basePath) {
     return false;
   }
+
+  setDefaultSecurityHeaders(res);
 
   if (req.method !== "GET" && req.method !== "HEAD") {
     res.statusCode = 405;

--- a/src/canvas-host/server.test.ts
+++ b/src/canvas-host/server.test.ts
@@ -108,6 +108,9 @@ describe("canvas host", () => {
     try {
       const { res, html } = await fetchCanvasHtml(server.port);
       expect(res.status).toBe(200);
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(res.headers.get("permissions-policy")).toContain("camera=()");
       expect(html).toContain("Interactive test page");
       expect(html).toContain("openclawSendUserAction");
       expect(html).toContain(CANVAS_WS_PATH);
@@ -284,6 +287,9 @@ describe("canvas host", () => {
       const res = await fetch(`http://127.0.0.1:${server.port}/__openclaw__/a2ui/`);
       const html = await res.text();
       expect(res.status).toBe(200);
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(res.headers.get("permissions-policy")).toContain("camera=()");
       expect(html).toContain("openclaw-a2ui-host");
       expect(html).toContain("openclawCanvasA2UIAction");
 
@@ -292,6 +298,8 @@ describe("canvas host", () => {
       );
       const js = await bundleRes.text();
       expect(bundleRes.status).toBe(200);
+      expect(bundleRes.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(bundleRes.headers.get("referrer-policy")).toBe("no-referrer");
       expect(js).toContain("openclawA2UI");
       const traversalRes = await fetch(
         `http://127.0.0.1:${server.port}${A2UI_PATH}/%2e%2e%2fpackage.json`,

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -7,6 +7,7 @@ import type { Duplex } from "node:stream";
 import chokidar from "chokidar";
 import { type WebSocket, WebSocketServer } from "ws";
 import { resolveStateDir } from "../config/paths.js";
+import { setDefaultSecurityHeaders } from "../gateway/http-common.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { detectMime } from "../media/mime.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -307,6 +308,7 @@ export async function createCanvasHostHandler(
     try {
       const url = new URL(urlRaw, "http://localhost");
       if (url.pathname === CANVAS_WS_PATH) {
+        setDefaultSecurityHeaders(res);
         res.statusCode = liveReload ? 426 : 404;
         res.setHeader("Content-Type", "text/plain; charset=utf-8");
         res.end(liveReload ? "upgrade required" : "not found");
@@ -322,11 +324,14 @@ export async function createCanvasHostHandler(
       }
 
       if (req.method !== "GET" && req.method !== "HEAD") {
+        setDefaultSecurityHeaders(res);
         res.statusCode = 405;
         res.setHeader("Content-Type", "text/plain; charset=utf-8");
         res.end("Method Not Allowed");
         return true;
       }
+
+      setDefaultSecurityHeaders(res);
 
       const opened = await resolveFileWithinRoot(rootReal, urlPath);
       if (!opened) {


### PR DESCRIPTION
## Summary

- Problem: canvas host and A2UI responses did not apply the repo's baseline browser security headers, even though `setDefaultSecurityHeaders` is explicitly documented as safe for these surfaces.
- Why it matters: these routes serve HTML and static assets for interactive UI entry points, so they should consistently send `nosniff`, `no-referrer`, and a restrictive `Permissions-Policy`.
- What changed: reuse `setDefaultSecurityHeaders` in `src/canvas-host/server.ts` and `src/canvas-host/a2ui.ts`, and add regression coverage for canvas HTML and A2UI asset responses.
- What did NOT change (scope boundary): no auth/capability behavior, live reload semantics, or canvas content rendering logic changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #42606

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): Canvas host / A2UI HTTP surfaces
- Relevant config (redacted): local canvas host with A2UI assets present

### Steps

1. Start the canvas host locally.
2. Request `GET /__openclaw__/canvas/` and `GET /__openclaw__/a2ui/`.
3. Inspect response headers on HTML and static asset responses.

### Expected

- Canvas host and A2UI continue serving the same content.
- Responses include the repo baseline security headers: `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, and the restrictive `Permissions-Policy`.

### Actual

- The handlers now attach those headers before returning HTML, JS, 404, and method error responses on the canvas/A2UI surfaces.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: the default canvas index, A2UI scaffold HTML, and A2UI bundle responses all include the baseline security headers while preserving existing content.
- Edge cases checked: existing traversal/symlink protections, live reload injection, and state-dir resolution tests still pass.
- What you did **not** verify: browser-level rendering on a real node device.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit f7e48a98b03022149f17ee21c3ffbb60bd11beb7.
- Files/config to restore: `src/canvas-host/server.ts`, `src/canvas-host/a2ui.ts`, `src/canvas-host/server.test.ts`
- Known bad symptoms reviewers should watch for: canvas/A2UI responses lose expected headers, or previously served content starts returning different body/status values.

## Risks and Mitigations

- Risk: header application could accidentally miss one of the canvas/A2UI code paths.
- Mitigation: regression tests now cover both the default canvas HTML surface and the A2UI scaffold/bundle responses.
