### PR TITLE
fix(status): skip tailscale probe when mode is off

### DIFF
--- a/src/commands/status-all.test.ts
+++ b/src/commands/status-all.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { readStatusAllTailscale } from "./status-all.js";
+
+describe("readStatusAllTailscale", () => {
+  it("skips tailscale status reads when gateway tailscale mode is off", async () => {
+    const readStatusJson = vi.fn();
+
+    const result = await readStatusAllTailscale({
+      tailscaleMode: "off",
+      readStatusJson,
+    });
+
+    expect(readStatusJson).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: true,
+      backendState: null,
+      dnsName: null,
+      ips: [],
+      error: null,
+    });
+  });
+
+  it("reads and normalizes tailscale status when gateway tailscale mode is enabled", async () => {
+    const readStatusJson = vi.fn().mockResolvedValue({
+      BackendState: "Running",
+      Self: {
+        DNSName: "host.tailnet.ts.net.",
+        TailscaleIPs: ["100.64.0.1", "  ", 42, "fd7a:115c:a1e0::1"],
+      },
+    });
+
+    const result = await readStatusAllTailscale({
+      tailscaleMode: "serve",
+      timeoutMs: 4321,
+      readStatusJson,
+    });
+
+    expect(readStatusJson).toHaveBeenCalledWith(expect.any(Function), {
+      timeoutMs: 4321,
+    });
+    expect(result).toEqual({
+      ok: true,
+      backendState: "Running",
+      dnsName: "host.tailnet.ts.net",
+      ips: ["100.64.0.1", "fd7a:115c:a1e0::1"],
+      error: null,
+    });
+  });
+});

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -37,6 +37,60 @@ import { buildStatusAllReportLines } from "./status-all/report-lines.js";
 import { readServiceStatusSummary } from "./status.service-summary.js";
 import { formatUpdateOneLiner } from "./status.update.js";
 
