### PR TITLE
fix(msteams): persist first-DM conversation reference in pairing path

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -152,4 +152,51 @@ describe("msteams monitor handler authz", () => {
 
     expect(conversationStore.upsert).not.toHaveBeenCalled();
   });
+
+  it("persists conversation reference for first-DM pairing requests", async () => {
+    const { conversationStore, deps } = createDeps({
+      channels: {
+        msteams: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler({
+      activity: {
+        id: "msg-1",
+        type: "message",
+        text: "hello",
+        from: {
+          id: "new-user-id",
+          aadObjectId: "new-user-aad",
+          name: "New User",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "dm:new-user-id",
+          conversationType: "personal",
+        },
+        channelData: {},
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
+    // Even though the DM is dropped (pairing mode, user not allowlisted),
+    // the conversation reference should be persisted so --notify works.
+    expect(conversationStore.upsert).toHaveBeenCalledWith(
+      "dm:new-user-id",
+      expect.objectContaining({
+        user: expect.objectContaining({ id: "new-user-id" }),
+        conversation: expect.objectContaining({ id: "dm:new-user-id" }),
+      }),
+    );
+  });
 });

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -198,6 +198,39 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     });
     const effectiveDmAllowFrom = access.effectiveAllowFrom;
 
+    // Build conversation reference for proactive replies.
+    // Constructed before the pairing early-return so it can be persisted for
+    // first-DM pairing requests — without this, --notify cannot deliver the
+    // approval message because no conversation reference exists yet.
+    const agent = activity.recipient;
+    const conversationRef: StoredConversationReference = {
+      activityId: activity.id,
+      user: { id: from.id, name: from.name, aadObjectId: from.aadObjectId },
+      agent,
+      bot: agent ? { id: agent.id, name: agent.name } : undefined,
+      conversation: {
+        id: conversationId,
+        conversationType,
+        tenantId: conversation?.tenantId,
+      },
+      teamId,
+      channelId: activity.channelId,
+      serviceUrl: activity.serviceUrl,
+      locale: activity.locale,
+    };
+    let conversationRefPersisted = false;
+    const persistConversationRef = () => {
+      if (conversationRefPersisted) {
+        return;
+      }
+      conversationRefPersisted = true;
+      conversationStore.upsert(conversationId, conversationRef).catch((err) => {
+        log.debug?.("failed to save conversation reference", {
+          error: formatUnknownError(err),
+        });
+      });
+    };
+
     if (isDirectMessage && msteamsCfg && access.decision !== "allow") {
       if (access.reason === "dmPolicy=disabled") {
         log.debug?.("dropping dm (dms disabled)");
@@ -210,6 +243,9 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         allowNameMatching: isDangerousNameMatchingEnabled(msteamsCfg),
       });
       if (access.decision === "pairing") {
+        // Persist conversation reference before early return so --notify
+        // can deliver the approval message to this first-DM user.
+        persistConversationRef();
         const request = await pairing.upsertPairingRequest({
           id: senderId,
           meta: { name: senderName },
@@ -317,28 +353,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       return;
     }
 
-    // Build conversation reference for proactive replies.
-    const agent = activity.recipient;
-    const conversationRef: StoredConversationReference = {
-      activityId: activity.id,
-      user: { id: from.id, name: from.name, aadObjectId: from.aadObjectId },
-      agent,
-      bot: agent ? { id: agent.id, name: agent.name } : undefined,
-      conversation: {
-        id: conversationId,
-        conversationType,
-        tenantId: conversation?.tenantId,
-      },
-      teamId,
-      channelId: activity.channelId,
-      serviceUrl: activity.serviceUrl,
-      locale: activity.locale,
-    };
-    conversationStore.upsert(conversationId, conversationRef).catch((err) => {
-      log.debug?.("failed to save conversation reference", {
-        error: formatUnknownError(err),
-      });
-    });
+    persistConversationRef();
 
     const pollVote = extractMSTeamsPollVote(activity);
     if (pollVote) {


### PR DESCRIPTION
Fix #43323

## Problem

In MS Teams pairing mode, the first DM from a new user triggers a pairing request but returns early before saving the conversation reference. This means `openclaw pairing approve msteams <code> --notify` cannot deliver the approval notification — no conversation reference exists for the just-approved user.

## Root Cause

The conversation reference construction and persistence happened after the pairing early-return path at line ~230. When `access.decision === 'pairing'`, the handler creates the pairing request but immediately returns, never reaching the conversation reference save at line ~337.

## Fix

Move conversation reference construction before the pairing early-return. Persist for pairing DMs with an idempotent helper so the normal (allowed) message path doesn't double-persist.

## Validation

3 tests passing including a new test that verifies conversation reference IS persisted when a DM triggers a pairing request.