### PR TITLE
feat: add Pilot Protocol channel plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Docs: https://docs.openclaw.ai
 
 ## Unreleased
+
 ### Changes
 
 - Android/chat settings: redesign the chat settings sheet with grouped device and media sections, refresh the Connect and Voice tabs, and tighten the chat composer/session header for a denser mobile layout. (#44894) Thanks @obviyus.
@@ -28,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Security/exec approvals: fail closed for Perl `-M` and `-I` approval flows so preload and load-path module resolution stays outside approval-backed runtime execution unless the operator uses a broader explicit trust path.
 - Control UI/insecure auth: preserve explicit shared token and password auth on plain-HTTP Control UI connects so LAN and reverse-proxy sessions no longer drop shared auth before the first WebSocket handshake. (#45088) Thanks @velvet-shark.
 - macOS/onboarding: avoid self-restarting freshly bootstrapped launchd gateways and give new daemon installs longer to become healthy, so `openclaw onboard --install-daemon` no longer false-fails on slower Macs and fresh VM snapshots.
+
 ## 2026.3.12
 
 ### Changes

--- a/extensions/pilot/index.ts
+++ b/extensions/pilot/index.ts
@@ -1,0 +1,19 @@
+import type { ChannelPlugin, OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/pilot";
+import { pilotPlugin } from "./src/channel.js";
+import { setPilotRuntime } from "./src/runtime.js";
+import { registerPilotTools } from "./src/tools/index.js";
+
+const plugin = {
+  id: "pilot",
+  name: "Pilot Protocol",
+  description: "Pilot Protocol channel plugin — P2P overlay network for autonomous agents",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setPilotRuntime(api.runtime);
+    api.registerChannel({ plugin: pilotPlugin as ChannelPlugin });
+    registerPilotTools(api);
+  },
+};
+
+export default plugin;

--- a/extensions/pilot/openclaw.plugin.json
+++ b/extensions/pilot/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "pilot",
+  "channels": ["pilot"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/pilot/package.json
+++ b/extensions/pilot/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/pilot",
+  "version": "2026.3.11",
+  "description": "OpenClaw Pilot Protocol channel plugin",
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/pilot/package.json
+++ b/extensions/pilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/pilot",
-  "version": "2026.3.11",
+  "version": "2026.3.13",
   "description": "OpenClaw Pilot Protocol channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/pilot/src/accounts.ts
+++ b/extensions/pilot/src/accounts.ts
@@ -1,0 +1,135 @@
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/pilot";
+import { createAccountListHelpers } from "openclaw/plugin-sdk/pilot";
+import type { CoreConfig, PilotAccountConfig } from "./types.js";
+
+export type ResolvedPilotAccount = {
+  accountId: string;
+  enabled: boolean;
+  name?: string;
+  configured: boolean;
+  hostname: string;
+  socketPath: string;
+  registry: string;
+  pilotctlPath: string;
+  pollIntervalMs: number;
+  config: PilotAccountConfig;
+};
+
+const {
+  listAccountIds: listPilotAccountIds,
+  resolveDefaultAccountId: resolveDefaultPilotAccountId,
+} = createAccountListHelpers("pilot", { normalizeAccountId });
+export { listPilotAccountIds, resolveDefaultPilotAccountId };
+
+function resolveAccountConfig(cfg: CoreConfig, accountId: string): PilotAccountConfig | undefined {
+  const accounts = cfg.channels?.pilot?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return undefined;
+  }
+  const direct = accounts[accountId] as PilotAccountConfig | undefined;
+  if (direct) {
+    return direct;
+  }
+  const normalized = normalizeAccountId(accountId);
+  const matchKey = Object.keys(accounts).find((key) => normalizeAccountId(key) === normalized);
+  return matchKey ? (accounts[matchKey] as PilotAccountConfig | undefined) : undefined;
+}
+
+function mergePilotAccountConfig(cfg: CoreConfig, accountId: string): PilotAccountConfig {
+  const {
+    accounts: _ignored,
+    defaultAccount: _ignoredDefaultAccount,
+    ...base
+  } = (cfg.channels?.pilot ?? {}) as PilotAccountConfig & {
+    accounts?: unknown;
+    defaultAccount?: unknown;
+  };
+  const account = resolveAccountConfig(cfg, accountId) ?? {};
+  return { ...base, ...account };
+}
+
+export function resolvePilotAccount(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+}): ResolvedPilotAccount {
+  const hasExplicitAccountId = Boolean(params.accountId?.trim());
+  const baseEnabled = params.cfg.channels?.pilot?.enabled !== false;
+
+  const resolve = (accountId: string): ResolvedPilotAccount => {
+    const merged = mergePilotAccountConfig(params.cfg, accountId);
+    const accountEnabled = merged.enabled !== false;
+    const enabled = baseEnabled && accountEnabled;
+
+    const hostname = (
+      merged.hostname?.trim() ||
+      (accountId === DEFAULT_ACCOUNT_ID ? process.env.PILOT_HOSTNAME?.trim() : "") ||
+      ""
+    ).trim();
+
+    const socketPath = (
+      merged.socketPath?.trim() ||
+      (accountId === DEFAULT_ACCOUNT_ID ? process.env.PILOT_SOCKET?.trim() : "") ||
+      "/tmp/pilot.sock"
+    ).trim();
+
+    const registry = (
+      merged.registry?.trim() ||
+      (accountId === DEFAULT_ACCOUNT_ID ? process.env.PILOT_REGISTRY?.trim() : "") ||
+      ""
+    ).trim();
+
+    const pilotctlPath = (
+      merged.pilotctlPath?.trim() ||
+      (accountId === DEFAULT_ACCOUNT_ID ? process.env.PILOTCTL_PATH?.trim() : "") ||
+      "pilotctl"
+    ).trim();
+
+    const pollIntervalMs = merged.pollIntervalMs ?? 2000;
+
+    return {
+      accountId,
+      enabled,
+      name: merged.name?.trim() || undefined,
+      configured: Boolean(hostname),
+      hostname,
+      socketPath,
+      registry,
+      pilotctlPath,
+      pollIntervalMs,
+      config: {
+        ...merged,
+        hostname,
+        socketPath,
+        registry,
+        pilotctlPath,
+        pollIntervalMs,
+      },
+    };
+  };
+
+  const normalized = normalizeAccountId(params.accountId);
+  const primary = resolve(normalized);
+  if (hasExplicitAccountId) {
+    return primary;
+  }
+  if (primary.configured) {
+    return primary;
+  }
+
+  const fallbackId = resolveDefaultPilotAccountId(params.cfg);
+  if (fallbackId === primary.accountId) {
+    return primary;
+  }
+  const fallback = resolve(fallbackId);
+  if (!fallback.configured) {
+    return primary;
+  }
+  return fallback;
+}
+
+export function listEnabledPilotAccounts(cfg: CoreConfig): ResolvedPilotAccount[] {
+  return listPilotAccountIds(cfg)
+    .map((accountId) => resolvePilotAccount({ cfg, accountId }))
+    .filter((account) => account.enabled);
+}

--- a/extensions/pilot/src/channel.ts
+++ b/extensions/pilot/src/channel.ts
@@ -6,9 +6,11 @@ import {
   createAccountStatusSink,
   createScopedAccountConfigAccessors,
   DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
   formatNormalizedAllowFromEntries,
   PAIRING_APPROVED_MESSAGE,
   runPassiveAccountLifecycle,
+  setAccountEnabledInConfigSection,
   type ChannelPlugin,
 } from "openclaw/plugin-sdk/pilot";
 import {
@@ -87,6 +89,31 @@ export const pilotPlugin: ChannelPlugin<ResolvedPilotAccount, PilotProbe> = {
       socketPath: account.socketPath,
       registry: account.registry,
     }),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg: cfg as CoreConfig,
+        sectionKey: "pilot",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg: cfg as CoreConfig,
+        sectionKey: "pilot",
+        accountId,
+        clearBaseFields: [
+          "name",
+          "hostname",
+          "socketPath",
+          "registry",
+          "pilotctlPath",
+          "pollIntervalMs",
+          "dmPolicy",
+          "allowFrom",
+          "defaultTo",
+        ],
+      }),
     ...pilotConfigAccessors,
   },
   security: {

--- a/extensions/pilot/src/channel.ts
+++ b/extensions/pilot/src/channel.ts
@@ -1,4 +1,5 @@
 import {
+  buildAccountScopedDmSecurityPolicy,
   buildBaseAccountStatusSnapshot,
   buildBaseChannelStatusSummary,
   buildChannelConfigSchema,
@@ -31,6 +32,7 @@ const meta = {
   id: "pilot" as const,
   label: "Pilot Protocol",
   selectionLabel: "Pilot Protocol",
+  docsPath: "/channels/pilot",
   blurb: "P2P overlay network for autonomous agents",
   order: 900,
 };
@@ -73,12 +75,17 @@ export const pilotPlugin: ChannelPlugin<ResolvedPilotAccount, PilotProbe> = {
     }),
   },
   security: {
-    resolveDmPolicy: ({ account }) => {
-      const policy = account.config.dmPolicy ?? "pairing";
-      return {
-        policy,
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      return buildAccountScopedDmSecurityPolicy({
+        cfg,
+        channelKey: "pilot",
+        accountId,
+        fallbackAccountId: account.accountId ?? DEFAULT_ACCOUNT_ID,
+        policy: account.config.dmPolicy,
         allowFrom: account.config.allowFrom ?? [],
-      };
+        policyPathSuffix: "dmPolicy",
+        normalizeEntry: (raw) => normalizePilotAllowEntry(raw),
+      });
     },
   },
   messaging: {

--- a/extensions/pilot/src/channel.ts
+++ b/extensions/pilot/src/channel.ts
@@ -1,0 +1,199 @@
+import {
+  buildBaseAccountStatusSnapshot,
+  buildBaseChannelStatusSummary,
+  buildChannelConfigSchema,
+  createAccountStatusSink,
+  DEFAULT_ACCOUNT_ID,
+  PAIRING_APPROVED_MESSAGE,
+  runPassiveAccountLifecycle,
+  type ChannelPlugin,
+} from "openclaw/plugin-sdk/pilot";
+import {
+  listPilotAccountIds,
+  resolveDefaultPilotAccountId,
+  resolvePilotAccount,
+  type ResolvedPilotAccount,
+} from "./accounts.js";
+import { PilotConfigSchema } from "./config-schema.js";
+import { monitorPilotProvider } from "./monitor.js";
+import {
+  normalizePilotTarget,
+  looksLikePilotTargetId,
+  normalizePilotAllowEntry,
+} from "./normalize.js";
+import { pilotOnboardingAdapter } from "./onboarding.js";
+import { probePilot } from "./probe.js";
+import { getPilotRuntime } from "./runtime.js";
+import { sendPilotMessage } from "./send.js";
+import type { CoreConfig, PilotProbe } from "./types.js";
+
+const meta = {
+  id: "pilot" as const,
+  label: "Pilot Protocol",
+  selectionLabel: "Pilot Protocol",
+  blurb: "P2P overlay network for autonomous agents",
+  order: 900,
+};
+
+export const pilotPlugin: ChannelPlugin<ResolvedPilotAccount, PilotProbe> = {
+  id: "pilot",
+  meta,
+  onboarding: pilotOnboardingAdapter,
+  pairing: {
+    idLabel: "pilotAddress",
+    normalizeAllowEntry: (entry) => normalizePilotAllowEntry(entry),
+    notifyApproval: async ({ id }) => {
+      const target = normalizePilotAllowEntry(id);
+      if (!target) {
+        throw new Error(`invalid Pilot pairing id: ${id}`);
+      }
+      await sendPilotMessage(target, PAIRING_APPROVED_MESSAGE);
+    },
+  },
+  capabilities: {
+    chatTypes: ["direct"],
+    media: false,
+    blockStreaming: true,
+  },
+  reload: { configPrefixes: ["channels.pilot"] },
+  configSchema: buildChannelConfigSchema(PilotConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listPilotAccountIds(cfg as CoreConfig),
+    resolveAccount: (cfg, accountId) => resolvePilotAccount({ cfg: cfg as CoreConfig, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultPilotAccountId(cfg as CoreConfig),
+    isConfigured: (account) => account.configured,
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      hostname: account.hostname,
+      socketPath: account.socketPath,
+      registry: account.registry,
+    }),
+  },
+  security: {
+    resolveDmPolicy: ({ account }) => {
+      const policy = account.config.dmPolicy ?? "pairing";
+      return {
+        policy,
+        allowFrom: account.config.allowFrom ?? [],
+      };
+    },
+  },
+  messaging: {
+    normalizeTarget: normalizePilotTarget,
+    targetResolver: {
+      looksLikeId: looksLikePilotTargetId,
+      hint: "<address (N:NNNN.HHHH.LLLL) | hostname>",
+    },
+  },
+  resolver: {
+    resolveTargets: async ({ inputs }) => {
+      return inputs.map((input) => {
+        const normalized = normalizePilotTarget(input);
+        if (!normalized) {
+          return {
+            input,
+            resolved: false,
+            note: "invalid Pilot target",
+          };
+        }
+        return {
+          input,
+          resolved: true,
+          id: normalized,
+          name: normalized,
+        };
+      });
+    },
+  },
+  directory: {
+    self: async () => null,
+    listPeers: async ({ cfg, accountId, query, limit }) => {
+      const account = resolvePilotAccount({ cfg: cfg as CoreConfig, accountId });
+      const q = query?.trim().toLowerCase() ?? "";
+      const ids = new Set<string>();
+
+      for (const entry of account.config.allowFrom ?? []) {
+        const normalized = normalizePilotAllowEntry(String(entry));
+        if (normalized && normalized !== "*") {
+          ids.add(normalized);
+        }
+      }
+
+      return Array.from(ids)
+        .filter((id) => (q ? id.includes(q) : true))
+        .slice(0, limit && limit > 0 ? limit : undefined)
+        .map((id) => ({ kind: "user", id }));
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    chunker: (text, limit) => getPilotRuntime().channel.text.chunkMarkdownText(text, limit),
+    chunkerMode: "markdown",
+    textChunkLimit: 4000,
+    sendText: async ({ cfg, to, text, accountId, replyToId }) => {
+      const result = await sendPilotMessage(to, text, {
+        cfg: cfg as CoreConfig,
+        accountId: accountId ?? undefined,
+        replyTo: replyToId ?? undefined,
+      });
+      return { channel: "pilot", ...result };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    buildChannelSummary: ({ account, snapshot }) => ({
+      ...buildBaseChannelStatusSummary(snapshot),
+      hostname: account.hostname,
+      probe: snapshot.probe,
+      lastProbeAt: snapshot.lastProbeAt ?? null,
+    }),
+    probeAccount: async ({ cfg, account, timeoutMs }) =>
+      probePilot(cfg as CoreConfig, { accountId: account.accountId, timeoutMs }),
+    buildAccountSnapshot: ({ account, runtime, probe }) => ({
+      ...buildBaseAccountStatusSnapshot({ account, runtime, probe }),
+      hostname: account.hostname,
+      socketPath: account.socketPath,
+      registry: account.registry,
+    }),
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      const statusSink = createAccountStatusSink({
+        accountId: ctx.accountId,
+        setStatus: ctx.setStatus,
+      });
+      if (!account.configured) {
+        throw new Error(
+          `Pilot is not configured for account "${account.accountId}" (need hostname in channels.pilot).`,
+        );
+      }
+      ctx.log?.info(
+        `[${account.accountId}] starting Pilot provider (hostname=${account.hostname})`,
+      );
+      await runPassiveAccountLifecycle({
+        abortSignal: ctx.abortSignal,
+        start: async () =>
+          await monitorPilotProvider({
+            accountId: account.accountId,
+            config: ctx.cfg as CoreConfig,
+            runtime: ctx.runtime,
+            abortSignal: ctx.abortSignal,
+            statusSink,
+          }),
+        stop: async (monitor) => {
+          monitor.stop();
+        },
+      });
+    },
+  },
+};

--- a/extensions/pilot/src/channel.ts
+++ b/extensions/pilot/src/channel.ts
@@ -4,7 +4,9 @@ import {
   buildBaseChannelStatusSummary,
   buildChannelConfigSchema,
   createAccountStatusSink,
+  createScopedAccountConfigAccessors,
   DEFAULT_ACCOUNT_ID,
+  formatNormalizedAllowFromEntries,
   PAIRING_APPROVED_MESSAGE,
   runPassiveAccountLifecycle,
   type ChannelPlugin,
@@ -36,6 +38,18 @@ const meta = {
   blurb: "P2P overlay network for autonomous agents",
   order: 900,
 };
+
+const pilotConfigAccessors = createScopedAccountConfigAccessors({
+  resolveAccount: ({ cfg, accountId }) =>
+    resolvePilotAccount({ cfg: cfg as CoreConfig, accountId }),
+  resolveAllowFrom: (account: ResolvedPilotAccount) => account.config.allowFrom,
+  formatAllowFrom: (allowFrom) =>
+    formatNormalizedAllowFromEntries({
+      allowFrom,
+      normalizeEntry: normalizePilotAllowEntry,
+    }),
+  resolveDefaultTo: (account: ResolvedPilotAccount) => account.config.defaultTo,
+});
 
 export const pilotPlugin: ChannelPlugin<ResolvedPilotAccount, PilotProbe> = {
   id: "pilot",
@@ -73,6 +87,7 @@ export const pilotPlugin: ChannelPlugin<ResolvedPilotAccount, PilotProbe> = {
       socketPath: account.socketPath,
       registry: account.registry,
     }),
+    ...pilotConfigAccessors,
   },
   security: {
     resolveDmPolicy: ({ cfg, accountId, account }) => {
@@ -198,7 +213,7 @@ export const pilotPlugin: ChannelPlugin<ResolvedPilotAccount, PilotProbe> = {
             statusSink,
           }),
         stop: async (monitor) => {
-          monitor.stop();
+          await monitor.stop();
         },
       });
     },

