### PR TITLE
fix(docker): add no-new-privileges to gateway service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   openclaw-gateway:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    security_opt:
+      - no-new-privileges:true
     environment:
       HOME: /home/node
       TERM: xterm-256color

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   openclaw-gateway:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    cap_drop:
+      - NET_RAW
+      - NET_ADMIN
     security_opt:
       - no-new-privileges:true
     environment:


### PR DESCRIPTION
## Summary

The `openclaw-cli` service already has `cap_drop` and `security_opt` hardening, but the `openclaw-gateway` service — which is the one **exposing ports to the network** — has **zero security hardening**. This PR brings gateway security in line with cli.

## Problem

| Service | `cap_drop` | `security_opt` | Exposes ports |
|---------|-----------|----------------|---------------|
| `openclaw-cli` | `NET_RAW`, `NET_ADMIN` | `no-new-privileges:true` | No |
| `openclaw-gateway` | _(none)_ | _(none)_ | **Yes** (18789, 18790) |

The gateway — which handles external HTTP traffic — has **fewer** security restrictions than the internal CLI service. This is the opposite of the expected security posture.

## Changes

Add to `openclaw-gateway`:
- `cap_drop: [NET_RAW, NET_ADMIN]` — drop unnecessary Linux capabilities
- `security_opt: [no-new-privileges:true]` — prevent privilege escalation

Both services now have identical security hardening.

### After this PR

| Service | `cap_drop` | `security_opt` | Exposes ports |
|---------|-----------|----------------|---------------|
| `openclaw-cli` | `NET_RAW`, `NET_ADMIN` | `no-new-privileges:true` | No |
| `openclaw-gateway` | `NET_RAW`, `NET_ADMIN` | `no-new-privileges:true` | **Yes** |

## Why this is safe

- The healthcheck uses `node -e fetch(...)` (plain TCP via Node.js `http` module), which does **not** require `NET_RAW`
- The gateway serves HTTP traffic over regular TCP sockets — no raw socket or network admin operations needed
- `no-new-privileges` prevents setuid/execve privilege escalation inside the container

## Testing

- `docker compose config` — valid YAML, no warnings
- Gateway starts and responds to health checks normally
- No functionality change; purely defense-in-depth

## Related

- PR #42043 added documentation about gateway security hardening
- This PR applies the hardening directly to the default `docker-compose.yml`
