### PR TITLE
fix(discord): route proxied REST requests through Carbon client

### DIFF
--- a/src/discord/client.proxy.test.ts
+++ b/src/discord/client.proxy.test.ts
@@ -1,0 +1,41 @@
+import type { RequestClient } from "@buape/carbon";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const { applyDiscordProxyToRequestClientMock } = vi.hoisted(() => ({
+  applyDiscordProxyToRequestClientMock: vi.fn((rest: RequestClient) => rest),
+}));
+
+vi.mock("./request-client-proxy.js", () => ({
+  applyDiscordProxyToRequestClient: applyDiscordProxyToRequestClientMock,
+}));
+
+describe("createDiscordRestClient proxy integration", () => {
+  it("applies the account proxy to newly created Discord REST clients", async () => {
+    const { createDiscordRestClient } = await import("./client.js");
+    const cfg = {
+      channels: {
+        discord: {
+          accounts: {
+            main: {
+              token: "discord-token",
+              proxy: "http://proxy.test:8080",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    createDiscordRestClient(
+      {
+        accountId: "main",
+      },
+      cfg,
+    );
+
+    expect(applyDiscordProxyToRequestClientMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      "http://proxy.test:8080",
+    );
+  });
+});

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -8,6 +8,7 @@ import {
   resolveDiscordAccount,
   type ResolvedDiscordAccount,
 } from "./accounts.js";
+import { applyDiscordProxyToRequestClient } from "./request-client-proxy.js";
 import { normalizeDiscordToken } from "./token.js";
 
 export type DiscordClientOpts = {
@@ -29,8 +30,8 @@ function resolveToken(params: { accountId: string; fallbackToken?: string }) {
   return fallback;
 }
 
-function resolveRest(token: string, rest?: RequestClient) {
-  return rest ?? new RequestClient(token);
+function resolveRest(token: string, rest: RequestClient | undefined, proxyUrl?: string) {
+  return applyDiscordProxyToRequestClient(rest ?? new RequestClient(token), proxyUrl);
 }
 
 function resolveAccountWithoutToken(params: {
@@ -66,7 +67,7 @@ export function createDiscordRestClient(
       accountId: account.accountId,
       fallbackToken: account.token,
     });
-  const rest = resolveRest(token, opts.rest);
+  const rest = resolveRest(token, opts.rest, account.config.proxy);
   return { token, rest, account };
 }
 

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -46,6 +46,7 @@ import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 import { summarizeStringEntries } from "../../shared/string-sample.js";
 import { resolveDiscordAccount } from "../accounts.js";
 import { fetchDiscordApplicationId } from "../probe.js";
+import { applyDiscordProxyToRequestClient } from "../request-client-proxy.js";
 import { normalizeDiscordToken } from "../token.js";
 import { createDiscordVoiceCommand } from "../voice/command.js";
 import { DiscordVoiceManager, DiscordVoiceReadyListener } from "../voice/manager.js";
@@ -624,6 +625,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       },
       clientPlugins,
     );
+    applyDiscordProxyToRequestClient(client.rest, rawDiscordCfg.proxy);
     const earlyGatewayErrorGuard = attachEarlyGatewayErrorGuard(client);
     releaseEarlyGatewayErrorGuard = earlyGatewayErrorGuard.release;
 

--- a/src/discord/request-client-proxy.test.ts
+++ b/src/discord/request-client-proxy.test.ts
@@ -48,4 +48,94 @@ describe("applyDiscordProxyToRequestClient", () => {
       directFetchSpy.mockRestore();
     }
   });
+
+  it("does not mutate multipart attachment metadata across repeated executions of the same request", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ id: "123" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const rest = new RequestClient("token-123", { queueRequests: false });
+    applyDiscordProxyToRequestClient(rest, "http://proxy.test:8080");
+
+    type MultipartRequest = {
+      method: "POST";
+      path: string;
+      data: {
+        body: {
+          files: Array<{ data: Blob; name: string }>;
+          attachments?: unknown[];
+        };
+      };
+      routeKey: string;
+    };
+
+    const request: MultipartRequest = {
+      method: "POST",
+      path: "/channels/123/messages",
+      data: {
+        body: {
+          files: [{ data: new Blob(["hello"]), name: "hello.txt" }],
+        },
+      },
+      routeKey: "POST:/channels/123/messages",
+    };
+
+    const executeRequest = (
+      rest as unknown as { executeRequest: (request: MultipartRequest) => Promise<unknown> }
+    ).executeRequest;
+
+    await executeRequest(request);
+    await executeRequest(request);
+
+    const firstCall = fetchMock.mock.calls[0]?.[1] as { body?: FormData } | undefined;
+    const secondCall = fetchMock.mock.calls[1]?.[1] as { body?: FormData } | undefined;
+    const firstPayload = JSON.parse(
+      (Array.from((firstCall?.body ?? new FormData()).entries()).find(
+        ([key]) => key === "payload_json",
+      )?.[1] as string) ?? "{}",
+    ) as { attachments?: unknown[] };
+    const secondPayload = JSON.parse(
+      (Array.from((secondCall?.body ?? new FormData()).entries()).find(
+        ([key]) => key === "payload_json",
+      )?.[1] as string) ?? "{}",
+    ) as { attachments?: unknown[] };
+
+    expect(firstPayload.attachments).toHaveLength(1);
+    expect(secondPayload.attachments).toHaveLength(1);
+    expect((request.data.body as { attachments?: unknown[] }).attachments).toBeUndefined();
+  });
+
+  it("reads the current token for each proxied request", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ id: "123" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const rest = new RequestClient("token-123", { queueRequests: false });
+    applyDiscordProxyToRequestClient(rest, "http://proxy.test:8080");
+    (rest as unknown as { token: string }).token = "rotated-token";
+
+    await rest.get("/users/@me");
+
+    const headers = (fetchMock.mock.calls[0]?.[1] as { headers?: Headers } | undefined)?.headers;
+    expect(headers?.get("Authorization")).toBe("Bot rotated-token");
+  });
+
+  it("does not append a trailing question mark for empty query objects", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ id: "123" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const rest = new RequestClient("token-123", { queueRequests: false });
+    applyDiscordProxyToRequestClient(rest, "http://proxy.test:8080");
+
+    await rest.get("/users/@me", {});
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://discord.com/api/users/@me");
+  });
 });

