### PR TITLE
Fix regex safety and enhance session log redaction

### DIFF
--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -1,4 +1,5 @@
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
+import { redactSensitiveText } from "../logging/redact.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
   applyInputProvenanceToUserMessage,
@@ -12,6 +13,29 @@ export type GuardedSessionManager = SessionManager & {
   /** Clear pending tool calls without persisting synthetic tool results. Idempotent. */
   clearPendingToolResults?: () => void;
 };
+
+// oxlint-disable-next-line typescript/no-explicit-any
+function redactMessageContent(message: any): any {
+  if (!message || typeof message !== "object") {
+    return message;
+  }
+  const copy = { ...message };
+  if (typeof copy.content === "string") {
+    copy.content = redactSensitiveText(copy.content);
+  } else if (Array.isArray(copy.content)) {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    copy.content = copy.content.map((block: any) => {
+      if (block.type === "text" && typeof block.text === "string") {
+        return { ...block, text: redactSensitiveText(block.text) };
+      }
+      if (block.type === "thinking" && typeof block.thinking === "string") {
+        return { ...block, thinking: redactSensitiveText(block.thinking) };
+      }
+      return block;
+    });
+  }
+  return copy;
+}
 
 /**
  * Apply the tool-result guard to a SessionManager exactly once and expose
@@ -63,8 +87,10 @@ export function guardSessionManager(
     : undefined;
 
   const guard = installSessionToolResultGuard(sessionManager, {
-    transformMessageForPersistence: (message) =>
-      applyInputProvenanceToUserMessage(message, opts?.inputProvenance),
+    transformMessageForPersistence: (message) => {
+      const withProvenance = applyInputProvenanceToUserMessage(message, opts?.inputProvenance);
+      return redactMessageContent(withProvenance);
+    },
     transformToolResultForPersistence: transform,
     allowSyntheticToolResults: opts?.allowSyntheticToolResults,
     allowedToolNames: opts?.allowedToolNames,

--- a/src/security/safe-regex.ts
+++ b/src/security/safe-regex.ts
@@ -124,16 +124,20 @@ function tokenizePattern(source: string): PatternToken[] {
   for (let i = 0; i < source.length; i += 1) {
     const ch = source[i];
 
-    if (ch === "\\") {
-      i += 1;
-      tokens.push({ kind: "simple-token" });
-      continue;
-    }
-
     if (inCharClass) {
+      if (ch === "\\") {
+        i += 1;
+        continue;
+      }
       if (ch === "]") {
         inCharClass = false;
       }
+      continue;
+    }
+
+    if (ch === "\\") {
+      i += 1;
+      tokens.push({ kind: "simple-token" });
       continue;
     }
 


### PR DESCRIPTION
## Summary


Co-Author:     GPT-5.2-Codex

- Problem:

- Fix Safe Regex Redact / Mask :Corrected the logic in compileSafeRegex to properly handle regex 
- Added support for redacting sensitive info in **thinking** blocks 
- Extended the guardSessionManager to intercept messages before they are persisted to session.jsonl .


## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # https://github.com/openclaw/openclaw/issues/42982
- Related #


### Steps


Example, to redact user email in logging

adding openclaw.json
```
  "logging": {
    "redactSensitive": "tools",
    "redactPatterns": [
      "([\\w]|[-.])+@([\\w]|[-.])+\\.\\w+"
    ]
  },
```

Then using tooling call to show email in a file
```
echo "peter@dc.io" > /app/test_email.txt 
openclaw agent --local --session-id test-thinking-redaction -m "read /app/test_email.txt and quote the email address in your thinking process before answering"
```

#### Expect

Logging should be like below
you will see both in **Thinking** and **response**, the emial is redacted : `peter@d***.io `

```
==> /home/node/.openclaw/agents/main/sessions/test-thinking-redaction.jsonl <==
{"type":"session","version":3,"id":"test-thinking-redaction","timestamp":"2026-03-11T08:15:01.193Z","cwd":"/root/data/openclaw-b33a85d6c64a/workspace"}
{"type":"model_change","id":"631d84ae","parentId":null,"timestamp":"2026-03-11T08:15:01.196Z","provider":"d-run-maas","modelId":"public/minimax-m2.5"}
{"type":"thinking_level_change","id":"4950ede8","parentId":"631d84ae","timestamp":"2026-03-11T08:15:01.196Z","thinkingLevel":"off"}
{"type":"custom","customType":"model-snapshot","data":{"timestamp":1773216901198,"provider":"d-run-maas","modelApi":"openai-completions","modelId":"public/minimax-m2.5"},"id":"78b9b210","parentId":"4950ede8","timestamp":"2026-03-11T08:15:01.198Z"}
{"type":"message","id":"8fe93bd0","parentId":"78b9b210","timestamp":"2026-03-11T08:15:01.208Z","message":{"role":"user","content":[{"type":"text","text":"read /app/test_email.txt and quote the email address in your thinking process before answering"}],"timestamp":1773216901201}}
{"type":"message","id":"846ee292","parentId":"8fe93bd0","timestamp":"2026-03-11T08:15:05.354Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"The user wants me to read a file and quote an email address from it. Let me read the file first.\n","thinkingSignature":"reasoning_content"},{"type":"text","text":"\n\n\n"},{"type":"toolCall","id":"call_23783fcb92614aaa8065603d","name":"read","arguments":{"path":"/app/test_email.txt"}}],"api":"openai-completions","provider":"d-run-maas","model":"public/minimax-m2.5","usage":{"input":11244,"output":52,"cacheRead":0,"cacheWrite":0,"totalTokens":11296,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":1773216901203}}
{"type":"message","id":"e058ce1f","parentId":"846ee292","timestamp":"2026-03-11T08:15:05.366Z","message":{"role":"toolResult","toolCallId":"call_23783fcb92614aaa8065603d","toolName":"read","content":[{"type":"text","text":"Please contact peter@d***.io for support.\n"}],"isError":false,"timestamp":1773216905363}}
{"type":"message","id":"84b52be1","parentId":"e058ce1f","timestamp":"2026-03-11T08:15:07.342Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"The email address in the file is peter@d***.io.\n","thinkingSignature":"reasoning_content"},{"type":"text","text":"\n\nThe email address in the file is **peter@d***.io**."}],"api":"openai-completions","provider":"d-run-maas","model":"public/minimax-m2.5","usage":{"input":11323,"output":30,"cacheRead":0,"cacheWrite":0,"totalTokens":11353,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1773216905365}}
```
``` 

