### PR TITLE
fix(models): prefer gemini 3.1 pro forward-compat template

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -33,7 +33,7 @@ const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7"] as const;
 // don't get "Unknown model" errors when Google releases a new minor version.
 const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
-const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
+const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3.1-pro-preview", "gemini-3-pro-preview"] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
 
 function resolveOpenAIGpt54ForwardCompatModel(

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { discoverModels } from "../pi-model-discovery.js";
 
 vi.mock("../pi-model-discovery.js", () => ({
   discoverAuthStorage: vi.fn(() => ({ mocked: true })),
@@ -123,6 +124,46 @@ describe("pi embedded model e2e smoke", () => {
       baseUrl: "https://generativelanguage.googleapis.com",
       id: "gemini-3.1-pro-preview",
       name: "gemini-3.1-pro-preview",
+      reasoning: true,
+    });
+  });
+
+  it("prefers a gemini-3.1-pro-preview template over the stale gemini-3-pro-preview template", () => {
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider !== "google") {
+          return null;
+        }
+        if (modelId === "gemini-3.1-pro-preview") {
+          return {
+            ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+            id: "gemini-3.1-pro-preview",
+            name: "Gemini 3.1 Pro",
+            provider: "google",
+            api: "google-generative-ai",
+            baseUrl: "https://generativelanguage.googleapis.com",
+          };
+        }
+        if (modelId === "gemini-3-pro-preview") {
+          return {
+            ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+            provider: "google",
+            api: "google-generative-ai",
+            baseUrl: "https://generativelanguage.googleapis.com",
+          };
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("google", "gemini-3.1-pro", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
+      provider: "google",
+      api: "google-generative-ai",
+      baseUrl: "https://generativelanguage.googleapis.com",
       reasoning: true,
     });
   });


### PR DESCRIPTION
## Summary
- prefer `gemini-3.1-pro-preview` as the forward-compat template for Gemini 3.1 Pro models
- keep `gemini-3-pro-preview` only as a fallback
- add regression coverage for template selection precedence

## Why
Issue #42854 reports that the model picker can show stale preview-era metadata for `google/gemini-3.1-pro`.

The forward-compat path for Gemini 3.1 Pro was still cloning metadata from the older `gemini-3-pro-preview` template. That works as a compatibility fallback, but when a current `gemini-3.1-pro-preview` template exists, OpenClaw should prefer it so newer IDs do not inherit stale preview labels/metadata.

## Changes
- `src/agents/model-forward-compat.ts`
  - change Gemini 3.1 Pro template precedence from:
    - `gemini-3-pro-preview`
  - to:
    - `gemini-3.1-pro-preview`
    - `gemini-3-pro-preview`
- `src/agents/pi-embedded-runner/model.forward-compat.test.ts`
  - add a regression test verifying that when both templates exist, the 3.1 template wins
  - add the missing `discoverModels` import used by the new test setup

## Validation
- `pnpm exec oxfmt --check src/agents/model-forward-compat.ts src/agents/pi-embedded-runner/model.forward-compat.test.ts`

## Notes
I could not run the targeted Vitest file end-to-end in this local environment because an upstream dependency import is currently unresolved here:

- `@mariozechner/pi-ai/oauth`

That failure is unrelated to this change.

Closes #42854
