### PR TITLE
fix(gateway): bootstrap macOS LaunchAgent when gateway start sees not-loaded service

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
@@ -164,6 +164,7 @@ describe("runServiceStart config pre-flight (#35862)", () => {
     service.restart.mockClear();
     service.isLoaded.mockResolvedValue(true);
     service.restart.mockResolvedValue(undefined);
+    vi.unstubAllEnvs();
   });
 
   it("aborts start when config is invalid", async () => {
@@ -202,5 +203,31 @@ describe("runServiceStart config pre-flight (#35862)", () => {
     });
 
     expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits started when a not-loaded fallback bootstraps the service", async () => {
+    service.isLoaded.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await runServiceStart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+      onNotLoaded: async () => ({
+        result: "started",
+        message: "Gateway LaunchAgent bootstrapped from existing plist.",
+      }),
+    });
+
+    expect(service.restart).not.toHaveBeenCalled();
+    const jsonLine = runtimeLogs.find((line) => line.trim().startsWith("{"));
+    const payload = JSON.parse(jsonLine ?? "{}") as {
+      result?: string;
+      message?: string;
+      service?: { loaded?: boolean };
+    };
+    expect(payload.result).toBe("started");
+    expect(payload.message).toContain("bootstrapped");
+    expect(payload.service?.loaded).toBe(true);
   });
 });

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -30,7 +30,7 @@ type RestartPostCheckContext = {
 };
 
 type NotLoadedActionResult = {
-  result: "stopped" | "restarted";
+  result: "started" | "stopped" | "restarted";
   message?: string;
   warnings?: string[];
 };