--- a/extensions/pilot/src/config-schema.ts
+++ b/extensions/pilot/src/config-schema.ts
@@ -1,0 +1,46 @@
+import {
+  DmPolicySchema,
+  MarkdownConfigSchema,
+  requireOpenAllowFrom,
+} from "openclaw/plugin-sdk/pilot";
+import { z } from "zod";
+
+export const PilotAccountSchemaBase = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    hostname: z.string().optional(),
+    socketPath: z.string().optional(),
+    registry: z.string().optional(),
+    pilotctlPath: z.string().optional(),
+    pollIntervalMs: z.number().int().min(500).max(60_000).optional(),
+    dmPolicy: DmPolicySchema.optional().default("pairing"),
+    allowFrom: z.array(z.string()).optional(),
+    defaultTo: z.string().optional(),
+    markdown: MarkdownConfigSchema,
+    blockStreaming: z.boolean().optional(),
+  })
+  .strict();
+
+export const PilotAccountSchema = PilotAccountSchemaBase.superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message: 'channels.pilot.dmPolicy="open" requires channels.pilot.allowFrom to include "*"',
+  });
+});
+
+export const PilotConfigSchema = PilotAccountSchemaBase.extend({
+  accounts: z.record(z.string(), PilotAccountSchema.optional()).optional(),
+  defaultAccount: z.string().optional(),
+}).superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message: 'channels.pilot.dmPolicy="open" requires channels.pilot.allowFrom to include "*"',
+  });
+});

--- a/extensions/pilot/src/inbound.ts
+++ b/extensions/pilot/src/inbound.ts
@@ -1,0 +1,181 @@
+import {
+  createScopedPairingAccess,
+  dispatchInboundReplyWithBase,
+  formatTextWithAttachmentLinks,
+  issuePairingChallenge,
+  resolveOutboundMediaUrls,
+  type OutboundReplyPayload,
+  type OpenClawConfig,
+  type RuntimeEnv,
+} from "openclaw/plugin-sdk/pilot";
+import type { ResolvedPilotAccount } from "./accounts.js";
+import { normalizePilotAllowlist, resolvePilotAllowlistMatch } from "./normalize.js";
+import { getPilotRuntime } from "./runtime.js";
+import { sendPilotMessage } from "./send.js";
+import type { CoreConfig, PilotInboundMessage } from "./types.js";
+
+const CHANNEL_ID = "pilot" as const;
+
+async function deliverPilotReply(params: {
+  payload: OutboundReplyPayload;
+  target: string;
+  accountId: string;
+  statusSink?: (patch: { lastOutboundAt?: number }) => void;
+}) {
+  const combined = formatTextWithAttachmentLinks(
+    params.payload.text,
+    resolveOutboundMediaUrls(params.payload),
+  );
+  if (!combined) {
+    return;
+  }
+  await sendPilotMessage(params.target, combined, {
+    accountId: params.accountId,
+    replyTo: params.payload.replyToId,
+  });
+  params.statusSink?.({ lastOutboundAt: Date.now() });
+}
+
+export async function handlePilotInbound(params: {
+  message: PilotInboundMessage;
+  account: ResolvedPilotAccount;
+  config: CoreConfig;
+  runtime: RuntimeEnv;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+}): Promise<void> {
+  const { message, account, config, runtime, statusSink } = params;
+  const core = getPilotRuntime();
+  const pairing = createScopedPairingAccess({
+    core,
+    channel: CHANNEL_ID,
+    accountId: account.accountId,
+  });
+
+  const rawBody = message.text?.trim() ?? "";
+  if (!rawBody) {
+    return;
+  }
+
+  statusSink?.({ lastInboundAt: message.timestamp });
+
+  const dmPolicy = account.config.dmPolicy ?? "pairing";
+  const configAllowFrom = normalizePilotAllowlist(account.config.allowFrom);
+
+  // DM-only protocol: no group handling needed.
+  if (dmPolicy === "disabled") {
+    runtime.log?.(`pilot: drop DM sender=${message.sender} (dmPolicy=disabled)`);
+    return;
+  }
+
+  if (dmPolicy !== "open") {
+    const storeAllowFrom = normalizePilotAllowlist(await pairing.readStoreForDmPolicy(dmPolicy));
+    const effectiveAllowFrom = [...configAllowFrom, ...storeAllowFrom];
+
+    const dmAllowed = resolvePilotAllowlistMatch({
+      allowFrom: effectiveAllowFrom,
+      sender: message.sender,
+      senderHostname: message.senderHostname,
+    }).allowed;
+
+    if (!dmAllowed) {
+      if (dmPolicy === "pairing") {
+        await issuePairingChallenge({
+          channel: CHANNEL_ID,
+          senderId: message.sender.toLowerCase(),
+          senderIdLine: `Your Pilot address: ${message.sender}${message.senderHostname ? ` (${message.senderHostname})` : ""}`,
+          meta: { name: message.senderHostname || undefined },
+          upsertPairingRequest: pairing.upsertPairingRequest,
+          sendPairingReply: async (text) => {
+            await deliverPilotReply({
+              payload: { text },
+              target: message.sender,
+              accountId: account.accountId,
+              statusSink,
+            });
+          },
+          onReplyError: (err) => {
+            runtime.error?.(`pilot: pairing reply failed for ${message.sender}: ${String(err)}`);
+          },
+        });
+      }
+      runtime.log?.(`pilot: drop DM sender=${message.sender} (dmPolicy=${dmPolicy})`);
+      return;
+    }
+  }
+
+  const peerId = message.sender;
+  const route = core.channel.routing.resolveAgentRoute({
+    cfg: config as OpenClawConfig,
+    channel: CHANNEL_ID,
+    accountId: account.accountId,
+    peer: {
+      kind: "direct",
+      id: peerId,
+    },
+  });
+
+  const senderLabel = message.senderHostname
+    ? `${message.senderHostname} (${message.sender})`
+    : message.sender;
+  const storePath = core.channel.session.resolveStorePath(config.session?.store, {
+    agentId: route.agentId,
+  });
+  const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(config as OpenClawConfig);
+  const previousTimestamp = core.channel.session.readSessionUpdatedAt({
+    storePath,
+    sessionKey: route.sessionKey,
+  });
+  const body = core.channel.reply.formatAgentEnvelope({
+    channel: "Pilot",
+    from: senderLabel,
+    timestamp: message.timestamp,
+    previousTimestamp,
+    envelope: envelopeOptions,
+    body: rawBody,
+  });
+
+  const ctxPayload = core.channel.reply.finalizeInboundContext({
+    Body: body,
+    RawBody: rawBody,
+    CommandBody: rawBody,
+    From: `pilot:${message.sender}`,
+    To: `pilot:${account.hostname}`,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId,
+    ChatType: "direct",
+    ConversationLabel: senderLabel,
+    SenderName: message.senderHostname || undefined,
+    SenderId: message.sender,
+    Provider: CHANNEL_ID,
+    Surface: CHANNEL_ID,
+    MessageSid: message.messageId,
+    Timestamp: message.timestamp,
+    OriginatingChannel: CHANNEL_ID,
+    OriginatingTo: `pilot:${peerId}`,
+    CommandAuthorized: true,
+  });
+
+  await dispatchInboundReplyWithBase({
+    cfg: config as OpenClawConfig,
+    channel: CHANNEL_ID,
+    accountId: account.accountId,
+    route,
+    storePath,
+    ctxPayload,
+    core,
+    deliver: async (payload) => {
+      await deliverPilotReply({
+        payload,
+        target: peerId,
+        accountId: account.accountId,
+        statusSink,
+      });
+    },
+    onRecordError: (err) => {
+      runtime.error?.(`pilot: failed updating session meta: ${String(err)}`);
+    },
+    onDispatchError: (err, info) => {
+      runtime.error?.(`pilot ${info.kind} reply failed: ${String(err)}`);
+    },
+  });
+}

