### PR TITLE
fix(feishu): prevent streaming card duplication on multi-final replies

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -283,8 +283,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               queueStreamingUpdate(text, { mode: "delta" });
             }
             if (info?.kind === "final") {
-              streamText = mergeStreamingText(streamText, text);
-              await closeStreaming();
+              // Append final text to the streaming card but do NOT close it yet.
+              // Multiple finals in a single turn should merge into one card;
+              // onIdle will close the card when the entire turn is done.
+              // Use "snapshot" mode so mergeStreamingText deduplicates against
+              // content already delivered via onPartialReply.
+              queueStreamingUpdate(text, { mode: "snapshot" });
               deliveredFinalTexts.add(text);
             }
             // Send media even when streaming handled the text


### PR DESCRIPTION
## Summary

- **Problem**: When `renderMode: "card"` and `streaming: true`, each `final` reply in a single agent turn creates a new streaming card via CardKit API. Turns with N tool calls produce N duplicate cards.
- **Why it matters**: Users see the same content repeated multiple times as separate card messages, degrading chat UX significantly in agentic workflows.
- **What changed**: `deliver(final)` no longer calls `closeStreaming()`. Instead it uses `queueStreamingUpdate(text, { mode: "snapshot" })` to merge text into the existing card. `onIdle` handles card finalization.
- **What did NOT change**: Block streaming, non-card render modes, media handling, typing indicators, and all other dispatch logic remain untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None

## User-visible / Behavior Changes

Multi-final turns now produce a single streaming card instead of N duplicate cards. No config changes required.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (fewer calls — eliminates redundant CardKit create calls)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows Server 2022
- Runtime/container: OpenClaw 2026.3.7 (42a1394)
- Model/provider: claude-opus-4-6
- Integration/channel: Feishu (websocket mode)
- Relevant config: `renderMode: "card"`, `streaming: true`, `cardkit:card:write` permission granted

### Steps

1. Configure Feishu account with `renderMode: "card"` and `streaming: true`
2. Send a message that triggers multiple tool calls (e.g. agent reads files, runs commands, then responds)
3. Agent responds with text between tool calls, producing multiple final replies
4. Observe Feishu chat output

### Expected

- Single streaming card with all content merged progressively

### Actual

- N separate streaming cards, each with progressively accumulated text. Gateway log shows `Started streaming` → `Closed streaming` repeated N times per turn.

## Evidence

Gateway log before fix:
```
06:54:01 feishu[ops] Started streaming: cardId=...329
06:54:01 feishu[ops] Closed streaming: cardId=...329
06:54:02 feishu[ops] Started streaming: cardId=...465
06:54:03 feishu[ops] Closed streaming: cardId=...465
... (repeated 8 times)
06:54:12 feishu[ops]: dispatch complete (queuedFinal=true, replies=8)
```

Gateway log after fix:
```
07:10:37 feishu[pipi] Started streaming: cardId=...312
07:10:57 feishu[pipi]: dispatch complete (queuedFinal=true, replies=1)
07:10:57 feishu[pipi] Closed streaming: cardId=...312
```

## Human Verification (required)

- Verified scenarios: Single-final turns (1 card ✅), multi-final turns with 3+ tool calls (1 card ✅), no duplicated content within card ✅
- Edge cases checked: First version used `mode: "delta"` which caused content duplication inside the card; fixed by switching to `mode: "snapshot"` for proper dedup via `mergeStreamingText()`
- What you did **not** verify: Thread reply mode (disabled for streaming cards by design), Lark (non-Feishu) domain

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single file change, or set `renderMode: "auto"` to avoid card streaming path entirely.
- Files/config to restore: `extensions/feishu/src/reply-dispatcher.ts`
- Known bad symptoms reviewers should watch for: Streaming card never closing (stuck "Generating..." state) — would indicate `onIdle` not firing.

## Risks and Mitigations

- Risk: If `onIdle` fails to fire, the streaming card stays open indefinitely with "Generating..." state.
  - Mitigation: `onError` also calls `closeStreaming()` as fallback. This is the same pattern used by block streaming.
