### PR TITLE
Feature: Add defaultHeaders config option to web_fetch tool

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -126,6 +126,23 @@ function resolveFetchMaxResponseBytes(fetch?: WebFetchConfig): number {
   return Math.min(FETCH_MAX_RESPONSE_BYTES_MAX, Math.max(FETCH_MAX_RESPONSE_BYTES_MIN, value));
 }
 
+function resolveFetchDefaultHeaders(fetch?: WebFetchConfig): Record<string, string> {
+  if (!fetch || typeof fetch !== "object") {
+    return {};
+  }
+  const defaultHeaders = "defaultHeaders" in fetch ? fetch.defaultHeaders : undefined;
+  if (!defaultHeaders || typeof defaultHeaders !== "object") {
+    return {};
+  }
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(defaultHeaders)) {
+    if (typeof value === "string") {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 function resolveFirecrawlConfig(fetch?: WebFetchConfig): FirecrawlFetchConfig {
   if (!fetch || typeof fetch !== "object") {
     return undefined;
@@ -451,6 +468,7 @@ type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   timeoutSeconds: number;
   cacheTtlMs: number;
   userAgent: string;
+  defaultHeaders: Record<string, string>;
   readabilityEnabled: boolean;
 };
 
@@ -538,6 +556,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
           "User-Agent": params.userAgent,
           "Accept-Language": "en-US,en;q=0.9",
+          ...params.defaultHeaders,
         },
       },
     });
@@ -744,6 +763,7 @@ export function createWebFetchTool(options?: {
   const userAgent =
     (fetch && "userAgent" in fetch && typeof fetch.userAgent === "string" && fetch.userAgent) ||
     DEFAULT_FETCH_USER_AGENT;
+  const defaultHeaders = resolveFetchDefaultHeaders(fetch);
   const maxResponseBytes = resolveFetchMaxResponseBytes(fetch);
   return {
     label: "Web Fetch",
@@ -770,6 +790,7 @@ export function createWebFetchTool(options?: {
         timeoutSeconds: resolveTimeoutSeconds(fetch?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
         cacheTtlMs: resolveCacheTtlMs(fetch?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         userAgent,
+        defaultHeaders,
         readabilityEnabled,
         firecrawlEnabled,
         firecrawlApiKey,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -680,6 +680,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.cacheTtlMinutes": "Cache TTL in minutes for web_fetch results.",
   "tools.web.fetch.maxRedirects": "Maximum redirects allowed for web_fetch (default: 3).",
   "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
+  "tools.web.fetch.defaultHeaders":
+    "Default headers to include in all web_fetch requests (e.g., { Accept: 'text/markdown' }).",
   "tools.web.fetch.readability":
     "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
   "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl fallback for web_fetch (if configured).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -236,6 +236,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.cacheTtlMinutes": "Web Fetch Cache TTL (min)",
   "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
+  "tools.web.fetch.defaultHeaders": "Web Fetch Default Headers",
   "tools.web.fetch.readability": "Web Fetch Readability Extraction",
   "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl Fallback",
   "tools.web.fetch.firecrawl.apiKey": "Firecrawl API Key", // pragma: allowlist secret

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -511,6 +511,8 @@ export type ToolsConfig = {
       maxRedirects?: number;
       /** Override User-Agent header for fetch requests. */
       userAgent?: string;
+      /** Default headers to include in all fetch requests. */
+      defaultHeaders?: Record<string, string>;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
       firecrawl?: {


### PR DESCRIPTION
# Issue #43149 - web_fetch: add defaultHeaders config option

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: web_fetch tool cannot send custom HTTP headers like `Accept: text/markdown` for Cloudflare Markdown for Agents
- Why it matters: Users want to optimize token usage by receiving Markdown instead of HTML from supporting APIs
- What changed: Added `defaultHeaders` config option to `tools.web.fetch` that merges custom headers with all fetch requests
- What did NOT change (scope boundary): Default behavior remains unchanged when not configured

## Issue Details

- **Issue Number:** #43149
- **Author:** k1dw41
- **Opened:** 9 hours ago
- **Type:** Feature request

## Description

Feature request: Add a `defaultHeaders` option to `tools.web.fetch` config.

Cloudflare Markdown for Agents (https://blog.cloudflare.com/markdown-for-agents/) serves native Markdown (80% fewer tokens) to clients sending `Accept: text/markdown`. `web_fetch` cannot send this header automatically.

**Proposed config:**
```json
tools: { web: { fetch: { defaultHeaders: { Accept: "text/markdown, text/html;q=0.9, */*;q=0.8" } } } }
```

Zero behavior change for sites that do not support it.

---

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

- New config option `tools.web.fetch.defaultHeaders` allows sending custom HTTP headers with all web_fetch requests
- When not configured, behavior is unchanged (zero behavior change)

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

---