### PR TITLE
Gateway: narrow model picker to available providers

### DIFF
--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -1,4 +1,6 @@
+import { ensureAuthProfileStore, listProfilesForProvider } from "../../agents/auth-profiles.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { hasUsableCustomProviderApiKey, resolveEnvApiKey } from "../../agents/model-auth.js";
 import { buildAllowedModelSet } from "../../agents/model-selection.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -8,6 +10,23 @@ import {
   validateModelsListParams,
 } from "../protocol/index.js";
 import type { GatewayRequestHandlers } from "./types.js";
+
+function hasAuthForProvider(
+  provider: string,
+  cfg: ReturnType<typeof loadConfig>,
+  store: ReturnType<typeof ensureAuthProfileStore>,
+) {
+  if (listProfilesForProvider(store, provider).length > 0) {
+    return true;
+  }
+  if (resolveEnvApiKey(provider)) {
+    return true;
+  }
+  if (hasUsableCustomProviderApiKey(cfg, provider)) {
+    return true;
+  }
+  return false;
+}
 
 export const modelsHandlers: GatewayRequestHandlers = {
   "models.list": async ({ params, respond, context }) => {
@@ -25,12 +44,23 @@ export const modelsHandlers: GatewayRequestHandlers = {
     try {
       const catalog = await context.loadGatewayModelCatalog();
       const cfg = loadConfig();
-      const { allowedCatalog } = buildAllowedModelSet({
+      const { allowAny, allowedCatalog } = buildAllowedModelSet({
         cfg,
         catalog,
         defaultProvider: DEFAULT_PROVIDER,
       });
-      const models = allowedCatalog.length > 0 ? allowedCatalog : catalog;
+      let models = allowedCatalog.length > 0 ? allowedCatalog : catalog;
+      if (allowAny) {
+        const store = ensureAuthProfileStore(undefined, {
+          allowKeychainPrompt: false,
+        });
+        const authFiltered = catalog.filter((entry) =>
+          hasAuthForProvider(entry.provider, cfg, store),
+        );
+        if (authFiltered.length > 0) {
+          models = authFiltered;
+        }
+      }
       respond(true, { models }, undefined);
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:net";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { WebSocket } from "ws";
+import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles.js";
 import { getChannelPlugin } from "../channels/plugins/index.js";
 import type { ChannelOutboundAdapter } from "../channels/plugins/types.js";
 import { clearConfigCache } from "../config/config.js";
@@ -191,6 +192,28 @@ describe("gateway server models + voicewake", () => {
     }
   };
 
+  const withIsolatedModelAuth = async <T>(
+    env: Record<string, string | undefined>,
+    fn: () => Promise<T>,
+  ): Promise<T> => {
+    clearRuntimeAuthProfileStoreSnapshots();
+    try {
+      return await withTempHome(async () =>
+        withEnvAsync(
+          {
+            OPENAI_API_KEY: undefined,
+            ANTHROPIC_API_KEY: undefined,
+            ANTHROPIC_OAUTH_TOKEN: undefined,
+            ...env,
+          },
+          fn,
+        ),
+      );
+    } finally {
+      clearRuntimeAuthProfileStoreSnapshots();
+    }
+  };
+
   const expectAllowlistedModels = async (options: {
     primary: string;
     models: Record<string, object>;
@@ -302,18 +325,20 @@ describe("gateway server models + voicewake", () => {
   });
 
   test("models.list returns model catalog", async () => {
-    seedPiCatalog();
+    await withIsolatedModelAuth({}, async () => {
+      seedPiCatalog();
 
-    const res1 = await listModels();
-    const res2 = await listModels();
+      const res1 = await listModels();
+      const res2 = await listModels();
 
-    expect(res1.ok).toBe(true);
-    expect(res2.ok).toBe(true);
+      expect(res1.ok).toBe(true);
+      expect(res2.ok).toBe(true);
 
-    const models = res1.payload?.models ?? [];
-    expect(models).toEqual(expectedSortedCatalog());
+      const models = res1.payload?.models ?? [];
+      expect(models).toEqual(expectedSortedCatalog());
 
-    expect(piSdkMock.discoverCalls).toBe(1);
+      expect(piSdkMock.discoverCalls).toBe(1);
+    });
   });
 
   test("models.list filters to allowlisted configured models by default", async () => {
@@ -337,6 +362,34 @@ describe("gateway server models + voicewake", () => {
         },
       ],
     });
+  });
+
+  test("models.list filters to authenticated providers when no allowlist is configured", async () => {
+    await withIsolatedModelAuth(
+      {
+        OPENAI_API_KEY: "sk-openai-test", // pragma: allowlist secret
+      },
+      async () => {
+        await withModelsConfig({}, async () => {
+          seedPiCatalog();
+          const res = await listModels();
+          expect(res.ok).toBe(true);
+          expect(res.payload?.models).toEqual([
+            {
+              id: "gpt-test-a",
+              name: "A-Model",
+              provider: "openai",
+              contextWindow: 8000,
+            },
+            {
+              id: "gpt-test-z",
+              name: "gpt-test-z",
+              provider: "openai",
+            },
+          ]);
+        });
+      },
+    );
   });
 
   test("models.list includes synthetic entries for allowlist models absent from catalog", async () => {


### PR DESCRIPTION
Closes #4349.

## Summary
- narrow `models.list` to providers that are actually usable when no explicit model allowlist is configured
- keep the full catalog fallback when no providers are authenticated so unconfigured installs still see the bundled list
- add gateway coverage for both the fallback path and the authenticated-provider filtering path

## Testing
- pnpm test src/gateway/server.models-voicewake-misc.test.ts
- pnpm test src/commands/model-picker.test.ts
- pnpm test src/tui/tui-command-handlers.test.ts
