### PR TITLE
Reply: preserve indentation after stripping inline tags

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  parseInlineDirectives,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "./directive-tags.js";
@@ -55,5 +56,37 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
     };
     const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
     expect(result).toEqual(input);
+  });
+});
+
+describe("parseInlineDirectives", () => {
+  test("preserves indentation inside fenced code blocks after stripping reply tags", () => {
+    const input = [
+      "[[reply_to_current]] Here is YAML:",
+      "",
+      "```yaml",
+      "a:",
+      "  b:",
+      "    c: sadffdsd",
+      "```",
+    ].join("\n");
+
+    const result = parseInlineDirectives(input, {
+      currentMessageId: "msg-1",
+    });
+
+    expect(result.replyToId).toBe("msg-1");
+    expect(result.text).toBe(
+      ["Here is YAML:", "", "```yaml", "a:", "  b:", "    c: sadffdsd", "```"].join("\n"),
+    );
+  });
+
+  test("removes inline reply tags without collapsing neighboring words", () => {
+    const result = parseInlineDirectives("see [[reply_to:abc-123]] now", {
+      currentMessageId: "msg-1",
+    });
+
+    expect(result.replyToId).toBe("abc-123");
+    expect(result.text).toBe("see now");
   });
 });

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -16,12 +16,37 @@ type InlineDirectiveParseOptions = {
 
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
+const DIRECTIVE_WHITESPACE_MARKER = "\u0000";
 
 function normalizeDirectiveWhitespace(text: string): string {
   return text
     .replace(/[ \t]+/g, " ")
     .replace(/[ \t]*\n[ \t]*/g, "\n")
     .trim();
+}
+
+function normalizeDirectiveWhitespaceAfterTagRemoval(text: string): string {
+  const lines = text.replace(/\r\n?/g, "\n").split("\n");
+  const cleanedLines = lines.map((line) => {
+    if (!line.includes(DIRECTIVE_WHITESPACE_MARKER)) {
+      return line;
+    }
+    const normalized = line
+      .replace(new RegExp(`^[ \\t]*${DIRECTIVE_WHITESPACE_MARKER}[ \\t]*`), "")
+      .replace(new RegExp(`[ \\t]*${DIRECTIVE_WHITESPACE_MARKER}[ \\t]*$`), "")
+      .replace(new RegExp(`[ \\t]*${DIRECTIVE_WHITESPACE_MARKER}[ \\t]*`, "g"), " ")
+      .trimEnd();
+    return normalized.trim() === "" ? "" : normalized;
+  });
+
+  while (cleanedLines[0]?.trim() === "") {
+    cleanedLines.shift();
+  }
+  while (cleanedLines.at(-1)?.trim() === "") {
+    cleanedLines.pop();
+  }
+
+  return cleanedLines.join("\n");
 }
 
 type StripInlineDirectiveTagsResult = {
@@ -116,7 +141,7 @@ export function parseInlineDirectives(
   cleaned = cleaned.replace(AUDIO_TAG_RE, (match) => {
     audioAsVoice = true;
     hasAudioTag = true;
-    return stripAudioTag ? " " : match;
+    return stripAudioTag ? DIRECTIVE_WHITESPACE_MARKER : match;
   });
 
   cleaned = cleaned.replace(REPLY_TAG_RE, (match, idRaw: string | undefined) => {
@@ -129,10 +154,12 @@ export function parseInlineDirectives(
         lastExplicitId = id;
       }
     }
-    return stripReplyTags ? " " : match;
+    return stripReplyTags ? DIRECTIVE_WHITESPACE_MARKER : match;
   });
 
-  cleaned = normalizeDirectiveWhitespace(cleaned);
+  cleaned = cleaned.includes(DIRECTIVE_WHITESPACE_MARKER)
+    ? normalizeDirectiveWhitespaceAfterTagRemoval(cleaned)
+    : normalizeDirectiveWhitespace(cleaned);
 
   const replyToId =
     lastExplicitId ?? (sawCurrent ? currentMessageId?.trim() || undefined : undefined);


### PR DESCRIPTION
Closes #42576.

## Summary
- stop collapsing indentation when reply/audio inline tags are stripped from assistant text
- keep inline tag cleanup for ordinary prose so neighboring words do not pick up double spaces
- add regression coverage for fenced YAML plus existing reply-tag parsing paths

## Testing
- pnpm test src/utils/directive-tags.test.ts
- pnpm test src/auto-reply/reply.directive.parse.test.ts
- pnpm test src/gateway/server-methods/chat.directive-tags.test.ts