@@ -188,6 +188,7 @@ export async function runServiceStart(params: {
   service: GatewayService;
   renderStartHints: () => string[];
   opts?: DaemonLifecycleOptions;
+  onNotLoaded?: (ctx: NotLoadedActionContext) => Promise<NotLoadedActionResult | null>;
 }) {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createActionIO({ action: "start", json });
@@ -201,6 +202,34 @@ export async function runServiceStart(params: {
     return;
   }
   if (!loaded) {
+    try {
+      const handled = await params.onNotLoaded?.({ json, stdout, fail });
+      if (handled) {
+        let started = handled.result === "started";
+        if (started) {
+          try {
+            started = await params.service.isLoaded({ env: process.env });
+          } catch {
+            started = true;
+          }
+        }
+        emit({
+          ok: true,
+          result: handled.result,
+          message: handled.message,
+          warnings: handled.warnings,
+          service: buildDaemonServiceSnapshot(params.service, started),
+        });
+        if (!json && handled.message) {
+          defaultRuntime.log(handled.message);
+        }
+        return;
+      }
+    } catch (err) {
+      fail(`${params.serviceNoun} start failed: ${String(err)}`);
+      return;
+    }
+
     await handleServiceNotLoaded({
       serviceNoun: params.serviceNoun,
       service: params.service,

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -25,9 +25,11 @@ type RestartParams = {
 const service = {
   readCommand: vi.fn(),
   restart: vi.fn(),
+  isLoaded: vi.fn(),
 };
 
 const runServiceRestart = vi.fn();
+const runServiceStart = vi.fn();
 const runServiceStop = vi.fn();
 const waitForGatewayHealthyListener = vi.fn();
 const waitForGatewayHealthyRestart = vi.fn();
@@ -48,6 +50,8 @@ const probeGateway = vi.fn<
 >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
+const launchAgentPlistExists = vi.fn();
+const repairLaunchAgentBootstrap = vi.fn();
 
 vi.mock("node:fs", () => ({
   default: {
@@ -85,6 +89,11 @@ vi.mock("../../daemon/service.js", () => ({
   resolveGatewayService: () => service,
 }));
 
+vi.mock("../../daemon/launchd.js", () => ({
+  launchAgentPlistExists,
+  repairLaunchAgentBootstrap,
+}));
+
 vi.mock("./restart-health.js", () => ({
   DEFAULT_RESTART_HEALTH_ATTEMPTS: 120,
   DEFAULT_RESTART_HEALTH_DELAY_MS: 500,
@@ -97,7 +106,7 @@ vi.mock("./restart-health.js", () => ({
 
 vi.mock("./lifecycle-core.js", () => ({
   runServiceRestart,
-  runServiceStart: vi.fn(),
+  runServiceStart,
   runServiceStop,
   runServiceUninstall: vi.fn(),
 }));
@@ -113,6 +122,8 @@ describe("runDaemonRestart health checks", () => {
   beforeEach(() => {
     service.readCommand.mockReset();
     service.restart.mockReset();
+    service.isLoaded.mockReset();
+    runServiceStart.mockReset();
     runServiceRestart.mockReset();
     runServiceStop.mockReset();
     waitForGatewayHealthyListener.mockReset();
@@ -125,6 +136,8 @@ describe("runDaemonRestart health checks", () => {
     probeGateway.mockReset();
     isRestartEnabled.mockReset();
     loadConfig.mockReset();
+    launchAgentPlistExists.mockReset();
+    repairLaunchAgentBootstrap.mockReset();
     mockReadFileSync.mockReset();
     mockSpawnSync.mockReset();
 
@@ -132,6 +145,9 @@ describe("runDaemonRestart health checks", () => {
       programArguments: ["openclaw", "gateway", "--port", "18789"],
       environment: {},
     });
+    service.isLoaded.mockResolvedValue(true);
+    launchAgentPlistExists.mockResolvedValue(true);
+    repairLaunchAgentBootstrap.mockResolvedValue({ ok: true });
 
     runServiceRestart.mockImplementation(async (params: RestartParams) => {
       const fail = (message: string, hints?: string[]) => {
@@ -148,6 +164,7 @@ describe("runDaemonRestart health checks", () => {
       return true;
     });
     runServiceStop.mockResolvedValue(undefined);
+    runServiceStart.mockResolvedValue(undefined);
     waitForGatewayHealthyListener.mockResolvedValue({
       healthy: true,
       portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
@@ -202,6 +219,20 @@ describe("runDaemonRestart health checks", () => {
     expect(terminateStaleGatewayPids).toHaveBeenCalledWith([1993]);
     expect(service.restart).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(2);
+  });
+
+  it("bootstraps the macOS LaunchAgent when start sees a not-loaded service", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    runServiceStart.mockImplementation(async (params: { onNotLoaded?: () => Promise<unknown> }) => {
+      await params.onNotLoaded?.();
+    });
+
+    const { runDaemonStart } = await import("./lifecycle.js");
+    await runDaemonStart({ json: true });
+
+    expect(launchAgentPlistExists).toHaveBeenCalledWith(process.env);
+    expect(repairLaunchAgentBootstrap).toHaveBeenCalledWith({ env: process.env });
+    expect(service.isLoaded).toHaveBeenCalledWith({ env: process.env });
   });
 
   it("fails restart when gateway remains unhealthy", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -3,6 +3,7 @@ import fsSync from "node:fs";
 import { isRestartEnabled } from "../../config/commands.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
 import { parseCmdScriptCommandLine } from "../../daemon/cmd-argv.js";
+import { launchAgentPlistExists, repairLaunchAgentBootstrap } from "../../daemon/launchd.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { probeGateway } from "../../gateway/probe.js";
 import { isGatewayArgv, parseProcCmdline } from "../../infra/gateway-process-argv.js";
@@ -180,6 +181,28 @@ async function restartGatewayWithoutServiceManager(port: number) {
   };
 }
 
+async function startGatewayLaunchAgentBootstrap(service = resolveGatewayService()) {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+  const plistExists = await launchAgentPlistExists(process.env);
+  if (!plistExists) {
+    return null;
+  }
+  const repair = await repairLaunchAgentBootstrap({ env: process.env });
+  if (!repair.ok) {
+    throw new Error(`LaunchAgent bootstrap failed: ${repair.detail ?? "unknown error"}`);
+  }
+  const loaded = await service.isLoaded({ env: process.env });
+  if (!loaded) {
+    throw new Error("LaunchAgent bootstrap did not load the gateway service");
+  }
+  return {
+    result: "started" as const,
+    message: "Gateway LaunchAgent bootstrapped from existing plist.",
+  };
+}
+
 export async function runDaemonUninstall(opts: DaemonLifecycleOptions = {}) {
   return await runServiceUninstall({
     serviceNoun: "Gateway",
@@ -191,11 +214,13 @@ export async function runDaemonUninstall(opts: DaemonLifecycleOptions = {}) {
 }
 
 export async function runDaemonStart(opts: DaemonLifecycleOptions = {}) {
+  const service = resolveGatewayService();
   return await runServiceStart({
     serviceNoun: "Gateway",
-    service: resolveGatewayService(),
+    service,
     renderStartHints: renderGatewayServiceStartHints,
     opts,
+    onNotLoaded: async () => startGatewayLaunchAgentBootstrap(service),
   });
 }
 


### PR DESCRIPTION
## Summary

Fix macOS gateway lifecycle recovery when the LaunchAgent plist still exists on disk but the service has been unloaded from `launchd`.

Today this sequence is broken:

```bash
openclaw gateway stop
openclaw gateway start
```

`stop` unloads the LaunchAgent with `launchctl bootout`, but `start` only checks `service.isLoaded()` and returns `Gateway service not loaded.` plus hints instead of re-bootstrapping the existing plist.

This PR makes `gateway start` recover that state on macOS by reusing the existing `repairLaunchAgentBootstrap()` helper.

## What changed

- Add `onNotLoaded` recovery support to `runServiceStart()` in the shared daemon lifecycle core.
- Wire `runDaemonStart()` to attempt macOS LaunchAgent bootstrap when:
  - platform is `darwin`
  - the gateway service is `not loaded`
  - the LaunchAgent plist still exists
- Verify the service becomes loaded after bootstrap before returning success.
- Add unit coverage for both:
  - the generic `runServiceStart()` fallback path
  - the gateway/macOS lifecycle glue path

## Why this is safe

- Non-macOS platforms keep existing behavior.
- macOS only uses the recovery path when the service is not loaded.
- If the plist does not exist, the CLI still falls back to the existing hint-based behavior.
- The actual bootstrap logic already existed in `repairLaunchAgentBootstrap()` and is also used by doctor flows.

## Fixes

- Fixes #41845
- Related: #41353

## Verification

Ran targeted unit tests:

```bash
pnpm exec vitest run --config vitest.unit.config.ts src/cli/daemon-cli/lifecycle-core.config-guard.test.ts src/cli/daemon-cli/lifecycle.test.ts
pnpm exec vitest run --config vitest.unit.config.ts src/daemon/launchd.test.ts
```
