### PR TITLE
fix(codex): canonicalize legacy gpt-5.4-codex runtime alias

### DIFF
--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -13,6 +13,7 @@ const ANTHROPIC_PREFIXES = [
 const OPENAI_MODELS = ["gpt-5.4", "gpt-5.2", "gpt-5.0"];
 const CODEX_MODELS = [
   "gpt-5.4",
+  "gpt-5.4-codex",
   "gpt-5.2",
   "gpt-5.2-codex",
   "gpt-5.3-codex",

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -302,6 +302,7 @@ describe("isModernModelRef", () => {
     expect(isModernModelRef({ provider: "openai", id: "gpt-5.4" })).toBe(true);
     expect(isModernModelRef({ provider: "openai", id: "gpt-5.4-pro" })).toBe(true);
     expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4" })).toBe(true);
+    expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4-codex" })).toBe(true);
   });
 
   it("excludes opencode minimax variants from modern selection", () => {

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -12,6 +12,11 @@ const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.2"] as const;
 const OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS = ["gpt-5.2-pro", "gpt-5.2"] as const;
 
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT_54_LEGACY_MODEL_ID = "gpt-5.4-codex";
+const OPENAI_CODEX_GPT_54_MODEL_ALIASES = new Set([
+  OPENAI_CODEX_GPT_54_MODEL_ID,
+  OPENAI_CODEX_GPT_54_LEGACY_MODEL_ID,
+]);
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
@@ -123,9 +128,13 @@ function resolveOpenAICodexForwardCompatModel(
 
   let templateIds: readonly string[];
   let eligibleProviders: Set<string>;
-  if (lower === OPENAI_CODEX_GPT_54_MODEL_ID) {
+  let resolvedModelId = trimmedModelId;
+  if (OPENAI_CODEX_GPT_54_MODEL_ALIASES.has(lower)) {
     templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
     eligibleProviders = CODEX_GPT54_ELIGIBLE_PROVIDERS;
+    // Keep runtime on the canonical transport model id even when users
+    // configure legacy "-codex" aliases.
+    resolvedModelId = OPENAI_CODEX_GPT_54_MODEL_ID;
   } else if (lower === OPENAI_CODEX_GPT_53_MODEL_ID) {
     templateIds = OPENAI_CODEX_TEMPLATE_MODEL_IDS;
     eligibleProviders = CODEX_GPT53_ELIGIBLE_PROVIDERS;
@@ -144,14 +153,14 @@ function resolveOpenAICodexForwardCompatModel(
     }
     return normalizeModelCompat({
       ...template,
-      id: trimmedModelId,
-      name: trimmedModelId,
+      id: resolvedModelId,
+      name: resolvedModelId,
     } as Model<Api>);
   }
 
   return normalizeModelCompat({
-    id: trimmedModelId,
-    name: trimmedModelId,
+    id: resolvedModelId,
+    name: resolvedModelId,
     api: "openai-codex-responses",
     provider: normalizedProvider,
     baseUrl: "https://chatgpt.com/backend-api",

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -522,6 +522,39 @@ describe("resolveModel", () => {
     });
   });
 
+  it("applies canonical gpt-5.4 overrides when request uses gpt-5.4-codex alias", () => {
+    mockOpenAICodexTemplateModel();
+    const cfg = {
+      models: {
+        providers: {
+          "openai-codex": {
+            models: [
+              {
+                id: "gpt-5.4",
+                reasoning: false,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 333000,
+                maxTokens: 65000,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("openai-codex", "gpt-5.4-codex", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      reasoning: false,
+      contextWindow: 333000,
+      maxTokens: 65000,
+    });
+  });
+
   it("applies provider overrides to openai gpt-5.4 forward-compat models", () => {
     mockDiscoveredModel({
       provider: "openai",

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -480,6 +480,48 @@ describe("resolveModel", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
+  it("maps legacy openai-codex gpt-5.4-codex alias to canonical gpt-5.4", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.4-codex", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
+  });
+
+  it("applies explicit per-model overrides when using gpt-5.4-codex alias", () => {
+    mockOpenAICodexTemplateModel();
+    const cfg = {
+      models: {
+        providers: {
+          "openai-codex": {
+            models: [
+              {
+                id: "gpt-5.4-codex",
+                reasoning: false,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 321000,
+                maxTokens: 64000,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("openai-codex", "gpt-5.4-codex", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      reasoning: false,
+      contextWindow: 321000,
+      maxTokens: 64000,
+    });
+  });
+
   it("applies provider overrides to openai gpt-5.4 forward-compat models", () => {
     mockDiscoveredModel({
       provider: "openai",
@@ -609,6 +651,10 @@ describe("resolveModel", () => {
 
   it("keeps unknown-model errors for non-gpt-5 openai-codex ids", () => {
     expectUnknownModelError("openai-codex", "gpt-4.1-mini");
+  });
+
+  it("keeps unknown-model errors for lookalike codex aliases that are not supported", () => {
+    expectUnknownModelError("openai-codex", "gpt-5.4-codex-mini");
   });
 
   it("uses codex fallback even when openai-codex provider is configured", () => {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -97,7 +97,11 @@ function applyConfiguredProviderOverrides(params: {
       headers: sanitizeModelHeaders(discoveredModel.headers, { stripSecretRefMarkers: true }),
     };
   }
-  const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
+  const configuredModel =
+    providerConfig.models?.find((candidate) => candidate.id === modelId) ??
+    (discoveredModel.id !== modelId
+      ? providerConfig.models?.find((candidate) => candidate.id === discoveredModel.id)
+      : undefined);
   const discoveredHeaders = sanitizeModelHeaders(discoveredModel.headers, {
     stripSecretRefMarkers: true,
   });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -23,6 +23,30 @@ type InlineProviderConfig = {
   headers?: unknown;
 };
 
+const OPENAI_CODEX_PROVIDER = "openai-codex";
+const OPENAI_CODEX_GPT54_LEGACY_MODEL_ID = "gpt-5.4-codex";
+const OPENAI_CODEX_GPT54_CANONICAL_MODEL_ID = "gpt-5.4";
+
+function normalizeModelIdForRuntime(params: { provider: string; model: Model<Api> }): Model<Api> {
+  if (normalizeProviderId(params.provider) !== OPENAI_CODEX_PROVIDER) {
+    return params.model;
+  }
+  const modelId = String(params.model.id ?? "").trim();
+  if (modelId.toLowerCase() !== OPENAI_CODEX_GPT54_LEGACY_MODEL_ID) {
+    return params.model;
+  }
+  const modelName = String(params.model.name ?? "").trim();
+
+  return {
+    ...params.model,
+    id: OPENAI_CODEX_GPT54_CANONICAL_MODEL_ID,
+    name:
+      modelName.toLowerCase() === OPENAI_CODEX_GPT54_LEGACY_MODEL_ID
+        ? OPENAI_CODEX_GPT54_CANONICAL_MODEL_ID
+        : (params.model.name ?? params.model.id),
+  };
+}
+
 function sanitizeModelHeaders(
   headers: unknown,
   opts?: { stripSecretRefMarkers?: boolean },
@@ -145,13 +169,16 @@ export function resolveModelWithRegistry(params: {
   const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
 
   if (model) {
-    return normalizeModelCompat(
-      applyConfiguredProviderOverrides({
-        discoveredModel: model,
-        providerConfig,
-        modelId,
-      }),
-    );
+    return normalizeModelIdForRuntime({
+      provider,
+      model: normalizeModelCompat(
+        applyConfiguredProviderOverrides({
+          discoveredModel: model,
+          providerConfig,
+          modelId,
+        }),
+      ),
+    });
   }
 
   const providers = cfg?.models?.providers ?? {};
@@ -161,64 +188,76 @@ export function resolveModelWithRegistry(params: {
     (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
   );
   if (inlineMatch) {
-    return normalizeModelCompat(inlineMatch as Model<Api>);
+    return normalizeModelIdForRuntime({
+      provider,
+      model: normalizeModelCompat(inlineMatch as Model<Api>),
+    });
   }
 
   // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.
   // Otherwise, configured providers can default to a generic API and break specific transports.
   const forwardCompat = resolveForwardCompatModel(provider, modelId, modelRegistry);
   if (forwardCompat) {
-    return normalizeModelCompat(
-      applyConfiguredProviderOverrides({
-        discoveredModel: forwardCompat,
-        providerConfig,
-        modelId,
-      }),
-    );
+    return normalizeModelIdForRuntime({
+      provider,
+      model: normalizeModelCompat(
+        applyConfiguredProviderOverrides({
+          discoveredModel: forwardCompat,
+          providerConfig,
+          modelId,
+        }),
+      ),
+    });
   }
 
   // OpenRouter is a pass-through proxy - any model ID available on OpenRouter
   // should work without being pre-registered in the local catalog.
   if (normalizedProvider === "openrouter") {
-    return normalizeModelCompat({
-      id: modelId,
-      name: modelId,
-      api: "openai-completions",
+    return normalizeModelIdForRuntime({
       provider,
-      baseUrl: "https://openrouter.ai/api/v1",
-      reasoning: false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: DEFAULT_CONTEXT_TOKENS,
-      // Align with OPENROUTER_DEFAULT_MAX_TOKENS in models-config.providers.ts
-      maxTokens: 8192,
-    } as Model<Api>);
+      model: normalizeModelCompat({
+        id: modelId,
+        name: modelId,
+        api: "openai-completions",
+        provider,
+        baseUrl: "https://openrouter.ai/api/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: DEFAULT_CONTEXT_TOKENS,
+        // Align with OPENROUTER_DEFAULT_MAX_TOKENS in models-config.providers.ts
+        maxTokens: 8192,
+      } as Model<Api>),
+    });
   }
 
   const configuredModel = providerConfig?.models?.find((candidate) => candidate.id === modelId);
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers);
   const modelHeaders = sanitizeModelHeaders(configuredModel?.headers);
   if (providerConfig || modelId.startsWith("mock-")) {
-    return normalizeModelCompat({
-      id: modelId,
-      name: modelId,
-      api: providerConfig?.api ?? "openai-responses",
+    return normalizeModelIdForRuntime({
       provider,
-      baseUrl: providerConfig?.baseUrl,
-      reasoning: configuredModel?.reasoning ?? false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow:
-        configuredModel?.contextWindow ??
-        providerConfig?.models?.[0]?.contextWindow ??
-        DEFAULT_CONTEXT_TOKENS,
-      maxTokens:
-        configuredModel?.maxTokens ??
-        providerConfig?.models?.[0]?.maxTokens ??
-        DEFAULT_CONTEXT_TOKENS,
-      headers:
-        providerHeaders || modelHeaders ? { ...providerHeaders, ...modelHeaders } : undefined,
-    } as Model<Api>);
+      model: normalizeModelCompat({
+        id: modelId,
+        name: modelId,
+        api: providerConfig?.api ?? "openai-responses",
+        provider,
+        baseUrl: providerConfig?.baseUrl,
+        reasoning: configuredModel?.reasoning ?? false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow:
+          configuredModel?.contextWindow ??
+          providerConfig?.models?.[0]?.contextWindow ??
+          DEFAULT_CONTEXT_TOKENS,
+        maxTokens:
+          configuredModel?.maxTokens ??
+          providerConfig?.models?.[0]?.maxTokens ??
+          DEFAULT_CONTEXT_TOKENS,
+        headers:
+          providerHeaders || modelHeaders ? { ...providerHeaders, ...modelHeaders } : undefined,
+      } as Model<Api>),
+    });
   }
 
   return undefined;


### PR DESCRIPTION
## Summary
- treat `openai-codex/gpt-5.4-codex` as a legacy alias and canonicalize runtime model id to `gpt-5.4`
- apply canonicalization across registry, inline provider, and provider-fallback resolution paths
- keep modern-model filtering in sync by recognizing `gpt-5.4-codex` as a modern codex ref

## Why
`#37623` reports a runtime gap where `gpt-5.4-codex` can show up as configured but still fail/miss at runtime. This patch keeps compatibility with legacy configs while routing execution through the canonical codex model id.

## Tests
- `src/agents/pi-embedded-runner/model.test.ts`
  - positive: alias resolves to canonical `gpt-5.4`
  - explicit override: alias-specific per-model overrides still apply
  - negative: `gpt-5.4-codex-mini` remains unknown
- `src/agents/model-compat.test.ts`
  - modern model filter includes `openai-codex/gpt-5.4-codex`
