### PR TITLE
fix(webchat): preserve attachment images for non-vision models

### DIFF
--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -254,7 +254,7 @@ describe("loadImageFromRef", () => {
 });
 
 describe("detectAndLoadPromptImages", () => {
-  it("returns no images for non-vision models even when existing images are provided", async () => {
+  it("preserves existing images for non-vision models (webchat attachments)", async () => {
     const result = await detectAndLoadPromptImages({
       prompt: "ignore",
       workspaceDir: "/tmp",
@@ -262,6 +262,20 @@ describe("detectAndLoadPromptImages", () => {
       existingImages: [{ type: "image", data: "abc", mimeType: "image/png" }],
     });
 
+    // Webchat attachment images should pass through even when the model
+    // does not declare image support — the user explicitly sent them (issue #42903)
+    expect(result.images).toHaveLength(1);
+    expect(result.detectedRefs).toHaveLength(0);
+  });
+
+  it("skips prompt-detected images for non-vision models", async () => {
+    const result = await detectAndLoadPromptImages({
+      prompt: "look at /tmp/test.png",
+      workspaceDir: "/tmp",
+      model: { input: ["text"] },
+    });
+
+    // Auto-detected prompt images should still be skipped for non-vision models
     expect(result.images).toHaveLength(0);
     expect(result.detectedRefs).toHaveLength(0);
   });

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -298,10 +298,12 @@ export async function detectAndLoadPromptImages(params: {
   loadedCount: number;
   skippedCount: number;
 }> {
-  // If model doesn't support images, return empty results
+  // If model doesn't support images, skip auto-detection from prompt text
+  // but still pass through explicitly-provided images (e.g. webchat attachments)
+  // so they reach the model — the user intentionally sent them.
   if (!modelSupportsImages(params.model)) {
     return {
-      images: [],
+      images: params.existingImages ?? [],
       detectedRefs: [],
       loadedCount: 0,
       skippedCount: 0,


### PR DESCRIPTION
## Summary

- Fixes webchat images being silently dropped when sent to non-default agents using models without explicit `input: ["image"]` in the model catalog (e.g. vLLM, custom OpenAI-compatible providers)
- Root cause: `detectAndLoadPromptImages()` returned `images: []` when `modelSupportsImages()` was false, discarding explicitly-provided webchat attachment images (`existingImages`)
- Fix: pass through `existingImages` (webchat attachments) regardless of model capabilities — only skip auto-detected prompt image references for non-vision models

## Linked Issue

Closes #42903

## Root Cause

In `src/agents/pi-embedded-runner/run/images.ts`, the `detectAndLoadPromptImages` function had an early return that dropped ALL images when the model's `input` array didn't include `"image"`:

```typescript
if (!modelSupportsImages(params.model)) {
    return { images: [], ... }; // ← drops existingImages (webchat attachments)
}
```

Webchat attachment images flow through `chat.send` → `replyOptions.images` → `runEmbeddedAttempt` → `detectAndLoadPromptImages(existingImages)`. When the target agent uses a model without declared image support (common for vLLM/custom providers that don't configure `input: ["image"]` in models config), the images were silently discarded.

## Fix

```typescript
if (!modelSupportsImages(params.model)) {
    return { images: params.existingImages ?? [], ... }; // ← preserve webchat attachments
}
```

This preserves explicitly-provided images (the user intentionally sent them) while still skipping auto-detection of prompt image references for non-vision models.

## Test Plan

- [x] Updated existing test: "preserves existing images for non-vision models (webchat attachments)" — verifies `existingImages` pass through when model lacks image support
- [x] Added new test: "skips prompt-detected images for non-vision models" — verifies auto-detected images are still skipped
- [x] All 28 tests in `images.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)