### PR TITLE
fix(agents): recover subagent runs after gateway restart

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -2625,6 +2625,7 @@ describe("subagent announce formatting", () => {
       previousRunId: "run-parent-phase-1",
       nextRunId: "run-parent-phase-2",
       preserveFrozenResultFallback: true,
+      task: expect.stringContaining("All pending descendants for that run have now settled"),
     });
   });
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -215,6 +215,9 @@ async function wakeSubagentRunAfterDescendants(params: {
     previousRunId: params.runId,
     nextRunId: wakeRunId,
     preserveFrozenResultFallback: true,
+    // Persist the wake message as the replacement run's task so that any
+    // post-restart redispatch reconstructs the correct prompt.
+    task: wakeMessage,
   });
 }
 

--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -606,6 +606,9 @@ export async function steerControlledSubagentRun(params: {
     nextRunId: runId,
     fallback: params.entry,
     runTimeoutSeconds: params.entry.runTimeoutSeconds ?? 0,
+    // Preserve the steered instruction so that restart redispatch rewraps the
+    // new message, not the stale pre-steer task (P1 correctness fix).
+    task: params.message,
   });
   if (!replaced) {
     clearSubagentRunSteerRestart(params.entry.runId);

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -117,6 +117,9 @@ async function resumeOrphanedSession(params: {
       previousRunId: params.originalRunId,
       nextRunId: result.runId,
       fallback: params.originalRun,
+      // Persist the resume message as the replacement run's task so that any
+      // post-restart redispatch reconstructs the correct prompt.
+      task: resumeMessage,
     });
     if (!remapped) {
       log.warn(

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -215,6 +215,11 @@ export function reconcileOrphanedRun(params: {
 }) {
   const now = Date.now();
   let changed = false;
+  // NOTE: The only orphan reasons reaching this function are
+  // `missing-session-entry` and `missing-session-id` — both imply no sessionId
+  // is available for transcript lookup. Any future transcript-based recovery
+  // must add a new orphan reason emitted from a path where sessionId is still
+  // known, and then apply a targeted recovery step here.
   if (typeof params.entry.endedAt !== "number") {
     params.entry.endedAt = now;
     changed = true;

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -53,6 +53,7 @@ vi.mock("../utils/delivery-context.js", () => ({
 }));
 
 vi.mock("./subagent-announce.js", () => ({
+  buildSubagentSystemPrompt: vi.fn(() => ""),
   captureSubagentCompletionReply: vi.fn(async () => undefined),
   runSubagentAnnounceFlow: vi.fn(async () => false),
 }));

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -53,6 +53,7 @@ export type RegisterSubagentRunParams = {
   attachmentsDir?: string;
   attachmentsRootDir?: string;
   retainAttachmentsOnKeep?: boolean;
+  extraSystemPrompt?: string;
 };
 
 export function createSubagentRunManager(params: {
@@ -336,6 +337,7 @@ export function createSubagentRunManager(params: {
       attachmentsDir: registerParams.attachmentsDir,
       attachmentsRootDir: registerParams.attachmentsRootDir,
       retainAttachmentsOnKeep: registerParams.retainAttachmentsOnKeep,
+      extraSystemPrompt: registerParams.extraSystemPrompt,
     };
     params.runs.set(runId, entry);
     try {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -276,6 +276,7 @@ export function createSubagentRunManager(params: {
       suppressAnnounceReason: undefined,
       announceRetryCount: undefined,
       lastAnnounceRetryAt: undefined,
+      extraSystemPrompt: undefined,
       spawnMode,
       archiveAtMs,
       runTimeoutSeconds,

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -210,6 +210,7 @@ export function createSubagentRunManager(params: {
     fallback?: SubagentRunRecord;
     runTimeoutSeconds?: number;
     preserveFrozenResultFallback?: boolean;
+    task?: string;
   }) => {
     const previousRunId = replaceParams.previousRunId.trim();
     const nextRunId = replaceParams.nextRunId.trim();
@@ -252,9 +253,21 @@ export function createSubagentRunManager(params: {
         typeof source.endedAt === "number" ? source.endedAt : now,
       ) ?? 0;
 
+    // Prefer the caller-supplied task (the text actually dispatched to the
+    // child session during steer/wake/orphan-resume) over the previous run's
+    // stale `task`.  Falling back to the prior task preserves behavior for any
+    // caller that does not pass a replacement message.  This is what
+    // redispatchSubagentRunAfterRestart rewraps after a gateway crash — using
+    // stale text would silently re-run the original instruction and lose the
+    // user's steer update.
+    const nextTask =
+      typeof replaceParams.task === "string" && replaceParams.task.length > 0
+        ? replaceParams.task
+        : source.task;
     const next: SubagentRunRecord = {
       ...source,
       runId: nextRunId,
+      task: nextTask,
       createdAt: now,
       startedAt: now,
       sessionStartedAt,

--- a/src/agents/subagent-registry-steer-runtime.ts
+++ b/src/agents/subagent-registry-steer-runtime.ts
@@ -6,6 +6,14 @@ export type ReplaceSubagentRunAfterSteerParams = {
   fallback?: SubagentRunRecord;
   runTimeoutSeconds?: number;
   preserveFrozenResultFallback?: boolean;
+  /**
+   * Optional task override for the replacement run.  Callers that dispatched a
+   * new message (steer, descendant wake, orphan resume) should pass the text
+   * actually sent so that restart-redispatch reconstructs the correct prompt
+   * after a gateway crash.  When omitted, the previous run's `task` is carried
+   * over untouched.
+   */
+  task?: string;
 };
 
 type ReplaceSubagentRunAfterSteerFn = (params: ReplaceSubagentRunAfterSteerParams) => boolean;

--- a/src/agents/subagent-registry.announce-loop-guard.test.ts
+++ b/src/agents/subagent-registry.announce-loop-guard.test.ts
@@ -53,6 +53,12 @@ vi.mock("../infra/agent-events.js", () => ({
   onAgentEvent: mocks.onAgentEvent,
 }));
 
+vi.mock("./subagent-announce.js", () => ({
+  buildSubagentSystemPrompt: vi.fn(() => ""),
+  runSubagentAnnounceFlow: mocks.runSubagentAnnounceFlow,
+  captureSubagentCompletionReply: mocks.captureSubagentCompletionReply,
+}));
+
 vi.mock("./subagent-registry.store.js", () => ({
   loadSubagentRegistryFromDisk: mocks.loadSubagentRegistryFromDisk,
   saveSubagentRegistryToDisk: mocks.saveSubagentRegistryToDisk,

--- a/src/agents/subagent-registry.archive.e2e.test.ts
+++ b/src/agents/subagent-registry.archive.e2e.test.ts
@@ -38,6 +38,8 @@ vi.mock("../config/config.js", async () => {
 });
 
 vi.mock("./subagent-announce.js", () => ({
+  buildSubagentSystemPrompt: vi.fn(() => ""),
+  captureSubagentCompletionReply: vi.fn(async () => undefined),
   runSubagentAnnounceFlow: vi.fn(async () => true),
 }));
 

--- a/src/agents/subagent-registry.nested.e2e.test.ts
+++ b/src/agents/subagent-registry.nested.e2e.test.ts
@@ -12,8 +12,9 @@ vi.mock("../config/config.js", async () => {
 });
 
 vi.mock("./subagent-announce.js", () => ({
-  runSubagentAnnounceFlow: vi.fn(async () => true),
   buildSubagentSystemPrompt: vi.fn(() => "test prompt"),
+  captureSubagentCompletionReply: vi.fn(async () => undefined),
+  runSubagentAnnounceFlow: vi.fn(async () => true),
 }));
 
 vi.mock("./subagent-registry.store.js", () => ({

--- a/src/agents/subagent-registry.persistence.resume.test.ts
+++ b/src/agents/subagent-registry.persistence.resume.test.ts
@@ -20,6 +20,8 @@ const hoisted = vi.hoisted(() => ({
 }));
 const { announceSpy } = hoisted;
 vi.mock("./subagent-announce.js", () => ({
+  buildSubagentSystemPrompt: vi.fn(() => ""),
+  captureSubagentCompletionReply: vi.fn(async () => undefined),
   runSubagentAnnounceFlow: announceSpy,
 }));
 

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -39,6 +39,8 @@ const { announceSpy } = vi.hoisted(() => ({
   announceSpy: vi.fn(async () => true),
 }));
 vi.mock("./subagent-announce.js", () => ({
+  buildSubagentSystemPrompt: vi.fn(() => ""),
+  captureSubagentCompletionReply: vi.fn(async () => undefined),
   runSubagentAnnounceFlow: announceSpy,
 }));
 

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -74,6 +74,7 @@ const noopContextEngine = {
   compact: async () => ({ ok: true, compacted: false }),
 } satisfies ContextEngine;
 vi.mock("./subagent-announce.js", () => ({
+  buildSubagentSystemPrompt: vi.fn(() => ""),
   captureSubagentCompletionReply: vi.fn(async () => undefined),
   runSubagentAnnounceFlow: announceSpy,
 }));

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -456,6 +456,28 @@ describe("subagent registry steer restarts", () => {
     expect(run.cleanupHandled).toBe(false);
   });
 
+  it("clears stale extraSystemPrompt when replacing after steer restart", () => {
+    registerRun({
+      runId: "run-prompt-old",
+      childSessionKey: "agent:main:subagent:prompt",
+      task: "prompt reset",
+    });
+
+    const previous = listMainRuns()[0];
+    expect(previous?.runId).toBe("run-prompt-old");
+    if (previous) {
+      previous.extraSystemPrompt = "stale prompt with attachment suffixes from prior run";
+    }
+
+    const run = replaceRunAfterSteer({
+      previousRunId: "run-prompt-old",
+      nextRunId: "run-prompt-new",
+      fallback: previous,
+    });
+
+    expect(run.extraSystemPrompt).toBeUndefined();
+  });
+
   it("preserves cumulative session timing across steer replacement runs", () => {
     registerRun({
       runId: "run-runtime-old",

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -218,11 +218,13 @@ describe("subagent registry steer restarts", () => {
     previousRunId: string;
     nextRunId: string;
     fallback?: ReturnType<typeof listMainRuns>[number];
+    task?: string;
   }) => {
     const replaced = mod.replaceSubagentRunAfterSteer({
       previousRunId: params.previousRunId,
       nextRunId: params.nextRunId,
       fallback: params.fallback,
+      task: params.task,
     });
     expect(replaced).toBe(true);
 
@@ -476,6 +478,53 @@ describe("subagent registry steer restarts", () => {
     });
 
     expect(run.extraSystemPrompt).toBeUndefined();
+  });
+
+  it("updates task to the dispatched steer message when provided", () => {
+    // Regression test: redispatchSubagentRunAfterRestart rewraps `entry.task`
+    // into the [Subagent Task] block. If steer replacement did not update
+    // `task` to the new message, a gateway restart classified as
+    // resumable-fresh would re-run the stale pre-steer instruction and lose
+    // the user's steer update.
+    registerRun({
+      runId: "run-steer-task-old",
+      childSessionKey: "agent:main:subagent:steer-task",
+      task: "original pre-steer task",
+    });
+
+    const previous = listMainRuns()[0];
+    expect(previous?.runId).toBe("run-steer-task-old");
+
+    const run = replaceRunAfterSteer({
+      previousRunId: "run-steer-task-old",
+      nextRunId: "run-steer-task-new",
+      fallback: previous,
+      task: "new steer instruction from user",
+    });
+
+    expect(run.task).toBe("new steer instruction from user");
+  });
+
+  it("preserves the previous task when no replacement is provided", () => {
+    // Backwards-compatibility guard: callers that do not pass a new task
+    // (legacy or test fixtures) should still inherit the prior task so that
+    // redispatch after restart stays deterministic.
+    registerRun({
+      runId: "run-task-preserve-old",
+      childSessionKey: "agent:main:subagent:task-preserve",
+      task: "preserve me verbatim",
+    });
+
+    const previous = listMainRuns()[0];
+    expect(previous?.runId).toBe("run-task-preserve-old");
+
+    const run = replaceRunAfterSteer({
+      previousRunId: "run-task-preserve-old",
+      nextRunId: "run-task-preserve-new",
+      fallback: previous,
+    });
+
+    expect(run.task).toBe("preserve me verbatim");
   });
 
   it("preserves cumulative session timing across steer replacement runs", () => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -74,6 +74,7 @@ vi.mock("./subagent-announce-queue.js", () => ({
 }));
 
 vi.mock("./subagent-announce.js", () => ({
+  buildSubagentSystemPrompt: vi.fn(() => ""),
   captureSubagentCompletionReply: mocks.captureSubagentCompletionReply,
   runSubagentAnnounceFlow: mocks.runSubagentAnnounceFlow,
 }));

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -57,6 +57,7 @@ import {
 } from "./subagent-registry-state.js";
 import { configureSubagentRegistrySteerRuntime } from "./subagent-registry-steer-runtime.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import { rehydrateSessionStoreEntries, routeResumedRun } from "./subagent-resume.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 
 export type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -493,9 +494,54 @@ function resumeSubagentRun(runId: string) {
     return;
   }
 
-  // Wait for completion again after restart.
+  // Classify the run and route to the appropriate recovery path.
   const cfg = subagentRegistryDeps.loadConfig();
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, entry.runTimeoutSeconds);
+  const handled = routeResumedRun({
+    runId,
+    entry,
+    waitTimeoutMs,
+    onCompleteReplay: async (replayRunId, endedAt) => {
+      await completeSubagentRun({
+        runId: replayRunId,
+        endedAt,
+        outcome: { status: "ok" },
+        reason: SUBAGENT_ENDED_REASON_COMPLETE,
+        sendFarewell: true,
+        accountId: entry.requesterOrigin?.accountId,
+        triggerCleanup: true,
+      });
+    },
+    onCompleteRedispatch: async (redispatchRunId, endedAt, outcome) => {
+      const runOutcome =
+        outcome.status === "error"
+          ? {
+              status: "error" as const,
+              error: (outcome as { status: string; error?: string }).error,
+            }
+          : outcome.status === "timeout"
+            ? { status: "timeout" as const }
+            : { status: "ok" as const };
+      await completeSubagentRun({
+        runId: redispatchRunId,
+        endedAt,
+        outcome: runOutcome,
+        reason:
+          outcome.status === "error" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
+        sendFarewell: true,
+        accountId: entry.requesterOrigin?.accountId,
+        triggerCleanup: true,
+      });
+    },
+  });
+  if (handled) {
+    resumedRuns.add(runId);
+    return;
+  }
+
+  // Default: wait for completion (covers cases where the gateway dedupe cache
+  // still has a valid snapshot, or agent.wait returns a timeout result that
+  // completeSubagentRun can handle).
   void subagentRunManager.waitForSubagentCompletion(runId, waitTimeoutMs, entry);
   resumedRuns.add(runId);
 }
@@ -513,12 +559,11 @@ function restoreSubagentRunsOnce() {
     if (restoredCount === 0) {
       return;
     }
-    if (
-      reconcileOrphanedRestoredRuns({
-        runs: subagentRuns,
-        resumedRuns,
-      })
-    ) {
+    // Inject synthetic session-store entries for runs whose store entry went
+    // missing in the race window between spawn and first store write.  Must run
+    // BEFORE reconcileOrphanedRestoredRuns so the orphan check sees them.
+    rehydrateSessionStoreEntries(subagentRuns);
+    if (reconcileOrphanedRestoredRuns({ runs: subagentRuns, resumedRuns })) {
       persistSubagentRuns();
     }
     if (subagentRuns.size === 0) {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -561,6 +561,11 @@ async function restoreSubagentRunsOnce(): Promise<void> {
     if (restoredCount === 0) {
       return;
     }
+    // Capture restored run IDs BEFORE the async rehydration step.
+    // New runs may be registered into subagentRuns during the await window;
+    // we must only resume the runs that were restored from disk, not any
+    // newly-registered runs that arrived concurrently during gateway startup.
+    const restoredRunIds = new Set(subagentRuns.keys());
     // Ordering: rehydrateSessionStoreEntries MUST run before
     // reconcileOrphanedRestoredRuns.  The rehydration step injects synthetic
     // session-store entries for runs whose store write fell inside the ~400 ms
@@ -581,8 +586,13 @@ async function restoreSubagentRunsOnce(): Promise<void> {
     ensureListener();
     // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
     startSweeper();
-    for (const runId of subagentRuns.keys()) {
-      resumeSubagentRun(runId);
+    // Only resume the runs that were present before the async rehydration step.
+    // Runs registered concurrently during the await window will be managed by
+    // their own lifecycle and must not be routed through restart recovery.
+    for (const runId of restoredRunIds) {
+      if (subagentRuns.has(runId)) {
+        resumeSubagentRun(runId);
+      }
     }
 
     // Cold-start restore path: queue the same recovery pass that restart

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -812,6 +812,7 @@ export function replaceSubagentRunAfterSteer(params: {
   fallback?: SubagentRunRecord;
   runTimeoutSeconds?: number;
   preserveFrozenResultFallback?: boolean;
+  task?: string;
 }) {
   return subagentRunManager.replaceSubagentRunAfterSteer(params);
 }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -546,7 +546,7 @@ function resumeSubagentRun(runId: string) {
   resumedRuns.add(runId);
 }
 
-function restoreSubagentRunsOnce() {
+async function restoreSubagentRunsOnce(): Promise<void> {
   if (restoreAttempted) {
     return;
   }
@@ -559,10 +559,16 @@ function restoreSubagentRunsOnce() {
     if (restoredCount === 0) {
       return;
     }
-    // Inject synthetic session-store entries for runs whose store entry went
-    // missing in the race window between spawn and first store write.  Must run
-    // BEFORE reconcileOrphanedRestoredRuns so the orphan check sees them.
-    rehydrateSessionStoreEntries(subagentRuns);
+    // Ordering: rehydrateSessionStoreEntries MUST run before
+    // reconcileOrphanedRestoredRuns.  The rehydration step injects synthetic
+    // session-store entries for runs whose store write fell inside the ~400 ms
+    // race window between sessions_spawn returning and the first store write
+    // completing.  reconcileOrphanedRestoredRuns reads the session store to
+    // determine the orphan reason; if it runs first it will mis-classify these
+    // runs as "missing-session-entry" orphans and prune them incorrectly.
+    // rehydrateSessionStoreEntries is async (writes via updateSessionStore to
+    // serialise concurrent store writers during startup through the lock).
+    await rehydrateSessionStoreEntries(subagentRuns);
     if (reconcileOrphanedRestoredRuns({ runs: subagentRuns, resumedRuns })) {
       persistSubagentRuns();
     }
@@ -967,5 +973,5 @@ export function getLatestSubagentRunByChildSessionKey(
 }
 
 export function initSubagentRegistry() {
-  restoreSubagentRunsOnce();
+  void restoreSubagentRunsOnce();
 }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -21,6 +21,7 @@ import {
   emitSubagentEndedHookOnce,
   resolveLifecycleOutcomeFromRunOutcome,
 } from "./subagent-registry-completion.js";
+import { runOutcomesEqual } from "./subagent-registry-completion.js";
 import {
   ANNOUNCE_EXPIRY_MS,
   MAX_ANNOUNCE_RETRY_COUNT,
@@ -31,6 +32,7 @@ import {
   resolveSubagentSessionStatus,
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
+import { resolveArchiveAfterMs } from "./subagent-registry-helpers.js";
 import { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
 import {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -21,7 +21,6 @@ import {
   emitSubagentEndedHookOnce,
   resolveLifecycleOutcomeFromRunOutcome,
 } from "./subagent-registry-completion.js";
-import { runOutcomesEqual } from "./subagent-registry-completion.js";
 import {
   ANNOUNCE_EXPIRY_MS,
   MAX_ANNOUNCE_RETRY_COUNT,
@@ -32,7 +31,6 @@ import {
   resolveSubagentSessionStatus,
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
-import { resolveArchiveAfterMs } from "./subagent-registry-helpers.js";
 import { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
 import {

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -41,4 +41,11 @@ export type SubagentRunRecord = {
   attachmentsDir?: string;
   attachmentsRootDir?: string;
   retainAttachmentsOnKeep?: boolean;
+  /**
+   * The full extraSystemPrompt that was passed to the initial agent dispatch,
+   * including any attachment-specific suffix appended after buildSubagentSystemPrompt.
+   * Stored so that restart-recovery redispatch can restore the original prompt verbatim
+   * rather than rebuilding it (which would omit attachment suffixes).
+   */
+  extraSystemPrompt?: string;
 };

--- a/src/agents/subagent-resume.test.ts
+++ b/src/agents/subagent-resume.test.ts
@@ -26,7 +26,9 @@ vi.mock("../config/config.js", () => ({
 }));
 
 // We will control the loadSessionStore output per-test via the spy.
-const mockLoadSessionStore = vi.fn(() => ({}) as Record<string, unknown>);
+const mockLoadSessionStore = vi.fn(
+  (_storePath: string, _opts?: { skipCache?: boolean }): Record<string, unknown> => ({}),
+);
 
 vi.mock("../config/sessions.js", () => ({
   loadSessionStore: (...args: Parameters<typeof mockLoadSessionStore>) =>
@@ -39,6 +41,29 @@ vi.mock("../config/sessions.js", () => ({
     const agentId = opts?.agentId ?? "main";
     return `/tmp/octest/agents/${agentId}/sessions/sessions.json`;
   },
+  resolveSessionFilePath: (
+    sessionId: string,
+    _entry?: unknown,
+    opts?: { sessionsDir?: string },
+  ) => {
+    const dir = opts?.sessionsDir ?? "/tmp/octest/agents/main/sessions";
+    return `${dir}/${sessionId}.jsonl`;
+  },
+  updateSessionStore: vi.fn(
+    async (
+      storePath: string,
+      mutator: (store: Record<string, unknown>) => void | Promise<void>,
+    ) => {
+      const store: Record<string, unknown> = {};
+      await mutator(store);
+      try {
+        fs.mkdirSync(path.dirname(storePath), { recursive: true });
+        fs.writeFileSync(storePath, `${JSON.stringify(store, null, 2)}\n`, { mode: 0o600 });
+      } catch {
+        // best-effort
+      }
+    },
+  ),
 }));
 
 vi.mock("../gateway/call.js", () => ({
@@ -345,18 +370,18 @@ describe("rehydrateSessionStoreEntries", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("skips entries that already have endedAt set", () => {
+  it("skips entries that already have endedAt set", async () => {
     const entry = makeRun({ endedAt: Date.now() });
     const runs = new Map([[entry.runId, entry]]);
 
     // loadSessionStore should never be called for a completed run.
-    mockLoadSessionStore.mockReturnValue({} as Record<string, unknown>);
-    rehydrateSessionStoreEntries(runs);
+    mockLoadSessionStore.mockReturnValue({});
+    await rehydrateSessionStoreEntries(runs);
 
     expect(mockLoadSessionStore).not.toHaveBeenCalled();
   });
 
-  it("skips entries that already have a session-store entry", () => {
+  it("skips entries that already have a session-store entry", async () => {
     const entry = makeRun();
     const runs = new Map([[entry.runId, entry]]);
 
@@ -364,13 +389,13 @@ describe("rehydrateSessionStoreEntries", () => {
     mockLoadSessionStore.mockReturnValue({
       [entry.childSessionKey]: { sessionId: "existing-sess", updatedAt: Date.now() },
     });
-    rehydrateSessionStoreEntries(runs);
+    await rehydrateSessionStoreEntries(runs);
 
     // Called once (for the skipCache read) — no write should occur.
     expect(mockLoadSessionStore).toHaveBeenCalledTimes(1);
   });
 
-  it("synthesises a session-store entry from a transcript when the store entry is missing", () => {
+  it("synthesises a session-store entry from a transcript when the store entry is missing", async () => {
     const agentId = "main";
 
     // The global mock for resolveStorePath returns:
@@ -397,9 +422,10 @@ describe("rehydrateSessionStoreEntries", () => {
     // through to the directory scan and inject path.
     mockLoadSessionStore.mockReturnValue({} as Record<string, unknown>);
 
-    rehydrateSessionStoreEntries(runs);
+    await rehydrateSessionStoreEntries(runs);
 
-    // The store file should now exist with our synthetic entry.
+    // The store file should now exist with our synthetic entry (written by the
+    // updateSessionStore mock, which simulates a real file write).
     const written = fs.existsSync(storePath)
       ? (JSON.parse(fs.readFileSync(storePath, "utf-8")) as Record<string, unknown>)
       : {};
@@ -479,11 +505,17 @@ describe("routeResumedRun", () => {
     expect(onCompleteRedispatch).not.toHaveBeenCalled();
   });
 
-  it("returns true and calls onCompleteReplay for resumable-replay runs", () => {
+  it("returns true and invokes onCompleteReplay for resumable-replay runs", async () => {
     const sessionId = "replay-sess";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    // Write the transcript at the path that resolveSubagentRunResumability will
+    // derive via the mocked resolveStorePath / resolveSessionFilePath:
+    //   sessionsDir = /tmp/octest/agents/main/sessions
+    //   transcriptPath = /tmp/octest/agents/main/sessions/replay-sess.jsonl
+    const mockSessionsDir = "/tmp/octest/agents/main/sessions";
+    const mockTranscriptPath = path.join(mockSessionsDir, `${sessionId}.jsonl`);
+    fs.mkdirSync(mockSessionsDir, { recursive: true });
     fs.writeFileSync(
-      transcriptPath,
+      mockTranscriptPath,
       [sessionHeaderLine(sessionId), userMessageLine(), assistantMessageLine()].join("\n"),
     );
 
@@ -501,29 +533,33 @@ describe("routeResumedRun", () => {
       waitTimeoutMs: 30_000,
       onCompleteReplay,
       onCompleteRedispatch,
-      // Pass the transcript path directly so the function doesn't have to
-      // derive it from the session store (which is mocked to return our own
-      // store data referencing `/tmp/octest/...` paths).
-      // We achieve this by overriding resolveSubagentRunResumability via
-      // opts passed as an argument through the transcript path override in
-      // resolveSubagentRunResumability.
     });
 
-    // routeResumedRun calls resolveSubagentRunResumability internally.
-    // Since we can't pass transcriptPath through routeResumedRun, we verify
-    // the return value and that the correct handler is invoked.
-    // The actual transcript resolution via the sessions dir is integration-level;
-    // here we confirm the routing table is correct.
     expect(result).toBe(true);
-    // onCompleteReplay is invoked asynchronously (void), so we just confirm it
-    // was called (or will be called) without awaiting the promise.
+
+    // recoverCompletedSubagentRunFromTranscript is called via `void`; wait for
+    // the async chain to complete before asserting on the callback.
+    await vi.waitUntil(() => onCompleteReplay.mock.calls.length > 0, { timeout: 500 });
+
+    // onCompleteReplay must be called with the original runId and a numeric endedAt.
+    expect(onCompleteReplay).toHaveBeenCalledWith(entry.runId, expect.any(Number));
+    expect(onCompleteRedispatch).not.toHaveBeenCalled();
+
+    // Cleanup the shared mock path.
+    try {
+      fs.rmSync(mockSessionsDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
   });
 
-  it("returns true and calls onCompleteRedispatch for resumable-fresh runs", () => {
+  it("returns true and invokes onCompleteRedispatch for resumable-fresh runs", async () => {
     const sessionId = "fresh-sess";
-    // Write a session header only (no assistant turns) to simulate fresh state.
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    fs.writeFileSync(transcriptPath, `${sessionHeaderLine(sessionId)}\n`);
+    // Write only a session header (no assistant turns) at the mocked path.
+    const mockSessionsDir = "/tmp/octest/agents/main/sessions";
+    const mockTranscriptPath = path.join(mockSessionsDir, `${sessionId}.jsonl`);
+    fs.mkdirSync(mockSessionsDir, { recursive: true });
+    fs.writeFileSync(mockTranscriptPath, `${sessionHeaderLine(sessionId)}\n`);
 
     const entry = makeRun({ childSessionKey: "agent:main:subagent:fresh-run" });
     mockLoadSessionStore.mockReturnValue({
@@ -531,23 +567,9 @@ describe("routeResumedRun", () => {
     });
 
     const onCompleteReplay = vi.fn();
+    // callGateway is mocked to return { status: "ok", runId: "new-run-id" } for
+    // both the `agent` and `agent.wait` calls made by redispatchSubagentRunAfterRestart.
     const onCompleteRedispatch = vi.fn().mockResolvedValue(undefined);
-
-    // For this test we confirm that a fresh session (session store has entry,
-    // transcript exists but is empty/header-only) leads to a redispatch.
-    // The function will internally call resolveSubagentRunResumability which
-    // will try to find the transcript at `sessionsDir/sessionId.jsonl`.
-    // Since the mock resolveStorePath returns `/tmp/octest/agents/main/sessions/sessions.json`,
-    // the transcript path would be `/tmp/octest/agents/main/sessions/fresh-sess.jsonl`.
-    // We write our transcript there so the function can find it.
-    const mockSessionsDir = "/tmp/octest/agents/main/sessions";
-    const mockTranscriptPath = path.join(mockSessionsDir, `${sessionId}.jsonl`);
-    try {
-      fs.mkdirSync(mockSessionsDir, { recursive: true });
-      fs.writeFileSync(mockTranscriptPath, `${sessionHeaderLine(sessionId)}\n`);
-    } catch {
-      // best-effort setup
-    }
 
     const result = routeResumedRun({
       runId: entry.runId,
@@ -557,10 +579,22 @@ describe("routeResumedRun", () => {
       onCompleteRedispatch,
     });
 
-    // The routing should handle the run (return true) for fresh or replay.
     expect(result).toBe(true);
 
-    // Cleanup the mock path.
+    // redispatchSubagentRunAfterRestart is called via `void`; wait for the async
+    // chain (agent + agent.wait callGateway calls) to resolve.
+    await vi.waitUntil(() => onCompleteRedispatch.mock.calls.length > 0, { timeout: 500 });
+
+    // onCompleteRedispatch must be called with the original runId, a numeric
+    // endedAt, and the outcome from agent.wait.
+    expect(onCompleteRedispatch).toHaveBeenCalledWith(
+      entry.runId,
+      expect.any(Number),
+      expect.objectContaining({ status: "ok" }),
+    );
+    expect(onCompleteReplay).not.toHaveBeenCalled();
+
+    // Cleanup the shared mock path.
     try {
       fs.rmSync(mockSessionsDir, { recursive: true, force: true });
     } catch {

--- a/src/agents/subagent-resume.test.ts
+++ b/src/agents/subagent-resume.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Unit tests for src/agents/subagent-resume.ts
+ *
+ * Phase 1 subagent restart recovery — covers:
+ *  - readTranscriptSessionId
+ *  - transcriptHasAssistantTurn
+ *  - resolveSubagentRunResumability (all 4 cases)
+ *  - rehydrateSessionStoreEntries (synthesizes store entry from transcript)
+ *  - routeResumedRun (dispatches to correct handler)
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({
+    session: { store: undefined, mainKey: "main" },
+    agents: {},
+  }),
+}));
+
+// We will control the loadSessionStore output per-test via the spy.
+const mockLoadSessionStore = vi.fn(() => ({}) as Record<string, unknown>);
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: (...args: Parameters<typeof mockLoadSessionStore>) =>
+    mockLoadSessionStore(...args),
+  resolveAgentIdFromSessionKey: (key: string) => {
+    const match = (key ?? "").match(/^agent:([^:]+):/i);
+    return (match?.[1] ?? "main").toLowerCase() || "main";
+  },
+  resolveStorePath: (_store: unknown, opts?: { agentId?: string }) => {
+    const agentId = opts?.agentId ?? "main";
+    return `/tmp/octest/agents/${agentId}/sessions/sessions.json`;
+  },
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async () => ({ status: "ok", runId: "new-run-id" })),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("./lanes.js", () => ({
+  AGENT_LANE_SUBAGENT: "subagent",
+}));
+
+vi.mock("./subagent-lifecycle-events.js", () => ({
+  SUBAGENT_ENDED_REASON_COMPLETE: "subagent-complete",
+  SUBAGENT_ENDED_REASON_ERROR: "subagent-error",
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import the module under test (after mocks are set up)
+// ---------------------------------------------------------------------------
+
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import {
+  readTranscriptSessionId,
+  rehydrateSessionStoreEntries,
+  resolveSubagentRunResumability,
+  routeResumedRun,
+  transcriptHasAssistantTurn,
+} from "./subagent-resume.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRun(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
+  const runId = overrides.runId ?? "run-test-1";
+  return {
+    runId,
+    childSessionKey: overrides.childSessionKey ?? `agent:main:subagent:${runId}`,
+    requesterSessionKey: overrides.requesterSessionKey ?? "agent:main:main",
+    requesterDisplayKey: overrides.requesterDisplayKey ?? "agent:main:main",
+    task: overrides.task ?? "do something useful",
+    cleanup: overrides.cleanup ?? "keep",
+    createdAt: overrides.createdAt ?? Date.now(),
+    ...overrides,
+  };
+}
+
+/** Build the minimal JSONL content for a transcript session header. */
+function sessionHeaderLine(sessionId: string): string {
+  return JSON.stringify({
+    type: "session",
+    version: 3,
+    id: sessionId,
+    timestamp: new Date().toISOString(),
+    cwd: "/workspace",
+  });
+}
+
+/** Build a JSONL line representing an assistant message turn. */
+function assistantMessageLine(): string {
+  return JSON.stringify({
+    type: "message",
+    id: "msg-1",
+    parentId: null,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "I have completed the task." }],
+    },
+  });
+}
+
+/** Build a JSONL line representing a user message turn. */
+function userMessageLine(text = "do something useful"): string {
+  return JSON.stringify({
+    type: "message",
+    id: "msg-0",
+    parentId: null,
+    timestamp: new Date().toISOString(),
+    message: { role: "user", content: text },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// readTranscriptSessionId
+// ---------------------------------------------------------------------------
+
+describe("readTranscriptSessionId", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-resume-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the session id from a valid transcript header", () => {
+    const sessionId = "aaaa-bbbb-cccc-dddd";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(transcriptPath, `${sessionHeaderLine(sessionId)}\n`);
+
+    expect(readTranscriptSessionId(transcriptPath)).toBe(sessionId);
+  });
+
+  it("returns null when the file does not exist", () => {
+    expect(readTranscriptSessionId(path.join(tmpDir, "missing.jsonl"))).toBeNull();
+  });
+
+  it("returns null when the first line is not a session header", () => {
+    const transcriptPath = path.join(tmpDir, "bad.jsonl");
+    fs.writeFileSync(transcriptPath, `${assistantMessageLine()}\n`);
+    expect(readTranscriptSessionId(transcriptPath)).toBeNull();
+  });
+
+  it("returns null when the file is empty", () => {
+    const transcriptPath = path.join(tmpDir, "empty.jsonl");
+    fs.writeFileSync(transcriptPath, "");
+    expect(readTranscriptSessionId(transcriptPath)).toBeNull();
+  });
+
+  it("returns null when the first line is malformed JSON", () => {
+    const transcriptPath = path.join(tmpDir, "malformed.jsonl");
+    fs.writeFileSync(transcriptPath, "not-json\n");
+    expect(readTranscriptSessionId(transcriptPath)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transcriptHasAssistantTurn
+// ---------------------------------------------------------------------------
+
+describe("transcriptHasAssistantTurn", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-resume-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns true when transcript contains an assistant message line", () => {
+    const sessionId = "sess-1";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), userMessageLine(), assistantMessageLine()].join("\n"),
+    );
+    expect(transcriptHasAssistantTurn(transcriptPath)).toBe(true);
+  });
+
+  it("returns false when transcript has only session header (no turns)", () => {
+    const sessionId = "sess-2";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(transcriptPath, `${sessionHeaderLine(sessionId)}\n`);
+    expect(transcriptHasAssistantTurn(transcriptPath)).toBe(false);
+  });
+
+  it("returns false when transcript has only user messages", () => {
+    const sessionId = "sess-3";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(transcriptPath, [sessionHeaderLine(sessionId), userMessageLine()].join("\n"));
+    expect(transcriptHasAssistantTurn(transcriptPath)).toBe(false);
+  });
+
+  it("returns false when the file does not exist", () => {
+    expect(transcriptHasAssistantTurn(path.join(tmpDir, "missing.jsonl"))).toBe(false);
+  });
+
+  it("returns false for an empty file", () => {
+    const transcriptPath = path.join(tmpDir, "empty.jsonl");
+    fs.writeFileSync(transcriptPath, "");
+    expect(transcriptHasAssistantTurn(transcriptPath)).toBe(false);
+  });
+
+  it("skips malformed lines and still finds a valid assistant turn later", () => {
+    const sessionId = "sess-4";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), "not-json", assistantMessageLine()].join("\n"),
+    );
+    expect(transcriptHasAssistantTurn(transcriptPath)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSubagentRunResumability
+// ---------------------------------------------------------------------------
+
+describe("resolveSubagentRunResumability", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-resume-test-"));
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns resumable-announce-only when endedAt is set", () => {
+    const entry = makeRun({ endedAt: Date.now() - 1_000 });
+    // Even without a session store entry, endedAt short-circuits everything.
+    mockLoadSessionStore.mockReturnValue({} as Record<string, unknown>);
+    expect(resolveSubagentRunResumability(entry)).toBe("resumable-announce-only");
+  });
+
+  it("returns orphaned when session store entry is missing", () => {
+    const entry = makeRun();
+    mockLoadSessionStore.mockReturnValue({} as Record<string, unknown>);
+    expect(resolveSubagentRunResumability(entry)).toBe("orphaned");
+  });
+
+  it("returns orphaned when session store entry exists but sessionId is empty", () => {
+    const entry = makeRun();
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId: "  ", updatedAt: Date.now() },
+    });
+    expect(resolveSubagentRunResumability(entry)).toBe("orphaned");
+  });
+
+  it("returns resumable-replay when transcript has assistant turns", () => {
+    const sessionId = "sess-replay";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), userMessageLine(), assistantMessageLine()].join("\n"),
+    );
+
+    const entry = makeRun({ childSessionKey: "agent:main:subagent:replay-run" });
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId, updatedAt: Date.now() },
+    });
+
+    expect(resolveSubagentRunResumability(entry, { transcriptPath })).toBe("resumable-replay");
+  });
+
+  it("returns resumable-fresh when transcript exists but has no assistant turns", () => {
+    const sessionId = "sess-fresh";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    // Only a session header — no turns at all.
+    fs.writeFileSync(transcriptPath, `${sessionHeaderLine(sessionId)}\n`);
+
+    const entry = makeRun({ childSessionKey: "agent:main:subagent:fresh-run" });
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId, updatedAt: Date.now() },
+    });
+
+    expect(resolveSubagentRunResumability(entry, { transcriptPath })).toBe("resumable-fresh");
+  });
+
+  it("returns resumable-fresh when transcript does not exist yet", () => {
+    const sessionId = "sess-no-transcript";
+    // No file written — transcript doesn't exist.
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    const entry = makeRun({ childSessionKey: "agent:main:subagent:no-transcript" });
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId, updatedAt: Date.now() },
+    });
+
+    expect(resolveSubagentRunResumability(entry, { transcriptPath })).toBe("resumable-fresh");
+  });
+
+  it("returns orphaned when childSessionKey is falsy", () => {
+    const entry = makeRun({ childSessionKey: "" });
+    mockLoadSessionStore.mockReturnValue({} as Record<string, unknown>);
+    expect(resolveSubagentRunResumability(entry)).toBe("orphaned");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rehydrateSessionStoreEntries
+// ---------------------------------------------------------------------------
+
+describe("rehydrateSessionStoreEntries", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-resume-test-"));
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("skips entries that already have endedAt set", () => {
+    const entry = makeRun({ endedAt: Date.now() });
+    const runs = new Map([[entry.runId, entry]]);
+
+    // loadSessionStore should never be called for a completed run.
+    mockLoadSessionStore.mockReturnValue({} as Record<string, unknown>);
+    rehydrateSessionStoreEntries(runs);
+
+    expect(mockLoadSessionStore).not.toHaveBeenCalled();
+  });
+
+  it("skips entries that already have a session-store entry", () => {
+    const entry = makeRun();
+    const runs = new Map([[entry.runId, entry]]);
+
+    // Return a store that already has the entry.
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId: "existing-sess", updatedAt: Date.now() },
+    });
+    rehydrateSessionStoreEntries(runs);
+
+    // Called once (for the skipCache read) — no write should occur.
+    expect(mockLoadSessionStore).toHaveBeenCalledTimes(1);
+  });
+
+  it("synthesises a session-store entry from a transcript when the store entry is missing", () => {
+    const agentId = "main";
+
+    // The global mock for resolveStorePath returns:
+    //   /tmp/octest/agents/${agentId}/sessions/sessions.json
+    // So we must create our sessions dir and transcript at that exact path.
+    const sessionsDir = `/tmp/octest/agents/${agentId}/sessions`;
+    const storePath = path.join(sessionsDir, "sessions.json");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+
+    const sessionId = "synth-session-id";
+    const transcriptPath = path.join(sessionsDir, `${sessionId}.jsonl`);
+    // Write transcript so the scanner can find it.
+    fs.writeFileSync(transcriptPath, `${sessionHeaderLine(sessionId)}\n`);
+
+    const createdAt = Date.now() - 1_000; // 1 second ago (within the 5-min tolerance)
+    const entry = makeRun({
+      runId: "run-synth",
+      childSessionKey: `agent:${agentId}:subagent:run-synth`,
+      createdAt,
+    });
+    const runs = new Map([[entry.runId, entry]]);
+
+    // First call (skipCache: true) returns no entry so the function falls
+    // through to the directory scan and inject path.
+    mockLoadSessionStore.mockReturnValue({} as Record<string, unknown>);
+
+    rehydrateSessionStoreEntries(runs);
+
+    // The store file should now exist with our synthetic entry.
+    const written = fs.existsSync(storePath)
+      ? (JSON.parse(fs.readFileSync(storePath, "utf-8")) as Record<string, unknown>)
+      : {};
+
+    // The key is the lowercased childSessionKey.
+    const normalizedKey = entry.childSessionKey.toLowerCase();
+    const injected = written[normalizedKey] as Record<string, unknown> | undefined;
+    expect(injected).toBeDefined();
+    expect(injected?.sessionId).toBe(sessionId);
+    expect(injected?.spawnedBy).toBe(entry.requesterSessionKey);
+    expect(injected?.spawnDepth).toBe(1);
+
+    // Cleanup the fixed path used by this test.
+    try {
+      fs.rmSync(sessionsDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routeResumedRun
+// ---------------------------------------------------------------------------
+
+describe("routeResumedRun", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-resume-test-"));
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns false (fall-through) for orphaned runs", () => {
+    const entry = makeRun();
+    mockLoadSessionStore.mockReturnValue({} as Record<string, unknown>);
+
+    const onCompleteReplay = vi.fn();
+    const onCompleteRedispatch = vi.fn();
+
+    const result = routeResumedRun({
+      runId: entry.runId,
+      entry,
+      waitTimeoutMs: 30_000,
+      onCompleteReplay,
+      onCompleteRedispatch,
+    });
+
+    expect(result).toBe(false);
+    expect(onCompleteReplay).not.toHaveBeenCalled();
+    expect(onCompleteRedispatch).not.toHaveBeenCalled();
+  });
+
+  it("returns false (fall-through) for resumable-announce-only runs", () => {
+    // endedAt is set → resumable-announce-only is handled by the caller's
+    // existing endedAt check, so routeResumedRun returns false to fall through.
+    const entry = makeRun({ endedAt: Date.now() - 500 });
+    mockLoadSessionStore.mockReturnValue({} as Record<string, unknown>);
+
+    const onCompleteReplay = vi.fn();
+    const onCompleteRedispatch = vi.fn();
+
+    const result = routeResumedRun({
+      runId: entry.runId,
+      entry,
+      waitTimeoutMs: 30_000,
+      onCompleteReplay,
+      onCompleteRedispatch,
+    });
+
+    expect(result).toBe(false);
+    expect(onCompleteReplay).not.toHaveBeenCalled();
+    expect(onCompleteRedispatch).not.toHaveBeenCalled();
+  });
+
+  it("returns true and calls onCompleteReplay for resumable-replay runs", () => {
+    const sessionId = "replay-sess";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), userMessageLine(), assistantMessageLine()].join("\n"),
+    );
+
+    const entry = makeRun({ childSessionKey: "agent:main:subagent:replay-run" });
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId, updatedAt: Date.now() },
+    });
+
+    const onCompleteReplay = vi.fn().mockResolvedValue(undefined);
+    const onCompleteRedispatch = vi.fn();
+
+    const result = routeResumedRun({
+      runId: entry.runId,
+      entry,
+      waitTimeoutMs: 30_000,
+      onCompleteReplay,
+      onCompleteRedispatch,
+      // Pass the transcript path directly so the function doesn't have to
+      // derive it from the session store (which is mocked to return our own
+      // store data referencing `/tmp/octest/...` paths).
+      // We achieve this by overriding resolveSubagentRunResumability via
+      // opts passed as an argument through the transcript path override in
+      // resolveSubagentRunResumability.
+    });
+
+    // routeResumedRun calls resolveSubagentRunResumability internally.
+    // Since we can't pass transcriptPath through routeResumedRun, we verify
+    // the return value and that the correct handler is invoked.
+    // The actual transcript resolution via the sessions dir is integration-level;
+    // here we confirm the routing table is correct.
+    expect(result).toBe(true);
+    // onCompleteReplay is invoked asynchronously (void), so we just confirm it
+    // was called (or will be called) without awaiting the promise.
+  });
+
+  it("returns true and calls onCompleteRedispatch for resumable-fresh runs", () => {
+    const sessionId = "fresh-sess";
+    // Write a session header only (no assistant turns) to simulate fresh state.
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(transcriptPath, `${sessionHeaderLine(sessionId)}\n`);
+
+    const entry = makeRun({ childSessionKey: "agent:main:subagent:fresh-run" });
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId, updatedAt: Date.now() },
+    });
+
+    const onCompleteReplay = vi.fn();
+    const onCompleteRedispatch = vi.fn().mockResolvedValue(undefined);
+
+    // For this test we confirm that a fresh session (session store has entry,
+    // transcript exists but is empty/header-only) leads to a redispatch.
+    // The function will internally call resolveSubagentRunResumability which
+    // will try to find the transcript at `sessionsDir/sessionId.jsonl`.
+    // Since the mock resolveStorePath returns `/tmp/octest/agents/main/sessions/sessions.json`,
+    // the transcript path would be `/tmp/octest/agents/main/sessions/fresh-sess.jsonl`.
+    // We write our transcript there so the function can find it.
+    const mockSessionsDir = "/tmp/octest/agents/main/sessions";
+    const mockTranscriptPath = path.join(mockSessionsDir, `${sessionId}.jsonl`);
+    try {
+      fs.mkdirSync(mockSessionsDir, { recursive: true });
+      fs.writeFileSync(mockTranscriptPath, `${sessionHeaderLine(sessionId)}\n`);
+    } catch {
+      // best-effort setup
+    }
+
+    const result = routeResumedRun({
+      runId: entry.runId,
+      entry,
+      waitTimeoutMs: 30_000,
+      onCompleteReplay,
+      onCompleteRedispatch,
+    });
+
+    // The routing should handle the run (return true) for fresh or replay.
+    expect(result).toBe(true);
+
+    // Cleanup the mock path.
+    try {
+      fs.rmSync(mockSessionsDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+});

--- a/src/agents/subagent-resume.test.ts
+++ b/src/agents/subagent-resume.test.ts
@@ -642,7 +642,10 @@ describe("rehydrateSessionStoreEntries", () => {
     expect(injected).toBeDefined();
     expect(injected?.sessionId).toBe(sessionId);
     expect(injected?.spawnedBy).toBe(entry.requesterSessionKey);
-    expect(injected?.spawnDepth).toBe(1);
+    // spawnDepth is now computed as getSubagentDepthFromSessionStore(requester) + 1.
+    // The test mock returns 1 for all getSubagentDepthFromSessionStore calls, so the
+    // child depth is 1 + 1 = 2 (validates dynamic computation, not hardcoded 1).
+    expect(injected?.spawnDepth).toBe(2);
 
     // Cleanup the fixed path used by this test.
     try {

--- a/src/agents/subagent-resume.test.ts
+++ b/src/agents/subagent-resume.test.ts
@@ -94,6 +94,18 @@ vi.mock("../runtime.js", () => ({
   },
 }));
 
+vi.mock("../config/agent-limits.js", () => ({
+  DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH: 1,
+}));
+
+vi.mock("./subagent-announce.js", () => ({
+  buildSubagentSystemPrompt: vi.fn(() => "mocked-system-prompt"),
+}));
+
+vi.mock("./subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: vi.fn(() => 1),
+}));
+
 // ---------------------------------------------------------------------------
 // Import the module under test (after mocks are set up)
 // ---------------------------------------------------------------------------

--- a/src/agents/subagent-resume.test.ts
+++ b/src/agents/subagent-resume.test.ts
@@ -104,6 +104,7 @@ import {
   rehydrateSessionStoreEntries,
   resolveSubagentRunResumability,
   routeResumedRun,
+  transcriptEndsWithCompletedAssistantTurn,
   transcriptHasAssistantTurn,
 } from "./subagent-resume.js";
 
@@ -158,6 +159,37 @@ function userMessageLine(text = "do something useful"): string {
     parentId: null,
     timestamp: new Date().toISOString(),
     message: { role: "user", content: text },
+  });
+}
+
+/** Build a JSONL line representing an assistant turn that has a pending tool_use block. */
+function assistantToolUseMessageLine(toolUseId = "toolu-1"): string {
+  return JSON.stringify({
+    type: "message",
+    id: "msg-tool-call",
+    parentId: null,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Let me check that for you." },
+        { type: "tool_use", id: toolUseId, name: "read_file", input: { path: "/tmp/foo" } },
+      ],
+    },
+  });
+}
+
+/** Build a JSONL line representing a user message that carries tool results. */
+function toolResultMessageLine(toolUseId = "toolu-1"): string {
+  return JSON.stringify({
+    type: "message",
+    id: "msg-tool-result",
+    parentId: null,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content: "file contents here" }],
+    },
   });
 }
 
@@ -268,6 +300,121 @@ describe("transcriptHasAssistantTurn", () => {
 });
 
 // ---------------------------------------------------------------------------
+// transcriptEndsWithCompletedAssistantTurn
+// ---------------------------------------------------------------------------
+
+describe("transcriptEndsWithCompletedAssistantTurn", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-resume-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns true when the last turn is an assistant text-only message", () => {
+    const sessionId = "cft-1";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), userMessageLine(), assistantMessageLine()].join("\n"),
+    );
+    expect(transcriptEndsWithCompletedAssistantTurn(transcriptPath)).toBe(true);
+  });
+
+  it("returns true after a full tool round-trip ending in an assistant text reply", () => {
+    const sessionId = "cft-2";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        sessionHeaderLine(sessionId),
+        userMessageLine(),
+        assistantToolUseMessageLine("toolu-a"),
+        toolResultMessageLine("toolu-a"),
+        // Final assistant reply with no tool_use — run is complete.
+        assistantMessageLine(),
+      ].join("\n"),
+    );
+    expect(transcriptEndsWithCompletedAssistantTurn(transcriptPath)).toBe(true);
+  });
+
+  it("returns false when the last turn is an assistant message with tool_use blocks", () => {
+    const sessionId = "cft-3";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    // Transcript ends mid-tool-use: assistant issued a tool call but the result
+    // never came back (run was interrupted).
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        sessionHeaderLine(sessionId),
+        userMessageLine(),
+        assistantToolUseMessageLine("toolu-b"),
+      ].join("\n"),
+    );
+    expect(transcriptEndsWithCompletedAssistantTurn(transcriptPath)).toBe(false);
+  });
+
+  it("returns false when the last turn is a user tool-result message (mid-tool-use)", () => {
+    const sessionId = "cft-4";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    // The tool result arrived but the assistant never replied — interrupted
+    // between the tool result and the follow-up assistant turn.
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        sessionHeaderLine(sessionId),
+        userMessageLine(),
+        assistantToolUseMessageLine("toolu-c"),
+        toolResultMessageLine("toolu-c"),
+      ].join("\n"),
+    );
+    expect(transcriptEndsWithCompletedAssistantTurn(transcriptPath)).toBe(false);
+  });
+
+  it("returns false when transcript has only session header (no turns)", () => {
+    const sessionId = "cft-5";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(transcriptPath, `${sessionHeaderLine(sessionId)}\n`);
+    expect(transcriptEndsWithCompletedAssistantTurn(transcriptPath)).toBe(false);
+  });
+
+  it("returns false when transcript has only user messages", () => {
+    const sessionId = "cft-6";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(transcriptPath, [sessionHeaderLine(sessionId), userMessageLine()].join("\n"));
+    expect(transcriptEndsWithCompletedAssistantTurn(transcriptPath)).toBe(false);
+  });
+
+  it("returns false when the file does not exist", () => {
+    expect(transcriptEndsWithCompletedAssistantTurn(path.join(tmpDir, "missing.jsonl"))).toBe(
+      false,
+    );
+  });
+
+  it("returns false for an empty file", () => {
+    const transcriptPath = path.join(tmpDir, "empty.jsonl");
+    fs.writeFileSync(transcriptPath, "");
+    expect(transcriptEndsWithCompletedAssistantTurn(transcriptPath)).toBe(false);
+  });
+
+  it("skips trailing malformed lines and evaluates the last valid message", () => {
+    const sessionId = "cft-7";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    // Last valid line is a completed assistant turn; trailing garbage ignored.
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), userMessageLine(), assistantMessageLine(), "not-json"].join(
+        "\n",
+      ),
+    );
+    expect(transcriptEndsWithCompletedAssistantTurn(transcriptPath)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // resolveSubagentRunResumability
 // ---------------------------------------------------------------------------
 
@@ -351,6 +498,53 @@ describe("resolveSubagentRunResumability", () => {
     const entry = makeRun({ childSessionKey: "" });
     mockLoadSessionStore.mockReturnValue({} as Record<string, unknown>);
     expect(resolveSubagentRunResumability(entry)).toBe("orphaned");
+  });
+
+  it("returns resumable-fresh (not resumable-replay) when transcript ends mid-tool-use", () => {
+    // The transcript has an assistant turn, but it ends with a pending tool_use
+    // block — the run was interrupted before the tool result arrived.
+    // Previously this would have returned resumable-replay (the bug); now it
+    // must return resumable-fresh so the run is re-dispatched.
+    const sessionId = "sess-mid-tool-use";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        sessionHeaderLine(sessionId),
+        userMessageLine(),
+        assistantToolUseMessageLine("toolu-x"),
+      ].join("\n"),
+    );
+
+    const entry = makeRun({ childSessionKey: "agent:main:subagent:mid-tool-use" });
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId, updatedAt: Date.now() },
+    });
+
+    expect(resolveSubagentRunResumability(entry, { transcriptPath })).toBe("resumable-fresh");
+  });
+
+  it("returns resumable-fresh when transcript ends with a tool-result user turn (not final)", () => {
+    // The tool result arrived but the assistant never replied — interrupted
+    // between the tool result and the follow-up assistant turn.
+    const sessionId = "sess-tool-result-only";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        sessionHeaderLine(sessionId),
+        userMessageLine(),
+        assistantToolUseMessageLine("toolu-y"),
+        toolResultMessageLine("toolu-y"),
+      ].join("\n"),
+    );
+
+    const entry = makeRun({ childSessionKey: "agent:main:subagent:tool-result-only" });
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId, updatedAt: Date.now() },
+    });
+
+    expect(resolveSubagentRunResumability(entry, { transcriptPath })).toBe("resumable-fresh");
   });
 });
 

--- a/src/agents/subagent-resume.test.ts
+++ b/src/agents/subagent-resume.test.ts
@@ -118,6 +118,7 @@ import {
   routeResumedRun,
   transcriptEndsWithCompletedAssistantTurn,
   transcriptHasAssistantTurn,
+  transcriptLastCompletedAssistantTurnTimestamp,
 } from "./subagent-resume.js";
 
 // ---------------------------------------------------------------------------
@@ -557,6 +558,185 @@ describe("resolveSubagentRunResumability", () => {
     });
 
     expect(resolveSubagentRunResumability(entry, { transcriptPath })).toBe("resumable-fresh");
+  });
+
+  it("returns resumable-fresh (not resumable-replay) when the last assistant turn pre-dates the current run start", () => {
+    // Scenario: replaceSubagentRunAfterSteer was called, producing a new run
+    // with a fresh startedAt.  The gateway restarted before the new run wrote
+    // anything.  The transcript still ends with the OLD run's completed
+    // assistant turn.  Without the boundary check this would incorrectly become
+    // resumable-replay, replaying stale output.
+    const sessionId = "sess-stale-post-steer";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    // Build a transcript whose final assistant turn has a timestamp
+    // well before the current run's startedAt.
+    const priorRunEndMs = Date.now() - 10_000; // 10 seconds ago
+    const staleAssistantLine = JSON.stringify({
+      type: "message",
+      id: "msg-stale",
+      parentId: null,
+      timestamp: new Date(priorRunEndMs).toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Prior run completed." }],
+      },
+    });
+
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), userMessageLine(), staleAssistantLine].join("\n"),
+    );
+
+    // The new (post-steer) run started 5 seconds ago — after the stale turn.
+    const newRunStartMs = Date.now() - 5_000;
+    const entry = makeRun({
+      childSessionKey: "agent:main:subagent:stale-post-steer",
+      startedAt: newRunStartMs,
+      createdAt: newRunStartMs - 100,
+    });
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId, updatedAt: Date.now() },
+    });
+
+    // Provide explicit runStartMs override to be independent of wall-clock
+    // drift during the test (uses entry.startedAt by default, but the override
+    // makes the intent explicit).
+    expect(
+      resolveSubagentRunResumability(entry, { transcriptPath, runStartMs: newRunStartMs }),
+    ).toBe("resumable-fresh");
+  });
+
+  it("returns resumable-replay when the last assistant turn post-dates the current run start", () => {
+    // Normal completion scenario: the assistant turn was written AFTER the
+    // current run started — it genuinely belongs to this run.
+    const sessionId = "sess-current-run-replay";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    const runStartMs = Date.now() - 5_000; // run started 5 seconds ago
+    const turnMs = Date.now() - 1_000; // turn written 1 second ago (after run start)
+
+    const currentAssistantLine = JSON.stringify({
+      type: "message",
+      id: "msg-current",
+      parentId: null,
+      timestamp: new Date(turnMs).toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Current run completed." }],
+      },
+    });
+
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), userMessageLine(), currentAssistantLine].join("\n"),
+    );
+
+    const entry = makeRun({
+      childSessionKey: "agent:main:subagent:current-run-replay",
+      startedAt: runStartMs,
+      createdAt: runStartMs - 100,
+    });
+    mockLoadSessionStore.mockReturnValue({
+      [entry.childSessionKey]: { sessionId, updatedAt: Date.now() },
+    });
+
+    expect(resolveSubagentRunResumability(entry, { transcriptPath, runStartMs })).toBe(
+      "resumable-replay",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transcriptLastCompletedAssistantTurnTimestamp
+// ---------------------------------------------------------------------------
+
+describe("transcriptLastCompletedAssistantTurnTimestamp", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-resume-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the epoch-ms timestamp of a completed assistant turn", () => {
+    const sessionId = "lcat-1";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const expectedMs = Date.now() - 2_000;
+    const line = JSON.stringify({
+      type: "message",
+      id: "msg-a",
+      parentId: null,
+      timestamp: new Date(expectedMs).toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Done." }],
+      },
+    });
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), userMessageLine(), line].join("\n"),
+    );
+    const result = transcriptLastCompletedAssistantTurnTimestamp(transcriptPath);
+    // Allow 1-second tolerance for ISO round-trip rounding.
+    expect(result).not.toBeNull();
+    expect(Math.abs((result as number) - expectedMs)).toBeLessThan(1_000);
+  });
+
+  it("returns null when the last message has a pending tool_use block", () => {
+    const sessionId = "lcat-2";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), userMessageLine(), assistantToolUseMessageLine("t1")].join(
+        "\n",
+      ),
+    );
+    expect(transcriptLastCompletedAssistantTurnTimestamp(transcriptPath)).toBeNull();
+  });
+
+  it("returns null when the last message is a user turn", () => {
+    const sessionId = "lcat-3";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(transcriptPath, [sessionHeaderLine(sessionId), userMessageLine()].join("\n"));
+    expect(transcriptLastCompletedAssistantTurnTimestamp(transcriptPath)).toBeNull();
+  });
+
+  it("returns null when the file does not exist", () => {
+    expect(
+      transcriptLastCompletedAssistantTurnTimestamp(path.join(tmpDir, "missing.jsonl")),
+    ).toBeNull();
+  });
+
+  it("returns null for an empty file", () => {
+    const transcriptPath = path.join(tmpDir, "empty.jsonl");
+    fs.writeFileSync(transcriptPath, "");
+    expect(transcriptLastCompletedAssistantTurnTimestamp(transcriptPath)).toBeNull();
+  });
+
+  it("accepts a numeric epoch-ms timestamp field", () => {
+    const sessionId = "lcat-4";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const expectedMs = Date.now() - 3_000;
+    const line = JSON.stringify({
+      type: "message",
+      id: "msg-b",
+      parentId: null,
+      timestamp: expectedMs, // numeric, not ISO string
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Done (numeric ts)." }],
+      },
+    });
+    fs.writeFileSync(
+      transcriptPath,
+      [sessionHeaderLine(sessionId), userMessageLine(), line].join("\n"),
+    );
+    const result = transcriptLastCompletedAssistantTurnTimestamp(transcriptPath);
+    expect(result).toBe(expectedMs);
   });
 });
 

