### PR TITLE
feat: importance-weighted temporal decay for memory search (rebased)

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -32,7 +32,7 @@ If you can write a small TypeScript function, you can write a hook. Managed and 
 
 The hooks system allows you to:
 
-- Save session context to memory when `/new` is issued
+- Save session context to memory when `/new` or `/reset` is issued
 - Log all commands for auditing
 - Trigger custom automations on agent lifecycle events
 - Extend OpenClaw's behavior without modifying core code
@@ -435,7 +435,7 @@ metadata: { "openclaw": { "emoji": "🎯", "events": ["command:new"] } }
 
 # My Custom Hook
 
-This hook does something useful when you issue `/new`.
+This hook does something useful when you issue `/new` or `/reset`.
 ```
 
 ### 4. Create handler.ts
@@ -825,6 +825,7 @@ The gateway logs hook loading at startup:
 
 ```
 Registered hook: session-memory -> command:new
+Registered hook: session-memory -> command:reset
 Registered hook: bootstrap-extra-files -> agent:bootstrap
 Registered hook: command-logger -> command
 Registered hook: boot-md -> gateway:startup

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -79,6 +79,7 @@ export type ResolvedMemorySearchConfig = {
       temporalDecay: {
         enabled: boolean;
         halfLifeDays: number;
+        importanceBoost?: Partial<import("../memory/temporal-decay.js").ImportanceBoostConfig>;
       };
     };
   };
@@ -362,6 +363,9 @@ function mergeConfig(
         temporalDecay: {
           enabled: Boolean(hybrid.temporalDecay.enabled),
           halfLifeDays: temporalDecayHalfLifeDays,
+          importanceBoost:
+            overrides?.query?.hybrid?.temporalDecay?.importanceBoost ??
+            defaults?.query?.hybrid?.temporalDecay?.importanceBoost,
         },
       },
     },

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -437,6 +437,12 @@ export type MemorySearchConfig = {
         enabled?: boolean;
         /** Half-life in days for exponential decay (default: 30). */
         halfLifeDays?: number;
+        /** Optional importance-weighted decay: slow decay for marked important memories. */
+        importanceBoost?: {
+          enabled?: boolean;
+          boostFactor?: number;
+          patterns?: { contentMarkers?: string[]; filePatterns?: string[] };
+        };
       };
     };
   };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -123,6 +123,15 @@ export const AgentDefaultsSchema = z
               .optional(),
             prompt: z.string().optional(),
             systemPrompt: z.string().optional(),
+            periodicExtraction: z
+              .object({
+                enabled: z.boolean().optional(),
+                every: z.string().optional(),
+                prompt: z.string().optional(),
+                systemPrompt: z.string().optional(),
+              })
+              .strict()
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -713,6 +713,20 @@ export const MemorySearchSchema = z
               .object({
                 enabled: z.boolean().optional(),
                 halfLifeDays: z.number().int().positive().optional(),
+                importanceBoost: z
+                  .object({
+                    enabled: z.boolean().optional(),
+                    boostFactor: z.number().positive().optional(),
+                    patterns: z
+                      .object({
+                        contentMarkers: z.array(z.string()).optional(),
+                        filePatterns: z.array(z.string()).optional(),
+                      })
+                      .strict()
+                      .optional(),
+                  })
+                  .strict()
+                  .optional(),
               })
               .strict()
               .optional(),

--- a/src/memory/temporal-decay.test.ts
+++ b/src/memory/temporal-decay.test.ts
@@ -7,6 +7,8 @@ import {
   applyTemporalDecayToHybridResults,
   applyTemporalDecayToScore,
   calculateTemporalDecayMultiplier,
+  isImportantChunk,
+  type ImportanceBoostConfig,
 } from "./temporal-decay.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -169,5 +171,187 @@ describe("temporal decay", () => {
     });
 
     expect(decayed[0]?.score).toBeCloseTo(0.5, 2);
