### PR TITLE
fix(directives): preserve whitespace inside fenced code blocks

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  parseInlineDirectives,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "./directive-tags.js";
@@ -24,6 +25,39 @@ describe("stripInlineDirectiveTagsForDisplay", () => {
     const result = stripInlineDirectiveTagsForDisplay(input);
     expect(result.changed).toBe(false);
     expect(result.text).toBe(input);
+  });
+});
+
+describe("parseInlineDirectives whitespace normalization", () => {
+  test("preserves indentation inside fenced code blocks", () => {
+    const input = "here is some yaml:\n```yaml\na:\n  b:\n    c: value\n```";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("here is some yaml:\n```yaml\na:\n  b:\n    c: value\n```");
+  });
+
+  test("normalizes whitespace outside code blocks but preserves inside", () => {
+    const input = "some   text\n```\n  indented\n    more\n```\nother   text";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("some text\n```\n  indented\n    more\n```\nother text");
+  });
+
+  test("handles directive tags with code blocks", () => {
+    const input = "[[reply_to_current]] here:\n```\n  keep  spaces\n```";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("here:\n```\n  keep  spaces\n```");
+    expect(result.replyToCurrent).toBe(true);
+  });
+
+  test("handles multiple code blocks", () => {
+    const input = "first:\n```\n  a\n```\nmiddle   text\n```\n  b\n```";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("first:\n```\n  a\n```\nmiddle text\n```\n  b\n```");
+  });
+
+  test("preserves indentation in 4+ backtick fences", () => {
+    const input = "text:\n````\n  ```\n  nested\n  ```\n````";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toBe("text:\n````\n  ```\n  nested\n  ```\n````");
   });
 });
 

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -18,10 +18,25 @@ const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 
 function normalizeDirectiveWhitespace(text: string): string {
-  return text
-    .replace(/[ \t]+/g, " ")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .trim();
+  // Split around fenced code blocks (3+ backticks) to avoid collapsing
+  // their indentation. We use replace to collect segments so we can
+  // match the opening fence length to the closing fence.
+  const parts: string[] = [];
+  let lastIndex = 0;
+  const fenceRe = /(`{3,})([^\n]*\n[\s\S]*?\n)\1/g;
+  let match: RegExpExecArray | null;
+  while ((match = fenceRe.exec(text)) !== null) {
+    // Normalize text before this code block
+    const before = text.slice(lastIndex, match.index);
+    parts.push(before.replace(/[ \t]+/g, " ").replace(/[ \t]*\n[ \t]*/g, "\n"));
+    // Keep the code block as-is
+    parts.push(match[0]);
+    lastIndex = match.index + match[0].length;
+  }
+  // Normalize remaining text after the last code block
+  const after = text.slice(lastIndex);
+  parts.push(after.replace(/[ \t]+/g, " ").replace(/[ \t]*\n[ \t]*/g, "\n"));
+  return parts.join("").trim();
 }
 
 type StripInlineDirectiveTagsResult = {


### PR DESCRIPTION
## Summary

- `normalizeDirectiveWhitespace()` was running its space/tab collapse regex across the entire message text, including inside fenced code blocks. This destroyed indentation in YAML, Python, and anything else where leading whitespace matters.
- Fixed it by splitting around ``` fences first and only normalizing the non-code segments.

## Test plan

- [x] Added test: indentation inside fenced code blocks is preserved
- [x] Added test: whitespace outside code blocks is still normalized
- [x] Added test: directive tags alongside code blocks work correctly
- [x] Added test: multiple code blocks in one message handled properly
- [x] Existing directive-tags tests still pass
- [x] `pnpm vitest run src/utils/directive-tags.test.ts` — 10/10 passing

Fixes #42576