### PR TITLE
UI/Chat: show full command in sidebar when clicking tool cards

### DIFF
--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -60,24 +60,24 @@ export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: 
           card.args && typeof (card.args as Record<string, unknown>).command === "string"
             ? ((card.args as Record<string, unknown>).command as string).trim()
             : undefined;
+        const hasUsableCommand = rawCommand !== undefined && rawCommand !== "";
         const rawArgsJson =
-          card.args && typeof card.args === "object" && !rawCommand
+          card.args && typeof card.args === "object" && !hasUsableCommand
             ? JSON.stringify(card.args, null, 2)
             : undefined;
-        const commandBlock =
-          rawCommand !== undefined
-            ? `**Command:**\n\`\`\`\n${rawCommand}\n\`\`\`\n\n`
-            : rawArgsJson !== undefined
-              ? `**Arguments:**\n\`\`\`json\n${rawArgsJson}\n\`\`\`\n\n`
-              : detail
-                ? `**Command:** \`${detail}\`\n\n`
-                : "";
+        // Sanitize backticks so fenced code blocks are not broken by command content.
+        const safeForFence = (s: string) => s.replace(/`{3,}/g, (m) => m.replace(/`/g, "ˋ"));
+        const commandBlock = hasUsableCommand
+          ? `**Command:**\n\`\`\`\n${safeForFence(rawCommand)}\n\`\`\`\n\n`
+          : rawArgsJson !== undefined
+            ? `**Arguments:**\n\`\`\`json\n${safeForFence(rawArgsJson)}\n\`\`\`\n\n`
+            : detail
+              ? `**Command:** \`${detail}\`\n\n`
+              : "";
         if (hasText) {
           const output = formatToolOutputForSidebar(card.text!);
           onOpenSidebar!(
-            commandBlock
-              ? `## ${display.label}\n\n${commandBlock}**Output:**\n\n${output}`
-              : output,
+            `## ${display.label}\n\n${commandBlock}${commandBlock ? "**Output:**\n\n" : ""}${output}`,
           );
           return;
         }

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -56,13 +56,32 @@ export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: 
   const canClick = Boolean(onOpenSidebar);
   const handleClick = canClick
     ? () => {
+        const rawCommand =
+          card.args && typeof (card.args as Record<string, unknown>).command === "string"
+            ? ((card.args as Record<string, unknown>).command as string).trim()
+            : undefined;
+        const rawArgsJson =
+          card.args && typeof card.args === "object" && !rawCommand
+            ? JSON.stringify(card.args, null, 2)
+            : undefined;
+        const commandBlock =
+          rawCommand !== undefined
+            ? `**Command:**\n\`\`\`\n${rawCommand}\n\`\`\`\n\n`
+            : rawArgsJson !== undefined
+              ? `**Arguments:**\n\`\`\`json\n${rawArgsJson}\n\`\`\`\n\n`
+              : detail
+                ? `**Command:** \`${detail}\`\n\n`
+                : "";
         if (hasText) {
-          onOpenSidebar!(formatToolOutputForSidebar(card.text!));
+          const output = formatToolOutputForSidebar(card.text!);
+          onOpenSidebar!(
+            commandBlock
+              ? `## ${display.label}\n\n${commandBlock}**Output:**\n\n${output}`
+              : output,
+          );
           return;
         }
-        const info = `## ${display.label}\n\n${
-          detail ? `**Command:** \`${detail}\`\n\n` : ""
-        }*No output — tool completed successfully.*`;
+        const info = `## ${display.label}\n\n${commandBlock}*No output — tool completed successfully.*`;
         onOpenSidebar!(info);
       }
     : undefined;


### PR DESCRIPTION
## Summary

- Tool card sidebar now displays the full, untruncated command/arguments when clicking a card.
- Card-level display remains compact with `…` truncation — no visual change to the chat timeline.

## Problem

When a tool (especially `exec`) has a long command string, the card's detail line is truncated to ~120 characters by `compactRawCommand`. Clicking the card to open the sidebar was supposed to reveal full details, but the click handler for cards with output (`hasText === true`) went straight to `formatToolOutputForSidebar(card.text)` and returned — only showing the output, completely skipping the command. For cards without output, the handler used `detail` (already truncated) instead of the original args, so the sidebar was equally incomplete.

## Fix

Restructured the click handler in `renderToolCardSidebar` so that it always extracts the **raw, untruncated** command from `card.args.command` (for exec) or serializes the full args object (for other tools) before deciding what to show. This raw content is rendered as a code block in the sidebar header, followed by the output (if any). The truncated `detail` is only used as a last resort when `card.args` is unavailable.

## Test plan

- [ ] Open Chat UI, trigger a long `exec` tool call (>120 chars)
- [ ] Verify card still shows truncated detail with `…`
- [ ] Click the card → sidebar shows full command in a code block + full output
- [ ] Click a tool card with no output → sidebar shows full command + "No output" message
- [ ] Click a non-exec tool card → sidebar shows full JSON arguments

## Issue

Closed  #43153 