### PR TITLE
fix: preserve fenced code block indentation in directive whitespace normalization

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  parseInlineDirectives,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "./directive-tags.js";
@@ -55,5 +56,72 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
     };
     const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
     expect(result).toEqual(input);
+  });
+});
+
+describe("parseInlineDirectives – whitespace normalization", () => {
+  test("collapses extra spaces in plain text after directive removal", () => {
+    const result = parseInlineDirectives("[[reply_to_current]]   hello   world");
+    expect(result.text).toBe("hello world");
+  });
+
+  test("preserves indentation inside a backtick fenced code block", () => {
+    const input = [
+      "[[reply_to_current]] Here is some YAML:",
+      "",
+      "```yaml",
+      "a:",
+      "  b:",
+      "    c: value",
+      "```",
+    ].join("\n");
+    const result = parseInlineDirectives(input);
+    expect(result.replyToCurrent).toBe(true);
+    // Indentation inside the code block must survive.
+    expect(result.text).toContain("  b:\n    c: value");
+  });
+
+  test("preserves indentation inside a tilde fenced code block", () => {
+    const input = [
+      "[[reply_to_current]] Example:",
+      "",
+      "~~~python",
+      "def foo():",
+      "    return 42",
+      "~~~",
+    ].join("\n");
+    const result = parseInlineDirectives(input);
+    expect(result.text).toContain("    return 42");
+  });
+
+  test("normalizes whitespace outside code blocks but not inside", () => {
+    const input = [
+      "[[audio_as_voice]]   intro text   with extra spaces",
+      "",
+      "```",
+      "  indented line",
+      "```",
+      "",
+      "  trailing text  ",
+    ].join("\n");
+    const result = parseInlineDirectives(input);
+    // Outside the fence: spaces collapsed.
+    expect(result.text).toContain("intro text with extra spaces");
+    // Inside the fence: indentation preserved.
+    expect(result.text).toContain("  indented line");
+    // Trailing whitespace collapsed to nothing at the very end.
+    expect(result.text.endsWith("trailing text")).toBe(true);
+  });
+
+  test("handles text with no directives and no code blocks", () => {
+    const result = parseInlineDirectives("  hello   world  ");
+    expect(result.text).toBe("hello world");
+  });
+
+  test("handles text with no directives but with a code block", () => {
+    const input = "  some text  \n\n```\n  indented\n```\n  more";
+    const result = parseInlineDirectives(input);
+    expect(result.text).toContain("  indented");
+    expect(result.text).toContain("some text");
   });
 });

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -17,11 +17,41 @@ type InlineDirectiveParseOptions = {
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 
+/**
+ * Collapse runs of spaces/tabs to a single space and strip whitespace around
+ * newlines, but **preserve fenced code blocks verbatim** so that indented
+ * YAML, code examples, and other whitespace-sensitive content is not mangled
+ * after directive tags are stripped.
+ *
+ * Fenced code blocks (``` ``` ``` or ~~~) are detected by the CommonMark rules:
+ * an opening fence of 3+ identical chars at the start of a line, with a
+ * matching closing fence of the same character type.
+ */
 function normalizeDirectiveWhitespace(text: string): string {
-  return text
-    .replace(/[ \t]+/g, " ")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .trim();
+  // Regex to match fenced code blocks in their entirety.
+  // Two alternatives for backtick and tilde fences respectively.
+  // The non-greedy [\s\S]*? ensures we match the nearest closing fence.
+  const FENCED_CODE_RE =
+    /^(`{3,})[^\n]*\n[\s\S]*?\n\1[ \t]*$|^(~{3,})[^\n]*\n[\s\S]*?\n\2[ \t]*$/gm;
+
+  const normalizeSection = (s: string): string =>
+    s.replace(/[ \t]+/g, " ").replace(/[ \t]*\n[ \t]*/g, "\n");
+
+  const parts: string[] = [];
+  let last = 0;
+  let match: RegExpExecArray | null;
+  FENCED_CODE_RE.lastIndex = 0;
+  while ((match = FENCED_CODE_RE.exec(text)) !== null) {
+    // Normalize the plain-text section before this code block.
+    parts.push(normalizeSection(text.slice(last, match.index)));
+    // Preserve the fenced code block exactly as written.
+    parts.push(match[0]);
+    last = match.index + match[0].length;
+  }
+  // Normalize any remaining text after the last code block.
+  parts.push(normalizeSection(text.slice(last)));
+
+  return parts.join("").trim();
 }
 
 type StripInlineDirectiveTagsResult = {


### PR DESCRIPTION
Fixes #42576

## Problem
`normalizeDirectiveWhitespace()` in `src/utils/directive-tags.ts` was applying
`.replace(/[ \t]+/g, " ")` globally to the entire message text, which collapsed
all leading whitespace including indentation inside fenced code blocks (YAML,
Python, etc.).

## Solution
Replaced the naive global replace with a fenced-code-block-aware normalizer:
- Uses a regex to locate ``` ``` ``` and `~~~` fenced code blocks
- Preserves content inside fences verbatim
- Only normalizes horizontal whitespace in plain-text sections around the fences

## Tests
Added 6 regression tests covering:
- YAML backtick fences
- Python tilde fences
- Mixed inside/outside normalization
- Edge cases (no directive, no code block)

All 12 tests pass (6 pre-existing + 6 new).