### PR TITLE
fix(discord): honor filePath/path params in thread-reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/providers: preserve scoped cold-load fallback for enabled external manifest-contract capability providers missing from the startup registry, so providers such as Fish Audio can resolve on request without requiring `activation.onStartup` for correctness. (#76536) Thanks @Conan-Scott.
 - Gateway/update: carry `continuationMessage` from `update.run` into successful restart sentinels so session-scoped self-updates can resume one follow-up turn after the Gateway restarts. Refs #71178. (#74362) Thanks @100menotu001, @HeilbronAILabs, and @artnking.
 - Agents/fallback: suppress duplicate current-turn user-message transcript writes after embedded fallback retries while still sending the retry prompt to the model. (#63696) Thanks @dashhuang.
+- Discord: honor `path` and `filePath` attachments for thread replies, so forum follow-up messages include agent-generated files. Fixes #43570. (#43574) Thanks @Perfecto23.
 
 ## 2026.5.2
 

--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -19,7 +19,13 @@ import {
 
 type Ctx = Pick<
   ChannelMessageActionContext,
-  "action" | "params" | "cfg" | "accountId" | "requesterSenderId" | "mediaLocalRoots"
+  | "action"
+  | "params"
+  | "cfg"
+  | "accountId"
+  | "requesterSenderId"
+  | "mediaLocalRoots"
+  | "mediaReadFile"
 >;
 
 export async function tryHandleDiscordMessageActionGuildAdmin(params: {
@@ -365,7 +371,11 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const content = readStringParam(actionParams, "message", {
       required: true,
     });
-    const mediaUrl = readStringParam(actionParams, "media", { trim: false });
+    // Support media, path, and filePath, aligned with `send` in handle-action.ts.
+    const mediaUrl =
+      readStringParam(actionParams, "media", { trim: false }) ??
+      readStringParam(actionParams, "path", { trim: false }) ??
+      readStringParam(actionParams, "filePath", { trim: false });
     const replyTo = readStringParam(actionParams, "replyTo");
 
     // `message.thread-reply` (tool) uses `threadId`, while the CLI historically used `to`/`channelId`.
@@ -383,6 +393,10 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         replyTo: replyTo ?? undefined,
       },
       cfg,
+      {
+        mediaLocalRoots: ctx.mediaLocalRoots,
+        mediaReadFile: ctx.mediaReadFile,
+      },
     );
   }
 

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -173,6 +173,144 @@ describe("handleDiscordMessageAction", () => {
     );
   });
 
+  it("honors thread-reply filePath when media is not set", async () => {
+    await handleDiscordMessageAction({
+      action: "thread-reply",
+      params: {
+        channelId: "123",
+        message: "see attachment",
+        filePath: "/tmp/report.md",
+      },
+      cfg: {
+        channels: { discord: { token: "tok" } },
+      } as OpenClawConfig,
+      accountId: "ops",
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "threadReply",
+        accountId: "ops",
+        channelId: "123",
+        content: "see attachment",
+        mediaUrl: "/tmp/report.md",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("honors thread-reply path when media is not set", async () => {
+    await handleDiscordMessageAction({
+      action: "thread-reply",
+      params: {
+        channelId: "123",
+        message: "see attachment",
+        path: "/tmp/report.md",
+      },
+      cfg: {
+        channels: { discord: { token: "tok" } },
+      } as OpenClawConfig,
+      accountId: "ops",
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "threadReply",
+        accountId: "ops",
+        channelId: "123",
+        content: "see attachment",
+        mediaUrl: "/tmp/report.md",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("prefers thread-reply media over filePath", async () => {
+    await handleDiscordMessageAction({
+      action: "thread-reply",
+      params: {
+        channelId: "123",
+        message: "see attachment",
+        media: "/tmp/a.md",
+        filePath: "/tmp/b.md",
+      },
+      cfg: {
+        channels: { discord: { token: "tok" } },
+      } as OpenClawConfig,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "threadReply",
+        channelId: "123",
+        content: "see attachment",
+        mediaUrl: "/tmp/a.md",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("prefers thread-reply path over filePath", async () => {
+    await handleDiscordMessageAction({
+      action: "thread-reply",
+      params: {
+        channelId: "123",
+        message: "see attachment",
+        path: "/tmp/a.md",
+        filePath: "/tmp/b.md",
+      },
+      cfg: {
+        channels: { discord: { token: "tok" } },
+      } as OpenClawConfig,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "threadReply",
+        channelId: "123",
+        content: "see attachment",
+        mediaUrl: "/tmp/a.md",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("forwards media read context for thread-reply filePath attachments", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("report"));
+
+    await handleDiscordMessageAction({
+      action: "thread-reply",
+      params: {
+        channelId: "123",
+        message: "see attachment",
+        filePath: "/workspace/report.md",
+      },
+      cfg: {
+        channels: { discord: { token: "tok" } },
+      } as OpenClawConfig,
+      mediaLocalRoots: ["/workspace"],
+      mediaReadFile,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "threadReply",
+        channelId: "123",
+        content: "see attachment",
+        mediaUrl: "/workspace/report.md",
+      }),
+      expect.any(Object),
+      {
+        mediaLocalRoots: ["/workspace"],
+        mediaReadFile,
+      },
+    );
+  });
+
   it("falls back to Discord toolContext.currentChannelId for upload-file", async () => {
     await handleDiscordMessageAction({
       action: "upload-file",


### PR DESCRIPTION
## Summary

Fixes #43570.

### Problem

The `thread-reply` handler in `handle-action.guild-admin.ts` only reads the `media` parameter for attachments, while the `send` handler in `handle-action.ts` reads `media`, `path`, and `filePath` with a fallback chain.

This causes `thread-reply` to **silently ignore** `filePath`/`path` — the tool returns `ok: true` but no attachment is included in the Discord message.

### How I Found This

Running a multi-agent pipeline where one agent generates a daily report and uses `thread-reply` with `filePath` to post it in a Discord forum thread. The tool returned success for two consecutive days but the attachment was consistently missing. Traced the execution path through `message-action-runner.ts` → `handlePluginAction` → Discord plugin → `handle-action.guild-admin.ts` and found the parameter name mismatch.

### Root Cause

```ts
// handle-action.ts (send) — reads all three
const mediaUrl =
  readStringParam(params, "media", { trim: false }) ??
  readStringParam(params, "path", { trim: false }) ??
  readStringParam(params, "filePath", { trim: false });

// handle-action.guild-admin.ts (thread-reply) — only reads media
const mediaUrl = readStringParam(actionParams, "media", { trim: false });
```

## Changes

**`src/channels/plugins/actions/discord/handle-action.guild-admin.ts`**

Align `thread-reply` media parameter reading with `send`:

```diff
  if (action === "thread-reply") {
    const content = readStringParam(actionParams, "message", {
      required: true,
    });
-   const mediaUrl = readStringParam(actionParams, "media", { trim: false });
+   // Support media, path, and filePath — aligned with `send` in handle-action.ts
+   const mediaUrl =
+     readStringParam(actionParams, "media", { trim: false }) ??
+     readStringParam(actionParams, "path", { trim: false }) ??
+     readStringParam(actionParams, "filePath", { trim: false });
```

**`src/channels/plugins/actions/actions.test.ts`**

Added 3 test cases:
- `thread-reply honors filePath when media is not set`
- `thread-reply honors path when media is not set`
- `thread-reply prefers media over filePath`

## Testing

All existing + new tests pass (47/47).
