### PR TITLE
fix: interpolate responsePrefix template variables in heartbeat replies

### DIFF
--- a/src/infra/heartbeat-runner.response-prefix-template.test.ts
+++ b/src/infra/heartbeat-runner.response-prefix-template.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramPlugin } from "../../extensions/telegram/src/channel.js";
+import { setTelegramRuntime } from "../../extensions/telegram/src/runtime.js";
+import { whatsappPlugin } from "../../extensions/whatsapp/src/channel.js";
+import { setWhatsAppRuntime } from "../../extensions/whatsapp/src/runtime.js";
+import * as replyModule from "../auto-reply/reply.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { seedSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+
+// Avoid pulling optional runtime deps during isolated runs.
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+beforeEach(() => {
+  const runtime = createPluginRuntime();
+  setTelegramRuntime(runtime);
+  setWhatsAppRuntime(runtime);
+  setActivePluginRegistry(
+    createTestRegistry([
+      { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
+      { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
+    ]),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("runHeartbeatOnce – responsePrefix template interpolation", () => {
+  it("passes onModelSelected callback to getReplyFromConfig", async () => {
+    await withTempHeartbeatSandbox(
+      async ({ tmpDir, storePath }) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: { every: "5m", target: "whatsapp" },
+            },
+          },
+          channels: {
+            whatsapp: {
+              allowFrom: ["*"],
+              responsePrefix: "{model}: ",
+            },
+          },
+          session: { store: storePath },
+        };
+        const sessionKey = resolveMainSessionKey(cfg);
+        await seedSessionStore(storePath, sessionKey, {
+          lastChannel: "whatsapp",
+          lastProvider: "whatsapp",
+          lastTo: "+1555",
+        });
+
+        const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+        replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+        await runHeartbeatOnce({
+          cfg,
+          deps: { getQueueSize: () => 0, nowMs: () => 0 },
+        });
+
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        const replyOpts = replySpy.mock.calls[0]?.[1];
+        expect(replyOpts).toHaveProperty("onModelSelected");
+        expect(typeof replyOpts?.onModelSelected).toBe("function");
+      },
+      { prefix: "openclaw-hb-prefix-" },
+    );
+  });
+
+  it("passes onModelSelected even without heartbeatModelOverride", async () => {
+    await withTempHeartbeatSandbox(
+      async ({ tmpDir, storePath }) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: { every: "5m", target: "whatsapp" },
+            },
+          },
+          channels: {
+            whatsapp: {
+              allowFrom: ["*"],
+              responsePrefix: "{model}: ",
+            },
+          },
+          session: { store: storePath },
+        };
+        const sessionKey = resolveMainSessionKey(cfg);
+        await seedSessionStore(storePath, sessionKey, {
+          lastChannel: "whatsapp",
+          lastProvider: "whatsapp",
+          lastTo: "+1555",
+        });
+
+        const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+        replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+        await runHeartbeatOnce({
+          cfg,
+          deps: { getQueueSize: () => 0, nowMs: () => 0 },
+        });
+
+        const replyOpts = replySpy.mock.calls[0]?.[1];
+        // onModelSelected should be present regardless of model override
+        expect(replyOpts).toEqual(
+          expect.objectContaining({
+            isHeartbeat: true,
+            onModelSelected: expect.any(Function),
+          }),
+        );
+      },
+      { prefix: "openclaw-hb-prefix-no-override-" },
+    );
+  });
+
+  it("passes onModelSelected with heartbeatModelOverride", async () => {
+    await withTempHeartbeatSandbox(
+      async ({ tmpDir, storePath }) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: { every: "5m", target: "whatsapp", model: "ollama/llama3.2:1b" },
+            },
+          },
+          channels: {
+            whatsapp: {
+              allowFrom: ["*"],
+              responsePrefix: "{model}: ",
+            },
+          },
+          session: { store: storePath },
+        };
+        const sessionKey = resolveMainSessionKey(cfg);
+        await seedSessionStore(storePath, sessionKey, {
+          lastChannel: "whatsapp",
+          lastProvider: "whatsapp",
+          lastTo: "+1555",
+        });
+
+        const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+        replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+        await runHeartbeatOnce({
+          cfg,
+          deps: { getQueueSize: () => 0, nowMs: () => 0 },
+        });
+
+        const replyOpts = replySpy.mock.calls[0]?.[1];
+        expect(replyOpts).toEqual(
+          expect.objectContaining({
+            isHeartbeat: true,
+            heartbeatModelOverride: "ollama/llama3.2:1b",
+            onModelSelected: expect.any(Function),
+          }),
+        );
+      },
+      { prefix: "openclaw-hb-prefix-with-override-" },
+    );
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -6,7 +6,6 @@ import {
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
 import { appendCronStyleCurrentTimeLine } from "../agents/current-time.js";
-import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
@@ -17,10 +16,12 @@ import {
   stripHeartbeatToken,
 } from "../auto-reply/heartbeat.js";
 import { getReplyFromConfig } from "../auto-reply/reply.js";
+import { resolveResponsePrefixTemplate } from "../auto-reply/reply/response-prefix-template.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { getChannelPlugin } from "../channels/plugins/index.js";
 import type { ChannelHeartbeatDeps } from "../channels/plugins/types.js";
+import { createReplyPrefixContext } from "../channels/reply-prefix.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
@@ -682,10 +683,17 @@ export async function runHeartbeatOnce(opts: {
         })
       : { showOk: false, showAlerts: true, useIndicator: true };
   const { sender } = resolveHeartbeatSenderContext({ cfg, entry, delivery });
-  const responsePrefix = resolveEffectiveMessagesConfig(cfg, agentId, {
-    channel: delivery.channel !== "none" ? delivery.channel : undefined,
+  const deliveryChannel = delivery.channel !== "none" ? delivery.channel : undefined;
+  const {
+    responsePrefix: rawResponsePrefix,
+    onModelSelected,
+    prefixContext,
+  } = createReplyPrefixContext({
+    cfg,
+    agentId,
+    channel: deliveryChannel,
     accountId: delivery.accountId,
-  }).responsePrefix;
+  });
 
   const canRelayToUser = Boolean(
     delivery.channel !== "none" && delivery.to && visibility.showAlerts,
@@ -720,7 +728,10 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: "alerts-disabled" };
   }
 
