### PR TITLE
feat(sessions_spawn): add lightContext param to skip workspace bootstrap files

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -540,6 +540,7 @@ public struct AgentParams: Codable, Sendable {
     public let label: String?
     public let spawnedby: String?
     public let workspacedir: String?
+    public let lightcontext: Bool?
 
     public init(
         message: String,
@@ -568,7 +569,8 @@ public struct AgentParams: Codable, Sendable {
         idempotencykey: String,
         label: String?,
         spawnedby: String?,
-        workspacedir: String?)
+        workspacedir: String?,
+        lightcontext: Bool?)
     {
         self.message = message
         self.agentid = agentid
@@ -597,6 +599,7 @@ public struct AgentParams: Codable, Sendable {
         self.label = label
         self.spawnedby = spawnedby
         self.workspacedir = workspacedir
+        self.lightcontext = lightcontext
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -627,6 +630,7 @@ public struct AgentParams: Codable, Sendable {
         case label
         case spawnedby = "spawnedBy"
         case workspacedir = "workspaceDir"
+        case lightcontext = "lightContext"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -540,6 +540,7 @@ public struct AgentParams: Codable, Sendable {
     public let label: String?
     public let spawnedby: String?
     public let workspacedir: String?
+    public let lightcontext: Bool?
 
     public init(
         message: String,
@@ -568,7 +569,8 @@ public struct AgentParams: Codable, Sendable {
         idempotencykey: String,
         label: String?,
         spawnedby: String?,
-        workspacedir: String?)
+        workspacedir: String?,
+        lightcontext: Bool?)
     {
         self.message = message
         self.agentid = agentid
@@ -597,6 +599,7 @@ public struct AgentParams: Codable, Sendable {
         self.label = label
         self.spawnedby = spawnedby
         self.workspacedir = workspacedir
+        self.lightcontext = lightcontext
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -627,6 +630,7 @@ public struct AgentParams: Codable, Sendable {
         case label
         case spawnedby = "spawnedBy"
         case workspacedir = "workspaceDir"
+        case lightcontext = "lightContext"
     }
 }
 

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -69,6 +69,7 @@ export async function runCliAgent(params: {
   /** Backward-compat fallback when only the previous signature is available. */
   bootstrapPromptWarningSignature?: string;
   images?: ImageContent[];
+  bootstrapContextMode?: "full" | "lightweight";
 }): Promise<EmbeddedPiRunResult> {
   const started = Date.now();
   const workspaceResolution = resolveRunWorkspaceDir({
@@ -111,6 +112,7 @@ export async function runCliAgent(params: {
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+    contextMode: params.bootstrapContextMode,
   });
   const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
   const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -55,6 +55,7 @@ export type SpawnSubagentParams = {
   mode?: SpawnSubagentMode;
   cleanup?: "delete" | "keep";
   sandbox?: SpawnSubagentSandboxMode;
+  lightContext?: boolean;
   expectsCompletionMessage?: boolean;
   attachments?: Array<{
     name: string;
@@ -581,6 +582,7 @@ export async function spawnSubagentDirect(
         thinking: thinkingOverride,
         timeout: runTimeoutSeconds,
         label: label || undefined,
+        lightContext: params.lightContext || undefined,
         ...spawnedMetadata,
       },
       timeoutMs: 10_000,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -42,6 +42,7 @@ const SessionsSpawnToolSchema = Type.Object({
   cleanup: optionalStringEnum(["delete", "keep"] as const),
   sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
   streamTo: optionalStringEnum(ACP_SPAWN_STREAM_TARGETS),
+  lightContext: Type.Optional(Type.Boolean()),
 
   // Inline attachments (snapshot-by-value).
   // NOTE: Attachment contents are redacted from transcript persistence by sanitizeToolCallInputs.
@@ -118,6 +119,7 @@ export function createSessionsSpawnTool(
           ? Math.max(0, Math.floor(timeoutSecondsCandidate))
           : undefined;
       const thread = params.thread === true;
+      const lightContext = params.lightContext === true;
       const attachments = Array.isArray(params.attachments)
         ? (params.attachments as Array<{
             name: string;
@@ -185,6 +187,7 @@ export function createSessionsSpawnTool(
           mode,
           cleanup,
           sandbox,
+          lightContext,
           expectsCompletionMessage: true,
           attachments,
           attachMountPath:

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -144,6 +144,13 @@ export function createSessionsSpawnTool(
       }
 
       if (runtime === "acp") {
+        if (lightContext) {
+          return jsonResult({
+            status: "error",
+            error:
+              "lightContext is currently unsupported for runtime=acp; use runtime=subagent or remove lightContext",
+          });
+        }
         if (Array.isArray(attachments) && attachments.length > 0) {
           return jsonResult({
             status: "error",

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -498,6 +498,7 @@ function runAgentAttempt(params: {
     onAgentEvent: params.onAgentEvent,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,
+    bootstrapContextMode: params.opts.lightContext ? "lightweight" : undefined,
   });
 }
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -376,6 +376,7 @@ function runAgentAttempt(params: {
         bootstrapPromptWarningSignature,
         images: params.isFallbackRetry ? undefined : params.opts.images,
         streamParams: params.opts.streamParams,
+        bootstrapContextMode: params.opts.lightContext ? "lightweight" : undefined,
       });
     return runCliWithSession(cliSessionId).catch(async (err) => {
       // Handle CLI session expired error

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -80,6 +80,8 @@ export type AgentCommandOpts = {
   streamParams?: AgentStreamParams;
   /** Explicit workspace directory override (for subagents to inherit parent workspace). */
   workspaceDir?: SpawnedRunMetadata["workspaceDir"];
+  /** Skip workspace bootstrap file injection (SOUL.md, USER.md, etc.) when true. */
+  lightContext?: boolean;
 };
 
 export type AgentCommandIngressOpts = Omit<AgentCommandOpts, "senderIsOwner"> & {

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -112,6 +112,7 @@ export const AgentParamsSchema = Type.Object(
     label: Type.Optional(SessionLabelString),
     spawnedBy: Type.Optional(Type.String()),
     workspaceDir: Type.Optional(Type.String()),
+    lightContext: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -193,6 +193,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       spawnedBy?: string;
       inputProvenance?: InputProvenance;
       workspaceDir?: string;
+      lightContext?: boolean;
     };
     const senderIsOwner = resolveSenderIsOwnerFromClient(client);
     const cfg = loadConfig();
@@ -631,6 +632,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           workspaceDir: request.workspaceDir,
         }),
         senderIsOwner,
+        lightContext: request.lightContext || undefined,
       },
       runId,
       idempotencyKey: idem,


### PR DESCRIPTION
## Summary

Adds `lightContext: boolean` parameter to `sessions_spawn`, allowing callers to skip workspace bootstrap file injection (SOUL.md, USER.md, AGENTS.md, MEMORY.md, etc.) for spawned subagents.

This is useful for code-only subagents (e.g. implementation agents in multi-agent workflows) that don't need persona/memory context, saving tokens and preventing unintended data leakage.

## How it works

Reuses the existing `bootstrapContextMode: "lightweight"` mechanism already used by cron (`lightContext` in `agentTurn` payload) and heartbeat runners. The new parameter simply exposes this to `sessions_spawn`.

## Changes (6 files, +11 lines)

- **`sessions-spawn-tool.ts`**: Parse `lightContext` from tool args, pass to `spawnSubagentDirect`
- **`subagent-spawn.ts`**: Add `lightContext` to `SpawnSubagentParams`, forward via `callGateway`
- **`gateway/protocol/schema/agent.ts`**: Add `lightContext` to agent RPC schema
- **`gateway/server-methods/agent.ts`**: Read `lightContext` from request, pass to ingress opts
- **`commands/agent/types.ts`**: Add `lightContext` to `AgentCommandOpts`
- **`commands/agent.ts`**: Convert `lightContext` → `bootstrapContextMode: "lightweight"` for `runEmbeddedPiAgent`

## Usage

```
sessions_spawn(task: "...", lightContext: true)
```

TypeScript compiles with zero errors.