### PR TITLE
Respect cacheRetention for OpenRouter Anthropic models

### DIFF
--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -19,7 +19,7 @@ const PI_AI_OAUTH_ANTHROPIC_BETAS = [
   ...PI_AI_DEFAULT_ANTHROPIC_BETAS,
 ] as const;
 
-type CacheRetention = "none" | "short" | "long";
+export type CacheRetention = "none" | "short" | "long";
 
 function isAnthropic1MModel(modelId: string): boolean {
   const normalized = modelId.trim().toLowerCase();
@@ -182,13 +182,15 @@ function normalizeOpenAiStringModeAnthropicToolChoice(toolChoice: unknown): unkn
 export function resolveCacheRetention(
   extraParams: Record<string, unknown> | undefined,
   provider: string,
+  modelId: string,
 ): CacheRetention | undefined {
   const isAnthropicDirect = provider === "anthropic";
   const hasBedrockOverride =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
   const isAnthropicBedrock = provider === "amazon-bedrock" && hasBedrockOverride;
+  const isAnthropicOpenRouter = provider === "openrouter" && modelId.startsWith("anthropic/");
 
-  if (!isAnthropicDirect && !isAnthropicBedrock) {
+  if (!isAnthropicDirect && !isAnthropicBedrock && !isAnthropicOpenRouter) {
     return undefined;
   }
 
@@ -205,7 +207,7 @@ export function resolveCacheRetention(
     return "long";
   }
 
-  return isAnthropicDirect ? "short" : undefined;
+  return isAnthropicDirect || isAnthropicOpenRouter ? "short" : undefined;
 }
 
 export function resolveAnthropicBetas(

--- a/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
@@ -11,14 +11,25 @@ type StreamPayload = {
   }>;
 };
 
-function runOpenRouterPayload(payload: StreamPayload, modelId: string) {
+function runOpenRouterPayload(
+  payload: StreamPayload,
+  modelId: string,
+  cacheRetention: string | undefined,
+) {
   const baseStreamFn: StreamFn = (model, _context, options) => {
     options?.onPayload?.(payload, model);
     return createAssistantMessageEventStream();
   };
   const agent = { streamFn: baseStreamFn };
 
-  applyExtraParamsToAgent(agent, undefined, "openrouter", modelId);
+  const conf = {
+    agents: {
+      defaults: {
+        models: { [`openrouter/${modelId}`]: { params: { cacheRetention: cacheRetention } } },
+      },
+    },
+  };
+  applyExtraParamsToAgent(agent, conf, "openrouter", modelId);
 
   const model = {
     api: "openai-completions",
@@ -39,12 +50,59 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
       ],
     };
 
-    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", "short");
 
     expect(payload.messages[0].content).toEqual([
       { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
     ]);
     expect(payload.messages[1].content).toBe("Hello");
+  });
+
+  it("injects cache_control by default if cacheRetention is not set", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello" },
+      ],
+    };
+
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", undefined);
+
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("doesn't inject cache_control if cacheRetention is none", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello" },
+      ],
+    };
+
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", "none");
+
+    expect(payload.messages[0].content).toEqual("You are a helpful assistant.");
+  });
+
+  it("injects cache_control with ttl 1h if cacheRetention is long", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello" },
+      ],
+    };
+
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", "long");
+
+    expect(payload.messages[0].content).toEqual([
+      {
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ]);
   });
 
   it("adds cache_control to last content block when system message is already array", () => {
@@ -60,7 +118,7 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
       ],
     };
 
-    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", "short");
 
     const content = payload.messages[0].content as Array<Record<string, unknown>>;
     expect(content[0]).toEqual({ type: "text", text: "Part 1" });
@@ -76,7 +134,7 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
       messages: [{ role: "system", content: "You are a helpful assistant." }],
     };
 
-    runOpenRouterPayload(payload, "google/gemini-3-pro");
+    runOpenRouterPayload(payload, "google/gemini-3-pro", "short");
 
     expect(payload.messages[0].content).toBe("You are a helpful assistant.");
   });
@@ -86,7 +144,7 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
       messages: [{ role: "user", content: "Hello" }],
     };
 
-    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6", "short");
 
     expect(payload.messages[0].content).toBe("Hello");
   });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -4,6 +4,7 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  type CacheRetention,
   createAnthropicBetaHeadersWrapper,
   createAnthropicToolPayloadCompatibilityWrapper,
   createBedrockNoCacheWrapper,
@@ -71,7 +72,7 @@ export function resolveExtraParams(params: {
 }
 
 type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
-  cacheRetention?: "none" | "short" | "long";
+  cacheRetention?: CacheRetention;
   openaiWsWarmup?: boolean;
 };
 
