### PR TITLE
fix(agents): resolve main agent config when no sessionKey is provided

### DIFF
--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -271,4 +271,26 @@ describe("resolveEffectiveToolPolicy", () => {
     const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "coder" });
     expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
   });
+
+  it("resolves main agent config when no sessionKey is provided", () => {
+    const cfg = {
+      tools: {
+        profile: "messaging",
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            tools: {
+              fs: { workspaceOnly: true },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    // When no sessionKey is provided, agentId should still resolve to the default agent
+    const result = resolveEffectiveToolPolicy({ config: cfg });
+    expect(result.agentId).toBe("main");
+    expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
+  });
 });

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -6,7 +6,11 @@ import type { AgentToolsConfig } from "../config/types.tools.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveThreadParentSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
-import { resolveAgentConfig, resolveAgentIdFromSessionKey } from "./agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentIdFromSessionKey,
+  resolveDefaultAgentId,
+} from "./agent-scope.js";
 import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
@@ -278,7 +282,8 @@ export function resolveEffectiveToolPolicy(params: {
       : undefined;
   const agentId =
     explicitAgentId ??
-    (params.sessionKey ? resolveAgentIdFromSessionKey(params.sessionKey) : undefined);
+    (params.sessionKey ? resolveAgentIdFromSessionKey(params.sessionKey) : undefined) ??
+    (params.config ? resolveDefaultAgentId(params.config) : undefined);
   const agentConfig =
     params.config && agentId ? resolveAgentConfig(params.config, agentId) : undefined;
   const agentTools = agentConfig?.tools;


### PR DESCRIPTION
Fixes #39971

## Summary

- Problem: `resolveEffectiveToolPolicy()` could leave `agentId` undefined when called without a `sessionKey` or explicit `agentId`.
- Why it matters: in that case, the default/main agent's tool configuration was skipped, so agent-specific tool policies were not applied.
- What changed: added a fallback to `resolveDefaultAgentId(config)` and added a regression test covering the no-`sessionKey` case.
- What did NOT change (scope boundary): no changes to gateway routing behavior, session-key resolution rules, or non-default agent selection semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39971
- Related #

## User-visible / Behavior Changes

When tool policy resolution runs without a `sessionKey`, the default/main agent configuration is now applied instead of being skipped.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu on WSL
- Runtime/container: local dev environment
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): config with default/main agent tool settings (`tools.fs.workspaceOnly: true`)

### Steps

1. Configure a default/main agent with tool-specific settings such as `tools.fs.workspaceOnly: true`.
2. Call `resolveEffectiveToolPolicy({ config })` without providing `sessionKey` or explicit `agentId`.
3. Observe the resolved `agentId` and `profileAlsoAllow`.

### Expected

- `agentId` resolves to the default/main agent.
- implicit tool exposure from the default/main agent config is applied.

### Actual

- before the fix, `agentId` was `undefined`, and agent-specific tool policy resolution was skipped.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - reproduced the failure with a regression test for `resolveEffectiveToolPolicy({ config })`
  - confirmed the test failed before the fix and passed after the fix
  - ran related targeted test suites successfully
- Edge cases checked:
  - explicit `agentId` path still works
  - sessionKey-derived agent resolution still works
  - implicit tool exposure from agent tool sections still works
- What you did **not** verify:
  - full end-to-end GitHub Actions / remote CI run
  - unrelated baseline failing tests outside the touched area

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `e4e6848ff`
- Files/config to restore:
  - `src/agents/pi-tools.policy.ts`
  - `src/agents/pi-tools.policy.test.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected default-agent tool policy application in no-`sessionKey` call sites

## Risks and Mitigations

- Risk: a no-`sessionKey`, no-`agentId` caller now resolves to the configured default agent instead of remaining unscoped.
  - Mitigation: this is the intended behavior, is config-driven, and is covered by the new regression test.