### PR TITLE
fix(agent): send user feedback when typing TTL expires during long-running agent runs

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -600,28 +600,27 @@ final class AppState {
     private func syncGatewayConfigIfNeeded() {
         guard !self.isPreview, !self.isInitializing else { return }
 
-        let connectionMode = self.connectionMode
-        let remoteTarget = self.remoteTarget
-        let remoteIdentity = self.remoteIdentity
-        let remoteTransport = self.remoteTransport
-        let remoteUrl = self.remoteUrl
-        let remoteToken = self.remoteToken
-        let remoteTokenDirty = self.remoteTokenDirty
-
         Task { @MainActor in
-            // Keep app-only connection settings local to avoid overwriting remote gateway config.
-            let synced = Self.syncedGatewayRoot(
-                currentRoot: OpenClawConfigFile.loadDict(),
-                connectionMode: connectionMode,
-                remoteTransport: remoteTransport,
-                remoteTarget: remoteTarget,
-                remoteIdentity: remoteIdentity,
-                remoteUrl: remoteUrl,
-                remoteToken: remoteToken,
-                remoteTokenDirty: remoteTokenDirty)
-            guard synced.changed else { return }
-            OpenClawConfigFile.saveDict(synced.root)
+            self.syncGatewayConfigNow()
         }
+    }
+
+    @MainActor
+    func syncGatewayConfigNow() {
+        guard !self.isPreview, !self.isInitializing else { return }
+
+        // Keep app-only connection settings local to avoid overwriting remote gateway config.
+        let synced = Self.syncedGatewayRoot(
+            currentRoot: OpenClawConfigFile.loadDict(),
+            connectionMode: self.connectionMode,
+            remoteTransport: self.remoteTransport,
+            remoteTarget: self.remoteTarget,
+            remoteIdentity: self.remoteIdentity,
+            remoteUrl: self.remoteUrl,
+            remoteToken: self.remoteToken,
+            remoteTokenDirty: self.remoteTokenDirty)
+        guard synced.changed else { return }
+        OpenClawConfigFile.saveDict(synced.root)
     }
 
     func triggerVoiceEars(ttl: TimeInterval? = 5) {
@@ -784,7 +783,7 @@ extension AppState {
         remoteToken: String,
         remoteTokenDirty: Bool) -> [String: Any]
     {
-        Self.updatedRemoteGatewayConfig(
+        self.updatedRemoteGatewayConfig(
             current: current,
             transport: transport,
             remoteUrl: remoteUrl,
@@ -805,7 +804,7 @@ extension AppState {
         remoteToken: String,
         remoteTokenDirty: Bool) -> [String: Any]
     {
-        Self.syncedGatewayRoot(
+        self.syncedGatewayRoot(
             currentRoot: currentRoot,
             connectionMode: connectionMode,
             remoteTransport: remoteTransport,

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -348,10 +348,18 @@ struct GeneralSettings: View {
             Text("Testing…")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-        case .ok:
-            Label("Ready", systemImage: "checkmark.circle.fill")
-                .font(.caption)
-                .foregroundStyle(.green)
+        case let .ok(success):
+            VStack(alignment: .leading, spacing: 2) {
+                Label(success.title, systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                if let detail = success.detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         case let .failed(message):
             Text(message)
                 .font(.caption)
@@ -518,7 +526,7 @@ struct GeneralSettings: View {
 private enum RemoteStatus: Equatable {
     case idle
     case checking
-    case ok
+    case ok(RemoteGatewayProbeSuccess)
     case failed(String)
 }
 
@@ -558,114 +566,14 @@ extension GeneralSettings {
     @MainActor
     func testRemote() async {
         self.remoteStatus = .checking
-        let settings = CommandResolver.connectionSettings()
-        if self.state.remoteTransport == .direct {
-            let trimmedUrl = self.state.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedUrl.isEmpty else {
-                self.remoteStatus = .failed("Set a gateway URL first")
-                return
-            }
-            guard Self.isValidWsUrl(trimmedUrl) else {
-                self.remoteStatus = .failed(
-                    "Gateway URL must use wss:// for remote hosts (ws:// only for localhost)")
-                return
-            }
-        } else {
-            guard !settings.target.isEmpty else {
-                self.remoteStatus = .failed("Set an SSH target first")
-                return
-            }
-
-            // Step 1: basic SSH reachability check
-            guard let sshCommand = Self.sshCheckCommand(
-                target: settings.target,
-                identity: settings.identity)
-            else {
-                self.remoteStatus = .failed("SSH target is invalid")
-                return
-            }
-            let sshResult = await ShellExecutor.run(
-                command: sshCommand,
-                cwd: nil,
-                env: nil,
-                timeout: 8)
-
-            guard sshResult.ok else {
-                self.remoteStatus = .failed(self.formatSSHFailure(sshResult, target: settings.target))
-                return
-            }
+        switch await RemoteGatewayProbe.run() {
+        case let .ready(success):
+            self.remoteStatus = .ok(success)
+        case let .authIssue(issue):
+            self.remoteStatus = .failed(issue.statusMessage)
+        case let .failed(message):
+            self.remoteStatus = .failed(message)
         }
-
-        // Step 2: control channel health check
-        let originalMode = AppStateStore.shared.connectionMode
-        do {
-            try await ControlChannel.shared.configure(mode: .remote(
-                target: settings.target,
-                identity: settings.identity))
-            let data = try await ControlChannel.shared.health(timeout: 10)
-            if decodeHealthSnapshot(from: data) != nil {
-                self.remoteStatus = .ok
-            } else {
-                self.remoteStatus = .failed("Control channel returned invalid health JSON")
-            }
-        } catch {
-            self.remoteStatus = .failed(error.localizedDescription)
-        }
-
-        // Restore original mode if we temporarily switched
-        switch originalMode {
-        case .remote:
-            break
-        case .local:
-            try? await ControlChannel.shared.configure(mode: .local)
-        case .unconfigured:
-            await ControlChannel.shared.disconnect()
-        }
-    }
-
-    private static func isValidWsUrl(_ raw: String) -> Bool {
-        GatewayRemoteConfig.normalizeGatewayUrl(raw) != nil
-    }
-
-    private static func sshCheckCommand(target: String, identity: String) -> [String]? {
-        guard let parsed = CommandResolver.parseSSHTarget(target) else { return nil }
-        let options = [
-            "-o", "BatchMode=yes",
-            "-o", "ConnectTimeout=5",
-            "-o", "StrictHostKeyChecking=accept-new",
-            "-o", "UpdateHostKeys=yes",
-        ]
-        let args = CommandResolver.sshArguments(
-            target: parsed,
-            identity: identity,
-            options: options,
-            remoteCommand: ["echo", "ok"])
-        return ["/usr/bin/ssh"] + args
-    }
-
-    private func formatSSHFailure(_ response: Response, target: String) -> String {
-        let payload = response.payload.flatMap { String(data: $0, encoding: .utf8) }
-        let trimmed = payload?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .split(whereSeparator: \.isNewline)
-            .joined(separator: " ")
-        if let trimmed,
-           trimmed.localizedCaseInsensitiveContains("host key verification failed")
-        {
-            let host = CommandResolver.parseSSHTarget(target)?.host ?? target
-            return "SSH check failed: Host key verification failed. Remove the old key with " +
-                "`ssh-keygen -R \(host)` and try again."
-        }
-        if let trimmed, !trimmed.isEmpty {
-            if let message = response.message, message.hasPrefix("exit ") {
-                return "SSH check failed: \(trimmed) (\(message))"
-            }
-            return "SSH check failed: \(trimmed)"
-        }
-        if let message = response.message {
-            return "SSH check failed (\(message))"
-        }
-        return "SSH check failed"
     }
 
     private func revealLogs() {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift
@@ -147,7 +147,9 @@ actor MacNodeBrowserProxy {
         }
 
         if method != "GET", let body = params.body {
-            request.httpBody = try JSONSerialization.data(withJSONObject: body.foundationValue, options: [.fragmentsAllowed])
+            request.httpBody = try JSONSerialization.data(
+                withJSONObject: body.foundationValue,
+                options: [.fragmentsAllowed])
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -2,6 +2,7 @@ import AppKit
 import OpenClawChatUI
 import OpenClawDiscovery
 import OpenClawIPC
+import OpenClawKit
 import SwiftUI
 
 extension OnboardingView {
@@ -97,6 +98,11 @@ extension OnboardingView {
 
                     self.gatewayDiscoverySection()
 
+                    if self.shouldShowRemoteConnectionSection {
+                        Divider().padding(.vertical, 4)
+                        self.remoteConnectionSection()
+                    }
+
                     self.connectionChoiceButton(
                         title: "Configure later",
                         subtitle: "Don’t start the Gateway yet.",
@@ -108,6 +114,22 @@ extension OnboardingView {
                     self.advancedConnectionSection()
                 }
             }
+        }
+        .onChange(of: self.state.connectionMode) { _, newValue in
+            guard Self.shouldResetRemoteProbeFeedback(
+                for: newValue,
+                suppressReset: self.suppressRemoteProbeReset)
+            else { return }
+            self.resetRemoteProbeFeedback()
+        }
+        .onChange(of: self.state.remoteTransport) { _, _ in
+            self.resetRemoteProbeFeedback()
+        }
+        .onChange(of: self.state.remoteTarget) { _, _ in
+            self.resetRemoteProbeFeedback()
+        }
+        .onChange(of: self.state.remoteUrl) { _, _ in
+            self.resetRemoteProbeFeedback()
         }
     }
 
@@ -199,25 +221,6 @@ extension OnboardingView {
                         .pickerStyle(.segmented)
                         .frame(width: fieldWidth)
                     }
-                    GridRow {
-                        Text("Gateway token")
-                            .font(.callout.weight(.semibold))
-                            .frame(width: labelWidth, alignment: .leading)
-                        SecureField("remote gateway auth token (gateway.remote.token)", text: self.$state.remoteToken)
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: fieldWidth)
-                    }
-                    if self.state.remoteTokenUnsupported {
-                        GridRow {
-                            Text("")
-                                .frame(width: labelWidth, alignment: .leading)
-                            Text(
-                                "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.")
-                                .font(.caption)
-                                .foregroundStyle(.orange)
-                                .frame(width: fieldWidth, alignment: .leading)
-                        }
-                    }
                     if self.state.remoteTransport == .direct {
                         GridRow {
                             Text("Gateway URL")
@@ -287,6 +290,249 @@ extension OnboardingView {
             }
             .transition(.opacity.combined(with: .move(edge: .top)))
         }
+    }
+
+    private var shouldShowRemoteConnectionSection: Bool {
+        self.state.connectionMode == .remote ||
+            self.showAdvancedConnection ||
+            self.remoteProbeState != .idle ||
+            self.remoteAuthIssue != nil ||
+            Self.shouldShowRemoteTokenField(
+                showAdvancedConnection: self.showAdvancedConnection,
+                remoteToken: self.state.remoteToken,
+                remoteTokenUnsupported: self.state.remoteTokenUnsupported,
+                authIssue: self.remoteAuthIssue)
+    }
+
+    private var shouldShowRemoteTokenField: Bool {
+        guard self.shouldShowRemoteConnectionSection else { return false }
+        return Self.shouldShowRemoteTokenField(
+            showAdvancedConnection: self.showAdvancedConnection,
+            remoteToken: self.state.remoteToken,
+            remoteTokenUnsupported: self.state.remoteTokenUnsupported,
+            authIssue: self.remoteAuthIssue)
+    }
+
+    private var remoteProbePreflightMessage: String? {
+        switch self.state.remoteTransport {
+        case .direct:
+            let trimmedUrl = self.state.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedUrl.isEmpty {
+                return "Select a nearby gateway or open Advanced to enter a gateway URL."
+            }
+            if GatewayRemoteConfig.normalizeGatewayUrl(trimmedUrl) == nil {
+                return "Gateway URL must use wss:// for remote hosts (ws:// only for localhost)."
+            }
+            return nil
+        case .ssh:
+            let trimmedTarget = self.state.remoteTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedTarget.isEmpty {
+                return "Select a nearby gateway or open Advanced to enter an SSH target."
+            }
+            return CommandResolver.sshTargetValidationMessage(trimmedTarget)
+        }
+    }
+
+    private var canProbeRemoteConnection: Bool {
+        self.remoteProbePreflightMessage == nil && self.remoteProbeState != .checking
+    }
+
+    private func remoteConnectionSection() -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Remote connection")
+                        .font(.callout.weight(.semibold))
+                    Text("Checks the real remote websocket and auth handshake.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+                Button {
+                    Task { await self.probeRemoteConnection() }
+                } label: {
+                    if self.remoteProbeState == .checking {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(minWidth: 120)
+                    } else {
+                        Text("Check connection")
+                            .frame(minWidth: 120)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!self.canProbeRemoteConnection)
+            }
+
+            if self.shouldShowRemoteTokenField {
+                self.remoteTokenField()
+            }
+
+            if let message = self.remoteProbePreflightMessage, self.remoteProbeState != .checking {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            self.remoteProbeStatusView()
+
+            if let issue = self.remoteAuthIssue {
+                self.remoteAuthPromptView(issue: issue)
+            }
+        }
+    }
+
+    private func remoteTokenField() -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 12) {
+                Text("Gateway token")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: 110, alignment: .leading)
+                SecureField("remote gateway auth token (gateway.remote.token)", text: self.$state.remoteToken)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 320)
+            }
+            Text("Used when the remote gateway requires token auth.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if self.state.remoteTokenUnsupported {
+                Text(
+                    "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func remoteProbeStatusView() -> some View {
+        switch self.remoteProbeState {
+        case .idle:
+            EmptyView()
+        case .checking:
+            Text("Checking remote gateway…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case let .ok(success):
+            VStack(alignment: .leading, spacing: 2) {
+                Label(success.title, systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                if let detail = success.detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        case let .failed(message):
+            if self.remoteAuthIssue == nil {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func remoteAuthPromptView(issue: RemoteGatewayAuthIssue) -> some View {
+        let promptStyle = Self.remoteAuthPromptStyle(for: issue)
+        return HStack(alignment: .top, spacing: 10) {
+            Image(systemName: promptStyle.systemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(promptStyle.tint)
+                .frame(width: 16, alignment: .center)
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(issue.title)
+                    .font(.caption.weight(.semibold))
+                Text(.init(issue.body))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if let footnote = issue.footnote {
+                    Text(.init(footnote))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func probeRemoteConnection() async {
+        let originalMode = self.state.connectionMode
+        let shouldRestoreMode = originalMode != .remote
+        if shouldRestoreMode {
+            // Reuse the shared remote endpoint stack for probing without committing the user's mode choice.
+            self.state.connectionMode = .remote
+        }
+        self.remoteProbeState = .checking
+        self.remoteAuthIssue = nil
+        defer {
+            if shouldRestoreMode {
+                self.suppressRemoteProbeReset = true
+                self.state.connectionMode = originalMode
+                self.suppressRemoteProbeReset = false
+            }
+        }
+
+        switch await RemoteGatewayProbe.run() {
+        case let .ready(success):
+            self.remoteProbeState = .ok(success)
+        case let .authIssue(issue):
+            self.remoteAuthIssue = issue
+            self.remoteProbeState = .failed(issue.statusMessage)
+        case let .failed(message):
+            self.remoteProbeState = .failed(message)
+        }
+    }
+
+    private func resetRemoteProbeFeedback() {
+        self.remoteProbeState = .idle
+        self.remoteAuthIssue = nil
+    }
+
+    static func remoteAuthPromptStyle(
+        for issue: RemoteGatewayAuthIssue)
+        -> (systemImage: String, tint: Color)
+    {
+        switch issue {
+        case .tokenRequired:
+            ("key.fill", .orange)
+        case .tokenMismatch:
+            ("exclamationmark.triangle.fill", .orange)
+        case .gatewayTokenNotConfigured:
+            ("wrench.and.screwdriver.fill", .orange)
+        case .setupCodeExpired:
+            ("qrcode.viewfinder", .orange)
+        case .passwordRequired:
+            ("lock.slash.fill", .orange)
+        case .pairingRequired:
+            ("link.badge.plus", .orange)
+        }
+    }
+
+    static func shouldShowRemoteTokenField(
+        showAdvancedConnection: Bool,
+        remoteToken: String,
+        remoteTokenUnsupported: Bool,
+        authIssue: RemoteGatewayAuthIssue?) -> Bool
+    {
+        showAdvancedConnection ||
+            remoteTokenUnsupported ||
+            !remoteToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+            authIssue?.showsTokenField == true
+    }
+
+    static func shouldResetRemoteProbeFeedback(
+        for connectionMode: AppState.ConnectionMode,
+        suppressReset: Bool) -> Bool
+    {
+        !suppressReset && connectionMode != .remote
     }
 
     func gatewaySubtitle(for gateway: GatewayDiscoveryModel.DiscoveredGateway) -> String? {

--- a/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
@@ -1,0 +1,237 @@
+import Foundation
+import OpenClawIPC
+import OpenClawKit
+
+enum RemoteGatewayAuthIssue: Equatable {
+    case tokenRequired
+    case tokenMismatch
+    case gatewayTokenNotConfigured
+    case setupCodeExpired
+    case passwordRequired
+    case pairingRequired
+
+    init?(error: Error) {
+        guard let authError = error as? GatewayConnectAuthError else {
+            return nil
+        }
+        switch authError.detail {
+        case .authTokenMissing:
+            self = .tokenRequired
+        case .authTokenMismatch:
+            self = .tokenMismatch
+        case .authTokenNotConfigured:
+            self = .gatewayTokenNotConfigured
+        case .authBootstrapTokenInvalid:
+            self = .setupCodeExpired
+        case .authPasswordMissing, .authPasswordMismatch, .authPasswordNotConfigured:
+            self = .passwordRequired
+        case .pairingRequired:
+            self = .pairingRequired
+        default:
+            return nil
+        }
+    }
+
+    var showsTokenField: Bool {
+        switch self {
+        case .tokenRequired, .tokenMismatch:
+            true
+        case .gatewayTokenNotConfigured, .setupCodeExpired, .passwordRequired, .pairingRequired:
+            false
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .tokenRequired:
+            "This gateway requires an auth token"
+        case .tokenMismatch:
+            "That token did not match the gateway"
+        case .gatewayTokenNotConfigured:
+            "This gateway host needs token setup"
+        case .setupCodeExpired:
+            "This setup code is no longer valid"
+        case .passwordRequired:
+            "This gateway is using unsupported auth"
+        case .pairingRequired:
+            "This device needs pairing approval"
+        }
+    }
+
+    var body: String {
+        switch self {
+        case .tokenRequired:
+            "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
+        case .tokenMismatch:
+            "Check `gateway.auth.token` or `OPENCLAW_GATEWAY_TOKEN` on the gateway host and try again."
+        case .gatewayTokenNotConfigured:
+            "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
+        case .setupCodeExpired:
+            "Scan or paste a fresh setup code from an already-paired OpenClaw client, then try again."
+        case .passwordRequired:
+            "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
+        case .pairingRequired:
+            "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
+        }
+    }
+
+    var footnote: String? {
+        switch self {
+        case .tokenRequired, .gatewayTokenNotConfigured:
+            "No token yet? Generate one on the gateway host with `openclaw doctor --generate-gateway-token`, then set it as `gateway.auth.token`."
+        case .setupCodeExpired:
+            nil
+        case .pairingRequired:
+            "If you do not have another paired OpenClaw client yet, approve the pending request on the gateway host with `openclaw devices approve`."
+        case .tokenMismatch, .passwordRequired:
+            nil
+        }
+    }
+
+    var statusMessage: String {
+        switch self {
+        case .tokenRequired:
+            "This gateway requires an auth token from the gateway host."
+        case .tokenMismatch:
+            "Gateway token mismatch. Check gateway.auth.token or OPENCLAW_GATEWAY_TOKEN on the gateway host."
+        case .gatewayTokenNotConfigured:
+            "This gateway has token auth enabled, but no gateway.auth.token is configured on the host."
+        case .setupCodeExpired:
+            "Setup code expired or already used. Scan a fresh setup code, then try again."
+        case .passwordRequired:
+            "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet."
+        case .pairingRequired:
+            "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
+        }
+    }
+}
+
+enum RemoteGatewayProbeResult: Equatable {
+    case ready(RemoteGatewayProbeSuccess)
+    case authIssue(RemoteGatewayAuthIssue)
+    case failed(String)
+}
+
+struct RemoteGatewayProbeSuccess: Equatable {
+    let authSource: GatewayAuthSource?
+
+    var title: String {
+        switch self.authSource {
+        case .some(.deviceToken):
+            "Connected via paired device"
+        case .some(.bootstrapToken):
+            "Connected with setup code"
+        case .some(.sharedToken):
+            "Connected with gateway token"
+        case .some(.password):
+            "Connected with password"
+        case .some(GatewayAuthSource.none), nil:
+            "Remote gateway ready"
+        }
+    }
+
+    var detail: String? {
+        switch self.authSource {
+        case .some(.deviceToken):
+            "This Mac used a stored device token. New or unpaired devices may still need the gateway token."
+        case .some(.bootstrapToken):
+            "This Mac is still using the temporary setup code. Approve pairing to finish provisioning device-scoped auth."
+        case .some(.sharedToken), .some(.password), .some(GatewayAuthSource.none), nil:
+            nil
+        }
+    }
+}
+
+enum RemoteGatewayProbe {
+    @MainActor
+    static func run() async -> RemoteGatewayProbeResult {
+        AppStateStore.shared.syncGatewayConfigNow()
+        let settings = CommandResolver.connectionSettings()
+        let transport = AppStateStore.shared.remoteTransport
+
+        if transport == .direct {
+            let trimmedUrl = AppStateStore.shared.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedUrl.isEmpty else {
+                return .failed("Set a gateway URL first")
+            }
+            guard self.isValidWsUrl(trimmedUrl) else {
+                return .failed("Gateway URL must use wss:// for remote hosts (ws:// only for localhost)")
+            }
+        } else {
+            let trimmedTarget = settings.target.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedTarget.isEmpty else {
+                return .failed("Set an SSH target first")
+            }
+            if let validationMessage = CommandResolver.sshTargetValidationMessage(trimmedTarget) {
+                return .failed(validationMessage)
+            }
+            guard let sshCommand = self.sshCheckCommand(target: settings.target, identity: settings.identity) else {
+                return .failed("SSH target is invalid")
+            }
+
+            let sshResult = await ShellExecutor.run(
+                command: sshCommand,
+                cwd: nil,
+                env: nil,
+                timeout: 8)
+            guard sshResult.ok else {
+                return .failed(self.formatSSHFailure(sshResult, target: settings.target))
+            }
+        }
+
+        do {
+            _ = try await GatewayConnection.shared.healthSnapshot(timeoutMs: 10000)
+            let authSource = await GatewayConnection.shared.authSource()
+            return .ready(RemoteGatewayProbeSuccess(authSource: authSource))
+        } catch {
+            if let authIssue = RemoteGatewayAuthIssue(error: error) {
+                return .authIssue(authIssue)
+            }
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    private static func isValidWsUrl(_ raw: String) -> Bool {
+        GatewayRemoteConfig.normalizeGatewayUrl(raw) != nil
+    }
+
+    private static func sshCheckCommand(target: String, identity: String) -> [String]? {
+        guard let parsed = CommandResolver.parseSSHTarget(target) else { return nil }
+        let options = [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=5",
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "UpdateHostKeys=yes",
+        ]
+        let args = CommandResolver.sshArguments(
+            target: parsed,
+            identity: identity,
+            options: options,
+            remoteCommand: ["echo", "ok"])
+        return ["/usr/bin/ssh"] + args
+    }
+
+    private static func formatSSHFailure(_ response: Response, target: String) -> String {
+        let payload = response.payload.flatMap { String(data: $0, encoding: .utf8) }
+        let trimmed = payload?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isNewline)
+            .joined(separator: " ")
+        if let trimmed,
+           trimmed.localizedCaseInsensitiveContains("host key verification failed")
+        {
+            let host = CommandResolver.parseSSHTarget(target)?.host ?? target
+            return "SSH check failed: Host key verification failed. Remove the old key with ssh-keygen -R \(host) and try again."
+        }
+        if let trimmed, !trimmed.isEmpty {
+            if let message = response.message, message.hasPrefix("exit ") {
+                return "SSH check failed: \(trimmed) (\(message))"
+            }
+            return "SSH check failed: \(trimmed)"
+        }
+        if let message = response.message {
+            return "SSH check failed (\(message))"
+        }
+        return "SSH check failed"
+    }
+}

--- a/apps/macos/Sources/OpenClaw/TalkModeGatewayConfig.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeGatewayConfig.swift
@@ -23,8 +23,8 @@ enum TalkModeGatewayConfigParser {
         defaultSilenceTimeoutMs: Int,
         envVoice: String?,
         sagVoice: String?,
-        envApiKey: String?
-    ) -> TalkModeGatewayConfigState {
+        envApiKey: String?) -> TalkModeGatewayConfigState
+    {
         let talk = snapshot.config?["talk"]?.dictionaryValue
         let selection = TalkConfigParsing.selectProviderConfig(talk, defaultProvider: defaultProvider)
         let activeProvider = selection?.provider ?? defaultProvider
@@ -81,8 +81,8 @@ enum TalkModeGatewayConfigParser {
         defaultSilenceTimeoutMs: Int,
         envVoice: String?,
         sagVoice: String?,
-        envApiKey: String?
-    ) -> TalkModeGatewayConfigState {
+        envApiKey: String?) -> TalkModeGatewayConfigState
+    {
         let resolvedVoice =
             (envVoice?.isEmpty == false ? envVoice : nil) ??
             (sagVoice?.isEmpty == false ? sagVoice : nil)

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -4,7 +4,7 @@
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "type": "module",
   "dependencies": {
-    "@tloncorp/api": "github:tloncorp/api-beta#7eede1c1a756977b09f96aa14a92e2b06318ae87",
+    "@tloncorp/api": "github:tloncorp/api-beta#c121deb82d97970418508691585aea4f71abcf9c",
     "@tloncorp/tlon-skill": "0.2.2",
     "@urbit/aura": "^3.0.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,8 +462,8 @@ importers:
   extensions/tlon:
     dependencies:
       '@tloncorp/api':
-        specifier: github:tloncorp/api-beta#7eede1c1a756977b09f96aa14a92e2b06318ae87
-        version: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87
+        specifier: github:tloncorp/api-beta#c121deb82d97970418508691585aea4f71abcf9c
+        version: https://codeload.github.com/tloncorp/api-beta/tar.gz/c121deb82d97970418508691585aea4f71abcf9c
       '@tloncorp/tlon-skill':
         specifier: 0.2.2
         version: 0.2.2
@@ -3156,8 +3156,8 @@ packages:
     resolution: {integrity: sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==}
     engines: {node: '>=12.17.0'}
 
-  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
-    resolution: {tarball: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87}
+  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/c121deb82d97970418508691585aea4f71abcf9c':
+    resolution: {tarball: https://codeload.github.com/tloncorp/api-beta/tar.gz/c121deb82d97970418508691585aea4f71abcf9c}
     version: 0.0.2
 
   '@tloncorp/tlon-skill-darwin-arm64@0.2.2':
@@ -9871,7 +9871,7 @@ snapshots:
 
   '@tinyhttp/content-disposition@2.2.4': {}
 
-  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
+  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/c121deb82d97970418508691585aea4f71abcf9c':
     dependencies:
       '@aws-sdk/client-s3': 3.1000.0
       '@aws-sdk/s3-request-presigner': 3.1000.0

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -408,6 +408,10 @@ export async function dispatchReplyFromConfig(params: {
     // isn't left wondering whether their message was received.
     // Only inject the default handler when typing is active and the caller
     // hasn't supplied their own handler.
+    // Track the in-flight notice send so the final-reply loop can await it,
+    // preventing a message-ordering inversion on cross-channel routed flows
+    // when the agent finishes very shortly after the TTL fires.
+    let ttlNoticePromise: Promise<void> | undefined;
     const onTypingTtlExpired =
       !typing.suppressTyping && !params.replyOptions?.onTypingTtlExpired
         ? () => {
@@ -415,7 +419,7 @@ export async function dispatchReplyFromConfig(params: {
               text: "⏳ Still working on it, this might take a little while longer…",
             };
             if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-              void sendPayloadAsync(noticePayload);
+              ttlNoticePromise = sendPayloadAsync(noticePayload);
             } else {
               dispatcher.sendBlockReply(noticePayload);
             }
@@ -514,6 +518,13 @@ export async function dispatchReplyFromConfig(params: {
     }
 
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
+
+    // Ensure the TTL notice has been delivered before we send the final reply.
+    // This preserves message ordering on cross-channel routed flows where the
+    // notice was fire-and-started (not fire-and-forgotten) above.
+    if (ttlNoticePromise) {
+      await ttlNoticePromise;
+    }
 
     let queuedFinal = false;
     let routedFinalCount = 0;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -403,12 +403,32 @@ export async function dispatchReplyFromConfig(params: {
       systemEvent: shouldRouteToOriginating,
     });
 
+    // When the typing TTL fires the agent is still running but the typing
+    // indicator has stopped. Send a short "still processing" note so the user
+    // isn't left wondering whether their message was received.
+    // Only inject the default handler when typing is active and the caller
+    // hasn't supplied their own handler.
+    const onTypingTtlExpired =
+      !typing.suppressTyping && !params.replyOptions?.onTypingTtlExpired
+        ? () => {
+            const noticePayload: ReplyPayload = {
+              text: "⏳ Still working on it, this might take a little while longer…",
+            };
+            if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+              void sendPayloadAsync(noticePayload);
+            } else {
+              dispatcher.sendBlockReply(noticePayload);
+            }
+          }
+        : params.replyOptions?.onTypingTtlExpired;
+
     const replyResult = await (params.replyResolver ?? getReplyFromConfig)(
       ctx,
       {
         ...params.replyOptions,
         typingPolicy: typing.typingPolicy,
         suppressTyping: typing.suppressTyping,
+        onTypingTtlExpired,
         onToolResult: (payload: ReplyPayload) => {
           const run = async () => {
             const ttsPayload = await maybeApplyTtsToPayload({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -118,15 +118,20 @@ export async function getReplyFromConfig(
     onReplyStart: opts?.onReplyStart,
     onCleanup: opts?.onTypingCleanup,
     onTtlExpired: opts?.onTypingTtlExpired
-      ? () => {
-          // Resolve the return value so async handlers' rejections are caught
-          // and logged rather than becoming unhandled rejections at runtime.
-          Promise.resolve(opts.onTypingTtlExpired()).catch((err: unknown) => {
-            defaultRuntime.log?.(
-              `typing TTL handler failed: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          });
-        }
+      ? (() => {
+          // Capture the handler in a const so TypeScript can narrow away
+          // 'undefined' inside the closure (TS2722).
+          const ttlHandler = opts.onTypingTtlExpired;
+          return () => {
+            // Resolve the return value so async handlers' rejections are caught
+            // and logged rather than becoming unhandled rejections at runtime.
+            Promise.resolve(ttlHandler()).catch((err: unknown) => {
+              defaultRuntime.log?.(
+                `typing TTL handler failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
+          };
+        })()
       : undefined,
     typingIntervalSeconds,
     silentToken: SILENT_REPLY_TOKEN,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -117,6 +117,11 @@ export async function getReplyFromConfig(
   const typing = createTypingController({
     onReplyStart: opts?.onReplyStart,
     onCleanup: opts?.onTypingCleanup,
+    onTtlExpired: opts?.onTypingTtlExpired
+      ? () => {
+          void opts.onTypingTtlExpired?.();
+        }
+      : undefined,
     typingIntervalSeconds,
     silentToken: SILENT_REPLY_TOKEN,
     log: defaultRuntime.log,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -119,7 +119,7 @@ export async function getReplyFromConfig(
     onCleanup: opts?.onTypingCleanup,
     onTtlExpired: opts?.onTypingTtlExpired
       ? () => {
-          void opts.onTypingTtlExpired?.();
+          void opts.onTypingTtlExpired();
         }
       : undefined,
     typingIntervalSeconds,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -119,7 +119,13 @@ export async function getReplyFromConfig(
     onCleanup: opts?.onTypingCleanup,
     onTtlExpired: opts?.onTypingTtlExpired
       ? () => {
-          void opts.onTypingTtlExpired();
+          // Resolve the return value so async handlers' rejections are caught
+          // and logged rather than becoming unhandled rejections at runtime.
+          Promise.resolve(opts.onTypingTtlExpired()).catch((err: unknown) => {
+            defaultRuntime.log?.(
+              `typing TTL handler failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
         }
       : undefined,
     typingIntervalSeconds,

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -103,8 +103,12 @@ export function createTypingController(params: {
       log?.(`typing TTL reached (${formatTypingTtl(typingTtlMs)}); stopping typing indicator`);
       // Notify caller so it can send a "still processing" message to the user
       // before the typing indicator disappears. The agent run continues.
-      onTtlExpired?.();
-      cleanup();
+      // Use try/finally so cleanup() always runs even if the callback throws.
+      try {
+        onTtlExpired?.();
+      } finally {
+        cleanup();
+      }
     }, typingTtlMs);
   };
 

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -16,6 +16,12 @@ export type TypingController = {
 export function createTypingController(params: {
   onReplyStart?: () => Promise<void> | void;
   onCleanup?: () => void;
+  /**
+   * Called when the typing TTL expires while the agent is still running.
+   * Use this to send a "still processing" feedback message to the user.
+   * The agent run continues after this callback fires.
+   */
+  onTtlExpired?: () => void;
   typingIntervalSeconds?: number;
   typingTtlMs?: number;
   silentToken?: string;
@@ -24,6 +30,7 @@ export function createTypingController(params: {
   const {
     onReplyStart,
     onCleanup,
+    onTtlExpired,
     typingIntervalSeconds = 6,
     typingTtlMs = 2 * 60_000,
     silentToken = SILENT_REPLY_TOKEN,
@@ -94,6 +101,9 @@ export function createTypingController(params: {
         return;
       }
       log?.(`typing TTL reached (${formatTypingTtl(typingTtlMs)}); stopping typing indicator`);
+      // Notify caller so it can send a "still processing" message to the user
+      // before the typing indicator disappears. The agent run continues.
+      onTtlExpired?.();
       cleanup();
     }, typingTtlMs);
   };

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -32,6 +32,12 @@ export type GetReplyOptions = {
   onReplyStart?: () => Promise<void> | void;
   /** Called when the typing controller cleans up (e.g., run ended with NO_REPLY). */
   onTypingCleanup?: () => void;
+  /**
+   * Called when the typing TTL expires while the agent run is still in progress.
+   * Use this to send a "still processing" feedback message to the user so they
+   * know the request is being handled even though the typing indicator has stopped.
+   */
+  onTypingTtlExpired?: () => Promise<void> | void;
   onTypingController?: (typing: TypingController) => void;
   isHeartbeat?: boolean;
   /** Policy-level typing control for run classes (user/system/internal/heartbeat). */


### PR DESCRIPTION
## Problem

When an agent session takes longer than the typing TTL (default: 2 minutes), the typing indicator silently stops. The agent continues running in the background but the user receives **zero feedback** — no error, no progress update, nothing. From the user's perspective, their message simply disappeared.

This was observed in Feishu (and affects all channels) when a complex task was dispatched at 19:32 — the typing indicator stopped at 19:38 after TTL, but the agent kept running silently until it either finished or the gateway was restarted.

## Root Cause

In `src/auto-reply/reply/typing.ts`, when the TTL timer fires, it only logs a message and calls `cleanup()` to stop the typing indicator. There was no hook to notify the caller or send any message back to the user.

```typescript
// Before: silent cleanup, user gets nothing
typingTtlTimer = setTimeout(() => {
  log?.(`typing TTL reached (${formatTypingTtl(typingTtlMs)}); stopping typing indicator`);
  cleanup();
}, typingTtlMs);
```

## Fix

Adds an `onTtlExpired` callback to `createTypingController` that fires when the TTL expires while the agent is still active. The dispatch layer (`dispatch-from-config.ts`) injects a default handler that sends a short **block reply** to the user so they know the request is still in progress.

```
⏳ Still working on it, this might take a little while longer…
```

The agent run continues uninterrupted after this message. When it eventually completes, the final reply follows normally.

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/reply/typing.ts` | Add `onTtlExpired` param; call it on TTL expiry before cleanup |
| `src/auto-reply/types.ts` | Add `onTypingTtlExpired` to `GetReplyOptions` |
| `src/auto-reply/reply/get-reply.ts` | Wire `onTypingTtlExpired` → `onTtlExpired` |
| `src/auto-reply/reply/dispatch-from-config.ts` | Inject default TTL feedback handler via dispatcher |

## Behaviour

- **Typing suppressed** (system events, heartbeats, cross-channel routes): no message sent ✓  
- **Caller provides own `onTypingTtlExpired`**: caller's handler is used instead ✓  
- **Normal short runs** (complete before TTL): no change ✓  
- **Long-running runs** (exceed TTL): user gets one informational message, run continues ✓  

## Testing

All existing tests pass:
- `src/auto-reply/reply/reply-utils.test.ts` — 33 tests ✓
- `src/auto-reply/reply/typing-policy.test.ts` — 5 tests ✓  
- `src/auto-reply/reply/typing-persistence.test.ts` — 3 tests ✓
- `src/auto-reply/reply/dispatch-from-config.test.ts` — 44 tests ✓
- `src/auto-reply/dispatch.test.ts` — 3 tests ✓