### PR TITLE
fix(feishu): harden voice reply delivery

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -182,6 +182,37 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
+  it("does not fail closed when buffer duration probing cannot write a temp file", async () => {
+    vi.spyOn(fs.promises, "mkdtemp").mockResolvedValue("/tmp/openclaw-feishu-probe-test");
+    vi.spyOn(fs.promises, "writeFile").mockRejectedValue(new Error("disk full"));
+    vi.spyOn(fs.promises, "rm").mockResolvedValue(undefined);
+
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("audio"),
+      fileName: "voice.opus",
+    });
+
+    expect(fileCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          file_type: "opus",
+          file_name: "voice.opus",
+        }),
+      }),
+    );
+
+    const uploadPayload = fileCreateMock.mock.calls[0]?.[0]?.data ?? {};
+    expect(uploadPayload.duration).toBeUndefined();
+
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ msg_type: "audio" }),
+      }),
+    );
+  });
+
   it("uses msg_type=file for documents", async () => {
     await sendMediaFeishu({
       cfg: {} as any,

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
@@ -5,10 +6,15 @@ const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
 const normalizeFeishuTargetMock = vi.hoisted(() => vi.fn());
 const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
 const loadWebMediaMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 
 const fileCreateMock = vi.hoisted(() => vi.fn());
 const messageCreateMock = vi.hoisted(() => vi.fn());
 const messageReplyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
 
 vi.mock("./client.js", () => ({
   createFeishuClient: createFeishuClientMock,
@@ -105,7 +111,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=media for opus", async () => {
+  it("uses msg_type=audio for opus", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -121,7 +127,57 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "audio" }),
+      }),
+    );
+  });
+
+  it("transcodes mp3 to opus and includes duration metadata", async () => {
+    vi.spyOn(fs.promises, "mkdtemp").mockResolvedValue("/tmp/openclaw-feishu-audio-test");
+    vi.spyOn(fs.promises, "writeFile").mockResolvedValue(undefined);
+    vi.spyOn(fs.promises, "readFile").mockResolvedValue(Buffer.from("opus-audio"));
+    vi.spyOn(fs.promises, "rm").mockResolvedValue(undefined);
+
+    execFileMock.mockImplementation(
+      (
+        file: string,
+        _args: readonly string[],
+        callback: (err: Error | null, result?: { stdout: string; stderr: string }) => void,
+      ) => {
+        const cb = callback;
+        if (file === "ffmpeg") {
+          cb(null, { stdout: "", stderr: "" });
+          return undefined;
+        }
+        if (file === "ffprobe") {
+          cb(null, { stdout: "10.0\n", stderr: "" });
+          return undefined;
+        }
+        cb(new Error(`unexpected binary: ${String(file)}`));
+        return undefined;
+      },
+    );
+
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("audio"),
+      fileName: "voice.mp3",
+    });
+
+    expect(fileCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          file_type: "opus",
+          file_name: "voice.ogg",
+          duration: 10000,
+        }),
+      }),
+    );
+
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ msg_type: "audio" }),
       }),
     );
   });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -428,7 +428,8 @@ async function transcodeAudioToFeishuOpus(params: {
       fileName: `${outputBase}.ogg`,
       ...(durationMs !== undefined ? { durationMs } : {}),
     };
-  } catch {
+  } catch (error) {
+    console.warn(`[feishu] failed to transcode audio to opus for ${params.fileName}:`, error);
     return null;
   } finally {
     await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
@@ -461,14 +462,19 @@ async function probeBufferDurationMs(params: {
   fileName: string;
 }): Promise<number | undefined> {
   const ext = path.extname(params.fileName).toLowerCase() || ".bin";
-  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-probe-"));
-  const filePath = path.join(tmpDir, `probe${ext}`);
+  let tmpDir: string | undefined;
 
   try {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-probe-"));
+    const filePath = path.join(tmpDir, `probe${ext}`);
     await fs.promises.writeFile(filePath, params.buffer);
     return await probeMediaDurationMs(filePath);
+  } catch {
+    return undefined;
   } finally {
-    await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+    if (tmpDir) {
+      await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+    }
   }
 }
 

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -1,13 +1,19 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { execFile } from "node:child_process";
 import { Readable } from "stream";
+import { promisify } from "node:util";
 import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveReceiveIdType, normalizeFeishuTarget } from "./targets.js";