--- a/src/discord/request-client-proxy.test.ts
+++ b/src/discord/request-client-proxy.test.ts
@@ -1,0 +1,51 @@
+import { RequestClient } from "@buape/carbon";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { applyDiscordProxyToRequestClient } from "./request-client-proxy.js";
+
+const { fetchMock, makeProxyFetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  makeProxyFetchMock: vi.fn(),
+}));
+
+vi.mock("../infra/net/proxy-fetch.js", () => ({
+  makeProxyFetch: makeProxyFetchMock,
+}));
+
+describe("applyDiscordProxyToRequestClient", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    makeProxyFetchMock.mockReset().mockReturnValue(fetchMock);
+  });
+
+  it("routes RequestClient REST calls through the configured proxy fetch", async () => {
+    const directFetchSpy = vi.spyOn(globalThis, "fetch");
+    directFetchSpy.mockRejectedValue(new Error("direct fetch should not be used"));
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ id: "123" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    try {
+      const rest = new RequestClient("token-123", { queueRequests: false });
+
+      applyDiscordProxyToRequestClient(rest, "http://proxy.test:8080");
+      const user = await rest.get("/users/@me");
+
+      expect(user).toEqual({ id: "123" });
+      expect(makeProxyFetchMock).toHaveBeenCalledWith("http://proxy.test:8080");
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://discord.com/api/users/@me",
+        expect.objectContaining({
+          method: "GET",
+          signal: expect.any(AbortSignal),
+          headers: expect.any(Headers),
+        }),
+      );
+      expect(directFetchSpy).not.toHaveBeenCalled();
+    } finally {
+      directFetchSpy.mockRestore();
+    }
+  });
+});

--- a/src/discord/request-client-proxy.ts
+++ b/src/discord/request-client-proxy.ts
@@ -31,11 +31,12 @@ function buildRequestUrl(
   path: string,
   query?: QueuedRequest["query"],
 ) {
-  const queryString = query
-    ? `?${Object.entries(query)
-        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-        .join("&")}`
-    : "";
+  const queryString =
+    query && Object.keys(query).length > 0
+      ? `?${Object.entries(query)
+          .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+          .join("&")}`
+      : "";
   return `${rest.options.baseUrl}${path}${queryString}`;
 }
 
@@ -71,20 +72,21 @@ function buildRequestBody(params: { headers: Headers; data?: RequestData }): Bod
     payload.files?.forEach((file, index) => {
       formData.append(`files[${index}]`, file.data, file.name);
     });
