### PR TITLE
fix(auto-reply): avoid duplicate local media note urls

### DIFF
--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -9,7 +9,7 @@ describe("buildInboundMediaNote", () => {
       MediaType: "image/png",
       MediaUrl: "/tmp/a.png",
     });
-    expect(note).toBe("[media attached: /tmp/a.png (image/png) | /tmp/a.png]");
+    expect(note).toBe("[media attached: /tmp/a.png (image/png)]");
   });
 
   it("formats multiple MediaPaths as numbered media notes", () => {
@@ -20,9 +20,9 @@ describe("buildInboundMediaNote", () => {
     expect(note).toBe(
       [
         "[media attached: 3 files]",
-        "[media attached 1/3: /tmp/a.png | /tmp/a.png]",
-        "[media attached 2/3: /tmp/b.png | /tmp/b.png]",
-        "[media attached 3/3: /tmp/c.png | /tmp/c.png]",
+        "[media attached 1/3: /tmp/a.png]",
+        "[media attached 2/3: /tmp/b.png]",
+        "[media attached 3/3: /tmp/c.png]",
       ].join("\n"),
     );
   });

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -13,7 +13,7 @@ function formatMediaAttachedLine(params: {
       : "[media attached: ";
   const typePart = params.type?.trim() ? ` (${params.type.trim()})` : "";
   const urlRaw = params.url?.trim();
-  const urlPart = urlRaw ? ` | ${urlRaw}` : "";
+  const urlPart = urlRaw && urlRaw !== params.path ? ` | ${urlRaw}` : "";
   return `${prefix}${params.path}${typePart}${urlPart}]`;
 }
 


### PR DESCRIPTION
## Summary
- stop appending `| url` in `[media attached: ...]` notes when the URL is identical to the local media path
- update media note tests to reflect the deduplicated output

## Why
Issue #42791 reports that inbound media notes can include the same local file path twice, for example:

```text
[media attached: /path/to/file.jpg (image/jpeg) | /path/to/file.jpg]
That duplicated path can then be picked up twice by downstream image-ref extraction, causing the same image to be injected into the LLM context twice.

## Changes
src/auto-reply/media-note.ts
only include the | url suffix when url is present and different from path
src/auto-reply/media-note.test.ts
update local-path expectations so duplicated local MediaUrl values are no longer rendered
preserve existing behavior for distinct remote URLs

## Validation
pnpm exec vitest run src/auto-reply/media-note.test.ts
pnpm exec oxfmt --check src/auto-reply/media-note.ts src/auto-reply/media-note.test.ts

Closes #42791