### PR TITLE
Terminal: fix note contrast in web terminals

### DIFF
--- a/src/terminal/note.test.ts
+++ b/src/terminal/note.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { clackNoteMock } = vi.hoisted(() => ({
+  clackNoteMock: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  note: clackNoteMock,
+}));
+
+describe("note", () => {
+  const originalSuppressNotes = process.env.OPENCLAW_SUPPRESS_NOTES;
+
+  beforeEach(() => {
+    clackNoteMock.mockClear();
+    delete process.env.OPENCLAW_SUPPRESS_NOTES;
+  });
+
+  afterEach(() => {
+    if (originalSuppressNotes === undefined) {
+      delete process.env.OPENCLAW_SUPPRESS_NOTES;
+    } else {
+      process.env.OPENCLAW_SUPPRESS_NOTES = originalSuppressNotes;
+    }
+    vi.resetModules();
+  });
+
+  it("applies an explicit foreground color to note bodies in rich terminals", async () => {
+    vi.doMock("./prompt-style.js", () => ({
+      stylePromptTitle: (value?: string) => value,
+    }));
+    vi.doMock("./theme.js", () => ({
+      isRich: () => true,
+      theme: { body: (value: string) => `body:${value}` },
+    }));
+
+    const { note } = await import("./note.js");
+    note("Provider notes go here", "Provider notes");
+
+    const renderedMessage = clackNoteMock.mock.calls[0]?.[0];
+    expect(renderedMessage).toBe("body:Provider notes go here");
+  });
+
+  it("leaves note bodies unstyled when colors are disabled", async () => {
+    vi.doMock("./prompt-style.js", () => ({
+      stylePromptTitle: (value?: string) => value,
+    }));
+    vi.doMock("./theme.js", () => ({
+      isRich: () => false,
+      theme: { body: (value: string) => `body:${value}` },
+    }));
+
+    const { note } = await import("./note.js");
+    note("Plain output", "Plain");
+
+    expect(clackNoteMock).toHaveBeenCalledWith("Plain output", "Plain");
+  });
+});

--- a/src/terminal/note.ts
+++ b/src/terminal/note.ts
@@ -1,6 +1,7 @@
 import { note as clackNote } from "@clack/prompts";
 import { visibleWidth } from "./ansi.js";
 import { stylePromptTitle } from "./prompt-style.js";
+import { isRich, theme } from "./theme.js";
 
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
@@ -144,5 +145,6 @@ export function note(message: string, title?: string) {
   if (isSuppressedByEnv(process.env.OPENCLAW_SUPPRESS_NOTES)) {
     return;
   }
-  clackNote(wrapNoteMessage(message), stylePromptTitle(title));
+  const wrapped = wrapNoteMessage(message);
+  clackNote(isRich() ? theme.body(wrapped) : wrapped, stylePromptTitle(title));
 }

--- a/src/terminal/palette.ts
+++ b/src/terminal/palette.ts
@@ -4,6 +4,7 @@ export const LOBSTER_PALETTE = {
   accent: "#FF5A2D",
   accentBright: "#FF7A3D",
   accentDim: "#D14A22",
+  body: "#F5EFE8",
   info: "#FF8A5B",
   success: "#2FBF71",
   warn: "#FFB020",

--- a/src/terminal/theme.ts
+++ b/src/terminal/theme.ts
@@ -14,6 +14,7 @@ export const theme = {
   accent: hex(LOBSTER_PALETTE.accent),
   accentBright: hex(LOBSTER_PALETTE.accentBright),
   accentDim: hex(LOBSTER_PALETTE.accentDim),
+  body: hex(LOBSTER_PALETTE.body),
   info: hex(LOBSTER_PALETTE.info),
   success: hex(LOBSTER_PALETTE.success),
   warn: hex(LOBSTER_PALETTE.warn),


### PR DESCRIPTION
## Summary

- Problem: CLI note boxes relied on the terminal default foreground color for the body text, which makes note content unreadable in some web-based terminals like Dokploy/xterm.js.
- Why it matters: provider notes and other note boxes become effectively invisible even though the borders render, which blocks setup and diagnostics flows.
- What changed: add an explicit Lobster body color for note content in rich terminals, while preserving plain output when colors are disabled.
- What did NOT change (scope boundary): box layout, wrapping, command behavior, and `NO_COLOR` behavior stay the same.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #3989
- Related #42770

## User-visible / Behavior Changes

- Note box bodies now use an explicit readable foreground color in rich terminals instead of inheriting the terminal default text color.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): CLI / terminal rendering
- Relevant config (redacted): rich terminal output enabled

### Steps

1. Trigger a CLI flow that emits `note()` output, such as provider setup notes.
2. Render the note box in a web-based terminal that mishandles default foreground colors.
3. Inspect the body text styling.

### Expected

- Note box body text remains readable with an explicit foreground color.
- `NO_COLOR=1` still emits plain unstyled content.

### Actual

- `note()` now applies an explicit body color in rich terminals and keeps plain text output when colors are disabled.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: rich-terminal `note()` path now applies an explicit body style before delegating to Clack, and the no-color path stays unchanged.
- Edge cases checked: existing prompt styling test still passes, and wizard session note flow tests still pass.
- What you did **not** verify: a live Dokploy/xterm.js instance end-to-end.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit 9b52d595573119bdf7236628f16a97eba26d9bec.
- Files/config to restore: `src/terminal/palette.ts`, `src/terminal/theme.ts`, `src/terminal/note.ts`, `src/terminal/note.test.ts`
- Known bad symptoms reviewers should watch for: note box text inherits terminal defaults again or `NO_COLOR` starts emitting ANSI styles.

## Risks and Mitigations

- Risk: explicit body styling could accidentally leak ANSI into no-color mode.
- Mitigation: regression coverage now asserts the no-color path remains plain and unstyled.