@@ -79,6 +80,7 @@ function createStreamFnWithExtraParams(
   baseStreamFn: StreamFn | undefined,
   extraParams: Record<string, unknown> | undefined,
   provider: string,
+  cacheRetention: CacheRetention | undefined,
 ): StreamFn | undefined {
   if (!extraParams || Object.keys(extraParams).length === 0) {
     return undefined;
@@ -101,7 +103,6 @@ function createStreamFnWithExtraParams(
   if (typeof extraParams.openaiWsWarmup === "boolean") {
     streamParams.openaiWsWarmup = extraParams.openaiWsWarmup;
   }
-  const cacheRetention = resolveCacheRetention(extraParams, provider);
   if (cacheRetention) {
     streamParams.cacheRetention = cacheRetention;
   }
@@ -351,7 +352,13 @@ export function applyExtraParamsToAgent(
         )
       : undefined;
   const merged = Object.assign({}, resolvedExtraParams, override);
-  const wrappedStreamFn = createStreamFnWithExtraParams(agent.streamFn, merged, provider);
+  const cacheRetention = resolveCacheRetention(merged, provider, modelId);
+  const wrappedStreamFn = createStreamFnWithExtraParams(
+    agent.streamFn,
+    merged,
+    provider,
+    cacheRetention,
+  );
 
   if (wrappedStreamFn) {
     log.debug(`applying extraParams to agent streamFn for ${provider}/${modelId}`);
@@ -404,7 +411,7 @@ export function applyExtraParamsToAgent(
     const skipReasoningInjection = modelId === "auto" || isProxyReasoningUnsupported(modelId);
     const openRouterThinkingLevel = skipReasoningInjection ? undefined : thinkingLevel;
     agent.streamFn = createOpenRouterWrapper(agent.streamFn, openRouterThinkingLevel);
-    agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn);
+    agent.streamFn = createOpenRouterSystemCacheWrapper(agent.streamFn, cacheRetention);
   }
 
   if (provider === "kilocode") {

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -1,6 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { CacheRetention } from "./anthropic-stream-wrappers.js";
 
 const OPENROUTER_APP_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://openclaw.ai",
@@ -59,18 +60,25 @@ function normalizeProxyReasoningPayload(payload: unknown, thinkingLevel?: ThinkL
   }
 }
 
-export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+export function createOpenRouterSystemCacheWrapper(
+  baseStreamFn: StreamFn | undefined,
+  cacheRetention: CacheRetention | undefined,
+): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     if (
       typeof model.provider !== "string" ||
       typeof model.id !== "string" ||
-      !isOpenRouterAnthropicModel(model.provider, model.id)
+      !isOpenRouterAnthropicModel(model.provider, model.id) ||
+      !cacheRetention ||
+      !["short", "long"].includes(cacheRetention)
     ) {
       return underlying(model, context, options);
     }
 
     const originalOnPayload = options?.onPayload;
+    const cacheControl =
+      cacheRetention === "short" ? { type: "ephemeral" } : { type: "ephemeral", ttl: "1h" };
     return underlying(model, context, {
       ...options,
       onPayload: (payload) => {
@@ -81,13 +89,11 @@ export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | unde
               continue;
             }
             if (typeof msg.content === "string") {
-              msg.content = [
-                { type: "text", text: msg.content, cache_control: { type: "ephemeral" } },
-              ];
+              msg.content = [{ type: "text", text: msg.content, cache_control: cacheControl }];
             } else if (Array.isArray(msg.content) && msg.content.length > 0) {
               const last = msg.content[msg.content.length - 1];
               if (last && typeof last === "object") {
-                (last as Record<string, unknown>).cache_control = { type: "ephemeral" };
+                (last as Record<string, unknown>).cache_control = cacheControl;
               }
             }
           }


### PR DESCRIPTION
## Summary

#17473 introduced caching of the system prompt for Anthropic models provided via OpenRouter similarly to those provided directly via Anthropic. But that implementation doesn't respect the cacheRetention setting, instead always adding a 5 minute cache_control marker (i.e. the "short" option), even if cacheRetention was explicitly off. The "long" option would be very useful to keep the cache warm in heartbeats and save up to 90% of costs.

This PR checks the cacheRetention setting for OpenRouter Anthropic before setting `cache_control` (adding `ttl: "1h"` for the "long" option, as per the [OpenRouter docs](https://openrouter.ai/docs/guides/best-practices/prompt-caching#anthropic-claude), or disabling cache on "none"). The default behavior (cacheRetention not specified) is the "short" cache, like the direct Anthropic models.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29441 

## User-visible / Behavior Changes

The cacheRetention setting is now respected for Anthropic models provided via OpenRouter.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Docker
- Model/provider: openrouter/anthropic/*

### Steps

1. Set `agents.defaults.models["openrouter/anthropic/<any>"].params.cacheRetention` to "long"
2. Tell the agent to say hi
3. Wait >5 minutes
4. Tell the agent to say hi again

### Expected

- The OpenRouter logs show a cache write on the first request, a steep discount for a cache read on the second

### Actual

- Both requests cost full price (plus useless cache write)

## Evidence

See below.

## Human Verification (required)

I've observed the broken behavior (described above) in the OpenRouter logs (30m heartbeats or requests >5m apart costing full price). With these changes, cache discounts are applied for these requests.

Also added unit tests for the new behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

Just revert.

## Risks and Mitigations
None