### PR TITLE
fix(cron): allow agentTurn jobs on main sessions

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -248,7 +248,7 @@ ISO timestamps without an explicit timezone are treated as UTC.
 PAYLOAD TYPES (payload.kind):
 - "systemEvent": Injects text as system event into session
   { "kind": "systemEvent", "text": "<message>" }
-- "agentTurn": Runs agent with message (isolated sessions only)
+- "agentTurn": Runs agent with message
   { "kind": "agentTurn", "message": "<prompt>", "model": "<optional>", "thinking": "<optional>", "timeoutSeconds": <optional, 0 means no timeout> }
 
 DELIVERY (top-level):
@@ -259,10 +259,10 @@ DELIVERY (top-level):
   - If the task needs to send to a specific chat/recipient, set announce delivery.channel/to; do not call messaging tools inside the run.
 
 CRITICAL CONSTRAINTS:
-- sessionTarget="main" REQUIRES payload.kind="systemEvent"
+- sessionTarget="main" supports payload.kind="systemEvent" and "agentTurn"
 - sessionTarget="isolated" REQUIRES payload.kind="agentTurn"
 - For webhook callbacks, use delivery.mode="webhook" with delivery.to set to a URL.
-Default: prefer isolated agentTurn jobs unless the user explicitly wants a main-session system event.
+Default: prefer main for agentTurn jobs that should reuse the agent's normal main-session execution path; use isolated when you explicitly want a fresh cron run session.
 
 WAKE MODES (for wake action):
 - "next-heartbeat" (default): Wake on next heartbeat

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -15,6 +15,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { MsgContext } from "../templating.js";
+import { normalizeThinkLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { emitResetCommandHooks, type ResetCommandAction } from "./commands-core.js";
@@ -110,6 +111,7 @@ export async function getReplyFromConfig(
   const workspaceDir = workspace.dir;
   const agentDir = resolveAgentDir(cfg, agentId);
   const timeoutMs = resolveAgentTimeoutMs({ cfg, overrideSeconds: opts?.timeoutOverrideSeconds });
+  const heartbeatThinkingOverride = opts?.heartbeatThinkingOverride?.trim() || undefined;
   const configuredTypingSeconds =
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
   const typingIntervalSeconds =
@@ -279,6 +281,9 @@ export async function getReplyFromConfig(
   } = directiveResult.result;
   provider = resolvedProvider;
   model = resolvedModel;
+  if (heartbeatThinkingOverride) {
+    resolvedThinkLevel = normalizeThinkLevel(heartbeatThinkingOverride) ?? resolvedThinkLevel;
+  }
 
   const maybeEmitMissingResetHooks = async () => {
     if (!resetTriggered || !command.isAuthorizedSender || command.resetHookTriggered) {

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -40,6 +40,8 @@ export type GetReplyOptions = {
   suppressTyping?: boolean;
   /** Resolved heartbeat model override (provider/model string from merged per-agent config). */
   heartbeatModelOverride?: string;
+  /** Optional one-off thinking override for the current run. */
+  heartbeatThinkingOverride?: string;
   /** Controls bootstrap workspace context injection (default: full). */
   bootstrapContextMode?: "full" | "lightweight";
   /** If true, suppress tool error warning payloads for this run. */

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -199,8 +199,12 @@ export function registerCronAddCommand(cron: Command) {
             throw new Error("Choose --delete-after-run or --keep-after-run, not both");
           }
 
-          if (sessionTarget === "main" && payload.kind !== "systemEvent") {
-            throw new Error("Main jobs require --system-event (systemEvent).");
+          if (
+            sessionTarget === "main" &&
+            payload.kind !== "systemEvent" &&
+            payload.kind !== "agentTurn"
+          ) {
+            throw new Error("Main jobs require --system-event or --message.");
           }
           if (sessionTarget === "isolated" && payload.kind !== "agentTurn") {
             throw new Error("Isolated jobs require --message (agentTurn).");

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -188,7 +188,7 @@ export function registerCronAddCommand(cron: Command) {
               : () => undefined;
           const sessionSource = optionSource("session");
           const sessionTargetRaw = typeof opts.session === "string" ? opts.session.trim() : "";
-          const inferredSessionTarget = payload.kind === "agentTurn" ? "isolated" : "main";
+          const inferredSessionTarget = "main";
           const sessionTarget =
             sessionSource === "cli" ? sessionTargetRaw || "" : inferredSessionTarget;
           if (sessionTarget !== "main" && sessionTarget !== "isolated") {

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyJobPatch, createJob } from "./service/jobs.js";
+import { applyJobPatch, createJob, resolveJobPayloadTextForMain } from "./service/jobs.js";
 import type { CronServiceState } from "./service/state.js";
 import { DEFAULT_TOP_OF_HOUR_STAGGER_MS } from "./stagger.js";
 import type { CronJob, CronJobPatch } from "./types.js";
@@ -68,6 +68,24 @@ describe("applyJobPatch", () => {
     expect(() => applyJobPatch(job, switchToMainPatch())).not.toThrow();
     expect(job.sessionTarget).toBe("main");
     expect(job.delivery).toEqual({ mode: "webhook", to: "https://example.invalid/cron" });
+  });
+
+  it("allows main-session agentTurn jobs for non-default agents", () => {
+    const job = createIsolatedAgentTurnJob("job-main-agentturn", {
+      mode: "none",
+    });
+
+    expect(() =>
+      applyJobPatch(job, {
+        sessionTarget: "main",
+        agentId: "eva-public",
+        payload: { kind: "agentTurn", message: "post update" },
+      }),
+    ).not.toThrow();
+    expect(job.sessionTarget).toBe("main");
+    expect(job.agentId).toBe("eva-public");
+    expect(job.payload).toEqual({ kind: "agentTurn", message: "post update" });
+    expect(job.delivery).toBeUndefined();
   });
 
   it("maps legacy payload delivery updates onto delivery", () => {
@@ -365,7 +383,7 @@ function createMockState(now: number, opts?: { defaultAgentId?: string }): CronS
   } as unknown as CronServiceState;
 }
 
-describe("createJob rejects sessionTarget main for non-default agents", () => {
+describe("createJob allows sessionTarget main for non-default agents", () => {
   const now = Date.parse("2026-02-28T12:00:00.000Z");
 
   const mainJobInput = (agentId?: string) => ({
@@ -389,18 +407,14 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
     expect(() => createJob(state, mainJobInput("MAIN"))).not.toThrow();
   });
 
-  it("rejects creating a main-session job for a non-default agentId", () => {
+  it("allows creating a main-session job for a non-default agentId", () => {
     const state = createMockState(now, { defaultAgentId: "main" });
-    expect(() => createJob(state, mainJobInput("custom-agent"))).toThrow(
-      'cron: sessionTarget "main" is only valid for the default agent',
-    );
+    expect(() => createJob(state, mainJobInput("custom-agent"))).not.toThrow();
   });
 
-  it("rejects main-session job for non-default agent even without explicit defaultAgentId", () => {
+  it("allows main-session job for non-default agent even without explicit defaultAgentId", () => {
     const state = createMockState(now);
-    expect(() => createJob(state, mainJobInput("custom-agent"))).toThrow(
-      'cron: sessionTarget "main" is only valid for the default agent',
-    );
+    expect(() => createJob(state, mainJobInput("custom-agent"))).not.toThrow();
   });
 
   it("allows isolated session job for non-default agents", () => {
@@ -438,7 +452,7 @@ describe("createJob rejects sessionTarget main for non-default agents", () => {
   });
 });
 
-describe("applyJobPatch rejects sessionTarget main for non-default agents", () => {
+describe("applyJobPatch allows sessionTarget main for non-default agents", () => {
   const now = Date.now();
 
   const createMainJob = (agentId?: string): CronJob => ({
@@ -455,13 +469,13 @@ describe("applyJobPatch rejects sessionTarget main for non-default agents", () =
     agentId,
   });
 
-  it("rejects patching agentId to non-default on a main-session job", () => {
+  it("allows patching agentId to non-default on a main-session job", () => {
     const job = createMainJob();
     expect(() =>
       applyJobPatch(job, { agentId: "custom-agent" } as CronJobPatch, {
         defaultAgentId: "main",
       }),
-    ).toThrow('cron: sessionTarget "main" is only valid for the default agent');
+    ).not.toThrow();
   });
 
   it("allows patching agentId to the default agent on a main-session job", () => {
@@ -556,6 +570,25 @@ describe("cron stagger defaults", () => {
     if (job.schedule.kind === "cron") {
       expect(job.schedule.staggerMs).toBe(DEFAULT_TOP_OF_HOUR_STAGGER_MS);
     }
+  });
+});
+
+describe("resolveJobPayloadTextForMain", () => {
+  it("returns trimmed agentTurn text for main-session cron execution", () => {
+    const text = resolveJobPayloadTextForMain({
+      id: "job-main-text",
+      name: "job-main-text",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "  do the thing  " },
+      state: {},
+    } as CronJob);
+
+    expect(text).toBe("do the thing");
   });
 });
 

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -590,6 +590,23 @@ describe("resolveJobPayloadTextForMain", () => {
 
     expect(text).toBe("do the thing");
   });
+
+  it("returns undefined for empty main-session agentTurn messages", () => {
+    const text = resolveJobPayloadTextForMain({
+      id: "job-main-empty",
+      name: "job-main-empty",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "   " },
+      state: {},
+    } as CronJob);
+
+    expect(text).toBeUndefined();
+  });
 });
 
 describe("createJob delivery defaults", () => {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { normalizeAgentId } from "../../routing/session-key.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import {
   coerceFiniteScheduleNumber,
@@ -132,8 +131,11 @@ function resolveEveryAnchorMs(params: {
 }
 
 export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "payload">) {
-  if (job.sessionTarget === "main" && job.payload.kind !== "systemEvent") {
-    throw new Error('main cron jobs require payload.kind="systemEvent"');
+  if (job.sessionTarget === "main") {
+    if (job.payload.kind !== "systemEvent" && job.payload.kind !== "agentTurn") {
+      throw new Error('main cron jobs require payload.kind="systemEvent" or "agentTurn"');
+    }
+    return;
   }
   if (job.sessionTarget === "isolated" && job.payload.kind !== "agentTurn") {
     throw new Error('isolated cron jobs require payload.kind="agentTurn"');
@@ -142,21 +144,12 @@ export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "pay
 
 function assertMainSessionAgentId(
   job: Pick<CronJob, "sessionTarget" | "agentId">,
-  defaultAgentId: string | undefined,
+  _defaultAgentId: string | undefined,
 ) {
   if (job.sessionTarget !== "main") {
     return;
   }
-  if (!job.agentId) {
-    return;
-  }
-  const normalized = normalizeAgentId(job.agentId);
-  const normalizedDefault = normalizeAgentId(defaultAgentId);
-  if (normalized !== normalizedDefault) {
-    throw new Error(
-      `cron: sessionTarget "main" is only valid for the default agent. Use sessionTarget "isolated" with payload.kind "agentTurn" for non-default agents (agentId: ${job.agentId})`,
-    );
-  }
+  return;
 }
 
 const TELEGRAM_TME_URL_REGEX = /^https?:\/\/t\.me\/|t\.me\//i;
@@ -892,9 +885,13 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
 }
 
 export function resolveJobPayloadTextForMain(job: CronJob): string | undefined {
-  if (job.payload.kind !== "systemEvent") {
-    return undefined;
+  if (job.payload.kind === "systemEvent") {
+    const text = normalizePayloadToSystemText(job.payload);
+    return text.trim() ? text : undefined;
   }
-  const text = normalizePayloadToSystemText(job.payload);
-  return text.trim() ? text : undefined;
+  if (job.payload.kind === "agentTurn") {
+    const text = job.payload.message?.trim() ?? "";
+    return text ? text : undefined;
+  }
+  return undefined;
 }

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -142,16 +142,6 @@ export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "pay
   }
 }
 
-function assertMainSessionAgentId(
-  job: Pick<CronJob, "sessionTarget" | "agentId">,
-  _defaultAgentId: string | undefined,
-) {
-  if (job.sessionTarget !== "main") {
-    return;
-  }
-  return;
-}
-
 const TELEGRAM_TME_URL_REGEX = /^https?:\/\/t\.me\/|t\.me\//i;
 const TELEGRAM_SLASH_TOPIC_REGEX = /^-?\d+\/\d+$/;
 
@@ -545,7 +535,6 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     },
   };
   assertSupportedJobSpec(job);
-  assertMainSessionAgentId(job, state.deps.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
   job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
@@ -555,7 +544,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
 export function applyJobPatch(
   job: CronJob,
   patch: CronJobPatch,
-  opts?: { defaultAgentId?: string },
+  _opts?: { defaultAgentId?: string },
 ) {
   if ("name" in patch) {
     job.name = normalizeRequiredName(patch.name);
@@ -635,7 +624,6 @@ export function applyJobPatch(
     job.sessionKey = normalizeOptionalSessionKey((patch as { sessionKey?: unknown }).sessionKey);
   }
   assertSupportedJobSpec(job);
-  assertMainSessionAgentId(job, opts?.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1058,6 +1058,14 @@ export async function executeJobCore(
       agentId: job.agentId,
       sessionKey: targetMainSessionKey,
       contextKey: `cron:${job.id}`,
+      runtimeOverrides:
+        job.payload.kind === "agentTurn"
+          ? {
+              model: job.payload.model,
+              thinking: job.payload.thinking,
+              timeoutSeconds: job.payload.timeoutSeconds,
+            }
+          : undefined,
     });
     if (job.wakeMode === "now" && state.deps.runHeartbeatOnce) {
       const reason = `cron:${job.id}`;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1047,7 +1047,7 @@ export async function executeJobCore(
         error:
           kind === "systemEvent"
             ? "main job requires non-empty systemEvent text"
-            : 'main job requires payload.kind="systemEvent"',
+            : "main agentTurn job requires a non-empty message",
       };
     }
     // Preserve the job session namespace for main-target reminders so heartbeat

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -203,4 +203,60 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
       }),
     );
   });
+
+  it("passes cron runtime overrides from queued main-session events", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await seedSession(sessionKey, { lastChannel: "whatsapp", lastTo: "+1555" });
+
+      const { enqueueSystemEvent, resetSystemEventsForTest } = await import("./system-events.js");
+      resetSystemEventsForTest();
+      enqueueSystemEvent("run cron payload", {
+        sessionKey,
+        contextKey: "cron:job-123",
+        runtimeOverrides: {
+          model: "openai-codex/gpt-5.4",
+          thinking: "low",
+          timeoutSeconds: 600,
+        },
+      });
+
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        reason: "cron:job-123",
+        sessionKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          isHeartbeat: true,
+          heartbeatModelOverride: "openai-codex/gpt-5.4",
+          heartbeatThinkingOverride: "low",
+          timeoutOverrideSeconds: 600,
+        }),
+        cfg,
+      );
+    });
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -563,6 +563,12 @@ type HeartbeatPromptResolution = {
   hasCronEvents: boolean;
 };
 
+type HeartbeatRuntimeOverrides = {
+  model?: string;
+  thinking?: string;
+  timeoutSeconds?: number;
+};
+
 function appendHeartbeatWorkspacePathHint(prompt: string, workspaceDir: string): string {
   if (!/heartbeat\.md/i.test(prompt)) {
     return prompt;
@@ -573,6 +579,22 @@ function appendHeartbeatWorkspacePathHint(prompt: string, workspaceDir: string):
     return prompt;
   }
   return `${prompt}\n${hint}`;
+}
+
+function resolveHeartbeatRuntimeOverrides(params: {
+  preflight: HeartbeatPreflight;
+  reason?: string;
+}): HeartbeatRuntimeOverrides | undefined {
+  const entries = params.preflight.pendingEventEntries;
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const matching =
+    typeof params.reason === "string" && params.reason.startsWith("cron:")
+      ? entries.filter((event) => event.contextKey === params.reason)
+      : entries.filter((event) => event.contextKey?.startsWith("cron:"));
+  const selected = matching.at(-1);
+  return selected?.runtimeOverrides;
 }
 
 function resolveHeartbeatRunPrompt(params: {
@@ -765,18 +787,25 @@ export async function runHeartbeatOnce(opts: {
       agentId,
     });
 
-    const heartbeatModelOverride = heartbeat?.model?.trim() || undefined;
+    const cronRuntimeOverrides = resolveHeartbeatRuntimeOverrides({
+      preflight,
+      reason: opts.reason,
+    });
+    const heartbeatModelOverride =
+      cronRuntimeOverrides?.model?.trim() || heartbeat?.model?.trim() || undefined;
+    const heartbeatThinkingOverride = cronRuntimeOverrides?.thinking?.trim() || undefined;
+    const timeoutOverrideSeconds = cronRuntimeOverrides?.timeoutSeconds;
     const suppressToolErrorWarnings = heartbeat?.suppressToolErrorWarnings === true;
     const bootstrapContextMode: "lightweight" | undefined =
       heartbeat?.lightContext === true ? "lightweight" : undefined;
-    const replyOpts = heartbeatModelOverride
-      ? {
-          isHeartbeat: true,
-          heartbeatModelOverride,
-          suppressToolErrorWarnings,
-          bootstrapContextMode,
-        }
-      : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode };
+    const replyOpts = {
+      isHeartbeat: true,
+      heartbeatModelOverride,
+      heartbeatThinkingOverride,
+      timeoutOverrideSeconds,
+      suppressToolErrorWarnings,
+      bootstrapContextMode,
+    };
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -3,7 +3,12 @@ import { drainFormattedSystemEvents } from "../auto-reply/reply/session-updates.
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import { isCronSystemEvent } from "./heartbeat-runner.js";
-import { enqueueSystemEvent, peekSystemEvents, resetSystemEventsForTest } from "./system-events.js";
+import {
+  enqueueSystemEvent,
+  peekSystemEventEntries,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "./system-events.js";
 
 const cfg = {} as unknown as OpenClawConfig;
 const mainKey = resolveMainSessionKey(cfg);
@@ -54,6 +59,31 @@ describe("system events (session routing)", () => {
 
     expect(first).toBe(true);
     expect(second).toBe(false);
+  });
+
+  it("preserves runtime overrides on queued events", () => {
+    const key = "agent:main:runtime-overrides";
+    enqueueSystemEvent("cron run", {
+      sessionKey: key,
+      contextKey: "cron:job-123",
+      runtimeOverrides: {
+        model: "openai-codex/gpt-5.4",
+        thinking: "low",
+        timeoutSeconds: 600,
+      },
+    });
+
+    expect(peekSystemEventEntries(key)).toEqual([
+      expect.objectContaining({
+        text: "cron run",
+        contextKey: "cron:job-123",
+        runtimeOverrides: {
+          model: "openai-codex/gpt-5.4",
+          thinking: "low",
+          timeoutSeconds: 600,
+        },
+      }),
+    ]);
   });
 
   it("filters heartbeat/noise lines, returning undefined", async () => {

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -2,7 +2,18 @@
 // prefixed to the next prompt. We intentionally avoid persistence to keep
 // events ephemeral. Events are session-scoped and require an explicit key.
 
-export type SystemEvent = { text: string; ts: number; contextKey?: string | null };
+export type SystemEventRuntimeOverrides = {
+  model?: string;
+  thinking?: string;
+  timeoutSeconds?: number;
+};
+
+export type SystemEvent = {
+  text: string;
+  ts: number;
+  contextKey?: string | null;
+  runtimeOverrides?: SystemEventRuntimeOverrides;
+};
 
 const MAX_EVENTS = 20;
 
@@ -14,9 +25,10 @@ type SessionQueue = {
 
 const queues = new Map<string, SessionQueue>();
 
-type SystemEventOptions = {
+export type SystemEventOptions = {
   sessionKey: string;
   contextKey?: string | null;
+  runtimeOverrides?: SystemEventRuntimeOverrides;
 };
 
 function requireSessionKey(key?: string | null): string {
@@ -75,6 +87,7 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
     text: cleaned,
     ts: Date.now(),
     contextKey: normalizedContextKey,
+    runtimeOverrides: options?.runtimeOverrides,
   });
   if (entry.queue.length > MAX_EVENTS) {
     entry.queue.shift();


### PR DESCRIPTION
## Summary
This fixes a cron-path reliability problem for heavyweight `agentTurn` jobs by allowing them to run on `sessionTarget: "main"` instead of forcing them onto isolated cron sessions.

## AI assistance
- AI-assisted PR: yes
- Testing level: lightly tested / focused cron tests passed
- I understand what the code does: yes

## What changed
- allow `sessionTarget: "main"` with `payload.kind: "agentTurn"`
- enqueue main-session `agentTurn` payloads using the same main-session heartbeat path already used for `systemEvent`
- remove the default-agent-only restriction for main-session cron jobs
- update cron CLI/tool guidance
- add regression tests for main-session `agentTurn` jobs and non-default agents

## Why
On my host, heavy GPT-5.4 cron jobs using the isolated `agentTurn` path were repeatedly stalling in cron while the exact same prompts completed quickly via direct `openclaw agent --agent ...` execution on the agent's normal main session.

This patch provides a healthy execution path for cron jobs that want normal main-session behavior instead of a fresh isolated run.

## Validation
Focused tests passed:
- `pnpm test -- --run src/cron/service.jobs.test.ts src/cron/service.main-job-passes-heartbeat-target-last.test.ts`

Not yet run locally for this PR:
- `pnpm build && pnpm check && pnpm test`
- local `codex review --base origin/main`
