### PR TITLE
fix: preserve pasted Web UI images for media understanding

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
@@ -11,6 +12,8 @@ import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.j
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
+import { extensionForMime } from "../../media/mime.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
@@ -82,6 +85,32 @@ type AbortedPartialSnapshot = {
   text: string;
   abortOrigin: AbortOrigin;
 };
+
+type MaterializedChatMedia = {
+  mediaDir: string;
+  mediaPaths: string[];
+  mediaTypes: string[];
+};
+
+async function materializeParsedChatImages(
+  images: ChatImageContent[],
+  runId: string,
+): Promise<MaterializedChatMedia | null> {
+  if (images.length === 0) {
+    return null;
+  }
+  const mediaDir = await fsp.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "chat-send-"));
+  const mediaPaths: string[] = [];
+  const mediaTypes: string[] = [];
+  for (const [index, image] of images.entries()) {
+    const ext = extensionForMime(image.mimeType) ?? ".bin";
+    const filePath = path.join(mediaDir, `${runId}-${index + 1}${ext}`);
+    await fsp.writeFile(filePath, Buffer.from(image.data, "base64"), { mode: 0o600 });
+    mediaPaths.push(filePath);
+    mediaTypes.push(image.mimeType);
+  }
+  return { mediaDir, mediaPaths, mediaTypes };
+}
 
 const CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
