### PR TITLE
fix: WhatsApp QR login failures in Control UI

### DIFF
--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -252,6 +252,8 @@ export type ChannelLoginWithQrStartResult = {
 export type ChannelLoginWithQrWaitResult = {
   connected: boolean;
   message: string;
+  /** Latest QR data URL; included on timeout/poll responses so the UI can refresh stale QR codes. */
+  qrDataUrl?: string;
 };
 
 export type ChannelLogoutContext<ResolvedAccount = unknown> = {

--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -317,6 +317,10 @@ export async function waitForWebLogin(
       return { connected: true, message };
     }
 
-    return { connected: false, message: "Login ended without a connection.", qrDataUrl: login.qrDataUrl };
+    return {
+      connected: false,
+      message: "Login ended without a connection.",
+      qrDataUrl: login.qrDataUrl,
+    };
   }
 }

--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -8,6 +8,7 @@ import { resolveWhatsAppAccount } from "./accounts.js";
 import { renderQrPngBase64 } from "./qr-image.js";
 import {
   createWaSocket,
+  flushCredsSaveQueue,
   formatError,
   getStatusCode,
   logoutWeb,
@@ -27,6 +28,8 @@ type ActiveLogin = {
   startedAt: number;
   qr?: string;
   qrDataUrl?: string;
+  /** Timestamp (ms) when `qrDataUrl` was last written. */
+  qrUpdatedAt?: number;
   connected: boolean;
   error?: string;
   errorStatus?: number;
@@ -88,6 +91,11 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
     info("WhatsApp asked for a restart after pairing (code 515); retrying connection once…"),
   );
   closeSocket(login.sock);
+  // Wait for any in-flight creds writes to reach disk before creating a new
+  // socket — Baileys fires creds.update *before* the 515 close event, but the
+  // write is async.  Without this flush the restarted socket may read stale
+  // auth state and fail immediately.
+  await flushCredsSaveQueue();
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,
@@ -127,7 +135,7 @@ export async function startWebLoginWithQr(
   }
 
   const existing = activeLogins.get(account.accountId);
-  if (existing && isLoginFresh(existing) && existing.qrDataUrl) {
+  if (!opts.force && existing && isLoginFresh(existing) && existing.qrDataUrl) {
     return {
       qrDataUrl: existing.qrDataUrl,
       message: "QR already active. Scan it in WhatsApp → Linked Devices.",
@@ -156,17 +164,33 @@ export async function startWebLoginWithQr(
     sock = await createWaSocket(false, Boolean(opts.verbose), {
       authDir: account.authDir,
       onQr: (qr: string) => {
-        if (pendingQr) {
-          return;
-        }
-        pendingQr = qr;
+        // Always update the active login with the latest QR from WhatsApp.
+        // Baileys rotates QR codes every ~20s; older codes become invalid.
         const current = activeLogins.get(account.accountId);
-        if (current && !current.qr) {
+        if (current) {
           current.qr = qr;
+          // Asynchronously re-render the PNG so poll callers get the fresh QR.
+          renderQrPngBase64(qr)
+            .then((base64) => {
+              const still = activeLogins.get(account.accountId);
+              if (still?.id === current.id) {
+                still.qrDataUrl = `data:image/png;base64,${base64}`;
+                still.qrUpdatedAt = Date.now();
+              }
+            })
+            .catch(() => {
+              // Best-effort; ignore render failures for rotated QR codes.
+            });
         }
-        clearTimeout(qrTimer);
-        runtime.log(info("WhatsApp QR received."));
-        resolveQr?.(qr);
+        // Resolve the initial QR promise only once.
+        if (!pendingQr) {
+          pendingQr = qr;
+          clearTimeout(qrTimer);
+          runtime.log(info("WhatsApp QR received."));
+          resolveQr?.(qr);
+        } else {
+          runtime.log(info("WhatsApp QR rotated."));
+        }
       },
     });
   } catch (err) {
@@ -207,6 +231,7 @@ export async function startWebLoginWithQr(
 
   const base64 = await renderQrPngBase64(qr);
   login.qrDataUrl = `data:image/png;base64,${base64}`;
+  login.qrUpdatedAt = Date.now();
   return {
     qrDataUrl: login.qrDataUrl,
     message: "Scan this QR in WhatsApp → Linked Devices.",
@@ -215,7 +240,7 @@ export async function startWebLoginWithQr(
 
 export async function waitForWebLogin(
   opts: { timeoutMs?: number; runtime?: RuntimeEnv; accountId?: string } = {},
-): Promise<{ connected: boolean; message: string }> {
+): Promise<{ connected: boolean; message: string; qrDataUrl?: string }> {
   const runtime = opts.runtime ?? defaultRuntime;
   const cfg = loadConfig();
   const account = resolveWhatsAppAccount({ cfg, accountId: opts.accountId });
@@ -244,6 +269,7 @@ export async function waitForWebLogin(
       return {
         connected: false,
         message: "Still waiting for the QR scan. Let me know when you’ve scanned it.",
+        qrDataUrl: login.qrDataUrl,
       };
     }
     const timeout = new Promise<"timeout">((resolve) =>
@@ -254,7 +280,8 @@ export async function waitForWebLogin(
     if (result === "timeout") {
       return {
         connected: false,
-        message: "Still waiting for the QR scan. Let me know when you’ve scanned it.",
+        message: "Still waiting for the QR scan. Let me know when you've scanned it.",
+        qrDataUrl: login.qrDataUrl,
       };
     }
 
@@ -290,6 +317,6 @@ export async function waitForWebLogin(
       return { connected: true, message };
     }
 
-    return { connected: false, message: "Login ended without a connection." };
+    return { connected: false, message: "Login ended without a connection.", qrDataUrl: login.qrDataUrl };
   }
 }

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -5,7 +5,13 @@ import { danger, info, success } from "../globals.js";
 import { logInfo } from "../logger.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { resolveWhatsAppAccount } from "./accounts.js";
-import { createWaSocket, flushCredsSaveQueue, formatError, logoutWeb, waitForWaConnection } from "./session.js";
+import {
+  createWaSocket,
+  flushCredsSaveQueue,
+  formatError,
+  logoutWeb,
+  waitForWaConnection,
+} from "./session.js";
 
 export async function loginWeb(
   verbose: boolean,

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -5,7 +5,7 @@ import { danger, info, success } from "../globals.js";
 import { logInfo } from "../logger.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { resolveWhatsAppAccount } from "./accounts.js";
-import { createWaSocket, formatError, logoutWeb, waitForWaConnection } from "./session.js";
+import { createWaSocket, flushCredsSaveQueue, formatError, logoutWeb, waitForWaConnection } from "./session.js";
 
 export async function loginWeb(
   verbose: boolean,
@@ -38,6 +38,8 @@ export async function loginWeb(
       } catch {
         // ignore
       }
+      // Wait for in-flight creds writes before restarting (same race as login-qr.ts).
+      await flushCredsSaveQueue();
       const retry = await createWaSocket(false, verbose, {
         authDir: account.authDir,
       });

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -32,6 +32,16 @@ export {
 } from "./auth-store.js";
 
 let credsSaveQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Wait for any pending creds writes to flush to disk.
+ * Must be awaited before restarting a socket that relies on saved creds
+ * (e.g. after a 515 "restart required" from WhatsApp).
+ */
+export function flushCredsSaveQueue(): Promise<void> {
+  return credsSaveQueue;
+}
+
 function enqueueSaveCreds(
   authDir: string,
   saveCreds: () => Promise<void> | void,
@@ -186,6 +196,8 @@ export async function waitForWaConnection(sock: ReturnType<typeof makeWASocket>)
 export function getStatusCode(err: unknown) {
   return (
     (err as { output?: { statusCode?: number } })?.output?.statusCode ??
+    // Baileys wraps Boom errors under `error` (e.g. lastDisconnect = { error: BoomError }).
+    (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode ??
     (err as { status?: number })?.status
   );
 }

--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -3,7 +3,6 @@ import {
   loadChannels,
   logoutWhatsApp,
   startWhatsAppLogin,
-  stopWhatsAppQrPoll,
   waitWhatsAppLogin,
 } from "./controllers/channels.ts";
 import { loadConfig, saveConfig } from "./controllers/config.ts";

--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -3,6 +3,7 @@ import {
   loadChannels,
   logoutWhatsApp,
   startWhatsAppLogin,
+  stopWhatsAppQrPoll,
   waitWhatsAppLogin,
 } from "./controllers/channels.ts";
 import { loadConfig, saveConfig } from "./controllers/config.ts";

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -16,6 +16,7 @@ import {
   syncTabWithLocation,
   syncThemeWithSettings,
 } from "./app-settings.ts";
+import { stopWhatsAppQrPoll } from "./controllers/channels.ts";
 import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap.ts";
 import type { Tab } from "./navigation.ts";
 
@@ -76,6 +77,7 @@ export function handleDisconnected(host: LifecycleHost) {
   stopNodesPolling(host as unknown as Parameters<typeof stopNodesPolling>[0]);
   stopLogsPolling(host as unknown as Parameters<typeof stopLogsPolling>[0]);
   stopDebugPolling(host as unknown as Parameters<typeof stopDebugPolling>[0]);
+  stopWhatsAppQrPoll();
   host.client?.stop();
   host.client = null;
   host.connected = false;

--- a/ui/src/ui/controllers/channels.ts
+++ b/ui/src/ui/controllers/channels.ts
@@ -3,6 +3,12 @@ import type { ChannelsState } from "./channels.types.ts";
 
 export type { ChannelsState };
 
+/**
+ * Generation counter for QR poll loops.
+ * Incrementing this cancels any in-flight poll iteration.
+ */
+let qrPollGeneration = 0;
+
 export async function loadChannels(state: ChannelsState, probe: boolean) {
   if (!state.client || !state.connected) {
     return;
@@ -27,6 +33,7 @@ export async function loadChannels(state: ChannelsState, probe: boolean) {
 }
 
 export async function startWhatsAppLogin(state: ChannelsState, force: boolean) {
+  stopWhatsAppQrPoll();
   if (!state.client || !state.connected || state.whatsappBusy) {
     return;
   }
@@ -49,22 +56,90 @@ export async function startWhatsAppLogin(state: ChannelsState, force: boolean) {
   } finally {
     state.whatsappBusy = false;
   }
+  // Auto-start polling for QR refresh + connection detection.
+  if (state.whatsappLoginQrDataUrl && state.client && state.connected) {
+    startWhatsAppQrPoll(state);
+  }
+}
+
+/**
+ * Poll `web.login.wait` in a loop with short timeouts.
+ * Each iteration returns the latest QR data URL (which may have
+ * rotated server-side) and connection status.
+ * The loop stops when the session connects, errors out, or is cancelled.
+ */
+export function startWhatsAppQrPoll(state: ChannelsState) {
+  stopWhatsAppQrPoll();
+  const myGeneration = ++qrPollGeneration;
+  (async () => {
+    while (
+      myGeneration === qrPollGeneration &&
+      state.client &&
+      state.connected &&
+      state.whatsappLoginQrDataUrl
+    ) {
+      try {
+        const res = await state.client.request<{
+          connected?: boolean;
+          message?: string;
+          qrDataUrl?: string;
+        }>("web.login.wait", {
+          timeoutMs: 15000,
+        });
+        if (myGeneration !== qrPollGeneration) {
+          break;
+        }
+        state.whatsappLoginMessage = res.message ?? null;
+        if (res.qrDataUrl) {
+          state.whatsappLoginQrDataUrl = res.qrDataUrl;
+        }
+        if (res.connected) {
+          state.whatsappLoginConnected = true;
+          state.whatsappLoginQrDataUrl = null;
+          // Refresh channel status now that WhatsApp is linked.
+          void loadChannels(state, true);
+          break;
+        }
+      } catch (err) {
+        if (myGeneration !== qrPollGeneration) {
+          break;
+        }
+        state.whatsappLoginMessage = String(err);
+        state.whatsappLoginConnected = null;
+        break;
+      }
+    }
+  })();
+}
+
+/** Cancel any in-flight QR poll loop. */
+export function stopWhatsAppQrPoll() {
+  qrPollGeneration++;
 }
 
 export async function waitWhatsAppLogin(state: ChannelsState) {
   if (!state.client || !state.connected || state.whatsappBusy) {
     return;
   }
+  // If a QR is displayed, just (re)start the poll loop; no need to block the UI.
+  if (state.whatsappLoginQrDataUrl) {
+    startWhatsAppQrPoll(state);
+    return;
+  }
   state.whatsappBusy = true;
   try {
-    const res = await state.client.request<{ message?: string; connected?: boolean }>(
-      "web.login.wait",
-      {
-        timeoutMs: 120000,
-      },
-    );
+    const res = await state.client.request<{
+      message?: string;
+      connected?: boolean;
+      qrDataUrl?: string;
+    }>("web.login.wait", {
+      timeoutMs: 120000,
+    });
     state.whatsappLoginMessage = res.message ?? null;
     state.whatsappLoginConnected = res.connected ?? null;
+    if (res.qrDataUrl) {
+      state.whatsappLoginQrDataUrl = res.qrDataUrl;
+    }
     if (res.connected) {
       state.whatsappLoginQrDataUrl = null;
     }
@@ -77,6 +152,7 @@ export async function waitWhatsAppLogin(state: ChannelsState) {
 }
 
 export async function logoutWhatsApp(state: ChannelsState) {
+  stopWhatsAppQrPoll();
   if (!state.client || !state.connected || state.whatsappBusy) {
     return;
   }

--- a/ui/src/ui/controllers/channels.ts
+++ b/ui/src/ui/controllers/channels.ts
@@ -71,7 +71,7 @@ export async function startWhatsAppLogin(state: ChannelsState, force: boolean) {
 export function startWhatsAppQrPoll(state: ChannelsState) {
   stopWhatsAppQrPoll();
   const myGeneration = ++qrPollGeneration;
-  (async () => {
+  void (async () => {
     while (
       myGeneration === qrPollGeneration &&
       state.client &&

--- a/ui/src/ui/controllers/channels.ts
+++ b/ui/src/ui/controllers/channels.ts
@@ -100,6 +100,13 @@ export function startWhatsAppQrPoll(state: ChannelsState) {
           void loadChannels(state, true);
           break;
         }
+        // Server returned a terminal non-connected response with no QR
+        // refresh (e.g. login TTL expired, session reset). Clear the
+        // stale QR and stop polling to avoid an infinite loop.
+        if (!res.qrDataUrl) {
+          state.whatsappLoginQrDataUrl = null;
+          break;
+        }
       } catch (err) {
         if (myGeneration !== qrPollGeneration) {
           break;


### PR DESCRIPTION
Fix multiple issues preventing WhatsApp QR code scanning from working in the web UI (Control UI channels tab) while TUI login worked fine.

Root causes and fixes:

1. QR rotation dropped after first code (login-qr.ts)
   - onQr callback had early return after first QR; Baileys rotates QR codes every ~20s so by the time user scans, the code is expired.
   - Now accepts all rotations and async-renders updated PNG data URLs.

2. force=true did not bypass active login cache (login-qr.ts)

3. waitForWebLogin did not return updated QR data URL (login-qr.ts)
   - Added qrDataUrl to return type and all timeout/poll responses so the UI can refresh stale QR images.

4. Credentials flush race on 515 restart (session.ts, login-qr.ts, login.ts)
   - After successful pairing, WhatsApp sends a 515 'restart required'. Baileys fires creds.update before the close event, but the write is async. Without flushing, the restarted socket reads stale creds.
   - Added flushCredsSaveQueue() export and await it before restart.

5. getStatusCode missed nested Boom path (session.ts)
   - waitForWaConnection rejects with { error: BoomError } but getStatusCode only checked err.output.statusCode and err.status, missing err.error.output.statusCode. The 515 status was never detected, so the restart path was never entered.
   - Added err.error.output.statusCode fallback.

6. UI QR auto-polling (controllers/channels.ts, app-lifecycle.ts)
   - Added generation-based poll loop that calls web.login.wait with 15s timeouts, updating QR image on rotation and detecting connection success automatically.
   - Poll is cancelled on logout, disconnect, or new login start.

Type: ChannelLoginWithQrWaitResult extended with optional qrDataUrl.

## Summary

- **Problem:** WhatsApp QR code scanning fails in Control UI (web) but works in TUI — expired QR codes displayed, 515 restart never triggered, creds race on reconnect.
- **Why it matters:** Users cannot link WhatsApp through the web UI at all; the QR expires silently and post-scan pairing crashes due to stale credentials.
- **What changed:** QR rotation handling, `getStatusCode` nested Boom extraction, creds flush before 515 restart, `qrDataUrl` in wait responses, UI auto-poll loop.
- **What did NOT change (scope boundary):** TUI login flow logic (only added creds flush there), Baileys socket creation, QR image rendering, auth store, gateway RPC contract shape.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # 15614
- Related # 15614

## User-visible / Behavior Changes

- QR code in Control UI channels tab now auto-refreshes every ~20s when Baileys rotates it (previously showed a stale/expired QR).
- After scanning QR, the 515 "restart required" handshake now completes successfully instead of failing silently.
- UI automatically detects successful WhatsApp linking and refreshes channel status without manual intervention.
- `ChannelLoginWithQrWaitResult` type now includes optional `qrDataUrl` field (additive, non-breaking).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — `flushCredsSaveQueue` only exposes a wait handle for the existing creds write queue; no new data access.
- New/changed network calls? `No` — UI polls the existing `web.login.wait` RPC; no new endpoints.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime/container: Docker (Node 22, `OPENCLAW_EXTENSIONS="whatsapp"`)
- Model/provider: N/A (channel linking, not LLM)
- Integration/channel: WhatsApp (Baileys / @whiskeysockets/baileys)
- Relevant config: `channels.whatsapp.enabled: true`, gateway bound on port 28789

### Steps

1. Run gateway with WhatsApp extension enabled.
2. Open Control UI → Channels tab → click "Link WhatsApp".
3. QR code appears — scan it with WhatsApp → Linked Devices.

### Expected

- QR refreshes every ~20s in the UI.
- After scan, gateway handles 515 restart and reports "Linked! WhatsApp is ready."

### Actual (before fix)

- QR was stale (first rotation only); scanning expired QR failed silently.
- 515 status code was not extracted from nested Boom error, so restart path never ran.
- Creds were not flushed to disk before restart socket read them back, causing auth failure.

## Evidence

- [x] Trace/log snippets — Docker gateway logs showing `WhatsApp QR received.`, `WhatsApp QR rotated.`, and successful 515 restart + link confirmation.
- [x] Screenshot/recording — Manual QR scan in Control UI confirmed working end-to-end after fix.

## Human Verification (required)

- **Verified scenarios:** Full QR login flow via Docker Control UI — QR display, QR rotation (~20s), scan, 515 restart, successful link, channel status refresh.
- **Edge cases checked:** Force relink (`force=true`), expired login TTL, multiple rapid poll iterations, disconnect during poll (generation cancellation).
- **What I did not verify:** macOS app build, iOS/Android, multiple WhatsApp accounts, existing linked session re-pairing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — `qrDataUrl` is an optional additive field; existing callers ignore it.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit; TUI login path is unaffected by the core fix.
- Files/config to restore: `src/web/login-qr.ts`, `src/web/session.ts`, `src/web/login.ts`, `src/channels/plugins/types.adapters.ts`, `ui/src/ui/controllers/channels.ts`, `ui/src/ui/app-lifecycle.ts`, `ui/src/ui/app-channels.ts`
- Known bad symptoms reviewers should watch for: QR not appearing at all (regression in `onQr`), infinite poll loop (generation counter bug), creds corruption (flush ordering).

## Risks and Mitigations

- Risk: Async QR PNG re-render races with login reset (stale `activeLogins` entry written to).
  - Mitigation: Render callback checks `still?.id === current.id` before writing; mismatched IDs are silently dropped.
- Risk: `flushCredsSaveQueue` blocks restart if a creds write hangs.
  - Mitigation: The queue already has error handling (`catch` in `enqueueSaveCreds`); a stuck write would have caused data loss regardless — flush just makes the timing explicit.