-  const heartbeatOkText = responsePrefix ? `${responsePrefix} ${HEARTBEAT_TOKEN}` : HEARTBEAT_TOKEN;
+  // heartbeatOkText is sent before the LLM runs, so use raw prefix (model unknown yet).
+  const heartbeatOkText = rawResponsePrefix
+    ? `${rawResponsePrefix} ${HEARTBEAT_TOKEN}`
+    : HEARTBEAT_TOKEN;
   const outboundSession = buildOutboundSessionContext({
     cfg,
     agentId,
@@ -775,8 +786,9 @@ export async function runHeartbeatOnce(opts: {
           heartbeatModelOverride,
           suppressToolErrorWarnings,
           bootstrapContextMode,
+          onModelSelected,
         }
-      : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode };
+      : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode, onModelSelected };
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;
@@ -809,6 +821,8 @@ export async function runHeartbeatOnce(opts: {
     }
 
     const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
+    // Interpolate template variables (e.g. {model}, {provider}) now that the LLM has responded.
+    const responsePrefix = resolveResponsePrefixTemplate(rawResponsePrefix, prefixContext);
     const normalized = normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars);
     // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
     // The model should be responding with exec results, not ack tokens.


### PR DESCRIPTION
## Summary

- Heartbeat replies now correctly interpolate `responsePrefix` template variables (`{model}`, `{provider}`, `{thinkingLevel}`, etc.) instead of showing them as literal text
- Wire up `createReplyPrefixContext()` in `runHeartbeatOnce()` so `onModelSelected` populates model/provider context during the LLM call
- After the LLM responds, call `resolveResponsePrefixTemplate()` to interpolate the prefix before passing it to `normalizeHeartbeatReply()`

## Root cause

`runHeartbeatOnce()` resolved `responsePrefix` from config as the raw template string (e.g. `"{model}: "`) and passed it directly to `normalizeHeartbeatReply()` without interpolation. The normal reply path uses `createReplyPrefixContext()` + `resolveResponsePrefixTemplate()` — the heartbeat path bypassed both.

## Changes

- `src/infra/heartbeat-runner.ts`: Replace `resolveEffectiveMessagesConfig()` with `createReplyPrefixContext()` to get the raw prefix, `onModelSelected` callback, and mutable `prefixContext`. Pass `onModelSelected` to `getReplyFromConfig()`. Interpolate the prefix after the LLM call.
- `src/infra/heartbeat-runner.response-prefix-template.test.ts`: 3 new tests verifying `onModelSelected` is passed to `getReplyFromConfig` in all heartbeat configurations.

## Test plan

- [x] All 63 heartbeat tests pass (60 existing + 3 new)
- [x] Build passes (`pnpm build`)
- [x] Lint/format passes (`pnpm check`)
- [ ] Manual: set `responsePrefix: "{model}: "`, trigger heartbeat alert, verify model name appears instead of `{model}`

Fixes #43064