@@ -955,6 +984,15 @@ export const chatHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+    let materializedMedia: MaterializedChatMedia | null = null;
+    if (parsedImages.length > 0) {
+      try {
+        materializedMedia = await materializeParsedChatImages(parsedImages, p.idempotencyKey);
+      } catch (err) {
+        respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
+        return;
+      }
+    }
     const rawSessionKey = p.sessionKey;
     const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
     const timeoutMs = resolveAgentTimeoutMs({
@@ -1068,6 +1106,11 @@ export const chatHandlers: GatewayRequestHandlers = {
         AccountId: accountId,
         MessageThreadId: messageThreadId,
         ChatType: "direct",
+        MediaDir: materializedMedia?.mediaDir,
+        MediaPath: materializedMedia?.mediaPaths[0],
+        MediaPaths: materializedMedia?.mediaPaths,
+        MediaType: materializedMedia?.mediaTypes[0],
+        MediaTypes: materializedMedia?.mediaTypes,
         CommandAuthorized: true,
         MessageSid: clientRunId,
         SenderId: clientInfo?.id,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -92,6 +92,20 @@ type MaterializedChatMedia = {
   mediaTypes: string[];
 };
 
+function sanitizeChatSendMediaRunId(runId: string): string {
+  const trimmed = String(runId ?? "").trim();
+  if (!trimmed) {
+    return "chat-send";
+  }
+  let base = path.posix.basename(trimmed);
+  base = path.win32.basename(base);
+  base = base.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+  if (!base) {
+    return "chat-send";
+  }
+  return base.slice(0, 120);
+}
+
 async function materializeParsedChatImages(
   images: ChatImageContent[],
   runId: string,
@@ -102,9 +116,10 @@ async function materializeParsedChatImages(
   const mediaDir = await fsp.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "chat-send-"));
   const mediaPaths: string[] = [];
   const mediaTypes: string[] = [];
+  const safeRunId = sanitizeChatSendMediaRunId(runId);
   for (const [index, image] of images.entries()) {
     const ext = extensionForMime(image.mimeType) ?? ".bin";
-    const filePath = path.join(mediaDir, `${runId}-${index + 1}${ext}`);
+    const filePath = path.join(mediaDir, `${safeRunId}-${index + 1}${ext}`);
     await fsp.writeFile(filePath, Buffer.from(image.data, "base64"), { mode: 0o600 });
     mediaPaths.push(filePath);
     mediaTypes.push(image.mimeType);
@@ -993,6 +1008,18 @@ export const chatHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+    const cleanupMaterializedMedia = async (): Promise<void> => {
+      if (!materializedMedia) {
+        return;
+      }
+      const mediaDir = materializedMedia.mediaDir;
+      materializedMedia = null;
+      try {
+        await fsp.rm(mediaDir, { recursive: true, force: true });
+      } catch (err) {
+        context.logGateway.warn(`chat.send temp media cleanup failed: ${formatForLog(err)}`);
+      }
+    };
     const rawSessionKey = p.sessionKey;
     const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
     const timeoutMs = resolveAgentTimeoutMs({
@@ -1010,6 +1037,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       chatType: entry?.chatType,
     });
     if (sendPolicy === "deny") {
+      await cleanupMaterializedMedia();
       respond(
         false,
         undefined,
@@ -1019,6 +1047,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
 
     if (stopCommand) {
+      await cleanupMaterializedMedia();
       const res = abortChatRunsForSessionKeyWithPartials({
         context,
         ops: createChatAbortOps(context),
@@ -1032,6 +1061,7 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     const cached = context.dedupe.get(`chat:${clientRunId}`);
     if (cached) {
+      await cleanupMaterializedMedia();
       respond(cached.ok, cached.payload, cached.error, {
         cached: true,
       });
@@ -1040,6 +1070,7 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     const activeExisting = context.chatAbortControllers.get(clientRunId);
     if (activeExisting) {
+      await cleanupMaterializedMedia();
       respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
         cached: true,
         runId: clientRunId,
@@ -1257,8 +1288,10 @@ export const chatHandlers: GatewayRequestHandlers = {
         })
         .finally(() => {
           context.chatAbortControllers.delete(clientRunId);
+          void cleanupMaterializedMedia();
         });
     } catch (err) {
+      await cleanupMaterializedMedia();
       const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
       const payload = {
         runId: clientRunId,

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -359,6 +359,10 @@ describe("gateway server chat", () => {
       );
       expect(imgRes.ok).toBe(true);
       expect(imgRes.payload?.runId).toBeDefined();
+
+      const mediaSpy = vi.mocked(getReplyFromConfig);
+      const mediaCalls = mediaSpy.mock.calls as unknown[][];
+      const beforeImageOnlyCtx = mediaCalls.length;
       const reqIdOnly = "chat-img-only";
       ws.send(
         JSON.stringify({
@@ -388,6 +392,17 @@ describe("gateway server chat", () => {
       );
       expect(imgOnlyRes.ok).toBe(true);
       expect(imgOnlyRes.payload?.runId).toBeDefined();
+      await waitFor(() => mediaCalls.length > beforeImageOnlyCtx);
+      const imageOnlyCtx = mediaCalls.at(-1)?.[0] as
+        | { MediaPath?: string; MediaPaths?: string[]; MediaType?: string; MediaTypes?: string[] }
+        | undefined;
+      expect(imageOnlyCtx?.MediaPath).toBeTypeOf("string");
+      expect(imageOnlyCtx?.MediaPath?.length ?? 0).toBeGreaterThan(0);
+      expect(imageOnlyCtx?.MediaPaths).toEqual([imageOnlyCtx?.MediaPath]);
+      expect(imageOnlyCtx?.MediaType).toBe("image/png");
+      expect(imageOnlyCtx?.MediaTypes).toEqual(["image/png"]);
+      const materializedImage = await fs.readFile(imageOnlyCtx?.MediaPath as string);
+      expect(materializedImage.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
 
       const historyDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
       tempDirs.push(historyDir);

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -6,6 +6,15 @@ import { WebSocket } from "ws";
 import { emitAgentEvent, registerAgentRunContext } from "../infra/agent-events.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+
+const preferredTmpDirMock = vi.hoisted(() => ({
+  value: process.env.TMPDIR || process.env.TEMP || process.env.TMP || "/tmp",
+}));
+
+vi.mock("../infra/tmp-openclaw-dir.js", () => ({
+  resolvePreferredOpenClawTmpDir: () => preferredTmpDirMock.value,
+}));
+
 import {
   connectOk,
   getReplyFromConfig,
@@ -205,8 +214,15 @@ describe("gateway server chat", () => {
   test("handles chat send and history flows", async () => {
     const tempDirs: string[] = [];
     let webchatWs: WebSocket | undefined;
+    const previousPreferredTmpDir = preferredTmpDirMock.value;
 
     try {
+      const materializedTmpRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-chat-send-media-"),
+      );
+      tempDirs.push(materializedTmpRoot);
+      preferredTmpDirMock.value = materializedTmpRoot;
+
       webchatWs = new WebSocket(`ws://127.0.0.1:${port}`, {
         headers: { origin: `http://127.0.0.1:${port}` },
       });
@@ -286,11 +302,21 @@ describe("gateway server chat", () => {
         sessionKey: "discord:group:dev",
         message: "hello",
         idempotencyKey: "idem-1",
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fileName: "blocked.png",
+            content:
+              "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
+          },
+        ],
       });
       expect(blockedRes.ok).toBe(false);
       expect((blockedRes.error as { message?: string } | undefined)?.message ?? "").toMatch(
         /send blocked/i,
       );
+      expect(await fs.readdir(materializedTmpRoot)).toEqual([]);
 
       testState.sessionStorePath = undefined;
       testState.sessionConfig = undefined;
@@ -372,7 +398,7 @@ describe("gateway server chat", () => {
           params: {
             sessionKey: "main",
             message: "",
-            idempotencyKey: "idem-img-only",
+            idempotencyKey: "../../escaped-image",
             attachments: [
               {
                 type: "image",
@@ -398,6 +424,7 @@ describe("gateway server chat", () => {
         | undefined;
       expect(imageOnlyCtx?.MediaPath).toBeTypeOf("string");
       expect(imageOnlyCtx?.MediaPath?.length ?? 0).toBeGreaterThan(0);
+      expect(path.dirname(imageOnlyCtx?.MediaPath as string)).toBe(imageOnlyCtx?.MediaDir);
       expect(imageOnlyCtx?.MediaPaths).toEqual([imageOnlyCtx?.MediaPath]);
       expect(imageOnlyCtx?.MediaType).toBe("image/png");
       expect(imageOnlyCtx?.MediaTypes).toEqual(["image/png"]);
@@ -438,6 +465,7 @@ describe("gateway server chat", () => {
       expect(defaultMsgs.length).toBe(200);
       expect(extractFirstTextBlock(defaultMsgs[0])).toBe("m100");
     } finally {
+      preferredTmpDirMock.value = previousPreferredTmpDir;
       testState.agentConfig = undefined;
       testState.sessionStorePath = undefined;
       testState.sessionConfig = undefined;


### PR DESCRIPTION
## Summary

- Problem: pasted images from the Web UI make it through `chat.send`, but they are dropped by the normal media-understanding path.
- Why it matters: text-only models and auxiliary media-understanding flows do not see pasted images, so the image is silently ignored.
- What changed: pasted chat images are now materialized into temporary local files and added to the normal media context (`MediaPath`, `MediaPaths`, `MediaType`, `MediaTypes`) while keeping the existing native image path intact.
- What did NOT change (scope boundary): this PR does not redesign Web UI uploads, change model retry behavior, or alter non-Web UI media flows.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #43237

## User-visible / Behavior Changes

- Pasted Web UI images are no longer silently ignored by text-only and media-understanding paths.
- The existing image path for models with native image support remains unchanged.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: local macOS dev environment
- Runtime/container: Node.js dev environment
- Model/provider: not required for the regression test
- Integration/channel (if any): Web UI chat / gateway `chat.send`
- Relevant config (redacted): not required

### Steps

1. Paste an image into the Web UI chat input.
2. Send the message through `chat.send`.
3. Observe the agent context used for the run.

### Expected

- The image should still be available to the native image path.
- The normal media context should also contain a real local file path so media understanding can process it.

### Actual

- Before this change, pasted images reached the parsed image path but were missing from `MediaPath` / `MediaPaths`, so the normal media-understanding path skipped them.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run src/gateway/server.chat.gateway-server-chat.test.ts`
- Edge cases checked: image + text message, image-only message, materialized file exists and has PNG signature, normal media context fields are present
- What you did **not** verify: a live browser session against a real text-only model plus media-understanding model after this patch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `src/gateway/server-methods/chat.ts`
- Known bad symptoms reviewers should watch for: Web UI pasted images creating temp files but still not showing up in downstream media processing

## Risks and Mitigations

- Risk: pasted images now create temporary files on the gateway host.
  - Mitigation: the change is limited to the Web UI pasted-image path, uses the existing OpenClaw temp root, and is covered by a focused gateway regression test.
