### PR TITLE
Daemon: preserve gateway bind mode in service args

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -89,6 +89,29 @@ describe("buildGatewayInstallPlan", () => {
     expect(mocks.resolvePreferredNodePath).not.toHaveBeenCalled();
   });
 
+  it("forwards configured gateway bind mode into the service command", async () => {
+    mockNodeGatewayPlanFixture();
+
+    await buildGatewayInstallPlan({
+      env: {},
+      port: 3000,
+      runtime: "node",
+      config: {
+        gateway: {
+          bind: "lan",
+        },
+      },
+    });
+
+    expect(mocks.resolveGatewayProgramArguments).toHaveBeenCalledWith({
+      port: 3000,
+      bind: "lan",
+      dev: false,
+      runtime: "node",
+      nodePath: "/opt/node",
+    });
+  });
+
   it("emits warnings when renderSystemNodeWarning returns one", async () => {
     const warn = vi.fn();
     mockNodeGatewayPlanFixture({

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -37,6 +37,7 @@ export async function buildGatewayInstallPlan(params: {
   });
   const { programArguments, workingDirectory } = await resolveGatewayProgramArguments({
     port: params.port,
+    bind: params.config?.gateway?.bind,
     dev: devMode,
     runtime: params.runtime,
     nodePath,

--- a/src/daemon/program-args.test.ts
+++ b/src/daemon/program-args.test.ts
@@ -87,4 +87,29 @@ describe("resolveGatewayProgramArguments", () => {
       "18789",
     ]);
   });
+
+  it("forwards gateway bind mode into the service command", async () => {
+    const argv1 = path.resolve("/tmp/.npm/_npx/63c3/node_modules/.bin/openclaw");
+    const indexPath = path.resolve("/tmp/.npm/_npx/63c3/node_modules/openclaw/dist/index.js");
+    process.argv = ["node", argv1];
+    fsMocks.realpath.mockRejectedValue(new Error("no realpath"));
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === indexPath) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const result = await resolveGatewayProgramArguments({ port: 18789, bind: "lan" });
+
+    expect(result.programArguments).toEqual([
+      process.execPath,
+      indexPath,
+      "gateway",
+      "--port",
+      "18789",
+      "--bind",
+      "lan",
+    ]);
+  });
 });

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -232,11 +232,15 @@ async function resolveCliProgramArguments(params: {
 
 export async function resolveGatewayProgramArguments(params: {
   port: number;
+  bind?: "auto" | "custom" | "lan" | "loopback" | "tailnet";
   dev?: boolean;
   runtime?: GatewayRuntimePreference;
   nodePath?: string;
 }): Promise<GatewayProgramArgs> {
   const gatewayArgs = ["gateway", "--port", String(params.port)];
+  if (params.bind) {
+    gatewayArgs.push("--bind", params.bind);
+  }
   return resolveCliProgramArguments({
     args: gatewayArgs,
     dev: params.dev,


### PR DESCRIPTION
## Summary

- Problem: daemon-installed gateway services only preserved `--port`, so `gateway.bind` was lost and the service restarted on the default loopback bind.
- Why it matters: users configuring `gateway.bind: "lan"`, `"tailnet"`, or `"custom"` saw the gateway come up on localhost after install/restart, matching #4947.
- What changed: `buildGatewayInstallPlan()` now forwards the configured bind mode into `resolveGatewayProgramArguments()`, and the gateway service command now includes `--bind <mode>`.
- What did NOT change (scope boundary): runtime bind resolution, auth, and config validation logic are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #4947
- Related #42785

## User-visible / Behavior Changes

- Gateway daemon installs/reinstalls now preserve the configured bind mode instead of silently falling back to loopback.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): Gateway daemon install flow
- Relevant config (redacted): `gateway.bind: "lan"`

### Steps

1. Configure `gateway.bind` to a non-loopback mode.
2. Build the daemon install plan / install the service.
3. Inspect the generated service command arguments.

### Expected

- The service command includes the configured bind mode, so restarts preserve the intended network listener.

### Actual

- The generated gateway service args now include `--bind <mode>` in addition to `--port`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `resolveGatewayProgramArguments()` now emits `--bind lan`, and `buildGatewayInstallPlan()` forwards `config.gateway.bind` into the service command generation path.
- Edge cases checked: existing daemon CLI coverage tests still pass, and the default no-bind case remains unchanged.
- What you did **not** verify: an end-to-end launchd/systemd install on a real non-loopback host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit 05e573fb555b36f5411fa2658205aa6792cbade6.
- Files/config to restore: `src/daemon/program-args.ts`, `src/daemon/program-args.test.ts`, `src/commands/daemon-install-helpers.ts`, `src/commands/daemon-install-helpers.test.ts`
- Known bad symptoms reviewers should watch for: installed services still bind only to localhost despite non-loopback config, or service command args gain duplicate/invalid bind flags.

## Risks and Mitigations

- Risk: install flows could accidentally pass an unexpected bind mode into the service command.
- Mitigation: the change only forwards already-validated config values, and tests now lock the generated argument list at both the low-level and install-plan layers.
