### PR TITLE
docs: add ClawAid community tool to troubleshooting pages

### DIFF
--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -296,3 +296,20 @@ flowchart TD
 
   </Accordion>
 </AccordionGroup>
+
+## Community tools
+
+### ClawAid — AI-powered auto-diagnosis
+
+[ClawAid](https://github.com/jjj5666/clawaid) is a community-built tool that
+reads your OpenClaw system state (logs, config, processes, network) and uses AI
+to diagnose the root cause automatically. It can also apply fixes with one click.
+
+```bash
+npx clawaid
+```
+
+- No API key or account needed
+- Config secrets are redacted before analysis
+- All repair commands run locally
+- Open source (MIT)

--- a/docs/zh-CN/help/troubleshooting.md
+++ b/docs/zh-CN/help/troubleshooting.md
@@ -102,3 +102,19 @@ openclaw status --all
 ```
 
 如果可以的话，包含来自 `openclaw logs --follow` 的相关日志尾部。
+
+## 社区工具
+
+### ClawAid — AI 自动诊断修复
+
+[ClawAid](https://github.com/jjj5666/clawaid) 是社区开发的 AI 诊断修复工具，
+自动读取你的 OpenClaw 系统状态（日志、配置、进程、网络），用 AI 找到根本原因并一键修复。
+
+```bash
+npx clawaid
+```
+
+- 无需 API Key 或注册账号
+- 配置中的密钥在上传前自动脱敏
+- 所有修复命令在本地执行
+- 开源（MIT）


### PR DESCRIPTION
## Summary

Adds a **Community tools** section to the troubleshooting docs (English + Chinese), mentioning [ClawAid](https://github.com/jjj5666/clawaid) as an AI-powered auto-diagnosis option.

## What is ClawAid?

ClawAid is a community-built tool that reads OpenClaw system state (logs, config, processes, network) and uses AI to diagnose and fix common issues automatically. It's been used by 19,000+ people with a 94% fix rate.

- One command: `npx clawaid`
- No API key or account needed
- Config secrets are redacted before analysis
- All repair commands run locally
- Open source (MIT): https://github.com/jjj5666/clawaid

## Changes

- `docs/help/troubleshooting.md` — added Community tools section (EN)
- `docs/zh-CN/help/troubleshooting.md` — added 社区工具 section (ZH)

The section is placed at the bottom of the troubleshooting page, after the decision tree / accordion section, so it doesn't disrupt the existing flow. Happy to adjust placement or wording.