### PR TITLE
fix(tui): show 0/ctx instead of ?/ctx for context tokens (#43009)

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -3,6 +3,7 @@ import {
   extractContentFromMessage,
   extractTextFromMessage,
   extractThinkingFromMessage,
+  formatTokens,
   isCommandMessage,
   sanitizeRenderableText,
 } from "./tui-formatters.js";
@@ -209,6 +210,26 @@ describe("isCommandMessage", () => {
     expect(isCommandMessage({ command: true })).toBe(true);
     expect(isCommandMessage({ command: false })).toBe(false);
     expect(isCommandMessage({})).toBe(false);
+  });
+});
+
+describe("formatTokens", () => {
+  it("renders tokens ? when both total and context are unknown", () => {
+    expect(formatTokens(null, null)).toBe("tokens ?");
+    // Also covers the fully-undefined callsite.
+    expect(formatTokens()).toBe("tokens ?");
+  });
+
+  it("treats missing total with known context as 0/ctx", () => {
+    expect(formatTokens(null, 200_000)).toBe("tokens 0/200k (0%)");
+  });
+
+  it("renders only total when context is unknown", () => {
+    expect(formatTokens(1_500, null)).toBe("tokens 1.5k");
+  });
+
+  it("renders total/context with percentage when both are known", () => {
+    expect(formatTokens(1_000, 200_000)).toBe("tokens 1.0k/200k (1%)");
   });
 });
 

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -349,13 +349,18 @@ export function formatTokens(total?: number | null, context?: number | null) {
   if (total == null && context == null) {
     return "tokens ?";
   }
-  const totalLabel = total == null ? "?" : formatTokenCount(total);
+  // When we know the context window but total tokens are missing, treat usage
+  // as 0 so the UI shows "0/ctx" instead of "?/ctx". This matches the
+  // gateway's session_status output and is less confusing than an unknown
+  // placeholder.
+  const effectiveTotal = total == null && context != null ? 0 : total;
+  const totalLabel = effectiveTotal == null ? "?" : formatTokenCount(effectiveTotal);
   if (context == null) {
     return `tokens ${totalLabel}`;
   }
   const pct =
-    typeof total === "number" && context > 0
-      ? Math.min(999, Math.round((total / context) * 100))
+    typeof effectiveTotal === "number" && context > 0
+      ? Math.min(999, Math.round((effectiveTotal / context) * 100))
       : null;
   return `tokens ${totalLabel}/${formatTokenCount(context)}${pct !== null ? ` (${pct}%)` : ""}`;
 }


### PR DESCRIPTION
Fixes #43009

## Problem

In the TUI footer, the token usage line is rendered via `formatTokens(totalTokens, contextTokens)`.
When `contextTokens` is known (e.g. `200k`) but `totalTokens` is `null/undefined`, the footer shows:

`tokens ?/200k`

while the gateway `session_status` API correctly reports `Context: 0/200k (0%)`. This is confusing and looks like the TUI is not tracking usage even though the context window is known.

## Solution

In the TUI-only `formatTokens` helper:

- When `context` is non-null and `total` is `null/undefined`, treat `total` as `0`.
- This changes the display from `tokens ?/200k` to `tokens 0/200k (0%)`, which better matches the gateway’s `session_status` semantics and is less confusing than an unknown placeholder.

Implementation (`src/tui/tui-formatters.ts`):

- Introduce `effectiveTotal = total == null && context != null ? 0 : total`.
- Use `effectiveTotal` for both the formatted label and percentage calculation.

Other behaviors are unchanged:

- `total == null` and `context == null` → `tokens ?`
- `total != null` and `context == null` → `tokens <total>`
- Both set → `tokens <total>/<context> (<pct>%)`

## Impact

- Only affects the TUI footer token display (`openclaw tui`); CLI and gateway status output remain unchanged.
- No protocol or API changes.