### PR TITLE
fix(channels): resolve log file path for cross-date Gateway runs

### DIFF
--- a/src/commands/channels/logs.test.ts
+++ b/src/commands/channels/logs.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { channelsLogsCommand } from "./logs.js";
+import { setLoggerOverride, resetLogger } from "../../logging.js";
+
+// Mock the channel plugins
+vi.mock("../../channels/plugins/index.js", () => ({
+  listChannelPlugins: () => [
+    { id: "telegram" },
+    { id: "discord" },
+    { id: "slack" },
+  ],
+}));
+
+describe("channelsLogsCommand", () => {
+  let tempDir: string;
+  let mockRuntime: { log: ReturnType<typeof vi.fn>; exit: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-logs-test-"));
+    mockRuntime = {
+      log: vi.fn(),
+      exit: vi.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    resetLogger();
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    vi.clearAllMocks();
+  });
+
+  it("should resolve to the most recent log file when current date file does not exist", async () => {
+    // Create log files for different dates (simulating Gateway running across date boundary)
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().split("T")[0]; // YYYY-MM-DD
+
+    const today = new Date();
+    const todayStr = today.toISOString().split("T")[0];
+
+    const yesterdayLogFile = path.join(tempDir, `openclaw-${yesterdayStr}.log`);
+    const todayLogFile = path.join(tempDir, `openclaw-${todayStr}.log`);
+
+    // Create yesterday's log file with some content (simulating Gateway still running)
+    await fs.writeFile(
+      yesterdayLogFile,
+      JSON.stringify({
+        time: "2026-03-10T12:00:00.000Z",
+        level: "info",
+        subsystem: "gateway/channels/feishu",
+        message: "Test message from yesterday",
+      }) + "\n"
+    );
+
+    // Set logger to today's file (which doesn't exist yet)
+    setLoggerOverride({ file: todayLogFile });
+
+    await channelsLogsCommand({ lines: 10 }, mockRuntime);
+
+    // Should find and read yesterday's log file
+    const output = mockRuntime.log.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain(yesterdayLogFile);
+    expect(output).toContain("Test message from yesterday");
+  });
+
+  it("should use current date file when it exists", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().split("T")[0];
+    const todayLogFile = path.join(tempDir, `openclaw-${todayStr}.log`);
+
+    // Create today's log file
+    await fs.writeFile(
+      todayLogFile,
+      JSON.stringify({
+        time: "2026-03-11T12:00:00.000Z",
+        level: "info",
+        subsystem: "gateway/channels/feishu",
+        message: "Test message from today",
+      }) + "\n"
+    );
+
+    setLoggerOverride({ file: todayLogFile });
+
+    await channelsLogsCommand({ lines: 10 }, mockRuntime);
+
+    const output = mockRuntime.log.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain(todayLogFile);
+    expect(output).toContain("Test message from today");
+  });
+
+  it("should select the most recent log file by mtime when multiple exist", async () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().split("T")[0];
+
+    const today = new Date();
+    const todayStr = today.toISOString().split("T")[0];
+
+    const yesterdayLogFile = path.join(tempDir, `openclaw-${yesterdayStr}.log`);
+    const todayLogFile = path.join(tempDir, `openclaw-${todayStr}.log`);
+
+    // Create both log files
+    await fs.writeFile(
+      yesterdayLogFile,
+      JSON.stringify({
+        time: "2026-03-10T12:00:00.000Z",
+        level: "info",
+        subsystem: "gateway/channels/feishu",
+        message: "Yesterday's message",
+      }) + "\n"
+    );
+
+    await fs.writeFile(
+      todayLogFile,
+      JSON.stringify({
+        time: "2026-03-11T12:00:00.000Z",
+        level: "info",
+        subsystem: "gateway/channels/feishu",
+        message: "Today's message",
+      }) + "\n"
+    );
+
+    // Set logger to a non-existent future file
+    const future = new Date();
+    future.setDate(future.getDate() + 1);
+    const futureStr = future.toISOString().split("T")[0];
+    const futureLogFile = path.join(tempDir, `openclaw-${futureStr}.log`);
+
+    setLoggerOverride({ file: futureLogFile });
+
+    await channelsLogsCommand({ lines: 10 }, mockRuntime);
+
+    // Should select today's file (most recent mtime)
+    const output = mockRuntime.log.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain(todayLogFile);
+    expect(output).toContain("Today's message");
+    expect(output).not.toContain("Yesterday's message");
+  });
+
+  it("should filter logs by channel", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().split("T")[0];
+    const todayLogFile = path.join(tempDir, `openclaw-${todayStr}.log`);
+
+    // Create log file with multiple channel messages
+    const lines = [
+      JSON.stringify({
+        time: "2026-03-11T12:00:00.000Z",
+        level: "info",
+        subsystem: "gateway/channels/telegram",
+        message: "Telegram message",
+      }),
+      JSON.stringify({
+        time: "2026-03-11T12:01:00.000Z",
+        level: "info",
+        subsystem: "gateway/channels/discord",
+        message: "Discord message",
+      }),
+      JSON.stringify({
+        time: "2026-03-11T12:02:00.000Z",
+        level: "info",
+        subsystem: "gateway/channels/telegram",
+        message: "Another Telegram message",
+      }),
+    ].join("\n") + "\n";
+
+    await fs.writeFile(todayLogFile, lines);
+
+    setLoggerOverride({ file: todayLogFile });
+
+    await channelsLogsCommand({ channel: "telegram", lines: 10 }, mockRuntime);
+
+    const output = mockRuntime.log.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("Telegram message");
+    expect(output).toContain("Another Telegram message");
+    expect(output).not.toContain("Discord message");
+  });
+
+  it("should return empty array when no log files exist", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().split("T")[0];
+    const todayLogFile = path.join(tempDir, `openclaw-${todayStr}.log`);
+
+    setLoggerOverride({ file: todayLogFile });
+
+    await channelsLogsCommand({ lines: 10 }, mockRuntime);
+
+    const output = mockRuntime.log.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("No matching log lines");
+  });
+
+  it("should handle non-rolling log file paths", async () => {
+    const customLogFile = path.join(tempDir, "custom.log");
+
+    await fs.writeFile(
+      customLogFile,
+      JSON.stringify({
+        time: "2026-03-11T12:00:00.000Z",
+        level: "info",
+        subsystem: "gateway/channels/feishu",
+        message: "Custom log message",
+      }) + "\n"
+    );
+
+    setLoggerOverride({ file: customLogFile });
+
+    await channelsLogsCommand({ lines: 10 }, mockRuntime);
+
+    const output = mockRuntime.log.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain(customLogFile);
+    expect(output).toContain("Custom log message");
+  });
+});

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import { getResolvedLoggerSettings } from "../../logging.js";
 import { parseLogLine } from "../../logging/parse-log-line.js";
