### PR TITLE
feat: add PPIO as implicit LLM provider

### DIFF
--- a/src/agents/model-auth-env-vars.ts
+++ b/src/agents/model-auth-env-vars.ts
@@ -35,6 +35,7 @@ export const PROVIDER_ENV_API_KEY_CANDIDATES: Record<string, string[]> = {
   ollama: ["OLLAMA_API_KEY"],
   vllm: ["VLLM_API_KEY"],
   kilocode: ["KILOCODE_API_KEY"],
+  ppio: ["PPIO_API_KEY"],
 };
 
 export function listKnownProviderEnvApiKeyNames(): string[] {

--- a/src/agents/models-config.e2e-harness.ts
+++ b/src/agents/models-config.e2e-harness.ts
@@ -114,6 +114,7 @@ export const MODELS_CONFIG_IMPLICIT_ENV_VARS = [
   "VENICE_API_KEY",
   "VLLM_API_KEY",
   "XIAOMI_API_KEY",
+  "PPIO_API_KEY",
   // Avoid ambient AWS creds unintentionally enabling Bedrock discovery.
   "AWS_ACCESS_KEY_ID",
   "AWS_CONFIG_FILE",

--- a/src/agents/models-config.providers.discovery.ts
+++ b/src/agents/models-config.providers.discovery.ts
@@ -10,6 +10,7 @@ import {
 } from "./huggingface-models.js";
 import { discoverKilocodeModels } from "./kilocode-models.js";
 import { OLLAMA_NATIVE_BASE_URL } from "./ollama-stream.js";
+import { discoverPpioModels, PPIO_BASE_URL } from "./ppio-models.js";
 import { discoverVeniceModels, VENICE_BASE_URL } from "./venice-models.js";
 import { discoverVercelAiGatewayModels, VERCEL_AI_GATEWAY_BASE_URL } from "./vercel-ai-gateway.js";
 
@@ -286,6 +287,19 @@ export async function buildKilocodeProviderWithDiscovery(): Promise<ProviderConf
   const models = await discoverKilocodeModels();
   return {
     baseUrl: KILOCODE_BASE_URL,
+    api: "openai-completions",
+    models,
+  };
+}
+
+/**
+ * Build the PPIO provider with dynamic model discovery.
+ * Falls back to the static catalog on failure.
+ */
+export async function buildPpioProvider(discoveryApiKey?: string): Promise<ProviderConfig> {
+  const models = await discoverPpioModels(discoveryApiKey);
+  return {
+    baseUrl: PPIO_BASE_URL,
     api: "openai-completions",
     models,
   };

--- a/src/agents/models-config.providers.ppio.test.ts
+++ b/src/agents/models-config.providers.ppio.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { resolveApiKeyForProvider } from "./model-auth.js";
+import { resolveImplicitProvidersForTest } from "./models-config.e2e-harness.js";
+
+describe("PPIO provider", () => {
+  it("should include ppio when PPIO_API_KEY is configured", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await withEnvAsync({ PPIO_API_KEY: "test-key" }, async () => {
+      const providers = await resolveImplicitProvidersForTest({ agentDir });
+      expect(providers?.ppio).toBeDefined();
+      expect(providers?.ppio?.baseUrl).toBe("https://api.ppinfra.com/v3/openai");
+      expect(providers?.ppio?.api).toBe("openai-completions");
+      expect(providers?.ppio?.models?.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("should not include ppio when no API key is configured", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await withEnvAsync({ PPIO_API_KEY: undefined }, async () => {
+      const providers = await resolveImplicitProvidersForTest({ agentDir });
+      expect(providers?.ppio).toBeUndefined();
+    });
+  });
+
+  it("resolves the ppio api key value from env", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await withEnvAsync({ PPIO_API_KEY: "ppio-test-api-key" }, async () => {
+      const auth = await resolveApiKeyForProvider({
+        provider: "ppio",
+        agentDir,
+      });
+
+      expect(auth.apiKey).toBe("ppio-test-api-key");
+      expect(auth.mode).toBe("api-key");
+      expect(auth.source).toContain("PPIO_API_KEY");
+    });
+  });
+
+  it("should use static catalog models in test env (discovery disabled)", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await withEnvAsync({ PPIO_API_KEY: "test-key" }, async () => {
+      const providers = await resolveImplicitProvidersForTest({ agentDir });
+      const models = providers?.ppio?.models ?? [];
+      const ids = models.map((m) => m.id);
+      expect(ids).toContain("deepseek/deepseek-v3.2");
+    });
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -15,6 +15,7 @@ import {
   buildHuggingfaceProvider,
   buildKilocodeProviderWithDiscovery,
   buildOllamaProvider,
+  buildPpioProvider,
   buildVeniceProvider,
   buildVercelAiGatewayProvider,
   buildVllmProvider,
@@ -516,6 +517,10 @@ const SIMPLE_IMPLICIT_PROVIDER_LOADERS: ImplicitProviderLoader[] = [
   withApiKey("nvidia", async ({ apiKey }) => ({ ...buildNvidiaProvider(), apiKey })),
   withApiKey("kilocode", async ({ apiKey }) => ({
     ...(await buildKilocodeProviderWithDiscovery()),
+    apiKey,
+  })),
+  withApiKey("ppio", async ({ apiKey, discoveryApiKey }) => ({
+    ...(await buildPpioProvider(discoveryApiKey)),
     apiKey,
   })),
 ];

--- a/src/agents/ppio-models.test.ts
+++ b/src/agents/ppio-models.test.ts
@@ -198,7 +198,7 @@ describe("ppio-models", () => {
 
     await runWithDiscoveryEnabled(() => discoverPpioModels("sk-test-key"));
     expect(fetchMock).toHaveBeenCalledOnce();
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer sk-test-key");
   });
 

--- a/src/agents/ppio-models.test.ts
+++ b/src/agents/ppio-models.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  discoverPpioModels,
+  PPIO_MODEL_CATALOG,
+  staticPpioModelDefinitions,
+} from "./ppio-models.js";
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_VITEST = process.env.VITEST;
+
+function restoreDiscoveryEnv(): void {
+  if (ORIGINAL_NODE_ENV === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  }
+  if (ORIGINAL_VITEST === undefined) {
+    delete process.env.VITEST;
+  } else {
+    process.env.VITEST = ORIGINAL_VITEST;
+  }
+}
+
+async function runWithDiscoveryEnabled<T>(operation: () => Promise<T>): Promise<T> {
+  process.env.NODE_ENV = "development";
+  delete process.env.VITEST;
+  try {
+    return await operation();
+  } finally {
+    restoreDiscoveryEnv();
+  }
+}
+
+function makePpioModelsResponse(
+  models: Array<{
+    id: string;
+    display_name?: string;
+    model_type?: string;
+    context_size?: number;
+    max_output_tokens?: number;
+    features?: string[];
+    endpoints?: string[];
+    input_modalities?: string[];
+    input_token_price_per_m?: number;
+    output_token_price_per_m?: number;
+  }>,
+): Response {
+  return new Response(
+    JSON.stringify({
+      data: models.map((m) => ({
+        model_type: "chat",
+        context_size: 128000,
+        max_output_tokens: 8192,
+        features: [],
+        endpoints: ["chat/completions"],
+        input_modalities: ["text"],
+        input_token_price_per_m: 0,
+        output_token_price_per_m: 0,
+        ...m,
+      })),
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("ppio-models", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    restoreDiscoveryEnv();
+  });
+
+  it("staticPpioModelDefinitions returns entries with required fields", () => {
+    const defs = staticPpioModelDefinitions();
+    expect(defs.length).toBe(PPIO_MODEL_CATALOG.length);
+    for (const def of defs) {
+      expect(def.id).toBeTruthy();
+      expect(def.name).toBeTruthy();
+      expect(typeof def.reasoning).toBe("boolean");
+      expect(def.input).toContain("text");
+      expect(def.contextWindow).toBeGreaterThan(0);
+      expect(def.maxTokens).toBeGreaterThan(0);
+      expect(def.cost).toBeDefined();
+      expect(def.cost.input).toBeGreaterThanOrEqual(0);
+      expect(def.cost.output).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("static catalog includes deepseek-v3.2 as default model", () => {
+    const defs = staticPpioModelDefinitions();
+    const ids = defs.map((d) => d.id);
+    expect(ids).toContain("deepseek/deepseek-v3.2");
+  });
+
+  it("discoverPpioModels returns static catalog in test env", async () => {
+    const models = await discoverPpioModels();
+    expect(models.length).toBe(PPIO_MODEL_CATALOG.length);
+    expect(models[0].id).toBe(PPIO_MODEL_CATALOG[0].id);
+  });
+
+  it("discovery parses API response and maps fields correctly", async () => {
+    const fetchMock = vi.fn(async () =>
+      makePpioModelsResponse([
+        {
+          id: "deepseek/deepseek-v3.2",
+          display_name: "DeepSeek V3.2",
+          model_type: "chat",
+          context_size: 163840,
+          max_output_tokens: 65536,
+          features: ["serverless", "function-calling", "reasoning"],
+          endpoints: ["chat/completions", "anthropic"],
+          input_modalities: ["text"],
+          input_token_price_per_m: 20000,
+          output_token_price_per_m: 30000,
+        },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverPpioModels());
+    expect(models).toHaveLength(1);
+    const model = models[0];
+    expect(model.id).toBe("deepseek/deepseek-v3.2");
+    expect(model.name).toBe("DeepSeek V3.2");
+    expect(model.reasoning).toBe(true);
+    expect(model.input).toEqual(["text"]);
+    expect(model.contextWindow).toBe(163840);
+    expect(model.maxTokens).toBe(65536);
+    // Price in 0.0001 CNY/M: 20000 → 2 CNY/M → ~$0.278/M
+    expect(model.cost.input).toBeGreaterThan(0);
+    expect(model.cost.output).toBeGreaterThan(model.cost.input);
+  });
+
+  it("discovery maps image/video input modalities to image", async () => {
+    const fetchMock = vi.fn(async () =>
+      makePpioModelsResponse([
+        {
+          id: "qwen/qwen3.5-397b-a17b",
+          display_name: "Qwen3.5-397B",
+          input_modalities: ["text", "image", "video"],
+        },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverPpioModels());
+    expect(models[0].input).toEqual(["text", "image"]);
+  });
+
+  it("discovery filters out non-chat models", async () => {
+    const fetchMock = vi.fn(async () =>
+      makePpioModelsResponse([
+        { id: "embedding-model", model_type: "embedding" },
+        { id: "deepseek/deepseek-v3.2", model_type: "chat" },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverPpioModels());
+    expect(models).toHaveLength(1);
+    expect(models[0].id).toBe("deepseek/deepseek-v3.2");
+  });
+
+  it("discovery falls back to static catalog on HTTP error", async () => {
+    const fetchMock = vi.fn(async () => new Response("Server Error", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverPpioModels());
+    expect(models.length).toBe(PPIO_MODEL_CATALOG.length);
+  });
+
+  it("discovery falls back to static catalog on network error", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverPpioModels());
+    expect(models.length).toBe(PPIO_MODEL_CATALOG.length);
+  });
+
+  it("discovery falls back to static catalog on empty response", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverPpioModels());
+    expect(models.length).toBe(PPIO_MODEL_CATALOG.length);
+  });
+
+  it("discovery passes API key as Authorization header when provided", async () => {
+    const fetchMock = vi.fn(async () => makePpioModelsResponse([{ id: "test-model" }]));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await runWithDiscoveryEnabled(() => discoverPpioModels("sk-test-key"));
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer sk-test-key");
+  });
+
+  it("discovery strips serverless from features when checking reasoning", async () => {
+    const fetchMock = vi.fn(async () =>
+      makePpioModelsResponse([
+        {
+          id: "non-reasoning-model",
+          features: ["serverless", "function-calling"],
+        },
+        {
+          id: "reasoning-model",
+          features: ["serverless", "reasoning", "function-calling"],
+        },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverPpioModels());
+    expect(models.find((m) => m.id === "non-reasoning-model")?.reasoning).toBe(false);
+    expect(models.find((m) => m.id === "reasoning-model")?.reasoning).toBe(true);
+  });
+});

--- a/src/agents/ppio-models.ts
+++ b/src/agents/ppio-models.ts
@@ -1,0 +1,291 @@
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("ppio-models");
+
+export const PPIO_BASE_URL = "https://api.ppinfra.com/v3/openai";
+export const PPIO_DEFAULT_MODEL_ID = "deepseek/deepseek-v3.2";
+export const PPIO_DEFAULT_MODEL_REF = `ppio/${PPIO_DEFAULT_MODEL_ID}`;
+
+const PPIO_DISCOVERY_TIMEOUT_MS = 10_000;
+
+// PPIO prices are in 0.0001 CNY per million tokens.
+// Convert to USD/M tokens using approximate rate (1 USD ≈ 7.2 CNY).
+const CNY_PER_UNIT = 0.0001;
+const CNY_TO_USD = 1 / 7.2;
+
+function ppioRawPriceToUsd(raw: number): number {
+  return raw * CNY_PER_UNIT * CNY_TO_USD;
+}
+
+interface PpioApiModel {
+  id: string;
+  display_name?: string;
+  model_type?: string;
+  context_size?: number;
+  max_output_tokens?: number;
+  features?: string[];
+  endpoints?: string[];
+  input_modalities?: string[];
+  output_modalities?: string[];
+  input_token_price_per_m?: number;
+  output_token_price_per_m?: number;
+}
+
+interface PpioModelsResponse {
+  data?: PpioApiModel[];
+}
+
+function buildPpioModelFromApi(m: PpioApiModel): ModelDefinitionConfig | null {
+  if (!m.id) {
+    return null;
+  }
+  const features = (m.features ?? []).filter((f) => f !== "serverless");
+  const reasoning = features.includes("reasoning");
+  const inputModalities = m.input_modalities ?? ["text"];
+  const input: Array<"text" | "image"> = ["text"];
+  if (inputModalities.includes("image") || inputModalities.includes("video")) {
+    input.push("image");
+  }
+  const inputPrice = ppioRawPriceToUsd(m.input_token_price_per_m ?? 0);
+  const outputPrice = ppioRawPriceToUsd(m.output_token_price_per_m ?? 0);
+  return {
+    id: m.id,
+    name: m.display_name || m.id,
+    reasoning,
+    input,
+    contextWindow: m.context_size ?? 32768,
+    maxTokens: m.max_output_tokens ?? 8192,
+    cost: {
+      input: inputPrice,
+      output: outputPrice,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+  };
+}
+
+export async function discoverPpioModels(apiKey?: string): Promise<ModelDefinitionConfig[]> {
+  // Skip API discovery in test environment
+  if (process.env.NODE_ENV === "test" || process.env.VITEST) {
+    return staticPpioModelDefinitions();
+  }
+
+  try {
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+    const response = await fetch(`${PPIO_BASE_URL}/models`, {
+      headers,
+      signal: AbortSignal.timeout(PPIO_DISCOVERY_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      log.warn(`Failed to discover PPIO models: HTTP ${response.status}, using static catalog`);
+      return staticPpioModelDefinitions();
+    }
+
+    const data = (await response.json()) as PpioModelsResponse;
+    if (!Array.isArray(data.data) || data.data.length === 0) {
+      log.warn("No PPIO models returned from API, using static catalog");
+      return staticPpioModelDefinitions();
+    }
+
+    const models: ModelDefinitionConfig[] = [];
+    for (const m of data.data) {
+      if (m.model_type !== "chat") {
+        continue;
+      }
+      const def = buildPpioModelFromApi(m);
+      if (def) {
+        models.push(def);
+      }
+    }
+
+    if (models.length === 0) {
+      return staticPpioModelDefinitions();
+    }
+    return models;
+  } catch (error) {
+    log.warn(`Failed to discover PPIO models: ${String(error)}, using static catalog`);
+    return staticPpioModelDefinitions();
+  }
+}
+
+/**
+ * Static fallback catalog with the most popular PPIO models.
+ * Used when the discovery API is unreachable.
+ */
+export function staticPpioModelDefinitions(): ModelDefinitionConfig[] {
+  return PPIO_MODEL_CATALOG.map((entry) => ({
+    id: entry.id,
+    name: entry.name,
+    reasoning: entry.reasoning,
+    input: entry.input as Array<"text" | "image">,
+    contextWindow: entry.contextWindow,
+    maxTokens: entry.maxTokens,
+    cost: {
+      input: ppioRawPriceToUsd(entry.rawInputPrice),
+      output: ppioRawPriceToUsd(entry.rawOutputPrice),
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+  }));
+}
+
+interface PpioCatalogEntry {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  input: string[];
+  contextWindow: number;
+  maxTokens: number;
+  /** Raw price in 0.0001 CNY per million tokens */
+  rawInputPrice: number;
+  /** Raw price in 0.0001 CNY per million tokens */
+  rawOutputPrice: number;
+}
+
+export const PPIO_MODEL_CATALOG: PpioCatalogEntry[] = [
+  {
+    id: "deepseek/deepseek-v3.2",
+    name: "DeepSeek V3.2",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 163840,
+    maxTokens: 65536,
+    rawInputPrice: 20000,
+    rawOutputPrice: 30000,
+  },
+  {
+    id: "deepseek/deepseek-r1-0528",
+    name: "DeepSeek R1 0528",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 163840,
+    maxTokens: 32768,
+    rawInputPrice: 40000,
+    rawOutputPrice: 160000,
+  },
+  {
+    id: "deepseek/deepseek-v3.1",
+    name: "DeepSeek V3.1",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 32768,
+    rawInputPrice: 40000,
+    rawOutputPrice: 120000,
+  },
+  {
+    id: "moonshotai/kimi-k2.5",
+    name: "Kimi K2.5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 262144,
+    maxTokens: 262144,
+    rawInputPrice: 40000,
+    rawOutputPrice: 210000,
+  },
+  {
+    id: "moonshotai/kimi-k2-thinking",
+    name: "Kimi K2 Thinking",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 262144,
+    maxTokens: 262144,
+    rawInputPrice: 40000,
+    rawOutputPrice: 160000,
+  },
+  {
+    id: "moonshotai/kimi-k2-instruct",
+    name: "Kimi K2 Instruct",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 128000,
+    rawInputPrice: 40000,
+    rawOutputPrice: 160000,
+  },
+  {
+    id: "qwen/qwen3-235b-a22b-thinking-2507",
+    name: "Qwen3-235B-A22B Thinking",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 114688,
+    rawInputPrice: 20000,
+    rawOutputPrice: 200000,
+  },
+  {
+    id: "qwen/qwen3-235b-a22b-instruct-2507",
+    name: "Qwen3-235B-A22B Instruct",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 262144,
+    maxTokens: 260000,
+    rawInputPrice: 14500,
+    rawOutputPrice: 58000,
+  },
+  {
+    id: "qwen/qwen3-coder-480b-a35b-instruct",
+    name: "Qwen3-Coder-480B-A35B Instruct",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 262144,
+    maxTokens: 65536,
+    rawInputPrice: 40000,
+    rawOutputPrice: 160000,
+  },
+  {
+    id: "qwen/qwen3.5-397b-a17b",
+    name: "Qwen3.5-397B-A17B",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 262144,
+    maxTokens: 65536,
+    rawInputPrice: 30000,
+    rawOutputPrice: 180000,
+  },
+  {
+    id: "minimax/minimax-m2.5",
+    name: "MiniMax M2.5",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 204800,
+    maxTokens: 131100,
+    rawInputPrice: 21000,
+    rawOutputPrice: 84000,
+  },
+  {
+    id: "minimax/minimax-m2.5-highspeed",
+    name: "MiniMax M2.5 Highspeed",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 204800,
+    maxTokens: 131100,
+    rawInputPrice: 42000,
+    rawOutputPrice: 168000,
+  },
+  {
+    id: "zai-org/glm-5",
+    name: "GLM-5",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 202800,
+    maxTokens: 131072,
+    rawInputPrice: 60000,
+    rawOutputPrice: 220000,
+  },
+  {
+    id: "zai-org/glm-4.7",
+    name: "GLM-4.7",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 204800,
+    maxTokens: 131072,
+    rawInputPrice: 40000,
+    rawOutputPrice: 160000,
+  },
+];

--- a/src/agents/ppio-models.ts
+++ b/src/agents/ppio-models.ts
@@ -11,6 +11,8 @@ const PPIO_DISCOVERY_TIMEOUT_MS = 10_000;
 
 // PPIO prices are in 0.0001 CNY per million tokens.
 // Convert to USD/M tokens using approximate rate (1 USD ≈ 7.2 CNY).
+// This is for rough cost display only. Review periodically.
+// Last verified: 2026-03-11
 const CNY_PER_UNIT = 0.0001;
 const CNY_TO_USD = 1 / 7.2;
 
@@ -147,6 +149,9 @@ interface PpioCatalogEntry {
   rawOutputPrice: number;
 }
 
+// Note: reasoning flags are sourced from PPIO's /models API `features` array.
+// PPIO classifies DeepSeek V3.1/V3.2 as reasoning-capable (they return
+// "reasoning" in features), unlike the older V3-0324 which does not.
 export const PPIO_MODEL_CATALOG: PpioCatalogEntry[] = [
   {
     id: "deepseek/deepseek-v3.2",


### PR DESCRIPTION
## Summary

- Problem: OpenClaw does not support PPIO (ppinfra.com) as an LLM provider
- Why it matters: PPIO offers stable, cost-efficient open-source LLM APIs (DeepSeek, Qwen, Kimi, MiniMax, GLM etc.) popular in the Chinese market
- What changed: Added PPIO as an implicit provider with dynamic model discovery via `/models` API, plus a 14-model static fallback catalog
- What did NOT change (scope boundary): No changes to existing providers or core provider infrastructure

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## User-visible / Behavior Changes

- Setting `PPIO_API_KEY` env var automatically enables PPIO as a provider with all available models discovered from the API
- PPIO models become available in `openclaw models list` and model selection

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — follows existing `withApiKey` pattern
- New/changed network calls? `Yes` — calls `https://api.ppinfra.com/v3/openai/models` for model discovery
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: Model discovery is a read-only GET request to PPIO's public API. Falls back to static catalog on any failure (timeout, HTTP error, network error). 10s timeout limit.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Bun / Node 22+
- Model/provider: PPIO
- Integration/channel (if any): N/A
- Relevant config (redacted): `PPIO_API_KEY=sk_***`

### Steps

1. Set `PPIO_API_KEY` env var
2. Run `openclaw models list` or use PPIO models in chat

### Expected

- PPIO models appear in the model list

### Actual

- PPIO models appear correctly with pricing and capabilities

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

15/15 tests pass: 11 unit tests (static catalog, API parsing, fallback scenarios) + 4 integration tests (provider registration, API key resolution).

## Human Verification (required)

- Verified scenarios: Dynamic discovery returns ~65 models from live API; static fallback works in test env; provider registers correctly with `PPIO_API_KEY`
- Edge cases checked: HTTP 500 fallback, network error fallback, empty response fallback, non-chat model filtering, API key header passing
- What you did **not** verify: End-to-end chat completion through PPIO models in the full gateway

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — new optional `PPIO_API_KEY` env var
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Unset `PPIO_API_KEY` env var; provider will not activate
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Slow startup if PPIO API is unreachable (mitigated by 10s timeout + fallback)

## Risks and Mitigations

- Risk: PPIO API changes response format
  - Mitigation: Static fallback catalog ensures models remain available; discovery gracefully degrades on any error