--- a/extensions/pilot/src/inbound.ts
+++ b/extensions/pilot/src/inbound.ts
@@ -3,6 +3,7 @@ import {
   dispatchInboundReplyWithBase,
   formatTextWithAttachmentLinks,
   issuePairingChallenge,
+  readStoreAllowFromForDmPolicy,
   resolveOutboundMediaUrls,
   type OutboundReplyPayload,
   type OpenClawConfig,
@@ -68,7 +69,14 @@ export async function handlePilotInbound(params: {
   }
 
   if (dmPolicy !== "open") {
-    const storeAllowFrom = normalizePilotAllowlist(await pairing.readStoreForDmPolicy(dmPolicy));
+    const storeAllowFrom = normalizePilotAllowlist(
+      await readStoreAllowFromForDmPolicy({
+        provider: CHANNEL_ID,
+        accountId: account.accountId,
+        dmPolicy,
+        readStore: pairing.readStoreForDmPolicy,
+      }),
+    );
     const effectiveAllowFrom = [...configAllowFrom, ...storeAllowFrom];
 
     const dmAllowed = resolvePilotAllowlistMatch({

--- a/extensions/pilot/src/inbound.ts
+++ b/extensions/pilot/src/inbound.ts
@@ -185,5 +185,11 @@ export async function handlePilotInbound(params: {
     onDispatchError: (err, info) => {
       runtime.error?.(`pilot ${info.kind} reply failed: ${String(err)}`);
     },
+    replyOptions: {
+      disableBlockStreaming:
+        typeof account.config.blockStreaming === "boolean"
+          ? !account.config.blockStreaming
+          : undefined,
+    },
   });
 }

--- a/extensions/pilot/src/monitor.ts
+++ b/extensions/pilot/src/monitor.ts
@@ -65,14 +65,23 @@ export async function monitorPilotProvider(
     pilotctlPath: account.pilotctlPath,
   };
 
-  // Ensure daemon is running.
+  // Ensure daemon is running with the correct identity.
   try {
     const status = await pilotctl.daemonStatus(pilotctlOpts);
     if (!status.running) {
       logger.info(`[${account.accountId}] daemon not running, starting...`);
       await pilotctl.daemonStart(account.hostname, account.registry, pilotctlOpts);
+    } else if (status.hostname && status.hostname !== account.hostname) {
+      throw new Error(
+        `Pilot daemon on ${account.socketPath} is running as "${status.hostname}" but account "${account.accountId}" expects "${account.hostname}". ` +
+          "Stop the existing daemon or use a different socketPath.",
+      );
     }
-  } catch {
+  } catch (err) {
+    // Re-throw identity mismatch errors.
+    if (err instanceof Error && err.message.includes("expects")) {
+      throw err;
+    }
     logger.info(`[${account.accountId}] starting daemon...`);
     await pilotctl.daemonStart(account.hostname, account.registry, pilotctlOpts);
   }
@@ -142,8 +151,8 @@ export async function monitorPilotProvider(
     }
   };
 
-  // Start polling in background.
-  poll().catch((err) => {
+  // Start polling in background; capture the promise so stop() can await it.
+  const pollDone = poll().catch((err) => {
     if (!stopped) {
       logger.error(`[${account.accountId}] monitor loop exited: ${String(err)}`);
     }
@@ -153,6 +162,7 @@ export async function monitorPilotProvider(
     stop: () => {
       stopped = true;
       abortController.abort(new Error("shutdown"));
+      return pollDone;
     },
   };
 }

--- a/extensions/pilot/src/monitor.ts
+++ b/extensions/pilot/src/monitor.ts
@@ -65,23 +65,35 @@ export async function monitorPilotProvider(
     pilotctlPath: account.pilotctlPath,
   };
 
-  // Ensure daemon is running with the correct identity.
+  // Ensure daemon is running with the correct identity and registry.
+  let needsStart = false;
   try {
     const status = await pilotctl.daemonStatus(pilotctlOpts);
     if (!status.running) {
-      logger.info(`[${account.accountId}] daemon not running, starting...`);
-      await pilotctl.daemonStart(account.hostname, account.registry, pilotctlOpts);
+      needsStart = true;
     } else if (status.hostname && status.hostname !== account.hostname) {
       throw new Error(
         `Pilot daemon on ${account.socketPath} is running as "${status.hostname}" but account "${account.accountId}" expects "${account.hostname}". ` +
           "Stop the existing daemon or use a different socketPath.",
       );
+    } else if (status.registry && account.registry && status.registry !== account.registry) {
+      throw new Error(
+        `Pilot daemon on ${account.socketPath} is connected to registry "${status.registry}" but account "${account.accountId}" expects "${account.registry}". ` +
+          "Stop the existing daemon or use a different socketPath.",
+      );
     }
   } catch (err) {
-    // Re-throw identity mismatch errors.
-    if (err instanceof Error && err.message.includes("expects")) {
+    if (
+      err instanceof Error &&
+      (err.message.includes("expects") || err.message.includes("connected to registry"))
+    ) {
       throw err;
     }
+    // Status call itself failed — daemon likely not running.
+    needsStart = true;
+  }
+
+  if (needsStart) {
     logger.info(`[${account.accountId}] starting daemon...`);
     await pilotctl.daemonStart(account.hostname, account.registry, pilotctlOpts);
   }

--- a/extensions/pilot/src/monitor.ts
+++ b/extensions/pilot/src/monitor.ts
@@ -20,15 +20,15 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
       reject(signal.reason);
       return;
     }
-    const timer = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timer);
-        reject(signal.reason);
-      },
-      { once: true },
-    );
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal!.reason);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
 
@@ -102,25 +102,31 @@ export async function monitorPilotProvider(
       try {
         const messages = await pilotctl.receiveMessages(pilotctlOpts);
         for (const message of messages) {
-          core.channel.activity.record({
-            channel: "pilot",
-            accountId: account.accountId,
-            direction: "inbound",
-            at: message.timestamp,
-          });
+          try {
+            core.channel.activity.record({
+              channel: "pilot",
+              accountId: account.accountId,
+              direction: "inbound",
+              at: message.timestamp,
+            });
 
-          if (opts.onMessage) {
-            await opts.onMessage(message);
-            continue;
+            if (opts.onMessage) {
+              await opts.onMessage(message);
+              continue;
+            }
+
+            await handlePilotInbound({
+              message,
+              account,
+              config: cfg,
+              runtime,
+              statusSink: opts.statusSink,
+            });
+          } catch (msgErr) {
+            logger.error(
+              `[${account.accountId}] failed processing message from ${message.sender}: ${String(msgErr)}`,
+            );
           }
-
-          await handlePilotInbound({
-            message,
-            account,
-            config: cfg,
-            runtime,
-            statusSink: opts.statusSink,
-          });
         }
       } catch (err) {
         if (!stopped) {

--- a/extensions/pilot/src/monitor.ts
+++ b/extensions/pilot/src/monitor.ts
@@ -1,0 +1,152 @@
+import { createLoggerBackedRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/pilot";
+import { resolvePilotAccount } from "./accounts.js";
+import { handlePilotInbound } from "./inbound.js";
+import * as pilotctl from "./pilotctl.js";
+import { getPilotRuntime } from "./runtime.js";
+import type { CoreConfig, PilotInboundMessage } from "./types.js";
+
+export type PilotMonitorOptions = {
+  accountId?: string;
+  config?: CoreConfig;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  onMessage?: (message: PilotInboundMessage) => void | Promise<void>;
+};
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(signal.reason);
+      },
+      { once: true },
+    );
+  });
+}
+
+export async function monitorPilotProvider(
+  opts: PilotMonitorOptions,
+): Promise<{ stop: () => void }> {
+  const core = getPilotRuntime();
+  const cfg = opts.config ?? (core.config.loadConfig() as CoreConfig);
+  const account = resolvePilotAccount({
+    cfg,
+    accountId: opts.accountId,
+  });
+
+  const runtime: RuntimeEnv =
+    opts.runtime ??
+    createLoggerBackedRuntime({
+      logger: core.logging.getChildLogger(),
+      exitError: () => new Error("Runtime exit not available"),
+    });
+
+  if (!account.configured) {
+    throw new Error(
+      `Pilot is not configured for account "${account.accountId}" (need hostname in channels.pilot).`,
+    );
+  }
+
+  const logger = core.logging.getChildLogger({
+    channel: "pilot",
+    accountId: account.accountId,
+  });
+
+  const pilotctlOpts = {
+    socketPath: account.socketPath,
+    pilotctlPath: account.pilotctlPath,
+  };
+
+  // Ensure daemon is running.
+  try {
+    const status = await pilotctl.daemonStatus(pilotctlOpts);
+    if (!status.running) {
+      logger.info(`[${account.accountId}] daemon not running, starting...`);
+      await pilotctl.daemonStart(account.hostname, account.registry, pilotctlOpts);
+    }
+  } catch {
+    logger.info(`[${account.accountId}] starting daemon...`);
+    await pilotctl.daemonStart(account.hostname, account.registry, pilotctlOpts);
+  }
+
+  logger.info(
+    `[${account.accountId}] connected to Pilot network as ${account.hostname} (polling every ${account.pollIntervalMs}ms)`,
+  );
+
+  let stopped = false;
+  const abortController = new AbortController();
+
+  // Link external abort signal.
+  if (opts.abortSignal) {
+    opts.abortSignal.addEventListener(
+      "abort",
+      () => {
+        stopped = true;
+        abortController.abort(opts.abortSignal?.reason);
+      },
+      { once: true },
+    );
+  }
+
+  // Polling loop.
+  const poll = async () => {
+    while (!stopped && !abortController.signal.aborted) {
+      try {
+        const messages = await pilotctl.receiveMessages(pilotctlOpts);
+        for (const message of messages) {
+          core.channel.activity.record({
+            channel: "pilot",
+            accountId: account.accountId,
+            direction: "inbound",
+            at: message.timestamp,
+          });
+
+          if (opts.onMessage) {
+            await opts.onMessage(message);
+            continue;
+          }
+
+          await handlePilotInbound({
+            message,
+            account,
+            config: cfg,
+            runtime,
+            statusSink: opts.statusSink,
+          });
+        }
+      } catch (err) {
+        if (!stopped) {
+          logger.error(`[${account.accountId}] poll error: ${String(err)}`);
+        }
+      }
+
+      try {
+        await sleep(account.pollIntervalMs, abortController.signal);
+      } catch {
+        break;
+      }
+    }
+  };
+
+  // Start polling in background.
+  poll().catch((err) => {
+    if (!stopped) {
+      logger.error(`[${account.accountId}] monitor loop exited: ${String(err)}`);
+    }
+  });
+
+  return {
+    stop: () => {
+      stopped = true;
+      abortController.abort(new Error("shutdown"));
+    },
+  };
+}

--- a/extensions/pilot/src/normalize.ts
+++ b/extensions/pilot/src/normalize.ts
@@ -1,0 +1,88 @@
+/**
+ * Pilot Protocol address format: N:NNNN.HHHH.LLLL (48-bit, colon-separated segments).
+ * Hostnames are human-readable labels registered with the daemon.
+ */
+
+const PILOT_ADDRESS_PATTERN = /^\d+:\d{4}\.\d{4}\.\d{4}$/;
+const PILOT_HOSTNAME_PATTERN = /^[a-z0-9][a-z0-9\-]{0,62}$/i;
+
+export function looksLikePilotAddress(raw: string): boolean {
+  return PILOT_ADDRESS_PATTERN.test(raw.trim());
+}
+
+export function looksLikePilotHostname(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (looksLikePilotAddress(trimmed)) {
+    return false;
+  }
+  return PILOT_HOSTNAME_PATTERN.test(trimmed);
+}
+
+export function looksLikePilotTargetId(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+  let target = trimmed;
+  if (target.toLowerCase().startsWith("pilot:")) {
+    target = target.slice("pilot:".length).trim();
+  }
+  return looksLikePilotAddress(target) || looksLikePilotHostname(target);
+}
+
+export function normalizePilotTarget(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  let target = trimmed;
+  if (target.toLowerCase().startsWith("pilot:")) {
+    target = target.slice("pilot:".length).trim();
+  }
+  if (!target || !looksLikePilotTargetId(target)) {
+    return undefined;
+  }
+  return target;
+}
+
+export function normalizePilotAllowEntry(raw: string): string {
+  let value = raw.trim().toLowerCase();
+  if (!value) {
+    return "";
+  }
+  if (value.startsWith("pilot:")) {
+    value = value.slice("pilot:".length);
+  }
+  return value.trim();
+}
+
+export function normalizePilotAllowlist(entries?: string[]): string[] {
+  return (entries ?? []).map((entry) => normalizePilotAllowEntry(entry)).filter(Boolean);
+}
+
+export function resolvePilotAllowlistMatch(params: {
+  allowFrom: string[];
+  sender: string;
+  senderHostname?: string;
+}): { allowed: boolean; source?: string } {
+  const allowFrom = new Set(
+    params.allowFrom.map((entry) => entry.trim().toLowerCase()).filter(Boolean),
+  );
+  if (allowFrom.has("*")) {
+    return { allowed: true, source: "wildcard" };
+  }
+  const senderLower = params.sender.trim().toLowerCase();
+  if (allowFrom.has(senderLower)) {
+    return { allowed: true, source: senderLower };
+  }
+  if (params.senderHostname) {
+    const hostnameLower = params.senderHostname.trim().toLowerCase();
+    if (allowFrom.has(hostnameLower)) {
+      return { allowed: true, source: hostnameLower };
+    }
+  }
+  return { allowed: false };
+}

--- a/extensions/pilot/src/onboarding.ts
+++ b/extensions/pilot/src/onboarding.ts
@@ -1,0 +1,223 @@
+import {
+  DEFAULT_ACCOUNT_ID,
+  formatDocsLink,
+  patchScopedAccountConfig,
+  resolveAccountIdForConfigure,
+  setTopLevelChannelDmPolicyWithAllowFrom,
+  type ChannelOnboardingAdapter,
+  type ChannelOnboardingDmPolicy,
+  type DmPolicy,
+  type WizardPrompter,
+} from "openclaw/plugin-sdk/pilot";
+import {
+  listPilotAccountIds,
+  resolveDefaultPilotAccountId,
+  resolvePilotAccount,
+} from "./accounts.js";
+import { normalizePilotAllowEntry } from "./normalize.js";
+import type { CoreConfig, PilotAccountConfig } from "./types.js";
+
+const channel = "pilot" as const;
+
+function parseListInput(raw: string): string[] {
+  return raw
+    .split(/[\n,;]+/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function updatePilotAccountConfig(
+  cfg: CoreConfig,
+  accountId: string,
+  patch: Partial<PilotAccountConfig>,
+): CoreConfig {
+  return patchScopedAccountConfig({
+    cfg,
+    channelKey: channel,
+    accountId,
+    patch,
+    ensureChannelEnabled: false,
+    ensureAccountEnabled: false,
+  }) as CoreConfig;
+}
+
+function setPilotDmPolicy(cfg: CoreConfig, dmPolicy: DmPolicy): CoreConfig {
+  return setTopLevelChannelDmPolicyWithAllowFrom({
+    cfg,
+    channel: "pilot",
+    dmPolicy,
+  }) as CoreConfig;
+}
+
+async function noteSetupHelp(prompter: WizardPrompter): Promise<void> {
+  await prompter.note(
+    [
+      "Pilot Protocol needs a hostname for your agent.",
+      "The hostname is your agent's human-readable identity on the network.",
+      "Optional: socketPath (default: /tmp/pilot.sock), registry address.",
+      "Env vars: PILOT_HOSTNAME, PILOT_SOCKET, PILOT_REGISTRY, PILOTCTL_PATH.",
+    ].join("\n"),
+    "Pilot setup",
+  );
+}
+
+async function promptPilotAllowFrom(params: {
+  cfg: CoreConfig;
+  prompter: WizardPrompter;
+  accountId?: string;
+}): Promise<CoreConfig> {
+  const existing = params.cfg.channels?.pilot?.allowFrom ?? [];
+
+  await params.prompter.note(
+    [
+      "Allowlist Pilot DMs by sender.",
+      "Use addresses (N:NNNN.HHHH.LLLL) or hostnames.",
+      "Multiple entries: comma-separated.",
+    ].join("\n"),
+    "Pilot allowlist",
+  );
+
+  const raw = await params.prompter.text({
+    message: "Pilot allowFrom (address or hostname)",
+    placeholder: "alice-agent, 0:0000.0000.0005",
+    initialValue: existing[0] ? String(existing[0]) : undefined,
+    validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+  });
+
+  const parsed = parseListInput(String(raw));
+  const normalized = [
+    ...new Set(parsed.map((entry) => normalizePilotAllowEntry(entry)).filter(Boolean)),
+  ];
+
+  return {
+    ...params.cfg,
+    channels: {
+      ...params.cfg.channels,
+      pilot: {
+        ...params.cfg.channels?.pilot,
+        allowFrom: normalized,
+      },
+    },
+  } as CoreConfig;
+}
+
+const dmPolicy: ChannelOnboardingDmPolicy = {
+  label: "Pilot",
+  channel,
+  policyKey: "channels.pilot.dmPolicy",
+  allowFromKey: "channels.pilot.allowFrom",
+  getCurrent: (cfg) => (cfg as CoreConfig).channels?.pilot?.dmPolicy ?? "pairing",
+  setPolicy: (cfg, policy) => setPilotDmPolicy(cfg as CoreConfig, policy),
+  promptAllowFrom: promptPilotAllowFrom,
+};
+
+export const pilotOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  getStatus: async ({ cfg }) => {
+    const coreCfg = cfg as CoreConfig;
+    const configured = listPilotAccountIds(coreCfg).some(
+      (accountId) => resolvePilotAccount({ cfg: coreCfg, accountId }).configured,
+    );
+    return {
+      channel,
+      configured,
+      statusLines: [`Pilot: ${configured ? "configured" : "needs hostname"}`],
+      selectionHint: configured ? "configured" : "needs hostname",
+      quickstartScore: configured ? 1 : 0,
+    };
+  },
+  configure: async ({
+    cfg,
+    prompter,
+    accountOverrides,
+    shouldPromptAccountIds,
+    forceAllowFrom,
+  }) => {
+    let next = cfg as CoreConfig;
+    const defaultAccountId = resolveDefaultPilotAccountId(next);
+    const accountId = await resolveAccountIdForConfigure({
+      cfg: next,
+      prompter,
+      label: "Pilot",
+      accountOverride: accountOverrides.pilot,
+      shouldPromptAccountIds,
+      listAccountIds: listPilotAccountIds,
+      defaultAccountId,
+    });
+
+    const resolved = resolvePilotAccount({ cfg: next, accountId });
+    const isDefaultAccount = accountId === DEFAULT_ACCOUNT_ID;
+    const envHostname = isDefaultAccount ? process.env.PILOT_HOSTNAME?.trim() : "";
+    const envReady = Boolean(envHostname);
+
+    if (!resolved.configured) {
+      await noteSetupHelp(prompter);
+    }
+
+    let useEnv = false;
+    if (envReady && isDefaultAccount && !resolved.config.hostname) {
+      useEnv = await prompter.confirm({
+        message: "PILOT_HOSTNAME detected. Use env var?",
+        initialValue: true,
+      });
+    }
+
+    if (useEnv) {
+      next = updatePilotAccountConfig(next, accountId, { enabled: true });
+    } else {
+      const hostname = String(
+        await prompter.text({
+          message: "Agent hostname",
+          initialValue: resolved.config.hostname || envHostname || undefined,
+          validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+        }),
+      ).trim();
+
+      const socketPath = String(
+        await prompter.text({
+          message: "Daemon socket path",
+          initialValue: resolved.config.socketPath || "/tmp/pilot.sock",
+        }),
+      ).trim();
+
+      const registry = String(
+        await prompter.text({
+          message: "Registry address (optional)",
+          initialValue: resolved.config.registry || "",
+        }),
+      ).trim();
+
+      next = updatePilotAccountConfig(next, accountId, {
+        enabled: true,
+        hostname,
+        socketPath: socketPath || undefined,
+        registry: registry || undefined,
+      });
+    }
+
+    if (forceAllowFrom) {
+      next = await promptPilotAllowFrom({ cfg: next, prompter, accountId });
+    }
+
+    await prompter.note(
+      [
+        "Next: ensure pilotctl + daemon are running, then restart gateway.",
+        "Command: openclaw channels status --probe",
+      ].join("\n"),
+      "Pilot next steps",
+    );
+
+    return { cfg: next, accountId };
+  },
+  dmPolicy,
+  disable: (cfg) => ({
+    ...(cfg as CoreConfig),
+    channels: {
+      ...(cfg as CoreConfig).channels,
+      pilot: {
+        ...(cfg as CoreConfig).channels?.pilot,
+        enabled: false,
+      },
+    },
+  }),
+};

--- a/extensions/pilot/src/pilotctl.ts
+++ b/extensions/pilot/src/pilotctl.ts
@@ -47,10 +47,11 @@ export async function daemonStart(
   registry: string,
   opts?: PilotctlOptions,
 ): Promise<PilotDaemonStatus> {
-  return run<PilotDaemonStatus>(
-    ["daemon", "start", "--hostname", hostname, "--registry", registry],
-    opts,
-  );
+  const args = ["daemon", "start", "--hostname", hostname];
+  if (registry) {
+    args.push("--registry", registry);
+  }
+  return run<PilotDaemonStatus>(args, opts);
 }
 
 export async function daemonInfo(opts?: PilotctlOptions): Promise<PilotDaemonStatus> {
@@ -67,11 +68,6 @@ export async function sendMessage(
 
 export async function receiveMessages(opts?: PilotctlOptions): Promise<PilotInboundMessage[]> {
   const data = await run<PilotInboundMessage[] | null>(["received", "--clear"], opts);
-  return data ?? [];
-}
-
-export async function inbox(opts?: PilotctlOptions): Promise<PilotInboundMessage[]> {
-  const data = await run<PilotInboundMessage[] | null>(["inbox", "--clear"], opts);
   return data ?? [];
 }
 

--- a/extensions/pilot/src/pilotctl.ts
+++ b/extensions/pilot/src/pilotctl.ts
@@ -1,0 +1,151 @@
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import type {
+  PilotDaemonStatus,
+  PilotInboundMessage,
+  PilotPeer,
+  PilotTrustRequest,
+} from "./types.js";
+
+const execFile = promisify(execFileCb);
+
+type PilotctlOptions = {
+  socketPath?: string;
+  pilotctlPath?: string;
+  timeoutMs?: number;
+};
+
+type PilotctlResult<T = unknown> = {
+  status: string;
+  data: T;
+};
+
+async function run<T = unknown>(args: string[], opts?: PilotctlOptions): Promise<T> {
+  const bin = opts?.pilotctlPath || process.env.PILOTCTL_PATH || "pilotctl";
+  const fullArgs = ["--json", ...args];
+  if (opts?.socketPath) {
+    fullArgs.unshift("--socket", opts.socketPath);
+  }
+  const timeout = opts?.timeoutMs ?? 15_000;
+  const { stdout } = await execFile(bin, fullArgs, {
+    timeout,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  const parsed = JSON.parse(stdout.trim()) as PilotctlResult<T>;
+  if (parsed.status !== "ok") {
+    throw new Error(`pilotctl error: ${JSON.stringify(parsed)}`);
+  }
+  return parsed.data;
+}
+
+export async function daemonStatus(opts?: PilotctlOptions): Promise<PilotDaemonStatus> {
+  return run<PilotDaemonStatus>(["daemon", "status"], opts);
+}
+
+export async function daemonStart(
+  hostname: string,
+  registry: string,
+  opts?: PilotctlOptions,
+): Promise<PilotDaemonStatus> {
+  return run<PilotDaemonStatus>(
+    ["daemon", "start", "--hostname", hostname, "--registry", registry],
+    opts,
+  );
+}
+
+export async function daemonInfo(opts?: PilotctlOptions): Promise<PilotDaemonStatus> {
+  return run<PilotDaemonStatus>(["info"], opts);
+}
+
+export async function sendMessage(
+  addr: string,
+  text: string,
+  opts?: PilotctlOptions,
+): Promise<{ messageId: string }> {
+  return run<{ messageId: string }>(["send-message", addr, "--data", text], opts);
+}
+
+export async function receiveMessages(opts?: PilotctlOptions): Promise<PilotInboundMessage[]> {
+  const data = await run<PilotInboundMessage[] | null>(["received", "--clear"], opts);
+  return data ?? [];
+}
+
+export async function inbox(opts?: PilotctlOptions): Promise<PilotInboundMessage[]> {
+  const data = await run<PilotInboundMessage[] | null>(["inbox", "--clear"], opts);
+  return data ?? [];
+}
+
+export async function trustHandshake(
+  addr: string,
+  opts?: PilotctlOptions,
+): Promise<{ status: string }> {
+  return run<{ status: string }>(["handshake", addr], opts);
+}
+
+export async function trustApprove(
+  addr: string,
+  opts?: PilotctlOptions,
+): Promise<{ status: string }> {
+  return run<{ status: string }>(["approve", addr], opts);
+}
+
+export async function trustReject(
+  addr: string,
+  opts?: PilotctlOptions,
+): Promise<{ status: string }> {
+  return run<{ status: string }>(["reject", addr], opts);
+}
+
+export async function trustList(opts?: PilotctlOptions): Promise<PilotPeer[]> {
+  const data = await run<PilotPeer[] | null>(["trust"], opts);
+  return data ?? [];
+}
+
+export async function trustPending(opts?: PilotctlOptions): Promise<PilotTrustRequest[]> {
+  const data = await run<PilotTrustRequest[] | null>(["pending"], opts);
+  return data ?? [];
+}
+
+export async function lookup(hostname: string, opts?: PilotctlOptions): Promise<PilotPeer | null> {
+  return run<PilotPeer | null>(["find", hostname], opts);
+}
+
+export async function listPeers(opts?: PilotctlOptions): Promise<PilotPeer[]> {
+  const data = await run<PilotPeer[] | null>(["peers"], opts);
+  return data ?? [];
+}
+
+export async function submitTask(
+  addr: string,
+  task: string,
+  opts?: PilotctlOptions,
+): Promise<{ taskId: string }> {
+  return run<{ taskId: string }>(["task", "submit", addr, "--task", task], opts);
+}
+
+export async function taskList(
+  opts?: PilotctlOptions,
+): Promise<Array<{ taskId: string; status: string; addr: string }>> {
+  const data = await run<Array<{ taskId: string; status: string; addr: string }> | null>(
+    ["task", "list"],
+    opts,
+  );
+  return data ?? [];
+}
+
+export async function publish(
+  addr: string,
+  topic: string,
+  data: string,
+  opts?: PilotctlOptions,
+): Promise<{ status: string }> {
+  return run<{ status: string }>(["publish", addr, topic, "--data", data], opts);
+}
+
+export async function subscribe(
+  addr: string,
+  topic: string,
+  opts?: PilotctlOptions,
+): Promise<{ subscriptionId: string }> {
+  return run<{ subscriptionId: string }>(["subscribe", addr, topic], opts);
+}

--- a/extensions/pilot/src/probe.ts
+++ b/extensions/pilot/src/probe.ts
@@ -1,0 +1,67 @@
+import { resolvePilotAccount } from "./accounts.js";
+import * as pilotctl from "./pilotctl.js";
+import type { CoreConfig, PilotProbe } from "./types.js";
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return typeof err === "string" ? err : JSON.stringify(err);
+}
+
+export async function probePilot(
+  cfg: CoreConfig,
+  opts?: { accountId?: string; timeoutMs?: number },
+): Promise<PilotProbe> {
+  const account = resolvePilotAccount({ cfg, accountId: opts?.accountId });
+  const base: PilotProbe = {
+    ok: false,
+    daemonRunning: false,
+    hostname: account.hostname || undefined,
+  };
+
+  if (!account.configured) {
+    return {
+      ...base,
+      error: "missing hostname",
+    };
+  }
+
+  const started = Date.now();
+  try {
+    const status = await pilotctl.daemonStatus({
+      socketPath: account.socketPath,
+      pilotctlPath: account.pilotctlPath,
+      timeoutMs: opts?.timeoutMs ?? 8000,
+    });
+    const elapsed = Date.now() - started;
+
+    if (!status.running) {
+      return {
+        ...base,
+        error: "daemon not running",
+      };
+    }
+
+    const peers = await pilotctl.trustList({
+      socketPath: account.socketPath,
+      pilotctlPath: account.pilotctlPath,
+      timeoutMs: opts?.timeoutMs ?? 8000,
+    });
+
+    return {
+      ...base,
+      ok: true,
+      daemonRunning: true,
+      address: status.address,
+      hostname: status.hostname ?? account.hostname,
+      trustedPeers: peers.length,
+      latencyMs: elapsed,
+    };
+  } catch (err) {
+    return {
+      ...base,
+      error: formatError(err),
+    };
+  }
+}

--- a/extensions/pilot/src/runtime.ts
+++ b/extensions/pilot/src/runtime.ts
@@ -1,0 +1,6 @@
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/compat";
+import type { PluginRuntime } from "openclaw/plugin-sdk/pilot";
+
+const { setRuntime: setPilotRuntime, getRuntime: getPilotRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Pilot runtime not initialized");
+export { getPilotRuntime, setPilotRuntime };

--- a/extensions/pilot/src/send.ts
+++ b/extensions/pilot/src/send.ts
@@ -1,0 +1,68 @@
+import { resolvePilotAccount } from "./accounts.js";
+import { normalizePilotTarget } from "./normalize.js";
+import * as pilotctl from "./pilotctl.js";
+import { getPilotRuntime } from "./runtime.js";
+import type { CoreConfig } from "./types.js";
+
+type SendPilotOptions = {
+  cfg?: CoreConfig;
+  accountId?: string;
+  replyTo?: string;
+};
+
+export type SendPilotResult = {
+  messageId: string;
+  target: string;
+};
+
+export async function sendPilotMessage(
+  to: string,
+  text: string,
+  opts: SendPilotOptions = {},
+): Promise<SendPilotResult> {
+  const runtime = getPilotRuntime();
+  const cfg = (opts.cfg ?? runtime.config.loadConfig()) as CoreConfig;
+  const account = resolvePilotAccount({
+    cfg,
+    accountId: opts.accountId,
+  });
+
+  if (!account.configured) {
+    throw new Error(
+      `Pilot is not configured for account "${account.accountId}" (need hostname in channels.pilot).`,
+    );
+  }
+
+  const target = normalizePilotTarget(to);
+  if (!target) {
+    throw new Error(`Invalid Pilot target: ${to}`);
+  }
+
+  const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+    cfg,
+    channel: "pilot",
+    accountId: account.accountId,
+  });
+  const prepared = runtime.channel.text.convertMarkdownTables(text.trim(), tableMode);
+  const payload = opts.replyTo ? `${prepared}\n\n[reply:${opts.replyTo}]` : prepared;
+
+  if (!payload.trim()) {
+    throw new Error("Message must be non-empty for Pilot sends");
+  }
+
+  const result = await pilotctl.sendMessage(target, payload, {
+    socketPath: account.socketPath,
+    pilotctlPath: account.pilotctlPath,
+  });
+
+  runtime.channel.activity.record({
+    channel: "pilot",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+
+  return {
+    messageId: result.messageId,
+    target,
+  };
+}

--- a/extensions/pilot/src/tools/index.ts
+++ b/extensions/pilot/src/tools/index.ts
@@ -1,0 +1,14 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
+import { registerPilotDiscoverTool } from "./pilot-discover.js";
+import { registerPilotEventTools } from "./pilot-events.js";
+import { registerPilotSendTool } from "./pilot-send.js";
+import { registerPilotTaskTool } from "./pilot-task.js";
+import { registerPilotTrustTool } from "./pilot-trust.js";
+
+export function registerPilotTools(api: OpenClawPluginApi) {
+  registerPilotSendTool(api);
+  registerPilotTrustTool(api);
+  registerPilotDiscoverTool(api);
+  registerPilotTaskTool(api);
+  registerPilotEventTools(api);
+}

--- a/extensions/pilot/src/tools/pilot-discover.ts
+++ b/extensions/pilot/src/tools/pilot-discover.ts
@@ -1,0 +1,65 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
+import { resolvePilotAccount } from "../accounts.js";
+import * as pilotctl from "../pilotctl.js";
+import type { CoreConfig } from "../types.js";
+
+export function registerPilotDiscoverTool(api: OpenClawPluginApi) {
+  api.registerTool({
+    name: "pilot_discover",
+    label: "Pilot Discover",
+    description:
+      "Discover peers on the Pilot Protocol network. " +
+      "Actions: lookup (find by hostname), peers (list known peers), info (daemon status).",
+    parameters: {
+      type: "object",
+      properties: {
+        action: {
+          type: "string",
+          description: "Discovery action: lookup, peers, info",
+        },
+        hostname: {
+          type: "string",
+          description: "Hostname to look up (only for lookup action)",
+        },
+      },
+      required: ["action"],
+    },
+    async execute(_id: string, params: { action: string; hostname?: string }) {
+      try {
+        const cfg = api.runtime.config.loadConfig() as CoreConfig;
+        const account = resolvePilotAccount({ cfg });
+        const opts = {
+          socketPath: account.socketPath,
+          pilotctlPath: account.pilotctlPath,
+        };
+
+        let result: unknown;
+        switch (params.action) {
+          case "lookup":
+            if (!params.hostname) throw new Error("hostname required for lookup");
+            result = await pilotctl.lookup(params.hostname, opts);
+            break;
+          case "peers":
+            result = await pilotctl.listPeers(opts);
+            break;
+          case "info":
+            result = await pilotctl.daemonInfo(opts);
+            break;
+          default:
+            throw new Error(`Unknown discover action: ${params.action}`);
+        }
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+          details: undefined,
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  });
+}

--- a/extensions/pilot/src/tools/pilot-events.ts
+++ b/extensions/pilot/src/tools/pilot-events.ts
@@ -1,0 +1,94 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
+import { resolvePilotAccount } from "../accounts.js";
+import * as pilotctl from "../pilotctl.js";
+import type { CoreConfig } from "../types.js";
+
+export function registerPilotEventTools(api: OpenClawPluginApi) {
+  api.registerTool({
+    name: "pilot_publish",
+    label: "Pilot Publish",
+    description:
+      "Publish a message to a topic on the Pilot Protocol Event Stream (port 1002). " +
+      "Broadcasts data to all subscribers of the topic on the target peer.",
+    parameters: {
+      type: "object",
+      properties: {
+        target: {
+          type: "string",
+          description: "Pilot address or hostname of the event stream host",
+        },
+        topic: {
+          type: "string",
+          description: "Topic name to publish to",
+        },
+        data: {
+          type: "string",
+          description: "Data payload to publish",
+        },
+      },
+      required: ["target", "topic", "data"],
+    },
+    async execute(_id: string, params: { target: string; topic: string; data: string }) {
+      try {
+        const cfg = api.runtime.config.loadConfig() as CoreConfig;
+        const account = resolvePilotAccount({ cfg });
+        const result = await pilotctl.publish(params.target, params.topic, params.data, {
+          socketPath: account.socketPath,
+          pilotctlPath: account.pilotctlPath,
+        });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+          details: undefined,
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  });
+
+  api.registerTool({
+    name: "pilot_subscribe",
+    label: "Pilot Subscribe",
+    description:
+      "Subscribe to a topic on the Pilot Protocol Event Stream (port 1002). " +
+      "Receives broadcasts from the topic on the target peer.",
+    parameters: {
+      type: "object",
+      properties: {
+        target: {
+          type: "string",
+          description: "Pilot address or hostname of the event stream host",
+        },
+        topic: {
+          type: "string",
+          description: "Topic name to subscribe to",
+        },
+      },
+      required: ["target", "topic"],
+    },
+    async execute(_id: string, params: { target: string; topic: string }) {
+      try {
+        const cfg = api.runtime.config.loadConfig() as CoreConfig;
+        const account = resolvePilotAccount({ cfg });
+        const result = await pilotctl.subscribe(params.target, params.topic, {
+          socketPath: account.socketPath,
+          pilotctlPath: account.pilotctlPath,
+        });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+          details: undefined,
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  });
+}

--- a/extensions/pilot/src/tools/pilot-events.ts
+++ b/extensions/pilot/src/tools/pilot-events.ts
@@ -1,5 +1,6 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
 import { resolvePilotAccount } from "../accounts.js";
+import { normalizePilotTarget } from "../normalize.js";
 import * as pilotctl from "../pilotctl.js";
 import type { CoreConfig } from "../types.js";
 
@@ -32,7 +33,9 @@ export function registerPilotEventTools(api: OpenClawPluginApi) {
       try {
         const cfg = api.runtime.config.loadConfig() as CoreConfig;
         const account = resolvePilotAccount({ cfg });
-        const result = await pilotctl.publish(params.target, params.topic, params.data, {
+        const target = normalizePilotTarget(params.target);
+        if (!target) throw new Error(`Invalid Pilot target: ${params.target}`);
+        const result = await pilotctl.publish(target, params.topic, params.data, {
           socketPath: account.socketPath,
           pilotctlPath: account.pilotctlPath,
         });
@@ -74,7 +77,9 @@ export function registerPilotEventTools(api: OpenClawPluginApi) {
       try {
         const cfg = api.runtime.config.loadConfig() as CoreConfig;
         const account = resolvePilotAccount({ cfg });
-        const result = await pilotctl.subscribe(params.target, params.topic, {
+        const target = normalizePilotTarget(params.target);
+        if (!target) throw new Error(`Invalid Pilot target: ${params.target}`);
+        const result = await pilotctl.subscribe(target, params.topic, {
           socketPath: account.socketPath,
           pilotctlPath: account.pilotctlPath,
         });

--- a/extensions/pilot/src/tools/pilot-send.ts
+++ b/extensions/pilot/src/tools/pilot-send.ts
@@ -1,0 +1,48 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
+import { resolvePilotAccount } from "../accounts.js";
+import * as pilotctl from "../pilotctl.js";
+import type { CoreConfig } from "../types.js";
+
+export function registerPilotSendTool(api: OpenClawPluginApi) {
+  api.registerTool({
+    name: "pilot_send",
+    label: "Pilot Send",
+    description:
+      "Send a text message to a peer on the Pilot Protocol network via Data Exchange (port 1001). " +
+      "Target can be a Pilot address (N:NNNN.HHHH.LLLL) or a hostname.",
+    parameters: {
+      type: "object",
+      properties: {
+        target: {
+          type: "string",
+          description: "Pilot address or hostname of the recipient",
+        },
+        message: {
+          type: "string",
+          description: "The message text to send",
+        },
+      },
+      required: ["target", "message"],
+    },
+    async execute(_id: string, params: { target: string; message: string }) {
+      try {
+        const cfg = api.runtime.config.loadConfig() as CoreConfig;
+        const account = resolvePilotAccount({ cfg });
+        const result = await pilotctl.sendMessage(params.target, params.message, {
+          socketPath: account.socketPath,
+          pilotctlPath: account.pilotctlPath,
+        });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+          details: undefined,
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  });
+}

--- a/extensions/pilot/src/tools/pilot-send.ts
+++ b/extensions/pilot/src/tools/pilot-send.ts
@@ -1,7 +1,5 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
-import { resolvePilotAccount } from "../accounts.js";
-import * as pilotctl from "../pilotctl.js";
-import type { CoreConfig } from "../types.js";
+import { sendPilotMessage } from "../send.js";
 
 export function registerPilotSendTool(api: OpenClawPluginApi) {
   api.registerTool({
@@ -26,12 +24,7 @@ export function registerPilotSendTool(api: OpenClawPluginApi) {
     },
     async execute(_id: string, params: { target: string; message: string }) {
       try {
-        const cfg = api.runtime.config.loadConfig() as CoreConfig;
-        const account = resolvePilotAccount({ cfg });
-        const result = await pilotctl.sendMessage(params.target, params.message, {
-          socketPath: account.socketPath,
-          pilotctlPath: account.pilotctlPath,
-        });
+        const result = await sendPilotMessage(params.target, params.message);
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result) }],
           details: undefined,

--- a/extensions/pilot/src/tools/pilot-task.ts
+++ b/extensions/pilot/src/tools/pilot-task.ts
@@ -1,0 +1,67 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
+import { resolvePilotAccount } from "../accounts.js";
+import * as pilotctl from "../pilotctl.js";
+import type { CoreConfig } from "../types.js";
+
+export function registerPilotTaskTool(api: OpenClawPluginApi) {
+  api.registerTool({
+    name: "pilot_task",
+    label: "Pilot Task",
+    description:
+      "Submit and manage tasks on the Pilot Protocol network via Task Submit (port 1003). " +
+      "Actions: submit (send task to peer), list (check task statuses).",
+    parameters: {
+      type: "object",
+      properties: {
+        action: {
+          type: "string",
+          description: "Task action: submit, list",
+        },
+        target: {
+          type: "string",
+          description: "Pilot address or hostname for task submission (only for submit)",
+        },
+        task: {
+          type: "string",
+          description: "Task description to submit (only for submit)",
+        },
+      },
+      required: ["action"],
+    },
+    async execute(_id: string, params: { action: string; target?: string; task?: string }) {
+      try {
+        const cfg = api.runtime.config.loadConfig() as CoreConfig;
+        const account = resolvePilotAccount({ cfg });
+        const opts = {
+          socketPath: account.socketPath,
+          pilotctlPath: account.pilotctlPath,
+        };
+
+        let result: unknown;
+        switch (params.action) {
+          case "submit":
+            if (!params.target) throw new Error("target required for submit");
+            if (!params.task) throw new Error("task required for submit");
+            result = await pilotctl.submitTask(params.target, params.task, opts);
+            break;
+          case "list":
+            result = await pilotctl.taskList(opts);
+            break;
+          default:
+            throw new Error(`Unknown task action: ${params.action}`);
+        }
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+          details: undefined,
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  });
+}

--- a/extensions/pilot/src/tools/pilot-task.ts
+++ b/extensions/pilot/src/tools/pilot-task.ts
@@ -1,5 +1,6 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
 import { resolvePilotAccount } from "../accounts.js";
+import { normalizePilotTarget } from "../normalize.js";
 import * as pilotctl from "../pilotctl.js";
 import type { CoreConfig } from "../types.js";
 
@@ -40,9 +41,13 @@ export function registerPilotTaskTool(api: OpenClawPluginApi) {
         let result: unknown;
         switch (params.action) {
           case "submit":
-            if (!params.target) throw new Error("target required for submit");
-            if (!params.task) throw new Error("task required for submit");
-            result = await pilotctl.submitTask(params.target, params.task, opts);
+            {
+              if (!params.target) throw new Error("target required for submit");
+              if (!params.task) throw new Error("task required for submit");
+              const normalized = normalizePilotTarget(params.target);
+              if (!normalized) throw new Error(`Invalid Pilot target: ${params.target}`);
+              result = await pilotctl.submitTask(normalized, params.task, opts);
+            }
             break;
           case "list":
             result = await pilotctl.taskList(opts);

--- a/extensions/pilot/src/tools/pilot-trust.ts
+++ b/extensions/pilot/src/tools/pilot-trust.ts
@@ -1,5 +1,6 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
 import { resolvePilotAccount } from "../accounts.js";
+import { normalizePilotTarget } from "../normalize.js";
 import * as trust from "../trust.js";
 import type { CoreConfig } from "../types.js";
 
@@ -33,19 +34,23 @@ export function registerPilotTrustTool(api: OpenClawPluginApi) {
           pilotctlPath: account.pilotctlPath,
         };
 
+        const resolveTarget = (raw?: string): string => {
+          if (!raw) throw new Error("target required");
+          const normalized = normalizePilotTarget(raw);
+          if (!normalized) throw new Error(`Invalid Pilot target: ${raw}`);
+          return normalized;
+        };
+
         let result: unknown;
         switch (params.action) {
           case "handshake":
-            if (!params.target) throw new Error("target required for handshake");
-            result = await trust.handshake(params.target, opts);
+            result = await trust.handshake(resolveTarget(params.target), opts);
             break;
           case "approve":
-            if (!params.target) throw new Error("target required for approve");
-            result = await trust.approve(params.target, opts);
+            result = await trust.approve(resolveTarget(params.target), opts);
             break;
           case "reject":
-            if (!params.target) throw new Error("target required for reject");
-            result = await trust.reject(params.target, opts);
+            result = await trust.reject(resolveTarget(params.target), opts);
             break;
           case "list":
             result = await trust.listTrusted(opts);

--- a/extensions/pilot/src/tools/pilot-trust.ts
+++ b/extensions/pilot/src/tools/pilot-trust.ts
@@ -1,0 +1,73 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/pilot";
+import { resolvePilotAccount } from "../accounts.js";
+import * as trust from "../trust.js";
+import type { CoreConfig } from "../types.js";
+
+export function registerPilotTrustTool(api: OpenClawPluginApi) {
+  api.registerTool({
+    name: "pilot_trust",
+    label: "Pilot Trust",
+    description:
+      "Manage trust relationships on the Pilot Protocol network. " +
+      "Actions: handshake (initiate), approve, reject, list (trusted peers), pending (requests).",
+    parameters: {
+      type: "object",
+      properties: {
+        action: {
+          type: "string",
+          description: "Trust action: handshake, approve, reject, list, pending",
+        },
+        target: {
+          type: "string",
+          description: "Pilot address for handshake/approve/reject (not needed for list/pending)",
+        },
+      },
+      required: ["action"],
+    },
+    async execute(_id: string, params: { action: string; target?: string }) {
+      try {
+        const cfg = api.runtime.config.loadConfig() as CoreConfig;
+        const account = resolvePilotAccount({ cfg });
+        const opts = {
+          socketPath: account.socketPath,
+          pilotctlPath: account.pilotctlPath,
+        };
+
+        let result: unknown;
+        switch (params.action) {
+          case "handshake":
+            if (!params.target) throw new Error("target required for handshake");
+            result = await trust.handshake(params.target, opts);
+            break;
+          case "approve":
+            if (!params.target) throw new Error("target required for approve");
+            result = await trust.approve(params.target, opts);
+            break;
+          case "reject":
+            if (!params.target) throw new Error("target required for reject");
+            result = await trust.reject(params.target, opts);
+            break;
+          case "list":
+            result = await trust.listTrusted(opts);
+            break;
+          case "pending":
+            result = await trust.listPending(opts);
+            break;
+          default:
+            throw new Error(`Unknown trust action: ${params.action}`);
+        }
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+          details: undefined,
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  });
+}

--- a/extensions/pilot/src/trust.ts
+++ b/extensions/pilot/src/trust.ts
@@ -1,0 +1,27 @@
+import * as pilotctl from "./pilotctl.js";
+import type { PilotPeer, PilotTrustRequest } from "./types.js";
+
+type TrustOptions = {
+  socketPath?: string;
+  pilotctlPath?: string;
+};
+
+export async function handshake(addr: string, opts?: TrustOptions): Promise<{ status: string }> {
+  return pilotctl.trustHandshake(addr, opts);
+}
+
+export async function approve(addr: string, opts?: TrustOptions): Promise<{ status: string }> {
+  return pilotctl.trustApprove(addr, opts);
+}
+
+export async function reject(addr: string, opts?: TrustOptions): Promise<{ status: string }> {
+  return pilotctl.trustReject(addr, opts);
+}
+
+export async function listTrusted(opts?: TrustOptions): Promise<PilotPeer[]> {
+  return pilotctl.trustList(opts);
+}
+
+export async function listPending(opts?: TrustOptions): Promise<PilotTrustRequest[]> {
+  return pilotctl.trustPending(opts);
+}

--- a/extensions/pilot/src/types.ts
+++ b/extensions/pilot/src/types.ts
@@ -1,0 +1,68 @@
+import type {
+  BaseProbeResult,
+  DmPolicy,
+  MarkdownConfig,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk/pilot";
+
+export type PilotAccountConfig = {
+  name?: string;
+  enabled?: boolean;
+  hostname?: string;
+  socketPath?: string;
+  registry?: string;
+  pilotctlPath?: string;
+  pollIntervalMs?: number;
+  dmPolicy?: DmPolicy;
+  allowFrom?: string[];
+  defaultTo?: string;
+  markdown?: MarkdownConfig;
+  blockStreaming?: boolean;
+};
+
+export type PilotConfig = PilotAccountConfig & {
+  accounts?: Record<string, PilotAccountConfig>;
+  defaultAccount?: string;
+};
+
+export type CoreConfig = OpenClawConfig & {
+  channels?: OpenClawConfig["channels"] & {
+    pilot?: PilotConfig;
+  };
+};
+
+export type PilotInboundMessage = {
+  messageId: string;
+  sender: string;
+  senderHostname?: string;
+  text: string;
+  timestamp: number;
+};
+
+export type PilotProbe = BaseProbeResult<string> & {
+  daemonRunning: boolean;
+  address?: string;
+  hostname?: string;
+  trustedPeers?: number;
+  latencyMs?: number;
+};
+
+export type PilotPeer = {
+  address: string;
+  hostname?: string;
+  trusted: boolean;
+};
+
+export type PilotDaemonStatus = {
+  running: boolean;
+  address?: string;
+  hostname?: string;
+  registry?: string;
+  uptime?: number;
+};
+
+export type PilotTrustRequest = {
+  address: string;
+  hostname?: string;
+  timestamp: number;
+};

--- a/package.json
+++ b/package.json
@@ -156,6 +156,10 @@
       "types": "./dist/plugin-sdk/nostr.d.ts",
       "default": "./dist/plugin-sdk/nostr.js"
     },
+    "./plugin-sdk/pilot": {
+      "types": "./dist/plugin-sdk/pilot.d.ts",
+      "default": "./dist/plugin-sdk/pilot.js"
+    },
     "./plugin-sdk/open-prose": {
       "types": "./dist/plugin-sdk/open-prose.d.ts",
       "default": "./dist/plugin-sdk/open-prose.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,7 +346,7 @@ importers:
         version: 10.6.1
       openclaw:
         specifier: '>=2026.3.11'
-        version: 2026.3.11(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        version: 2026.3.12(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/imessage: {}
 
@@ -407,7 +407,7 @@ importers:
     dependencies:
       openclaw:
         specifier: '>=2026.3.11'
-        version: 2026.3.11(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        version: 2026.3.12(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/memory-lancedb:
     dependencies:
@@ -450,6 +450,12 @@ importers:
   extensions/ollama: {}
 
   extensions/open-prose: {}
+
+  extensions/pilot:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   extensions/sglang: {}
 
@@ -651,10 +657,6 @@ packages:
     resolution: {integrity: sha512-t8cl+bPLlHZQD2Sw1a4hSLUybqJZU71+m8znkyeU8CHntFqEp2mMbuLKdHKaAYQ1fAApXMsvzenCAkDzNeeJlw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-bedrock@3.1007.0':
-    resolution: {integrity: sha512-49hH8o6ALKkCiBUgg20HkwxNamP1yYA/n8Si73Z438EqhZGpCfScP3FfxVhrfD5o+4bV4Whi9BTzPKCa/PfUww==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/client-bedrock@3.1008.0':
     resolution: {integrity: sha512-mzxO/DplpZZT7AIZUCG7Q78OlaeHeDybYz+ZlWZPaXFjGDJwUv1E3SKskmaaQvTsMeieie0WX7gzueYrCx4YfQ==}
     engines: {node: '>=20.0.0'}
@@ -711,10 +713,6 @@ packages:
     resolution: {integrity: sha512-dFqh7nfX43B8dO1aPQHOcjC0SnCJ83H3F+1LoCh3X1P7E7N09I+0/taID0asU6GCddfDExqnEvQtDdkuMe5tKQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.18':
-    resolution: {integrity: sha512-vthIAXJISZnj2576HeyLBj4WTeX+I7PwWeRkbOa0mVX39K13SCGxCgOFuKj2ytm9qTlLOmXe4cdEnroteFtJfw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-ini@3.972.19':
     resolution: {integrity: sha512-pVJVjWqVrPqjpFq7o0mCmeZu1Y0c94OCHSYgivdCD2wfmYVtBbwQErakruhgOD8pcMcx9SCqRw1pzHKR7OGBcA==}
     engines: {node: '>=20.0.0'}
@@ -727,10 +725,6 @@ packages:
     resolution: {integrity: sha512-gf2E5b7LpKb+JX2oQsRIDxdRZjBFZt2olCGlWCdb3vBERbXIPgm2t1R5mEnwd4j0UEO/Tbg5zN2KJbHXttJqwA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.18':
-    resolution: {integrity: sha512-kINzc5BBxdYBkPZ0/i1AMPMOk5b5QaFNbYMElVw5QTX13AKj6jcxnv/YNl9oW9mg+Y08ti19hh01HhyEAxsSJQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-login@3.972.19':
     resolution: {integrity: sha512-jOXdZ1o+CywQKr6gyxgxuUmnGwTTnY2Kxs1PM7fI6AYtDWDnmW/yKXayNqkF8KjP1unflqMWKVbVt5VgmE3L0g==}
     engines: {node: '>=20.0.0'}
@@ -741,10 +735,6 @@ packages:
 
   '@aws-sdk/credential-provider-node@3.972.18':
     resolution: {integrity: sha512-ZDJa2gd1xiPg/nBDGhUlat02O8obaDEnICBAVS8qieZ0+nDfaB0Z3ec6gjZj27OqFTjnB/Q5a0GwQwb7rMVViw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.19':
-    resolution: {integrity: sha512-yDWQ9dFTr+IMxwanFe7+tbN5++q8psZBjlUwOiCXn1EzANoBgtqBwcpYcHaMGtn0Wlfj4NuXdf2JaEx1lz5RaQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.20':
@@ -771,10 +761,6 @@ packages:
     resolution: {integrity: sha512-wGtte+48xnhnhHMl/MsxzacBPs5A+7JJedjiP452IkHY7vsbYKcvQBqFye8LwdTJVeHtBHv+JFeTscnwepoWGg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.18':
-    resolution: {integrity: sha512-YHYEfj5S2aqInRt5ub8nDOX8vAxgMvd84wm2Y3WVNfFa/53vOv9T7WOAqXI25qjj3uEcV46xxfqdDQk04h5XQA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-sso@3.972.19':
     resolution: {integrity: sha512-kVjQsEU3b///q7EZGrUzol9wzwJFKbEzqJKSq82A9ShrUTEO7FNylTtby3sPV19ndADZh1H3FB3+5ZrvKtEEeg==}
     engines: {node: '>=20.0.0'}
@@ -785,10 +771,6 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.17':
     resolution: {integrity: sha512-8aiVJh6fTdl8gcyL+sVNcNwTtWpmoFa1Sh7xlj6Z7L/cZ/tYMEBHq44wTYG8Kt0z/PpGNopD89nbj3FHl9QmTA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.18':
-    resolution: {integrity: sha512-OqlEQpJ+J3T5B96qtC1zLLwkBloechP+fezKbCH0sbd2cCc0Ra55XpxWpk/hRj69xAOYtHvoC4orx6eTa4zU7g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.19':
@@ -875,10 +857,6 @@ packages:
     resolution: {integrity: sha512-MlGWA8uPaOs5AiTZ5JLM4uuWDm9EEAnm9cqwvqQIc6kEgel/8s1BaOWm9QgUcfc9K8qd7KkC3n43yDbeXOA2tg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.8':
-    resolution: {integrity: sha512-6HlLm8ciMW8VzfB80kfIx16PBA9lOa9Dl+dmCBi78JDhvGlx3I7Rorwi5PpVRkL31RprXnYna3yBf6UKkD/PqA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/nested-clients@3.996.9':
     resolution: {integrity: sha512-+RpVtpmQbbtzFOKhMlsRcXM/3f1Z49qTOHaA8gEpHOYruERmog6f2AUtf/oTRLCWjR9H2b3roqryV/hI7QMW8w==}
     engines: {node: '>=20.0.0'}
@@ -901,14 +879,6 @@ packages:
 
   '@aws-sdk/token-providers@3.1004.0':
     resolution: {integrity: sha512-j9BwZZId9sFp+4GPhf6KrwO8Tben2sXibZA8D1vv2I1zBdvkUHcBA2g4pkqIpTRalMTLC0NPkBPX0gERxfy/iA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1005.0':
-    resolution: {integrity: sha512-vMxd+ivKqSxU9bHx5vmAlFKDAkjGotFU56IOkDa5DaTu1WWwbcse0yFHEm9I537oVvodaiwMl3VBwgHfzQ2rvw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1007.0':
-    resolution: {integrity: sha512-kKvVyr53vvVc5k6RbvI6jhafxufxO2SkEw8QeEzJqwOXH/IMY7Cm0IyhnBGdqj80iiIIiIM2jGe7Fn3TIdwdrw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1008.0':
@@ -951,10 +921,6 @@ packages:
     resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-locate-window@3.965.5':
-    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/util-user-agent-browser@3.972.6':
     resolution: {integrity: sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==}
 
@@ -972,15 +938,6 @@ packages:
 
   '@aws-sdk/util-user-agent-node@3.973.4':
     resolution: {integrity: sha512-uqKeLqZ9D3nQjH7HGIERNXK9qnSpUK08l4MlJ5/NZqSSdeJsVANYp437EM9sEzwU28c2xfj2V6qlkqzsgtKs6Q==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
-
-  '@aws-sdk/util-user-agent-node@3.973.5':
-    resolution: {integrity: sha512-Dyy38O4GeMk7UQ48RupfHif//gqnOPbq/zlvRssc11E2mClT+aUfc3VS2yD8oLtzqO3RsqQ9I3gOBB4/+HjPOw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -1007,10 +964,6 @@ packages:
 
   '@aws/lambda-invoke-store@0.2.3':
     resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws/lambda-invoke-store@0.2.4':
-    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
   '@azure/abort-controller@2.1.2':
@@ -1081,6 +1034,9 @@ packages:
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@borewit/text-codec@0.2.1':
+    resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -2823,10 +2779,6 @@ packages:
     resolution: {integrity: sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/abort-controller@4.2.12':
-    resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/chunked-blob-reader-native@4.2.2':
     resolution: {integrity: sha512-QzzYIlf4yg0w5TQaC9VId3B3ugSk1MI/wb7tgcHtd7CBV9gNRKZrhc2EPSxSZuDy10zUZ0lomNMgkc6/VVe8xg==}
     engines: {node: '>=18.0.0'}
@@ -2839,16 +2791,8 @@ packages:
     resolution: {integrity: sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/config-resolver@4.4.11':
-    resolution: {integrity: sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/config-resolver@4.4.9':
     resolution: {integrity: sha512-ejQvXqlcU30h7liR9fXtj7PIAau1t/sFbJpgWPfiYDs7zd16jpH0IsSXKcba2jF6ChTXvIjACs27kNMc5xxE2Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/core@3.23.11':
-    resolution: {integrity: sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/core@3.23.6':
@@ -2865,10 +2809,6 @@ packages:
 
   '@smithy/credential-provider-imds@4.2.11':
     resolution: {integrity: sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/credential-provider-imds@4.2.12':
-    resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.10':
@@ -2919,10 +2859,6 @@ packages:
     resolution: {integrity: sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/fetch-http-handler@5.3.15':
-    resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/hash-blob-browser@4.2.11':
     resolution: {integrity: sha512-DrcAx3PM6AEbWZxsKl6CWAGnVwiz28Wp1ZhNu+Hi4uI/6C1PIZBIaPM2VoqBDAsOWbM6ZVzOEQMxFLLdmb4eBQ==}
     engines: {node: '>=18.0.0'}
@@ -2935,10 +2871,6 @@ packages:
     resolution: {integrity: sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/hash-node@4.2.12':
-    resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/hash-stream-node@4.2.10':
     resolution: {integrity: sha512-w78xsYrOlwXKwN5tv1GnKIRbHb1HygSpeZMP6xDxCPGf1U/xDHjCpJu64c5T35UKyEPwa0bPeIcvU69VY3khUA==}
     engines: {node: '>=18.0.0'}
@@ -2949,10 +2881,6 @@ packages:
 
   '@smithy/invalid-dependency@4.2.11':
     resolution: {integrity: sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/invalid-dependency@4.2.12':
-    resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -2979,20 +2907,12 @@ packages:
     resolution: {integrity: sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-content-length@4.2.12':
-    resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/middleware-endpoint@4.4.20':
     resolution: {integrity: sha512-9W6Np4ceBP3XCYAGLoMCmn8t2RRVzuD1ndWPLBbv7H9CrwM9Bprf6Up6BM9ZA/3alodg0b7Kf6ftBK9R1N04vw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-endpoint@4.4.23':
     resolution: {integrity: sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-endpoint@4.4.25':
-    resolution: {integrity: sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-retry@4.4.37':
@@ -3003,20 +2923,12 @@ packages:
     resolution: {integrity: sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.4.42':
-    resolution: {integrity: sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/middleware-serde@4.2.11':
     resolution: {integrity: sha512-STQdONGPwbbC7cusL60s7vOa6He6A9w2jWhoapL0mgVjmR19pr26slV+yoSP76SIssMTX/95e5nOZ6UQv6jolg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-serde@4.2.12':
     resolution: {integrity: sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-serde@4.2.14':
-    resolution: {integrity: sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-stack@4.2.10':
@@ -3027,20 +2939,12 @@ packages:
     resolution: {integrity: sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-stack@4.2.12':
-    resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-config-provider@4.3.10':
     resolution: {integrity: sha512-UALRbJtVX34AdP2VECKVlnNgidLHA2A7YgcJzwSBg1hzmnO/bZBHl/LDQQyYifzUwp1UOODnl9JJ3KNawpUJ9w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-config-provider@4.3.11':
     resolution: {integrity: sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-config-provider@4.3.12':
-    resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.4.12':
@@ -3051,20 +2955,12 @@ packages:
     resolution: {integrity: sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.4.16':
-    resolution: {integrity: sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/property-provider@4.2.10':
     resolution: {integrity: sha512-5jm60P0CU7tom0eNrZ7YrkgBaoLFXzmqB0wVS+4uK8PPGmosSrLNf6rRd50UBvukztawZ7zyA8TxlrKpF5z9jw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.2.11':
     resolution: {integrity: sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/property-provider@4.2.12':
-    resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/protocol-http@5.3.10':
@@ -3075,20 +2971,12 @@ packages:
     resolution: {integrity: sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/protocol-http@5.3.12':
-    resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/querystring-builder@4.2.10':
     resolution: {integrity: sha512-HeN7kEvuzO2DmAzLukE9UryiUvejD3tMp9a1D1NJETerIfKobBUCLfviP6QEk500166eD2IATaXM59qgUI+YDA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-builder@4.2.11':
     resolution: {integrity: sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-builder@4.2.12':
-    resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-parser@4.2.10':
@@ -3099,20 +2987,12 @@ packages:
     resolution: {integrity: sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-parser@4.2.12':
-    resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/service-error-classification@4.2.10':
     resolution: {integrity: sha512-0R/+/Il5y8nB/By90o8hy/bWVYptbIfvoTYad0igYQO5RefhNCDmNzqxaMx7K1t/QWo0d6UynqpqN5cCQt1MCg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/service-error-classification@4.2.11':
     resolution: {integrity: sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/service-error-classification@4.2.12':
-    resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/shared-ini-file-loader@4.4.5':
@@ -3123,20 +3003,12 @@ packages:
     resolution: {integrity: sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/shared-ini-file-loader@4.4.7':
-    resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/signature-v4@5.3.10':
     resolution: {integrity: sha512-Wab3wW8468WqTKIxI+aZe3JYO52/RYT/8sDOdzkUhjnLakLe9qoQqIcfih/qxcF4qWEFoWBszY0mj5uxffaVXA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.3.11':
     resolution: {integrity: sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/signature-v4@5.3.12':
-    resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.0':
@@ -3147,16 +3019,8 @@ packages:
     resolution: {integrity: sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@4.12.5':
-    resolution: {integrity: sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/types@4.13.0':
     resolution: {integrity: sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.13.1':
-    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.10':
@@ -3165,10 +3029,6 @@ packages:
 
   '@smithy/url-parser@4.2.11':
     resolution: {integrity: sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/url-parser@4.2.12':
-    resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-base64@4.3.1':
@@ -3223,10 +3083,6 @@ packages:
     resolution: {integrity: sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-browser@4.3.41':
-    resolution: {integrity: sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-defaults-mode-node@4.2.39':
     resolution: {integrity: sha512-otWuoDm35btJV1L8MyHrPl462B07QCdMTktKc7/yM+Psv6KbED/ziXiHnmr7yPHUjfIwE9S8Max0LO24Mo3ZVg==}
     engines: {node: '>=18.0.0'}
@@ -3235,20 +3091,12 @@ packages:
     resolution: {integrity: sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-node@4.2.44':
-    resolution: {integrity: sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-endpoints@3.3.1':
     resolution: {integrity: sha512-xyctc4klmjmieQiF9I1wssBWleRV0RhJ2DpO8+8yzi2LO1Z+4IWOZNGZGNj4+hq9kdo+nyfrRLmQTzc16Op2Vg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-endpoints@3.3.2':
     resolution: {integrity: sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-endpoints@3.3.3':
-    resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-hex-encoding@4.2.1':
@@ -3267,10 +3115,6 @@ packages:
     resolution: {integrity: sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-middleware@4.2.12':
-    resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-retry@4.2.10':
     resolution: {integrity: sha512-HrBzistfpyE5uqTwiyLsFHscgnwB0kgv8vySp7q5kZ0Eltn/tjosaSGGDj/jJ9ys7pWzIP/icE2d+7vMKXLv7A==}
     engines: {node: '>=18.0.0'}
@@ -3279,20 +3123,12 @@ packages:
     resolution: {integrity: sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-retry@4.2.12':
-    resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-stream@4.5.15':
     resolution: {integrity: sha512-OlOKnaqnkU9X+6wEkd7mN+WB7orPbCVDauXOj22Q7VtiTkvy7ZdSsOg4QiNAZMgI4OkvNf+/VLUC3VXkxuWJZw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-stream@4.5.17':
     resolution: {integrity: sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.5.19':
-    resolution: {integrity: sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.1':
@@ -3580,8 +3416,8 @@ packages:
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
-  '@types/node@24.12.0':
-    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
+  '@types/node@24.11.0':
+    resolution: {integrity: sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==}
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
@@ -3976,36 +3812,6 @@ packages:
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
-
-  bare-fs@4.5.5:
-    resolution: {integrity: sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==}
-    engines: {bare: '>=1.16.0'}
-    peerDependencies:
-      bare-buffer: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-
-  bare-os@3.7.1:
-    resolution: {integrity: sha512-ebvMaS5BgZKmJlvuWh14dg9rbUI84QeV3WlWn6Ph6lFI8jJoh7ADtVTyD2c93euwbe+zgi0DVrl4YmqXeM9aIA==}
-    engines: {bare: '>=1.14.0'}
-
-  bare-path@3.0.0:
-    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
-
-  bare-stream@2.8.1:
-    resolution: {integrity: sha512-bSeR8RfvbRwDpD7HWZvn8M3uYNDrk7m9DQjYOFkENZlXW8Ju/MPaqUPQq5LqJ3kyjEm07siTaAQ7wBKCU59oHg==}
-    peerDependencies:
-      bare-buffer: '*'
-      bare-events: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-      bare-events:
-        optional: true
-
-  bare-url@2.3.2:
-    resolution: {integrity: sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -5689,13 +5495,16 @@ packages:
       zod:
         optional: true
 
-  openclaw@2026.3.11:
-    resolution: {integrity: sha512-bxwiBmHPakwfpY5tqC9lrV5TCu5PKf0c1bHNc3nhrb+pqKcPEWV4zOjDVFLQUHr98ihgWA+3pacy4b3LQ8wduQ==}
-    engines: {node: '>=22.12.0'}
+  openclaw@2026.3.12:
+    resolution: {integrity: sha512-Y/KDt1vrxMqKqbBRL0ZELmNhleGZ0657a65WyH3Dy/0s+MfrbfqG0jb2b9TUE+P5BVEbj80U+37If7/v2l/eiQ==}
+    engines: {node: '>=22.16.0'}
     hasBin: true
     peerDependencies:
       '@napi-rs/canvas': ^0.1.89
       node-llama-cpp: 3.16.2
+    peerDependenciesMeta:
+      node-llama-cpp:
+        optional: true
 
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
@@ -6488,15 +6297,12 @@ packages:
     resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
     engines: {node: '>=12.17'}
 
-  tar-stream@3.1.8:
-    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
   tar@7.5.11:
     resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
     engines: {node: '>=18'}
-
-  teex@1.0.1:
-    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -6526,8 +6332,8 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
-  tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -6666,10 +6472,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
-    engines: {node: '>=20.18.1'}
 
   undici@7.24.0:
     resolution: {integrity: sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==}
@@ -7048,7 +6850,7 @@ snapshots:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.973.5
-      '@aws-sdk/util-locate-window': 3.965.5
+      '@aws-sdk/util-locate-window': 3.965.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -7120,22 +6922,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-bedrock@3.1007.0':
+  '@aws-sdk/client-bedrock@3.1008.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.973.19
-      '@aws-sdk/credential-provider-node': 3.972.19
+      '@aws-sdk/credential-provider-node': 3.972.20
       '@aws-sdk/middleware-host-header': 3.972.7
       '@aws-sdk/middleware-logger': 3.972.7
       '@aws-sdk/middleware-recursion-detection': 3.972.7
       '@aws-sdk/middleware-user-agent': 3.972.20
       '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/token-providers': 3.1007.0
+      '@aws-sdk/token-providers': 3.1008.0
       '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
-      '@aws-sdk/util-user-agent-node': 3.973.5
+      '@aws-sdk/util-user-agent-node': 3.973.6
       '@smithy/config-resolver': 4.4.10
       '@smithy/core': 3.23.9
       '@smithy/fetch-http-handler': 5.3.13
@@ -7160,51 +6962,6 @@ snapshots:
       '@smithy/util-endpoints': 3.3.2
       '@smithy/util-middleware': 4.2.11
       '@smithy/util-retry': 4.2.11
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-bedrock@3.1008.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.19
-      '@aws-sdk/credential-provider-node': 3.972.20
-      '@aws-sdk/middleware-host-header': 3.972.7
-      '@aws-sdk/middleware-logger': 3.972.7
-      '@aws-sdk/middleware-recursion-detection': 3.972.7
-      '@aws-sdk/middleware-user-agent': 3.972.20
-      '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/token-providers': 3.1008.0
-      '@aws-sdk/types': 3.973.5
-      '@aws-sdk/util-endpoints': 3.996.4
-      '@aws-sdk/util-user-agent-browser': 3.972.7
-      '@aws-sdk/util-user-agent-node': 3.973.6
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7306,15 +7063,15 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.5
       '@aws-sdk/xml-builder': 3.972.10
-      '@smithy/core': 3.23.11
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
+      '@smithy/core': 3.23.9
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/property-provider': 4.2.11
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/signature-v4': 5.3.11
+      '@smithy/smithy-client': 4.12.3
+      '@smithy/types': 4.13.0
       '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-middleware': 4.2.11
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
@@ -7343,8 +7100,8 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/property-provider': 4.2.11
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.15':
@@ -7377,13 +7134,13 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/types': 3.973.5
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.19
+      '@smithy/fetch-http-handler': 5.3.13
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/property-provider': 4.2.11
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.3
+      '@smithy/types': 4.13.0
+      '@smithy/util-stream': 4.5.17
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.13':
@@ -7424,25 +7181,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.972.18':
-    dependencies:
-      '@aws-sdk/core': 3.973.19
-      '@aws-sdk/credential-provider-env': 3.972.17
-      '@aws-sdk/credential-provider-http': 3.972.19
-      '@aws-sdk/credential-provider-login': 3.972.18
-      '@aws-sdk/credential-provider-process': 3.972.17
-      '@aws-sdk/credential-provider-sso': 3.972.18
-      '@aws-sdk/credential-provider-web-identity': 3.972.18
-      '@aws-sdk/nested-clients': 3.996.8
-      '@aws-sdk/types': 3.973.5
-      '@smithy/credential-provider-imds': 4.2.11
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-ini@3.972.19':
     dependencies:
       '@aws-sdk/core': 3.973.19
@@ -7454,10 +7192,10 @@ snapshots:
       '@aws-sdk/credential-provider-web-identity': 3.972.19
       '@aws-sdk/nested-clients': 3.996.9
       '@aws-sdk/types': 3.973.5
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/credential-provider-imds': 4.2.11
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7488,28 +7226,15 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.18':
-    dependencies:
-      '@aws-sdk/core': 3.973.19
-      '@aws-sdk/nested-clients': 3.996.8
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-login@3.972.19':
     dependencies:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.996.9
       '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/property-provider': 4.2.11
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7548,23 +7273,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.19':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.17
-      '@aws-sdk/credential-provider-http': 3.972.19
-      '@aws-sdk/credential-provider-ini': 3.972.18
-      '@aws-sdk/credential-provider-process': 3.972.17
-      '@aws-sdk/credential-provider-sso': 3.972.18
-      '@aws-sdk/credential-provider-web-identity': 3.972.18
-      '@aws-sdk/types': 3.973.5
-      '@smithy/credential-provider-imds': 4.2.11
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-node@3.972.20':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.972.17
@@ -7574,10 +7282,10 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.972.19
       '@aws-sdk/credential-provider-web-identity': 3.972.19
       '@aws-sdk/types': 3.973.5
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/credential-provider-imds': 4.2.11
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7604,9 +7312,9 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.13':
@@ -7635,28 +7343,15 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-sso@3.972.18':
-    dependencies:
-      '@aws-sdk/core': 3.973.19
-      '@aws-sdk/nested-clients': 3.996.8
-      '@aws-sdk/token-providers': 3.1005.0
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-sso@3.972.19':
     dependencies:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.996.9
       '@aws-sdk/token-providers': 3.1008.0
       '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7685,26 +7380,14 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.18':
-    dependencies:
-      '@aws-sdk/core': 3.973.19
-      '@aws-sdk/nested-clients': 3.996.8
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-web-identity@3.972.19':
     dependencies:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.996.9
       '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7767,8 +7450,8 @@ snapshots:
   '@aws-sdk/middleware-host-header@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.5
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-location-constraint@3.972.6':
@@ -7786,7 +7469,7 @@ snapshots:
   '@aws-sdk/middleware-logger@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.5
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.972.6':
@@ -7800,9 +7483,9 @@ snapshots:
   '@aws-sdk/middleware-recursion-detection@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.5
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.972.15':
@@ -7854,10 +7537,10 @@ snapshots:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-endpoints': 3.996.4
-      '@smithy/core': 3.23.11
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-retry': 4.2.12
+      '@smithy/core': 3.23.9
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/types': 4.13.0
+      '@smithy/util-retry': 4.2.11
       tslib: 2.8.1
 
   '@aws-sdk/middleware-websocket@3.972.12':
@@ -7961,7 +7644,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/nested-clients@3.996.8':
+  '@aws-sdk/nested-clients@3.996.9':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
@@ -7974,7 +7657,7 @@ snapshots:
       '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-endpoints': 3.996.4
       '@aws-sdk/util-user-agent-browser': 3.972.7
-      '@aws-sdk/util-user-agent-node': 3.973.5
+      '@aws-sdk/util-user-agent-node': 3.973.6
       '@smithy/config-resolver': 4.4.10
       '@smithy/core': 3.23.9
       '@smithy/fetch-http-handler': 5.3.13
@@ -7999,49 +7682,6 @@ snapshots:
       '@smithy/util-endpoints': 3.3.2
       '@smithy/util-middleware': 4.2.11
       '@smithy/util-retry': 4.2.11
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/nested-clients@3.996.9':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.19
-      '@aws-sdk/middleware-host-header': 3.972.7
-      '@aws-sdk/middleware-logger': 3.972.7
-      '@aws-sdk/middleware-recursion-detection': 3.972.7
-      '@aws-sdk/middleware-user-agent': 3.972.20
-      '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
-      '@aws-sdk/util-endpoints': 3.996.4
-      '@aws-sdk/util-user-agent-browser': 3.972.7
-      '@aws-sdk/util-user-agent-node': 3.973.6
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -8095,38 +7735,14 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/token-providers@3.1005.0':
-    dependencies:
-      '@aws-sdk/core': 3.973.19
-      '@aws-sdk/nested-clients': 3.996.8
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/token-providers@3.1007.0':
-    dependencies:
-      '@aws-sdk/core': 3.973.19
-      '@aws-sdk/nested-clients': 3.996.8
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/token-providers@3.1008.0':
     dependencies:
       '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.996.9
       '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -8168,9 +7784,9 @@ snapshots:
   '@aws-sdk/util-endpoints@3.996.4':
     dependencies:
       '@aws-sdk/types': 3.973.5
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-endpoints': 3.3.3
+      '@smithy/types': 4.13.0
+      '@smithy/url-parser': 4.2.11
+      '@smithy/util-endpoints': 3.3.2
       tslib: 2.8.1
 
   '@aws-sdk/util-format-url@3.972.6':
@@ -8191,10 +7807,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-locate-window@3.965.5':
-    dependencies:
-      tslib: 2.8.1
-
   '@aws-sdk/util-user-agent-browser@3.972.6':
     dependencies:
       '@aws-sdk/types': 3.973.4
@@ -8205,7 +7817,7 @@ snapshots:
   '@aws-sdk/util-user-agent-browser@3.972.7':
     dependencies:
       '@aws-sdk/types': 3.973.5
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.13.0
       bowser: 2.14.1
       tslib: 2.8.1
 
@@ -8225,20 +7837,12 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.5':
+  '@aws-sdk/util-user-agent-node@3.973.6':
     dependencies:
       '@aws-sdk/middleware-user-agent': 3.972.20
       '@aws-sdk/types': 3.973.5
       '@smithy/node-config-provider': 4.3.11
       '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-node@3.973.6':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.20
-      '@aws-sdk/types': 3.973.5
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
@@ -8255,8 +7859,6 @@ snapshots:
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
-
-  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@azure/abort-controller@2.1.2':
     dependencies:
@@ -8326,6 +7928,8 @@ snapshots:
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@blazediff/core@1.9.1': {}
+
+  '@borewit/text-codec@0.2.1': {}
 
   '@borewit/text-codec@0.2.2': {}
 
@@ -8928,7 +8532,7 @@ snapshots:
 
   '@line/bot-sdk@10.6.0':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.11.0
     optionalDependencies:
       axios: 1.13.5
     transitivePeerDependencies:
@@ -10047,11 +9651,6 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@smithy/abort-controller@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/chunked-blob-reader-native@4.2.2':
     dependencies:
       '@smithy/util-base64': 4.3.1
@@ -10070,15 +9669,6 @@ snapshots:
       '@smithy/util-middleware': 4.2.11
       tslib: 2.8.1
 
-  '@smithy/config-resolver@4.4.11':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
   '@smithy/config-resolver@4.4.9':
     dependencies:
       '@smithy/node-config-provider': 4.3.10
@@ -10086,19 +9676,6 @@ snapshots:
       '@smithy/util-config-provider': 4.2.1
       '@smithy/util-endpoints': 3.3.1
       '@smithy/util-middleware': 4.2.10
-      tslib: 2.8.1
-
-  '@smithy/core@3.23.11':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.19
-      '@smithy/util-utf8': 4.2.2
-      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
   '@smithy/core@3.23.6':
@@ -10141,14 +9718,6 @@ snapshots:
       '@smithy/property-provider': 4.2.11
       '@smithy/types': 4.13.0
       '@smithy/url-parser': 4.2.11
-      tslib: 2.8.1
-
-  '@smithy/credential-provider-imds@4.2.12':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.10':
@@ -10227,14 +9796,6 @@ snapshots:
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
-  '@smithy/fetch-http-handler@5.3.15':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      tslib: 2.8.1
-
   '@smithy/hash-blob-browser@4.2.11':
     dependencies:
       '@smithy/chunked-blob-reader': 5.2.1
@@ -10256,13 +9817,6 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/hash-node@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
   '@smithy/hash-stream-node@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -10277,11 +9831,6 @@ snapshots:
   '@smithy/invalid-dependency@4.2.11':
     dependencies:
       '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/invalid-dependency@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -10314,12 +9863,6 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@smithy/middleware-content-length@4.2.12':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/middleware-endpoint@4.4.20':
     dependencies:
       '@smithy/core': 3.23.6
@@ -10340,17 +9883,6 @@ snapshots:
       '@smithy/types': 4.13.0
       '@smithy/url-parser': 4.2.11
       '@smithy/util-middleware': 4.2.11
-      tslib: 2.8.1
-
-  '@smithy/middleware-endpoint@4.4.25':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
   '@smithy/middleware-retry@4.4.37':
@@ -10377,18 +9909,6 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/middleware-retry@4.4.42':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/uuid': 1.1.2
-      tslib: 2.8.1
-
   '@smithy/middleware-serde@4.2.11':
     dependencies:
       '@smithy/protocol-http': 5.3.10
@@ -10401,13 +9921,6 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@smithy/middleware-serde@4.2.14':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/middleware-stack@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -10416,11 +9929,6 @@ snapshots:
   '@smithy/middleware-stack@4.2.11':
     dependencies:
       '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-stack@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.10':
@@ -10435,13 +9943,6 @@ snapshots:
       '@smithy/property-provider': 4.2.11
       '@smithy/shared-ini-file-loader': 4.4.6
       '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.3.12':
-    dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.4.12':
@@ -10460,14 +9961,6 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.4.16':
-    dependencies:
-      '@smithy/abort-controller': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/property-provider@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -10478,11 +9971,6 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@smithy/property-provider@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/protocol-http@5.3.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -10491,11 +9979,6 @@ snapshots:
   '@smithy/protocol-http@5.3.11':
     dependencies:
       '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.3.12':
-    dependencies:
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/querystring-builder@4.2.10':
@@ -10510,12 +9993,6 @@ snapshots:
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/querystring-builder@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-uri-escape': 4.2.2
-      tslib: 2.8.1
-
   '@smithy/querystring-parser@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -10526,11 +10003,6 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@smithy/querystring-parser@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/service-error-classification@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -10538,10 +10010,6 @@ snapshots:
   '@smithy/service-error-classification@4.2.11':
     dependencies:
       '@smithy/types': 4.13.0
-
-  '@smithy/service-error-classification@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
 
   '@smithy/shared-ini-file-loader@4.4.5':
     dependencies:
@@ -10551,11 +10019,6 @@ snapshots:
   '@smithy/shared-ini-file-loader@4.4.6':
     dependencies:
       '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/shared-ini-file-loader@4.4.7':
-    dependencies:
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.3.10':
@@ -10580,17 +10043,6 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/signature-v4@5.3.12':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-uri-escape': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
   '@smithy/smithy-client@4.12.0':
     dependencies:
       '@smithy/core': 3.23.6
@@ -10611,21 +10063,7 @@ snapshots:
       '@smithy/util-stream': 4.5.17
       tslib: 2.8.1
 
-  '@smithy/smithy-client@4.12.5':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.19
-      tslib: 2.8.1
-
   '@smithy/types@4.13.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/types@4.13.1':
     dependencies:
       tslib: 2.8.1
 
@@ -10639,12 +10077,6 @@ snapshots:
     dependencies:
       '@smithy/querystring-parser': 4.2.11
       '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/url-parser@4.2.12':
-    dependencies:
-      '@smithy/querystring-parser': 4.2.12
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/util-base64@4.3.1':
@@ -10712,13 +10144,6 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-browser@4.3.41':
-    dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/util-defaults-mode-node@4.2.39':
     dependencies:
       '@smithy/config-resolver': 4.4.9
@@ -10739,16 +10164,6 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-node@4.2.44':
-    dependencies:
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/util-endpoints@3.3.1':
     dependencies:
       '@smithy/node-config-provider': 4.3.10
@@ -10759,12 +10174,6 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 4.3.11
       '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/util-endpoints@3.3.3':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/util-hex-encoding@4.2.1':
@@ -10785,11 +10194,6 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@smithy/util-middleware@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/util-retry@4.2.10':
     dependencies:
       '@smithy/service-error-classification': 4.2.10
@@ -10800,12 +10204,6 @@ snapshots:
     dependencies:
       '@smithy/service-error-classification': 4.2.11
       '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/util-retry@4.2.12':
-    dependencies:
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.15':
@@ -10824,17 +10222,6 @@ snapshots:
       '@smithy/fetch-http-handler': 5.3.13
       '@smithy/node-http-handler': 4.4.14
       '@smithy/types': 4.13.0
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.19':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
@@ -11159,7 +10546,7 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.12.0':
+  '@types/node@24.11.0':
     dependencies:
       undici-types: 7.16.0
 
@@ -11294,7 +10681,7 @@ snapshots:
       '@vitest/browser': 4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.0.3
       vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/browser-playwright@4.1.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
@@ -11310,7 +10697,7 @@ snapshots:
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.0.3
       vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/browser-playwright@4.1.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
@@ -11330,7 +10717,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       std-env: 4.0.0
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.0.3
       vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/browser-playwright@4.1.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
       '@vitest/browser': 4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
@@ -11342,7 +10729,7 @@ snapshots:
       '@vitest/spy': 4.1.0
       '@vitest/utils': 4.1.0
       chai: 6.2.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.0.3
 
   '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -11354,7 +10741,7 @@ snapshots:
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.0.3
 
   '@vitest/runner@4.1.0':
     dependencies:
@@ -11374,7 +10761,7 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.1.0
       convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.0.3
 
   '@wasm-audio-decoders/common@9.0.7':
     dependencies:
@@ -11456,7 +10843,6 @@ snapshots:
       skillflag: 0.1.4
     transitivePeerDependencies:
       - bare-abort-controller
-      - bare-buffer
       - react-native-b4a
       - zod
 
@@ -11614,37 +11000,6 @@ snapshots:
   balanced-match@4.0.4: {}
 
   bare-events@2.8.2: {}
-
-  bare-fs@4.5.5:
-    dependencies:
-      bare-events: 2.8.2
-      bare-path: 3.0.0
-      bare-stream: 2.8.1(bare-events@2.8.2)
-      bare-url: 2.3.2
-      fast-fifo: 1.3.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  bare-os@3.7.1: {}
-
-  bare-path@3.0.0:
-    dependencies:
-      bare-os: 3.7.1
-
-  bare-stream@2.8.1(bare-events@2.8.2):
-    dependencies:
-      streamx: 2.23.0
-      teex: 1.0.1
-    optionalDependencies:
-      bare-events: 2.8.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  bare-url@2.3.2:
-    dependencies:
-      bare-path: 3.0.0
 
   base64-js@1.5.1: {}
 
@@ -13497,10 +12852,10 @@ snapshots:
       ws: 8.19.0
       zod: 4.3.6
 
-  openclaw@2026.3.11(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+  openclaw@2026.3.12(@discordjs/opus@0.10.0)(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(node-llama-cpp@3.16.2(typescript@5.9.3)):
     dependencies:
       '@agentclientprotocol/sdk': 0.16.1(zod@4.3.6)
-      '@aws-sdk/client-bedrock': 3.1007.0
+      '@aws-sdk/client-bedrock': 3.1008.0
       '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.7)(opusscript@0.1.1)
       '@clack/prompts': 1.1.0
       '@discordjs/voice': 0.19.1(@discordjs/opus@0.10.0)(opusscript@0.1.1)
@@ -13541,7 +12896,6 @@ snapshots:
       long: 5.3.2
       markdown-it: 14.1.1
       node-edge-tts: 1.2.10
-      node-llama-cpp: 3.16.2(typescript@5.9.3)
       opusscript: 0.1.1
       osc-progress: 0.3.0
       pdfjs-dist: 5.5.207
@@ -13551,10 +12905,12 @@ snapshots:
       sqlite-vec: 0.1.7-alpha.2
       tar: 7.5.11
       tslog: 4.10.2
-      undici: 7.22.0
+      undici: 7.24.0
       ws: 8.19.0
       yaml: 2.8.2
       zod: 4.3.6
+    optionalDependencies:
+      node-llama-cpp: 3.16.2(typescript@5.9.3)
     transitivePeerDependencies:
       - '@discordjs/opus'
       - '@modelcontextprotocol/sdk'
@@ -14360,10 +13716,9 @@ snapshots:
   skillflag@0.1.4:
     dependencies:
       '@clack/prompts': 1.1.0
-      tar-stream: 3.1.8
+      tar-stream: 3.1.7
     transitivePeerDependencies:
       - bare-abort-controller
-      - bare-buffer
       - react-native-b4a
 
   sleep-promise@9.1.0: {}
@@ -14551,15 +13906,13 @@ snapshots:
       array-back: 6.2.2
       wordwrapjs: 5.1.1
 
-  tar-stream@3.1.8:
+  tar-stream@3.1.7:
     dependencies:
       b4a: 1.8.0
-      bare-fs: 4.5.5
       fast-fifo: 1.3.2
       streamx: 2.23.0
     transitivePeerDependencies:
       - bare-abort-controller
-      - bare-buffer
       - react-native-b4a
 
   tar@7.5.11:
@@ -14569,13 +13922,6 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
-
-  teex@1.0.1:
-    dependencies:
-      streamx: 2.23.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
 
   text-decoder@1.2.7:
     dependencies:
@@ -14606,7 +13952,7 @@ snapshots:
 
   tinypool@2.1.0: {}
 
-  tinyrainbow@3.1.0: {}
+  tinyrainbow@3.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -14620,7 +13966,7 @@ snapshots:
 
   token-types@6.1.2:
     dependencies:
-      '@borewit/text-codec': 0.2.2
+      '@borewit/text-codec': 0.2.1
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
@@ -14724,8 +14070,6 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici-types@7.18.2: {}
-
-  undici@7.22.0: {}
 
   undici@7.24.0: {}
 
@@ -14838,7 +14182,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.0.3
       vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/src/plugin-sdk/pilot.ts
+++ b/src/plugin-sdk/pilot.ts
@@ -1,0 +1,45 @@
+// Narrow plugin-sdk surface for the bundled pilot plugin.
+// Keep this list additive and scoped to symbols used under extensions/pilot.
+
+export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
+export { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
+export { formatPairingApproveHint } from "../channels/plugins/helpers.js";
+export type {
+  ChannelOnboardingAdapter,
+  ChannelOnboardingDmPolicy,
+} from "../channels/plugins/onboarding-types.js";
+export {
+  resolveAccountIdForConfigure,
+  setTopLevelChannelDmPolicyWithAllowFrom,
+} from "../channels/plugins/onboarding/helpers.js";
+export { PAIRING_APPROVED_MESSAGE } from "../channels/plugins/pairing-message.js";
+export { patchScopedAccountConfig } from "../channels/plugins/setup-helpers.js";
+export type { BaseProbeResult } from "../channels/plugins/types.js";
+export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+export type { OpenClawConfig } from "../config/config.js";
+export type { DmPolicy, MarkdownConfig } from "../config/types.js";
+export {
+  DmPolicySchema,
+  MarkdownConfigSchema,
+  requireOpenAllowFrom,
+} from "../config/zod-schema.core.js";
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export type { PluginRuntime } from "../plugins/runtime/types.js";
+export type { OpenClawPluginApi } from "../plugins/types.js";
+export { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+export type { RuntimeEnv } from "../runtime.js";
+export { createAccountStatusSink, runPassiveAccountLifecycle } from "./channel-lifecycle.js";
+export { createScopedPairingAccess } from "./pairing-access.js";
+export { issuePairingChallenge } from "../pairing/pairing-challenge.js";
+export { dispatchInboundReplyWithBase } from "./inbound-reply-dispatch.js";
+export type { OutboundReplyPayload } from "./reply-payload.js";
+export { formatTextWithAttachmentLinks, resolveOutboundMediaUrls } from "./reply-payload.js";
+export { createLoggerBackedRuntime } from "./runtime.js";
+export { buildBaseAccountStatusSnapshot, buildBaseChannelStatusSummary } from "./status-helpers.js";
+export {
+  collectStatusIssuesFromLastError,
+  createDefaultChannelRuntimeState,
+} from "./status-helpers.js";
+export { mapAllowFromEntries } from "./channel-config-helpers.js";
+export { formatDocsLink } from "../terminal/links.js";
+export type { WizardPrompter } from "../wizard/prompts.js";

--- a/src/plugin-sdk/pilot.ts
+++ b/src/plugin-sdk/pilot.ts
@@ -4,6 +4,10 @@
 export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
 export { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 export {
+  deleteAccountFromConfigSection,
+  setAccountEnabledInConfigSection,
+} from "../channels/plugins/config-helpers.js";
+export {
   buildAccountScopedDmSecurityPolicy,
   formatPairingApproveHint,
 } from "../channels/plugins/helpers.js";

--- a/src/plugin-sdk/pilot.ts
+++ b/src/plugin-sdk/pilot.ts
@@ -3,7 +3,11 @@
 
 export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
 export { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
-export { formatPairingApproveHint } from "../channels/plugins/helpers.js";
+export {
+  buildAccountScopedDmSecurityPolicy,
+  formatPairingApproveHint,
+} from "../channels/plugins/helpers.js";
+export { readStoreAllowFromForDmPolicy } from "../security/dm-policy-shared.js";
 export type {
   ChannelOnboardingAdapter,
   ChannelOnboardingDmPolicy,

--- a/src/plugin-sdk/pilot.ts
+++ b/src/plugin-sdk/pilot.ts
@@ -44,6 +44,10 @@ export {
   collectStatusIssuesFromLastError,
   createDefaultChannelRuntimeState,
 } from "./status-helpers.js";
-export { mapAllowFromEntries } from "./channel-config-helpers.js";
+export {
+  createScopedAccountConfigAccessors,
+  mapAllowFromEntries,
+} from "./channel-config-helpers.js";
+export { formatNormalizedAllowFromEntries } from "./allow-from.js";
 export { formatDocsLink } from "../terminal/links.js";
 export type { WizardPrompter } from "../wizard/prompts.js";

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -71,6 +71,7 @@ const pluginSdkEntrypoints = [
   "minimax-portal-auth",
   "nextcloud-talk",
   "nostr",
+  "pilot",
   "open-prose",
   "phone-control",
   "qwen-portal-auth",


### PR DESCRIPTION
## Summary

- Adds a new channel plugin (`extensions/pilot/`) for [Pilot Protocol](https://github.com/nickolasgamba/pilot-protocol) — a L3/L4 P2P overlay network for autonomous agents
- Bridges to the Go daemon via `pilotctl --json` CLI (same pattern as existing IRC/Nostr plugins using external CLIs)
- Registers 6 agent tools: `pilot_send`, `pilot_trust`, `pilot_discover`, `pilot_task`, `pilot_publish`, `pilot_subscribe`
- Full channel lifecycle: onboarding wizard, inbound polling, outbound send, pairing/trust, status probe

### What is Pilot Protocol?

Pilot Protocol provides a virtual network stack for AI agents — 48-bit addresses, 16-bit ports, reliable streams, NAT traversal, Ed25519 identity, encrypted tunnels. It gives agents the same level of addressability and connectivity that IP gives machines, but designed for autonomous peers.

### Files

| Path | Purpose |
|------|---------|
| `src/plugin-sdk/pilot.ts` | Narrow SDK surface |
| `extensions/pilot/index.ts` | Plugin entry point |
| `extensions/pilot/openclaw.plugin.json` | Manifest |
| `extensions/pilot/src/pilotctl.ts` | CLI bridge (execFile + JSON) |
| `extensions/pilot/src/channel.ts` | ChannelPlugin assembly |
| `extensions/pilot/src/inbound.ts` | Inbound DM dispatch + pairing |
| `extensions/pilot/src/monitor.ts` | Daemon lifecycle + polling loop |
| `extensions/pilot/src/tools/*.ts` | 6 agent tools |

Closes #43197

## Test plan

- [x] `pnpm tsgo` — type-check passes (no pilot errors)
- [x] `pnpm format` — formatting passes
- [ ] Manual: `openclaw channels list` shows "Pilot Protocol"
- [ ] Manual: configure via `openclaw setup`, verify daemon auto-starts
- [ ] Manual: send message to trusted peer, verify delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)