### PR TITLE
fix: use file identity (dev:ino) for memory file deduplication

### DIFF
--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -131,6 +131,35 @@ describe("listMemoryFiles", () => {
     const memoryMatches = files.filter((file) => file.endsWith("MEMORY.md"));
     expect(memoryMatches).toHaveLength(1);
   });
+
+  it("dedupes paths referring to the same inode on case-insensitive filesystems", async () => {
+    const tmpDir = getTmpDir();
+    await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Default memory");
+
+    // On case-insensitive filesystems (macOS), both MEMORY.md and memory.md
+    // refer to the same physical file (same inode).  The dedup should detect
+    // this via dev:ino identity even though realpath returns different strings.
+    const upperPath = path.join(tmpDir, "MEMORY.md");
+    const lowerPath = path.join(tmpDir, "memory.md");
+
+    let isSamePath = false;
+    try {
+      const upperStat = await fs.stat(upperPath);
+      const lowerStat = await fs.stat(lowerPath);
+      isSamePath = upperStat.ino === lowerStat.ino && upperStat.dev === lowerStat.dev;
+    } catch {
+      // If lowerPath stat fails, the FS is case-sensitive; skip the assertion.
+    }
+
+    if (isSamePath) {
+      // Both paths point to the same file; listMemoryFiles should deduplicate.
+      const files = await listMemoryFiles(tmpDir);
+      const memoryFiles = files.filter(
+        (f) => f.endsWith("MEMORY.md") || f.endsWith("memory.md"),
+      );
+      expect(memoryFiles).toHaveLength(1);
+    }
+  });
 });
 
 describe("buildFileEntry", () => {

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -132,10 +132,24 @@ export async function listMemoryFiles(
   const seen = new Set<string>();
   const deduped: string[] = [];
   for (const entry of result) {
-    let key = entry;
+    let key: string;
     try {
-      key = await fs.realpath(entry);
-    } catch {}
+      // Use device + inode as file identity key.  This correctly deduplicates
+      // paths that refer to the same physical file on case-insensitive
+      // filesystems (e.g. macOS HFS+/APFS) where realpath preserves the
+      // original casing and would not detect that MEMORY.md and memory.md
+      // point to the same inode.
+      const stat = await fs.stat(entry);
+      key = `${stat.dev}:${stat.ino}`;
+    } catch {
+      // stat may fail for broken mounts or race conditions; fall back to
+      // realpath which still handles symlink-based duplicates.
+      try {
+        key = await fs.realpath(entry);
+      } catch {
+        key = entry;
+      }
+    }
     if (seen.has(key)) {
       continue;
     }

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -139,8 +139,16 @@ export async function listMemoryFiles(
       // filesystems (e.g. macOS HFS+/APFS) where realpath preserves the
       // original casing and would not detect that MEMORY.md and memory.md
       // point to the same inode.
+      //
+      // Guard: some filesystems (FAT32, network mounts) report ino as 0 for
+      // every file.  In that case fall through to realpath-based dedup to
+      // avoid collapsing unrelated files into a single key.
       const stat = await fs.stat(entry);
-      key = `${stat.dev}:${stat.ino}`;
+      if (stat.ino !== 0) {
+        key = `${stat.dev}:${stat.ino}`;
+      } else {
+        key = await fs.realpath(entry);
+      }
     } catch {
       // stat may fail for broken mounts or race conditions; fall back to
       // realpath which still handles symlink-based duplicates.


### PR DESCRIPTION
## Problem

`listMemoryFiles()` in `src/memory/internal.ts` deduplicates discovered memory files using `fs.realpath()`. On case-insensitive filesystems (macOS HFS+/APFS default), `MEMORY.md` and `memory.md` resolve to the same physical file (same inode), but `realpath()` preserves the original casing and returns different path strings. This means both paths pass the dedup check, causing duplicate memory content to be injected into the bootstrap context.

Ref: #43408

## Fix

Replace `realpath`-based dedup with `fs.stat()` `dev:ino` file identity as the primary dedup key. The `dev:ino` pair uniquely identifies a physical file regardless of how it was accessed (different casing, hardlinks, different mount paths). Falls back to `realpath` when `stat` fails for robustness.

```diff
-    let key = entry;
+    let key: string;
     try {
-      key = await fs.realpath(entry);
-    } catch {}
+      const stat = await fs.stat(entry);
+      key = `${stat.dev}:${stat.ino}`;
+    } catch {
+      try {
+        key = await fs.realpath(entry);
+      } catch {
+        key = entry;
+      }
+    }
```

## Tests

Added test that verifies dedup works via inode identity on case-insensitive filesystems. The test checks whether `MEMORY.md` and `memory.md` share the same inode (auto-detected at runtime) and asserts that only one entry is returned.
