### PR TITLE
fix: strip store param from openai-completions request when compat.supportsStore is false (#43086)

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -20,6 +20,7 @@ import {
 } from "./moonshot-stream-wrappers.js";
 import {
   createCodexDefaultTransportWrapper,
+  createOpenAICompletionsStripStoreWrapper,
   createOpenAIDefaultTransportWrapper,
   createOpenAIResponsesContextManagementWrapper,
   createOpenAIServiceTierWrapper,
@@ -446,6 +447,12 @@ export function applyExtraParamsToAgent(
   // Force `store=true` for direct OpenAI Responses models and auto-enable
   // server-side compaction for compatible OpenAI Responses payloads.
   agent.streamFn = createOpenAIResponsesContextManagementWrapper(agent.streamFn, merged);
+
+  // Strip `store` from openai-completions payloads when compat.supportsStore is
+  // explicitly false. Google AI's OpenAI-compatible endpoint rejects requests that
+  // include the `store` field with a 400 INVALID_ARGUMENT error.
+  // See: openclaw/openclaw#43086
+  agent.streamFn = createOpenAICompletionsStripStoreWrapper(agent.streamFn);
 
   const rawParallelToolCalls = resolveAliasedParamValue(
     [resolvedExtraParams, override],

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -232,6 +232,42 @@ export function createOpenAIServiceTierWrapper(
   };
 }
 
+/**
+ * Strip the `store` field from openai-completions payloads when the model
+ * declares `compat.supportsStore: false`.
+ *
+ * Some OpenAI-compatible backends (e.g. Google AI's
+ * `generativelanguage.googleapis.com/v1beta/openai`) reject requests that
+ * include unknown fields such as `store` with a 400 INVALID_ARGUMENT error.
+ * The `compat.supportsStore` flag is already used in the openai-responses path;
+ * this wrapper applies the same guard for the openai-completions API path.
+ *
+ * Fixes: openclaw/openclaw#43086
+ */
+export function createOpenAICompletionsStripStoreWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (
+      model.api !== "openai-completions" ||
+      (model as { compat?: { supportsStore?: boolean } }).compat?.supportsStore !== false
+    ) {
+      return underlying(model, context, options);
+    }
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          delete (payload as Record<string, unknown>).store;
+        }
+        return originalOnPayload?.(payload, model);
+      },
+    });
+  };
+}
+
 export function createCodexDefaultTransportWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) =>


### PR DESCRIPTION
## Summary

Gemini models via the Google AI OpenAI-compatible endpoint (`generativelanguage.googleapis.com/v1beta/openai`) were returning 400 errors because OpenClaw was including `"store": false` in the request body. Google AI does not support this OpenAI-specific parameter and responds with:

```json
{
  "error": {
    "code": 400,
    "message": "Invalid JSON payload received. Unknown name \"store\": Cannot find field.",
    "status": "INVALID_ARGUMENT"
  }
}
```

The `compat.supportsStore: false` flag was already used to guard the `openai-responses` path (via `shouldStripResponsesStore` in `openai-stream-wrappers.ts`), but it was not applied to the `openai-completions` path that Gemini models use.

## Root Cause

`shouldStripResponsesStore` only checked `OPENAI_RESPONSES_APIS` (which contains only `"openai-responses"`). For `openai-completions` models, the `store` field was added by the upstream `pi-ai` library and never stripped, even when `compat.supportsStore` was explicitly set to `false`.

## Fix

Add `createOpenAICompletionsStripStoreWrapper` in `openai-stream-wrappers.ts` that hooks the `onPayload` callback and deletes the `store` field from the request payload when:
- `model.api === "openai-completions"`, **and**
- `model.compat.supportsStore === false`

Wire the new wrapper into `applyExtraParamsToAgent` in `extra-params.ts`, immediately after the existing `createOpenAIResponsesContextManagementWrapper` call.

The fix is minimal and surgical — it only removes the `store` field for models that explicitly opt out via `supportsStore: false`, leaving all other providers unaffected.

## Test plan

- [ ] Configure a Gemini model via Google AI endpoint (`generativelanguage.googleapis.com/v1beta/openai`) with `compat.supportsStore: false`
- [ ] Verify requests succeed (200) instead of failing with 400 INVALID_ARGUMENT
- [ ] Verify `store` is absent from the outgoing request body when `compat.supportsStore: false`
- [ ] Verify providers that DO support `store` (e.g. native OpenAI `openai-responses`) still send it correctly
- [ ] Verify other `openai-completions` providers without `supportsStore` set are unaffected

Fixes #43086