### PR TITLE
improve: Harden gateway HTTP/WS surfaces and improve GatewayClient ro…

### DIFF
--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -149,10 +149,12 @@ describe("chrome extension relay server", () => {
       "OPENCLAW_GATEWAY_TOKEN",
       "OPENCLAW_EXTENSION_RELAY_RECONNECT_GRACE_MS",
       "OPENCLAW_EXTENSION_RELAY_COMMAND_RECONNECT_WAIT_MS",
+      "OPENCLAW_EXTENSION_RELAY_ALLOW_QUERY_TOKEN",
     ]);
     process.env.OPENCLAW_GATEWAY_TOKEN = TEST_GATEWAY_TOKEN;
     delete process.env.OPENCLAW_EXTENSION_RELAY_RECONNECT_GRACE_MS;
     delete process.env.OPENCLAW_EXTENSION_RELAY_COMMAND_RECONNECT_WAIT_MS;
+    delete process.env.OPENCLAW_EXTENSION_RELAY_ALLOW_QUERY_TOKEN;
   });
 
   afterEach(async () => {
@@ -573,9 +575,25 @@ describe("chrome extension relay server", () => {
       .toBe(true);
   });
 
-  it("accepts extension websocket access with relay token query param", async () => {
+  it("rejects extension websocket access with relay token query param by default", async () => {
     const sharedUrl = await ensureSharedRelayServer();
     const sharedPort = new URL(sharedUrl).port;
+
+    const token = relayAuthHeaders(`ws://127.0.0.1:${sharedPort}/extension`)[
+      "x-openclaw-relay-token"
+    ];
+    expect(token).toBeTruthy();
+    const ext = new WebSocket(
+      `ws://127.0.0.1:${sharedPort}/extension?token=${encodeURIComponent(String(token))}`,
+    );
+    const err = await waitForError(ext);
+    expect(err.message).toContain("401");
+  });
+
+  it("accepts extension websocket access with relay token query param when explicitly enabled", async () => {
+    const sharedUrl = await ensureSharedRelayServer();
+    const sharedPort = new URL(sharedUrl).port;
+    process.env.OPENCLAW_EXTENSION_RELAY_ALLOW_QUERY_TOKEN = "1";
 
     const token = relayAuthHeaders(`ws://127.0.0.1:${sharedPort}/extension`)[
       "x-openclaw-relay-token"
@@ -588,8 +606,20 @@ describe("chrome extension relay server", () => {
     ext.close();
   });
 
-  it("accepts /json endpoints with relay token query param", async () => {
+  it("rejects /json endpoints with relay token query param by default", async () => {
     const sharedUrl = await ensureSharedRelayServer();
+
+    const token = relayAuthHeaders(sharedUrl)["x-openclaw-relay-token"];
+    expect(token).toBeTruthy();
+    const versionRes = await fetch(
+      `${sharedUrl}/json/version?token=${encodeURIComponent(String(token))}`,
+    );
+    expect(versionRes.status).toBe(401);
+  });
+
+  it("accepts /json endpoints with relay token query param when explicitly enabled", async () => {
+    const sharedUrl = await ensureSharedRelayServer();
+    process.env.OPENCLAW_EXTENSION_RELAY_ALLOW_QUERY_TOKEN = "1";
 
     const token = relayAuthHeaders(sharedUrl)["x-openclaw-relay-token"];
     expect(token).toBeTruthy();
@@ -602,6 +632,7 @@ describe("chrome extension relay server", () => {
   it("accepts raw gateway token for relay auth compatibility", async () => {
     const sharedUrl = await ensureSharedRelayServer();
     const sharedPort = new URL(sharedUrl).port;
+    process.env.OPENCLAW_EXTENSION_RELAY_ALLOW_QUERY_TOKEN = "1";
 
     const versionRes = await fetch(`${sharedUrl}/json/version`, {
       headers: { "x-openclaw-relay-token": TEST_GATEWAY_TOKEN },

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -84,6 +84,7 @@ type ConnectedTarget = {
 const RELAY_AUTH_HEADER = "x-openclaw-relay-token";
 const DEFAULT_EXTENSION_RECONNECT_GRACE_MS = 20_000;
 const DEFAULT_EXTENSION_COMMAND_RECONNECT_WAIT_MS = 3_000;
+const ALLOW_QUERY_TOKEN_ENV = "OPENCLAW_EXTENSION_RELAY_ALLOW_QUERY_TOKEN";
 
 function headerValue(value: string | string[] | undefined): string | undefined {
   if (!value) {
@@ -104,9 +105,13 @@ function getRelayAuthTokenFromRequest(req: IncomingMessage, url?: URL): string |
   if (headerToken) {
     return headerToken;
   }
-  const queryToken = url?.searchParams.get("token")?.trim();
-  if (queryToken) {
-    return queryToken;
+  // Avoid leaking tokens via URL (history, logs, referrers). Keep this behind
+  // an explicit debug-only env override for backwards compatibility.
+  if (process.env[ALLOW_QUERY_TOKEN_ENV] === "1") {
+    const queryToken = url?.searchParams.get("token")?.trim();
+    if (queryToken) {
+      return queryToken;
+    }
   }
   return undefined;
 }

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -581,3 +581,49 @@ describe("GatewayClient connect auth payload", () => {
     vi.useRealTimers();
   });
 });
+
+describe("GatewayClient request lifecycle", () => {
+  beforeEach(() => {
+    wsInstances.length = 0;
+  });
+
+  it("rejects requests that exceed the pending limit", async () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      maxPendingRequests: 1,
+    });
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+
+    const first = client.request("test.method", { a: 1 });
+    await expect(client.request("test.method", { a: 2 })).rejects.toThrow(/pending request limit/i);
+    client.stop();
+    await expect(first).rejects.toThrow(/stopped|closed/i);
+  });
+
+  it("times out pending requests and cleans them up", async () => {
+    vi.useFakeTimers();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      requestTimeoutMs: 500,
+    });
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+
+    const p = client.request("test.timeout", { ok: true });
+    const pExpectation = expect(p).rejects.toThrow(/timeout/i);
+    await vi.advanceTimersByTimeAsync(600);
+    await pExpectation;
+
+    // If cleanup worked, a new request should be allowed without tripping maxPending.
+    const p2 = client.request("test.timeout.2", { ok: true }, { timeoutMs: 500 });
+    const p2Expectation = expect(p2).rejects.toThrow(/timeout/i);
+    await vi.advanceTimersByTimeAsync(600);
+    await p2Expectation;
+
+    client.stop();
+    vi.useRealTimers();
+  });
+});

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -44,6 +44,7 @@ type Pending = {
   resolve: (value: unknown) => void;
   reject: (err: unknown) => void;
   expectFinal: boolean;
+  timer: NodeJS.Timeout | null;
 };
 
 type GatewayClientErrorShape = {
@@ -68,6 +69,8 @@ export type GatewayClientOptions = {
   url?: string; // ws://127.0.0.1:18789
   connectDelayMs?: number;
   tickWatchMinIntervalMs?: number;
+  requestTimeoutMs?: number;
+  maxPendingRequests?: number;
   token?: string;
   deviceToken?: string;
   password?: string;
@@ -123,12 +126,20 @@ export class GatewayClient {
   private lastTick: number | null = null;
   private tickIntervalMs = 30_000;
   private tickTimer: NodeJS.Timeout | null = null;
+  private requestTimeoutMs = 30_000;
+  private maxPendingRequests = 1000;
 
   constructor(opts: GatewayClientOptions) {
     this.opts = {
       ...opts,
       deviceIdentity: opts.deviceIdentity ?? loadOrCreateDeviceIdentity(),
     };
+    if (typeof opts.requestTimeoutMs === "number" && Number.isFinite(opts.requestTimeoutMs)) {
+      this.requestTimeoutMs = Math.max(250, Math.min(5 * 60_000, opts.requestTimeoutMs));
+    }
+    if (typeof opts.maxPendingRequests === "number" && Number.isFinite(opts.maxPendingRequests)) {
+      this.maxPendingRequests = Math.max(1, Math.floor(opts.maxPendingRequests));
+    }
   }
 
   start() {
@@ -536,6 +547,10 @@ export class GatewayClient {
           return;
         }
         this.pending.delete(parsed.id);
+        if (pending.timer) {
+          clearTimeout(pending.timer);
+          pending.timer = null;
+        }
         if (parsed.ok) {
           pending.resolve(parsed.payload);
         } else {
@@ -588,6 +603,10 @@ export class GatewayClient {
 
   private flushPendingErrors(err: Error) {
     for (const [, p] of this.pending) {
+      if (p.timer) {
+        clearTimeout(p.timer);
+        p.timer = null;
+      }
       p.reject(err);
     }
     this.pending.clear();
@@ -647,10 +666,13 @@ export class GatewayClient {
   async request<T = Record<string, unknown>>(
     method: string,
     params?: unknown,
-    opts?: { expectFinal?: boolean },
+    opts?: { expectFinal?: boolean; timeoutMs?: number },
   ): Promise<T> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new Error("gateway not connected");
+    }
+    if (this.pending.size >= this.maxPendingRequests) {
+      throw new Error(`gateway client pending request limit exceeded (${this.maxPendingRequests})`);
     }
     const id = randomUUID();
     const frame: RequestFrame = { type: "req", id, method, params };
@@ -660,11 +682,27 @@ export class GatewayClient {
       );
     }
     const expectFinal = opts?.expectFinal === true;
+    const timeoutMsRaw = opts?.timeoutMs;
+    const timeoutMs =
+      typeof timeoutMsRaw === "number" && Number.isFinite(timeoutMsRaw)
+        ? Math.max(250, Math.min(10 * 60_000, timeoutMsRaw))
+        : this.requestTimeoutMs;
     const p = new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const pending = this.pending.get(id);
+        if (!pending) {
+          return;
+        }
+        this.pending.delete(id);
+        pending.timer = null;
+        pending.reject(new Error(`gateway request timeout: ${method}`));
+      }, timeoutMs);
+      timer.unref?.();
       this.pending.set(id, {
         resolve: (value) => resolve(value as T),
         reject,
         expectFinal,
+        timer,
       });
     });
     this.ws.send(JSON.stringify(frame));

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -280,13 +280,27 @@ export async function resolveGatewayBindHost(
 export async function canBindToHost(host: string): Promise<boolean> {
   return new Promise((resolve) => {
     const testServer = net.createServer();
-    testServer.once("error", () => {
-      resolve(false);
-    });
+    let settled = false;
+    const finish = (ok: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      try {
+        testServer.close();
+      } catch {
+        // ignore
+      }
+      resolve(ok);
+    };
+    testServer.unref();
+    testServer.once("error", () => finish(false));
     testServer.once("listening", () => {
-      testServer.close();
-      resolve(true);
+      finish(true);
     });
+    const timer = setTimeout(() => finish(false), 1000);
+    timer.unref?.();
     // Use port 0 to let OS pick an available port for testing
     testServer.listen(0, host);
   });

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -84,10 +84,13 @@ function resolveResponsesLimits(
         : DEFAULT_MAX_URL_PARTS,
     files: {
       ...fileLimits,
+      // URL inputs are a powerful egress capability. Default to disabled unless explicitly enabled.
+      allowUrl: files?.allowUrl ?? false,
       urlAllowlist: normalizeInputHostnameAllowlist(files?.urlAllowlist),
     },
     images: {
-      allowUrl: images?.allowUrl ?? true,
+      // URL inputs are a powerful egress capability. Default to disabled unless explicitly enabled.
+      allowUrl: images?.allowUrl ?? false,
       urlAllowlist: normalizeInputHostnameAllowlist(images?.urlAllowlist),
       allowedMimes: normalizeMimeList(images?.allowedMimes, DEFAULT_INPUT_IMAGE_MIMES),
       maxBytes: images?.maxBytes ?? DEFAULT_INPUT_IMAGE_MAX_BYTES,

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -146,7 +146,9 @@ export async function startGatewaySidecars(params: {
         deps: params.deps,
         workspaceDir: params.defaultWorkspaceDir,
       });
-      void triggerInternalHook(hookEvent);
+      triggerInternalHook(hookEvent).catch((err) => {
+        params.logHooks.warn(`internal startup hook failed: ${String(err)}`);
+      });
     }, 250);
   }
 
@@ -183,7 +185,9 @@ export async function startGatewaySidecars(params: {
 
   if (shouldWakeFromRestartSentinel()) {
     setTimeout(() => {
-      void scheduleRestartSentinelWake({ deps: params.deps });
+      scheduleRestartSentinelWake({ deps: params.deps }).catch((err) => {
+        params.log.warn(`restart sentinel wake failed: ${String(err)}`);
+      });
     }, 750);
   }
 

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -9,7 +9,7 @@ import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { isLoopbackAddress } from "../net.js";
-import { getHandshakeTimeoutMs } from "../server-constants.js";
+import { getHandshakeTimeoutMs, MAX_BUFFERED_BYTES } from "../server-constants.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
 import { logWs } from "../ws-log.js";
@@ -165,6 +165,16 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
 
     const send = (obj: unknown) => {
       try {
+        // Backpressure guard: avoid unbounded buffering for slow clients.
+        // If the outbound buffer grows too large, disconnect to protect gateway memory.
+        if (typeof socket.bufferedAmount === "number" && socket.bufferedAmount > MAX_BUFFERED_BYTES) {
+          setCloseCause("slow-client", {
+            bufferedAmount: socket.bufferedAmount,
+            bufferedLimit: MAX_BUFFERED_BYTES,
+          });
+          close(1013, "client too slow");
+          return;
+        }
         socket.send(JSON.stringify(obj));
       } catch {
         /* ignore */

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -9,7 +9,7 @@ import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { isLoopbackAddress } from "../net.js";
-import { getHandshakeTimeoutMs } from "../server-constants.js";
+import { getHandshakeTimeoutMs, MAX_BUFFERED_BYTES } from "../server-constants.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
 import { logWs } from "../ws-log.js";
@@ -165,6 +165,19 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
 
     const send = (obj: unknown) => {
       try {
+        // Backpressure guard: avoid unbounded buffering for slow clients.
+        // If the outbound buffer grows too large, disconnect to protect gateway memory.
+        if (
+          typeof socket.bufferedAmount === "number" &&
+          socket.bufferedAmount > MAX_BUFFERED_BYTES
+        ) {
+          setCloseCause("slow-client", {
+            bufferedAmount: socket.bufferedAmount,
+            bufferedLimit: MAX_BUFFERED_BYTES,
+          });
+          close(1013, "client too slow");
+          return;
+        }
         socket.send(JSON.stringify(obj));
       } catch {
         /* ignore */


### PR DESCRIPTION
…bustness

Tighten OpenResponses HTTP defaults by disabling URL-based file and image inputs unless explicitly enabled in gateway.http.endpoints.responses.{files,images}.allowUrl, preserving SSRF guards while avoiding unexpected public egress. Keep URL-based input egress constrained by requiring hostname allowlists when URL inputs are turned on, and rely on existing SSRF protections for private/metadata endpoints. Reduce token exposure risk in the Chrome Extension Relay by defaulting getRelayAuthTokenFromRequest to header-only auth and gating ?token= query param support behind the OPENCLAW_EXTENSION_RELAY_ALLOW_QUERY_TOKEN=1 break-glass env flag. Preserve existing relay behavior (including /json and /extension access via query token) only when the explicit debug env flag is set, and extend tests to cover both default-deny and opt-in modes. Fix a potential resource leak in canBindToHost by unref’ing the temporary server, adding a short timeout, and ensuring the probe server is closed on both success and error paths. Add .catch handlers and warning logs around fire-and-forget startup tasks (triggerInternalHook, scheduleRestartSentinelWake) so internal hook failures and restart sentinel issues surface as warnings instead of unhandled rejections. Introduce per-request timeouts and a bounded maxPendingRequests limit in GatewayClient.request, with cleanup of timers and pending entries on resolution/timeout/stop to prevent unbounded memory growth and permanently-hung callers. Add simple WS backpressure protection on the gateway server by checking socket.bufferedAmount against MAX_BUFFERED_BYTES and closing slow clients with a clear “client too slow” close reason when they exceed the per-connection send buffer budget. Extend and adjust unit tests for OpenResponses URL policy, extension relay auth compatibility, and GatewayClient pending/timeout behavior so the new defaults and guard rails are exercised and regressions are less likely.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
