### PR TITLE
fix(security): block non-self messages in WhatsApp self-chat mode

### DIFF
--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -77,7 +77,7 @@ export async function checkInboundAccessControl(params: {
   // Self-chat mode: absolute isolation — only process messages from the owner's own phone.
   // This guard must run before group/DM policy evaluation to ensure no non-self message
   // ever reaches downstream processing (mention gating, debounce, auto-reply, etc.).
-  if (isSelfChat && !isSamePhone && params.selfE164 !== null) {
+  if (isSelfChat && !isSamePhone) {
     logVerbose(
       `Blocked non-self message in self-chat mode: from=${params.from} selfE164=${params.selfE164 ?? "null"} group=${params.group}`,
     );

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -74,6 +74,20 @@ export async function checkInboundAccessControl(params: {
     account.groupAllowFrom ?? (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
   const isSamePhone = params.from === params.selfE164;
   const isSelfChat = account.selfChatMode ?? isSelfChatMode(params.selfE164, configuredAllowFrom);
+  // Self-chat mode: absolute isolation — only process messages from the owner's own phone.
+  // This guard must run before group/DM policy evaluation to ensure no non-self message
+  // ever reaches downstream processing (mention gating, debounce, auto-reply, etc.).
+  if (isSelfChat && !isSamePhone && params.selfE164 !== null) {
+    logVerbose(
+      `Blocked non-self message in self-chat mode: from=${params.from} selfE164=${params.selfE164 ?? "null"} group=${params.group}`,
+    );
+    return {
+      allowed: false,
+      shouldMarkRead: false,
+      isSelfChat,
+      resolvedAccountId: account.accountId,
+    };
+  }
   const pairingGraceMs =
     typeof params.pairingGraceMs === "number" && params.pairingGraceMs > 0
       ? params.pairingGraceMs

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -77,7 +77,7 @@ export async function checkInboundAccessControl(params: {
   // Self-chat mode: absolute isolation — only process messages from the owner's own phone.
   // This guard must run before group/DM policy evaluation to ensure no non-self message
   // ever reaches downstream processing (mention gating, debounce, auto-reply, etc.).
-  if (isSelfChat && !isSamePhone) {
+  if (account.selfChatMode === true && !isSamePhone) {
     logVerbose(
       `Blocked non-self message in self-chat mode: from=${params.from} selfE164=${params.selfE164 ?? "null"} group=${params.group}`,
     );


### PR DESCRIPTION
## Summary

- **Problem:** `checkInboundAccessControl()` computes `isSelfChat` (line 76) but never uses it as a guard. Non-self messages (groups, DMs from strangers, broadcasts) pass through because `resolveWhatsAppRuntimeGroupPolicy()` defaults to `"open"` when `cfg.channels.whatsapp` is defined with no explicit `groupPolicy`.
- **Why it matters:** This is a message boundary violation. Self-chat mode is meant to be absolute isolation. Non-self messages bypass this boundary entirely and reach downstream processing (mention gating, debounce, auto-reply).
- **What changed:** Added an early-return guard in `checkInboundAccessControl()` that blocks all non-self messages when `account.selfChatMode === true`. The guard fires before group/DM policy evaluation so no non-self message reaches downstream processing. The guard intentionally checks only the explicit config flag, not the heuristic `isSelfChat` variable, because `isSelfChatMode()` returns `true` whenever the owner's number appears anywhere in `allowFrom` (even alongside other approved numbers like `allowFrom: [owner, teammate]`). Using `isSelfChat` would silently block teammates that were previously allowed through normal DM policy.
- **What did NOT change (scope boundary):** Group policy resolution, DM policy, mention gating, `monitor.ts`, or any other channel's access control. The `isSelfChat` variable is still computed and returned in the result for softer downstream behavior (UI hints, logging). Auto-detected self-chat mode (where `isSelfChatMode()` returns `true` but `selfChatMode` is not explicitly set) is not covered by this hard block by design.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Self-chat mode isolation enforcement

## User-visible / Behavior Changes

Self-chat mode deployments with explicit `selfChatMode: true` now properly reject all non-self messages at the access control layer. Previously, group messages (and other non-self messages) could pass through when groupPolicy defaulted to "open". Deployments without explicit `selfChatMode: true` are unaffected (no regression for `allowFrom` lists containing the owner alongside teammates).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes. Self-chat mode now properly restricts message processing to self-only. This is a security boundary fix: `isSelfChat` was computed but never enforced as a gate.

## Repro + Verification

### Environment

- Any self-chat mode deployment with `selfChatMode: true` in WhatsApp channel config and no explicit `groupPolicy`

### Steps

1. Configure explicit self-chat mode (`selfChatMode: true`)
2. Send a group message to the WhatsApp number
3. Observe message passes access control

### Expected

- Group message blocked at access control with `allowed: false`

### Actual

- (Before fix) Group message passes with `allowed: true` because groupPolicy defaults to "open"

## Evidence

- [x] Trace/log snippets

Code path trace: `isSelfChat` computed at line 76 but never used as guard. Group policy resolution at lines 104-109 returns "open" for configured providers. `resolveDmGroupAccessWithLists` allows group with "open" policy. No rejection triggered.

Fix verification: Guard returns `{ allowed: false }` before group policy is ever evaluated. All 9 existing tests in `access-control.test.ts` and `access-control.group-policy.test.ts` pass.

## Human Verification (required)

- Verified scenarios: Code path analysis confirms guard placement before all policy evaluation. Verified `account.selfChatMode === true` does not fire for auto-detected mode (no teammate regression). Verified `isSamePhone` check preserves self-messages.
- Edge cases checked: Explicit `selfChatMode: true` (hard block), auto-detected self-chat via heuristic (no hard block, normal DM policy), `selfE164` is null with `selfChatMode: true` (fail-closed, blocks all), group messages, DMs from strangers
- What you did **not** verify: Live deployment test (code path analysis only)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the early-return guard block (lines 77-90) in `access-control.ts`
- Files/config to restore: `src/web/inbound/access-control.ts`
- Known bad symptoms reviewers should watch for: If incorrectly applied, self-chat users might not receive their own messages (but guard uses `!isSamePhone` which preserves self-messages)

## Risks and Mitigations

- Risk: Auto-detected self-chat mode (heuristic only, no explicit config) does not get the hard block
  - Mitigation: This is intentional. The heuristic fires when the owner's number appears in `allowFrom` alongside other numbers, which would break teammate access. A follow-up can address auto-detected mode with a narrower heuristic (e.g. only when `allowFrom` contains exactly the owner's number and nothing else).