--- a/src/agents/subagent-resume.ts
+++ b/src/agents/subagent-resume.ts
@@ -55,9 +55,10 @@ const log = createSubsystemLogger("agents/subagent-resume");
  *
  * - `resumable-announce-only`  — `endedAt` is already set; the run completed
  *   before restart, the announce delivery just needs to be retried.
- * - `resumable-replay`         — transcript exists with ≥1 assistant turn and
- *   `endedAt` is unset; the run finished but its completion was never recorded
- *   in the registry.  Capture the result from the transcript and complete.
+ * - `resumable-replay`         — transcript ends with a completed assistant
+ *   turn (no pending `tool_use` blocks) and `endedAt` is unset; the run
+ *   finished but its completion was never recorded in the registry.  Capture
+ *   the result from the transcript and complete.
  * - `resumable-fresh`          — session-store entry exists, transcript is
  *   empty / session-header only, `endedAt` is unset; the agent process was
  *   spawned but never ran.  Re-dispatch the original task.
@@ -136,6 +137,91 @@ export function transcriptHasAssistantTurn(transcriptPath: string): boolean {
         // ignore malformed lines
       }
     }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return `true` when the transcript's **last** message line is an assistant
+ * turn that contains **no** pending `tool_use` content blocks.
+ *
+ * An assistant turn qualifies as a completed final turn only when:
+ *  - It is the very last message in the transcript (nothing follows it), AND
+ *  - Its `content` array contains only non-`tool_use` blocks (e.g. `text`).
+ *
+ * Returns `false` (i.e. "not definitely complete") when:
+ *  - The transcript does not end with an assistant turn — e.g. it ends with a
+ *    user message or tool-result turn (run was interrupted mid-tool-use or
+ *    still awaiting further input).
+ *  - The last assistant turn contains `tool_use` blocks (run was cut off while
+ *    waiting for the tool result to come back).
+ *  - There are no message lines at all (session header only, or empty file).
+ *  - The file is absent or unreadable.
+ *
+ * When in doubt this function returns `false` so callers fall back to the
+ * safer `resumable-fresh` path rather than incorrectly marking a run as done.
+ */
+export function transcriptEndsWithCompletedAssistantTurn(transcriptPath: string): boolean {
+  try {
+    const content = fs.readFileSync(transcriptPath, "utf-8");
+    const lines = content.split("\n");
+
+    // Walk from the end to find the last non-empty, parseable message line.
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const trimmed = lines[i]?.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        // Malformed line — skip it and keep looking backward.
+        continue;
+      }
+
+      if (parsed === null || typeof parsed !== "object") {
+        continue;
+      }
+
+      const record = parsed as Record<string, unknown>;
+      if (record.type !== "message") {
+        // Session header or other non-message record; keep scanning backward.
+        continue;
+      }
+
+      // Found the last message line — check if it's a completed assistant turn.
+      const msg = record.message;
+      if (msg === null || typeof msg !== "object") {
+        return false;
+      }
+      const msgRecord = msg as Record<string, unknown>;
+      if (msgRecord.role !== "assistant") {
+        // Last turn is not from the assistant (e.g. user / tool-result turn) —
+        // the run was interrupted before the assistant could reply.
+        return false;
+      }
+
+      // Check that the content array has no pending tool_use blocks.
+      const contentArr = msgRecord.content;
+      if (!Array.isArray(contentArr)) {
+        // Non-array content (e.g. plain string) — treat as a completed text turn.
+        return true;
+      }
+      const hasPendingToolUse = contentArr.some(
+        (block) =>
+          block !== null &&
+          typeof block === "object" &&
+          (block as Record<string, unknown>).type === "tool_use",
+      );
+      // If there are outstanding tool_use blocks the run is mid-tool-use, not done.
+      return !hasPendingToolUse;
+    }
+
+    // No message lines found at all.
     return false;
   } catch {
     return false;
@@ -407,13 +493,20 @@ export function resolveSubagentRunResumability(
     return "resumable-fresh";
   }
 
-  if (transcriptHasAssistantTurn(transcriptPath)) {
-    // The agent ran and produced output — we just need to capture and announce.
+  if (transcriptEndsWithCompletedAssistantTurn(transcriptPath)) {
+    // The transcript ends with a completed assistant turn (no pending tool_use
+    // blocks) — the run finished but its completion was never recorded in the
+    // registry.  Capture the result from the transcript and complete.
     return "resumable-replay";
   }
 
-  // Transcript exists but has no assistant turns → agent was spawned, wrote
-  // the session header, but never completed a turn.  Re-dispatch.
+  // Transcript exists but does not end with a completed assistant turn.
+  // This covers:
+  //   • header-only / no turns at all (agent spawned but never ran)
+  //   • last turn is a user/tool-result message (interrupted mid-tool-use)
+  //   • last assistant turn has pending tool_use blocks (cut off mid-tool-use)
+  //   • only intermediate planning / partial assistant turns present
+  // In all these cases re-dispatch is safer than falsely marking the run done.
   return "resumable-fresh";
 }
 

--- a/src/agents/subagent-resume.ts
+++ b/src/agents/subagent-resume.ts
@@ -231,6 +231,106 @@ export function transcriptEndsWithCompletedAssistantTurn(transcriptPath: string)
   }
 }
 
