### PR TITLE
fix(agents): suppress gateway schema lookup warning noise

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -142,6 +142,18 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadText(payloads, "All good");
   });
 
+  it("suppresses gateway config.schema.lookup path-not-found warnings for read-only calls", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "gateway",
+        error: "config schema path not found",
+        mutatingAction: false,
+      },
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
   it("does not add synthetic completion text when tools run without final assistant text", () => {
     const payloads = buildPayloads({
       sessionKey: "agent:main:discord:direct:u123",

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -52,6 +52,15 @@ function isVerboseToolDetailEnabled(level?: VerboseLevel): boolean {
   return level === "on" || level === "full";
 }
 
+function shouldSuppressGatewayReadOnlyToolError(params: { lastToolError: LastToolError }): boolean {
+  const normalizedToolName = params.lastToolError.toolName.trim().toLowerCase();
+  if (normalizedToolName !== "gateway" || params.lastToolError.mutatingAction !== false) {
+    return false;
+  }
+  const errorLower = (params.lastToolError.error ?? "").trim().toLowerCase();
+  return errorLower === "config schema path not found";
+}
+
 function resolveToolErrorWarningPolicy(params: {
   lastToolError: LastToolError;
   hasUserFacingReply: boolean;
@@ -65,6 +74,9 @@ function resolveToolErrorWarningPolicy(params: {
   }
   const normalizedToolName = params.lastToolError.toolName.trim().toLowerCase();
   if ((normalizedToolName === "exec" || normalizedToolName === "bash") && !includeDetails) {
+    return { showWarning: false, includeDetails };
+  }
+  if (shouldSuppressGatewayReadOnlyToolError(params)) {
     return { showWarning: false, includeDetails };
   }
   // sessions_send timeouts and errors are transient inter-session communication


### PR DESCRIPTION
## Summary
- suppress user-facing tool warning payloads for read-only `gateway` `config.schema.lookup` misses
- add a regression test for the `config schema path not found` case

## Why
Issue #42856 reports that when an agent calls:

- `gateway`
- `action: "config.schema.lookup"`

with a non-existent path, the gateway correctly returns an error response, but the agent layer also emits a visible warning like:

`⚠️ Gateway: ... failed`

That warning is noisy for this specific case because:
- `config.schema.lookup` is a read-only inspection action
- `path not found` is an expected query miss, not a destructive failure
- the agent already receives the structured error response and can handle it

## Changes
- `src/agents/pi-embedded-runner/run/payloads.ts`
  - suppress warning emission when:
    - tool is `gateway`
    - `mutatingAction === false`
    - error is exactly `config schema path not found`
- `src/agents/pi-embedded-runner/run/payloads.errors.test.ts`
  - add regression coverage for this read-only gateway lookup miss

## Validation
- `pnpm exec oxfmt --check src/agents/pi-embedded-runner/run/payloads.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts`

## Notes
I could not run the targeted Vitest files end-to-end in this local environment because an upstream dependency import is currently unresolved here:

- `@mariozechner/pi-ai/oauth`

That import failure is pre-existing and unrelated to this change.

Closes #42856
