### PR TITLE
fix(feishu): bypass per-chat queue for control commands

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -277,20 +277,20 @@ function registerEventHandlers(
       error(`${params.errorMessage}: ${String(err)}`);
     }
   };
+  const invokeHandler = (event: FeishuMessageEvent) =>
+    handleFeishuMessage({
+      cfg,
+      event,
+      botOpenId: botOpenIds.get(accountId),
+      botName: botNames.get(accountId),
+      runtime,
+      chatHistories,
+      accountId,
+      processingClaimHeld: true,
+    });
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
     const chatId = event.message.chat_id?.trim() || "unknown";
-    const task = () =>
-      handleFeishuMessage({
-        cfg,
-        event,
-        botOpenId: botOpenIds.get(accountId),
-        botName: botNames.get(accountId),
-        runtime,
-        chatHistories,
-        accountId,
-        processingClaimHeld: true,
-      });
-    await enqueue(chatId, task);
+    await enqueue(chatId, () => invokeHandler(event));
   };
   const resolveSenderDebounceId = (event: FeishuMessageEvent): string | undefined => {
     const senderId =
@@ -328,18 +328,20 @@ function registerEventHandlers(
   const isMessageAlreadyProcessed = async (entry: FeishuMessageEvent): Promise<boolean> => {
     return await hasProcessedFeishuMessage(entry.message.message_id, accountId, log);
   };
+  /** Build the debounce buffer key for an event. */
+  const resolveDebounceKey = (event: FeishuMessageEvent): string | null => {
+    const chatId = event.message.chat_id?.trim();
+    const senderId = resolveSenderDebounceId(event);
+    if (!chatId || !senderId) {
+      return null;
+    }
+    const rootId = event.message.root_id?.trim();
+    const threadKey = rootId ? `thread:${rootId}` : "chat";
+    return `feishu:${accountId}:${chatId}:${threadKey}:${senderId}`;
+  };
   const inboundDebouncer = core.channel.debounce.createInboundDebouncer<FeishuMessageEvent>({
     debounceMs: inboundDebounceMs,
-    buildKey: (event) => {
-      const chatId = event.message.chat_id?.trim();
-      const senderId = resolveSenderDebounceId(event);
-      if (!chatId || !senderId) {
-        return null;
-      }
-      const rootId = event.message.root_id?.trim();
-      const threadKey = rootId ? `thread:${rootId}` : "chat";
-      return `feishu:${accountId}:${chatId}:${threadKey}:${senderId}`;
-    },
+    buildKey: resolveDebounceKey,
     shouldDebounce: (event) => {
       if (event.message.message_type !== "text") {
         return false;
@@ -407,6 +409,38 @@ function registerEventHandlers(
     },
   });
 
+  const isControlCommand = (event: FeishuMessageEvent): boolean => {
+    if (event.message.message_type !== "text") {
+      return false;
+    }
+    const text = resolveDebounceText(event);
+    return Boolean(text) && core.channel.text.hasControlCommand(text, cfg);
+  };
+
+  /** Commands that discard pending work — buffered text should be dropped. */
+  const DESTRUCTIVE_COMMAND_RE = /^\/(?:stop|new|reset)\b/i;
+  const isDestructiveCommand = (text: string): boolean => {
+    return DESTRUCTIVE_COMMAND_RE.test(text.trim());
+  };
+
+  /**
+   * Dispatch a control command bypassing the per-chat queue.
+   * For destructive commands (/stop, /new, /reset), pending debounced text
+   * is dropped so stale input cannot restart work after the command.
+   * Informational commands (/status, /help) bypass the queue without
+   * discarding buffered text.
+   */
+  const dispatchCommandDirectly = async (event: FeishuMessageEvent) => {
+    const key = resolveDebounceKey(event);
+    if (key) {
+      const text = resolveDebounceText(event);
+      if (isDestructiveCommand(text)) {
+        inboundDebouncer.dropKey(key);
+      }
+    }
+    await invokeHandler(event);
+  };
+
   eventDispatcher.register({
     "im.message.receive_v1": async (data) => {
       const event = data as unknown as FeishuMessageEvent;
@@ -416,6 +450,12 @@ function registerEventHandlers(
         return;
       }
       const processMessage = async () => {
+        // Control commands (/stop, /new, /status) bypass the debouncer and
+        // per-chat queue so they execute immediately during active runs (#42803).
+        if (isControlCommand(event)) {
+          await dispatchCommandDirectly(event);
+          return;
+        }
         await inboundDebouncer.enqueue(event);
       };
       if (fireAndForget) {

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -712,6 +712,7 @@ describe("Feishu inbound debounce regressions", () => {
                 params.onError?.(new Error("dispatch failed"), [item]);
               },
               flushKey: async () => {},
+              dropKey: () => {},
             }),
             resolveInboundDebounceMs,
           },

--- a/extensions/feishu/src/monitor.test-mocks.ts
+++ b/extensions/feishu/src/monitor.test-mocks.ts
@@ -18,6 +18,7 @@ export function createFeishuRuntimeMockModule(): {
         createInboundDebouncer: () => {
           enqueue: () => Promise<void>;
           flushKey: () => Promise<void>;
+          dropKey: () => void;
         };
       };
       text: {
@@ -34,6 +35,7 @@ export function createFeishuRuntimeMockModule(): {
           createInboundDebouncer: () => ({
             enqueue: async () => {},
             flushKey: async () => {},
+            dropKey: () => {},
           }),
         },
         text: {

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -124,5 +124,21 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     scheduleFlush(key, buffer);
   };
 
-  return { enqueue, flushKey };
+  /** Drop any buffered items for `key` without flushing them. */
+  const dropKey = (key: string) => {
+    const buffer = buffers.get(key);
+    if (!buffer) {
+      return;
+    }
+    buffers.delete(key);
+    if (buffer.timeout) {
+      clearTimeout(buffer.timeout);
+      buffer.timeout = null;
+    }
+    // Clear items so a racing timer callback (already queued in the event
+    // loop) hits the length === 0 guard in flushBuffer and becomes a no-op.
+    buffer.items.length = 0;
+  };
+
+  return { enqueue, flushKey, dropKey };
 }


### PR DESCRIPTION
## Summary
- Bypass the per-chat serialization queue for control commands (`/stop`, `/new`, `/status`, etc.) in the Feishu message monitor
- Detect control commands before enqueueing to the debouncer and dispatch them directly, so they execute immediately even when an active agent run holds the chat queue

## Root cause
`extensions/feishu/src/monitor.account.ts` serializes all same-chat events through a per-chat queue (`createChatQueue()`). Since command-only Feishu messages also went through that queue, `/stop`/`/new`/`/status` could not execute until the active run finished.

## Fix
- Added `isControlCommand()` check in the `im.message.receive_v1` handler that detects text messages matching known control commands via `core.channel.text.hasControlCommand()`
- When a control command is detected, it is dispatched directly via `handleFeishuMessage()` instead of going through the debouncer and chat queue
- Non-command messages continue through the existing debounce + queue path unchanged

## Test plan
- [x] All 348 Feishu extension tests pass (`pnpm test extensions/feishu/`)
- [ ] Manual: send `/stop` during an active Feishu agent run and verify it executes immediately

Closes #42803
