### PR TITLE
fix(docker): add log rotation to prevent unbounded disk growth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ services:
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
     init: true
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     command:
       [
         "node",
@@ -71,6 +76,11 @@ services:
     stdin_open: true
     tty: true
     init: true
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     entrypoint: ["node", "dist/index.js"]
     depends_on:
       - openclaw-gateway


### PR DESCRIPTION
## Summary

Both `openclaw-gateway` and `openclaw-cli` services in `docker-compose.yml` use Docker's default `json-file` logging driver **with no size limits**. On long-running instances this silently fills the disk, eventually causing service failures.

## Problem

- Docker's default `json-file` log driver keeps **all** container output with no rotation
- The docs mention "watch disk growth hotspots" (`docs/install/docker.md` L543) but the compose file itself provides **no logging configuration**
- Both services (gateway + cli) are affected
- This is a common production issue — containers running for weeks/months accumulate GB of logs

## Changes

Add `logging` configuration to both services:

```yaml
logging:
  driver: json-file
  options:
    max-size: "10m"
    max-file: "3"
```

This caps total log storage at ~30 MB per service (~60 MB total) while preserving the 3 most recent log files for debugging.

## Why these values

| Setting | Value | Rationale |
|---------|-------|-----------|
| `driver` | `json-file` | Docker default, widest compatibility, works with `docker logs` |
| `max-size` | `10m` | Enough to capture meaningful log history without waste |
| `max-file` | `3` | Keeps ~30 MB per service; sufficient for debugging recent issues |

## Testing

- Verified with `docker compose config` — valid YAML, no warnings
- Confirmed `docker logs` still works with these settings
- No behavior change for users; purely a disk-safety guardrail

## Related

- `docs/install/docker.md` L543 mentions disk growth but provides no compose-level mitigation
