### PR TITLE
fix(browser): harden extension relay auth-redirect tab continuity

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1
       file-type:
-        specifier: ^21.3.1
+        specifier: 21.3.1
         version: 21.3.1
       grammy:
         specifier: ^1.41.1

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -120,6 +120,22 @@ function createMessageQueue(ws: WebSocket) {
   return { next };
 }
 
+async function waitForJsonMessageMatching<T>(
+  queue: ReturnType<typeof createMessageQueue>,
+  match: (value: T) => boolean,
+  timeoutMs = 5000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = Math.max(1, deadline - Date.now());
+    const next = JSON.parse(await queue.next(remaining)) as T;
+    if (match(next)) {
+      return next;
+    }
+  }
+  throw new Error("timeout waiting for matching message");
+}
+
 async function waitForListMatch<T>(
   fetchList: () => Promise<T>,
   predicate: (value: T) => boolean,
@@ -934,6 +950,95 @@ describe("chrome extension relay server", () => {
       (attached?.params as { targetInfo?: { targetId?: string } } | undefined)?.targetInfo
         ?.targetId,
     ).toBe("t2");
+
+    cdp.close();
+    ext.close();
+  });
+
+  it("resolves stale target ids after redirect-style target swaps", async () => {
+    const port = await getFreePort();
+    cdpUrl = `http://127.0.0.1:${port}`;
+    await ensureChromeExtensionRelayServer({ cdpUrl });
+
+    const ext = new WebSocket(`ws://127.0.0.1:${port}/extension`, {
+      headers: relayAuthHeaders(`ws://127.0.0.1:${port}/extension`),
+    });
+    await waitForOpen(ext);
+    const extQ = createMessageQueue(ext);
+
+    ext.send(
+      JSON.stringify({
+        method: "forwardCDPEvent",
+        params: {
+          method: "Target.attachedToTarget",
+          params: {
+            sessionId: "login-session",
+            targetInfo: {
+              targetId: "target-old",
+              type: "page",
+              title: "Login step 1",
+              url: "https://login.example/start",
+            },
+            waitingForDebugger: false,
+          },
+        },
+      }),
+    );
+
+    ext.send(
+      JSON.stringify({
+        method: "forwardCDPEvent",
+        params: {
+          method: "Target.attachedToTarget",
+          params: {
+            sessionId: "login-session",
+            targetInfo: {
+              targetId: "target-new",
+              type: "page",
+              title: "Login step 2",
+              url: "https://login.example/redirect",
+            },
+            waitingForDebugger: false,
+          },
+        },
+      }),
+    );
+
+    const cdp = new WebSocket(`ws://127.0.0.1:${port}/cdp`, {
+      headers: relayAuthHeaders(`ws://127.0.0.1:${port}/cdp`),
+    });
+    await waitForOpen(cdp);
+    const cdpQ = createMessageQueue(cdp);
+
+    cdp.send(
+      JSON.stringify({
+        id: 1,
+        method: "Target.attachToTarget",
+        params: { targetId: "target-old" },
+      }),
+    );
+    const attachRes = await waitForJsonMessageMatching<{ id?: number; result?: unknown }>(
+      cdpQ,
+      (msg) => msg.id === 1,
+    );
+    expect(JSON.stringify(attachRes.result ?? {})).toContain("login-session");
+
+    const resolvedTarget = (await fetch(`${cdpUrl}/json/resolve/target-old`, {
+      headers: relayAuthHeaders(cdpUrl),
+    }).then((r) => r.json())) as { targetId?: string };
+    expect(resolvedTarget.targetId).toBe("target-new");
+
+    await fetch(`${cdpUrl}/json/activate/target-old`, {
+      headers: relayAuthHeaders(cdpUrl),
+    });
+    const activateCmd = await waitForJsonMessageMatching<{
+      method?: string;
+      params?: { method?: string; params?: { targetId?: string } };
+    }>(
+      extQ,
+      (msg) => msg.method === "forwardCDPCommand" && msg.params?.method === "Target.activateTarget",
+    );
+    expect(activateCmd.params?.params?.targetId).toBe("target-new");
 
     cdp.close();
     ext.close();

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -73,6 +73,7 @@ type AttachedToTargetEvent = {
 type DetachedFromTargetEvent = {
   sessionId: string;
   targetId?: string;
+  reason?: string;
 };
 
 type ConnectedTarget = {
@@ -84,6 +85,27 @@ type ConnectedTarget = {
 const RELAY_AUTH_HEADER = "x-openclaw-relay-token";
 const DEFAULT_EXTENSION_RECONNECT_GRACE_MS = 20_000;
 const DEFAULT_EXTENSION_COMMAND_RECONNECT_WAIT_MS = 3_000;
+const TARGET_ALIAS_TTL_MS = 60_000;
+const TARGET_ALIAS_MAX_DEPTH = 8;
+
+type TargetAlias = {
+  targetId: string;
+  sessionId: string;
+  updatedAt: number;
+};
+
+function relayLog(
+  event: string,
+  data: Record<string, unknown>,
+  level: "info" | "warn" = "info",
+): void {
+  const payload = { ts: new Date().toISOString(), event, ...data };
+  if (level === "warn") {
+    console.warn("[browser-relay]", payload);
+    return;
+  }
+  console.info("[browser-relay]", payload);
+}
 
 function headerValue(value: string | string[] | undefined): string | undefined {
   if (!value) {
@@ -266,6 +288,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
     let extensionWs: WebSocket | null = null;
     const cdpClients = new Set<WebSocket>();
     const connectedTargets = new Map<string, ConnectedTarget>();
+    const targetAliasByTargetId = new Map<string, TargetAlias>();
     const extensionConnected = () => extensionWs?.readyState === WebSocket.OPEN;
     const hasConnectedTargets = () => connectedTargets.size > 0;
     let extensionDisconnectCleanupTimer: NodeJS.Timeout | null = null;
@@ -291,7 +314,17 @@ export async function ensureChromeExtensionRelayServer(opts: {
     };
 
     const closeCdpClientsAfterExtensionDisconnect = () => {
+      relayLog(
+        "relay.disconnect.final",
+        {
+          cause: "extension-disconnected-grace-expired",
+          connectedTargets: connectedTargets.size,
+          cdpClients: cdpClients.size,
+        },
+        "warn",
+      );
       connectedTargets.clear();
+      targetAliasByTargetId.clear();
       for (const client of cdpClients) {
         try {
           client.close(1011, "extension disconnected");
@@ -301,6 +334,79 @@ export async function ensureChromeExtensionRelayServer(opts: {
       }
       cdpClients.clear();
       flushExtensionReconnectWaiters(false);
+    };
+
+    const pruneExpiredTargetAliases = (now = Date.now()) => {
+      for (const [sourceTargetId, alias] of targetAliasByTargetId) {
+        if (now - alias.updatedAt <= TARGET_ALIAS_TTL_MS) {
+          continue;
+        }
+        targetAliasByTargetId.delete(sourceTargetId);
+      }
+    };
+
+    const dropAliasesForTarget = (targetId: string) => {
+      targetAliasByTargetId.delete(targetId);
+      for (const [sourceTargetId, alias] of targetAliasByTargetId) {
+        if (alias.targetId === targetId) {
+          targetAliasByTargetId.delete(sourceTargetId);
+        }
+      }
+    };
+
+    const setTargetAlias = (params: {
+      sourceTargetId: string;
+      targetId: string;
+      sessionId: string;
+    }) => {
+      const sourceTargetId = params.sourceTargetId.trim();
+      const targetId = params.targetId.trim();
+      if (!sourceTargetId || !targetId || sourceTargetId === targetId) {
+        return;
+      }
+      pruneExpiredTargetAliases();
+      targetAliasByTargetId.set(sourceTargetId, {
+        targetId,
+        sessionId: params.sessionId,
+        updatedAt: Date.now(),
+      });
+      relayLog("target.transition", {
+        sessionId: params.sessionId,
+        from: sourceTargetId,
+        to: targetId,
+      });
+    };
+
+    const resolveConnectedTargetId = (targetId: string): string => {
+      pruneExpiredTargetAliases();
+      let current = targetId.trim();
+      if (!current) {
+        return current;
+      }
+      const visited = new Set<string>();
+      for (let depth = 0; depth < TARGET_ALIAS_MAX_DEPTH; depth++) {
+        if (visited.has(current)) {
+          break;
+        }
+        visited.add(current);
+        const alias = targetAliasByTargetId.get(current);
+        if (!alias) {
+          break;
+        }
+        if (
+          !Array.from(connectedTargets.values()).some(
+            (target) => target.sessionId === alias.sessionId,
+          )
+        ) {
+          targetAliasByTargetId.delete(current);
+          break;
+        }
+        current = alias.targetId;
+      }
+      if (current !== targetId) {
+        relayLog("target.alias.resolve", { requested: targetId, resolved: current });
+      }
+      return current;
     };
 
     const scheduleExtensionDisconnectCleanup = () => {
@@ -424,9 +530,20 @@ export async function ensureChromeExtensionRelayServer(opts: {
       if (!isMissingTargetError(err)) {
         return;
       }
+      relayLog(
+        "command.fail.missing-target",
+        {
+          method: cmd.method,
+          sessionId: cmd.sessionId,
+          classification: "target-not-found-command-failure",
+          error: err instanceof Error ? err.message : String(err),
+        },
+        "warn",
+      );
       if (cmd.sessionId) {
         const removed = dropConnectedTargetSession(cmd.sessionId);
         if (removed) {
+          dropAliasesForTarget(removed.targetId);
           broadcastDetachedTarget(removed);
           return;
         }
@@ -438,6 +555,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
       }
       const removedTargets = dropConnectedTargetsByTargetId(targetId);
       for (const removed of removedTargets) {
+        dropAliasesForTarget(removed.targetId);
         broadcastDetachedTarget(removed, targetId);
       }
     };
@@ -490,7 +608,10 @@ export async function ensureChromeExtensionRelayServer(opts: {
           };
         case "Target.getTargetInfo": {
           const params = (cmd.params ?? {}) as { targetId?: string };
-          const targetId = typeof params.targetId === "string" ? params.targetId : undefined;
+          const targetId =
+            typeof params.targetId === "string"
+              ? resolveConnectedTargetId(params.targetId)
+              : undefined;
           if (targetId) {
             for (const t of connectedTargets.values()) {
               if (t.targetId === targetId) {
@@ -509,7 +630,10 @@ export async function ensureChromeExtensionRelayServer(opts: {
         }
         case "Target.attachToTarget": {
           const params = (cmd.params ?? {}) as { targetId?: string };
-          const targetId = typeof params.targetId === "string" ? params.targetId : undefined;
+          const targetId =
+            typeof params.targetId === "string"
+              ? resolveConnectedTargetId(params.targetId)
+              : undefined;
           if (!targetId) {
             throw new Error("targetId required");
           }
@@ -643,18 +767,26 @@ export async function ensureChromeExtensionRelayServer(opts: {
         if (!match || (req.method !== "GET" && req.method !== "PUT")) {
           return false;
         }
-        let targetId = "";
+        let requestedTargetId = "";
         try {
-          targetId = decodeURIComponent(match[1] ?? "").trim();
+          requestedTargetId = decodeURIComponent(match[1] ?? "").trim();
         } catch {
           res.writeHead(400);
           res.end("invalid targetId encoding");
           return true;
         }
-        if (!targetId) {
+        if (!requestedTargetId) {
           res.writeHead(400);
           res.end("targetId required");
           return true;
+        }
+        const targetId = resolveConnectedTargetId(requestedTargetId);
+        if (targetId !== requestedTargetId) {
+          relayLog("target.action.resolve", {
+            method: cdpMethod,
+            requestedTargetId,
+            resolvedTargetId: targetId,
+          });
         }
         void (async () => {
           try {
@@ -671,6 +803,27 @@ export async function ensureChromeExtensionRelayServer(opts: {
         res.end("OK");
         return true;
       };
+
+      const resolveMatch = path.match(/^\/json\/resolve\/(.+)$/);
+      if (resolveMatch && (req.method === "GET" || req.method === "PUT")) {
+        let requestedTargetId = "";
+        try {
+          requestedTargetId = decodeURIComponent(resolveMatch[1] ?? "").trim();
+        } catch {
+          res.writeHead(400);
+          res.end("invalid targetId encoding");
+          return;
+        }
+        if (!requestedTargetId) {
+          res.writeHead(400);
+          res.end("targetId required");
+          return;
+        }
+        const targetId = resolveConnectedTargetId(requestedTargetId);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ targetId }));
+        return;
+      }
 
       if (
         handleTargetActionRoute(path.match(/^\/json\/activate\/(.+)$/), "Target.activateTarget")
@@ -822,7 +975,17 @@ export async function ensureChromeExtensionRelayServer(opts: {
                 targetId: nextTargetId,
                 targetInfo: attached.targetInfo,
               });
+              relayLog("target.attached", {
+                sessionId: attached.sessionId,
+                targetId: nextTargetId,
+                url: attached.targetInfo.url ?? "",
+              });
               if (changedTarget && prevTargetId) {
+                setTargetAlias({
+                  sourceTargetId: prevTargetId,
+                  targetId: nextTargetId,
+                  sessionId: attached.sessionId,
+                });
                 broadcastToCdpClients({
                   method: "Target.detachedFromTarget",
                   params: { sessionId: attached.sessionId, targetId: prevTargetId },
@@ -838,10 +1001,21 @@ export async function ensureChromeExtensionRelayServer(opts: {
 
           if (method === "Target.detachedFromTarget") {
             const detached = (params ?? {}) as DetachedFromTargetEvent;
+            relayLog("target.detached", {
+              sessionId: detached.sessionId,
+              targetId: detached.targetId ?? "",
+              reason: detached.reason ?? "unknown",
+            });
             if (detached?.sessionId) {
-              dropConnectedTargetSession(detached.sessionId);
+              const removed = dropConnectedTargetSession(detached.sessionId);
+              if (removed) {
+                dropAliasesForTarget(removed.targetId);
+              }
             } else if (detached?.targetId) {
-              dropConnectedTargetsByTargetId(detached.targetId);
+              const removedTargets = dropConnectedTargetsByTargetId(detached.targetId);
+              for (const removed of removedTargets) {
+                dropAliasesForTarget(removed.targetId);
+              }
             }
             broadcastToCdpClients({ method, params, sessionId });
             return;
@@ -850,7 +1024,11 @@ export async function ensureChromeExtensionRelayServer(opts: {
           if (method === "Target.targetDestroyed" || method === "Target.targetCrashed") {
             const targetEvent = (params ?? {}) as { targetId?: string };
             if (targetEvent.targetId) {
-              dropConnectedTargetsByTargetId(targetEvent.targetId);
+              relayLog("target.destroyed", { targetId: targetEvent.targetId, source: method });
+              const removedTargets = dropConnectedTargetsByTargetId(targetEvent.targetId);
+              for (const removed of removedTargets) {
+                dropAliasesForTarget(removed.targetId);
+              }
             }
             broadcastToCdpClients({ method, params, sessionId });
             return;
@@ -879,11 +1057,26 @@ export async function ensureChromeExtensionRelayServer(opts: {
         }
       });
 
-      ws.on("close", () => {
+      ws.on("close", (code, reason) => {
         clearInterval(ping);
         if (extensionWs !== ws) {
           return;
         }
+        const reasonText =
+          typeof reason === "string"
+            ? reason
+            : Buffer.isBuffer(reason)
+              ? reason.toString("utf8")
+              : "";
+        relayLog(
+          "relay.ws.close",
+          {
+            source: "extension",
+            code,
+            reason: reasonText || "none",
+          },
+          "warn",
+        );
         extensionWs = null;
         for (const [, pending] of pendingExtension) {
           clearTimeout(pending.timer);
@@ -937,7 +1130,10 @@ export async function ensureChromeExtensionRelayServer(opts: {
           }
           if (cmd.method === "Target.attachToTarget") {
             const params = (cmd.params ?? {}) as { targetId?: string };
-            const targetId = typeof params.targetId === "string" ? params.targetId : undefined;
+            const targetId =
+              typeof params.targetId === "string"
+                ? resolveConnectedTargetId(params.targetId)
+                : undefined;
             if (targetId) {
               const target = Array.from(connectedTargets.values()).find(
                 (t) => t.targetId === targetId,
@@ -1021,6 +1217,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
         relayRuntimeByPort.delete(port);
         clearExtensionDisconnectCleanupTimer();
         flushExtensionReconnectWaiters(false);
+        targetAliasByTargetId.clear();
         for (const [, pending] of pendingExtension) {
           clearTimeout(pending.timer);
           pending.reject(new Error("server stopping"));

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -393,11 +393,7 @@ export async function ensureChromeExtensionRelayServer(opts: {
         if (!alias) {
           break;
         }
-        if (
-          !Array.from(connectedTargets.values()).some(
-            (target) => target.sessionId === alias.sessionId,
-          )
-        ) {
+        if (!connectedTargets.has(alias.sessionId)) {
           targetAliasByTargetId.delete(current);
           break;
         }

--- a/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
+++ b/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
@@ -12,6 +12,57 @@ afterEach(async () => {
   await closePlaywrightBrowserConnection().catch(() => {});
 });
 
+function fetchInputToUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  if (input instanceof Request) {
+    return input.url;
+  }
+  return "";
+}
+
+function mockRelayFetch(opts: {
+  targets: Array<{ id: string; url: string; title?: string }>;
+  aliases?: Record<string, string>;
+}) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+    const raw = fetchInputToUrl(url);
+    if (raw.includes("/json/version")) {
+      return {
+        ok: true,
+        json: async () => ({ Browser: "OpenClaw/extension-relay" }),
+      } as Response;
+    }
+    const resolveMatch = raw.match(/\/json\/resolve\/([^/?#]+)/);
+    if (resolveMatch) {
+      const requested = decodeURIComponent(resolveMatch[1] ?? "");
+      const mapped = opts.aliases?.[requested];
+      if (!mapped) {
+        return {
+          ok: false,
+          status: 404,
+          json: async () => ({}),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({ targetId: mapped }),
+      } as Response;
+    }
+    if (raw.includes("/json/list")) {
+      return {
+        ok: true,
+        json: async () => opts.targets,
+      } as Response;
+    }
+    throw new Error(`unexpected fetch url: ${raw}`);
+  });
+}
+
 describe("pw-session getPageForTargetId", () => {
   it("falls back to the only page when CDP session attachment is blocked (extension relays)", async () => {
     connectOverCdpSpy.mockClear();
@@ -46,15 +97,22 @@ describe("pw-session getPageForTargetId", () => {
 
     connectOverCdpSpy.mockResolvedValue(browser);
     getChromeWebSocketUrlSpy.mockResolvedValue(null);
-
-    const resolved = await getPageForTargetId({
-      cdpUrl: "http://127.0.0.1:18792",
-      targetId: "NOT_A_TAB",
+    const fetchSpy = mockRelayFetch({
+      targets: [{ id: "SOME_OTHER_TAB", url: "https://other.example" }],
     });
-    expect(resolved).toBe(page);
 
-    await closePlaywrightBrowserConnection();
-    expect(browserClose).toHaveBeenCalled();
+    try {
+      const resolved = await getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "NOT_A_TAB",
+      });
+      expect(resolved).toBe(page);
+
+      await closePlaywrightBrowserConnection();
+      expect(browserClose).toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("uses the shared HTTP-base normalization when falling back to /json/list for direct WebSocket CDP URLs", async () => {
@@ -92,14 +150,12 @@ describe("pw-session getPageForTargetId", () => {
 
     connectOverCdpSpy.mockResolvedValue(browser);
     getChromeWebSocketUrlSpy.mockResolvedValue(null);
-
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      json: async () => [
+    const fetchSpy = mockRelayFetch({
+      targets: [
         { id: "TARGET_A", url: "https://alpha.example" },
         { id: "TARGET_B", url: "https://beta.example" },
       ],
-    } as Response);
+    });
 
     try {
       const resolved = await getPageForTargetId({
@@ -107,10 +163,69 @@ describe("pw-session getPageForTargetId", () => {
         targetId: "TARGET_B",
       });
       expect(resolved).toBe(pageB);
-      expect(fetchSpy).toHaveBeenCalledWith(
-        "http://127.0.0.1:18792/json/list?token=abc",
-        expect.any(Object),
-      );
+      expect(
+        fetchSpy.mock.calls.some((args) =>
+          fetchInputToUrl(args[0]).includes("/json/list?token=abc"),
+        ),
+      ).toBe(true);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("resolves stale extension target ids through /json/resolve", async () => {
+    const pageOn = vi.fn();
+    const contextOn = vi.fn();
+    const browserOn = vi.fn();
+    const browserClose = vi.fn(async () => {});
+
+    const context = {
+      pages: () => [],
+      on: contextOn,
+      newCDPSession: vi.fn(async () => {
+        throw new Error("Not allowed");
+      }),
+    } as unknown as import("playwright-core").BrowserContext;
+
+    const pageA = {
+      on: pageOn,
+      context: () => context,
+      url: () => "https://alpha.example",
+    } as unknown as import("playwright-core").Page;
+    const pageB = {
+      on: pageOn,
+      context: () => context,
+      url: () => "https://beta.example",
+    } as unknown as import("playwright-core").Page;
+    (context as unknown as { pages: () => unknown[] }).pages = () => [pageA, pageB];
+
+    const browser = {
+      contexts: () => [context],
+      on: browserOn,
+      close: browserClose,
+    } as unknown as import("playwright-core").Browser;
+
+    connectOverCdpSpy.mockResolvedValue(browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    const fetchSpy = mockRelayFetch({
+      targets: [
+        { id: "TARGET_A", url: "https://alpha.example" },
+        { id: "TARGET_B", url: "https://beta.example" },
+      ],
+      aliases: { OLD_TARGET: "TARGET_B" },
+    });
+
+    try {
+      const resolved = await getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:19993",
+        targetId: "OLD_TARGET",
+      });
+      expect(resolved).toBe(pageB);
+      expect(
+        fetchSpy.mock.calls.some((args) =>
+          fetchInputToUrl(args[0]).includes("/json/resolve/OLD_TARGET"),
+        ),
+      ).toBe(true);
     } finally {
       fetchSpy.mockRestore();
     }
@@ -152,20 +267,12 @@ describe("pw-session getPageForTargetId", () => {
 
     connectOverCdpSpy.mockResolvedValue(browser);
     getChromeWebSocketUrlSpy.mockResolvedValue(null);
-
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    fetchSpy
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ Browser: "OpenClaw/extension-relay" }),
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [
-          { id: "TARGET_A", url: "https://alpha.example" },
-          { id: "TARGET_B", url: "https://beta.example" },
-        ],
-      } as Response);
+    const fetchSpy = mockRelayFetch({
+      targets: [
+        { id: "TARGET_A", url: "https://alpha.example" },
+        { id: "TARGET_B", url: "https://beta.example" },
+      ],
+    });
 
     try {
       const resolved = await getPageForTargetId({
@@ -174,6 +281,119 @@ describe("pw-session getPageForTargetId", () => {
       });
       expect(resolved).toBe(pageB);
       expect(newCDPSession).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("handles duplicate-URL count skew between relay list and Playwright pages", async () => {
+    const pageOn = vi.fn();
+    const contextOn = vi.fn();
+    const browserOn = vi.fn();
+    const browserClose = vi.fn(async () => {});
+    const newCDPSession = vi.fn(async () => {
+      throw new Error("Not allowed");
+    });
+
+    const context = {
+      pages: () => [],
+      on: contextOn,
+      newCDPSession,
+    } as unknown as import("playwright-core").BrowserContext;
+
+    const pageA = {
+      on: pageOn,
+      context: () => context,
+      url: () => "https://e-services.empower.ae/",
+    } as unknown as import("playwright-core").Page;
+    const pageB = {
+      on: pageOn,
+      context: () => context,
+      url: () => "https://e-services.empower.ae/",
+    } as unknown as import("playwright-core").Page;
+    const pageC = {
+      on: pageOn,
+      context: () => context,
+      url: () => "https://e-services.empower.ae/",
+    } as unknown as import("playwright-core").Page;
+    (context as unknown as { pages: () => unknown[] }).pages = () => [pageA, pageB, pageC];
+
+    const browser = {
+      contexts: () => [context],
+      on: browserOn,
+      close: browserClose,
+    } as unknown as import("playwright-core").Browser;
+
+    connectOverCdpSpy.mockResolvedValue(browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    const fetchSpy = mockRelayFetch({
+      targets: [
+        { id: "TARGET_A", url: "https://e-services.empower.ae/" },
+        { id: "TARGET_B", url: "https://e-services.empower.ae/" },
+      ],
+    });
+
+    try {
+      const resolved = await getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "TARGET_B",
+      });
+      expect(resolved).toBe(pageB);
+      expect(newCDPSession).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("keeps continuity when relay lists target but page mapping temporarily misses", async () => {
+    const pageOn = vi.fn();
+    const contextOn = vi.fn();
+    const browserOn = vi.fn();
+    const browserClose = vi.fn(async () => {});
+    const newCDPSession = vi.fn(async () => {
+      throw new Error("Target.attachToBrowserTarget: Not allowed");
+    });
+
+    const context = {
+      pages: () => [],
+      on: contextOn,
+      newCDPSession,
+    } as unknown as import("playwright-core").BrowserContext;
+
+    const pageA = {
+      on: pageOn,
+      context: () => context,
+      url: () => "about:blank",
+      evaluate: vi.fn(async () => false),
+      title: vi.fn(async () => ""),
+    } as unknown as import("playwright-core").Page;
+    const pageB = {
+      on: pageOn,
+      context: () => context,
+      url: () => "about:blank",
+      evaluate: vi.fn(async () => false),
+      title: vi.fn(async () => ""),
+    } as unknown as import("playwright-core").Page;
+    (context as unknown as { pages: () => unknown[] }).pages = () => [pageA, pageB];
+
+    const browser = {
+      contexts: () => [context],
+      on: browserOn,
+      close: browserClose,
+    } as unknown as import("playwright-core").Browser;
+
+    connectOverCdpSpy.mockResolvedValue(browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    const fetchSpy = mockRelayFetch({
+      targets: [{ id: "TARGET_STILL_LISTED", url: "https://e-services.empower.ae/Login" }],
+    });
+
+    try {
+      const resolved = await getPageForTargetId({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "TARGET_STILL_LISTED",
+      });
+      expect(resolved).toBe(pageA);
     } finally {
       fetchSpy.mockRestore();
     }

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -66,6 +66,12 @@ type TargetInfoResponse = {
   };
 };
 
+type RelayListTarget = {
+  id: string;
+  url: string;
+  title?: string;
+};
+
 type ConnectedBrowser = {
   browser: Browser;
   cdpUrl: string;
@@ -118,6 +124,23 @@ const MAX_NETWORK_REQUESTS = 500;
 
 const cachedByCdpUrl = new Map<string, ConnectedBrowser>();
 const connectingByCdpUrl = new Map<string, Promise<ConnectedBrowser>>();
+
+function pwSessionLog(
+  event: string,
+  data: Record<string, unknown>,
+  level: "info" | "warn" = "info",
+) {
+  const payload = {
+    ts: new Date().toISOString(),
+    event,
+    ...data,
+  };
+  if (level === "warn") {
+    console.warn("[browser-pw-session]", payload);
+    return;
+  }
+  console.info("[browser-pw-session]", payload);
+}
 
 function normalizeCdpUrl(raw: string) {
   return raw.replace(/\/$/, "");
@@ -408,7 +431,7 @@ async function pageTargetId(page: Page): Promise<string | null> {
 
 function matchPageByTargetList(
   pages: Page[],
-  targets: Array<{ id: string; url: string; title?: string }>,
+  targets: RelayListTarget[],
   targetId: string,
 ): Page | null {
   const target = targets.find((entry) => entry.id === targetId);
@@ -422,14 +445,130 @@ function matchPageByTargetList(
   }
   if (urlMatch.length > 1) {
     const sameUrlTargets = targets.filter((entry) => entry.url === target.url);
-    if (sameUrlTargets.length === urlMatch.length) {
-      const idx = sameUrlTargets.findIndex((entry) => entry.id === targetId);
-      if (idx >= 0 && idx < urlMatch.length) {
-        return urlMatch[idx] ?? null;
-      }
+    const idx = sameUrlTargets.findIndex((entry) => entry.id === targetId);
+    if (idx >= 0 && idx < urlMatch.length) {
+      return urlMatch[idx] ?? null;
+    }
+    if (sameUrlTargets.length > 0 && idx >= 0) {
+      // Auth redirect flows can leave Playwright's page set and /json/list with different
+      // counts for the same URL for a short time. Clamp the index instead of hard failing.
+      const clampedIdx = Math.min(idx, urlMatch.length - 1);
+      return urlMatch[clampedIdx] ?? null;
     }
   }
   return null;
+}
+
+async function resolveExtensionRelayAliasTargetId(opts: {
+  cdpUrl: string;
+  targetId: string;
+}): Promise<string> {
+  const requested = opts.targetId.trim();
+  if (!requested) {
+    return requested;
+  }
+  const cdpHttpBase = normalizeCdpHttpBaseForJsonEndpoints(opts.cdpUrl);
+  const resolveUrl = appendCdpPath(cdpHttpBase, `/json/resolve/${encodeURIComponent(requested)}`);
+  const payload = await fetchJson<{ targetId?: unknown }>(resolveUrl, 1200).catch(() => null);
+  const resolved = typeof payload?.targetId === "string" ? payload.targetId.trim() : "";
+  if (!resolved) {
+    return requested;
+  }
+  if (resolved !== requested) {
+    pwSessionLog("extension.target.alias-resolved", {
+      requested,
+      resolved,
+    });
+  }
+  return resolved;
+}
+
+async function fetchRelayTargets(cdpUrl: string): Promise<RelayListTarget[]> {
+  const cdpHttpBase = normalizeCdpHttpBaseForJsonEndpoints(cdpUrl);
+  const targets = await fetchJson<Array<{ id: string; url: string; title?: string }>>(
+    appendCdpPath(cdpHttpBase, "/json/list"),
+    2000,
+  );
+  return targets;
+}
+
+async function findPageByRelayTargetList(opts: {
+  pages: Page[];
+  targets: RelayListTarget[];
+  targetId: string;
+}): Promise<Page | null> {
+  const direct = matchPageByTargetList(opts.pages, opts.targets, opts.targetId);
+  if (direct) {
+    return direct;
+  }
+
+  const target = opts.targets.find((entry) => entry.id === opts.targetId);
+  if (!target) {
+    return null;
+  }
+
+  const urlMatches = opts.pages.filter((page) => page.url() === target.url);
+  if (urlMatches.length === 0) {
+    return null;
+  }
+
+  const sameUrlTargets = opts.targets.filter((entry) => entry.url === target.url);
+  const idx = sameUrlTargets.findIndex((entry) => entry.id === opts.targetId);
+  if (idx >= 0 && idx < urlMatches.length) {
+    return urlMatches[idx] ?? null;
+  }
+  if (idx >= 0 && urlMatches.length > 0) {
+    const clamped = urlMatches[Math.min(idx, urlMatches.length - 1)];
+    if (clamped) {
+      return clamped;
+    }
+  }
+
+  const normalizedTitle = String(target.title ?? "").trim();
+  if (normalizedTitle) {
+    const titleMatches: Page[] = [];
+    for (const page of urlMatches) {
+      const title = await page.title().catch(() => "");
+      if (title.trim() === normalizedTitle) {
+        titleMatches.push(page);
+      }
+    }
+    if (titleMatches.length === 1) {
+      return titleMatches[0] ?? null;
+    }
+    if (idx >= 0 && idx < titleMatches.length) {
+      return titleMatches[idx] ?? null;
+    }
+    if (titleMatches.length > 0) {
+      return titleMatches[0] ?? null;
+    }
+  }
+
+  return urlMatches[0] ?? null;
+}
+
+async function findPageByTargetProbe(pages: Page[], targetId: string): Promise<Page | null> {
+  for (const page of pages) {
+    const probedTargetId = await pageTargetId(page).catch(() => null);
+    if (probedTargetId === targetId) {
+      return page;
+    }
+  }
+  return null;
+}
+
+async function findFocusedPage(pages: Page[]): Promise<Page | null> {
+  const focused: Page[] = [];
+  for (const page of pages) {
+    const hasFocus = await page.evaluate(() => document.hasFocus()).catch(() => false);
+    if (hasFocus) {
+      focused.push(page);
+      if (focused.length > 1) {
+        return null;
+      }
+    }
+  }
+  return focused[0] ?? null;
 }
 
 async function findPageByTargetIdViaTargetList(
@@ -437,15 +576,8 @@ async function findPageByTargetIdViaTargetList(
   targetId: string,
   cdpUrl: string,
 ): Promise<Page | null> {
-  const cdpHttpBase = normalizeCdpHttpBaseForJsonEndpoints(cdpUrl);
-  const targets = await fetchJson<
-    Array<{
-      id: string;
-      url: string;
-      title?: string;
-    }>
-  >(appendCdpPath(cdpHttpBase, "/json/list"), 2000);
-  return matchPageByTargetList(pages, targets, targetId);
+  const targets = await fetchRelayTargets(cdpUrl);
+  return await findPageByRelayTargetList({ pages, targets, targetId });
 }
 
 async function findPageByTargetId(
@@ -458,15 +590,114 @@ async function findPageByTargetId(
     ? await isExtensionRelayCdpEndpoint(cdpUrl).catch(() => false)
     : false;
   if (cdpUrl && isExtensionRelay) {
-    try {
-      const matched = await findPageByTargetIdViaTargetList(pages, targetId, cdpUrl);
+    const resolvedTargetId = await resolveExtensionRelayAliasTargetId({
+      cdpUrl,
+      targetId,
+    }).catch(() => targetId);
+
+    const relayTargets = await fetchRelayTargets(cdpUrl).catch(() => null);
+    if (relayTargets) {
+      const matched = await findPageByRelayTargetList({
+        pages,
+        targets: relayTargets,
+        targetId: resolvedTargetId,
+      });
       if (matched) {
+        pwSessionLog("extension.target.match", {
+          requestedTargetId: targetId,
+          resolvedTargetId,
+          method: "target-list",
+          pages: pages.length,
+        });
+        return matched;
+      }
+    }
+
+    const targetProbeMatch = await findPageByTargetProbe(pages, resolvedTargetId).catch(() => null);
+    if (targetProbeMatch) {
+      pwSessionLog("extension.target.match", {
+        requestedTargetId: targetId,
+        resolvedTargetId,
+        method: "page-target-probe",
+        pages: pages.length,
+      });
+      return targetProbeMatch;
+    }
+
+    const targetListed = relayTargets?.some((target) => target.id === resolvedTargetId) ?? false;
+    if (targetListed) {
+      const focused = await findFocusedPage(pages).catch(() => null);
+      if (focused) {
+        pwSessionLog("extension.target.match-fallback", {
+          requestedTargetId: targetId,
+          resolvedTargetId,
+          method: "focused-page-fallback",
+          pages: pages.length,
+        });
+        return focused;
+      }
+      if (pages.length > 0) {
+        // Last-resort continuity: if relay still lists the target but Playwright cannot map it,
+        // keep the session alive by returning the first available page instead of hard failing.
+        pwSessionLog(
+          "extension.target.match-fallback",
+          {
+            requestedTargetId: targetId,
+            resolvedTargetId,
+            method: "first-page-when-listed",
+            pages: pages.length,
+            classification: "target-listed-but-playwright-mapping-missed",
+          },
+          "warn",
+        );
+        return pages[0] ?? null;
+      }
+    }
+
+    try {
+      const matched = await findPageByTargetIdViaTargetList(pages, resolvedTargetId, cdpUrl);
+      if (matched) {
+        pwSessionLog("extension.target.match", {
+          requestedTargetId: targetId,
+          resolvedTargetId,
+          method: "target-list-retry",
+          pages: pages.length,
+        });
         return matched;
       }
     } catch {
       // Ignore fetch errors and fall through to best-effort single-page fallback.
+      pwSessionLog(
+        "extension.target.match-fetch-failed",
+        {
+          requestedTargetId: targetId,
+          resolvedTargetId,
+          cdpUrl: normalizeCdpUrl(cdpUrl),
+          pages: pages.length,
+        },
+        "warn",
+      );
     }
-    return pages.length === 1 ? (pages[0] ?? null) : null;
+    if (pages.length === 1) {
+      pwSessionLog("extension.target.match-fallback", {
+        requestedTargetId: targetId,
+        resolvedTargetId,
+        method: "single-page-fallback",
+      });
+      return pages[0] ?? null;
+    }
+    pwSessionLog(
+      "extension.target.match-failed",
+      {
+        requestedTargetId: targetId,
+        resolvedTargetId,
+        pages: pages.length,
+        pageUrls: pages.map((page) => page.url()).slice(0, 20),
+        classification: "target-listed-but-playwright-page-unresolved",
+      },
+      "warn",
+    );
+    return null;
   }
 
   let resolvedViaCdp = false;

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -497,54 +497,9 @@ async function findPageByRelayTargetList(opts: {
   targets: RelayListTarget[];
   targetId: string;
 }): Promise<Page | null> {
-  const direct = matchPageByTargetList(opts.pages, opts.targets, opts.targetId);
-  if (direct) {
-    return direct;
-  }
-
-  const target = opts.targets.find((entry) => entry.id === opts.targetId);
-  if (!target) {
-    return null;
-  }
-
-  const urlMatches = opts.pages.filter((page) => page.url() === target.url);
-  if (urlMatches.length === 0) {
-    return null;
-  }
-
-  const sameUrlTargets = opts.targets.filter((entry) => entry.url === target.url);
-  const idx = sameUrlTargets.findIndex((entry) => entry.id === opts.targetId);
-  if (idx >= 0 && idx < urlMatches.length) {
-    return urlMatches[idx] ?? null;
-  }
-  if (idx >= 0 && urlMatches.length > 0) {
-    const clamped = urlMatches[Math.min(idx, urlMatches.length - 1)];
-    if (clamped) {
-      return clamped;
-    }
-  }
-
-  const normalizedTitle = String(target.title ?? "").trim();
-  if (normalizedTitle) {
-    const titleMatches: Page[] = [];
-    for (const page of urlMatches) {
-      const title = await page.title().catch(() => "");
-      if (title.trim() === normalizedTitle) {
-        titleMatches.push(page);
-      }
-    }
-    if (titleMatches.length === 1) {
-      return titleMatches[0] ?? null;
-    }
-    if (idx >= 0 && idx < titleMatches.length) {
-      return titleMatches[idx] ?? null;
-    }
-    if (titleMatches.length > 0) {
-      return titleMatches[0] ?? null;
-    }
-  }
-
-  return urlMatches[0] ?? null;
+  // Keep matching deterministic through one path; matchPageByTargetList already
+  // handles count skew and index clamping during redirect churn.
+  return matchPageByTargetList(opts.pages, opts.targets, opts.targetId);
 }
 
 async function findPageByTargetProbe(pages: Page[], targetId: string): Promise<Page | null> {

--- a/src/browser/server-context.ensure-tab-available.extension-alias.test.ts
+++ b/src/browser/server-context.ensure-tab-available.extension-alias.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
+import type { BrowserServerState } from "./server-context.js";
+import "./server-context.chrome-test-harness.js";
+import { createBrowserRouteContext } from "./server-context.js";
+
+function makeBrowserState(): BrowserServerState {
+  return {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    server: null as any,
+    port: 0,
+    resolved: {
+      enabled: true,
+      controlPort: 18791,
+      cdpPortRangeStart: 18800,
+      cdpPortRangeEnd: 18899,
+      cdpProtocol: "http",
+      cdpHost: "127.0.0.1",
+      cdpIsLoopback: true,
+      evaluateEnabled: false,
+      remoteCdpTimeoutMs: 1500,
+      remoteCdpHandshakeTimeoutMs: 3000,
+      extraArgs: [],
+      color: "#FF4500",
+      headless: true,
+      noSandbox: false,
+      attachOnly: false,
+      defaultProfile: "chrome",
+      profiles: {
+        chrome: {
+          driver: "extension",
+          cdpUrl: "http://127.0.0.1:18792",
+          cdpPort: 18792,
+          color: "#00AA00",
+        },
+        openclaw: { cdpPort: 18800, color: "#FF4500" },
+      },
+    },
+    profiles: new Map(),
+  };
+}
+
+function stubExtensionRelayFetch(opts: {
+  lists: unknown[];
+  aliases?: Record<string, string>;
+  activated?: string[];
+  closed?: string[];
+}) {
+  const queue = [...opts.lists];
+  const aliases = opts.aliases ?? {};
+  const activated = opts.activated ?? [];
+  const closed = opts.closed ?? [];
+  const fetchMock = vi.fn(async (url: unknown) => {
+    const raw = String(url);
+    if (raw.includes("/json/list")) {
+      const next = queue.shift();
+      if (!next) {
+        throw new Error("no more /json/list responses");
+      }
+      return { ok: true, json: async () => next } as unknown as Response;
+    }
+    const resolveMatch = raw.match(/\/json\/resolve\/([^/?#]+)/);
+    if (resolveMatch) {
+      const requested = decodeURIComponent(resolveMatch[1] ?? "");
+      const mapped = aliases[requested];
+      if (!mapped) {
+        return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+      }
+      return { ok: true, json: async () => ({ targetId: mapped }) } as unknown as Response;
+    }
+    const activateMatch = raw.match(/\/json\/activate\/([^/?#]+)/);
+    if (activateMatch) {
+      activated.push(decodeURIComponent(activateMatch[1] ?? ""));
+      return { ok: true, text: async () => "OK" } as unknown as Response;
+    }
+    const closeMatch = raw.match(/\/json\/close\/([^/?#]+)/);
+    if (closeMatch) {
+      closed.push(decodeURIComponent(closeMatch[1] ?? ""));
+      return { ok: true, text: async () => "OK" } as unknown as Response;
+    }
+    throw new Error(`unexpected fetch: ${raw}`);
+  });
+
+  global.fetch = withFetchPreconnect(fetchMock);
+  return { fetchMock, activated, closed };
+}
+
+describe("browser server-context ensureTabAvailable extension target aliases", () => {
+  it("resolves stale target ids via relay alias endpoint", async () => {
+    stubExtensionRelayFetch({
+      lists: [
+        [
+          {
+            id: "fresh-B",
+            type: "page",
+            url: "https://login.example",
+            webSocketDebuggerUrl: "ws://x/b",
+          },
+          {
+            id: "tab-C",
+            type: "page",
+            url: "https://other.example",
+            webSocketDebuggerUrl: "ws://x/c",
+          },
+        ],
+        [
+          {
+            id: "fresh-B",
+            type: "page",
+            url: "https://login.example",
+            webSocketDebuggerUrl: "ws://x/b",
+          },
+          {
+            id: "tab-C",
+            type: "page",
+            url: "https://other.example",
+            webSocketDebuggerUrl: "ws://x/c",
+          },
+        ],
+      ],
+      aliases: { "stale-A": "fresh-B" },
+    });
+    const state = makeBrowserState();
+    const ctx = createBrowserRouteContext({ getState: () => state });
+
+    const chosen = await ctx.forProfile("chrome").ensureTabAvailable("stale-A");
+    expect(chosen.targetId).toBe("fresh-B");
+  });
+
+  it("keeps focus continuity for stale ids after redirect target swap", async () => {
+    const { activated } = stubExtensionRelayFetch({
+      lists: [
+        [
+          {
+            id: "fresh-B",
+            type: "page",
+            url: "https://login.example",
+            webSocketDebuggerUrl: "ws://x/b",
+          },
+        ],
+        [
+          {
+            id: "fresh-B",
+            type: "page",
+            url: "https://login.example",
+            webSocketDebuggerUrl: "ws://x/b",
+          },
+        ],
+      ],
+      aliases: { "stale-A": "fresh-B" },
+    });
+    const state = makeBrowserState();
+    const ctx = createBrowserRouteContext({ getState: () => state });
+
+    await ctx.forProfile("chrome").focusTab("stale-A");
+    expect(activated).toEqual(["fresh-B"]);
+  });
+
+  it("keeps close continuity for stale ids after redirect target swap", async () => {
+    const { closed } = stubExtensionRelayFetch({
+      lists: [
+        [
+          {
+            id: "fresh-B",
+            type: "page",
+            url: "https://login.example",
+            webSocketDebuggerUrl: "ws://x/b",
+          },
+        ],
+        [
+          {
+            id: "fresh-B",
+            type: "page",
+            url: "https://login.example",
+            webSocketDebuggerUrl: "ws://x/b",
+          },
+        ],
+      ],
+      aliases: { "stale-A": "fresh-B" },
+    });
+    const state = makeBrowserState();
+    const ctx = createBrowserRouteContext({ getState: () => state });
+
+    await ctx.forProfile("chrome").closeTab("stale-A");
+    expect(closed).toEqual(["fresh-B"]);
+  });
+});

--- a/src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts
+++ b/src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts
@@ -122,6 +122,19 @@ describe("browser server-context ensureTabAvailable", () => {
     await expect(chrome.ensureTabAvailable()).rejects.toThrow(/no attached Chrome tabs/i);
   });
 
+  it("keeps a non-empty extension tab read when a follow-up read briefly returns empty", async () => {
+    const responses = [
+      [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
+    ];
+    stubChromeJsonList(responses);
+    const state = makeBrowserState();
+
+    const ctx = createBrowserRouteContext({ getState: () => state });
+    const chrome = ctx.forProfile("chrome");
+    const chosen = await chrome.ensureTabAvailable("A");
+    expect(chosen.targetId).toBe("A");
+  });
+
   it("waits briefly for extension tabs to reappear when a previous target exists", async () => {
     vi.useFakeTimers();
     try {
@@ -155,7 +168,6 @@ describe("browser server-context ensureTabAvailable", () => {
     vi.useFakeTimers();
     try {
       const responses = [
-        [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
         [{ id: "A", type: "page", url: "https://a.example", webSocketDebuggerUrl: "ws://x/a" }],
         ...Array.from({ length: 20 }, () => []),
       ];

--- a/src/browser/server-context.selection.ts
+++ b/src/browser/server-context.selection.ts
@@ -1,4 +1,4 @@
-import { fetchOk, normalizeCdpHttpBaseForJsonEndpoints } from "./cdp.helpers.js";
+import { fetchJson, fetchOk, normalizeCdpHttpBaseForJsonEndpoints } from "./cdp.helpers.js";
 import { appendCdpPath } from "./cdp.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { BrowserTabNotFoundError, BrowserTargetAmbiguousError } from "./errors.js";
@@ -7,6 +7,11 @@ import type { PwAiModule } from "./pw-ai-module.js";
 import { getPwAiModule } from "./pw-ai-module.js";
 import type { BrowserTab, ProfileRuntimeState } from "./server-context.types.js";
 import { resolveTargetIdFromTabs } from "./target-id.js";
+
+const EXTENSION_TARGET_RESOLVE_RETRY_WINDOW_MS = 1200;
+const EXTENSION_TARGET_RESOLVE_RETRY_STEP_MS = 150;
+
+type ResolveResult = { kind: "ok"; targetId: string } | { kind: "ambiguous" } | null;
 
 type SelectionDeps = {
   profile: ResolvedBrowserProfile;
@@ -32,23 +37,178 @@ export function createProfileSelectionOps({
   const cdpHttpBase = normalizeCdpHttpBaseForJsonEndpoints(profile.cdpUrl);
   const capabilities = getBrowserProfileCapabilities(profile);
 
+  const selectionLog = (
+    event: string,
+    data: Record<string, unknown>,
+    level: "info" | "warn" = "info",
+  ) => {
+    const payload = {
+      ts: new Date().toISOString(),
+      profile: profile.name,
+      event,
+      ...data,
+    };
+    if (level === "warn") {
+      console.warn("[browser-selection]", payload);
+      return;
+    }
+    console.info("[browser-selection]", payload);
+  };
+
+  const buildCandidates = (tabs: BrowserTab[]) =>
+    capabilities.supportsPerTabWs ? tabs.filter((tab) => Boolean(tab.wsUrl)) : tabs;
+
+  const resolveByIdLocal = (raw: string, candidates: BrowserTab[]) => {
+    const resolved = resolveTargetIdFromTabs(raw, candidates);
+    if (!resolved.ok) {
+      if (resolved.reason === "ambiguous") {
+        return "AMBIGUOUS" as const;
+      }
+      return null;
+    }
+    return candidates.find((tab) => tab.targetId === resolved.targetId) ?? null;
+  };
+
+  const resolveTargetAliasViaRelay = async (raw: string): Promise<string | null> => {
+    if (!capabilities.requiresAttachedTab) {
+      return null;
+    }
+    const requested = raw.trim();
+    if (!requested) {
+      return null;
+    }
+    const encoded = encodeURIComponent(requested);
+    const resolveUrl = appendCdpPath(cdpHttpBase, `/json/resolve/${encoded}`);
+    const payload = await fetchJson<{ targetId?: unknown }>(resolveUrl, 1000).catch(() => null);
+    const resolved = typeof payload?.targetId === "string" ? payload.targetId.trim() : "";
+    if (!resolved) {
+      selectionLog("target.alias.lookup", { requested, result: "miss" });
+      return null;
+    }
+    if (resolved !== requested) {
+      selectionLog("target.alias.lookup", { requested, resolved, result: "hit" });
+    }
+    return resolved;
+  };
+
+  const resolveTargetIdWithRelayAlias = async (
+    rawTargetId: string,
+    tabs: BrowserTab[],
+  ): Promise<ResolveResult> => {
+    const requested = rawTargetId.trim();
+    if (!requested) {
+      return null;
+    }
+
+    let currentTabs = tabs;
+    let currentCandidates = buildCandidates(currentTabs);
+
+    const resolveRequested = () => resolveByIdLocal(requested, currentCandidates);
+    const resolveAlias = async () => {
+      const alias = await resolveTargetAliasViaRelay(requested);
+      if (!alias || alias === requested) {
+        return null;
+      }
+      const resolvedAlias = resolveByIdLocal(alias, currentCandidates);
+      if (resolvedAlias || resolvedAlias === "AMBIGUOUS") {
+        return resolvedAlias;
+      }
+      const refreshedTabs = await listTabs().catch(() => currentTabs);
+      if (refreshedTabs.length > 0) {
+        currentTabs = refreshedTabs;
+        currentCandidates = buildCandidates(currentTabs);
+      }
+      return resolveByIdLocal(alias, currentCandidates);
+    };
+
+    const initial = resolveRequested();
+    if (initial === "AMBIGUOUS") {
+      return { kind: "ambiguous" };
+    }
+    if (initial) {
+      return { kind: "ok", targetId: initial.targetId };
+    }
+
+    const initialAlias = await resolveAlias();
+    if (initialAlias === "AMBIGUOUS") {
+      return { kind: "ambiguous" };
+    }
+    if (initialAlias) {
+      return { kind: "ok", targetId: initialAlias.targetId };
+    }
+
+    if (!capabilities.requiresAttachedTab) {
+      return null;
+    }
+
+    if (currentCandidates.length > 0) {
+      // When we still have visible candidates but the requested target does not resolve,
+      // this is likely a genuinely invalid/stale id, not a transient relay flap.
+      return null;
+    }
+
+    const deadline = Date.now() + EXTENSION_TARGET_RESOLVE_RETRY_WINDOW_MS;
+    selectionLog("target.resolve.retry.start", {
+      requested,
+      retryWindowMs: EXTENSION_TARGET_RESOLVE_RETRY_WINDOW_MS,
+      retryStepMs: EXTENSION_TARGET_RESOLVE_RETRY_STEP_MS,
+    });
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, EXTENSION_TARGET_RESOLVE_RETRY_STEP_MS));
+      const refreshedTabs = await listTabs().catch(() => currentTabs);
+      if (refreshedTabs.length === 0) {
+        continue;
+      }
+      currentTabs = refreshedTabs;
+      currentCandidates = buildCandidates(currentTabs);
+
+      const next = resolveRequested();
+      if (next === "AMBIGUOUS") {
+        return { kind: "ambiguous" };
+      }
+      if (next) {
+        selectionLog("target.resolve.retry.hit", { requested, resolved: next.targetId });
+        return { kind: "ok", targetId: next.targetId };
+      }
+
+      const aliased = await resolveAlias();
+      if (aliased === "AMBIGUOUS") {
+        return { kind: "ambiguous" };
+      }
+      if (aliased) {
+        selectionLog("target.resolve.retry.alias-hit", { requested, resolved: aliased.targetId });
+        return { kind: "ok", targetId: aliased.targetId };
+      }
+    }
+
+    selectionLog(
+      "target.resolve.retry.exhausted",
+      {
+        requested,
+        classification: "tab-not-found-after-bounded-retry",
+      },
+      "warn",
+    );
+    return null;
+  };
+
   const ensureTabAvailable = async (targetId?: string): Promise<BrowserTab> => {
     await ensureBrowserAvailable();
     const profileState = getProfileState();
-    let tabs1 = await listTabs();
-    if (tabs1.length === 0) {
+    let tabs = await listTabs();
+    if (tabs.length === 0) {
       if (capabilities.requiresAttachedTab) {
         // Chrome extension relay can briefly drop its WebSocket connection (MV3 service worker
         // lifecycle, relay restart). If we previously had a target selected, wait briefly for
         // the extension to reconnect and re-announce its attached tabs before failing.
         if (profileState.lastTargetId?.trim()) {
           const deadlineAt = Date.now() + 3_000;
-          while (tabs1.length === 0 && Date.now() < deadlineAt) {
+          while (tabs.length === 0 && Date.now() < deadlineAt) {
             await new Promise((resolve) => setTimeout(resolve, 200));
-            tabs1 = await listTabs();
+            tabs = await listTabs();
           }
         }
-        if (tabs1.length === 0) {
+        if (tabs.length === 0) {
           throw new BrowserTabNotFoundError(
             `tab not found (no attached Chrome tabs for profile "${profile.name}"). ` +
               "Click the OpenClaw Browser Relay toolbar icon on the tab you want to control (badge ON).",
@@ -59,23 +219,16 @@ export function createProfileSelectionOps({
       }
     }
 
-    const tabs = await listTabs();
-    const candidates = capabilities.supportsPerTabWs ? tabs.filter((t) => Boolean(t.wsUrl)) : tabs;
-
-    const resolveById = (raw: string) => {
-      const resolved = resolveTargetIdFromTabs(raw, candidates);
-      if (!resolved.ok) {
-        if (resolved.reason === "ambiguous") {
-          return "AMBIGUOUS" as const;
-        }
-        return null;
-      }
-      return candidates.find((t) => t.targetId === resolved.targetId) ?? null;
-    };
+    // Extension profile tabs can flap briefly during redirect/session transitions.
+    // Keep the first non-empty read instead of immediately replacing it with another read.
+    if (!capabilities.requiresAttachedTab) {
+      tabs = await listTabs();
+    }
+    let candidates = buildCandidates(tabs);
 
     const pickDefault = () => {
       const last = profileState.lastTargetId?.trim() || "";
-      const lastResolved = last ? resolveById(last) : null;
+      const lastResolved = last ? resolveByIdLocal(last, candidates) : null;
       if (lastResolved && lastResolved !== "AMBIGUOUS") {
         return lastResolved;
       }
@@ -84,13 +237,43 @@ export function createProfileSelectionOps({
       return page ?? candidates.at(0) ?? null;
     };
 
-    const chosen = targetId ? resolveById(targetId) : pickDefault();
+    const resolvedTarget = targetId
+      ? await resolveTargetIdWithRelayAlias(targetId, tabs)
+      : (() => {
+          const chosen = pickDefault();
+          if (!chosen) {
+            return null;
+          }
+          return { kind: "ok", targetId: chosen.targetId } as const;
+        })();
 
-    if (chosen === "AMBIGUOUS") {
+    if (resolvedTarget?.kind === "ambiguous") {
       throw new BrowserTargetAmbiguousError();
     }
-    if (!chosen) {
+    if (!resolvedTarget || resolvedTarget.kind !== "ok") {
+      if (targetId?.trim()) {
+        selectionLog(
+          "target.resolve.fail",
+          {
+            requested: targetId.trim(),
+            classification: "tab-not-found-while-requested-target-missing",
+          },
+          "warn",
+        );
+      }
       throw new BrowserTabNotFoundError();
+    }
+    const chosen = candidates.find((tab) => tab.targetId === resolvedTarget.targetId);
+    if (!chosen) {
+      // Last chance refresh in case a retry resolved an alias on a just-refreshed target set.
+      const refreshedTabs = await listTabs().catch(() => tabs);
+      candidates = buildCandidates(refreshedTabs);
+      const refreshedChosen = candidates.find((tab) => tab.targetId === resolvedTarget.targetId);
+      if (!refreshedChosen) {
+        throw new BrowserTabNotFoundError();
+      }
+      profileState.lastTargetId = refreshedChosen.targetId;
+      return refreshedChosen;
     }
     profileState.lastTargetId = chosen.targetId;
     return chosen;
@@ -98,11 +281,19 @@ export function createProfileSelectionOps({
 
   const resolveTargetIdOrThrow = async (targetId: string): Promise<string> => {
     const tabs = await listTabs();
-    const resolved = resolveTargetIdFromTabs(targetId, tabs);
-    if (!resolved.ok) {
-      if (resolved.reason === "ambiguous") {
-        throw new BrowserTargetAmbiguousError();
-      }
+    const resolved = await resolveTargetIdWithRelayAlias(targetId, tabs);
+    if (resolved?.kind === "ambiguous") {
+      throw new BrowserTargetAmbiguousError();
+    }
+    if (!resolved || resolved.kind !== "ok") {
+      selectionLog(
+        "target.resolve.fail",
+        {
+          requested: targetId.trim(),
+          classification: "tab-not-found-in-focus-or-close",
+        },
+        "warn",
+      );
       throw new BrowserTabNotFoundError();
     }
     return resolved.targetId;

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -3,12 +3,18 @@ import type { AddressInfo } from "node:net";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const TEST_GATEWAY_TOKEN = "test-gateway-token-1234567890";
+type BeforeToolCallOutcomeMock =
+  | { blocked: true; reason: string }
+  | { blocked: false; params: unknown };
+
 const hookMocks = vi.hoisted(() => ({
   resolveToolLoopDetectionConfig: vi.fn(() => ({ warnAt: 3 })),
-  runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
-    blocked: false as const,
-    params,
-  })),
+  runBeforeToolCallHook: vi.fn(
+    async ({ params }: { params: unknown }): Promise<BeforeToolCallOutcomeMock> => ({
+      blocked: false,
+      params,
+    }),
+  ),
 }));
 
 let cfg: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
This PR fixes Browser Relay instability in extension profile flows where auth/login redirects caused control to fail with `tab not found` even while the tab was still listed.

AI-assisted PR.

## Problem
In live Empower/UAE Pass style redirect flows:
- `tabs` listed the target tab
- `snapshot`/`navigate` intermittently failed with `INVALID_REQUEST: Error: tab not found`
- failures clustered around cross-origin auth transitions and target/session churn

## Root Cause (RCA)
1. Extension relay target identity could churn across redirects, but consumers still used stale target IDs.
2. Selection and per-request target resolution lacked relay alias reconciliation for stale IDs.
3. Playwright page resolution in extension mode could fail under URL duplication/count skew, then hard-fail with `tab not found` even when relay still listed the target.

## Fix
- Added extension relay alias tracking and `/json/resolve/<targetId>` endpoint.
- Added bounded alias-aware target resolution in server selection ops.
- Hardened extension Playwright target-to-page resolution in `pw-session`:
  - alias resolution before page lookup
  - robust target-list matching for duplicate URL skew
  - CDP target probe fallback
  - bounded fallback when relay still lists the target (with explicit classification logs)
- Added high-signal logs for:
  - target transitions and alias resolution decisions
  - target attach/detach/destroy lifecycle
  - relay close / disconnect classification
  - extension page-resolution fallback classifications

## Tests
Added/updated targeted tests:
- `src/browser/extension-relay.test.ts`
- `src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts`
- `src/browser/server-context.ensure-tab-available.extension-alias.test.ts` (new)
- `src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts`

Validation commands:
- `pnpm build`
- `pnpm test -- src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts src/browser/extension-relay.test.ts src/browser/server-context.ensure-tab-available.prefers-last-target.test.ts src/browser/server-context.ensure-tab-available.extension-alias.test.ts`
- `pnpm check`

## Live Evidence (local runtime, extension profile)
- First 10-cycle stress run: `SUMMARY fail_count=1 notfound_while_listed=0`
  - log: `/tmp/openclaw-browser-relay-e2e-retest-20260312-032417.log`
  - one transient gateway timeout; no `tab not found while listed`
- Second 10-cycle run (lower overhead): `SUMMARY fail_count=0 notfound_while_listed=0`
  - log: `/tmp/openclaw-browser-relay-e2e-retest-lite-20260312-032729.log`

## Risk
- In extension-only ambiguous mapping windows, fallback can choose first available page when relay still lists target.
- This is intentionally bounded and heavily logged (`classification: target-listed-but-playwright-mapping-missed`) to avoid hard failure while preserving diagnosability.

## Rollback
- Revert this PR commit to restore prior relay/selection/page-resolution behavior.
