### PR TITLE
fix(scripts): update copy-hook-metadata script to correct destination…

### DIFF
--- a/scripts/copy-hook-metadata.ts
+++ b/scripts/copy-hook-metadata.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 /**
- * Copy HOOK.md files from src/hooks/bundled to dist/bundled
+ * Copy HOOK.md files from src/hooks/bundled to dist/hooks/bundled.
+ * Must match resolveBundledHooksDir() in src/hooks/bundled-dir.ts (dir of bundled-dir.js + "bundled").
  */
 
 import fs from "node:fs";
@@ -12,7 +13,7 @@ const projectRoot = path.resolve(__dirname, "..");
 const verbose = process.env.OPENCLAW_BUILD_VERBOSE === "1";
 
 const srcBundled = path.join(projectRoot, "src", "hooks", "bundled");
-const distBundled = path.join(projectRoot, "dist", "bundled");
+const distBundled = path.join(projectRoot, "dist", "hooks", "bundled");
 
 function copyHookMetadata() {
   if (!fs.existsSync(srcBundled)) {


### PR DESCRIPTION
Fixes #43180

Problem
After installing OpenClaw globally (e.g. pnpm add -g openclaw@latest on Windows), openclaw hooks list showed "No hooks found" and openclaw hooks enable session-memory failed with Error: Hook "session-memory" not found. This is a regression: bundled hooks used to be discoverable.

Root cause
Path mismatch between build and runtime:

Runtime (src/hooks/bundled-dir.ts): resolveBundledHooksDir() resolves the directory of the compiled bundled-dir.js and appends "bundled". For a global install that is .../openclaw/dist/hooks/bundled-dir.js, so it looks for dist/hooks/bundled.
Build (scripts/copy-hook-metadata.ts): HOOK.md files were copied to dist/bundled, so the runtime never saw them.
Change
scripts/copy-hook-metadata.ts: Copy destination changed from dist/bundled to dist/hooks/bundled so HOOK.md files sit next to the compiled handlers and match what resolveBundledHooksDir() expects. Comment updated to reference that resolutio