### PR TITLE
fix(sessions): thread agentChannel through sessions_send instead of hardcoding INTERNAL_MESSAGE_CHANNEL

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -4,10 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
-import {
-  type GatewayMessageChannel,
-  INTERNAL_MESSAGE_CHANNEL,
-} from "../../utils/message-channel.js";
+import { type GatewayMessageChannel, INTER_SESSION_CHANNEL } from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
@@ -248,7 +245,7 @@ export function createSessionsSendTool(opts?: {
         sessionKey: resolvedKey,
         idempotencyKey,
         deliver: false,
-        channel: opts?.agentChannel ?? INTERNAL_MESSAGE_CHANNEL,
+        channel: INTER_SESSION_CHANNEL,
         lane: AGENT_LANE_NESTED,
         extraSystemPrompt: agentMessageContext,
         inputProvenance: {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -248,7 +248,7 @@ export function createSessionsSendTool(opts?: {
         sessionKey: resolvedKey,
         idempotencyKey,
         deliver: false,
-        channel: INTERNAL_MESSAGE_CHANNEL,
+        channel: opts?.agentChannel ?? INTERNAL_MESSAGE_CHANNEL,
         lane: AGENT_LANE_NESTED,
         extraSystemPrompt: agentMessageContext,
         inputProvenance: {

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -450,10 +450,17 @@ describe("sessions_send gating", () => {
     expect(result.details).toMatchObject({ status: "forbidden" });
   });
 
-  it("threads agentChannel through to the agent gateway call instead of hardcoding webchat", async () => {
-    // Regression test for: sessions_send hardcodes INTERNAL_MESSAGE_CHANNEL ("webchat"),
-    // causing reply routing to flip from Discord/external channel to control UI.
-    // Fix: channel should be opts.agentChannel ?? INTERNAL_MESSAGE_CHANNEL.
+  it("uses INTER_SESSION_CHANNEL sentinel instead of hardcoding webchat or threading sender channel", async () => {
+    // Regression test for: sessions_send hardcoded INTERNAL_MESSAGE_CHANNEL ("webchat"),
+    // causing the receiver's reply to flip from its external channel to the webchat UI.
+    //
+    // First fix attempt threaded agentChannel directly, but that caused a different bug:
+    // channel alone without paired to/accountId/threadId leaves the receiver with a
+    // mismatched channel+to state (resolveLastToRaw falls back to stale persistedLastTo).
+    //
+    // Correct fix: always use INTER_SESSION_CHANNEL ("inter_session") as a sentinel so
+    // resolveLastChannelRaw/resolveLastToRaw preserve the receiver's established route.
+    //
     // See: https://github.com/openclaw/openclaw/issues/43318
     loadConfigMock.mockReturnValue({
       session: { scope: "per-sender", mainKey: "main" },
@@ -467,30 +474,30 @@ describe("sessions_send gating", () => {
 
     const tool = createSessionsSendTool({
       agentSessionKey: MAIN_AGENT_SESSION_KEY,
-      agentChannel: MAIN_AGENT_CHANNEL, // "whatsapp"
+      agentChannel: MAIN_AGENT_CHANNEL, // "whatsapp" — should NOT be injected as channel
     });
 
-    await tool.execute("call-channel-threading", {
+    await tool.execute("call-inter-session-sentinel", {
       sessionKey: "agent:other:main",
       message: "hello from whatsapp agent",
       timeoutSeconds: 0,
     });
 
-    // Find the "agent" gateway call (the one that carries sendParams)
     const agentCall = callGatewayMock.mock.calls.find(
       (call) => (call[0] as { method?: string })?.method === "agent",
     );
     expect(agentCall).toBeDefined();
-    // Channel must be the source agent's channel, NOT "webchat"
-    expect((agentCall![0] as { params?: { channel?: string } })?.params?.channel).toBe(
-      MAIN_AGENT_CHANNEL,
-    );
-    expect((agentCall![0] as { params?: { channel?: string } })?.params?.channel).not.toBe(
-      "webchat",
-    );
+    const channel = (agentCall![0] as { params?: { channel?: string } })?.params?.channel;
+    // Must be the inter_session sentinel — NOT the sender's channel, NOT "webchat"
+    expect(channel).toBe("inter_session");
+    expect(channel).not.toBe("webchat");
+    expect(channel).not.toBe(MAIN_AGENT_CHANNEL);
   });
 
-  it("falls back to webchat channel when agentChannel is not provided", async () => {
+  it("uses INTER_SESSION_CHANNEL sentinel even when agentChannel is not provided", async () => {
+    // Even for internal spawns with no agentChannel, we use the sentinel so that
+    // resolveLastChannelRaw can still preserve any established external route on
+    // the receiver rather than unconditionally flipping to webchat.
     loadConfigMock.mockReturnValue({
       session: { scope: "per-sender", mainKey: "main" },
       tools: { agentToAgent: { enabled: true }, sessions: { visibility: "all" } },
@@ -501,12 +508,12 @@ describe("sessions_send gating", () => {
     });
     callGatewayMock.mockResolvedValueOnce({ runId: "run-test-456" });
 
-    // No agentChannel provided — internal spawn case
     const tool = createSessionsSendTool({
       agentSessionKey: MAIN_AGENT_SESSION_KEY,
+      // no agentChannel
     });
 
-    await tool.execute("call-no-channel", {
+    await tool.execute("call-no-channel-sentinel", {
       sessionKey: "agent:other:main",
       message: "internal message",
       timeoutSeconds: 0,
@@ -516,7 +523,8 @@ describe("sessions_send gating", () => {
       (call) => (call[0] as { method?: string })?.method === "agent",
     );
     expect(agentCall).toBeDefined();
-    // Should fall back to webchat when no agentChannel is set
-    expect((agentCall![0] as { params?: { channel?: string } })?.params?.channel).toBe("webchat");
+    expect((agentCall![0] as { params?: { channel?: string } })?.params?.channel).toBe(
+      "inter_session",
+    );
   });
 });

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -449,4 +449,74 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ method: "sessions.list" });
     expect(result.details).toMatchObject({ status: "forbidden" });
   });
+
+  it("threads agentChannel through to the agent gateway call instead of hardcoding webchat", async () => {
+    // Regression test for: sessions_send hardcodes INTERNAL_MESSAGE_CHANNEL ("webchat"),
+    // causing reply routing to flip from Discord/external channel to control UI.
+    // Fix: channel should be opts.agentChannel ?? INTERNAL_MESSAGE_CHANNEL.
+    // See: https://github.com/openclaw/openclaw/issues/43318
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: { agentToAgent: { enabled: true }, sessions: { visibility: "all" } },
+    });
+
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [{ key: "agent:other:main" }],
+    });
+    callGatewayMock.mockResolvedValueOnce({ runId: "run-test-123" });
+
+    const tool = createSessionsSendTool({
+      agentSessionKey: MAIN_AGENT_SESSION_KEY,
+      agentChannel: MAIN_AGENT_CHANNEL, // "whatsapp"
+    });
+
+    await tool.execute("call-channel-threading", {
+      sessionKey: "agent:other:main",
+      message: "hello from whatsapp agent",
+      timeoutSeconds: 0,
+    });
+
+    // Find the "agent" gateway call (the one that carries sendParams)
+    const agentCall = callGatewayMock.mock.calls.find(
+      (call) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(agentCall).toBeDefined();
+    // Channel must be the source agent's channel, NOT "webchat"
+    expect((agentCall![0] as { params?: { channel?: string } })?.params?.channel).toBe(
+      MAIN_AGENT_CHANNEL,
+    );
+    expect((agentCall![0] as { params?: { channel?: string } })?.params?.channel).not.toBe(
+      "webchat",
+    );
+  });
+
+  it("falls back to webchat channel when agentChannel is not provided", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: { agentToAgent: { enabled: true }, sessions: { visibility: "all" } },
+    });
+
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [{ key: "agent:other:main" }],
+    });
+    callGatewayMock.mockResolvedValueOnce({ runId: "run-test-456" });
+
+    // No agentChannel provided — internal spawn case
+    const tool = createSessionsSendTool({
+      agentSessionKey: MAIN_AGENT_SESSION_KEY,
+    });
+
+    await tool.execute("call-no-channel", {
+      sessionKey: "agent:other:main",
+      message: "internal message",
+      timeoutSeconds: 0,
+    });
+
+    const agentCall = callGatewayMock.mock.calls.find(
+      (call) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(agentCall).toBeDefined();
+    // Should fall back to webchat when no agentChannel is set
+    expect((agentCall![0] as { params?: { channel?: string } })?.params?.channel).toBe("webchat");
+  });
 });

--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -28,14 +28,17 @@ describe("INTER_SESSION_CHANNEL sentinel routing", () => {
     expect(result).toBe("discord");
   });
 
-  it("falls back to session-key channel hint when no persisted channel is set", () => {
+  it("returns undefined when persisted channel is absent and only session-key hint exists (no channel synthesis)", () => {
+    // Inter-session turns must not synthesise a channel from the session key alone.
+    // Without a persisted external channel, returning a channel-only route would leave
+    // lastTo undefined and risk misdelivery via the channel defaultTo fallback.
     expect(
       resolveLastChannelRaw({
         originatingChannelRaw: INTER_SESSION_CHANNEL,
         persistedLastChannel: undefined,
         sessionKey: "agent:navi:discord:direct:channel:123",
       }),
-    ).toBe("discord");
+    ).toBeUndefined();
   });
 
   it("returns undefined when no external route can be determined", () => {

--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -105,6 +105,46 @@ describe("INTER_SESSION_CHANNEL sentinel routing", () => {
     ).toBe("channel:receiver-discord-channel");
   });
 
+  it("returns undefined from resolveLastToRaw when persistedLastChannel is empty string", () => {
+    // Empty string is not an external routing channel — treat same as absent.
+    // Returning stale persistedLastTo would risk a channel/to mismatch.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        persistedLastChannel: "",
+        persistedLastTo: "channel:some-target",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined from resolveLastToRaw when persistedLastChannel is the sentinel itself (leaked state)", () => {
+    // Guard against corrupted persisted state where persistedLastChannel was
+    // accidentally set to "inter_session". The sentinel is not a deliverable
+    // channel and should never be treated as an established external route.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        persistedLastChannel: INTER_SESSION_CHANNEL,
+        persistedLastTo: "channel:some-target",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves persistedLastTo for non-discord external channels (e.g. telegram)", () => {
+    // The sentinel path should work for any external channel, not just discord.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        originatingToRaw: "channel:sender-telegram",
+        persistedLastChannel: "telegram",
+        persistedLastTo: "user:987654321",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBe("user:987654321");
+  });
+
   it("does not treat a real deliverable channel named 'inter_session' as the sentinel (Codex P2 guard)", () => {
     // isInterSessionChannel guards against plugin channel collision:
     // if a real channel plugin registers with id="inter_session", it must not

--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -74,6 +74,37 @@ describe("INTER_SESSION_CHANNEL sentinel routing", () => {
     ).toBeUndefined();
   });
 
+  it("returns undefined from resolveLastToRaw when channel will be resolved via session-key hint (Codex P1 fix)", () => {
+    // Scenario: persisted state is webchat (not external), so resolveLastChannelRaw
+    // falls back to the session-key hint and returns "discord". Blindly returning
+    // persistedLastTo here would create a mismatched lastChannel/lastTo pair
+    // (discord channel + stale webchat target). The sentinel must return undefined
+    // so the caller can derive an appropriate target from the new channel.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        originatingToRaw: "channel:sender-discord-channel",
+        persistedLastChannel: "webchat",
+        persistedLastTo: "session:stale-webchat-target",
+        sessionKey: "agent:navi:discord:direct:channel:123",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves persistedLastTo when persisted channel is already external (consistent pair)", () => {
+    // When the receiver already has an established external route (e.g. discord),
+    // both channel and to come from persisted state — no mismatch risk.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        originatingToRaw: "channel:sender-channel",
+        persistedLastChannel: "discord",
+        persistedLastTo: "channel:receiver-discord-channel",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBe("channel:receiver-discord-channel");
+  });
+
   it("does not treat a real deliverable channel named 'inter_session' as the sentinel (Codex P2 guard)", () => {
     // isInterSessionChannel guards against plugin channel collision:
     // if a real channel plugin registers with id="inter_session", it must not

--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -1,5 +1,79 @@
 import { describe, expect, it } from "vitest";
+import { INTER_SESSION_CHANNEL } from "../../utils/message-channel.js";
 import { resolveLastChannelRaw, resolveLastToRaw } from "./session-delivery.js";
+
+describe("INTER_SESSION_CHANNEL sentinel routing", () => {
+  it("preserves an established external channel for a main session", () => {
+    // sessions_send uses INTER_SESSION_CHANNEL so the receiver's Discord route
+    // is not flipped to webchat or replaced with the sender's channel.
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        persistedLastChannel: "discord",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBe("discord");
+  });
+
+  it("does not flip to webchat for a main session (original bug regression)", () => {
+    // Before the fix, INTERNAL_MESSAGE_CHANNEL ("webchat") was injected here,
+    // which caused resolveLastChannelRaw to return "webchat" for main sessions,
+    // overriding the Discord route. INTER_SESSION_CHANNEL must never produce "webchat".
+    const result = resolveLastChannelRaw({
+      originatingChannelRaw: INTER_SESSION_CHANNEL,
+      persistedLastChannel: "discord",
+      sessionKey: "agent:navi:main",
+    });
+    expect(result).not.toBe("webchat");
+    expect(result).toBe("discord");
+  });
+
+  it("falls back to session-key channel hint when no persisted channel is set", () => {
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        persistedLastChannel: undefined,
+        sessionKey: "agent:navi:discord:direct:channel:123",
+      }),
+    ).toBe("discord");
+  });
+
+  it("returns undefined when no external route can be determined", () => {
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        persistedLastChannel: undefined,
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves the receiver's persisted destination (resolveLastToRaw)", () => {
+    // Threading the sender's to/accountId/threadId would leave the receiver with
+    // a mismatched channel+to pair. The sentinel signals: keep the receiver's own dest.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        originatingToRaw: "channel:sender-discord-channel",
+        persistedLastChannel: "discord",
+        persistedLastTo: "channel:receiver-discord-channel",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBe("channel:receiver-discord-channel");
+  });
+
+  it("returns undefined from resolveLastToRaw when no persisted destination exists", () => {
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        originatingToRaw: "channel:sender-discord-channel",
+        persistedLastChannel: undefined,
+        persistedLastTo: undefined,
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBeUndefined();
+  });
+});
 
 describe("session delivery direct-session routing overrides", () => {
   it.each([

--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -73,6 +73,25 @@ describe("INTER_SESSION_CHANNEL sentinel routing", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("does not treat a real deliverable channel named 'inter_session' as the sentinel (Codex P2 guard)", () => {
+    // isInterSessionChannel guards against plugin channel collision:
+    // if a real channel plugin registers with id="inter_session", it must not
+    // be silently swallowed by the sentinel path.
+    // With no such plugin registered in the test registry, isDeliverableMessageChannel
+    // returns false for "inter_session" so the sentinel fires as expected.
+    // This test documents the invariant: sentinel only applies when the value is
+    // NOT a real deliverable channel.
+    const result = resolveLastChannelRaw({
+      originatingChannelRaw: INTER_SESSION_CHANNEL,
+      persistedLastChannel: "discord",
+      sessionKey: "agent:navi:main",
+    });
+    // In test env, "inter_session" is not a registered plugin channel, so
+    // isInterSessionChannel returns true and the sentinel path preserves "discord".
+    expect(result).toBe("discord");
+    expect(result).not.toBe(INTER_SESSION_CHANNEL);
+  });
 });
 
 describe("session delivery direct-session routing overrides", () => {

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -99,10 +99,6 @@ export function resolveLastChannelRaw(params: {
     if (isExternalRoutingChannel(persistedChannel)) {
       return persistedChannel;
     }
-    const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
-    if (isExternalRoutingChannel(sessionKeyChannelHint)) {
-      return sessionKeyChannelHint;
-    }
     return undefined;
   }
 

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -90,8 +90,6 @@ export function resolveLastChannelRaw(params: {
   persistedLastChannel?: string;
   sessionKey?: string;
 }): string | undefined {
-  const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
-
   // Inter-session messages (from sessions_send): preserve the receiver's
   // established external channel without injecting the sender's channel.
   // Threading the sender's channel alone — without paired to/accountId/threadId —
@@ -107,6 +105,11 @@ export function resolveLastChannelRaw(params: {
     }
     return undefined;
   }
+
+  // originatingChannel is only needed for the webchat-flip and external-routing
+  // checks below — declared after the inter-session guard to avoid computing it
+  // for the common inter-session fast path.
+  const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
 
   // WebChat should own reply routing for direct-session UI turns, even when the
   // session previously replied through an external channel like iMessage.

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -142,10 +142,19 @@ export function resolveLastToRaw(params: {
   persistedLastChannel?: string;
   sessionKey?: string;
 }): string | undefined {
-  // Inter-session messages: preserve the receiver's established destination.
-  // The sender's to/accountId/threadId are irrelevant to the receiver's route.
+  // Inter-session messages: preserve the receiver's established destination,
+  // but only when the persisted channel is already external. If the channel
+  // resolver falls back to a session-key hint (e.g. discord derived from the
+  // key while persistedLastChannel is still webchat), returning a stale
+  // persistedLastTo would create a mismatched lastChannel/lastTo pair and route
+  // replies to an invalid destination. In that case return undefined so the
+  // caller can derive an appropriate target from the new channel.
   if (isInterSessionChannel(params.originatingChannelRaw)) {
-    return params.persistedLastTo;
+    const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
+    if (isExternalRoutingChannel(persistedChannel)) {
+      return params.persistedLastTo;
+    }
+    return undefined;
   }
 
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -9,6 +9,7 @@ import {
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
+  isInterSessionChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import type { MsgContext } from "../templating.js";
@@ -90,6 +91,23 @@ export function resolveLastChannelRaw(params: {
   sessionKey?: string;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
+
+  // Inter-session messages (from sessions_send): preserve the receiver's
+  // established external channel without injecting the sender's channel.
+  // Threading the sender's channel alone — without paired to/accountId/threadId —
+  // would leave the receiver with a mismatched channel+to state.
+  if (isInterSessionChannel(params.originatingChannelRaw)) {
+    const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
+    if (isExternalRoutingChannel(persistedChannel)) {
+      return persistedChannel;
+    }
+    const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
+    if (isExternalRoutingChannel(sessionKeyChannelHint)) {
+      return sessionKeyChannelHint;
+    }
+    return undefined;
+  }
+
   // WebChat should own reply routing for direct-session UI turns, even when the
   // session previously replied through an external channel like iMessage.
   if (
@@ -121,6 +139,12 @@ export function resolveLastToRaw(params: {
   persistedLastChannel?: string;
   sessionKey?: string;
 }): string | undefined {
+  // Inter-session messages: preserve the receiver's established destination.
+  // The sender's to/accountId/threadId are irrelevant to the receiver's route.
+  if (isInterSessionChannel(params.originatingChannelRaw)) {
+    return params.persistedLastTo;
+  }
+
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
   if (
     originatingChannel === INTERNAL_MESSAGE_CHANNEL &&

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -522,6 +522,7 @@ describe("gateway agent handler", () => {
   it("rejects deliver=true when backend callers use the inter_session sentinel", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();
+    const context = makeContext();
     const selectionSpy = vi.spyOn(channelSelection, "resolveMessageChannelSelection");
     selectionSpy.mockResolvedValue({
       channel: "telegram",
@@ -540,6 +541,7 @@ describe("gateway agent handler", () => {
       },
       {
         reqId: "inter-session-backend-deliver-1",
+        context,
         client: {
           connect: {
             role: "operator",
@@ -566,6 +568,11 @@ describe("gateway agent handler", () => {
       code: "INVALID_REQUEST",
       message: expect.stringContaining("inter_session"),
     });
+    expect(context.addChatRun).not.toHaveBeenCalled();
+    expect(mocks.registerAgentRunContext).not.toHaveBeenCalledWith(
+      "test-inter-session-backend-deliver",
+      expect.anything(),
+    );
     expect(mocks.agentCommand).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
+import * as channelSelection from "../../infra/outbound/channel-selection.js";
 import { agentHandlers } from "./agent.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -475,6 +476,55 @@ describe("gateway agent handler", () => {
       | undefined;
     expect(callArgs?.messageChannel).toBe("inter_session");
     expect(callArgs?.runContext?.messageChannel).toBe("inter_session");
+  });
+
+  it("rejects deliver=true when backend callers use the inter_session sentinel", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+    const selectionSpy = vi.spyOn(channelSelection, "resolveMessageChannelSelection");
+    selectionSpy.mockResolvedValue({
+      channel: "telegram",
+      configured: ["telegram"],
+      source: "single-configured",
+    });
+
+    const respond = await invokeAgent(
+      {
+        message: "strict delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        channel: "inter_session",
+        deliver: true,
+        idempotencyKey: "test-inter-session-backend-deliver",
+      },
+      {
+        reqId: "inter-session-backend-deliver-1",
+        client: {
+          connect: {
+            role: "operator",
+            scopes: ["operator.write"],
+            client: {
+              id: "gateway-client",
+              mode: "backend",
+              version: "1.0.0",
+              platform: "node",
+            },
+          },
+        } as unknown as AgentHandlerArgs["client"],
+      },
+    );
+
+    selectionSpy.mockRestore();
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("inter_session"),
+    });
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
   });
 
   it("only forwards workspaceDir for spawned subagent runs", async () => {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -441,7 +441,47 @@ describe("gateway agent handler", () => {
     expect(mocks.agentCommand).not.toHaveBeenCalled();
   });
 
-  it("allows the inter_session sentinel for backend gateway callers", async () => {
+  it("rejects spoofed backend metadata for the inter_session sentinel", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+
+    const respond = await invokeAgent(
+      {
+        message: "strict delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        channel: "inter_session",
+        idempotencyKey: "test-inter-session-spoofed-backend",
+      },
+      {
+        reqId: "inter-session-spoofed-backend-1",
+        client: {
+          connect: {
+            role: "operator",
+            scopes: ["operator.write"],
+            client: {
+              id: "gateway-client",
+              mode: "backend",
+              version: "1.0.0",
+              platform: "node",
+            },
+          },
+        } as unknown as AgentHandlerArgs["client"],
+      },
+    );
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("unknown channel: inter_session"),
+    });
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+  });
+
+  it("allows the inter_session sentinel only for server-attested internal backend callers", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();
 
@@ -466,6 +506,7 @@ describe("gateway agent handler", () => {
               platform: "node",
             },
           },
+          isInternalBackendClient: true,
         } as unknown as AgentHandlerArgs["client"],
       },
     );
@@ -510,6 +551,7 @@ describe("gateway agent handler", () => {
               platform: "node",
             },
           },
+          isInternalBackendClient: true,
         } as unknown as AgentHandlerArgs["client"],
       },
     );

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -519,6 +519,47 @@ describe("gateway agent handler", () => {
     expect(callArgs?.runContext?.messageChannel).toBe("inter_session");
   });
 
+  it("rejects inter_session when it is only provided via replyChannel", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+
+    const respond = await invokeAgent(
+      {
+        message: "strict delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        replyChannel: "inter_session",
+        idempotencyKey: "test-inter-session-reply-only",
+      },
+      {
+        reqId: "inter-session-reply-only-1",
+        client: {
+          connect: {
+            role: "operator",
+            scopes: ["operator.write"],
+            client: {
+              id: "gateway-client",
+              mode: "backend",
+              version: "1.0.0",
+              platform: "node",
+            },
+          },
+          isInternalBackendClient: true,
+        } as unknown as AgentHandlerArgs["client"],
+      },
+    );
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("replyChannel"),
+    });
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+  });
+
   it("rejects deliver=true when backend callers use the inter_session sentinel", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -405,7 +405,79 @@ describe("gateway agent handler", () => {
     expect(callArgs.bestEffortDeliver).toBe(false);
   });
 
-  it("rejects public spawned-run metadata fields", async () => {
+  it("rejects the inter_session sentinel from non-backend callers", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+
+    const respond = await invokeAgent(
+      {
+        message: "strict delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        channel: "inter_session",
+        idempotencyKey: "test-inter-session-public",
+      },
+      {
+        reqId: "inter-session-public-1",
+        client: {
+          connect: {
+            role: "operator",
+            scopes: ["operator.write"],
+            client: { id: "test-client", mode: "ui", version: "1.0.0", platform: "test" },
+          },
+        } as unknown as AgentHandlerArgs["client"],
+      },
+    );
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("unknown channel: inter_session"),
+    });
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+  });
+
+  it("allows the inter_session sentinel for backend gateway callers", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+
+    await invokeAgent(
+      {
+        message: "strict delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        channel: "inter_session",
+        idempotencyKey: "test-inter-session-backend",
+      },
+      {
+        reqId: "inter-session-backend-1",
+        client: {
+          connect: {
+            role: "operator",
+            scopes: ["operator.write"],
+            client: {
+              id: "gateway-client",
+              mode: "backend",
+              version: "1.0.0",
+              platform: "node",
+            },
+          },
+        } as unknown as AgentHandlerArgs["client"],
+      },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as
+      | { messageChannel?: string; runContext?: { messageChannel?: string } }
+      | undefined;
+    expect(callArgs?.messageChannel).toBe("inter_session");
+    expect(callArgs?.runContext?.messageChannel).toBe("inter_session");
+  });
+
+  it("only forwards workspaceDir for spawned subagent runs", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();
     const respond = vi.fn();

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -38,12 +38,7 @@ import { resolveAssistantIdentity } from "../assistant-identity.js";
 import { parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
-import {
-  GATEWAY_CLIENT_CAPS,
-  GATEWAY_CLIENT_IDS,
-  GATEWAY_CLIENT_MODES,
-  hasGatewayClientCap,
-} from "../protocol/client-info.js";
+import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -78,10 +73,7 @@ function resolveSenderIsOwnerFromClient(client: GatewayRequestHandlerOptions["cl
 }
 
 function isInternalInterSessionCaller(client: GatewayRequestHandlerOptions["client"]): boolean {
-  return (
-    client?.connect?.client?.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
-    client.connect.client.mode === GATEWAY_CLIENT_MODES.BACKEND
-  );
+  return client?.isInternalBackendClient === true;
 }
 
 async function runSessionResetFromAgent(params: {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -481,6 +481,20 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     const wantsDelivery = request.deliver === true;
+    const requestedInterSessionForDelivery = [request.channel, request.replyChannel].some((value) =>
+      isInterSessionChannel(normalizeMessageChannel(value)),
+    );
+    if (wantsDelivery && requestedInterSessionForDelivery) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "delivery channel cannot use the inter_session sentinel",
+        ),
+      );
+      return;
+    }
     const explicitTo =
       typeof request.replyTo === "string" && request.replyTo.trim()
         ? request.replyTo.trim()

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -313,6 +313,23 @@ export const agentHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+
+    const wantsDelivery = request.deliver === true;
+    const requestedInterSessionForDelivery = [request.channel, request.replyChannel].some((value) =>
+      isInterSessionChannel(normalizeMessageChannel(value)),
+    );
+    if (wantsDelivery && requestedInterSessionForDelivery) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "delivery channel cannot use the inter_session sentinel",
+        ),
+      );
+      return;
+    }
+
     let resolvedSessionId = request.sessionId?.trim() || undefined;
     let sessionEntry: SessionEntry | undefined;
     let bestEffortDeliver = requestedBestEffortDeliver ?? false;
@@ -472,21 +489,6 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const wantsDelivery = request.deliver === true;
-    const requestedInterSessionForDelivery = [request.channel, request.replyChannel].some((value) =>
-      isInterSessionChannel(normalizeMessageChannel(value)),
-    );
-    if (wantsDelivery && requestedInterSessionForDelivery) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          "delivery channel cannot use the inter_session sentinel",
-        ),
-      );
-      return;
-    }
     const explicitTo =
       typeof request.replyTo === "string" && request.replyTo.trim()
         ? request.replyTo.trim()

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -29,8 +29,10 @@ import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
+  RESERVED_CHANNEL_IDS,
   isDeliverableMessageChannel,
   isGatewayMessageChannel,
+  isInterSessionChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
@@ -231,7 +233,13 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const isKnownGatewayChannel = (value: string): boolean => isGatewayMessageChannel(value);
+    const isKnownGatewayChannel = (raw: string): boolean => {
+      // Capture as a plain string before any type-guard narrowing, since
+      // GatewayMessageChannel includes (string & {}) and TypeScript would
+      // otherwise narrow the remainder to never after the type guard.
+      const lower: string = String(raw).toLowerCase();
+      return isGatewayMessageChannel(raw) || RESERVED_CHANNEL_IDS.has(lower);
+    };
     const channelHints = [request.channel, request.replyChannel]
       .filter((value): value is string => typeof value === "string")
       .map((value) => value.trim())
@@ -549,8 +557,14 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     const normalizedTurnSource = normalizeMessageChannel(turnSourceChannel);
+    // Allow internal sentinels (e.g. INTER_SESSION_CHANNEL) to propagate as
+    // the turn source so resolveLastChannelRaw can handle them correctly.
+    // External callers cannot reach this path with a sentinel: the channel hint
+    // validation above rejects any unknown channel that is not in RESERVED_CHANNEL_IDS,
+    // and RESERVED_CHANNEL_IDS are not in listGatewayMessageChannels().
     const turnSourceMessageChannel =
-      normalizedTurnSource && isGatewayMessageChannel(normalizedTurnSource)
+      normalizedTurnSource &&
+      (isGatewayMessageChannel(normalizedTurnSource) || isInterSessionChannel(normalizedTurnSource))
         ? normalizedTurnSource
         : undefined;
     const originMessageChannel =

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -29,7 +29,6 @@ import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
-  RESERVED_CHANNEL_IDS,
   isDeliverableMessageChannel,
   isGatewayMessageChannel,
   isInterSessionChannel,
@@ -39,7 +38,12 @@ import { resolveAssistantIdentity } from "../assistant-identity.js";
 import { parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
-import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
+import {
+  GATEWAY_CLIENT_CAPS,
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+  hasGatewayClientCap,
+} from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -71,6 +75,13 @@ const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
 function resolveSenderIsOwnerFromClient(client: GatewayRequestHandlerOptions["client"]): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
   return scopes.includes(ADMIN_SCOPE);
+}
+
+function isInternalInterSessionCaller(client: GatewayRequestHandlerOptions["client"]): boolean {
+  return (
+    client?.connect?.client?.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+    client.connect.client.mode === GATEWAY_CLIENT_MODES.BACKEND
+  );
 }
 
 async function runSessionResetFromAgent(params: {
@@ -233,13 +244,9 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const isKnownGatewayChannel = (raw: string): boolean => {
-      // Capture as a plain string before any type-guard narrowing, since
-      // GatewayMessageChannel includes (string & {}) and TypeScript would
-      // otherwise narrow the remainder to never after the type guard.
-      const lower: string = String(raw).toLowerCase();
-      return isGatewayMessageChannel(raw) || RESERVED_CHANNEL_IDS.has(lower);
-    };
+    const allowInterSessionSentinel = isInternalInterSessionCaller(client);
+    const isKnownGatewayChannel = (raw: string): boolean =>
+      isGatewayMessageChannel(raw) || (allowInterSessionSentinel && isInterSessionChannel(raw));
     const channelHints = [request.channel, request.replyChannel]
       .filter((value): value is string => typeof value === "string")
       .map((value) => value.trim())
@@ -557,14 +564,13 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     const normalizedTurnSource = normalizeMessageChannel(turnSourceChannel);
-    // Allow internal sentinels (e.g. INTER_SESSION_CHANNEL) to propagate as
-    // the turn source so resolveLastChannelRaw can handle them correctly.
-    // External callers cannot reach this path with a sentinel: the channel hint
-    // validation above rejects any unknown channel that is not in RESERVED_CHANNEL_IDS,
-    // and RESERVED_CHANNEL_IDS are not in listGatewayMessageChannels().
+    // Only backend-internal gateway callers may propagate the inter-session
+    // sentinel so resolveLastChannelRaw can preserve an established external
+    // route. Public RPC callers must not inject sentinel channels here.
     const turnSourceMessageChannel =
       normalizedTurnSource &&
-      (isGatewayMessageChannel(normalizedTurnSource) || isInterSessionChannel(normalizedTurnSource))
+      (isGatewayMessageChannel(normalizedTurnSource) ||
+        (allowInterSessionSentinel && isInterSessionChannel(normalizedTurnSource)))
         ? normalizedTurnSource
         : undefined;
     const originMessageChannel =

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -257,6 +257,21 @@ export const agentHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+    if (
+      allowInterSessionSentinel &&
+      isInterSessionChannel(request.replyChannel) &&
+      !isInterSessionChannel(request.channel)
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          'invalid agent params: replyChannel cannot use "inter_session" without channel',
+        ),
+      );
+      return;
+    }
 
     const agentIdRaw = typeof request.agentId === "string" ? request.agentId.trim() : "";
     const agentId = agentIdRaw ? normalizeAgentId(agentIdRaw) : undefined;

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -21,6 +21,8 @@ export type GatewayClient = {
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;
+  /** Server-attested marker for gateway-created internal backend clients. */
+  isInternalBackendClient?: boolean;
 };
 
 export type RespondFn = (

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -61,6 +61,7 @@ function createSyntheticOperatorClient(): GatewayRequestOptions["client"] {
       role: "operator",
       scopes: ["operator.admin", "operator.approvals", "operator.pairing"],
     },
+    isInternalBackendClient: true,
   };
 }
 

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -140,9 +140,18 @@ describe("sessions_send gateway loopback", () => {
     expect(details.sessionKey).toBe("main");
 
     const firstCall = spy.mock.calls[0]?.[0] as
-      | { lane?: string; inputProvenance?: { kind?: string; sourceTool?: string } }
+      | {
+          lane?: string;
+          channel?: string;
+          messageChannel?: string;
+          runContext?: { messageChannel?: string };
+          inputProvenance?: { kind?: string; sourceTool?: string };
+        }
       | undefined;
     expect(firstCall?.lane).toBe("nested");
+    expect(firstCall?.channel).toBe("inter_session");
+    expect(firstCall?.messageChannel).toBe("inter_session");
+    expect(firstCall?.runContext?.messageChannel).toBe("inter_session");
     expect(firstCall?.inputProvenance).toMatchObject({
       kind: "inter_session",
       sourceTool: "sessions_send",

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, type Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type Mock } from "vitest";
 import { resolveSessionTranscriptPath } from "../config/sessions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { captureEnv } from "../test-utils/env.js";
@@ -75,7 +75,7 @@ async function emitLifecycleAssistantReply(params: {
   });
 }
 
-beforeAll(async () => {
+beforeEach(async () => {
   envSnapshot = captureEnv(["OPENCLAW_GATEWAY_PORT", "OPENCLAW_GATEWAY_TOKEN"]);
   gatewayPort = await getFreePort();
   testState.gatewayAuth = { mode: "token", token: gatewayToken };
@@ -98,7 +98,7 @@ beforeAll(async () => {
   server = await startGatewayServer(gatewayPort);
 });
 
-afterAll(async () => {
+afterEach(async () => {
   await server.close();
   envSnapshot.restore();
 });
@@ -149,7 +149,7 @@ describe("sessions_send gateway loopback", () => {
         }
       | undefined;
     expect(firstCall?.lane).toBe("nested");
-    expect(firstCall?.channel).toBe("inter_session");
+    expect(firstCall?.channel).toBe("webchat");
     expect(firstCall?.messageChannel).toBe("inter_session");
     expect(firstCall?.runContext?.messageChannel).toBe("inter_session");
     expect(firstCall?.inputProvenance).toMatchObject({

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -178,6 +178,40 @@ describe("createGatewayPluginRequestHandler", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("missing scope: operator.admin"));
   });
 
+  it("does not mark unauthenticated plugin routes as internal backend clients", async () => {
+    loadOpenClawPlugins.mockReset();
+    handleGatewayRequest.mockReset();
+    handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
+      opts.respond(true, { internal: opts.client?.isInternalBackendClient === true });
+    });
+
+    const subagent = await createSubagentRuntime();
+    const handler = createGatewayPluginRequestHandler({
+      registry: createTestRegistry({
+        httpRoutes: [
+          createRoute({
+            path: "/hook",
+            auth: "plugin",
+            handler: async (_req, _res) => {
+              await subagent.deleteSession({ sessionKey: "agent:main:subagent:child" });
+              return true;
+            },
+          }),
+        ],
+      }),
+      log: createPluginLog(),
+    });
+
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/hook" } as IncomingMessage, res, undefined, {
+      gatewayAuthSatisfied: false,
+    });
+
+    expect(handled).toBe(true);
+    expect(handleGatewayRequest).toHaveBeenCalledTimes(1);
+    expect(handleGatewayRequest.mock.calls[0]?.[0]?.client?.isInternalBackendClient).toBe(false);
+  });
+
   it("returns false when no routes are registered", async () => {
     const log = createPluginLog();
     const handler = createGatewayPluginRequestHandler({

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -49,6 +49,7 @@ function createPluginRouteRuntimeClient(params: {
       role: "operator",
       scopes,
     },
+    isInternalBackendClient: true,
   };
 }
 

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -49,7 +49,7 @@ function createPluginRouteRuntimeClient(params: {
       role: "operator",
       scopes,
     },
-    isInternalBackendClient: true,
+    isInternalBackendClient: params.requiresGatewayAuth && params.gatewayAuthSatisfied !== false,
   };
 }
 

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "vitest";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
 import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
   resolveControlUiAuthPolicy,
+  shouldSkipBackendSelfPairing,
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
 
@@ -299,5 +301,90 @@ describe("ws connect policy", () => {
         }),
       ).toBe(tc.expected);
     }
+  });
+
+  test("backend self-pairing skip requires trusted local backend handshake conditions", () => {
+    const makeConnectParams = (clientId: string, mode: string) => ({
+      client: {
+        id: clientId,
+        mode,
+        version: "1.0.0",
+      },
+    });
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "trusted-proxy",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams("not-gateway-client", GATEWAY_CLIENT_MODES.BACKEND),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -5,6 +5,7 @@ import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
   resolveControlUiAuthPolicy,
+  resolveInternalBackendClientAttestation,
   shouldSkipBackendSelfPairing,
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
@@ -640,6 +641,58 @@ describe("ws connect policy", () => {
         sharedAuthOk: false,
         authOk: false,
         authMethod: "none",
+      }),
+    ).toBe(false);
+  });
+
+  test("promotes bootstrap-paired backend clients to internal attestation", () => {
+    const backendConnect: ConnectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+        version: "1.0.0",
+        platform: "node",
+      },
+      minProtocol: 1,
+      maxProtocol: 1,
+    };
+
+    expect(
+      resolveInternalBackendClientAttestation({
+        connectParams: backendConnect,
+        hasBrowserOriginHeader: false,
+        initialIsInternalBackendClient: false,
+        authMethod: "bootstrap-token",
+        deviceTokenIssued: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      resolveInternalBackendClientAttestation({
+        connectParams: backendConnect,
+        hasBrowserOriginHeader: true,
+        initialIsInternalBackendClient: false,
+        authMethod: "bootstrap-token",
+        deviceTokenIssued: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      resolveInternalBackendClientAttestation({
+        connectParams: {
+          client: {
+            id: "desktop",
+            mode: GATEWAY_CLIENT_MODES.TEST,
+            version: "1.0.0",
+            platform: "node",
+          },
+          minProtocol: 1,
+          maxProtocol: 1,
+        },
+        hasBrowserOriginHeader: false,
+        initialIsInternalBackendClient: false,
+        authMethod: "bootstrap-token",
+        deviceTokenIssued: true,
       }),
     ).toBe(false);
   });

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -424,6 +424,20 @@ describe("ws connect policy", () => {
       }),
     ).toBe(false);
 
+    // Backend client authenticating via device-token (derived from initial shared-secret pairing) is trusted.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "device-token",
+      }),
+    ).toBe(true);
+
     // Remote backend client (gateway.mode=remote) with valid shared-secret auth is trusted.
     expect(
       shouldSkipBackendSelfPairing({

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -524,8 +524,8 @@ describe("ws connect policy", () => {
       }),
     ).toBe(false);
 
-    // bootstrap-token should also count as a trusted backend authOk method so
-    // first-time paired sessions can still use internal inter_session delivery.
+    // bootstrap-token is onboarding-only auth: first-time backend connects must still
+    // go through pairing so the session can mint/persist a device token.
     expect(
       shouldSkipBackendSelfPairing({
         connectParams: makeConnectParams(
@@ -538,7 +538,7 @@ describe("ws connect policy", () => {
         authOk: true,
         authMethod: "bootstrap-token",
       }),
-    ).toBe(true);
+    ).toBe(false);
 
     // Remote device-token backend client is trusted when authOk=true.
     expect(
@@ -555,7 +555,7 @@ describe("ws connect policy", () => {
       }),
     ).toBe(true);
 
-    // Remote bootstrap-token backend client is trusted when authOk=true.
+    // Remote bootstrap-token backend clients are also still onboarding and must pair.
     expect(
       shouldSkipBackendSelfPairing({
         connectParams: makeConnectParams(
@@ -568,7 +568,7 @@ describe("ws connect policy", () => {
         authOk: true,
         authMethod: "bootstrap-token",
       }),
-    ).toBe(true);
+    ).toBe(false);
 
     // Remote backend client (gateway.mode=remote) with valid shared-secret auth is trusted.
     expect(

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
+import type { ConnectParams } from "../../protocol/index.js";
 import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
@@ -304,12 +305,18 @@ describe("ws connect policy", () => {
   });
 
   test("backend self-pairing skip requires trusted local backend handshake conditions", () => {
-    const makeConnectParams = (clientId: string, mode: string) => ({
+    const makeConnectParams = (
+      clientId: ConnectParams["client"]["id"],
+      mode: ConnectParams["client"]["mode"],
+    ): ConnectParams => ({
       client: {
         id: clientId,
         mode,
         version: "1.0.0",
+        platform: "node",
       },
+      minProtocol: 1,
+      maxProtocol: 1,
     });
 
     expect(
@@ -379,7 +386,7 @@ describe("ws connect policy", () => {
 
     expect(
       shouldSkipBackendSelfPairing({
-        connectParams: makeConnectParams("not-gateway-client", GATEWAY_CLIENT_MODES.BACKEND),
+        connectParams: makeConnectParams("webchat", GATEWAY_CLIENT_MODES.BACKEND),
         isLocalClient: true,
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -385,6 +385,48 @@ describe("ws connect policy", () => {
       }),
     ).toBe(false);
 
+    // Backend client authenticated via verified Tailscale identity is trusted.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "tailscale",
+      }),
+    ).toBe(true);
+
+    // Remote backend client over Tailscale is also trusted.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "tailscale",
+      }),
+    ).toBe(true);
+
+    // Browser-origin Tailscale backend connection is still rejected.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: true,
+        authMethod: "tailscale",
+      }),
+    ).toBe(false);
+
     expect(
       shouldSkipBackendSelfPairing({
         connectParams: makeConnectParams("webchat", GATEWAY_CLIENT_MODES.BACKEND),

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -393,5 +393,48 @@ describe("ws connect policy", () => {
         authMethod: "token",
       }),
     ).toBe(false);
+
+    // auth.mode="none": local backend client with no browser origin is trusted even without a
+    // shared secret, because there is no secret to verify.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "none",
+      }),
+    ).toBe(true);
+
+    // auth.mode="none" with remote client is still rejected (isLocalClient=false).
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "none",
+      }),
+    ).toBe(false);
+
+    // auth.mode="none" with browser origin header is still rejected (hasBrowserOriginHeader=true).
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: false,
+        authMethod: "none",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -385,7 +385,8 @@ describe("ws connect policy", () => {
       }),
     ).toBe(false);
 
-    // Backend client authenticated via verified Tailscale identity is trusted.
+    // Backend client authenticated via verified Tailscale identity is trusted via authOk,
+    // not sharedAuthOk (sharedAuthOk stays false for tailscale per auth-context.ts).
     expect(
       shouldSkipBackendSelfPairing({
         connectParams: makeConnectParams(
@@ -394,7 +395,8 @@ describe("ws connect policy", () => {
         ),
         isLocalClient: true,
         hasBrowserOriginHeader: false,
-        sharedAuthOk: true,
+        sharedAuthOk: false,
+        authOk: true,
         authMethod: "tailscale",
       }),
     ).toBe(true);
@@ -408,10 +410,26 @@ describe("ws connect policy", () => {
         ),
         isLocalClient: false,
         hasBrowserOriginHeader: false,
-        sharedAuthOk: true,
+        sharedAuthOk: false,
+        authOk: true,
         authMethod: "tailscale",
       }),
     ).toBe(true);
+
+    // Tailscale with authOk=false is rejected.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: false,
+        authMethod: "tailscale",
+      }),
+    ).toBe(false);
 
     // Browser-origin Tailscale backend connection is still rejected.
     expect(
@@ -422,7 +440,8 @@ describe("ws connect policy", () => {
         ),
         isLocalClient: false,
         hasBrowserOriginHeader: true,
-        sharedAuthOk: true,
+        sharedAuthOk: false,
+        authOk: true,
         authMethod: "tailscale",
       }),
     ).toBe(false);

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -516,6 +516,22 @@ describe("ws connect policy", () => {
       }),
     ).toBe(false);
 
+    // bootstrap-token should also count as a trusted backend authOk method so
+    // first-time paired sessions can still use internal inter_session delivery.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "bootstrap-token",
+      }),
+    ).toBe(true);
+
     // Remote backend client (gateway.mode=remote) with valid shared-secret auth is trusted.
     expect(
       shouldSkipBackendSelfPairing({

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -334,7 +334,8 @@ describe("ws connect policy", () => {
       }),
     ).toBe(true);
 
-    // Remote backend client with valid shared-secret auth is now trusted (gateway.mode=remote support).
+    // Remote shared-secret backend clients must still complete pairing; the
+    // client-reported gateway-client/backend label is not enough to skip it.
     expect(
       shouldSkipBackendSelfPairing({
         connectParams: makeConnectParams(
@@ -347,7 +348,7 @@ describe("ws connect policy", () => {
         authOk: true,
         authMethod: "token",
       }),
-    ).toBe(true);
+    ).toBe(false);
 
     expect(
       shouldSkipBackendSelfPairing({
@@ -407,7 +408,8 @@ describe("ws connect policy", () => {
       }),
     ).toBe(true);
 
-    // Remote backend client over Tailscale is also trusted.
+    // Remote Tailscale-authenticated backend clients still need pairing. A
+    // spoofed gateway-client/backend label must not create implicit trust.
     expect(
       shouldSkipBackendSelfPairing({
         connectParams: makeConnectParams(
@@ -420,7 +422,7 @@ describe("ws connect policy", () => {
         authOk: true,
         authMethod: "tailscale",
       }),
-    ).toBe(true);
+    ).toBe(false);
 
     // Tailscale with authOk=false is rejected.
     expect(
@@ -541,7 +543,8 @@ describe("ws connect policy", () => {
       }),
     ).toBe(false);
 
-    // Remote device-token backend client is trusted when authOk=true.
+    // Remote device-token backend clients also keep the pairing check. Device
+    // token auth proves the credential, not the self-declared backend label.
     expect(
       shouldSkipBackendSelfPairing({
         connectParams: makeConnectParams(
@@ -554,7 +557,7 @@ describe("ws connect policy", () => {
         authOk: true,
         authMethod: "device-token",
       }),
-    ).toBe(true);
+    ).toBe(false);
 
     // Remote bootstrap-token backend clients are also still onboarding and must pair.
     expect(
@@ -571,7 +574,8 @@ describe("ws connect policy", () => {
       }),
     ).toBe(false);
 
-    // Remote backend client (gateway.mode=remote) with valid shared-secret auth is trusted.
+    // Duplicate regression guard: remote shared-secret backend clients must not
+    // bypass pairing just by claiming the backend client identity.
     expect(
       shouldSkipBackendSelfPairing({
         connectParams: makeConnectParams(
@@ -584,7 +588,7 @@ describe("ws connect policy", () => {
         authOk: true,
         authMethod: "token",
       }),
-    ).toBe(true);
+    ).toBe(false);
 
     // Remote backend client with browser origin header is still rejected.
     expect(

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -532,6 +532,36 @@ describe("ws connect policy", () => {
       }),
     ).toBe(true);
 
+    // Remote device-token backend client is trusted when authOk=true.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "device-token",
+      }),
+    ).toBe(true);
+
+    // Remote bootstrap-token backend client is trusted when authOk=true.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "bootstrap-token",
+      }),
+    ).toBe(true);
+
     // Remote backend client (gateway.mode=remote) with valid shared-secret auth is trusted.
     expect(
       shouldSkipBackendSelfPairing({
@@ -557,6 +587,34 @@ describe("ws connect policy", () => {
         hasBrowserOriginHeader: true,
         sharedAuthOk: true,
         authMethod: "token",
+      }),
+    ).toBe(false);
+
+    // Browser-origin device-token / bootstrap-token backend connections are also rejected.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "device-token",
+      }),
+    ).toBe(false);
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "bootstrap-token",
       }),
     ).toBe(false);
 

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -328,6 +328,7 @@ describe("ws connect policy", () => {
         isLocalClient: true,
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
+        authOk: true,
         authMethod: "token",
       }),
     ).toBe(true);
@@ -342,6 +343,7 @@ describe("ws connect policy", () => {
         isLocalClient: false,
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
+        authOk: true,
         authMethod: "token",
       }),
     ).toBe(true);
@@ -355,6 +357,7 @@ describe("ws connect policy", () => {
         isLocalClient: true,
         hasBrowserOriginHeader: true,
         sharedAuthOk: true,
+        authOk: true,
         authMethod: "token",
       }),
     ).toBe(false);
@@ -368,6 +371,7 @@ describe("ws connect policy", () => {
         isLocalClient: true,
         hasBrowserOriginHeader: false,
         sharedAuthOk: false,
+        authOk: false,
         authMethod: "token",
       }),
     ).toBe(false);
@@ -381,6 +385,7 @@ describe("ws connect policy", () => {
         isLocalClient: true,
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
+        authOk: true,
         authMethod: "trusted-proxy",
       }),
     ).toBe(false);
@@ -452,6 +457,7 @@ describe("ws connect policy", () => {
         isLocalClient: true,
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
+        authOk: true,
         authMethod: "token",
       }),
     ).toBe(false);
@@ -467,6 +473,7 @@ describe("ws connect policy", () => {
         isLocalClient: true,
         hasBrowserOriginHeader: false,
         sharedAuthOk: false,
+        authOk: false,
         authMethod: "none",
       }),
     ).toBe(true);
@@ -481,6 +488,7 @@ describe("ws connect policy", () => {
         isLocalClient: false,
         hasBrowserOriginHeader: false,
         sharedAuthOk: false,
+        authOk: false,
         authMethod: "none",
       }),
     ).toBe(false);
@@ -572,6 +580,7 @@ describe("ws connect policy", () => {
         isLocalClient: false,
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
+        authOk: true,
         authMethod: "token",
       }),
     ).toBe(true);
@@ -586,6 +595,7 @@ describe("ws connect policy", () => {
         isLocalClient: false,
         hasBrowserOriginHeader: true,
         sharedAuthOk: true,
+        authOk: true,
         authMethod: "token",
       }),
     ).toBe(false);
@@ -628,6 +638,7 @@ describe("ws connect policy", () => {
         isLocalClient: true,
         hasBrowserOriginHeader: true,
         sharedAuthOk: false,
+        authOk: false,
         authMethod: "none",
       }),
     ).toBe(false);

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -424,7 +424,8 @@ describe("ws connect policy", () => {
       }),
     ).toBe(false);
 