+
+const execFileAsync = promisify(execFile);
+const FEISHU_IMAGE_EXTS = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"];
+const FEISHU_AUDIO_TRANSCODE_EXTS = [".mp3", ".m4a", ".wav", ".aac", ".flac", ".webm"];
 
 export type DownloadImageResult = {
   buffer: Buffer;
@@ -307,8 +313,8 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "media" for audio/video files, "file" for documents */
-  msgType?: "file" | "media";
+  /** Use "audio" for audio, "media" for video, "file" for documents */
+  msgType?: "file" | "audio" | "media";
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
@@ -383,6 +389,89 @@ export function detectFileType(
   }
 }
 
+async function transcodeAudioToFeishuOpus(params: {
+  buffer: Buffer;
+  fileName: string;
+}): Promise<{ buffer: Buffer; fileName: string; durationMs?: number } | null> {
+  const ext = path.extname(params.fileName).toLowerCase();
+  if (!FEISHU_AUDIO_TRANSCODE_EXTS.includes(ext)) {
+    return null;
+  }
+
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-audio-"));
+  const inputPath = path.join(tmpDir, `input${ext || ".bin"}`);
+  const outputBase = path.basename(params.fileName, ext) || "audio";
+  const outputPath = path.join(tmpDir, `${outputBase}.ogg`);
+
+  try {
+    await fs.promises.writeFile(inputPath, params.buffer);
+    await execFileAsync("ffmpeg", [
+      "-y",
+      "-loglevel",
+      "error",
+      "-i",
+      inputPath,
+      "-c:a",
+      "libopus",
+      "-b:a",
+      "24k",
+      "-ar",
+      "24000",
+      "-ac",
+      "1",
+      outputPath,
+    ]);
+
+    const durationMs = await probeMediaDurationMs(outputPath);
+    return {
+      buffer: await fs.promises.readFile(outputPath),
+      fileName: `${outputBase}.ogg`,
+      ...(durationMs !== undefined ? { durationMs } : {}),
+    };
+  } catch {
+    return null;
+  } finally {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+async function probeMediaDurationMs(filePath: string): Promise<number | undefined> {
+  try {
+    const { stdout } = await execFileAsync("ffprobe", [
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "default=nk=1:nw=1",
+      filePath,
+    ]);
+    const seconds = Number.parseFloat(stdout.trim());
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return undefined;
+    }
+    return Math.max(1, Math.ceil(seconds * 1000));
+  } catch {
+    return undefined;
+  }
+}
+
+async function probeBufferDurationMs(params: {
+  buffer: Buffer;
+  fileName: string;
+}): Promise<number | undefined> {
+  const ext = path.extname(params.fileName).toLowerCase() || ".bin";
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-probe-"));
+  const filePath = path.join(tmpDir, `probe${ext}`);
+
+  try {
+    await fs.promises.writeFile(filePath, params.buffer);
+    return await probeMediaDurationMs(filePath);
+  } finally {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
 /**
  * Upload and send media (image or file) from URL, local path, or buffer
  */
@@ -421,27 +510,35 @@ export async function sendMediaFeishu(params: {
 
   // Determine if it's an image based on extension
   const ext = path.extname(name).toLowerCase();
-  const isImage = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"].includes(ext);
+  const isImage = FEISHU_IMAGE_EXTS.includes(ext);
 
   if (isImage) {
     const { imageKey } = await uploadImageFeishu({ cfg, image: buffer, accountId });
     return sendImageFeishu({ cfg, to, imageKey, replyToMessageId, accountId });
   } else {
-    const fileType = detectFileType(name);
+    const transcodedAudio = await transcodeAudioToFeishuOpus({ buffer, fileName: name });
+    const normalizedBuffer = transcodedAudio?.buffer ?? buffer;
+    const normalizedName = transcodedAudio?.fileName ?? name;
+    const fileType = detectFileType(normalizedName);
+    const durationMs =
+      fileType === "opus" || fileType === "mp4"
+        ? (transcodedAudio?.durationMs ??
+          (await probeBufferDurationMs({ buffer: normalizedBuffer, fileName: normalizedName })))
+        : undefined;
     const { fileKey } = await uploadFileFeishu({
       cfg,
-      file: buffer,
-      fileName: name,
+      file: normalizedBuffer,
+      fileName: normalizedName,
       fileType,
+      duration: durationMs,
       accountId,
     });
-    // Feishu requires msg_type "media" for audio/video, "file" for documents
-    const isMedia = fileType === "mp4" || fileType === "opus";
+    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
     return sendFileFeishu({
       cfg,
       to,
       fileKey,
-      msgType: isMedia ? "media" : "file",
+      msgType,
       replyToMessageId,
       accountId,
     });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -113,4 +113,35 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
+
+  it("strips internal tts tags from streaming partial updates", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({
+      text: "[[tts:provider=edge]]Visible text[[tts:text]]Spoken only[[/tts:text]]",
+    });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].update).toHaveBeenCalledWith("Visible text");
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("Visible text");
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -21,6 +21,14 @@ function shouldUseCard(text: string): boolean {
   return /```[\s\S]*?```/.test(text) || /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
 }
 
+function stripInternalTtsTags(text: string): string {
+  return text
+    .replace(/\[\[tts:text\]\][\s\S]*?\[\[\/tts:text\]\]/gi, "")
+    .replace(/\[\[tts:[^\]]+\]\]/gi, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 export type CreateFeishuReplyDispatcherParams = {
   cfg: ClawdbotConfig;
   agentId: string;
@@ -137,7 +145,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         void typingCallbacks.onReplyStart?.();
       },
       deliver: async (payload: ReplyPayload, info) => {
-        const text = payload.text ?? "";
+        const text = stripInternalTtsTags(payload.text ?? "");
         if (!text.trim()) {
           return;
         }
@@ -218,11 +226,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       onModelSelected: prefixContext.onModelSelected,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
-            if (!payload.text || payload.text === lastPartial) {
+            const text = stripInternalTtsTags(payload.text ?? "");
+            if (!text || text === lastPartial) {
               return;
             }
-            lastPartial = payload.text;
-            streamText = payload.text;
+            lastPartial = text;
+            streamText = text;
             partialUpdateQueue = partialUpdateQueue.then(async () => {
               if (streamingStartPromise) {
                 await streamingStartPromise;

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -853,6 +853,16 @@ describe("normalizeOutboundPayloads", () => {
     const normalized = normalizeOutboundPayloads([{ channelData }]);
     expect(normalized).toEqual([{ text: "", mediaUrls: [], channelData }]);
   });
+
+  it("strips internal tts tags from outbound text", () => {
+    const normalized = normalizeOutboundPayloads([
+      {
+        text:
+          "[[tts:provider=edge voice=zh-CN-XiaoxiaoNeural]]Visible line\n[[tts:text]]Spoken only[[/tts:text]]",
+      },
+    ]);
+    expect(normalized).toEqual([{ text: "Visible line", mediaUrls: [] }]);
+  });
 });
 
 describe("formatOutboundPayloadLog", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -37,9 +37,18 @@ function mergeMediaUrls(...lists: Array<Array<string | undefined> | undefined>):
   return merged;
 }
 
+function stripInternalTtsTags(text: string): string {
+  return text
+    .replace(/\[\[tts:text\]\][\s\S]*?\[\[\/tts:text\]\]/gi, "")
+    .replace(/\[\[tts:[^\]]+\]\]/gi, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 export function normalizeReplyPayloadsForDelivery(payloads: ReplyPayload[]): ReplyPayload[] {
   return payloads.flatMap((payload) => {
     const parsed = parseReplyDirectives(payload.text ?? "");
+    const cleanedText = stripInternalTtsTags(parsed.text ?? "");
     const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
     const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;
     const mergedMedia = mergeMediaUrls(
@@ -50,7 +59,7 @@ export function normalizeReplyPayloadsForDelivery(payloads: ReplyPayload[]): Rep
     const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
     const next: ReplyPayload = {
       ...payload,
-      text: parsed.text ?? "",
+      text: cleanedText,
       mediaUrls: mergedMedia.length ? mergedMedia : undefined,
       mediaUrl: resolvedMediaUrl,
       replyToId: payload.replyToId ?? parsed.replyToId,


### PR DESCRIPTION
## Summary
- transcode audio-like outbound media to ogg/opus before Feishu audio send
- include duration metadata for Feishu audio/media uploads
- strip internal [[tts]] tags from Feishu reply dispatch and outbound payload normalization
- add regression coverage for media send and reply cleanup

## Why
Feishu voice replies were not reliable in practice:
- Edge TTS produced mp3, but Feishu audio messages need a compatible audio upload path
- missing duration metadata could show 0:00 or incorrect duration in the client
- internal [[tts]] tags could leak into user-visible messages

## Testing
- local runtime validation on mini against a real Feishu group
- verified Feishu audio messages were sent successfully after transcode
- verified client duration display after adding duration metadata
- verified latest messages no longer exposed raw [[tts]] tags
- added test coverage in the Feishu extension and outbound normalization layers
