### PR TITLE
fix(models): skip implicit local Ollama probe when remote Ollama provider is configured

### DIFF
--- a/src/agents/models-config.providers.matrix.test.ts
+++ b/src/agents/models-config.providers.matrix.test.ts
@@ -154,6 +154,30 @@ const MATRIX_CASES: MatrixCase[] = [
       expect(providers?.ollama?.models).toHaveLength(1);
     },
   },
+  {
+    name: "skip implicit local ollama when explicit remote ollama-api provider exists",
+    env: { OLLAMA_API_KEY: "test-ollama-key" }, // pragma: allowlist secret
+    explicitProviders: {
+      "ollama-cloud": {
+        baseUrl: "https://ollama.com",
+        api: "ollama",
+        models: [
+          {
+            id: "kimi-k2.5",
+            name: "Kimi K2.5",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+    assertProviders(providers) {
+      expect(providers?.ollama).toBeUndefined();
+    },
+  },
 ];
 
 describe("implicit provider resolution matrix", () => {

--- a/src/agents/models-config.providers.matrix.test.ts
+++ b/src/agents/models-config.providers.matrix.test.ts
@@ -178,6 +178,30 @@ const MATRIX_CASES: MatrixCase[] = [
       expect(providers?.ollama).toBeUndefined();
     },
   },
+  {
+    name: "treat full 127/8 as local when deciding remote ollama-api providers",
+    env: { OLLAMA_API_KEY: "test-ollama-key" }, // pragma: allowlist secret
+    explicitProviders: {
+      "ollama-alt-local": {
+        baseUrl: "http://127.0.0.2:11434",
+        api: "ollama",
+        models: [
+          {
+            id: "kimi-k2.5",
+            name: "Kimi K2.5",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+    assertProviders(providers) {
+      expect(providers?.ollama).toBeDefined();
+    },
+  },
 ];
 
 describe("implicit provider resolution matrix", () => {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -671,7 +671,7 @@ async function resolveOllamaImplicitProvider(
   }
 
   const ollamaProvider = await buildOllamaProvider(ollamaBaseUrl, {
-    quiet: !hasExplicitOllamaConfig,
+    quiet: !ollamaKey && !hasExplicitOllamaConfig,
   });
   if (ollamaProvider.models.length === 0 && !ollamaKey && !explicitOllama?.apiKey) {
     return undefined;

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -606,6 +606,45 @@ async function resolveCloudflareAiGatewayImplicitProvider(
   return undefined;
 }
 
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "[::1]"
+  );
+}
+
+function hasExplicitRemoteOllamaApiProvider(
+  explicitProviders: ImplicitProviderContext["explicitProviders"],
+): boolean {
+  if (!explicitProviders) {
+    return false;
+  }
+  for (const [providerId, provider] of Object.entries(explicitProviders)) {
+    if (!provider || providerId === "ollama") {
+      continue;
+    }
+    if ((provider.api ?? "").trim().toLowerCase() !== "ollama") {
+      continue;
+    }
+    const baseUrl = (provider.baseUrl ?? "").trim();
+    if (!baseUrl) {
+      continue;
+    }
+    try {
+      const parsed = new URL(baseUrl);
+      if (!isLoopbackHost(parsed.hostname)) {
+        return true;
+      }
+    } catch {
+      // Ignore malformed explicit base URLs here; validation happens elsewhere.
+    }
+  }
+  return false;
+}
+
 async function resolveOllamaImplicitProvider(
   ctx: ImplicitProviderContext,
 ): Promise<Record<string, ProviderConfig> | undefined> {
@@ -626,8 +665,13 @@ async function resolveOllamaImplicitProvider(
 
   const ollamaBaseUrl = explicitOllama?.baseUrl;
   const hasExplicitOllamaConfig = Boolean(explicitOllama);
+  const hasRemoteOllamaApiProvider = hasExplicitRemoteOllamaApiProvider(ctx.explicitProviders);
+  if (!hasExplicitOllamaConfig && hasRemoteOllamaApiProvider) {
+    return undefined;
+  }
+
   const ollamaProvider = await buildOllamaProvider(ollamaBaseUrl, {
-    quiet: !ollamaKey && !hasExplicitOllamaConfig,
+    quiet: !hasExplicitOllamaConfig,
   });
   if (ollamaProvider.models.length === 0 && !ollamaKey && !explicitOllama?.apiKey) {
     return undefined;

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -610,9 +610,9 @@ function isLoopbackHost(hostname: string): boolean {
   const normalized = hostname.trim().toLowerCase();
   return (
     normalized === "localhost" ||
-    normalized === "127.0.0.1" ||
     normalized === "::1" ||
-    normalized === "[::1]"
+    normalized === "[::1]" ||
+    /^127(?:\.\d{1,3}){3}$/.test(normalized)
   );
 }
 


### PR DESCRIPTION
## Summary
- avoid noisy implicit local Ollama discovery when an explicit remote `api: "ollama"` provider is configured
- keep local aliases in the full `127/8` range treated as loopback (not remote)
- preserve existing warning behavior for local `OLLAMA_API_KEY` users

## Problem
On hosts that use remote Ollama-compatible providers (for example `ollama-cloud`) and do not run a local daemon on `127.0.0.1:11434`, many CLI commands emit:

`Failed to discover Ollama models: TypeError: fetch failed`

because implicit local Ollama discovery still probes loopback.

## Changes
- In implicit provider resolution, skip creating implicit local `ollama` when:
  - there is no explicit `ollama` provider, and
  - at least one explicit provider uses `api: "ollama"` with a non-loopback base URL.
- Expanded loopback detection to include full IPv4 `127/8` range (not only `127.0.0.1`) plus localhost/`::1`.
- Restored prior `quiet` behavior for local discovery:
  - `quiet: !ollamaKey && !hasExplicitOllamaConfig`
  - this keeps diagnostics for local `OLLAMA_API_KEY` users when local Ollama is unreachable.

## Tests
- Updated matrix tests to cover:
  - remote explicit Ollama API provider -> implicit local Ollama skipped
  - explicit `127.0.0.2` Ollama API provider -> treated as local (implicit local logic not skipped)

## Validation
```bash
corepack pnpm vitest run src/agents/models-config.providers.matrix.test.ts
```

Result: **1 test file passed, 9 tests passed**.
