### PR TITLE
fix: validate Edge TTS output file is non-empty before reporting success

### DIFF
--- a/src/tts/edge-tts-validation.test.ts
+++ b/src/tts/edge-tts-validation.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+let mockTtsPromise = vi.fn<(text: string, filePath: string) => Promise<void>>();
+
+vi.mock("node-edge-tts", () => ({
+  EdgeTTS: class {
+    ttsPromise(text: string, filePath: string) {
+      return mockTtsPromise(text, filePath);
+    }
+  },
+}));
+
+// Must import after mock setup so the mock is applied.
+const { edgeTTS } = await import("./tts-core.js");
+
+const baseEdgeConfig = {
+  enabled: true,
+  voice: "en-US-MichelleNeural",
+  lang: "en-US",
+  outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+  outputFormatConfigured: false,
+  saveSubtitles: false,
+};
+
+describe("edgeTTS – empty audio validation", () => {
+  it("throws when the output file is 0 bytes", async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
+    const outputPath = path.join(tempDir, "voice.mp3");
+
+    // Simulate ttsPromise resolving but writing nothing (0-byte file).
+    mockTtsPromise = vi.fn(async (_text: string, filePath: string) => {
+      writeFileSync(filePath, "");
+    });
+
+    await expect(
+      edgeTTS({
+        text: "Hello",
+        outputPath,
+        config: baseEdgeConfig,
+        timeoutMs: 10_000,
+      }),
+    ).rejects.toThrow("Edge TTS produced empty audio file");
+  });
+
+  it("succeeds when the output file has content", async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
+    const outputPath = path.join(tempDir, "voice.mp3");
+
+    mockTtsPromise = vi.fn(async (_text: string, filePath: string) => {
+      writeFileSync(filePath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    });
+
+    await expect(
+      edgeTTS({
+        text: "Hello",
+        outputPath,
+        config: baseEdgeConfig,
+        timeoutMs: 10_000,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -1,4 +1,4 @@
-import { rmSync } from "node:fs";
+import { rmSync, statSync } from "node:fs";
 import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
 import { EdgeTTS } from "node-edge-tts";
 import { getApiKeyForModel, requireApiKey } from "../agents/model-auth.js";
@@ -670,4 +670,12 @@ export async function edgeTTS(params: {
     timeout: config.timeoutMs ?? timeoutMs,
   });
   await tts.ttsPromise(text, outputPath);
+
+  // Validate that audio data was actually produced. The Edge TTS service may
+  // send `turn.end` without any preceding audio frames, which causes
+  // ttsPromise to resolve successfully while the output file remains empty.
+  const { size } = statSync(outputPath);
+  if (size === 0) {
+    throw new Error("Edge TTS produced empty audio file");
+  }
 }


### PR DESCRIPTION
## Summary

- Add a file-size check after `tts.ttsPromise()` resolves in `edgeTTS()` — if the output is 0 bytes, throw an error so the provider-fallback loop in `textToSpeech()` tries the next provider instead of delivering an empty audio file
- Add unit tests for the empty-file and valid-file cases

## Root Cause

`node-edge-tts`'s `ttsPromise()` creates a `WriteStream`, connects to Bing's TTS WebSocket, and resolves the promise when it receives `turn.end`. However, if the service sends `turn.end` without any preceding audio frames (e.g. due to rate-limiting, unsupported voice/format, or transient errors), the promise still resolves successfully — leaving a 0-byte file on disk.

`textToSpeech()` then treats this as a successful result and delivers the empty file to the channel (e.g. Telegram voice message with no audio).

## Fix

A single `statSync` check after `ttsPromise` resolves:

```ts
const { size } = statSync(outputPath);
if (size === 0) {
  throw new Error("Edge TTS produced empty audio file");
}
```

This allows the existing provider-fallback mechanism to kick in and try OpenAI/ElevenLabs TTS instead.

## Test plan

- [x] New test: `edgeTTS` throws when output file is 0 bytes
- [x] New test: `edgeTTS` succeeds when output file has content
- [x] All 26 existing TTS tests pass unchanged

Closes #43229