### PR TITLE
fix(model-scan): add null check for model.input to prevent crashes with custom providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Docs: https://docs.openclaw.ai
 - Commands/config writes: enforce `configWrites` against both the originating account and the targeted account scope for `/config` and config-backed `/allowlist` edits, blocking sibling-account mutations while preserving gateway `operator.admin` flows. Thanks @tdjackey for reporting.
 - Security/system.run: fail closed for approval-backed interpreter/runtime commands when OpenClaw cannot bind exactly one concrete local file operand, while extending best-effort direct-file binding to additional runtime forms. Thanks @tdjackey for reporting.
 - Gateway/session reset auth: split conversation `/new` and `/reset` handling away from the admin-only `sessions.reset` control-plane RPC so write-scoped gateway callers can no longer reach the privileged reset path through `agent`. Thanks @tdjackey for reporting.
+- Model scan: add null check for `model.input` to prevent crashes when using custom OpenAI-compatible providers that do not define the `input` field on model objects. (#42068)
 
 ## 2026.3.8
 

--- a/src/agents/model-scan.test.ts
+++ b/src/agents/model-scan.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
-import { scanOpenRouterModels } from "./model-scan.js";
+import { ensureImageInput, scanOpenRouterModels } from "./model-scan.js";
 
 function createFetchFixture(payload: unknown): typeof fetch {
   return withFetchPreconnect(
@@ -79,5 +79,55 @@ describe("scanOpenRouterModels", () => {
         }),
       ).rejects.toThrow(/Missing OpenRouter API key/);
     });
+  });
+});
+
+describe("ensureImageInput", () => {
+  const baseModel = {
+    id: "test/model",
+    provider: "openai-completions",
+    contextWindow: 4096,
+    maxTokens: 1024,
+  } as const;
+
+  it("adds image to model without input field (undefined)", () => {
+    const model = { ...baseModel, input: undefined } as unknown as Parameters<
+      typeof ensureImageInput
+    >[0];
+    const result = ensureImageInput(model);
+    expect(result.input).toContain("image");
+    expect(result.input).toBeDefined();
+    expect(Array.isArray(result.input)).toBe(true);
+  });
+
+  it("adds image to model with null input", () => {
+    const model = { ...baseModel, input: null } as unknown as Parameters<
+      typeof ensureImageInput
+    >[0];
+    const result = ensureImageInput(model);
+    expect(result.input).toContain("image");
+    expect(result.input).toBeDefined();
+    expect(Array.isArray(result.input)).toBe(true);
+  });
+
+  it("adds image to model with empty input array", () => {
+    const model = { ...baseModel, input: [] as ("text" | "image")[] };
+    const result = ensureImageInput(model);
+    expect(result.input).toContain("image");
+    expect(result.input).toHaveLength(1);
+  });
+
+  it("preserves existing image capability without modification", () => {
+    const model = { ...baseModel, input: ["text", "image"] as ("text" | "image")[] };
+    const result = ensureImageInput(model);
+    expect(result.input).toEqual(["text", "image"]);
+    expect(result.input).toHaveLength(2);
+  });
+
+  it("adds image to text-only model while preserving text", () => {
+    const model = { ...baseModel, input: ["text"] as ("text" | "image")[] };
+    const result = ensureImageInput(model);
+    expect(result.input).toContain("image");
+    expect(result.input).toContain("text");
   });
 });

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -325,13 +325,13 @@ async function probeImage(
   }
 }
 
-function ensureImageInput(model: OpenAIModel): OpenAIModel {
-  if (model.input.includes("image")) {
+export function ensureImageInput(model: OpenAIModel): OpenAIModel {
+  if (model.input?.includes("image")) {
     return model;
   }
   return {
     ...model,
-    input: Array.from(new Set([...model.input, "image"])),
+    input: Array.from(new Set([...(model.input ?? []), "image"])),
   };
 }
 
@@ -472,7 +472,7 @@ export async function scanOpenRouterModels(
       };
 
       const toolResult = await probeTool(model, apiKey, timeoutMs);
-      const imageResult = model.input.includes("image")
+      const imageResult = model.input?.includes("image")
         ? await probeImage(ensureImageInput(model), apiKey, timeoutMs)
         : { ok: false, latencyMs: null, skipped: true };
 


### PR DESCRIPTION
## Summary

- **Problem:** Custom OpenAI-compatible providers (e.g., MiniMax) that don't define the `input` field on model objects cause crashes when `model.input.includes("image")` is called without null-checking.
- **Why it matters:** LCM (Lossless Context Management) compaction fails for custom providers, forcing fallback to truncation and blocking proper context management.
- **What changed:** Added optional chaining (`?.`) and nullish coalescing (`??`) for safe property access on `model.input` in `model-scan.ts`. Also exported `ensureImageInput` for reuse and added comprehensive unit tests.
- **What did NOT change:** No changes to pi-ai library (external dependency) - that fix needs to be done separately.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42068

## User-visible / Behavior Changes

- Custom OpenAI-compatible providers without `input` field will no longer crash during model scanning
- LCM compaction will work correctly for these providers (pending pi-ai fix for complete resolution)

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Evidence

- [x] Failing test/log before + passing after

```
Test output:
✓ src/agents/model-scan.test.ts (7 tests) 6ms
  ✓ lists free models without probing
  ✓ requires an API key when probing
  ✓ adds image to model without input field (undefined)
  ✓ adds image to model with null input
  ✓ adds image to model with empty input array
  ✓ preserves existing image capability without modification
  ✓ adds image to text-only model while preserving text
```

## Human Verification (required)

- Verified scenarios: Null input, undefined input, empty array input, existing image capability, text-only input
- Edge cases checked: All null/undefined variants of `model.input`
- What you did **not** verify: Live testing with actual MiniMax provider (would require API key)

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** Partial fix - issue #42068 also requires fixes in pi-ai library (`providers/openai-completions.js` lines 445, 562)
  - **Mitigation:** This PR fixes the openclaw codebase portion; pi-ai fix should be tracked separately

## AI-Assisted PR 🤖

- [x] Mark as AI-assisted
- [x] Degree of testing: **Fully tested** (7 unit tests)
- [x] Confirm understanding: Defensive null-checking for `model.input` property access

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