@@ -15,6 +16,7 @@ type LogLine = ReturnType<typeof parseLogLine>;
 
 const DEFAULT_LIMIT = 200;
 const MAX_BYTES = 1_000_000;
+const ROLLING_LOG_RE = /^openclaw-\d{4}-\d{2}-\d{2}\.log$/;
 
 const getChannelSet = () =>
   new Set<string>([...listChannelPlugins().map((plugin) => plugin.id), "all"]);
@@ -39,6 +41,40 @@ function matchesChannel(line: NonNullable<LogLine>, channel: string) {
     return true;
   }
   return false;
+}
+
+function isRollingLogFile(file: string): boolean {
+  return ROLLING_LOG_RE.test(path.basename(file));
+}
+
+async function resolveLogFile(file: string): Promise<string> {
+  const stat = await fs.stat(file).catch(() => null);
+  if (stat) {
+    return file;
+  }
+  if (!isRollingLogFile(file)) {
+    return file;
+  }
+
+  const dir = path.dirname(file);
+  const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => null);
+  if (!entries) {
+    return file;
+  }
+
+  const candidates = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && ROLLING_LOG_RE.test(entry.name))
+      .map(async (entry) => {
+        const fullPath = path.join(dir, entry.name);
+        const fileStat = await fs.stat(fullPath).catch(() => null);
+        return fileStat ? { path: fullPath, mtimeMs: fileStat.mtimeMs } : null;
+      }),
+  );
+  const sorted = candidates
+    .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry))
+    .toSorted((a, b) => b.mtimeMs - a.mtimeMs);
+  return sorted[0]?.path ?? file;
 }
 
 async function readTailLines(file: string, limit: number): Promise<string[]> {
@@ -84,7 +120,8 @@ export async function channelsLogsCommand(
       ? Math.floor(limitRaw)
       : DEFAULT_LIMIT;
 
-  const file = getResolvedLoggerSettings().file;
+  const configuredFile = getResolvedLoggerSettings().file;
+  const file = await resolveLogFile(configuredFile);
   const rawLines = await readTailLines(file, limit * 4);
   const parsed = rawLines
     .map(parseLogLine)


### PR DESCRIPTION
## Summary

Fixes #42875

When Gateway runs across date boundaries, the log file is created based on the startup date (e.g., `openclaw-2026-03-10.log`). However, the CLI command `openclaw channels logs` was using `getResolvedLoggerSettings().file` which returns the current date'\''s log file (e.g., `openclaw-2026-03-11.log`), causing users to see empty or stale logs.

## Changes

Added a `resolveLogFile()` function to `src/commands/channels/logs.ts` that:
1. Returns the configured file if it exists
2. For rolling log files (`openclaw-YYYY-MM-DD.log`), finds the most recent log file by mtime in the same directory
3. Falls back to the configured file if no rolling logs are found

This mirrors the behavior already implemented in the Gateway'\''s `logs.tail` handler (`src/gateway/server-methods/logs.ts`), ensuring consistent log file resolution across CLI and Gateway.

## Testing

Added comprehensive tests in `src/commands/channels/logs.test.ts` covering:
- Resolving to most recent log file when current date file does not exist
- Using current date file when it exists
- Selecting most recent file by mtime when multiple exist
- Channel filtering
- Empty log directory handling
- Non-rolling log file paths

## Checklist

- [x] Bug fix
- [x] Tests added
- [x] Backward compatible
- [x] No breaking changes