### PR TITLE
fix(cron): respect OPENCLAW_STATE_DIR for cron store path at runtime

### DIFF
--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -2,12 +2,38 @@ import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
+import { resolveStateDir } from "../config/paths.js";
 import { expandHomePrefix } from "../infra/home-dir.js";
-import { CONFIG_DIR } from "../utils.js";
 import type { CronStoreFile } from "./types.js";
 
-export const DEFAULT_CRON_DIR = path.join(CONFIG_DIR, "cron");
+/**
+ * Resolve the default cron directory at runtime to respect OPENCLAW_STATE_DIR.
+ * This function is called lazily to ensure environment variables are loaded before path resolution.
+ */
+export function resolveDefaultCronDir(): string {
+  return path.join(resolveStateDir(), "cron");
+}
+
+/**
+ * Resolve the default cron store path at runtime to respect OPENCLAW_STATE_DIR.
+ * This function is called lazily to ensure environment variables are loaded before path resolution.
+ */
+export function resolveDefaultCronStorePath(): string {
+  return path.join(resolveDefaultCronDir(), "jobs.json");
+}
+
+/**
+ * @deprecated Use resolveDefaultCronDir() instead.
+ * This constant is kept for backward compatibility but may not respect OPENCLAW_STATE_DIR when loaded before dotenv.
+ */
+export const DEFAULT_CRON_DIR = path.join(resolveStateDir(), "cron");
+
+/**
+ * @deprecated Use resolveDefaultCronStorePath() instead.
+ * This constant is kept for backward compatibility but may not respect OPENCLAW_STATE_DIR when loaded before dotenv.
+ */
 export const DEFAULT_CRON_STORE_PATH = path.join(DEFAULT_CRON_DIR, "jobs.json");
+
 const serializedStoreCache = new Map<string, string>();
 
 export function resolveCronStorePath(storePath?: string) {
@@ -18,7 +44,7 @@ export function resolveCronStorePath(storePath?: string) {
     }
     return path.resolve(raw);
   }
-  return DEFAULT_CRON_STORE_PATH;
+  return resolveDefaultCronStorePath();
 }
 
 export async function loadCronStore(storePath: string): Promise<CronStoreFile> {


### PR DESCRIPTION
## Problem

The cron store module uses module-level constants (`DEFAULT_CRON_DIR`, `DEFAULT_CRON_STORE_PATH`) that are evaluated at import time, before `.env` files are loaded via `loadDotEnv()`. This causes the cron jobs to be stored in `~/.openclaw/cron/` even when `OPENCLAW_STATE_DIR` is configured to a./.openclaw/`.

## Root Cause

ES modules evaluate all static imports before any runtime code executes. The import chain is:

1. `src/index.ts` starts loading
2. Static imports are resolved (including `src/cron/store.ts`)
3. `CONFIG_DIR` constant is evaluated at module load time
4. `DEFAULT_CRON_STORE_PATH` is calculated using the pre-dotenv `CONFIG_DIR`
5. Finally, `loadDotEnv()` executes

At step 3, `process.env.OPENCLAW_STATE_DIR` is still `undefined`, so the default `~/.openclaw` is used.

## Solution

Replace module-level constants with lazy-evaluated functions that call `resolveStateDir()` at runtime:

1. Add `resolveDefaultCronDir()` function - resolves cron directory at runtime
2. Add `resolveDefaultCronStorePath()` function - resolves cron store path at runtime
3. Update `resolveCronStorePath()` to use the new function instead of the constant
4. Keep `DEFAULT_CRON_DIR` and `DEFAULT_CRON_STORE_PATH` as `@deprecated` for backward compatibility

## Testing

- All 22 existing tests in `src/cron/store.test.ts` pass
- Verified that `resolveCronStorePath()` now correctly respects `OPENCLAW_STATE_DIR` when called after `loadDotEnv()`

## Impact

- Users who set `OPENCLAW_STATE_DIR` in `.env` will now see cron jobs stored in the correct directory
- No breaking changes - deprecated constants still work for existing code