+/**
+ * Return the timestamp (epoch ms) of the last **completed** assistant turn in
+ * the transcript, or `null` if no completed assistant turn exists.
+ *
+ * A "completed" turn is an assistant message whose `content` array contains no
+ * pending `tool_use` blocks.  The same backward-scan logic as
+ * `transcriptEndsWithCompletedAssistantTurn` is used, but this function also
+ * returns the turn's timestamp so callers can compare it against a run-start
+ * boundary to detect stale output left by a prior run on the same session.
+ *
+ * Timestamp parsing is best-effort: ISO-8601 strings and epoch-ms numbers are
+ * both accepted.  Returns `null` when the timestamp is absent or unparseable.
+ */
+export function transcriptLastCompletedAssistantTurnTimestamp(
+  transcriptPath: string,
+): number | null {
+  try {
+    const content = fs.readFileSync(transcriptPath, "utf-8");
+    const lines = content.split("\n");
+
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const trimmed = lines[i]?.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+
+      if (parsed === null || typeof parsed !== "object") {
+        continue;
+      }
+
+      const record = parsed as Record<string, unknown>;
+      if (record.type !== "message") {
+        continue;
+      }
+
+      const msg = record.message;
+      if (msg === null || typeof msg !== "object") {
+        return null;
+      }
+
+      const msgRecord = msg as Record<string, unknown>;
+      if (msgRecord.role !== "assistant") {
+        // Last turn is not from the assistant — no completed assistant turn here.
+        return null;
+      }
+
+      const contentArr = msgRecord.content;
+      if (!Array.isArray(contentArr)) {
+        // Non-array content (plain string) — treat as a completed text turn.
+        return parseRecordTimestampToMs(record);
+      }
+
+      const hasPendingToolUse = contentArr.some(
+        (block) =>
+          block !== null &&
+          typeof block === "object" &&
+          (block as Record<string, unknown>).type === "tool_use",
+      );
+
+      if (hasPendingToolUse) {
+        // Last assistant turn has pending tool_use — not a completed turn.
+        return null;
+      }
+
+      return parseRecordTimestampToMs(record);
+    }
+
+    // No message lines found at all.
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a `timestamp` field from a JSONL transcript record into epoch ms.
+ * Accepts ISO-8601 strings and numeric epoch-ms values.  Returns `null` when
+ * the field is absent, empty, or cannot be parsed.
+ */
+function parseRecordTimestampToMs(record: Record<string, unknown>): number | null {
+  const ts = record.timestamp;
+  if (typeof ts === "number" && ts > 0 && Number.isFinite(ts)) {
+    return ts;
+  }
+  if (typeof ts === "string" && ts.trim()) {
+    const ms = Date.parse(ts);
+    if (!Number.isNaN(ms)) {
+      return ms;
+    }
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Session-store helper (private)
 // ---------------------------------------------------------------------------
@@ -440,7 +540,15 @@ export async function rehydrateSessionStoreEntries(
  */
 export function resolveSubagentRunResumability(
   entry: SubagentRunRecord,
-  opts?: { transcriptPath?: string },
+  opts?: {
+    transcriptPath?: string;
+    /**
+     * Override the run-start boundary used for the stale-transcript check.
+     * Defaults to `entry.startedAt ?? entry.createdAt`.  Pass a value here in
+     * tests to control the comparison without manipulating real timestamps.
+     */
+    runStartMs?: number;
+  },
 ): SubagentRunResumability {
   // ① Already completed — just needs announce retry.
   if (typeof entry.endedAt === "number" && entry.endedAt > 0) {
@@ -505,10 +613,29 @@ export function resolveSubagentRunResumability(
     return "resumable-fresh";
   }
 
-  if (transcriptEndsWithCompletedAssistantTurn(transcriptPath)) {
-    // The transcript ends with a completed assistant turn (no pending tool_use
-    // blocks) — the run finished but its completion was never recorded in the
-    // registry.  Capture the result from the transcript and complete.
+  const lastAssistantTurnMs = transcriptLastCompletedAssistantTurnTimestamp(transcriptPath);
+  if (lastAssistantTurnMs !== null) {
+    // The transcript has a completed assistant turn — but verify it belongs to
+    // the CURRENT run, not a prior run that shared the same childSessionKey.
+    //
+    // After replaceSubagentRunAfterSteer, the new run record is assigned a
+    // fresh runId and startedAt while keeping the same childSessionKey as the
+    // steered-away run.  If the gateway restarts before the new run has written
+    // anything to the transcript, the old run's final assistant turn is still
+    // the last line.  Without this boundary check we would incorrectly replay
+    // stale output from the prior run instead of re-dispatching the pending task.
+    //
+    // The run-start boundary defaults to startedAt (set by
+    // replaceSubagentRunAfterSteer) or falls back to createdAt if startedAt was
+    // never set (e.g. the run was registered but never actually started).
+    const runStartMs = opts?.runStartMs ?? entry.startedAt ?? entry.createdAt;
+    if (lastAssistantTurnMs < runStartMs) {
+      // The final assistant turn pre-dates this run's start time — it is stale
+      // output from a prior run on the same session.  Re-dispatch to avoid
+      // replaying the wrong result.
+      return "resumable-fresh";
+    }
+    // The turn was written during (or after) the current run — safe to replay.
     return "resumable-replay";
   }
 

--- a/src/agents/subagent-resume.ts
+++ b/src/agents/subagent-resume.ts
@@ -1,0 +1,624 @@
+/**
+ * Subagent restart recovery — Phase 1.
+ *
+ * When the gateway restarts mid-run, subagent sessions that were in-flight lose
+ * their running agent process. `waitForSubagentCompletion` → `agent.wait` then
+ * fails silently because the agent process is gone, leaving runs in limbo or
+ * mis-classifying them as timeouts.
+ *
+ * This module provides:
+ *  1. `rehydrateSessionStoreEntries` — injects synthetic session-store entries
+ *     for runs whose session-store entry went missing in the ~400 ms race window
+ *     between spawn and first session-store write.  Called in
+ *     `restoreSubagentRunsOnce` **before** `reconcileOrphanedRestoredRuns` so
+ *     the orphan check sees the rehydrated entry.
+ *
+ *  2. `resolveSubagentRunResumability` — replaces the binary orphan/no-orphan
+ *     check with a 4-way classification so `resumeSubagentRun` can choose the
+ *     right recovery path without blindly calling `agent.wait`.
+ *
+ *  3. `recoverCompletedSubagentRunFromTranscript` / `redispatchSubagentRunAfterRestart`
+ *     — handlers for the two resumable sub-cases.
+ *
+ * Phase 2 (not in this PR): synthetic tool_result injection, SIGTERM
+ * checkpointing, per-run max-resume caps.
+ *
+ * Related issues: #27875, #19780, #20436
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { loadConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveAgentIdFromSessionKey,
+  resolveStorePath,
+  type SessionEntry,
+} from "../config/sessions.js";
+import { callGateway } from "../gateway/call.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { defaultRuntime } from "../runtime.js";
+import { AGENT_LANE_SUBAGENT } from "./lanes.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+const log = createSubsystemLogger("agents/subagent-resume");
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * 4-way resumability classification for a single in-flight registry entry.
+ *
+ * - `resumable-announce-only`  — `endedAt` is already set; the run completed
+ *   before restart, the announce delivery just needs to be retried.
+ * - `resumable-replay`         — transcript exists with ≥1 assistant turn and
+ *   `endedAt` is unset; the run finished but its completion was never recorded
+ *   in the registry.  Capture the result from the transcript and complete.
+ * - `resumable-fresh`          — session-store entry exists, transcript is
+ *   empty / session-header only, `endedAt` is unset; the agent process was
+ *   spawned but never ran.  Re-dispatch the original task.
+ * - `orphaned`                 — no session-store entry AND no recoverable
+ *   transcript, or transcript has zero model turns (spawn began but aborted
+ *   before writing anything useful).
+ */
+export type SubagentRunResumability =
+  | "orphaned"
+  | "resumable-announce-only"
+  | "resumable-replay"
+  | "resumable-fresh";
+
+// ---------------------------------------------------------------------------
+// Low-level transcript helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the first line of a `.jsonl` transcript file and return the session id
+ * embedded in the `{type:'session', id:'<uuid>'}` header.  Returns `null` on
+ * any error or when the header is absent / malformed.
+ */
+export function readTranscriptSessionId(transcriptPath: string): string | null {
+  try {
+    const content = fs.readFileSync(transcriptPath, "utf-8");
+    const firstLine = content.split("\n")[0]?.trim();
+    if (!firstLine) {
+      return null;
+    }
+    const parsed = JSON.parse(firstLine) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      (parsed as Record<string, unknown>).type === "session" &&
+      typeof (parsed as Record<string, unknown>).id === "string"
+    ) {
+      const id = ((parsed as Record<string, unknown>).id as string).trim();
+      return id || null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return `true` when the transcript at `transcriptPath` contains at least one
+ * `{type:'message', message:{role:'assistant'}}` line.  Returns `false` on any
+ * error or when the file is absent.
+ */
+export function transcriptHasAssistantTurn(transcriptPath: string): boolean {
+  try {
+    const content = fs.readFileSync(transcriptPath, "utf-8");
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (
+          parsed !== null &&
+          typeof parsed === "object" &&
+          (parsed as Record<string, unknown>).type === "message"
+        ) {
+          const msg = (parsed as Record<string, unknown>).message;
+          if (
+            msg !== null &&
+            typeof msg === "object" &&
+            (msg as Record<string, unknown>).role === "assistant"
+          ) {
+            return true;
+          }
+        }
+      } catch {
+        // ignore malformed lines
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session-store helper (private)
+// ---------------------------------------------------------------------------
+
+function findEntryByKey(
+  store: Record<string, SessionEntry>,
+  sessionKey: string,
+): SessionEntry | undefined {
+  const direct = store[sessionKey];
+  if (direct) {
+    return direct;
+  }
+  const normalized = sessionKey.toLowerCase();
+  for (const [k, v] of Object.entries(store)) {
+    if (k.toLowerCase() === normalized) {
+      return v;
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Sessions-directory scanner (private, used by rehydrateSessionStoreEntries)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan `sessionsDir` for a `.jsonl` transcript that was created close to
+ * `targetCreatedAtMs` (within `toleranceMs`).  Returns the absolute path of
+ * the candidate if exactly one candidate is found, otherwise `null`.
+ *
+ * The one-candidate constraint prevents false matches when multiple subagents
+ * were spawned at nearly the same time; in that case rehydration is skipped
+ * (best-effort) and the orphan logic runs instead.
+ */
+function scanSessionsDirForTranscriptCandidate(
+  sessionsDir: string,
+  targetCreatedAtMs: number,
+  toleranceMs: number,
+): string | null {
+  try {
+    const files = fs.readdirSync(sessionsDir);
+    const now = Date.now();
+    const candidates: string[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".jsonl")) {
+        continue;
+      }
+      const fullPath = path.join(sessionsDir, file);
+      try {
+        const stat = fs.statSync(fullPath);
+        const fileAgeMs = now - stat.mtimeMs;
+        const timeDiffMs = Math.abs(stat.mtimeMs - targetCreatedAtMs);
+        if (fileAgeMs <= 60 * 60_000 && timeDiffMs <= toleranceMs) {
+          candidates.push(fullPath);
+        }
+      } catch {
+        // ignore stat failures for individual files
+      }
+    }
+    return candidates.length === 1 ? (candidates[0] ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Change 1: rehydrateSessionStoreEntries
+// ---------------------------------------------------------------------------
+
+/**
+ * Inject synthetic session-store entries for in-flight registry runs whose
+ * session-store entry is missing.
+ *
+ * Called in `restoreSubagentRunsOnce` **before** `reconcileOrphanedRestoredRuns`
+ * so that the orphan-reason check sees a populated store entry rather than
+ * returning `"missing-session-entry"` and incorrectly pruning the run.
+ *
+ * Strategy
+ * --------
+ * 1. For every in-flight entry (no `endedAt`), force a cache-bypassing read of
+ *    the relevant `sessions.json`.  This handles the common race where the
+ *    session-store write completed but the in-memory cache is stale.
+ * 2. If still missing after the fresh read, scan the agent's sessions directory
+ *    for a single `.jsonl` file created within a 5-minute tolerance of the
+ *    registry entry's `createdAt`.  If exactly one candidate is found, read its
+ *    session header to extract the `sessionId` and write a minimal synthetic
+ *    store entry.
+ *
+ * Both steps are best-effort: any failure is logged at debug level and silently
+ * ignored so that the normal orphan-pruning path can still fire.
+ */
+export function rehydrateSessionStoreEntries(entries: Map<string, SubagentRunRecord>): void {
+  const TOLERANCE_MS = 5 * 60_000; // 5 minutes
+
+  for (const entry of entries.values()) {
+    if (typeof entry.endedAt === "number") {
+      // Already done — nothing to rehydrate.
+      continue;
+    }
+
+    const childSessionKey = entry.childSessionKey?.trim();
+    if (!childSessionKey) {
+      continue;
+    }
+
+    try {
+      const cfg = loadConfig();
+      const agentId = resolveAgentIdFromSessionKey(childSessionKey);
+      const storePath = resolveStorePath(cfg.session?.store, { agentId });
+
+      // Step 1: force a fresh (no-cache) read of the session store.
+      const store = loadSessionStore(storePath, { skipCache: true });
+      if (findEntryByKey(store, childSessionKey)) {
+        // Entry found — no rehydration needed.
+        continue;
+      }
+
+      // Step 2: session-store entry is genuinely missing; try to find the
+      // transcript by scanning the sessions directory.
+      const sessionsDir = path.dirname(storePath);
+      const targetCreatedAtMs = entry.createdAt ?? Date.now();
+      const transcriptPath = scanSessionsDirForTranscriptCandidate(
+        sessionsDir,
+        targetCreatedAtMs,
+        TOLERANCE_MS,
+      );
+      if (!transcriptPath) {
+        log.debug("rehydrate: no transcript candidate found", { childSessionKey });
+        continue;
+      }
+
+      const sessionId = readTranscriptSessionId(transcriptPath);
+      if (!sessionId) {
+        log.debug("rehydrate: transcript has no session header", { childSessionKey });
+        continue;
+      }
+
+      // Build a minimal synthetic session-store entry.
+      const sessionFile = path.relative(sessionsDir, transcriptPath);
+      const synthetic: SessionEntry = {
+        sessionId,
+        updatedAt: targetCreatedAtMs,
+        sessionFile,
+        spawnedBy: entry.requesterSessionKey,
+        spawnDepth: 1,
+      };
+
+      // Re-read, mutate, write back — keep it simple for Phase 1.
+      // We write with a direct synchronous fs call to stay compatible with the
+      // synchronous `restoreSubagentRunsOnce` call path.
+      const freshStore = loadSessionStore(storePath, { skipCache: true });
+      const normalizedKey = childSessionKey.toLowerCase();
+      if (!findEntryByKey(freshStore, childSessionKey)) {
+        freshStore[normalizedKey] = synthetic;
+        try {
+          fs.mkdirSync(path.dirname(storePath), { recursive: true });
+          const serialized = JSON.stringify(freshStore, null, 2);
+          fs.writeFileSync(storePath, `${serialized}\n`, { mode: 0o600 });
+          log.info("rehydrated session store entry", { childSessionKey, sessionId });
+        } catch (writeErr) {
+          log.debug("rehydrate: session-store write failed", {
+            childSessionKey,
+            error: String(writeErr),
+          });
+        }
+      }
+    } catch (err) {
+      // Best-effort — any config/IO error is silently swallowed.
+      log.debug("rehydrate: unexpected error", {
+        childSessionKey: entry.childSessionKey,
+        error: String(err),
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Change 2: resolveSubagentRunResumability
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify an in-flight registry entry into one of four resumability states.
+ *
+ * Callers must call `rehydrateSessionStoreEntries` first so that synthetic
+ * session-store entries are available for the `missing-session-entry` recovery
+ * path.
+ *
+ * @param entry   The registry entry to classify.
+ * @param opts    Optional overrides for testing (e.g. transcript path).
+ */
+export function resolveSubagentRunResumability(
+  entry: SubagentRunRecord,
+  opts?: { transcriptPath?: string },
+): SubagentRunResumability {
+  // ① Already completed — just needs announce retry.
+  if (typeof entry.endedAt === "number" && entry.endedAt > 0) {
+    return "resumable-announce-only";
+  }
+
+  const childSessionKey = entry.childSessionKey?.trim();
+  if (!childSessionKey) {
+    return "orphaned";
+  }
+
+  // ② Look up session-store entry.
+  let sessionId: string | null = null;
+  try {
+    const cfg = loadConfig();
+    const agentId = resolveAgentIdFromSessionKey(childSessionKey);
+    const storePath = resolveStorePath(cfg.session?.store, { agentId });
+    const store = loadSessionStore(storePath, { skipCache: true });
+    const sessionEntry = findEntryByKey(store, childSessionKey);
+    if (
+      sessionEntry &&
+      typeof sessionEntry.sessionId === "string" &&
+      sessionEntry.sessionId.trim()
+    ) {
+      sessionId = sessionEntry.sessionId.trim();
+    }
+  } catch {
+    // Best-effort — treat as if session store is missing.
+  }
+
+  if (!sessionId) {
+    // No session-store entry even after rehydration → orphaned.
+    return "orphaned";
+  }
+
+  // ③ Resolve transcript path.
+  let transcriptPath: string;
+  if (opts?.transcriptPath) {
+    transcriptPath = opts.transcriptPath;
+  } else {
+    try {
+      const cfg = loadConfig();
+      const agentId = resolveAgentIdFromSessionKey(childSessionKey);
+      const storePath = resolveStorePath(cfg.session?.store, { agentId });
+      const sessionsDir = path.dirname(storePath);
+      transcriptPath = path.join(sessionsDir, `${sessionId}.jsonl`);
+    } catch {
+      return "orphaned";
+    }
+  }
+
+  // ④ Check transcript content.
+  const transcriptExists = fs.existsSync(transcriptPath);
+  if (!transcriptExists) {
+    // Session-store entry exists but no transcript was ever written.
+    // The agent was registered but never actually ran.
+    return "resumable-fresh";
+  }
+
+  if (transcriptHasAssistantTurn(transcriptPath)) {
+    // The agent ran and produced output — we just need to capture and announce.
+    return "resumable-replay";
+  }
+
+  // Transcript exists but has no assistant turns → agent was spawned, wrote
+  // the session header, but never completed a turn.  Re-dispatch.
+  return "resumable-fresh";
+}
+
+// ---------------------------------------------------------------------------
+// Change 3a: recoverCompletedSubagentRunFromTranscript ('resumable-replay')
+// ---------------------------------------------------------------------------
+
+/**
+ * Recover a run that completed while the gateway was running but whose
+ * completion was never recorded in the registry.
+ *
+ * The transcript already contains the final assistant reply, so we directly
+ * invoke `completeSubagentRun` (imported from subagent-registry) via the
+ * exported `completeSubagentRunForRecover` hook rather than calling
+ * `agent.wait` (which would fail because the agent process is gone).
+ *
+ * To avoid a circular import the actual `completeSubagentRun` call is executed
+ * via the `onRecoverComplete` callback supplied by `subagent-registry.ts`.
+ */
+export async function recoverCompletedSubagentRunFromTranscript(
+  runId: string,
+  entry: SubagentRunRecord,
+  onComplete: (runId: string, endedAt: number) => Promise<void>,
+): Promise<void> {
+  try {
+    const endedAt = Date.now();
+    log.info("restart recovery: replaying completed run from transcript", {
+      runId,
+      childSessionKey: entry.childSessionKey,
+    });
+    await onComplete(runId, endedAt);
+  } catch (err) {
+    defaultRuntime.log(
+      `[warn] subagent-resume: replay recovery failed run=${runId}: ${String(err)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Change 3b: redispatchSubagentRunAfterRestart ('resumable-fresh')
+// ---------------------------------------------------------------------------
+
+/**
+ * Recover a run that never executed (empty transcript) by re-dispatching the
+ * original task to the existing child session via `callGateway('agent')`.
+ *
+ * After the gateway restart the original `runId` is no longer tracked by the
+ * gateway's in-memory run-lifecycle state, so we cannot use `agent.wait` with
+ * it.  Instead we:
+ *   1. Call `agent` with a fresh idempotency key → get back a new `runId`.
+ *   2. Poll `agent.wait` with the new `runId`.
+ *   3. Invoke `onComplete` with the original `entry.runId` so the registry
+ *      entry is closed out correctly.
+ *
+ * @param runId          The original registry run id.
+ * @param entry          The registry entry.
+ * @param waitTimeoutMs  Timeout to pass to `agent.wait`.
+ * @param onComplete     Callback (supplied by subagent-registry) that calls
+ *                       `completeSubagentRun` for the original `runId`.
+ */
+export async function redispatchSubagentRunAfterRestart(
+  runId: string,
+  entry: SubagentRunRecord,
+  waitTimeoutMs: number,
+  onComplete: (runId: string, endedAt: number, outcome: { status: string }) => Promise<void>,
+): Promise<void> {
+  const childSessionKey = entry.childSessionKey?.trim();
+  if (!childSessionKey || !entry.task) {
+    defaultRuntime.log(
+      `[warn] subagent-resume: cannot redispatch run=${runId}: missing sessionKey or task`,
+    );
+    return;
+  }
+
+  // Notify the requester that recovery is in progress.
+  try {
+    await callGateway({
+      method: "chat.send",
+      params: {
+        sessionKey: entry.requesterSessionKey,
+        message: `[gateway restart recovery] Re-dispatching subagent task after restart (run ${runId}). The previous agent process was interrupted; starting fresh in the same session.`,
+        idempotencyKey: `restart-notify-${runId}`,
+        deliver: false,
+      },
+      timeoutMs: 5_000,
+    });
+  } catch {
+    // Best-effort notification — don't abort recovery if this fails.
+  }
+
+  // Re-dispatch the original task to the child session.
+  const redispatchIdem = crypto.randomUUID();
+  let newRunId: string = redispatchIdem;
+  try {
+    log.info("restart recovery: re-dispatching task to child session", {
+      runId,
+      childSessionKey,
+      redispatchIdem,
+    });
+    const response = await callGateway<{ runId?: string }>({
+      method: "agent",
+      params: {
+        message: entry.task,
+        sessionKey: childSessionKey,
+        idempotencyKey: redispatchIdem,
+        deliver: false,
+        lane: AGENT_LANE_SUBAGENT,
+        timeout: entry.runTimeoutSeconds,
+      },
+      timeoutMs: 10_000,
+    });
+    if (typeof response?.runId === "string" && response.runId) {
+      newRunId = response.runId;
+    }
+  } catch (err) {
+    defaultRuntime.log(
+      `[warn] subagent-resume: redispatch agent call failed run=${runId}: ${String(err)}`,
+    );
+    return;
+  }
+
+  // Wait for the new dispatch to complete.
+  try {
+    const timeoutMs = Math.max(1, Math.floor(waitTimeoutMs));
+    const wait = await callGateway<{
+      status?: string;
+      startedAt?: number;
+      endedAt?: number;
+      error?: string;
+    }>({
+      method: "agent.wait",
+      params: { runId: newRunId, timeoutMs },
+      timeoutMs: timeoutMs + 10_000,
+    });
+    if (wait?.status !== "ok" && wait?.status !== "error" && wait?.status !== "timeout") {
+      return;
+    }
+    const endedAt = typeof wait.endedAt === "number" ? wait.endedAt : Date.now();
+    const outcome =
+      wait.status === "error"
+        ? {
+            status: "error" as const,
+            error: typeof wait.error === "string" ? wait.error : undefined,
+          }
+        : wait.status === "timeout"
+          ? { status: "timeout" as const }
+          : { status: "ok" as const };
+
+    await onComplete(runId, endedAt, outcome);
+  } catch (err) {
+    defaultRuntime.log(
+      `[warn] subagent-resume: agent.wait for redispatch failed run=${runId}: ${String(err)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inline resume routing helper (used by subagent-registry.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Route a resumed run based on its `SubagentRunResumability` classification.
+ *
+ * This is a convenience wrapper used by `resumeSubagentRun` in
+ * `subagent-registry.ts` so that the routing logic lives here alongside the
+ * resumability resolver.
+ *
+ * Returns `true` when this function handled the run (caller should mark it as
+ * resumed and return), `false` when the caller should fall through to the
+ * default `waitForSubagentCompletion` path.
+ */
+export function routeResumedRun(params: {
+  runId: string;
+  entry: SubagentRunRecord;
+  waitTimeoutMs: number;
+  onCompleteReplay: (runId: string, endedAt: number) => Promise<void>;
+  onCompleteRedispatch: (
+    runId: string,
+    endedAt: number,
+    outcome: { status: string },
+  ) => Promise<void>;
+}): boolean {
+  const resumability = resolveSubagentRunResumability(params.entry);
+
+  if (resumability === "resumable-announce-only") {
+    // Already handled by the existing endedAt check in resumeSubagentRun.
+    return false;
+  }
+
+  if (resumability === "orphaned") {
+    // Let the caller's orphan check handle it.
+    return false;
+  }
+
+  if (resumability === "resumable-replay") {
+    log.info("restart recovery: resuming as replay (transcript has assistant turns)", {
+      runId: params.runId,
+      childSessionKey: params.entry.childSessionKey,
+    });
+    void recoverCompletedSubagentRunFromTranscript(
+      params.runId,
+      params.entry,
+      params.onCompleteReplay,
+    );
+    return true;
+  }
+
+  if (resumability === "resumable-fresh") {
+    log.info("restart recovery: resuming as fresh redispatch (empty transcript)", {
+      runId: params.runId,
+      childSessionKey: params.entry.childSessionKey,
+    });
+    void redispatchSubagentRunAfterRestart(
+      params.runId,
+      params.entry,
+      params.waitTimeoutMs,
+      params.onCompleteRedispatch,
+    );
+    return true;
+  }
+
+  return false;
+}

--- a/src/agents/subagent-resume.ts
+++ b/src/agents/subagent-resume.ts
@@ -33,7 +33,9 @@ import { loadConfig } from "../config/config.js";
 import {
   loadSessionStore,
   resolveAgentIdFromSessionKey,
+  resolveSessionFilePath,
   resolveStorePath,
+  updateSessionStore,
   type SessionEntry,
 } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
@@ -166,9 +168,14 @@ function findEntryByKey(
 // ---------------------------------------------------------------------------
 
 /**
- * Scan `sessionsDir` for a `.jsonl` transcript that was created close to
- * `targetCreatedAtMs` (within `toleranceMs`).  Returns the absolute path of
- * the candidate if exactly one candidate is found, otherwise `null`.
+ * Scan `sessionsDir` for a `.jsonl` transcript whose creation time is close to
+ * `targetCreatedAtMs` (within `toleranceMs`).  Uses `stat.birthtimeMs`
+ * (creation time) as the primary signal.  On platforms that do not support
+ * birth-time (Linux filesystems where `birthtimeMs === mtimeMs`), `mtimeMs` is
+ * used as a proxy for creation time.
+ *
+ * Returns the absolute path of the candidate if exactly one candidate is found,
+ * otherwise `null`.
  *
  * The one-candidate constraint prevents false matches when multiple subagents
  * were spawned at nearly the same time; in that case rehydration is skipped
@@ -190,8 +197,12 @@ function scanSessionsDirForTranscriptCandidate(
       const fullPath = path.join(sessionsDir, file);
       try {
         const stat = fs.statSync(fullPath);
-        const fileAgeMs = now - stat.mtimeMs;
-        const timeDiffMs = Math.abs(stat.mtimeMs - targetCreatedAtMs);
+        // Use birthtimeMs (creation time) as the primary signal.
+        // On Linux filesystems that do not report birth-time, birthtimeMs equals
+        // mtimeMs; in that case fall back to mtimeMs as a reasonable proxy.
+        const fileCreatedAtMs = stat.birthtimeMs !== stat.mtimeMs ? stat.birthtimeMs : stat.mtimeMs;
+        const fileAgeMs = now - fileCreatedAtMs;
+        const timeDiffMs = Math.abs(fileCreatedAtMs - targetCreatedAtMs);
         if (fileAgeMs <= 60 * 60_000 && timeDiffMs <= toleranceMs) {
           candidates.push(fullPath);
         }
@@ -231,7 +242,9 @@ function scanSessionsDirForTranscriptCandidate(
  * Both steps are best-effort: any failure is logged at debug level and silently
  * ignored so that the normal orphan-pruning path can still fire.
  */
-export function rehydrateSessionStoreEntries(entries: Map<string, SubagentRunRecord>): void {
+export async function rehydrateSessionStoreEntries(
+  entries: Map<string, SubagentRunRecord>,
+): Promise<void> {
   const TOLERANCE_MS = 5 * 60_000; // 5 minutes
 
   for (const entry of entries.values()) {
@@ -287,24 +300,21 @@ export function rehydrateSessionStoreEntries(entries: Map<string, SubagentRunRec
         spawnDepth: 1,
       };
 
-      // Re-read, mutate, write back — keep it simple for Phase 1.
-      // We write with a direct synchronous fs call to stay compatible with the
-      // synchronous `restoreSubagentRunsOnce` call path.
-      const freshStore = loadSessionStore(storePath, { skipCache: true });
+      // Write the synthetic entry via updateSessionStore so that concurrent
+      // session-store writes during startup are serialised through the lock.
       const normalizedKey = childSessionKey.toLowerCase();
-      if (!findEntryByKey(freshStore, childSessionKey)) {
-        freshStore[normalizedKey] = synthetic;
-        try {
-          fs.mkdirSync(path.dirname(storePath), { recursive: true });
-          const serialized = JSON.stringify(freshStore, null, 2);
-          fs.writeFileSync(storePath, `${serialized}\n`, { mode: 0o600 });
-          log.info("rehydrated session store entry", { childSessionKey, sessionId });
-        } catch (writeErr) {
-          log.debug("rehydrate: session-store write failed", {
-            childSessionKey,
-            error: String(writeErr),
-          });
-        }
+      try {
+        await updateSessionStore(storePath, (freshStore) => {
+          if (!findEntryByKey(freshStore, childSessionKey)) {
+            freshStore[normalizedKey] = synthetic;
+            log.info("rehydrated session store entry", { childSessionKey, sessionId });
+          }
+        });
+      } catch (writeErr) {
+        log.debug("rehydrate: session-store write failed", {
+          childSessionKey,
+          error: String(writeErr),
+        });
       }
     } catch (err) {
       // Best-effort — any config/IO error is silently swallowed.
@@ -346,6 +356,8 @@ export function resolveSubagentRunResumability(
 
   // ② Look up session-store entry.
   let sessionId: string | null = null;
+  let sessionEntryForPath: SessionEntry | undefined;
+  let sessionsDir: string | undefined;
   try {
     const cfg = loadConfig();
     const agentId = resolveAgentIdFromSessionKey(childSessionKey);
@@ -358,6 +370,8 @@ export function resolveSubagentRunResumability(
       sessionEntry.sessionId.trim()
     ) {
       sessionId = sessionEntry.sessionId.trim();
+      sessionEntryForPath = sessionEntry;
+      sessionsDir = path.dirname(storePath);
     }
   } catch {
     // Best-effort — treat as if session store is missing.
@@ -369,16 +383,17 @@ export function resolveSubagentRunResumability(
   }
 
   // ③ Resolve transcript path.
+  // Use resolveSessionFilePath so that sessions with non-standard transcript
+  // paths (sessionFile field set) are handled correctly, consistent with all
+  // other transcript-locating code in the codebase.
   let transcriptPath: string;
   if (opts?.transcriptPath) {
     transcriptPath = opts.transcriptPath;
   } else {
     try {
-      const cfg = loadConfig();
-      const agentId = resolveAgentIdFromSessionKey(childSessionKey);
-      const storePath = resolveStorePath(cfg.session?.store, { agentId });
-      const sessionsDir = path.dirname(storePath);
-      transcriptPath = path.join(sessionsDir, `${sessionId}.jsonl`);
+      transcriptPath = resolveSessionFilePath(sessionId, sessionEntryForPath, {
+        sessionsDir,
+      });
     } catch {
       return "orphaned";
     }
@@ -464,6 +479,7 @@ export async function redispatchSubagentRunAfterRestart(
   entry: SubagentRunRecord,
   waitTimeoutMs: number,
   onComplete: (runId: string, endedAt: number, outcome: { status: string }) => Promise<void>,
+  suppressNotifications?: boolean,
 ): Promise<void> {
   const childSessionKey = entry.childSessionKey?.trim();
   if (!childSessionKey || !entry.task) {
@@ -473,25 +489,31 @@ export async function redispatchSubagentRunAfterRestart(
     return;
   }
 
-  // Notify the requester that recovery is in progress.
-  try {
-    await callGateway({
-      method: "chat.send",
-      params: {
-        sessionKey: entry.requesterSessionKey,
-        message: `[gateway restart recovery] Re-dispatching subagent task after restart (run ${runId}). The previous agent process was interrupted; starting fresh in the same session.`,
-        idempotencyKey: `restart-notify-${runId}`,
-        deliver: false,
-      },
-      timeoutMs: 5_000,
-    });
-  } catch {
-    // Best-effort notification — don't abort recovery if this fails.
+  // Notify the requester that recovery is in progress — skipped when
+  // suppressNotifications is true so that the recovery path does not fire
+  // user-visible chat messages before the recovered run completes.
+  if (!suppressNotifications) {
+    try {
+      await callGateway({
+        method: "chat.send",
+        params: {
+          sessionKey: entry.requesterSessionKey,
+          message: `[gateway restart recovery] Re-dispatching subagent task after restart (run ${runId}). The previous agent process was interrupted; starting fresh in the same session.`,
+          idempotencyKey: `restart-notify-${runId}`,
+          deliver: false,
+        },
+        timeoutMs: 5_000,
+      });
+    } catch {
+      // Best-effort notification — don't abort recovery if this fails.
+    }
   }
 
   // Re-dispatch the original task to the child session.
   const redispatchIdem = crypto.randomUUID();
-  let newRunId: string = redispatchIdem;
+  // Use a fresh UUID for newRunId so it is never confused with the idempotency
+  // key, which is for deduplication only and is not a valid run ID.
+  let newRunId: string = crypto.randomUUID();
   try {
     log.info("restart recovery: re-dispatching task to child session", {
       runId,
@@ -507,6 +529,9 @@ export async function redispatchSubagentRunAfterRestart(
         deliver: false,
         lane: AGENT_LANE_SUBAGENT,
         timeout: entry.runTimeoutSeconds,
+        // Preserve original run's depth/parent context so the session tree
+        // remains consistent after restart.
+        spawnedBy: entry.requesterSessionKey,
       },
       timeoutMs: 10_000,
     });
@@ -616,6 +641,7 @@ export function routeResumedRun(params: {
       params.entry,
       params.waitTimeoutMs,
       params.onCompleteRedispatch,
+      true, // suppressNotifications — no user-visible messages before recovered run completes
     );
     return true;
   }

--- a/src/agents/subagent-resume.ts
+++ b/src/agents/subagent-resume.ts
@@ -381,13 +381,21 @@ export async function rehydrateSessionStoreEntries(
       }
 
       // Build a minimal synthetic session-store entry.
+      // Derive the child's spawn depth from the requester's depth rather than
+      // hardcoding 1, so that recovered depth-2+ runs are classified correctly
+      // by getSubagentDepthFromSessionStore (which prefers stored spawnDepth
+      // over ancestry traversal).
+      const requesterSpawnDepth = getSubagentDepthFromSessionStore(entry.requesterSessionKey, {
+        cfg,
+      });
+      const childSpawnDepth = requesterSpawnDepth + 1;
       const sessionFile = path.relative(sessionsDir, transcriptPath);
       const synthetic: SessionEntry = {
         sessionId,
         updatedAt: targetCreatedAtMs,
         sessionFile,
         spawnedBy: entry.requesterSessionKey,
-        spawnDepth: 1,
+        spawnDepth: childSpawnDepth,
       };
 
       // Write the synthetic entry via updateSessionStore so that concurrent
@@ -578,130 +586,167 @@ export async function redispatchSubagentRunAfterRestart(
   onComplete: (runId: string, endedAt: number, outcome: { status: string }) => Promise<void>,
   suppressNotifications?: boolean,
 ): Promise<void> {
-  const childSessionKey = entry.childSessionKey?.trim();
-  if (!childSessionKey || !entry.task) {
-    defaultRuntime.log(
-      `[warn] subagent-resume: cannot redispatch run=${runId}: missing sessionKey or task`,
-    );
-    return;
-  }
-
-  // Notify the requester that recovery is in progress — skipped when
-  // suppressNotifications is true so that the recovery path does not fire
-  // user-visible chat messages before the recovered run completes.
-  if (!suppressNotifications) {
-    try {
-      await callGateway({
-        method: "chat.send",
-        params: {
-          sessionKey: entry.requesterSessionKey,
-          message: `[gateway restart recovery] Re-dispatching subagent task after restart (run ${runId}). The previous agent process was interrupted; starting fresh in the same session.`,
-          idempotencyKey: `restart-notify-${runId}`,
-          deliver: false,
-        },
-        timeoutMs: 5_000,
-      });
-    } catch {
-      // Best-effort notification — don't abort recovery if this fails.
+  // Track whether onComplete has been called so the finally block can guarantee
+  // it fires on every exit path (fix for resume-lock leak on early return or
+  // thrown error).
+  let onCompleteCalled = false;
+  const safeComplete = async (endedAt: number, outcome: { status: string }): Promise<void> => {
+    if (!onCompleteCalled) {
+      onCompleteCalled = true;
+      await onComplete(runId, endedAt, outcome);
     }
-  }
+  };
 
-  // Re-dispatch the original task to the child session.
-  // Reconstruct the full prompt contract that was used in the original dispatch
-  // (subagent-spawn.ts) so that the re-dispatched run behaves identically:
-  //   • childTaskMessage — wraps the task with [Subagent Context] / [Subagent Task] headers
-  //   • extraSystemPrompt — the full subagent system-prompt block from buildSubagentSystemPrompt
-  const cfg = loadConfig();
-  const maxSpawnDepth =
-    cfg.agents?.defaults?.subagents?.maxSpawnDepth ?? DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
-  const childDepth = getSubagentDepthFromSessionStore(childSessionKey, { cfg });
-  const childTaskMessage = [
-    `[Subagent Context] You are running as a subagent (depth ${childDepth}/${maxSpawnDepth}). Results auto-announce to your requester; do not busy-poll for status.`,
-    entry.spawnMode === "session"
-      ? "[Subagent Context] This subagent session is persistent and remains available for thread follow-up messages."
-      : undefined,
-    `[Subagent Task]: ${entry.task}`,
-  ]
-    .filter((line): line is string => Boolean(line))
-    .join("\n\n");
-  const extraSystemPrompt = buildSubagentSystemPrompt({
-    requesterSessionKey: entry.requesterSessionKey,
-    requesterOrigin: entry.requesterOrigin,
-    childSessionKey,
-    label: entry.label,
-    task: entry.task,
-    childDepth,
-    maxSpawnDepth,
-  });
-
-  const redispatchIdem = crypto.randomUUID();
-  // Use a fresh UUID for newRunId so it is never confused with the idempotency
-  // key, which is for deduplication only and is not a valid run ID.
-  let newRunId: string = crypto.randomUUID();
   try {
-    log.info("restart recovery: re-dispatching task to child session", {
-      runId,
-      childSessionKey,
-      redispatchIdem,
-    });
-    const response = await callGateway<{ runId?: string }>({
-      method: "agent",
-      params: {
-        message: childTaskMessage,
-        sessionKey: childSessionKey,
-        idempotencyKey: redispatchIdem,
-        deliver: false,
-        lane: AGENT_LANE_SUBAGENT,
-        timeout: entry.runTimeoutSeconds,
-        extraSystemPrompt,
-        // Preserve original run's depth/parent context so the session tree
-        // remains consistent after restart.
-        spawnedBy: entry.requesterSessionKey,
-      },
-      timeoutMs: 10_000,
-    });
-    if (typeof response?.runId === "string" && response.runId) {
-      newRunId = response.runId;
-    }
-  } catch (err) {
-    defaultRuntime.log(
-      `[warn] subagent-resume: redispatch agent call failed run=${runId}: ${String(err)}`,
-    );
-    return;
-  }
-
-  // Wait for the new dispatch to complete.
-  try {
-    const timeoutMs = Math.max(1, Math.floor(waitTimeoutMs));
-    const wait = await callGateway<{
-      status?: string;
-      startedAt?: number;
-      endedAt?: number;
-      error?: string;
-    }>({
-      method: "agent.wait",
-      params: { runId: newRunId, timeoutMs },
-      timeoutMs: timeoutMs + 10_000,
-    });
-    if (wait?.status !== "ok" && wait?.status !== "error" && wait?.status !== "timeout") {
+    const childSessionKey = entry.childSessionKey?.trim();
+    if (!childSessionKey || !entry.task) {
+      defaultRuntime.log(
+        `[warn] subagent-resume: cannot redispatch run=${runId}: missing sessionKey or task`,
+      );
       return;
     }
-    const endedAt = typeof wait.endedAt === "number" ? wait.endedAt : Date.now();
-    const outcome =
-      wait.status === "error"
-        ? {
-            status: "error" as const,
-            error: typeof wait.error === "string" ? wait.error : undefined,
-          }
-        : wait.status === "timeout"
-          ? { status: "timeout" as const }
-          : { status: "ok" as const };
 
-    await onComplete(runId, endedAt, outcome);
-  } catch (err) {
-    defaultRuntime.log(
-      `[warn] subagent-resume: agent.wait for redispatch failed run=${runId}: ${String(err)}`,
-    );
+    // Notify the requester that recovery is in progress — skipped when
+    // suppressNotifications is true so that the recovery path does not fire
+    // user-visible chat messages before the recovered run completes.
+    if (!suppressNotifications) {
+      try {
+        await callGateway({
+          method: "chat.send",
+          params: {
+            sessionKey: entry.requesterSessionKey,
+            message: `[gateway restart recovery] Re-dispatching subagent task after restart (run ${runId}). The previous agent process was interrupted; starting fresh in the same session.`,
+            idempotencyKey: `restart-notify-${runId}`,
+            deliver: false,
+          },
+          timeoutMs: 5_000,
+        });
+      } catch {
+        // Best-effort notification — don't abort recovery if this fails.
+      }
+    }
+
+    // Re-dispatch the original task to the child session.
+    // Reconstruct the full prompt contract that was used in the original dispatch
+    // (subagent-spawn.ts) so that the re-dispatched run behaves identically:
+    //   • childTaskMessage — wraps the task with [Subagent Context] / [Subagent Task] headers
+    //   • extraSystemPrompt — restored verbatim from the stored entry when available so that
+    //     attachment-specific suffixes appended during the original spawn are preserved; only
+    //     falls back to buildSubagentSystemPrompt when no stored prompt is available
+    const cfg = loadConfig();
+    const maxSpawnDepth =
+      cfg.agents?.defaults?.subagents?.maxSpawnDepth ?? DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
+    const childDepth = getSubagentDepthFromSessionStore(childSessionKey, { cfg });
+    const childTaskMessage = [
+      `[Subagent Context] You are running as a subagent (depth ${childDepth}/${maxSpawnDepth}). Results auto-announce to your requester; do not busy-poll for status.`,
+      entry.spawnMode === "session"
+        ? "[Subagent Context] This subagent session is persistent and remains available for thread follow-up messages."
+        : undefined,
+      `[Subagent Task]: ${entry.task}`,
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n\n");
+
+    // Fix (comment 3): restore the original extraSystemPrompt verbatim from the
+    // stored session entry so that attachment suffixes are not lost.  Fall back to
+    // buildSubagentSystemPrompt only when the stored entry predates this field.
+    const extraSystemPrompt =
+      typeof entry.extraSystemPrompt === "string" && entry.extraSystemPrompt.trim()
+        ? entry.extraSystemPrompt
+        : buildSubagentSystemPrompt({
+            requesterSessionKey: entry.requesterSessionKey,
+            requesterOrigin: entry.requesterOrigin,
+            childSessionKey,
+            label: entry.label,
+            task: entry.task,
+            childDepth,
+            maxSpawnDepth,
+          });
+
+    const redispatchIdem = crypto.randomUUID();
+    // Use a fresh UUID for newRunId so it is never confused with the idempotency
+    // key, which is for deduplication only and is not a valid run ID.
+    let newRunId: string = crypto.randomUUID();
+    try {
+      log.info("restart recovery: re-dispatching task to child session", {
+        runId,
+        childSessionKey,
+        redispatchIdem,
+      });
+      const response = await callGateway<{ runId?: string }>({
+        method: "agent",
+        params: {
+          message: childTaskMessage,
+          sessionKey: childSessionKey,
+          idempotencyKey: redispatchIdem,
+          deliver: false,
+          lane: AGENT_LANE_SUBAGENT,
+          timeout: entry.runTimeoutSeconds,
+          extraSystemPrompt,
+          // Preserve original run's depth/parent context and workspace so the
+          // session tree and any relative-path file operations remain consistent
+          // after restart (fix for comment 1: include workspaceDir from entry).
+          spawnedBy: entry.requesterSessionKey,
+          workspaceDir: entry.workspaceDir,
+        },
+        timeoutMs: 10_000,
+      });
+      if (typeof response?.runId === "string" && response.runId) {
+        newRunId = response.runId;
+      }
+    } catch (err) {
+      defaultRuntime.log(
+        `[warn] subagent-resume: redispatch agent call failed run=${runId}: ${String(err)}`,
+      );
+      return;
+    }
+
+    // Wait for the new dispatch to complete.
+    try {
+      const timeoutMs = Math.max(1, Math.floor(waitTimeoutMs));
+      const wait = await callGateway<{
+        status?: string;
+        startedAt?: number;
+        endedAt?: number;
+        error?: string;
+      }>({
+        method: "agent.wait",
+        params: { runId: newRunId, timeoutMs },
+        timeoutMs: timeoutMs + 10_000,
+      });
+      if (wait?.status !== "ok" && wait?.status !== "error" && wait?.status !== "timeout") {
+        return;
+      }
+      const endedAt = typeof wait.endedAt === "number" ? wait.endedAt : Date.now();
+      const outcome =
+        wait.status === "error"
+          ? {
+              status: "error" as const,
+              error: typeof wait.error === "string" ? wait.error : undefined,
+            }
+          : wait.status === "timeout"
+            ? { status: "timeout" as const }
+            : { status: "ok" as const };
+
+      await safeComplete(endedAt, outcome);
+    } catch (err) {
+      defaultRuntime.log(
+        `[warn] subagent-resume: agent.wait for redispatch failed run=${runId}: ${String(err)}`,
+      );
+    }
+  } finally {
+    // Guarantee onComplete is always called even when an early return or
+    // unexpected error prevented the normal completion path from running.
+    // This ensures the resume lock is never permanently leaked (fix for comment 4).
+    if (!onCompleteCalled) {
+      try {
+        await onComplete(runId, Date.now(), { status: "error" });
+      } catch (err) {
+        defaultRuntime.log(
+          `[warn] subagent-resume: finally-path onComplete failed run=${runId}: ${String(err)}`,
+        );
+      }
+    }
   }
 }
 

--- a/src/agents/subagent-resume.ts
+++ b/src/agents/subagent-resume.ts
@@ -800,7 +800,7 @@ export async function redispatchSubagentRunAfterRestart(
         childSessionKey,
         redispatchIdem,
       });
-      const response = await callGateway<{ runId?: string }>({
+      const response = await callGateway({
         method: "agent",
         params: {
           message: childTaskMessage,
@@ -831,12 +831,7 @@ export async function redispatchSubagentRunAfterRestart(
     // Wait for the new dispatch to complete.
     try {
       const timeoutMs = Math.max(1, Math.floor(waitTimeoutMs));
-      const wait = await callGateway<{
-        status?: string;
-        startedAt?: number;
-        endedAt?: number;
-        error?: string;
-      }>({
+      const wait = await callGateway({
         method: "agent.wait",
         params: { runId: newRunId, timeoutMs },
         timeoutMs: timeoutMs + 10_000,

--- a/src/agents/subagent-resume.ts
+++ b/src/agents/subagent-resume.ts
@@ -29,6 +29,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
 import {
   loadSessionStore,
@@ -42,6 +43,8 @@ import { callGateway } from "../gateway/call.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { defaultRuntime } from "../runtime.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
+import { buildSubagentSystemPrompt } from "./subagent-announce.js";
+import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const log = createSubsystemLogger("agents/subagent-resume");
@@ -274,7 +277,6 @@ function scanSessionsDirForTranscriptCandidate(
 ): string | null {
   try {
     const files = fs.readdirSync(sessionsDir);
-    const now = Date.now();
     const candidates: string[] = [];
     for (const file of files) {
       if (!file.endsWith(".jsonl")) {
@@ -287,9 +289,11 @@ function scanSessionsDirForTranscriptCandidate(
         // On Linux filesystems that do not report birth-time, birthtimeMs equals
         // mtimeMs; in that case fall back to mtimeMs as a reasonable proxy.
         const fileCreatedAtMs = stat.birthtimeMs !== stat.mtimeMs ? stat.birthtimeMs : stat.mtimeMs;
-        const fileAgeMs = now - fileCreatedAtMs;
         const timeDiffMs = Math.abs(fileCreatedAtMs - targetCreatedAtMs);
-        if (fileAgeMs <= 60 * 60_000 && timeDiffMs <= toleranceMs) {
+        // No upper age bound: a run that started hours before a restart must
+        // still be recoverable.  The toleranceMs window relative to the
+        // registry entry's createdAt already constrains the match tightly.
+        if (timeDiffMs <= toleranceMs) {
           candidates.push(fullPath);
         }
       } catch {
@@ -603,6 +607,33 @@ export async function redispatchSubagentRunAfterRestart(
   }
 
   // Re-dispatch the original task to the child session.
+  // Reconstruct the full prompt contract that was used in the original dispatch
+  // (subagent-spawn.ts) so that the re-dispatched run behaves identically:
+  //   • childTaskMessage — wraps the task with [Subagent Context] / [Subagent Task] headers
+  //   • extraSystemPrompt — the full subagent system-prompt block from buildSubagentSystemPrompt
+  const cfg = loadConfig();
+  const maxSpawnDepth =
+    cfg.agents?.defaults?.subagents?.maxSpawnDepth ?? DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
+  const childDepth = getSubagentDepthFromSessionStore(childSessionKey, { cfg });
+  const childTaskMessage = [
+    `[Subagent Context] You are running as a subagent (depth ${childDepth}/${maxSpawnDepth}). Results auto-announce to your requester; do not busy-poll for status.`,
+    entry.spawnMode === "session"
+      ? "[Subagent Context] This subagent session is persistent and remains available for thread follow-up messages."
+      : undefined,
+    `[Subagent Task]: ${entry.task}`,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n\n");
+  const extraSystemPrompt = buildSubagentSystemPrompt({
+    requesterSessionKey: entry.requesterSessionKey,
+    requesterOrigin: entry.requesterOrigin,
+    childSessionKey,
+    label: entry.label,
+    task: entry.task,
+    childDepth,
+    maxSpawnDepth,
+  });
+
   const redispatchIdem = crypto.randomUUID();
   // Use a fresh UUID for newRunId so it is never confused with the idempotency
   // key, which is for deduplication only and is not a valid run ID.
@@ -616,12 +647,13 @@ export async function redispatchSubagentRunAfterRestart(
     const response = await callGateway<{ runId?: string }>({
       method: "agent",
       params: {
-        message: entry.task,
+        message: childTaskMessage,
         sessionKey: childSessionKey,
         idempotencyKey: redispatchIdem,
         deliver: false,
         lane: AGENT_LANE_SUBAGENT,
         timeout: entry.runTimeoutSeconds,
+        extraSystemPrompt,
         // Preserve original run's depth/parent context so the session tree
         // remains consistent after restart.
         spawnedBy: entry.requesterSessionKey,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -849,6 +849,7 @@ export async function spawnSubagentDirect(
       attachmentsDir: attachmentAbsDir,
       attachmentsRootDir: attachmentRootDir,
       retainAttachmentsOnKeep: retainOnSessionKeep,
+      extraSystemPrompt: childSystemPrompt,
     });
   } catch (err) {
     if (attachmentAbsDir) {

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -687,7 +687,7 @@ describe("gateway server hooks", () => {
       mockIsolatedRunOkOnce();
       const resNoAgent = await postHook(port, "/hooks/agent", { message: "No explicit agent" });
       expect(resNoAgent.status).toBe(200);
-      await waitForSystemEvent();
+      await waitForSystemEvent(5_000);
       const noAgentCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
       };
@@ -700,7 +700,7 @@ describe("gateway server hooks", () => {
         agentId: "hooks",
       });
       expect(resAllowed.status).toBe(200);
-      await waitForSystemEvent();
+      await waitForSystemEvent(5_000);
       const allowedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
       };


### PR DESCRIPTION
## Problem

When the OpenClaw gateway restarts mid-run, subagent sessions that were in-flight lose their running agent process. The session store (`sessions.json`) survives on disk, but `waitForSubagentCompletion` → `agent.wait` RPC fails silently (or returns a spurious `'timeout'` status) because the agent process is gone — causing a false failure cascade. Runs that actually completed never deliver their results.

## What this PR does (Phase 1)

Three targeted changes in `src/agents/`:

### Change 1: `rehydrateSessionStoreEntries()` — `subagent-resume.ts`

Called in `restoreSubagentRunsOnce()` **before** `reconcileOrphanedRestoredRuns()` so the orphan check sees a populated store entry.

For in-flight registry entries whose session-store entry is missing:
1. Force a cache-bypassing re-read of `sessions.json` (handles the case where the store was written but the in-memory cache is stale)
2. If still missing, scan the agent's sessions directory for a `.jsonl` transcript created within 5 minutes of the registry entry's `createdAt`
3. If exactly one candidate is found, read its `{type:'session'}` header to extract the `sessionId`, then write a minimal synthetic store entry: `{ sessionId, updatedAt, sessionFile, spawnedBy, spawnDepth: 1 }`

This prevents false `'missing-session-entry'` orphan conclusions for the ~400ms race window between spawn and first store write.

### Change 2: `resolveSubagentRunResumability()` — `subagent-resume.ts`

Replaces the binary orphan/no-orphan check with a **4-way classification**:

| State | Condition | Recovery action |
|---|---|---|
| `resumable-announce-only` | `endedAt` is already set | Retry announce delivery (already handled) |
| `resumable-replay` | Session-store entry exists, transcript has ≥1 assistant turn, no `endedAt` | Capture result from transcript, call `completeSubagentRun` |
| `resumable-fresh` | Session-store entry exists, transcript is empty/header-only, no `endedAt` | Re-dispatch original task via `callGateway('agent')` |
| `orphaned` | No session-store entry AND no recoverable transcript | Existing orphan-pruning behaviour |

### Change 3: `resumeSubagentRun()` routing — `subagent-registry.ts`

Modified to call `routeResumedRun()` (which calls `resolveSubagentRunResumability()`) before falling through to the default `waitForSubagentCompletion` path:

- **`resumable-replay`**: calls `completeSubagentRun` directly with `{ status: 'ok' }`, which uses the existing `freezeRunResultAtCompletion` → `captureSubagentCompletionReply` flow to read the transcript result and trigger the announce flow. No `agent.wait` call needed.
- **`resumable-fresh`**: re-dispatches the original task to the child session via `callGateway('agent')` (new idempotency key), waits with `agent.wait` on the **new** run ID, then calls `completeSubagentRun` for the **original** run entry.
- **`orphaned`** / **`resumable-announce-only`**: unchanged — routed by existing logic.

## What Phase 2 will cover (not in this PR)

- Synthetic `tool_result` injection for partially-completed transcripts (to avoid re-running from scratch when the agent was mid-tool-call)
- `SIGTERM` checkpointing to write a graceful shutdown marker to the transcript
- Per-run max-resume caps to prevent infinite retry loops on pathological transcripts

## Tests

25 new unit tests in `src/agents/subagent-resume.test.ts`:
- `readTranscriptSessionId` — 5 cases (valid header, missing file, wrong type, empty, malformed JSON)
- `transcriptHasAssistantTurn` — 6 cases (has assistant, header only, user only, missing, empty, malformed + valid)
- `resolveSubagentRunResumability` — 7 cases covering all 4 classifications
- `rehydrateSessionStoreEntries` — skip completed, skip existing, synthesise from transcript
- `routeResumedRun` — orphaned → false, announce-only → false, replay → true, fresh → true

## References

Closes #27875
Related: #19780, #20436