-    if (payload.attachments == null) {
-      payload.attachments = [];
-    }
+    const attachments = [...(payload.attachments ?? [])];
     payload.files?.forEach((file, index) => {
-      payload.attachments?.push({
-        id: index,
-        filename: file.name,
-        description: file.description,
-      });
+      if (!attachments.some((attachment) => attachment.id === index)) {
+        attachments.push({
+          id: index,
+          filename: file.name,
+          description: file.description,
+        });
+      }
     });
     formData.append(
       "payload_json",
       JSON.stringify({
         ...payload,
+        attachments,
         files: undefined,
       }),
     );
@@ -217,9 +219,8 @@ export function applyDiscordProxyToRequestClient(
   }
 
   const proxyFetch = makeProxyFetch(proxy);
-  const token = readToken(rest);
   internal.executeRequest = (request: QueuedRequest) =>
-    executeRequestWithProxy(internal, token, proxyFetch, request);
+    executeRequestWithProxy(internal, readToken(rest), proxyFetch, request);
 
   Object.defineProperty(internal, DISCORD_REQUEST_CLIENT_PROXY_URL, {
     value: proxy,

--- a/src/discord/request-client-proxy.ts
+++ b/src/discord/request-client-proxy.ts
@@ -1,0 +1,232 @@
+import {
+  DiscordError,
+  RateLimitError,
+  RequestClient,
+  type QueuedRequest,
+  type RequestData,
+} from "@buape/carbon";
+import { makeProxyFetch } from "../infra/net/proxy-fetch.js";
+
+const DISCORD_REQUEST_CLIENT_PROXY_URL = Symbol.for("openclaw.discord.requestClient.proxyUrl");
+
+type DiscordRateLimitBody = ConstructorParameters<typeof RateLimitError>[1];
+type DiscordErrorBody = ConstructorParameters<typeof DiscordError>[1];
+
+type RequestClientProxyTarget = {
+  abortController: AbortController | null;
+  executeRequest: (request: QueuedRequest) => Promise<unknown>;
+  options: RequestClient["options"];
+  scheduleRateLimit: (routeKey: string, path: string, error: RateLimitError) => void;
+  updateBucketFromHeaders: (routeKey: string, path: string, response: Response) => void;
+  waitForBucket: (routeKey: string) => Promise<void>;
+  [DISCORD_REQUEST_CLIENT_PROXY_URL]?: string;
+};
+
+function readToken(rest: RequestClient): string {
+  return (rest as unknown as { token: string }).token;
+}
+
+function buildRequestUrl(
+  rest: RequestClientProxyTarget,
+  path: string,
+  query?: QueuedRequest["query"],
+) {
+  const queryString = query
+    ? `?${Object.entries(query)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+        .join("&")}`
+    : "";
+  return `${rest.options.baseUrl}${path}${queryString}`;
+}
+
+function buildHeaders(rest: RequestClientProxyTarget, token: string, data?: RequestData): Headers {
+  const headers =
+    token === "webhook"
+      ? new Headers()
+      : new Headers({
+          Authorization: `${rest.options.tokenHeader} ${token}`,
+        });
+
+  if (data?.headers) {
+    for (const [key, value] of Object.entries(data.headers)) {
+      headers.set(key, value);
+    }
+  }
+
+  return headers;
+}
+
+function buildRequestBody(params: { headers: Headers; data?: RequestData }): BodyInit | undefined {
+  const { headers, data } = params;
+  if (
+    data?.body &&
+    typeof FormData !== "undefined" &&
+    "files" in (data.body as Record<string, unknown>)
+  ) {
+    const formData = new FormData();
+    const payload = data.body as {
+      files?: Array<{ data: Blob; name: string; description?: string }>;
+      attachments?: Array<Record<string, unknown>>;
+    };
+    payload.files?.forEach((file, index) => {
+      formData.append(`files[${index}]`, file.data, file.name);
+    });
+    if (payload.attachments == null) {
+      payload.attachments = [];
+    }
+    payload.files?.forEach((file, index) => {
+      payload.attachments?.push({
+        id: index,
+        filename: file.name,
+        description: file.description,
+      });
+    });
+    formData.append(
+      "payload_json",
+      JSON.stringify({
+        ...payload,
+        files: undefined,
+      }),
+    );
+    return formData;
+  }
+
+  if (data?.body != null) {
+    headers.set("Content-Type", "application/json");
+    return data.rawBody ? (data.body as BodyInit) : JSON.stringify(data.body);
+  }
+
+  return undefined;
+}
+
+async function executeRequestWithProxy(
+  rest: RequestClientProxyTarget,
+  token: string,
+  fetchImpl: typeof fetch,
+  request: QueuedRequest,
+): Promise<unknown> {
+  const { method, path, data, query, routeKey } = request;
+  await rest.waitForBucket(routeKey);
+
+  const url = buildRequestUrl(rest, path, query);
+  const headers = buildHeaders(rest, token, data);
+  const body = buildRequestBody({ headers, data });
+
+  rest.abortController = new AbortController();
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  if (rest.options.timeout !== undefined) {
+    timeoutId = setTimeout(() => {
+      rest.abortController?.abort();
+    }, rest.options.timeout);
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method,
+      headers,
+      body,
+      signal: rest.abortController.signal,
+    });
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  let rawBody = "";
+  let parsedBody: unknown;
+  try {
+    rawBody = await response.text();
+  } catch {
+    rawBody = "";
+  }
+  if (rawBody.length > 0) {
+    try {
+      parsedBody = JSON.parse(rawBody);
+    } catch {
+      parsedBody = undefined;
+    }
+  }
+
+  if (response.status === 429) {
+    const rateLimitBody: DiscordRateLimitBody =
+      parsedBody &&
+      typeof parsedBody === "object" &&
+      "retry_after" in parsedBody &&
+      "message" in parsedBody &&
+      "global" in parsedBody
+        ? (parsedBody as DiscordRateLimitBody)
+        : {
+            message:
+              typeof parsedBody === "string"
+                ? parsedBody
+                : rawBody || "You are being rate limited.",
+            retry_after: (() => {
+              const retryAfterHeader = response.headers.get("Retry-After");
+              if (retryAfterHeader && !Number.isNaN(Number(retryAfterHeader))) {
+                return Number(retryAfterHeader);
+              }
+              return 1;
+            })(),
+            global: response.headers.get("X-RateLimit-Scope") === "global",
+          };
+    const rateLimitError = new RateLimitError(response, rateLimitBody);
+    rest.scheduleRateLimit(routeKey, path, rateLimitError);
+    throw rateLimitError;
+  }
+
+  rest.updateBucketFromHeaders(routeKey, path, response);
+
+  if (response.status >= 400 && response.status < 600) {
+    const discordErrorBody: DiscordErrorBody =
+      parsedBody &&
+      typeof parsedBody === "object" &&
+      "message" in parsedBody &&
+      "code" in parsedBody
+        ? (parsedBody as DiscordErrorBody)
+        : {
+            message: rawBody || "Discord API error",
+            code: 0,
+          };
+    throw new DiscordError(response, discordErrorBody);
+  }
+
+  if (parsedBody !== undefined) {
+    return parsedBody;
+  }
+  if (rawBody.length > 0) {
+    return rawBody;
+  }
+  return null;
+}
+
+export function applyDiscordProxyToRequestClient(
+  rest: RequestClient,
+  proxyUrl: string | undefined,
+): RequestClient {
+  const proxy = proxyUrl?.trim();
+  if (!proxy) {
+    return rest;
+  }
+
+  const internal = rest as unknown as RequestClientProxyTarget;
+  if (internal[DISCORD_REQUEST_CLIENT_PROXY_URL] === proxy) {
+    return rest;
+  }
+
+  const proxyFetch = makeProxyFetch(proxy);
+  const token = readToken(rest);
+  internal.executeRequest = (request: QueuedRequest) =>
+    executeRequestWithProxy(internal, token, proxyFetch, request);
+
+  Object.defineProperty(internal, DISCORD_REQUEST_CLIENT_PROXY_URL, {
+    value: proxy,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+
+  return rest;
+}


### PR DESCRIPTION
## Summary
- route Discord Carbon REST client requests through the configured `channels.discord.proxy`
- apply the proxy patch both to shared Discord REST clients and the monitor provider client
- add regression tests for the RequestClient proxy patch and Discord client integration

## Why
In proxy-required networks, Discord gateway login could succeed while Carbon REST calls still bypassed the configured proxy. That caused startup errors like `failed to fetch bot identity: TypeError: fetch failed` and `failed to deploy native commands: fetch failed`, leaving bots online but non-responsive.

## Testing
- `pnpm exec vitest run src/discord/request-client-proxy.test.ts src/discord/client.proxy.test.ts src/discord/client.test.ts src/discord/monitor/provider.proxy.test.ts src/discord/monitor/provider.rest-proxy.test.ts`
- `pnpm build`
- `pnpm check`
- `pnpm test`

## AI-assisted
- AI-assisted: yes
- Testing depth: fully tested locally
- Source repo verification included foreground `openclawsource gateway run --verbose --force` to confirm Discord startup no longer emits the REST `fetch failed` errors in a proxy-required environment.