+type StatusAllTailscaleState = {
+  ok: boolean;
+  backendState: string | null;
+  dnsName: string | null;
+  ips: string[];
+  error: string | null;
+};
+
+export async function readStatusAllTailscale(params: {
+  tailscaleMode?: string;
+  exec?: typeof runExec;
+  timeoutMs?: number;
+  readStatusJson?: typeof readTailscaleStatusJson;
+}): Promise<StatusAllTailscaleState> {
+  if ((params.tailscaleMode ?? "off") === "off") {
+    return {
+      ok: true,
+      backendState: null,
+      dnsName: null,
+      ips: [],
+      error: null,
+    };
+  }
+
+  const readStatusJson = params.readStatusJson ?? readTailscaleStatusJson;
+  try {
+    const parsed = await readStatusJson(params.exec ?? runExec, {
+      timeoutMs: params.timeoutMs ?? 1200,
+    });
+    const backendState = typeof parsed.BackendState === "string" ? parsed.BackendState : null;
+    const self =
+      typeof parsed.Self === "object" && parsed.Self !== null
+        ? (parsed.Self as Record<string, unknown>)
+        : null;
+    const dnsNameRaw = self && typeof self.DNSName === "string" ? self.DNSName : null;
+    const dnsName = dnsNameRaw ? dnsNameRaw.replace(/\.$/, "") : null;
+    const ips =
+      self && Array.isArray(self.TailscaleIPs)
+        ? (self.TailscaleIPs as unknown[])
+            .filter((v) => typeof v === "string" && v.trim().length > 0)
+            .map((v) => (v as string).trim())
+        : [];
+    return { ok: true, backendState, dnsName, ips, error: null };
+  } catch (err) {
+    return {
+      ok: false,
+      backendState: null,
+      dnsName: null,
+      ips: [],
+      error: String(err),
+    };
+  }
+}
+
 export async function statusAllCommand(
   runtime: RuntimeEnv,
   opts?: { timeoutMs?: number },
@@ -56,35 +110,11 @@ export async function statusAllCommand(
 
     progress.setLabel("Checking Tailscale…");
     const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
-    const tailscale = await (async () => {
-      try {
-        const parsed = await readTailscaleStatusJson(runExec, {
-          timeoutMs: 1200,
-        });
-        const backendState = typeof parsed.BackendState === "string" ? parsed.BackendState : null;
-        const self =
-          typeof parsed.Self === "object" && parsed.Self !== null
-            ? (parsed.Self as Record<string, unknown>)
-            : null;
-        const dnsNameRaw = self && typeof self.DNSName === "string" ? self.DNSName : null;
-        const dnsName = dnsNameRaw ? dnsNameRaw.replace(/\.$/, "") : null;
-        const ips =
-          self && Array.isArray(self.TailscaleIPs)
-            ? (self.TailscaleIPs as unknown[])
-                .filter((v) => typeof v === "string" && v.trim().length > 0)
-                .map((v) => (v as string).trim())
-            : [];
-        return { ok: true as const, backendState, dnsName, ips, error: null };
-      } catch (err) {
-        return {
-          ok: false as const,
-          backendState: null,
-          dnsName: null,
-          ips: [] as string[],
-          error: String(err),
-        };
-      }
-    })();
+    const tailscale = await readStatusAllTailscale({
+      tailscaleMode,
+      exec: runExec,
+      timeoutMs: 1200,
+    });
     const tailscaleHttpsUrl =
       tailscaleMode !== "off" && tailscale.dnsName
         ? `https://${tailscale.dnsName}${normalizeControlUiBasePath(cfg.gateway?.controlUi?.basePath)}`

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { appendStatusAllDiagnosis } from "./diagnosis.js";
+
+describe("appendStatusAllDiagnosis", () => {
+  it("marks tailscale off mode as healthy even when backend state is unknown", async () => {
+    const lines: string[] = [];
+    await appendStatusAllDiagnosis({
+      lines,
+      progress: {
+        setLabel: () => {},
+        setPercent: () => {},
+        tick: () => {},
+        done: () => {},
+      },
+      muted: (text) => text,
+      ok: (text) => text,
+      warn: (text) => text,
+      fail: (text) => text,
+      connectionDetailsForReport: "local",
+      snap: null,
+      remoteUrlMissing: false,
+      sentinel: null,
+      lastErr: null,
+      port: 18789,
+      portUsage: null,
+      tailscaleMode: "off",
+      tailscale: {
+        backendState: null,
+        dnsName: null,
+        ips: [],
+        error: null,
+      },
+      tailscaleHttpsUrl: null,
+      skillStatus: null,
+      channelsStatus: null,
+      channelIssues: [],
+      gatewayReachable: false,
+      health: null,
+    });
+
+    expect(lines).toContain("✓ Tailscale: off · unknown");
+  });
+});

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -139,7 +139,8 @@ export async function appendStatusAllDiagnosis(params: {
       params.tailscaleMode === "off"
         ? `Tailscale: off · ${backend}${params.tailscale.dnsName ? ` · ${params.tailscale.dnsName}` : ""}`
         : `Tailscale: ${params.tailscaleMode} · ${backend}${params.tailscale.dnsName ? ` · ${params.tailscale.dnsName}` : ""}`;
-    emitCheck(label, okBackend && (params.tailscaleMode === "off" || hasDns) ? "ok" : "warn");
+    const tailscaleHealthy = params.tailscaleMode === "off" ? true : okBackend && hasDns;
+    emitCheck(label, tailscaleHealthy ? "ok" : "warn");
     if (params.tailscale.error) {
       lines.push(`  ${muted(`error: ${params.tailscale.error}`)}`);
     }


### PR DESCRIPTION
## Summary
- avoid probing `tailscale status --json` when `gateway.tailscale.mode` is `off`
- extract tailscale read logic into `readStatusAllTailscale` for easier gating/testing
- add regression tests for both `off` mode skip path and enabled-mode parsing path

## Why
`openclaw status` could surface a noisy ENOENT warning for tailscale even when tailscale mode was explicitly disabled. This keeps disabled mode quiet while preserving existing behavior when tailscale is enabled.

Fixes #42685

## Testing
- Added `src/commands/status-all.test.ts`
- Attempted local test run in a clean clone, but monorepo install in this environment hit an unrelated git-hosted dependency prepare failure (`@tloncorp/api` npm-install spawn ENOENT).