-    // Backend client authenticating via device-token (derived from initial shared-secret pairing) is trusted.
+    // Backend client authenticating via device-token is trusted via authOk, not sharedAuthOk
+    // (sharedAuthOk stays false for device-token in the WS flow per auth-context.ts).
     expect(
       shouldSkipBackendSelfPairing({
         connectParams: makeConnectParams(
@@ -433,10 +434,26 @@ describe("ws connect policy", () => {
         ),
         isLocalClient: true,
         hasBrowserOriginHeader: false,
-        sharedAuthOk: true,
+        sharedAuthOk: false,
+        authOk: true,
         authMethod: "device-token",
       }),
     ).toBe(true);
+
+    // device-token with authOk=false is rejected.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: false,
+        authMethod: "device-token",
+      }),
+    ).toBe(false);
 
     // Remote backend client (gateway.mode=remote) with valid shared-secret auth is trusted.
     expect(

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -713,7 +713,7 @@ describe("ws connect policy", () => {
       maxProtocol: 1,
     };
 
-    for (const authMethod of ["token", "password", "device-token", "tailscale"] as const) {
+    for (const authMethod of ["token", "password", "device-token", "tailscale", "trusted-proxy"] as const) {
       expect(
         resolveInternalBackendClientAttestation({
           connectParams: backendConnect,

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -332,6 +332,7 @@ describe("ws connect policy", () => {
       }),
     ).toBe(true);
 
+    // Remote backend client with valid shared-secret auth is now trusted (gateway.mode=remote support).
     expect(
       shouldSkipBackendSelfPairing({
         connectParams: makeConnectParams(
@@ -343,7 +344,7 @@ describe("ws connect policy", () => {
         sharedAuthOk: true,
         authMethod: "token",
       }),
-    ).toBe(false);
+    ).toBe(true);
 
     expect(
       shouldSkipBackendSelfPairing({
@@ -420,6 +421,34 @@ describe("ws connect policy", () => {
         hasBrowserOriginHeader: false,
         sharedAuthOk: false,
         authMethod: "none",
+      }),
+    ).toBe(false);
+
+    // Remote backend client (gateway.mode=remote) with valid shared-secret auth is trusted.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(true);
+
+    // Remote backend client with browser origin header is still rejected.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: true,
+        authMethod: "token",
       }),
     ).toBe(false);
 

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -700,4 +700,39 @@ describe("ws connect policy", () => {
       }),
     ).toBe(false);
   });
+
+  test("attests authenticated remote backend clients for inter_session", () => {
+    const backendConnect: ConnectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+        version: "1.0.0",
+        platform: "node",
+      },
+      minProtocol: 1,
+      maxProtocol: 1,
+    };
+
+    for (const authMethod of ["token", "password", "device-token", "tailscale"] as const) {
+      expect(
+        resolveInternalBackendClientAttestation({
+          connectParams: backendConnect,
+          hasBrowserOriginHeader: false,
+          initialIsInternalBackendClient: false,
+          authMethod,
+          deviceTokenIssued: false,
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      resolveInternalBackendClientAttestation({
+        connectParams: backendConnect,
+        hasBrowserOriginHeader: true,
+        initialIsInternalBackendClient: false,
+        authMethod: "token",
+        deviceTokenIssued: false,
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -82,6 +82,7 @@ export function shouldSkipBackendSelfPairing(params: {
   isLocalClient: boolean;
   hasBrowserOriginHeader: boolean;
   sharedAuthOk: boolean;
+  authOk: boolean;
   authMethod: GatewayAuthResult["method"];
 }): boolean {
   const isGatewayBackendClient =
@@ -90,23 +91,22 @@ export function shouldSkipBackendSelfPairing(params: {
   if (!isGatewayBackendClient) {
     return false;
   }
-  // device-token is a derived credential issued after initial shared-secret pairing, so it
-  // carries equivalent trust for the internal backend path.
-  const usesSharedSecretAuth =
-    params.authMethod === "token" ||
-    params.authMethod === "password" ||
-    params.authMethod === "device-token";
-  // When auth is disabled entirely (mode="none"), there is no shared secret to verify, but a
-  // local client with no browser origin and the correct gateway-client/backend identity is still
-  // a trusted internal connection.
+  // token/password: sharedAuthOk is set specifically for these in auth-context.ts.
+  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  // device-token: a derived credential issued after initial shared-secret pairing. sharedAuthOk
+  // stays false for device-token in the WS flow (auth-context.ts only sets it for token/password/
+  // trusted-proxy), so we gate on authOk directly instead.
+  const usesDeviceTokenAuth = params.authMethod === "device-token";
+  // When auth is disabled entirely (mode="none"), there is no credential to verify. Restrict to
+  // local connections only — remote + no-auth would be a security hole.
   const authIsDisabled = params.authMethod === "none";
-  // Remote backend clients (gateway.mode=remote) connecting with a valid shared-secret credential
-  // are trusted too — isLocalClient is false for remote gateways but the shared secret provides
-  // equivalent trust. Only the auth-disabled path is restricted to local connections, because
-  // remote + no-auth would be a security hole.
+  // Remote backend clients (gateway.mode=remote) with shared-secret or device-token auth are
+  // trusted. Only the auth-disabled path requires isLocalClient.
   return (
     !params.hasBrowserOriginHeader &&
-    ((params.sharedAuthOk && usesSharedSecretAuth) || (params.isLocalClient && authIsDisabled))
+    ((params.sharedAuthOk && usesSharedSecretAuth) ||
+      (params.authOk && usesDeviceTokenAuth) ||
+      (params.isLocalClient && authIsDisabled))
   );
 }
 

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -93,12 +93,15 @@ export function shouldSkipBackendSelfPairing(params: {
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   // When auth is disabled entirely (mode="none"), there is no shared secret to verify, but a
   // local client with no browser origin and the correct gateway-client/backend identity is still
-  // a trusted internal connection. Allow attestation in that case too.
+  // a trusted internal connection.
   const authIsDisabled = params.authMethod === "none";
+  // Remote backend clients (gateway.mode=remote) connecting with a valid shared-secret credential
+  // are trusted too — isLocalClient is false for remote gateways but the shared secret provides
+  // equivalent trust. Only the auth-disabled path is restricted to local connections, because
+  // remote + no-auth would be a security hole.
   return (
-    params.isLocalClient &&
     !params.hasBrowserOriginHeader &&
-    ((params.sharedAuthOk && usesSharedSecretAuth) || authIsDisabled)
+    ((params.sharedAuthOk && usesSharedSecretAuth) || (params.isLocalClient && authIsDisabled))
   );
 }
 

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -92,7 +92,11 @@ export function shouldSkipBackendSelfPairing(params: {
     return false;
   }
   // token/password: sharedAuthOk is set specifically for these in auth-context.ts.
-  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  // tailscale: WS auth can also attest a backend client via verified Tailscale identity.
+  const usesSharedSecretAuth =
+    params.authMethod === "token" ||
+    params.authMethod === "password" ||
+    params.authMethod === "tailscale";
   // device-token: a derived credential issued after initial shared-secret pairing. sharedAuthOk
   // stays false for device-token in the WS flow (auth-context.ts only sets it for token/password/
   // trusted-proxy), so we gate on authOk directly instead.

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -93,11 +93,13 @@ export function shouldSkipBackendSelfPairing(params: {
   }
   // token/password: sharedAuthOk is set specifically for these in auth-context.ts.
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
-  // device-token and tailscale: both are valid auth methods but sharedAuthOk is never set for
-  // either in the WS flow (auth-context.ts only sets it for token/password/trusted-proxy).
-  // Gate on authOk directly for these instead.
+  // device-token, tailscale, and bootstrap-token: all are valid auth methods but
+  // sharedAuthOk is never set for them in the WS flow (auth-context.ts only sets it for
+  // token/password/trusted-proxy). Gate on authOk directly for these instead.
   const usesAuthOkMethod =
-    params.authMethod === "device-token" || params.authMethod === "tailscale";
+    params.authMethod === "device-token" ||
+    params.authMethod === "tailscale" ||
+    params.authMethod === "bootstrap-token";
   // When auth is disabled entirely (mode="none"), there is no credential to verify. Restrict to
   // local connections only — remote + no-auth would be a security hole.
   const authIsDisabled = params.authMethod === "none";

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -92,24 +92,21 @@ export function shouldSkipBackendSelfPairing(params: {
     return false;
   }
   // token/password: sharedAuthOk is set specifically for these in auth-context.ts.
-  // tailscale: WS auth can also attest a backend client via verified Tailscale identity.
-  const usesSharedSecretAuth =
-    params.authMethod === "token" ||
-    params.authMethod === "password" ||
-    params.authMethod === "tailscale";
-  // device-token: a derived credential issued after initial shared-secret pairing. sharedAuthOk
-  // stays false for device-token in the WS flow (auth-context.ts only sets it for token/password/
-  // trusted-proxy), so we gate on authOk directly instead.
-  const usesDeviceTokenAuth = params.authMethod === "device-token";
+  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  // device-token and tailscale: both are valid auth methods but sharedAuthOk is never set for
+  // either in the WS flow (auth-context.ts only sets it for token/password/trusted-proxy).
+  // Gate on authOk directly for these instead.
+  const usesAuthOkMethod =
+    params.authMethod === "device-token" || params.authMethod === "tailscale";
   // When auth is disabled entirely (mode="none"), there is no credential to verify. Restrict to
   // local connections only — remote + no-auth would be a security hole.
   const authIsDisabled = params.authMethod === "none";
-  // Remote backend clients (gateway.mode=remote) with shared-secret or device-token auth are
-  // trusted. Only the auth-disabled path requires isLocalClient.
+  // Remote backend clients (gateway.mode=remote) with any trusted credential are allowed.
+  // Only the auth-disabled path requires isLocalClient.
   return (
     !params.hasBrowserOriginHeader &&
     ((params.sharedAuthOk && usesSharedSecretAuth) ||
-      (params.authOk && usesDeviceTokenAuth) ||
+      (params.authOk && usesAuthOkMethod) ||
       (params.isLocalClient && authIsDisabled))
   );
 }

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -1,5 +1,5 @@
+import type { GatewayAuthResult } from "../../auth.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
-import type { GatewayAuthResult } from "../../protocol/index.js";
 import type { ConnectParams } from "../../protocol/index.js";
 import type { GatewayRole } from "../../role-policy.js";
 import { roleCanSkipDeviceIdentity } from "../../role-policy.js";

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -91,11 +91,14 @@ export function shouldSkipBackendSelfPairing(params: {
     return false;
   }
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  // When auth is disabled entirely (mode="none"), there is no shared secret to verify, but a
+  // local client with no browser origin and the correct gateway-client/backend identity is still
+  // a trusted internal connection. Allow attestation in that case too.
+  const authIsDisabled = params.authMethod === "none";
   return (
     params.isLocalClient &&
     !params.hasBrowserOriginHeader &&
-    params.sharedAuthOk &&
-    usesSharedSecretAuth
+    ((params.sharedAuthOk && usesSharedSecretAuth) || authIsDisabled)
   );
 }
 

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -134,7 +134,8 @@ export function resolveInternalBackendClientAttestation(params: {
     params.authMethod === "token" ||
     params.authMethod === "password" ||
     params.authMethod === "device-token" ||
-    params.authMethod === "tailscale"
+    params.authMethod === "tailscale" ||
+    params.authMethod === "trusted-proxy"
   ) {
     return true;
   }

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -91,6 +91,9 @@ export function shouldSkipBackendSelfPairing(params: {
   if (!isGatewayBackendClient) {
     return false;
   }
+  if (params.hasBrowserOriginHeader || !params.isLocalClient) {
+    return false;
+  }
   // token/password: sharedAuthOk is set specifically for these in auth-context.ts.
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   // device-token and tailscale are valid backend auth methods, but sharedAuthOk is never
@@ -100,16 +103,14 @@ export function shouldSkipBackendSelfPairing(params: {
   // complete pairing so the gateway can mint and persist a device token.
   const usesAuthOkMethod =
     params.authMethod === "device-token" || params.authMethod === "tailscale";
-  // When auth is disabled entirely (mode="none"), there is no credential to verify. Restrict to
-  // local connections only — remote + no-auth would be a security hole.
+  // When auth is disabled entirely (mode="none"), there is no credential to verify. Restricting
+  // backend self-pairing skip to locally attested clients keeps remote callers from turning a
+  // client-reported gateway-client/backend label into implicit trust.
   const authIsDisabled = params.authMethod === "none";
-  // Remote backend clients (gateway.mode=remote) with any trusted credential are allowed.
-  // Only the auth-disabled path requires isLocalClient.
   return (
-    !params.hasBrowserOriginHeader &&
-    ((params.sharedAuthOk && usesSharedSecretAuth) ||
-      (params.authOk && usesAuthOkMethod) ||
-      (params.isLocalClient && authIsDisabled))
+    (params.sharedAuthOk && usesSharedSecretAuth) ||
+    (params.authOk && usesAuthOkMethod) ||
+    authIsDisabled
   );
 }
 

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -130,6 +130,14 @@ export function resolveInternalBackendClientAttestation(params: {
   if (!isGatewayBackendClient || params.hasBrowserOriginHeader) {
     return false;
   }
+  if (
+    params.authMethod === "token" ||
+    params.authMethod === "password" ||
+    params.authMethod === "device-token" ||
+    params.authMethod === "tailscale"
+  ) {
+    return true;
+  }
   return params.authMethod === "bootstrap-token" && params.deviceTokenIssued;
 }
 

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -90,7 +90,12 @@ export function shouldSkipBackendSelfPairing(params: {
   if (!isGatewayBackendClient) {
     return false;
   }
-  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  // device-token is a derived credential issued after initial shared-secret pairing, so it
+  // carries equivalent trust for the internal backend path.
+  const usesSharedSecretAuth =
+    params.authMethod === "token" ||
+    params.authMethod === "password" ||
+    params.authMethod === "device-token";
   // When auth is disabled entirely (mode="none"), there is no shared secret to verify, but a
   // local client with no browser origin and the correct gateway-client/backend identity is still
   // a trusted internal connection.

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -93,13 +93,13 @@ export function shouldSkipBackendSelfPairing(params: {
   }
   // token/password: sharedAuthOk is set specifically for these in auth-context.ts.
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
-  // device-token, tailscale, and bootstrap-token: all are valid auth methods but
-  // sharedAuthOk is never set for them in the WS flow (auth-context.ts only sets it for
-  // token/password/trusted-proxy). Gate on authOk directly for these instead.
+  // device-token and tailscale are valid backend auth methods, but sharedAuthOk is never
+  // set for them in the WS flow (auth-context.ts only sets it for token/password/
+  // trusted-proxy). Gate on authOk directly for these instead.
+  // bootstrap-token is intentionally excluded: first-time bootstrap connects must still
+  // complete pairing so the gateway can mint and persist a device token.
   const usesAuthOkMethod =
-    params.authMethod === "device-token" ||
-    params.authMethod === "tailscale" ||
-    params.authMethod === "bootstrap-token";
+    params.authMethod === "device-token" || params.authMethod === "tailscale";
   // When auth is disabled entirely (mode="none"), there is no credential to verify. Restrict to
   // local connections only — remote + no-auth would be a security hole.
   const authIsDisabled = params.authMethod === "none";

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -113,6 +113,25 @@ export function shouldSkipBackendSelfPairing(params: {
   );
 }
 
+export function resolveInternalBackendClientAttestation(params: {
+  connectParams: ConnectParams;
+  hasBrowserOriginHeader: boolean;
+  initialIsInternalBackendClient: boolean;
+  authMethod: GatewayAuthResult["method"];
+  deviceTokenIssued: boolean;
+}): boolean {
+  if (params.initialIsInternalBackendClient) {
+    return true;
+  }
+  const isGatewayBackendClient =
+    params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+    params.connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND;
+  if (!isGatewayBackendClient || params.hasBrowserOriginHeader) {
+    return false;
+  }
+  return params.authMethod === "bootstrap-token" && params.deviceTokenIssued;
+}
+
 export type MissingDeviceIdentityDecision =
   | { kind: "allow" }
   | { kind: "reject-control-ui-insecure-auth" }

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -1,3 +1,5 @@
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
+import type { GatewayAuthResult } from "../../protocol/index.js";
 import type { ConnectParams } from "../../protocol/index.js";
 import type { GatewayRole } from "../../role-policy.js";
 import { roleCanSkipDeviceIdentity } from "../../role-policy.js";
@@ -72,6 +74,28 @@ export function isTrustedProxyControlUiOperatorAuth(params: {
     params.authMode === "trusted-proxy" &&
     params.authOk &&
     params.authMethod === "trusted-proxy"
+  );
+}
+
+export function shouldSkipBackendSelfPairing(params: {
+  connectParams: ConnectParams;
+  isLocalClient: boolean;
+  hasBrowserOriginHeader: boolean;
+  sharedAuthOk: boolean;
+  authMethod: GatewayAuthResult["method"];
+}): boolean {
+  const isGatewayBackendClient =
+    params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+    params.connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND;
+  if (!isGatewayBackendClient) {
+    return false;
+  }
+  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  return (
+    params.isLocalClient &&
+    !params.hasBrowserOriginHeader &&
+    params.sharedAuthOk &&
+    usesSharedSecretAuth
   );
 }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -679,6 +679,7 @@ export function attachGatewayWsMessageHandler(params: {
           isLocalClient,
           hasBrowserOriginHeader,
           sharedAuthOk,
+          authOk,
           authMethod,
         });
         // auth.mode=none disables all authentication — device pairing is an

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -683,10 +683,7 @@ export function attachGatewayWsMessageHandler(params: {
           authOk,
           authMethod,
         });
-        // auth.mode=none disables all authentication — device pairing is an
-        // auth mechanism and must also be skipped when the operator opted out.
         const skipPairing =
-          resolvedAuth.mode === "none" ||
           isInternalBackendClient ||
           shouldSkipControlUiPairing(
             controlUiAuthPolicy,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -83,6 +83,7 @@ import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
   resolveControlUiAuthPolicy,
+  shouldSkipBackendSelfPairing,
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
 import {
@@ -90,7 +91,6 @@ import {
   resolveHandshakeBrowserSecurityContext,
   resolveUnauthorizedHandshakeContext,
   shouldAllowSilentLocalPairing,
-  shouldSkipBackendSelfPairing,
 } from "./handshake-auth-helpers.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -83,6 +83,7 @@ import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
   resolveControlUiAuthPolicy,
+  resolveInternalBackendClientAttestation,
   shouldSkipBackendSelfPairing,
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
@@ -891,6 +892,13 @@ export function attachGatewayWsMessageHandler(params: {
         const deviceToken = device
           ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
           : null;
+        const attestedInternalBackendClient = resolveInternalBackendClientAttestation({
+          connectParams,
+          hasBrowserOriginHeader,
+          initialIsInternalBackendClient: isInternalBackendClient,
+          authMethod,
+          deviceTokenIssued: deviceToken !== null,
+        });
 
         if (role === "node") {
           const cfg = loadConfig();
@@ -995,7 +1003,7 @@ export function attachGatewayWsMessageHandler(params: {
           canvasHostUrl,
           canvasCapability,
           canvasCapabilityExpiresAtMs,
-          isInternalBackendClient,
+          isInternalBackendClient: attestedInternalBackendClient,
         };
         setSocketMaxPayload(socket, MAX_PAYLOAD_BYTES);
         setClient(nextClient);

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -674,14 +674,18 @@ export function attachGatewayWsMessageHandler(params: {
           authOk,
           authMethod,
         });
+        const isInternalBackendClient = shouldSkipBackendSelfPairing({
+          connectParams,
+          isLocalClient,
+          hasBrowserOriginHeader,
+          sharedAuthOk,
+          authMethod,
+        });
+        // auth.mode=none disables all authentication — device pairing is an
+        // auth mechanism and must also be skipped when the operator opted out.
         const skipPairing =
-          shouldSkipBackendSelfPairing({
-            connectParams,
-            isLocalClient,
-            hasBrowserOriginHeader,
-            sharedAuthOk,
-            authMethod,
-          }) ||
+          resolvedAuth.mode === "none" ||
+          isInternalBackendClient ||
           shouldSkipControlUiPairing(
             controlUiAuthPolicy,
             role,
@@ -990,9 +994,7 @@ export function attachGatewayWsMessageHandler(params: {
           canvasHostUrl,
           canvasCapability,
           canvasCapabilityExpiresAtMs,
-          isInternalBackendClient:
-            connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
-            connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND,
+          isInternalBackendClient,
         };
         setSocketMaxPayload(socket, MAX_PAYLOAD_BYTES);
         setClient(nextClient);

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -990,6 +990,9 @@ export function attachGatewayWsMessageHandler(params: {
           canvasHostUrl,
           canvasCapability,
           canvasCapabilityExpiresAtMs,
+          isInternalBackendClient:
+            connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+            connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND,
         };
         setSocketMaxPayload(socket, MAX_PAYLOAD_BYTES);
         setClient(nextClient);

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -10,4 +10,6 @@ export type GatewayWsClient = {
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;
+  /** Server-attested marker for gateway-created internal backend clients. */
+  isInternalBackendClient?: boolean;
 };

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -4,8 +4,8 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { normalizeAccountId } from "../../utils/account-id.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
-  RESERVED_CHANNEL_IDS,
   isDeliverableMessageChannel,
+  isReservedChannelId,
   isGatewayMessageChannel,
   normalizeMessageChannel,
   type GatewayMessageChannel,
@@ -94,7 +94,7 @@ export function resolveAgentDeliveryPlan(params: {
     // before reaching this planner.
     if (
       requestedChannel &&
-      RESERVED_CHANNEL_IDS.has(requestedChannel.toLowerCase()) &&
+      isReservedChannelId(requestedChannel) &&
       requestedChannel !== INTERNAL_MESSAGE_CHANNEL
     ) {
       return INTERNAL_MESSAGE_CHANNEL;

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -88,9 +88,10 @@ export function resolveAgentDeliveryPlan(params: {
   });
 
   const resolvedChannel = (() => {
-    // Hard-reject internal sentinel channels. INTER_SESSION_CHANNEL is excluded
-    // from listGatewayMessageChannels() so external callers are already blocked,
-    // but defend here too in case the channel reaches delivery via another path.
+    // Internal sentinels must never resolve to a deliverable channel. Keep
+    // them on the internal/webchat path here so non-delivery flows stay
+    // internal; callers that request real delivery must reject sentinels
+    // before reaching this planner.
     if (
       requestedChannel &&
       RESERVED_CHANNEL_IDS.has(requestedChannel.toLowerCase()) &&

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -4,6 +4,7 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { normalizeAccountId } from "../../utils/account-id.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
+  RESERVED_CHANNEL_IDS,
   isDeliverableMessageChannel,
   isGatewayMessageChannel,
   normalizeMessageChannel,
@@ -87,6 +88,16 @@ export function resolveAgentDeliveryPlan(params: {
   });
 
   const resolvedChannel = (() => {
+    // Hard-reject internal sentinel channels. INTER_SESSION_CHANNEL is excluded
+    // from listGatewayMessageChannels() so external callers are already blocked,
+    // but defend here too in case the channel reaches delivery via another path.
+    if (
+      requestedChannel &&
+      RESERVED_CHANNEL_IDS.has(requestedChannel.toLowerCase()) &&
+      requestedChannel !== INTERNAL_MESSAGE_CHANNEL
+    ) {
+      return INTERNAL_MESSAGE_CHANNEL;
+    }
     if (requestedChannel === INTERNAL_MESSAGE_CHANNEL) {
       return INTERNAL_MESSAGE_CHANNEL;
     }

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -500,6 +500,25 @@ describe("installPluginFromArchive", () => {
     });
   });
 
+  it("rejects internal sentinel channel ids as plugin names", async () => {
+    for (const reservedId of ["inter_session", "webchat"]) {
+      const result = await installArchivePackageAndReturnResult({
+        packageJson: {
+          name: `@evil/${reservedId}`,
+          version: "0.0.1",
+          openclaw: { extensions: ["./dist/index.js"] },
+        },
+        outName: `reserved-channel-${reservedId}.tgz`,
+        withDistIndex: true,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        return;
+      }
+      expect(result.error).toContain("reserved internal channel id");
+    }
+  });
+
   it("rejects packages without openclaw.extensions", async () => {
     const result = await installArchivePackageAndReturnResult({
       packageJson: { name: "@openclaw/nope", version: "0.0.1" },

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -31,6 +31,7 @@ import { validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import * as skillScanner from "../security/skill-scanner.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
+import { RESERVED_CHANNEL_IDS } from "../utils/message-channel.js";
 import {
   loadPluginManifest,
   resolvePackageExtensionEntries,
@@ -94,13 +95,6 @@ function encodePluginInstallDirName(pluginId: string): string {
   // with valid unscoped ids that happen to match the hashed slug.
   return `@${safePathSegmentHashed(trimmed)}`;
 }
-
-/**
- * Channel IDs that are reserved for internal OpenClaw routing and must never
- * be used as plugin identifiers. Claiming one of these would silently shadow
- * a sentinel value and break cross-session message delivery.
- */
-const RESERVED_CHANNEL_IDS = new Set(["inter_session", "webchat"]);
 
 function validatePluginId(pluginId: string): string | null {
   const trimmed = pluginId.trim();

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -31,7 +31,7 @@ import { validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import * as skillScanner from "../security/skill-scanner.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
-import { RESERVED_CHANNEL_IDS } from "../utils/message-channel.js";
+import { isReservedChannelId } from "../utils/message-channel.js";
 import {
   loadPluginManifest,
   resolvePackageExtensionEntries,
@@ -86,6 +86,8 @@ function safeFileName(input: string): string {
   return safeDirName(input);
 }
 
+// Reserved plugin ids are checked through message-channel.ts so plugin install
+// and runtime registration share one immutable source of truth.
 function encodePluginInstallDirName(pluginId: string): string {
   const trimmed = pluginId.trim();
   if (!trimmed.includes("/")) {
@@ -115,12 +117,12 @@ function validatePluginId(pluginId: string): string | null {
     if (trimmed.startsWith("@")) {
       return "invalid plugin name: scoped ids must use @scope/name format";
     }
-    if (RESERVED_CHANNEL_IDS.has(trimmed.toLowerCase())) {
+    if (isReservedChannelId(trimmed)) {
       return `invalid plugin name: "${pluginId}" is a reserved internal channel id`;
     }
     return null;
   }
-  if (RESERVED_CHANNEL_IDS.has(unscopedPackageName(trimmed).toLowerCase())) {
+  if (isReservedChannelId(unscopedPackageName(trimmed))) {
     return `invalid plugin name: "${pluginId}" is a reserved internal channel id`;
   }
   if (segments.length !== 2) {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -95,6 +95,13 @@ function encodePluginInstallDirName(pluginId: string): string {
   return `@${safePathSegmentHashed(trimmed)}`;
 }
 
+/**
+ * Channel IDs that are reserved for internal OpenClaw routing and must never
+ * be used as plugin identifiers. Claiming one of these would silently shadow
+ * a sentinel value and break cross-session message delivery.
+ */
+const RESERVED_CHANNEL_IDS = new Set(["inter_session", "webchat"]);
+
 function validatePluginId(pluginId: string): string | null {
   const trimmed = pluginId.trim();
   if (!trimmed) {
@@ -114,7 +121,13 @@ function validatePluginId(pluginId: string): string | null {
     if (trimmed.startsWith("@")) {
       return "invalid plugin name: scoped ids must use @scope/name format";
     }
+    if (RESERVED_CHANNEL_IDS.has(trimmed.toLowerCase())) {
+      return `invalid plugin name: "${pluginId}" is a reserved internal channel id`;
+    }
     return null;
+  }
+  if (RESERVED_CHANNEL_IDS.has(unscopedPackageName(trimmed).toLowerCase())) {
+    return `invalid plugin name: "${pluginId}" is a reserved internal channel id`;
   }
   if (segments.length !== 2) {
     return "invalid plugin name: path separators not allowed";

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -971,6 +971,56 @@ describe("loadOpenClawPlugins", () => {
     ).toBe(true);
   });
 
+  it("strips reserved names from channel aliases and emits an error diagnostic (Codex P2)", () => {
+    // A plugin whose meta.aliases includes "inter_session" or "webchat" would
+    // cause normalizeMessageChannel to remap the sentinel into a real deliverable
+    // channel, bypassing resolveLastChannelRaw / resolveLastToRaw guards.
+    // Reserved aliases must be stripped at registration time.
+    useNoBundledPlugins();
+    for (const reservedAlias of ["inter_session", "webchat"]) {
+      const plugin = writePlugin({
+        id: `alias-bypass-${reservedAlias}`,
+        filename: `alias-bypass-${reservedAlias}.cjs`,
+        body: `module.exports = { id: "alias-bypass-${reservedAlias}", register(api) {
+  api.registerChannel({
+    plugin: {
+      id: "legit-channel",
+      meta: {
+        id: "legit-channel",
+        label: "Legit",
+        selectionLabel: "Legit",
+        docsPath: "/channels/legit",
+        blurb: "legit channel",
+        aliases: ["${reservedAlias}", "legit-alias"]
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({ accountId: "default" })
+      },
+      outbound: { deliveryMode: "direct" }
+    }
+  });
+} };`,
+      });
+
+      const registry = loadRegistryFromSinglePlugin({
+        plugin,
+        pluginConfig: { allow: [`alias-bypass-${reservedAlias}`] },
+      });
+
+      const channel = registry.channels.find((entry) => entry.plugin.id === "legit-channel");
+      expect(channel).toBeDefined();
+
+      const aliases = channel?.plugin.meta?.aliases ?? [];
+      expect(aliases).not.toContain(reservedAlias);
+      expect(aliases).toContain("legit-alias");
+
+      expect(
+        registry.diagnostics.some((d) => d.level === "error" && d.message.includes(reservedAlias)),
+      ).toBe(true);
+    }
+  });
   it("registers http routes with auth and match options", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -10,6 +10,7 @@ import type {
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import { resolveUserPath } from "../utils.js";
+import { RESERVED_CHANNEL_IDS } from "../utils/message-channel.js";
 import { registerPluginCommand } from "./commands.js";
 import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
@@ -427,6 +428,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         pluginId: record.id,
         source: record.source,
         message: "channel registration missing id",
+      });
+      return;
+    }
+    if (RESERVED_CHANNEL_IDS.has(id.toLowerCase())) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `channel id "${id}" is reserved for internal OpenClaw routing and cannot be registered by a plugin`,
       });
       return;
     }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -440,6 +440,27 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       });
       return;
     }
+    // Strip reserved names from aliases too. A plugin alias that maps to
+    // "inter_session" or "webchat" would cause normalizeMessageChannel to
+    // remap the sentinel into a real deliverable channel, bypassing the guards
+    // in resolveLastChannelRaw / resolveLastToRaw.
+    const reservedAliases =
+      plugin.meta?.aliases?.filter((a) => RESERVED_CHANNEL_IDS.has(a.trim().toLowerCase())) ?? [];
+    if (reservedAliases.length > 0) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `channel aliases [${reservedAliases.join(", ")}] are reserved for internal OpenClaw routing and cannot be used by a plugin`,
+      });
+      // Strip reserved aliases rather than blocking the whole registration so
+      // the rest of the channel can still be used normally.
+      if (plugin.meta?.aliases) {
+        plugin.meta.aliases = plugin.meta.aliases.filter(
+          (a) => !RESERVED_CHANNEL_IDS.has(a.trim().toLowerCase()),
+        );
+      }
+    }
     const existing = registry.channels.find((entry) => entry.plugin.id === id);
     if (existing) {
       pushDiagnostic({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -10,7 +10,7 @@ import type {
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import { resolveUserPath } from "../utils.js";
-import { RESERVED_CHANNEL_IDS } from "../utils/message-channel.js";
+import { isReservedChannelId } from "../utils/message-channel.js";
 import { registerPluginCommand } from "./commands.js";
 import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
@@ -431,7 +431,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       });
       return;
     }
-    if (RESERVED_CHANNEL_IDS.has(id.toLowerCase())) {
+    if (isReservedChannelId(id)) {
       pushDiagnostic({
         level: "error",
         pluginId: record.id,
@@ -444,8 +444,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     // "inter_session" or "webchat" would cause normalizeMessageChannel to
     // remap the sentinel into a real deliverable channel, bypassing the guards
     // in resolveLastChannelRaw / resolveLastToRaw.
-    const reservedAliases =
-      plugin.meta?.aliases?.filter((a) => RESERVED_CHANNEL_IDS.has(a.trim().toLowerCase())) ?? [];
+    const reservedAliases = plugin.meta?.aliases?.filter((a) => isReservedChannelId(a)) ?? [];
     if (reservedAliases.length > 0) {
       pushDiagnostic({
         level: "error",
@@ -456,9 +455,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       // Strip reserved aliases rather than blocking the whole registration so
       // the rest of the channel can still be used normally.
       if (plugin.meta?.aliases) {
-        plugin.meta.aliases = plugin.meta.aliases.filter(
-          (a) => !RESERVED_CHANNEL_IDS.has(a.trim().toLowerCase()),
-        );
+        plugin.meta.aliases = plugin.meta.aliases.filter((a) => !isReservedChannelId(a));
       }
     }
     const existing = registry.channels.find((entry) => entry.plugin.id === id);

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createMSTeamsTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { resolveGatewayMessageChannel } from "./message-channel.js";
+import {
+  INTER_SESSION_CHANNEL,
+  normalizeMessageChannel,
+  resolveGatewayMessageChannel,
+} from "./message-channel.js";
 
 const emptyRegistry = createTestRegistry([]);
 const msteamsPlugin: ChannelPlugin = {
@@ -30,5 +34,20 @@ describe("message-channel", () => {
       createTestRegistry([{ pluginId: "msteams", plugin: msteamsPlugin, source: "test" }]),
     );
     expect(resolveGatewayMessageChannel("teams")).toBe("msteams");
+  });
+
+  it("does not remap reserved sentinel ids through mutable plugin aliases", () => {
+    const plugin: ChannelPlugin = {
+      ...createMSTeamsTestPluginBase(),
+      meta: {
+        ...createMSTeamsTestPluginBase().meta,
+        aliases: ["teams"],
+      },
+    };
+    setActivePluginRegistry(createTestRegistry([{ pluginId: "msteams", plugin, source: "test" }]));
+
+    plugin.meta.aliases?.push(INTER_SESSION_CHANNEL);
+
+    expect(normalizeMessageChannel(INTER_SESSION_CHANNEL)).toBe(INTER_SESSION_CHANNEL);
   });
 });

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -4,6 +4,7 @@ import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createMSTeamsTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
   INTER_SESSION_CHANNEL,
+  listReservedChannelIds,
   normalizeMessageChannel,
   resolveGatewayMessageChannel,
 } from "./message-channel.js";
@@ -49,5 +50,15 @@ describe("message-channel", () => {
     plugin.meta.aliases?.push(INTER_SESSION_CHANNEL);
 
     expect(normalizeMessageChannel(INTER_SESSION_CHANNEL)).toBe(INTER_SESSION_CHANNEL);
+  });
+
+  it("does not let callers mutate the reserved channel source of truth", () => {
+    const reserved = listReservedChannelIds();
+
+    reserved.length = 0;
+    reserved.push("discord");
+
+    expect(normalizeMessageChannel(INTER_SESSION_CHANNEL)).toBe(INTER_SESSION_CHANNEL);
+    expect(normalizeMessageChannel("webchat")).toBe("webchat");
   });
 });

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -52,6 +52,21 @@ describe("message-channel", () => {
     expect(normalizeMessageChannel(INTER_SESSION_CHANNEL)).toBe(INTER_SESSION_CHANNEL);
   });
 
+  it("ignores non-string plugin aliases during channel normalization", () => {
+    const plugin: ChannelPlugin = {
+      ...createMSTeamsTestPluginBase(),
+      meta: {
+        ...createMSTeamsTestPluginBase().meta,
+        aliases: ["teams", 42 as never, null as never],
+      },
+    };
+    setActivePluginRegistry(createTestRegistry([{ pluginId: "msteams", plugin, source: "test" }]));
+
+    expect(resolveGatewayMessageChannel("teams")).toBe("msteams");
+    expect(() => normalizeMessageChannel("unknown-channel")).not.toThrow();
+    expect(normalizeMessageChannel("unknown-channel")).toBe("unknown-channel");
+  });
+
   it("does not let callers mutate the reserved channel source of truth", () => {
     const reserved = listReservedChannelIds();
 

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -38,8 +38,11 @@ const RESERVED_CHANNEL_IDS: ReadonlySet<string> = new Set([
   INTERNAL_MESSAGE_CHANNEL,
 ]);
 
-export function isReservedChannelId(raw?: string | null): boolean {
-  const normalized = raw?.trim().toLowerCase();
+export function isReservedChannelId(raw?: unknown): boolean {
+  if (typeof raw !== "string") {
+    return false;
+  }
+  const normalized = raw.trim().toLowerCase();
   return Boolean(normalized) && RESERVED_CHANNEL_IDS.has(normalized);
 }
 
@@ -110,7 +113,7 @@ export function normalizeMessageChannel(raw?: string | null): string | undefined
       return true;
     }
     return (entry.plugin.meta.aliases ?? []).some(
-      (alias) => alias.trim().toLowerCase() === normalized,
+      (alias) => typeof alias === "string" && alias.trim().toLowerCase() === normalized,
     );
   });
   return pluginMatch?.plugin.id ?? normalized;
@@ -129,7 +132,9 @@ const listPluginChannelAliases = (): string[] => {
   if (!registry) {
     return [];
   }
-  return registry.channels.flatMap((entry) => entry.plugin.meta.aliases ?? []);
+  return registry.channels.flatMap((entry) =>
+    (entry.plugin.meta.aliases ?? []).filter((alias): alias is string => typeof alias === "string"),
+  );
 };
 
 export const listDeliverableMessageChannels = (): ChannelId[] =>

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -33,7 +33,10 @@ export type InterSessionChannel = typeof INTER_SESSION_CHANNEL;
  * Checked in both plugin install (validatePluginId) and runtime channel
  * registration (registerChannel) to cover all registration paths.
  */
-export const RESERVED_CHANNEL_IDS = new Set([INTER_SESSION_CHANNEL, INTERNAL_MESSAGE_CHANNEL]);
+export const RESERVED_CHANNEL_IDS: Set<string> = new Set([
+  INTER_SESSION_CHANNEL,
+  INTERNAL_MESSAGE_CHANNEL,
+]);
 
 export function isInterSessionChannel(raw?: string | null): boolean {
   // Guard against collision with real deliverable plugin channels: a plugin

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -26,6 +26,15 @@ export type InternalMessageChannel = typeof INTERNAL_MESSAGE_CHANNEL;
 export const INTER_SESSION_CHANNEL = "inter_session" as const;
 export type InterSessionChannel = typeof INTER_SESSION_CHANNEL;
 
+/**
+ * Channel IDs that are reserved for internal OpenClaw routing.
+ * No plugin may register a channel with these IDs — doing so would shadow
+ * a sentinel value and silently break cross-session message delivery.
+ * Checked in both plugin install (validatePluginId) and runtime channel
+ * registration (registerChannel) to cover all registration paths.
+ */
+export const RESERVED_CHANNEL_IDS = new Set([INTER_SESSION_CHANNEL, INTERNAL_MESSAGE_CHANNEL]);
+
 export function isInterSessionChannel(raw?: string | null): boolean {
   // Guard against collision with real deliverable plugin channels: a plugin
   // could theoretically register a channel named "inter_session", which must

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -17,6 +17,19 @@ import { getActivePluginRegistry } from "../plugins/runtime.js";
 export const INTERNAL_MESSAGE_CHANNEL = "webchat" as const;
 export type InternalMessageChannel = typeof INTERNAL_MESSAGE_CHANNEL;
 
+/**
+ * Sentinel channel used when sessions_send injects a message into a target
+ * session. Distinct from INTERNAL_MESSAGE_CHANNEL so that resolveLastChannelRaw
+ * does NOT flip the receiver's route to webchat. Instead it falls through to
+ * the persisted external channel, preserving the receiver's established route.
+ */
+export const INTER_SESSION_CHANNEL = "inter_session" as const;
+export type InterSessionChannel = typeof INTER_SESSION_CHANNEL;
+
+export function isInterSessionChannel(raw?: string | null): boolean {
+  return raw?.trim().toLowerCase() === INTER_SESSION_CHANNEL;
+}
+
 const MARKDOWN_CAPABLE_CHANNELS = new Set<string>([
   "slack",
   "telegram",
@@ -97,11 +110,15 @@ export const listDeliverableMessageChannels = (): ChannelId[] =>
 
 export type DeliverableMessageChannel = ChannelId;
 
-export type GatewayMessageChannel = DeliverableMessageChannel | InternalMessageChannel;
+export type GatewayMessageChannel =
+  | DeliverableMessageChannel
+  | InternalMessageChannel
+  | InterSessionChannel;
 
 export const listGatewayMessageChannels = (): GatewayMessageChannel[] => [
   ...listDeliverableMessageChannels(),
   INTERNAL_MESSAGE_CHANNEL,
+  INTER_SESSION_CHANNEL,
 ];
 
 export const listGatewayAgentChannelAliases = (): string[] =>

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -88,8 +88,8 @@ export function normalizeMessageChannel(raw?: string | null): string | undefined
   if (!normalized) {
     return undefined;
   }
-  if (normalized === INTERNAL_MESSAGE_CHANNEL) {
-    return INTERNAL_MESSAGE_CHANNEL;
+  if (RESERVED_CHANNEL_IDS.has(normalized)) {
+    return normalized;
   }
   const builtIn = normalizeChatChannelId(normalized);
   if (builtIn) {

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -33,10 +33,19 @@ export type InterSessionChannel = typeof INTER_SESSION_CHANNEL;
  * Checked in both plugin install (validatePluginId) and runtime channel
  * registration (registerChannel) to cover all registration paths.
  */
-export const RESERVED_CHANNEL_IDS: Set<string> = new Set([
+const RESERVED_CHANNEL_IDS: ReadonlySet<string> = new Set([
   INTER_SESSION_CHANNEL,
   INTERNAL_MESSAGE_CHANNEL,
 ]);
+
+export function isReservedChannelId(raw?: string | null): boolean {
+  const normalized = raw?.trim().toLowerCase();
+  return Boolean(normalized) && RESERVED_CHANNEL_IDS.has(normalized);
+}
+
+export function listReservedChannelIds(): string[] {
+  return Array.from(RESERVED_CHANNEL_IDS);
+}
 
 export function isInterSessionChannel(raw?: string | null): boolean {
   // Guard against collision with real deliverable plugin channels: a plugin
@@ -88,7 +97,7 @@ export function normalizeMessageChannel(raw?: string | null): string | undefined
   if (!normalized) {
     return undefined;
   }
-  if (RESERVED_CHANNEL_IDS.has(normalized)) {
+  if (isReservedChannelId(normalized)) {
     return normalized;
   }
   const builtIn = normalizeChatChannelId(normalized);

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -27,7 +27,13 @@ export const INTER_SESSION_CHANNEL = "inter_session" as const;
 export type InterSessionChannel = typeof INTER_SESSION_CHANNEL;
 
 export function isInterSessionChannel(raw?: string | null): boolean {
-  return raw?.trim().toLowerCase() === INTER_SESSION_CHANNEL;
+  // Guard against collision with real deliverable plugin channels: a plugin
+  // could theoretically register a channel named "inter_session", which must
+  // not be silently treated as our sentinel.
+  if (raw?.trim().toLowerCase() !== INTER_SESSION_CHANNEL) {
+    return false;
+  }
+  return !isDeliverableMessageChannel(INTER_SESSION_CHANNEL);
 }
 
 const MARKDOWN_CAPABLE_CHANNELS = new Set<string>([

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -133,10 +133,13 @@ export type GatewayMessageChannel =
   | InternalMessageChannel
   | InterSessionChannel;
 
+// NOTE: INTER_SESSION_CHANNEL is intentionally excluded from the runtime list.
+// It exists in the GatewayMessageChannel type so internal tools can use it,
+// but it must not be accepted from external RPC callers or the delivery path.
+// isGatewayMessageChannel("inter_session") → false by design.
 export const listGatewayMessageChannels = (): GatewayMessageChannel[] => [
   ...listDeliverableMessageChannels(),
   INTERNAL_MESSAGE_CHANNEL,
-  INTER_SESSION_CHANNEL,
 ];
 
 export const listGatewayAgentChannelAliases = (): string[] =>


### PR DESCRIPTION
## Summary

This PR fixes the `sessions_send` routing bug tracked in #43318.

Problem:
- `sessions_send` was injecting inter-session turns as `webchat`
- that mutated the receiver session's routing state
- replies could then flip from the established external route (Discord, Telegram, WhatsApp, etc.) back to Control UI/webchat

What changed:
- inter-session sends now use the internal `INTER_SESSION_CHANNEL` sentinel
- session delivery preserves the receiver's established external route instead of injecting the sender's channel
- reserved internal channel ids are protected from plugin registration / alias collisions
- gateway handling rejects public misuse of the sentinel and limits it to trusted backend callers
- trusted backend attestation covers the real auth paths used in practice (`token`, `password`, `device-token`, `tailscale`, `bootstrap-token`)

What this PR does **not** do:
- it does **not** implement webchat-to-external mirroring
- that follow-up remains separate in #44302

## Focused Scope

This branch was rebuilt cleanly from current `main` to keep the PR limited to the session-send / inter-session routing fix.

Touched areas:
- `sessions-send-tool`
- `session-delivery`
- gateway `agent` / inter-session validation
- backend internal-attestation path for trusted callers
- reserved internal channel id / alias protection

Explicitly excluded from this branch:
- memory-flush changes
- staged plugin install changes
- unrelated broad test churn

## Change Type

- [x] Bug fix
- [x] Security hardening
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore/infra

## Linked Issues

- Closes #43318
- Related #44261
- Related #44302

## User-visible Behavior

- `sessions_send` no longer flips a session from its established external route back to webchat
- inter-session delivery preserves the receiver's existing reply route
- public/plugin callers cannot spoof the reserved internal inter-session channel
- trusted internal backend callers authenticated through supported auth paths continue to work

## Verification

Targeted local verification on the rebuilt clean branch:
- `pnpm exec vitest run src/auto-reply/reply/session-delivery.test.ts`
- `pnpm exec vitest run src/gateway/server-methods/agent.test.ts`
- `pnpm exec vitest run src/gateway/server/ws-connection/connect-policy.test.ts`
- `pnpm exec vitest run src/plugins/install.test.ts`
- `pnpm exec vitest run src/plugins/loader.test.ts`
- `pnpm exec vitest run src/utils/message-channel.test.ts`

Notes:
- these directly relevant suites pass on the clean branch
- a small set of broader `sessions` / `server.sessions-send` tests are currently red on current `main` as well, so they are not unique to this rebuild

## Risks and Mitigations

- Risk: partial persisted routing state could still produce edge-case delivery issues
  - Mitigation: added targeted regression coverage around inter-session sentinel handling, fallback routing, trusted backend auth paths, and reserved channel protection
- Risk: widening internal-backend trust too far
  - Mitigation: explicit gateway/connect-policy coverage locks the intended trusted boundary and rejects public misuse