+  });
+});
+
+describe("importance-weighted decay", () => {
+  const enabledConfig: ImportanceBoostConfig = {
+    enabled: true,
+    boostFactor: 3,
+    patterns: {
+      contentMarkers: ["<!-- important -->", "**IMPORTANT**", "[!important]"],
+      filePatterns: ["MEMORY.md"],
+    },
+  };
+
+  describe("isImportantChunk", () => {
+    it("matches file patterns case-insensitively", () => {
+      expect(isImportantChunk({ filePath: "MEMORY.md", config: enabledConfig })).toBe(true);
+      expect(isImportantChunk({ filePath: "memory.md", config: enabledConfig })).toBe(true);
+      expect(isImportantChunk({ filePath: "foo/MEMORY.md", config: enabledConfig })).toBe(true);
+    });
+
+    it("matches content markers", () => {
+      expect(
+        isImportantChunk({
+          filePath: "memory/2025-01-01.md",
+          snippet: "some text <!-- important --> more text",
+          config: enabledConfig,
+        }),
+      ).toBe(true);
+      expect(
+        isImportantChunk({
+          filePath: "memory/2025-01-01.md",
+          snippet: "**IMPORTANT** note",
+          config: enabledConfig,
+        }),
+      ).toBe(true);
+      expect(
+        isImportantChunk({
+          filePath: "memory/2025-01-01.md",
+          snippet: "has [!important] callout",
+          config: enabledConfig,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false when no patterns match", () => {
+      expect(
+        isImportantChunk({
+          filePath: "memory/2025-01-01.md",
+          snippet: "just normal text",
+          config: enabledConfig,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns false when disabled", () => {
+      expect(
+        isImportantChunk({
+          filePath: "MEMORY.md",
+          config: { ...enabledConfig, enabled: false },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  it("important memories decay slower than normal ones", async () => {
+    const results = await applyTemporalDecayToHybridResults({
+      results: [
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "normal memory",
+        },
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "<!-- important --> key memory",
+        },
+      ],
+      temporalDecay: {
+        enabled: true,
+        halfLifeDays: 30,
+        importanceBoost: { enabled: true, boostFactor: 3 },
+      },
+      nowMs: NOW_MS,
+    });
+
+    // Both started at 0.8, ~92 days old
+    // Normal decays with full age, important with age/3
+    expect(results[1]!.score).toBeGreaterThan(results[0]!.score);
+  });
+
+  it("boost is disabled by default (backwards-compatible)", async () => {
+    const results = await applyTemporalDecayToHybridResults({
+      results: [
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "<!-- important --> key memory",
+        },
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "normal memory",
+        },
+      ],
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    // Without importance boost, both should decay identically
+    expect(results[0]!.score).toBeCloseTo(results[1]!.score);
+  });
+
+  it("boostFactor of 1 has no effect", async () => {
+    const results = await applyTemporalDecayToHybridResults({
+      results: [
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "<!-- important --> key memory",
+        },
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "normal memory",
+        },
+      ],
+      temporalDecay: {
+        enabled: true,
+        halfLifeDays: 30,
+        importanceBoost: { enabled: true, boostFactor: 1 },
+      },
+      nowMs: NOW_MS,
+    });
+
+    expect(results[0]!.score).toBeCloseTo(results[1]!.score);
+  });
+
+  it("integrates with hybrid merge via file pattern matching", async () => {
+    const merged = await mergeHybridResults({
+      vectorWeight: 1,
+      textWeight: 0,
+      temporalDecay: {
+        enabled: true,
+        halfLifeDays: 30,
+        importanceBoost: { enabled: true, boostFactor: 3 },
+      },
+      mmr: { enabled: false },
+      nowMs: NOW_MS,
+      vector: [
+        {
+          id: "old-normal",
+          path: "memory/2025-11-10.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "old normal memory",
+          vectorScore: 0.9,
+        },
+        {
+          id: "old-important",
+          path: "memory/2025-11-10.md",
+          startLine: 10,
+          endLine: 15,
+          source: "memory",
+          snippet: "old but <!-- important --> memory",
+          vectorScore: 0.9,
+        },
+      ],
+      keyword: [],
+    });
+
+    // Important one should rank higher despite same age and vector score
+    const importantEntry = merged.find((e) => e.snippet.includes("important"));
+    const normalEntry = merged.find((e) => !e.snippet.includes("important"));
+    expect(importantEntry!.score).toBeGreaterThan(normalEntry!.score);
   });
 });

--- a/src/memory/temporal-decay.test.ts
+++ b/src/memory/temporal-decay.test.ts
@@ -261,7 +261,7 @@ describe("importance-weighted decay", () => {
 
     // Both started at 0.8, ~92 days old
     // Normal decays with full age, important with age/3
-    expect(results[1]!.score).toBeGreaterThan(results[0]!.score);
+    expect(results[1].score).toBeGreaterThan(results[0].score);
   });
 
   it("boost is disabled by default (backwards-compatible)", async () => {
@@ -285,7 +285,7 @@ describe("importance-weighted decay", () => {
     });
 
     // Without importance boost, both should decay identically
-    expect(results[0]!.score).toBeCloseTo(results[1]!.score);
+    expect(results[0].score).toBeCloseTo(results[1].score);
   });
 
   it("boostFactor of 1 has no effect", async () => {
@@ -312,7 +312,7 @@ describe("importance-weighted decay", () => {
       nowMs: NOW_MS,
     });
 
-    expect(results[0]!.score).toBeCloseTo(results[1]!.score);
+    expect(results[0].score).toBeCloseTo(results[1].score);
   });
 
   it("integrates with hybrid merge via file pattern matching", async () => {

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -1,9 +1,34 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+export type ImportanceBoostPatterns = {
+  /** Content markers that indicate importance (matched case-insensitively) */
+  contentMarkers?: string[];
+  /** File path patterns (matched case-insensitively against the normalized path) */
+  filePatterns?: string[];
+};
+
+export type ImportanceBoostConfig = {
+  enabled: boolean;
+  /** Multiplier for important memories (e.g., 3.0 = effective age is divided by 3) */
+  boostFactor: number;
+  /** Patterns that indicate importance */
+  patterns?: ImportanceBoostPatterns;
+};
+
+export const DEFAULT_IMPORTANCE_BOOST_CONFIG: ImportanceBoostConfig = {
+  enabled: false,
+  boostFactor: 3,
+  patterns: {
+    contentMarkers: ["<!-- important -->", "**IMPORTANT**", "[!important]"],
+    filePatterns: ["MEMORY.md"],
+  },
+};
+
 export type TemporalDecayConfig = {
   enabled: boolean;
   halfLifeDays: number;
+  importanceBoost?: Partial<ImportanceBoostConfig>;
 };
 
 export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
@@ -113,13 +138,39 @@ async function extractTimestamp(params: {
   }
 }
 
+export function isImportantChunk(params: {
+  filePath: string;
+  snippet?: string;
+  config: ImportanceBoostConfig;
+}): boolean {
+  const { filePath, snippet, config } = params;
+  if (!config.enabled) return false;
+  const patterns = { ...DEFAULT_IMPORTANCE_BOOST_CONFIG.patterns, ...config.patterns };
+  const normalized = filePath.replaceAll("\\", "/").replace(/^\.\//, "").toLowerCase();
+
+  if (patterns.filePatterns) {
+    for (const fp of patterns.filePatterns) {
+      if (normalized.includes(fp.toLowerCase())) return true;
+    }
+  }
+
+  if (snippet && patterns.contentMarkers) {
+    const lower = snippet.toLowerCase();
+    for (const marker of patterns.contentMarkers) {
+      if (lower.includes(marker.toLowerCase())) return true;
+    }
+  }
+
+  return false;
+}
+
 function ageInDaysFromTimestamp(timestamp: Date, nowMs: number): number {
   const ageMs = Math.max(0, nowMs - timestamp.getTime());
   return ageMs / DAY_MS;
 }
 
 export async function applyTemporalDecayToHybridResults<
-  T extends { path: string; score: number; source: string },
+  T extends { path: string; score: number; source: string; snippet?: string },
 >(params: {
   results: T[];
   temporalDecay?: Partial<TemporalDecayConfig>;
@@ -130,6 +181,11 @@ export async function applyTemporalDecayToHybridResults<
   if (!config.enabled) {
     return [...params.results];
   }
+
+  const importanceConfig: ImportanceBoostConfig = {
+    ...DEFAULT_IMPORTANCE_BOOST_CONFIG,
+    ...config.importanceBoost,
+  };
 
   const nowMs = params.nowMs ?? Date.now();
   const timestampPromiseCache = new Map<string, Promise<Date | null>>();
@@ -152,9 +208,24 @@ export async function applyTemporalDecayToHybridResults<
         return entry;
       }
 
+      let ageInDays = ageInDaysFromTimestamp(timestamp, nowMs);
+
+      // Important memories decay slower by dividing their effective age
+      if (
+        importanceConfig.enabled &&
+        importanceConfig.boostFactor > 1 &&
+        isImportantChunk({
+          filePath: entry.path,
+          snippet: (entry as { snippet?: string }).snippet,
+          config: importanceConfig,
+        })
+      ) {
+        ageInDays = ageInDays / importanceConfig.boostFactor;
+      }
+
       const decayedScore = applyTemporalDecayToScore({
         score: entry.score,
-        ageInDays: ageInDaysFromTimestamp(timestamp, nowMs),
+        ageInDays,
         halfLifeDays: config.halfLifeDays,
       });
 

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -144,20 +144,26 @@ export function isImportantChunk(params: {
   config: ImportanceBoostConfig;
 }): boolean {
   const { filePath, snippet, config } = params;
-  if (!config.enabled) return false;
+  if (!config.enabled) {
+    return false;
+  }
   const patterns = { ...DEFAULT_IMPORTANCE_BOOST_CONFIG.patterns, ...config.patterns };
   const normalized = filePath.replaceAll("\\", "/").replace(/^\.\//, "").toLowerCase();
 
   if (patterns.filePatterns) {
     for (const fp of patterns.filePatterns) {
-      if (normalized.includes(fp.toLowerCase())) return true;
+      if (normalized.includes(fp.toLowerCase())) {
+        return true;
+      }
     }
   }
 
   if (snippet && patterns.contentMarkers) {
     const lower = snippet.toLowerCase();
     for (const marker of patterns.contentMarkers) {
-      if (lower.includes(marker.toLowerCase())) return true;
+      if (lower.includes(marker.toLowerCase())) {
+        return true;
+      }
     }
   }
 

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -222,7 +222,7 @@ export async function applyTemporalDecayToHybridResults<
         importanceConfig.boostFactor > 1 &&
         isImportantChunk({
           filePath: entry.path,
-          snippet: (entry as { snippet?: string }).snippet,
+          snippet: entry.snippet,
           config: importanceConfig,
         })
       ) {


### PR DESCRIPTION
## Summary
Rebased follow-up of #18919 to resolve merge conflicts against current `main`.

### Included changes
- importance-weighted temporal decay for memory search
- config/schema updates for `importanceBoost` and periodic extraction fields
- session memory reset/new behavior fixes
- cleanup fixes for tests/lint/casts

## Validation
- `pnpm -s vitest src/hooks/bundled/session-memory/handler.test.ts src/auto-reply/reply/commands.test.ts`

## Notes
This PR supersedes #18919.
