### PR TITLE
agents: fix false unknown-tool warning for optional core tools in coding profile

### DIFF
--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -1,5 +1,6 @@
 import { filterToolsByPolicy } from "./pi-tools.policy.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
+import { isKnownCoreToolId } from "./tool-catalog.js";
 import {
   buildPluginToolGroups,
   expandPolicyWithPluginGroups,
@@ -88,7 +89,12 @@ export function applyToolPolicyPipeline(params: {
 
     let policy: ToolPolicyLike | undefined = step.policy;
     if (step.stripPluginOnlyAllowlist) {
-      const resolved = stripPluginOnlyAllowlist(policy, pluginGroups, coreToolNames);
+      const resolved = stripPluginOnlyAllowlist(
+        policy,
+        pluginGroups,
+        coreToolNames,
+        isKnownCoreToolId,
+      );
       if (resolved.unknownAllowlist.length > 0) {
         const entries = resolved.unknownAllowlist.join(", ");
         const suffix = resolved.strippedAllowlist

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -178,7 +178,8 @@ export function stripPluginOnlyAllowlist(
     // (e.g., memory_search/memory_get when the memory plugin is disabled).
     const isCoreEntry =
       expanded.some((tool) => coreTools.has(tool)) ||
-      (isStaticCoreId !== undefined && isStaticCoreId(entry));
+      (isStaticCoreId !== undefined &&
+        (isStaticCoreId(entry) || expanded.some((tool) => isStaticCoreId!(tool))));
     if (isCoreEntry) {
       hasCoreEntry = true;
     }

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -152,6 +152,7 @@ export function stripPluginOnlyAllowlist(
   policy: ToolPolicyLike | undefined,
   groups: PluginToolGroups,
   coreTools: Set<string>,
+  isStaticCoreId?: (id: string) => boolean,
 ): AllowlistResolution {
   if (!policy?.allow || policy.allow.length === 0) {
     return { policy, unknownAllowlist: [], strippedAllowlist: false };
@@ -172,7 +173,12 @@ export function stripPluginOnlyAllowlist(
     const isPluginEntry =
       entry === "group:plugins" || pluginIds.has(entry) || pluginTools.has(entry);
     const expanded = expandToolGroups([entry]);
-    const isCoreEntry = expanded.some((tool) => coreTools.has(tool));
+    // Check against currently-loaded core tools and also static catalog to avoid false
+    // "unknown" warnings for optional core tools not loaded at runtime
+    // (e.g., memory_search/memory_get when the memory plugin is disabled).
+    const isCoreEntry =
+      expanded.some((tool) => coreTools.has(tool)) ||
+      (isStaticCoreId !== undefined && isStaticCoreId(entry));
     if (isCoreEntry) {
       hasCoreEntry = true;
     }


### PR DESCRIPTION
## Problem

When the memory plugin is disabled, optional core tools like `memory_search` and `memory_get` exist in the static tool catalog but are not loaded at runtime. The `stripPluginOnlyAllowlist` function only checked against the runtime-loaded tool set, causing these valid catalog entries to be falsely flagged as unknown — producing the warning:

```
tools.profile (coding) allowlist contains unknown entries (apply_patch, memory_search, memory_get)
```

Fixes #42726

## Solution

Added an optional 4th parameter `isStaticCoreId?: (id: string) => boolean` to `stripPluginOnlyAllowlist`. When provided, a tool entry is considered a known core entry if it either:
- Is present in the runtime-loaded core tool set, **or**
- Is recognized by the static catalog via `isKnownCoreToolId`

Updated `applyToolPolicyPipeline` in `tool-policy-pipeline.ts` to pass `isKnownCoreToolId` from the tool catalog.

## Tests

All 20 existing `tool-policy.test.ts` tests pass.