### PR TITLE
fix(docker): sanitize .env file to remove BOM and CRLF artifacts

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -32,6 +32,32 @@ is_truthy_value() {
   esac
 }
 
+# Sanitize a .env file so Docker Compose reads it correctly.
+# Removes UTF-8 BOM, converts CRLF to LF, and strips stray carriage returns.
+# This prevents subtle bugs when the file is edited on Windows (e.g. Notepad
+# saves with BOM + CRLF, causing variable values to carry trailing \r).
+sanitize_env_file() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+
+  local tmp
+  tmp="$(mktemp)"
+
+  # 1. Strip UTF-8 BOM (EF BB BF) if present at the start of file
+  # 2. Convert CRLF to LF
+  # 3. Remove any remaining bare CR characters
+  LC_ALL=C sed '1s/^\xef\xbb\xbf//' "$file" \
+    | tr -d '\r' \
+    >"$tmp"
+
+  # Only overwrite if content actually changed (preserves timestamps)
+  if ! cmp -s "$file" "$tmp"; then
+    mv "$tmp" "$file"
+  else
+    rm -f "$tmp"
+  fi
+}
+
 read_config_gateway_token() {
   local config_path="$OPENCLAW_CONFIG_DIR/openclaw.json"
   if [[ ! -f "$config_path" ]]; then
@@ -409,6 +435,9 @@ upsert_env "$ENV_FILE" \
   DOCKER_GID \
   OPENCLAW_INSTALL_DOCKER_CLI \
   OPENCLAW_ALLOW_INSECURE_PRIVATE_WS
+
+# Clean up any BOM / CRLF artifacts so Docker Compose reads the .env correctly.
+sanitize_env_file "$ENV_FILE"
 
 if [[ "$IMAGE_NAME" == "openclaw:local" ]]; then
   echo "==> Building Docker image: $IMAGE_NAME"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -43,19 +43,23 @@ sanitize_env_file() {
   local tmp
   tmp="$(mktemp)"
 
-  # 1. Strip UTF-8 BOM (EF BB BF) if present at the start of file
-  # 2. Convert CRLF to LF
-  # 3. Remove any remaining bare CR characters
-  LC_ALL=C sed '1s/^\xef\xbb\xbf//' "$file" \
+  # Build the 3-byte UTF-8 BOM using ANSI-C quoting so the pattern works
+  # with both GNU sed and BSD sed (which lacks \xNN escape support).
+  local bom
+  bom=$'\xef\xbb\xbf'
+
+  # 1. Strip UTF-8 BOM if present at the start of file
+  # 2. Convert CRLF to LF and remove any remaining bare CR characters
+  LC_ALL=C sed "1s/^${bom}//" "$file" \
     | tr -d '\r' \
     >"$tmp"
 
-  # Only overwrite if content actually changed (preserves timestamps)
+  # Only overwrite if content actually changed (preserves timestamps).
+  # Use cat to rewrite the inode in-place, preserving owner/group/mode.
   if ! cmp -s "$file" "$tmp"; then
-    mv "$tmp" "$file"
-  else
-    rm -f "$tmp"
+    cat "$tmp" > "$file"
   fi
+  rm -f "$tmp"
 }
 
 read_config_gateway_token() {


### PR DESCRIPTION
## Problem

When the `.env` file is edited on Windows (e.g. with Notepad), it may contain:

- **UTF-8 BOM** (byte order mark, `EF BB BF`) at the start of the file
- **CRLF line endings** (`\r\n`) instead of Unix LF (`\n`)

Docker Compose reads the `.env` file literally, so these invisible bytes become part of the variable values. This causes subtle, hard-to-debug failures:

- BOM in the first variable name makes it unrecognizable
- Trailing `\r` in values causes image pull failures (`openclaw:local\r` is not a valid image name), broken paths, and silent configuration mismatches

Users don't see these characters in their editor, so the errors appear completely mysterious.

## Solution

Add a `sanitize_env_file()` function that cleans the `.env` file after `upsert_env` writes it:

1. **Strip UTF-8 BOM** from the first line (using `LC_ALL=C sed`)
2. **Convert CRLF to LF** and remove any stray bare CR characters (using `tr -d '\r'`)
3. **Preserve timestamps** -- only overwrites if content actually changed (using `cmp -s`)

The function is intentionally conservative:
- Only removes known-harmful invisible characters (BOM, CR)
- Preserves comments, blank lines, and all visible content
- Uses `mktemp` for atomic file replacement
- No-op if the file doesn't exist or is already clean

## Changes

- **`sanitize_env_file()`**: New function (26 lines) added after `is_truthy_value()` in the utility section
- **Call site**: One-line call after `upsert_env "$ENV_FILE"`, before Docker image build/pull

## Testing

- Tested with BOM + CRLF `.env` file -> correctly cleaned
- Tested with clean `.env` file -> no modification, timestamps preserved
- Tested with missing `.env` file -> no-op, no error
- ShellCheck: zero warnings
- Compatible with `set -euo pipefail` and Bash 3.2+ (macOS default)
- Works with both GNU and BSD sed
