### PR TITLE
fix(auth): add bailian env api key mapping

### DIFF
--- a/src/agents/model-auth-env-vars.ts
+++ b/src/agents/model-auth-env-vars.ts
@@ -30,6 +30,7 @@ export const PROVIDER_ENV_API_KEY_CANDIDATES: Record<string, string[]> = {
   synthetic: ["SYNTHETIC_API_KEY"],
   venice: ["VENICE_API_KEY"],
   mistral: ["MISTRAL_API_KEY"],
+  bailian: ["BAILIAN_API_KEY"],
   together: ["TOGETHER_API_KEY"],
   qianfan: ["QIANFAN_API_KEY"],
   ollama: ["OLLAMA_API_KEY"],

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -287,6 +287,17 @@ describe("getApiKeyForModel", () => {
     });
   });
 
+  it("resolves Bailian API key from env", async () => {
+    await withEnvAsync({ BAILIAN_API_KEY: "bailian-test-key" }, async () => {
+      const resolved = await resolveApiKeyForProvider({
+        provider: "bailian",
+        store: { version: 1, profiles: {} },
+      });
+      expect(resolved.apiKey).toBe("bailian-test-key");
+      expect(resolved.source).toContain("BAILIAN_API_KEY");
+    });
+  });
+
   it("resolves Vercel AI Gateway API key from env", async () => {
     await withEnvAsync({ [envVar("AI_GATEWAY", "API", "KEY")]: "gateway-test-key" }, async () => {
       // pragma: allowlist secret


### PR DESCRIPTION
## Summary
- add `BAILIAN_API_KEY` to the built-in provider env API key candidates
- add a regression test for resolving Bailian auth from env

## Why
Issue #42858 reports that the Bailian provider cannot resolve auth from:

```json
{
  "apiKey": "__env__:BAILIAN_API_KEY"
}
The root cause is that bailian was missing from the built-in provider env API key mapping table, so env-based API key resolution returned no key for that provider.

## Changes
src/agents/model-auth-env-vars.ts
add bailian: ["BAILIAN_API_KEY"]
src/agents/model-auth.profiles.test.ts
add a regression test covering Bailian env API key resolution