### PR TITLE
fix: remap skill paths to sandbox workspace in non-main sessions

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -376,10 +376,10 @@ export async function compactEmbeddedPiSessionDirect(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
-    // In sandboxed non-rw sessions, skill files live inside the sandbox workspace
-    // (synced by syncSkillsToWorkspace), not at host paths. The pre-built snapshot
-    // prompt contains host-compacted paths (~/...) that are unreachable from inside
-    // the sandbox, so we skip the snapshot and rebuild from the sandbox workspace.
+    // In sandboxed non-rw sessions, skill files are synced into the sandbox
+    // workspace but the pre-built snapshot prompt contains host-compacted paths
+    // (~/...) that are unreachable inside the container. When sandboxed, skip
+    // the snapshot and rebuild the prompt with container-relative paths.
     const isSandboxedNonRw = sandbox?.enabled && sandbox.workspaceAccess !== "rw";
     const effectiveSnapshot = isSandboxedNonRw ? undefined : params.skillsSnapshot;
 
@@ -402,6 +402,7 @@ export async function compactEmbeddedPiSessionDirect(
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      containerSkillsPrefix: isSandboxedNonRw ? sandbox.containerWorkdir : undefined,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -376,10 +376,17 @@ export async function compactEmbeddedPiSessionDirect(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
+    // In sandboxed non-rw sessions, skill files live inside the sandbox workspace
+    // (synced by syncSkillsToWorkspace), not at host paths. The pre-built snapshot
+    // prompt contains host-compacted paths (~/...) that are unreachable from inside
+    // the sandbox, so we skip the snapshot and rebuild from the sandbox workspace.
+    const isSandboxedNonRw = sandbox?.enabled && sandbox.workspaceAccess !== "rw";
+    const effectiveSnapshot = isSandboxedNonRw ? undefined : params.skillsSnapshot;
+
     const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
       workspaceDir: effectiveWorkspace,
       config: params.config,
-      skillsSnapshot: params.skillsSnapshot,
+      skillsSnapshot: effectiveSnapshot,
     });
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
@@ -391,7 +398,7 @@ export async function compactEmbeddedPiSessionDirect(
           config: params.config,
         });
     const skillsPrompt = resolveSkillsPromptForRun({
-      skillsSnapshot: params.skillsSnapshot,
+      skillsSnapshot: effectiveSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -779,10 +779,17 @@ export async function runEmbeddedAttempt(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
+    // In sandboxed non-rw sessions, skill files live inside the sandbox workspace
+    // (synced by syncSkillsToWorkspace), not at host paths. The pre-built snapshot
+    // prompt contains host-compacted paths (~/...) that are unreachable from inside
+    // the sandbox, so we skip the snapshot and rebuild from the sandbox workspace.
+    const isSandboxedNonRw = sandbox?.enabled && sandbox.workspaceAccess !== "rw";
+    const effectiveSnapshot = isSandboxedNonRw ? undefined : params.skillsSnapshot;
+
     const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
       workspaceDir: effectiveWorkspace,
       config: params.config,
-      skillsSnapshot: params.skillsSnapshot,
+      skillsSnapshot: effectiveSnapshot,
     });
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
@@ -795,7 +802,7 @@ export async function runEmbeddedAttempt(
         });
 
     const skillsPrompt = resolveSkillsPromptForRun({
-      skillsSnapshot: params.skillsSnapshot,
+      skillsSnapshot: effectiveSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -779,10 +779,10 @@ export async function runEmbeddedAttempt(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
-    // In sandboxed non-rw sessions, skill files live inside the sandbox workspace
-    // (synced by syncSkillsToWorkspace), not at host paths. The pre-built snapshot
-    // prompt contains host-compacted paths (~/...) that are unreachable from inside
-    // the sandbox, so we skip the snapshot and rebuild from the sandbox workspace.
+    // In sandboxed non-rw sessions, skill files are synced into the sandbox
+    // workspace but the pre-built snapshot prompt contains host-compacted paths
+    // (~/...) that are unreachable inside the container. When sandboxed, skip
+    // the snapshot and rebuild the prompt with container-relative paths.
     const isSandboxedNonRw = sandbox?.enabled && sandbox.workspaceAccess !== "rw";
     const effectiveSnapshot = isSandboxedNonRw ? undefined : params.skillsSnapshot;
 
@@ -806,6 +806,7 @@ export async function runEmbeddedAttempt(
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      containerSkillsPrefix: isSandboxedNonRw ? sandbox.containerWorkdir : undefined,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -53,6 +53,18 @@ function compactSkillPaths(skills: Skill[]): Skill[] {
   }));
 }
 
+/**
+ * Remap skill file paths to container-relative paths for sandboxed sessions.
+ * Skills synced into the sandbox workspace live at `<containerPrefix>/skills/<name>/SKILL.md`.
+ * The model inside the container can only access these paths, not the host paths.
+ */
+function remapSkillPathsToContainer(skills: Skill[], containerPrefix: string): Skill[] {
+  return skills.map((s) => ({
+    ...s,
+    filePath: path.posix.join(containerPrefix, "skills", path.basename(s.baseDir), "SKILL.md"),
+  }));
+}
+
 function debugSkillCommandOnce(
   messageKey: string,
   message: string,
@@ -598,6 +610,13 @@ type WorkspaceSkillBuildOptions = {
   /** If provided, only include skills with these names */
   skillFilter?: string[];
   eligibility?: SkillEligibilityContext;
+  /**
+   * When set, skill file paths in the prompt are remapped to container-relative
+   * paths under this prefix (e.g. `/workspace`) instead of using `~` compaction.
+   * This is needed for sandboxed non-rw sessions where the model can only access
+   * files inside the container, not host paths.
+   */
+  containerSkillsPrefix?: string;
 };
 
 function resolveWorkspaceSkillPromptState(
@@ -627,11 +646,10 @@ function resolveWorkspaceSkillPromptState(
   const truncationNote = truncated
     ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}. Run \`openclaw skills check\` to audit.`
     : "";
-  const prompt = [
-    remoteNote,
-    truncationNote,
-    formatSkillsForPrompt(compactSkillPaths(skillsForPrompt)),
-  ]
+  const remappedSkills = opts?.containerSkillsPrefix
+    ? remapSkillPathsToContainer(skillsForPrompt, opts.containerSkillsPrefix)
+    : compactSkillPaths(skillsForPrompt);
+  const prompt = [remoteNote, truncationNote, formatSkillsForPrompt(remappedSkills)]
     .filter(Boolean)
     .join("\n");
   return { eligible, prompt, resolvedSkills };
@@ -642,6 +660,8 @@ export function resolveSkillsPromptForRun(params: {
   entries?: SkillEntry[];
   config?: OpenClawConfig;
   workspaceDir: string;
+  /** When set, remap skill paths to container-relative paths (for sandbox sessions). */
+  containerSkillsPrefix?: string;
 }): string {
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
   if (snapshotPrompt) {
@@ -651,6 +671,7 @@ export function resolveSkillsPromptForRun(params: {
     const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
       entries: params.entries,
       config: params.config,
+      containerSkillsPrefix: params.containerSkillsPrefix,
     });
     return prompt.trim() ? prompt : "";
   }


### PR DESCRIPTION
## Summary

- In sandboxed non-rw sessions, the pre-built skills snapshot prompt contains host-compacted paths (`~/.openclaw/skills/...`) that are unreachable inside the Docker sandbox container, causing `Path escapes sandbox root` errors
- Add `remapSkillPathsToContainer()` in `src/agents/skills/workspace.ts` which rewrites skill `filePath` values to container-relative paths (e.g., `/workspace/skills/<skill>/SKILL.md`)
- Thread `containerSkillsPrefix` through `resolveSkillsPromptForRun` → `buildWorkspaceSkillsPrompt` → `resolveWorkspaceSkillPromptState` so the embedded runner can pass the container workdir when in a sandboxed non-rw session
- Applied to both `attempt.ts` (run path) and `compact.ts` (compaction path)

Fixes #43383

## Test plan

- [x] Existing skill tests pass (36/36 across all skill test files)
- [x] Build passes (`pnpm build`)
- [ ] Manual verification: install a managed skill, start a non-main sandboxed session, confirm skill paths in the prompt reference `/workspace/skills/<skill>/SKILL.md` instead of `~/.openclaw/skills/<skill>/SKILL.md`
- [ ] Verify the model can successfully read the skill file without "Path escapes sandbox root" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)