### PR TITLE
fix(cron): stop raw-stdout jobs from re-running after tool success

### DIFF
--- a/src/cron/isolated-agent/run.interim-retry.test.ts
+++ b/src/cron/isolated-agent/run.interim-retry.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   makeIsolatedAgentTurnParams,
@@ -95,5 +96,40 @@ describe("runCronIsolatedAgentTurn — interim ack retry", () => {
 
     mockFallbackPassthrough();
     await runTurnAndExpectOk(1, 1);
+  });
+
+  it("does not retry raw-stdout cron requests after a successful tool result", async () => {
+    usePayloadTextExtraction();
+    const transcriptPath = "/tmp/transcript.jsonl";
+    const toolResultText = '{"action":"send","payload":{"ok":true,"messageId":"670"}}';
+    fs.writeFileSync(
+      transcriptPath,
+      `${JSON.stringify({
+        type: "message",
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "toolResult",
+          isError: false,
+          content: [{ type: "text", text: toolResultText }],
+        },
+      })}\n`,
+      "utf8",
+    );
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    mockFallbackPassthrough();
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        message: "执行脚本，只返回原始 stdout。",
+      }),
+    );
+    expect(result.status).toBe("ok");
+    expect(result.outputText).toBe(toolResultText);
+    expect(runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    fs.rmSync(transcriptPath, { force: true });
   });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import {
   resolveAgentConfig,
   resolveAgentDir,
@@ -196,6 +197,59 @@ function appendCronDeliveryInstruction(params: {
     return params.commandBody;
   }
   return `${params.commandBody}\n\nReturn your summary as plain text; it will be delivered automatically. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`.trim();
+}
+
+function isRawStdoutCronRequest(message: string) {
+  return /raw stdout|原始 stdout|原始输出/i.test(message);
+}
+
+async function readLatestSuccessfulToolResultText(sessionFile: string, runStartedAt: number) {
+  try {
+    const raw = await fs.promises.readFile(sessionFile, "utf8");
+    const lines = raw.split("\n");
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      const line = lines[index]?.trim();
+      if (!line) {
+        continue;
+      }
+      let entry: Record<string, unknown>;
+      try {
+        entry = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (entry.type !== "message") {
+        continue;
+      }
+      const message = entry.message as Record<string, unknown> | undefined;
+      if (message?.role !== "toolResult" || message.isError === true) {
+        continue;
+      }
+      const timestamp =
+        typeof entry.timestamp === "string" ? Date.parse(entry.timestamp) : Number.NaN;
+      if (Number.isFinite(timestamp) && timestamp < runStartedAt) {
+        continue;
+      }
+      const content = Array.isArray(message.content) ? message.content : [];
+      const text = content
+        .map((item) =>
+          typeof item === "object" &&
+          item &&
+          "text" in item &&
+          typeof item.text === "string" &&
+          item.text.trim()
+            ? item.text.trim()
+            : "",
+        )
+        .find(Boolean);
+      if (text) {
+        return text;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
 }
 
 export async function runCronIsolatedAgentTurn(params: {
@@ -529,6 +583,8 @@ export async function runCronIsolatedAgentTurn(params: {
   let fallbackModel = model;
   const runStartedAt = Date.now();
   let runEndedAt = runStartedAt;
+  const rawStdoutCronRequest = isRawStdoutCronRequest(params.message);
+  let rawStdoutToolResultText: string | undefined;
   try {
     const sessionFile = resolveSessionTranscriptPath(cronSession.sessionEntry.sessionId, agentId);
     const resolvedVerboseLevel =
@@ -647,6 +703,12 @@ export async function runCronIsolatedAgentTurn(params: {
     if (!runResult) {
       throw new Error("cron isolated run returned no result");
     }
+    if (rawStdoutCronRequest) {
+      rawStdoutToolResultText = await readLatestSuccessfulToolResultText(
+        sessionFile,
+        runStartedAt,
+      );
+    }
 
     // Guardrail for cron jobs: if the first turn is only an interim ack
     // (e.g. "on it") and no descendants are active, run one focused follow-up
@@ -668,6 +730,7 @@ export async function runCronIsolatedAgentTurn(params: {
         },
       );
       const shouldRetryInterimAck =
+        !rawStdoutCronRequest &&
         !interimRunResult.meta?.error &&
         !interimRunResult.didSendViaMessagingTool &&
         !interimPayloadHasStructuredContent &&
@@ -769,6 +832,10 @@ export async function runCronIsolatedAgentTurn(params: {
   const firstText = payloads[0]?.text ?? "";
   let summary = pickSummaryFromPayloads(payloads) ?? pickSummaryFromOutput(firstText);
   let outputText = pickLastNonEmptyTextFromPayloads(payloads);
+  if (!outputText?.trim() && rawStdoutToolResultText) {
+    outputText = rawStdoutToolResultText;
+    summary = rawStdoutToolResultText;
+  }
   let synthesizedText = outputText?.trim() || summary?.trim() || undefined;
   const deliveryPayload = pickLastDeliverablePayload(payloads);
   let deliveryPayloads =


### PR DESCRIPTION
## Summary
- avoid the interim-ack follow-up rerun for cron agent jobs that explicitly ask for raw stdout output
- recover the final cron output from the latest successful toolResult when the agent returns no text payload
- add a regression test covering raw-stdout cron requests that complete via a tool result

## Problem
For cron jobs that ask the agent to execute a script and return only the script's raw stdout, the isolated cron runner currently treats the empty assistant payload as an interim acknowledgement and issues a follow-up prompt. In practice this causes the tool to re-run multiple times, which can duplicate side effects like Telegram sends and eventually time out the cron run even though the first tool execution already succeeded.

## Notes
- this keeps the existing interim-ack retry behavior for normal text-based cron runs
- raw-stdout jobs now reuse the latest successful toolResult text as the final output when no assistant text payload is present
