### PR TITLE
fix(control-ui): share gateway token scope across loopback hosts

### DIFF
--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -207,6 +207,90 @@ describe("loadSettings default gateway URL derivation", () => {
     });
   });
 
+  it("reuses a session token across loopback host aliases", async () => {
+    setTestLocation({
+      protocol: "http:",
+      host: "127.0.0.1:18789",
+      pathname: "/",
+    });
+
+    const { loadSettings, saveSettings } = await import("./storage.ts");
+    saveSettings({
+      gatewayUrl: "ws://127.0.0.1:18789",
+      token: "loopback-token",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "system",
+      chatFocusMode: false,
+      chatShowThinking: true,
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navGroupsCollapsed: {},
+    });
+
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({
+        gatewayUrl: "ws://localhost:18789",
+        sessionKey: "main",
+        lastActiveSessionKey: "main",
+        theme: "system",
+        chatFocusMode: false,
+        chatShowThinking: true,
+        splitRatio: 0.6,
+        navCollapsed: false,
+        navGroupsCollapsed: {},
+      }),
+    );
+
+    expect(loadSettings()).toMatchObject({
+      gatewayUrl: "ws://localhost:18789",
+      token: "loopback-token",
+    });
+  });
+
+  it("does not reuse a loopback token across different ports", async () => {
+    setTestLocation({
+      protocol: "http:",
+      host: "127.0.0.1:18789",
+      pathname: "/",
+    });
+
+    const { loadSettings, saveSettings } = await import("./storage.ts");
+    saveSettings({
+      gatewayUrl: "ws://127.0.0.1:18789",
+      token: "loopback-token",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "system",
+      chatFocusMode: false,
+      chatShowThinking: true,
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navGroupsCollapsed: {},
+    });
+
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({
+        gatewayUrl: "ws://localhost:19999",
+        sessionKey: "main",
+        lastActiveSessionKey: "main",
+        theme: "system",
+        chatFocusMode: false,
+        chatShowThinking: true,
+        splitRatio: 0.6,
+        navCollapsed: false,
+        navGroupsCollapsed: {},
+      }),
+    );
+
+    expect(loadSettings()).toMatchObject({
+      gatewayUrl: "ws://localhost:19999",
+      token: "",
+    });
+  });
+
   it("does not persist gateway tokens when saving settings", async () => {
     setTestLocation({
       protocol: "https:",

--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -249,6 +249,48 @@ describe("loadSettings default gateway URL derivation", () => {
     });
   });
 
+  it("reuses a session token across IPv6 and IPv4 loopback aliases", async () => {
+    setTestLocation({
+      protocol: "http:",
+      host: "[::1]:18789",
+      pathname: "/",
+    });
+
+    const { loadSettings, saveSettings } = await import("./storage.ts");
+    saveSettings({
+      gatewayUrl: "ws://[::1]:18789",
+      token: "loopback-token",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "system",
+      chatFocusMode: false,
+      chatShowThinking: true,
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navGroupsCollapsed: {},
+    });
+
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({
+        gatewayUrl: "ws://127.0.0.1:18789",
+        sessionKey: "main",
+        lastActiveSessionKey: "main",
+        theme: "system",
+        chatFocusMode: false,
+        chatShowThinking: true,
+        splitRatio: 0.6,
+        navCollapsed: false,
+        navGroupsCollapsed: {},
+      }),
+    );
+
+    expect(loadSettings()).toMatchObject({
+      gatewayUrl: "ws://127.0.0.1:18789",
+      token: "loopback-token",
+    });
+  });
+
   it("does not reuse a loopback token across different ports", async () => {
     setTestLocation({
       protocol: "http:",

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -43,9 +43,19 @@ function normalizeGatewayTokenScope(gatewayUrl: string): string {
         ? `${location.protocol}//${location.host}${location.pathname || "/"}`
         : undefined;
     const parsed = base ? new URL(trimmed, base) : new URL(trimmed);
+    const host = parsed.hostname.trim().toLowerCase();
+    const isLoopbackHost =
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host === "[::1]" ||
+      host.startsWith("127.");
     const pathname =
       parsed.pathname === "/" ? "" : parsed.pathname.replace(/\/+$/, "") || parsed.pathname;
-    return `${parsed.protocol}//${parsed.host}${pathname}`;
+    const hostPort = isLoopbackHost
+      ? `127.0.0.1${parsed.port ? `:${parsed.port}` : ""}`
+      : parsed.host;
+    return `${parsed.protocol}//${hostPort}${pathname}`;
   } catch {
     return trimmed;
   }

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -45,11 +45,7 @@ function normalizeGatewayTokenScope(gatewayUrl: string): string {
     const parsed = base ? new URL(trimmed, base) : new URL(trimmed);
     const host = parsed.hostname.trim().toLowerCase();
     const isLoopbackHost =
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "::1" ||
-      host === "[::1]" ||
-      host.startsWith("127.");
+      host === "localhost" || host === "127.0.0.1" || host === "[::1]" || host.startsWith("127.");
     const pathname =
       parsed.pathname === "/" ? "" : parsed.pathname.replace(/\/+$/, "") || parsed.pathname;
     const hostPort = isLoopbackHost


### PR DESCRIPTION
## Summary

Fix a Control UI auth footgun where gateway tokens are scoped by exact `gatewayUrl`, causing same-machine loopback aliases to fragment auth state.

Today these are treated as different token scopes even though they refer to the same local gateway:

- `ws://127.0.0.1:18789`
- `ws://localhost:18789`
- `ws://::1:18789` / `[::1]` variants

Because the Control UI stores the token in `sessionStorage` and keys it by exact `gatewayUrl`, switching between loopback aliases can produce:

- `unauthorized: gateway token missing`
- Control UI reconnect loops that feel intermittent

## What changed

- In `ui/src/ui/storage.ts`, normalize loopback hosts to a shared token scope:
  - `localhost`
  - `127.0.0.1`
  - `127.*`
  - `::1`
  - `[::1]`
- Preserve port and pathname in the scope key so distinct local gateways remain isolated.
- Add unit coverage proving:
  - `127.0.0.1` and `localhost` reuse the same token scope
  - different loopback ports do not share tokens

## Why this is safe

- Non-loopback hosts keep the existing exact-match behavior.
- Tokens remain in `sessionStorage`; this PR does not relax persistence or broaden auth beyond loopback alias normalization.
- Port boundaries remain intact.

## Related

- Related to #43037
- Related to #17745
- Related to #33157

## Verification

```bash
pnpm exec vitest run --config /tmp/openclaw-vitest-storage-only.config.ts
```

The temporary config used:

```ts
import { defineConfig } from 'vitest/config';
export default defineConfig({
  test: {
    environment: 'node',
    include: ['ui/src/ui/storage.node.test.ts'],
    unstubEnvs: true,
    unstubGlobals: true,
  },
});
```
