### PR TITLE
fix(ui): hide mobile sidebar container when nav is collapsed

### DIFF
--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -18,12 +18,7 @@
   .shell--nav-collapsed .nav,
   .nav.nav--collapsed {
     display: none;
-    padding: 0;
-    margin: 0;
-    width: 0;
-    min-width: 0;
-    overflow: hidden;
-  }
+    display: none;
 
   .nav::-webkit-scrollbar {
     display: none;

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -15,6 +15,16 @@
     scrollbar-width: none;
   }
 
+  .shell--nav-collapsed .nav,
+  .nav.nav--collapsed {
+    display: none;
+    padding: 0;
+    margin: 0;
+    width: 0;
+    min-width: 0;
+    overflow: hidden;
+  }
+
   .nav::-webkit-scrollbar {
     display: none;
   }


### PR DESCRIPTION
## Summary
- fix mobile/tablet nav collapse behavior so burger toggle hides the entire sidebar container
- prevent partial top-strip/sidebar remnants on small screens

## What changed
- in `ui/src/styles/layout.mobile.css` add collapsed-state overrides for mobile breakpoints:
  - `.shell--nav-collapsed .nav`
  - `.nav.nav--collapsed`
- force full hide with `display: none` plus zeroed spacing/size safeguards

## Why
On small devices, nav reflows to a top horizontal strip. Collapsing via burger could still leave partial sidebar chrome visible due to mobile `.nav` rules overriding collapsed sizing.

## Scope
- CSS-only change
- no desktop behavior changes