### PR TITLE
fix(agents): ignore stale requiresOpenAiAnthropicToolPayload override for kimi-coding

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -890,6 +890,50 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]?.tool_choice).toEqual({ type: "tool", name: "read" });
   });
 
+  it("ignores legacy compat override for kimi-coding tool payloads", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        tools: [
+          {
+            name: "read",
+            description: "Read file",
+            input_schema: { type: "object", properties: {} },
+          },
+        ],
+        tool_choice: { type: "tool", name: "read" },
+      };
+      options?.onPayload?.(payload, model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "kimi-coding", "k2p5", undefined, "low");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "kimi-coding",
+      id: "k2p5",
+      baseUrl: "https://api.kimi.com/coding/",
+      compat: {
+        requiresOpenAiAnthropicToolPayload: true,
+      },
+    } as unknown as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.tools).toEqual([
+      {
+        name: "read",
+        description: "Read file",
+        input_schema: { type: "object", properties: {} },
+      },
+    ]);
+    expect(payloads[0]?.tool_choice).toEqual({ type: "tool", name: "read" });
+  });
+
   it("does not rewrite anthropic tool schema for non-kimi endpoints", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -1,6 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { resolveFastModeParam } from "../fast-mode.js";
+import { normalizeProviderId } from "../model-selection.js";
 import {
   requiresOpenAiCompatibleAnthropicToolPayload,
   usesOpenAiFunctionAnthropicToolSchema,
@@ -83,11 +84,18 @@ function requiresAnthropicToolPayloadCompatibilityForModel(model: {
     return false;
   }
 
-  if (
-    typeof model.provider === "string" &&
-    requiresOpenAiCompatibleAnthropicToolPayload(model.provider)
-  ) {
-    return true;
+  if (typeof model.provider === "string") {
+    const normalizedProvider = normalizeProviderId(model.provider);
+    // Legacy configs may still contain compat.requiresOpenAiAnthropicToolPayload=true
+    // from old kimi-coding defaults. That marker is now invalid for kimi-coding
+    // and causes textual pseudo tool calls (for example [[read:0]]{...}) instead
+    // of native tool_use blocks, so we must ignore the stale override.
+    if (normalizedProvider === "kimi-coding") {
+      return false;
+    }
+    if (requiresOpenAiCompatibleAnthropicToolPayload(model.provider)) {
+      return true;
+    }
   }
 
   if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -43,8 +43,8 @@ describe("resolveProviderCapabilities", () => {
       resolveProviderCapabilities("kimi-code"),
     );
     expect(resolveProviderCapabilities("kimi-code")).toEqual({
-      anthropicToolSchemaMode: "native",
-      anthropicToolChoiceMode: "native",
+      anthropicToolSchemaMode: "openai-functions",
+      anthropicToolChoiceMode: "openai-string-modes",
       providerFamily: "default",
       preserveAnthropicThinkingSignatures: false,
       openAiCompatTurnValidation: true,
@@ -85,9 +85,11 @@ describe("resolveProviderCapabilities", () => {
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
   });
 
-  it("treats kimi aliases as native anthropic tool payload providers", () => {
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(false);
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(false);
+  it("treats kimi aliases as OpenAI-compatible anthropic tool payload providers", () => {
+    // kimi-coding requires OpenAI-style tool payloads (tools[].function + string-mode tool_choice)
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(true);
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(true);
+    // anthropic native does not require OpenAI-compatible payloads
     expect(requiresOpenAiCompatibleAnthropicToolPayload("anthropic")).toBe(false);
   });
 

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -43,8 +43,8 @@ describe("resolveProviderCapabilities", () => {
       resolveProviderCapabilities("kimi-code"),
     );
     expect(resolveProviderCapabilities("kimi-code")).toEqual({
-      anthropicToolSchemaMode: "openai-functions",
-      anthropicToolChoiceMode: "openai-string-modes",
+      anthropicToolSchemaMode: "native",
+      anthropicToolChoiceMode: "native",
       providerFamily: "default",
       preserveAnthropicThinkingSignatures: false,
       openAiCompatTurnValidation: true,
@@ -85,10 +85,11 @@ describe("resolveProviderCapabilities", () => {
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
   });
 
-  it("treats kimi aliases as OpenAI-compatible anthropic tool payload providers", () => {
-    // kimi-coding requires OpenAI-style tool payloads (tools[].function + string-mode tool_choice)
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(true);
-    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(true);
+  it("treats kimi aliases as native anthropic tool payload providers", () => {
+    // kimi-coding uses native Anthropic tool format (input_schema)
+    // Legacy compat.requiresOpenAiAnthropicToolPayload=true is ignored by the wrapper guard
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-coding")).toBe(false);
+    expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(false);
     // anthropic native does not require OpenAI-compatible payloads
     expect(requiresOpenAiCompatibleAnthropicToolPayload("anthropic")).toBe(false);
   });

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -35,10 +35,12 @@ const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
     providerFamily: "anthropic",
     dropThinkingBlockModelHints: ["claude"],
   },
-  // kimi-coding natively supports Anthropic tool framing (input_schema);
-  // converting to OpenAI format causes XML text fallback instead of tool_use blocks.
+  // kimi-coding uses anthropic-messages API but requires OpenAI-style tool payloads
+  // (tools[].function + string-mode tool_choice) for proper tool call support.
   "kimi-coding": {
     preserveAnthropicThinkingSignatures: false,
+    anthropicToolSchemaMode: "openai-functions",
+    anthropicToolChoiceMode: "openai-string-modes",
   },
   mistral: {
     transcriptToolCallIdMode: "strict9",

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -35,12 +35,10 @@ const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
     providerFamily: "anthropic",
     dropThinkingBlockModelHints: ["claude"],
   },
-  // kimi-coding uses anthropic-messages API but requires OpenAI-style tool payloads
-  // (tools[].function + string-mode tool_choice) for proper tool call support.
+  // kimi-coding natively supports Anthropic tool framing (input_schema);
+  // converting to OpenAI format causes XML text fallback instead of tool_use blocks.
   "kimi-coding": {
     preserveAnthropicThinkingSignatures: false,
-    anthropicToolSchemaMode: "openai-functions",
-    anthropicToolChoiceMode: "openai-string-modes",
   },
   mistral: {
     transcriptToolCallIdMode: "strict9",


### PR DESCRIPTION
## Summary

Fixes a critical bug where kimi-coding/k2p5 cannot execute tool calls and exhibits repeating panic output behavior. This is a **complementary fix** to PR #40008 that addresses the root cause of issues #42481, #42117, and related reports.

### Problem

When using kimi-coding/k2p5 (native provider via KIMI_API_KEY), tool calls fail in two ways:

1. **Tool calls appear as text instead of executing**: The model outputs tool calls as pseudo-text (e.g., `[[read:0]]{...}` or `read file: ~/.openclaw/skills/...`) rather than structured `tool_use` blocks

2. **Repeating panic output**: The model enters a loop repeating the same tool-calling text indefinitely

### Root Cause

PR #40008 correctly changed kimi-coding to use native Anthropic tool format (`input_schema`) instead of OpenAI format. However, **legacy user configs** that previously had `compat.requiresOpenAiAnthropicToolPayload=true` are still being respected by `requiresAnthropicToolPayloadCompatibilityForModel()`.

This causes a mismatch:
- Tools are sent in native Anthropic format (correct after #40008)
- But the compat flag triggers OpenAI-style normalization in the payload wrapper
- Kimi's endpoint receives conflicting signals and responds with text-based pseudo tool calls instead of structured `tool_use` blocks

### The Fix

Add a guard in `requiresAnthropicToolPayloadCompatibilityForModel()` to **ignore the stale override** when `normalizedProvider === "kimi-coding"`:

```typescript
if (normalizedProvider === "kimi-coding") {
  return false; // Ignore legacy override
}
```

This ensures kimi-coding always uses native Anthropic tool format regardless of legacy config state.

### Relation to Previous Work

| PR/Issue | Role | Status |
|----------|------|--------|
| #40008 | Fixed outbound tool format to native Anthropic | Merged in v3.8 |
| #40457 | Attempted to add text/XML tool call recovery | **Closed without merge** |
| #42481 | Reports JSON parse error with trailing characters | Open |
| #42117 | Reports plaintext tool calls leak to chat | Open |
| **This PR** | Fixes legacy config compatibility issue | **Proposed** |

PR #40457 was closed because maintainers believed #40008 fixed all kimi tool issues. However, as noted in the comments on #42117 and #42481, the issue persists for users with legacy configs. This PR addresses the **actual remaining root cause**.

### Visual Evidence

**Tool calls appearing as text instead of executing:**
![issue-toolcall](https://github.com/user-attachments/assets/c69b4644-c608-41e6-b234-a4536dacb946)


**Repeating panic output behavior:**
![issue-repeat](https://github.com/user-attachments/assets/67a35f53-060d-4382-b8f3-6c7656a0193f)


### Changes

- `src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts`: Add guard to ignore stale compat override for kimi-coding
- `src/agents/pi-embedded-runner-extraparams.test.ts`: Add test case for legacy config scenario

### Testing

```bash
pnpm test src/agents/pi-embedded-runner-extraparams.test.ts
```

All 68 tests pass, including the new test that verifies legacy configs with `compat.requiresOpenAiAnthropicToolPayload=true` are properly ignored for kimi-coding.

### Verification

- [x] Tested with legacy config containing `compat.requiresOpenAiAnthropicToolPayload=true`
- [x] Verified tool calls execute correctly (not shown as text)
- [x] Verified no repeating output behavior
- [x] Non-kimi providers still respect the compat flag correctly

### Backward Compatibility

Fully backward compatible. This only affects kimi-coding provider behavior, forcing it to use the correct native Anthropic tool format regardless of stale config values.

### Linked Issues

- Related to #40008 (complementary fix)
- Fixes #42481
- Fixes #42117
- Related to #40457 (closed alternative approach)
