### PR TITLE
gateway: add configurable concurrency for nested command lane

### DIFF
--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
+export const DEFAULT_NESTED_MAX_CONCURRENT = 8;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;
 
@@ -19,4 +20,12 @@ export function resolveSubagentMaxConcurrent(cfg?: OpenClawConfig): number {
     return Math.max(1, Math.floor(raw));
   }
   return DEFAULT_SUBAGENT_MAX_CONCURRENT;
+}
+
+export function resolveNestedMaxConcurrent(cfg?: OpenClawConfig): number {
+  const raw = cfg?.agents?.defaults?.nestedMaxConcurrent;
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.max(1, Math.floor(raw));
+  }
+  return DEFAULT_NESTED_MAX_CONCURRENT;
 }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -263,6 +263,8 @@ export type AgentDefaultsConfig = {
   };
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;
+  /** Max concurrent nested agent runs (inter-agent sessions_send). Default: 8. */
+  nestedMaxConcurrent?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */
   subagents?: {
     /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -160,6 +160,7 @@ export const AgentDefaultsSchema = z
     typingMode: TypingModeSchema.optional(),
     heartbeat: HeartbeatSchema,
     maxConcurrent: z.number().int().positive().optional(),
+    nestedMaxConcurrent: z.number().int().positive().optional(),
     subagents: z
       .object({
         maxConcurrent: z.number().int().positive().optional(),

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -1,4 +1,8 @@
-import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
+import {
+  resolveAgentMaxConcurrent,
+  resolveNestedMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "../config/agent-limits.js";
 import type { loadConfig } from "../config/config.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
@@ -7,4 +11,5 @@ export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) 
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  setCommandLaneConcurrency(CommandLane.Nested, resolveNestedMaxConcurrent(cfg));
 }


### PR DESCRIPTION
## Summary

- Add `nestedMaxConcurrent` config option under `agents.defaults` to control the concurrency of the `nested` command lane
- The `nested` lane handles inter-agent communication (`sessions_send`) and nested agent calls, but was hardcoded to concurrency 1 (sequential)
- Default raised from 1 to 8, matching the `subagent` lane default

## Problem

In multi-agent setups (10+ agents), all `sessions_send` calls and nested invocations queue on a single `nested` lane with `maxConcurrent = 1`. This causes severe queuing delays — observed wait times of 300+ seconds with 10 tasks ahead in the queue.

## Changes

- `src/config/agent-limits.ts`: Add `resolveNestedMaxConcurrent()` with default of 8
- `src/gateway/server-lanes.ts`: Apply nested lane concurrency from config
- `src/config/types.agent-defaults.ts`: Add `nestedMaxConcurrent` type field
- `src/config/zod-schema.agent-defaults.ts`: Add zod validation for new field

## Usage

```jsonc
"agents": {
  "defaults": {
    "nestedMaxConcurrent": 16  // default: 8
  }
}
```

## Test plan

- [x] Existing `config.agent-concurrency-defaults.test.ts` passes (4/4)
- [x] TypeScript compiles with zero errors
- [ ] Verify nested lane queue wait times improve in multi-agent gateway