### PR TITLE
fix: make enqueueCommandInLane abort-aware to prevent stale cron queue entries

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,6 +1,9 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
+import type { RunEmbeddedPiAgentParams } from "./run/params.js";
+import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import {
   ensureContextEnginesInitialized,
   resolveContextEngine,
@@ -8,7 +11,6 @@ import {
 import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
@@ -62,13 +64,11 @@ import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
 import { createFailoverDecisionLogger } from "./run/failover-observation.js";
-import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import {
   truncateOversizedToolResultsInSession,
   sessionLikelyHasOversizedToolResults,
 } from "./tool-result-truncation.js";
-import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { describeUnknownError } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
@@ -257,10 +257,13 @@ export async function runEmbeddedPiAgent(
 ): Promise<EmbeddedPiRunResult> {
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
   const globalLane = resolveGlobalLane(params.lane);
+  const abortSignal = params.abortSignal;
   const enqueueGlobal =
-    params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
+    params.enqueue ??
+    ((task, opts) => enqueueCommandInLane(globalLane, task, { ...opts, signal: abortSignal }));
   const enqueueSession =
-    params.enqueue ?? ((task, opts) => enqueueCommandInLane(sessionLane, task, opts));
+    params.enqueue ??
+    ((task, opts) => enqueueCommandInLane(sessionLane, task, { ...opts, signal: abortSignal }));
   const channelHint = params.messageChannel ?? params.messageProvider;
   const resolvedToolResultFormat =
     params.toolResultFormat ??

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -18,6 +18,7 @@ vi.mock("../logging/diagnostic.js", () => ({
 
 import {
   clearCommandLane,
+  CommandLaneAbortedError,
   CommandLaneClearedError,
   enqueueCommand,
   enqueueCommandInLane,
@@ -333,5 +334,92 @@ describe("command queue", () => {
     markGatewayDraining();
     resetAllLanes();
     await expect(enqueueCommand(async () => "ok")).resolves.toBe("ok");
+  });
+});
+
+describe("abort-aware queue entries", () => {
+  const lane = "abort-test";
+
+  beforeEach(() => {
+    resetAllLanes();
+    setCommandLaneConcurrency(lane, 1);
+  });
+
+  it("rejects immediately if signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort("pre-aborted");
+    await expect(
+      enqueueCommandInLane(lane, async () => "should-not-run", { signal: ac.signal }),
+    ).rejects.toBeInstanceOf(CommandLaneAbortedError);
+  });
+
+  it("removes queued entry and rejects when signal fires before dequeue", async () => {
+    const ac = new AbortController();
+    // Block the lane with a long-running task so the second entry stays queued.
+    const deferred = createDeferred();
+    const first = enqueueCommandInLane(lane, async () => {
+      await deferred.promise;
+      return "first";
+    });
+    // Second entry queued behind the first, with abort signal.
+    const second = enqueueCommandInLane(lane, async () => "should-not-run", {
+      signal: ac.signal,
+    });
+
+    // Abort while still queued.
+    ac.abort("timed-out");
+
+    // The second entry should reject with CommandLaneAbortedError.
+    await expect(second).rejects.toBeInstanceOf(CommandLaneAbortedError);
+
+    // The first entry should still complete normally.
+    deferred.resolve();
+    await expect(first).resolves.toBe("first");
+  });
+
+  it("does not remove an already-active task when signal fires after dequeue", async () => {
+    const ac = new AbortController();
+    const deferred = createDeferred();
+    // Single task that starts running immediately (lane concurrency = 1, no queue).
+    const task = enqueueCommandInLane(
+      lane,
+      async () => {
+        await deferred.promise;
+        return "completed";
+      },
+      { signal: ac.signal },
+    );
+
+    // Wait a tick so the task is dequeued and running.
+    await Promise.resolve();
+
+    // Abort after task is already active — should NOT reject the running task.
+    ac.abort("late-abort");
+
+    deferred.resolve();
+    await expect(task).resolves.toBe("completed");
+  });
+
+  it("aborted entry does not execute when the lane later drains", async () => {
+    const ac = new AbortController();
+    const taskFn = vi.fn(async () => "ran");
+    const deferred = createDeferred();
+
+    const first = enqueueCommandInLane(lane, async () => {
+      await deferred.promise;
+      return "first";
+    });
+    const second = enqueueCommandInLane(lane, taskFn, { signal: ac.signal });
+
+    // Abort the second entry while it's queued.
+    ac.abort();
+    await expect(second).rejects.toBeInstanceOf(CommandLaneAbortedError);
+
+    // Now let the first task finish and the lane drain.
+    deferred.resolve();
+    await expect(first).resolves.toBe("first");
+
+    // The aborted task should never have been called.
+    expect(taskFn).not.toHaveBeenCalled();
   });
 });

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -158,29 +158,80 @@ export function setCommandLaneConcurrency(lane: string, maxConcurrent: number) {
   drainLane(cleaned);
 }
 
+/**
+ * Dedicated error type thrown when a queued command is aborted via an
+ * `AbortSignal` before it was dequeued for execution.
+ */
+export class CommandLaneAbortedError extends Error {
+  constructor(lane?: string, reason?: unknown) {
+    super(
+      lane
+        ? `Command lane "${lane}" entry aborted before execution`
+        : "Command lane entry aborted before execution",
+    );
+    this.name = "CommandLaneAbortedError";
+    if (reason !== undefined) {
+      this.cause = reason;
+    }
+  }
+}
+
 export function enqueueCommandInLane<T>(
   lane: string,
   task: () => Promise<T>,
   opts?: {
     warnAfterMs?: number;
     onWait?: (waitMs: number, queuedAhead: number) => void;
+    signal?: AbortSignal;
   },
 ): Promise<T> {
   if (gatewayDraining) {
     return Promise.reject(new GatewayDrainingError());
   }
+  const signal = opts?.signal;
+  if (signal?.aborted) {
+    return Promise.reject(new CommandLaneAbortedError(lane, signal.reason));
+  }
   const cleaned = lane.trim() || CommandLane.Main;
   const warnAfterMs = opts?.warnAfterMs ?? 2_000;
   const state = getLaneState(cleaned);
   return new Promise<T>((resolve, reject) => {
-    state.queue.push({
+    const entry: QueueEntry = {
       task: () => task(),
       resolve: (value) => resolve(value as T),
       reject,
       enqueuedAt: Date.now(),
       warnAfterMs,
       onWait: opts?.onWait,
-    });
+    };
+    state.queue.push(entry);
+
+    // If the caller provides an AbortSignal, listen for abort and remove
+    // the entry from the queue if it hasn't been dequeued yet.
+    if (signal) {
+      const onAbort = () => {
+        const idx = state.queue.indexOf(entry);
+        if (idx !== -1) {
+          state.queue.splice(idx, 1);
+          reject(new CommandLaneAbortedError(cleaned, signal.reason));
+        }
+        // If idx === -1, the entry was already dequeued and is either running
+        // or completed — do nothing (the task itself should check the signal).
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      // Clean up the listener when the promise settles to avoid leaks.
+      const originalResolve = entry.resolve;
+      const originalReject = entry.reject;
+      entry.resolve = (value) => {
+        signal.removeEventListener("abort", onAbort);
+        originalResolve(value);
+      };
+      entry.reject = (reason) => {
+        signal.removeEventListener("abort", onAbort);
+        originalReject(reason);
+      };
+    }
+
     logLaneEnqueue(cleaned, state.queue.length + state.activeTaskIds.size);
     drainLane(cleaned);
   });


### PR DESCRIPTION
## Problem

Queued isolated cron runs can spend their full timeout waiting on the global `cron` lane and still remain queued after the caller times out (see #43141).

The run never reaches model invocation because queued command-lane work is not abort-aware. When `executeJobCoreWithTimeout()` fires its abort signal, the queued entry in `enqueueCommandInLane()` has no mechanism to detect or honor it — the entry sits in the queue until the lane drains naturally.

## Root Cause

Two facts together cause the bug:
1. Global `cron` lane concurrency defaults to `1`
2. `enqueueCommandInLane()` does not accept or honor an abort signal while the entry is still queued

The cron timeout creates an `AbortController` and passes the signal through `executeJobCore()` → `runIsolatedAgentJob()` → `runEmbeddedPiAgent()`, but `runEmbeddedPiAgent()` never threads the signal into its `enqueueCommandInLane()` calls.

## Fix

1. **`src/process/command-queue.ts`**: Add optional `signal?: AbortSignal` to `enqueueCommandInLane()` options:
   - If signal is already aborted at enqueue time, reject immediately with `CommandLaneAbortedError`
   - If signal fires while the entry is still queued, remove it from the queue and reject
   - Clean up abort listeners when the promise settles to prevent leaks
   - Already-active (dequeued) tasks are not affected — the signal is only for queue removal

2. **`src/agents/pi-embedded-runner/run.ts`**: Thread `params.abortSignal` through both the session-lane and global-lane `enqueueCommandInLane()` calls in `runEmbeddedPiAgent()`

## Tests

Added 4 test cases in `command-queue.test.ts`:
- Rejects immediately if signal is already aborted
- Removes queued entry and rejects when signal fires before dequeue
- Does not interfere with already-active tasks when signal fires after dequeue
- Verifies aborted entry's task function is never called when lane drains

## Risk

- Minimal: only affects queued entries (not active tasks)
- Abort listener cleanup is symmetric (removed on resolve, reject, and abort)
- No changes to model behavior, cron scheduling, or lane concurrency policies

Fixes #43141