### PR TITLE
decode Windows console output (GBK/CP936)

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -57,6 +57,18 @@ export function shouldUseShellForCommand(cmd, platform = process.platform) {
   if (platform !== "win32") {
     return false;
   }
+  // When `which()` resolves to an absolute path like
+  // `C:\Program Files\nodejs\pnpm.CMD`, spawning that directly works
+  // without `shell: true`. Using `shell: true` with such paths causes
+  // Windows to split on the space (`C:\Program`) and fail.
+  //
+  // To avoid this, only route through the shell for bare command names
+  // (no path separators). Anything that already contains a path is
+  // executed directly.
+  const hasPathSeparator = cmd.includes("\\") || cmd.includes("/");
+  if (hasPathSeparator) {
+    return false;
+  }
   const extension = path.extname(cmd).toLowerCase();
   return WINDOWS_SHELL_EXTENSIONS.has(extension);
 }
@@ -69,30 +81,44 @@ export function assertSafeWindowsShellArgs(args, platform = process.platform) {
   if (!unsafeArg) {
     return;
   }
-  // SECURITY: `shell: true` routes through cmd.exe; reject risky metacharacters
-  // in forwarded args to prevent shell control-flow/env-expansion injection.
+  // Reject risky metacharacters when we have to construct a cmd.exe
+  // command line to avoid shell injection issues.
   throw new Error(
     `Unsafe Windows shell argument: ${unsafeArg}. Remove shell metacharacters (" & | < > ^ % !).`,
   );
 }
 
-function createSpawnOptions(cmd, args, envOverride) {
-  const useShell = shouldUseShellForCommand(cmd);
-  if (useShell) {
-    assertSafeWindowsShellArgs(args);
-  }
+function createSpawnOptions(_cmd, _args, envOverride) {
   return {
     cwd: uiDir,
     stdio: "inherit",
     env: envOverride ?? process.env,
-    ...(useShell ? { shell: true } : {}),
   };
+}
+
+function normalizeWindowsCommand(cmd, args) {
+  if (process.platform !== "win32") {
+    return { command: cmd, commandArgs: args };
+  }
+  const extension = path.extname(cmd).toLowerCase();
+  if (!WINDOWS_SHELL_EXTENSIONS.has(extension)) {
+    return { command: cmd, commandArgs: args };
+  }
+
+  const hasPathSeparator = cmd.includes("\\") || cmd.includes("/");
+  const quotedCmd = hasPathSeparator ? `"${cmd}"` : cmd;
+  const commandLine = args.length > 0 ? `${quotedCmd} ${args.join(" ")}` : quotedCmd;
+
+  const command = process.env.comspec || "cmd.exe";
+  const commandArgs = ["/d", "/s", "/c", commandLine];
+  return { command, commandArgs };
 }
 
 function run(cmd, args) {
   let child;
+  const { command, commandArgs } = normalizeWindowsCommand(cmd, args);
   try {
-    child = spawn(cmd, args, createSpawnOptions(cmd, args));
+    child = spawn(command, commandArgs, createSpawnOptions(command, commandArgs));
   } catch (err) {
     console.error(`Failed to launch ${cmd}:`, err);
     process.exit(1);
@@ -112,8 +138,9 @@ function run(cmd, args) {
 
 function runSync(cmd, args, envOverride) {
   let result;
+  const { command, commandArgs } = normalizeWindowsCommand(cmd, args);
   try {
-    result = spawnSync(cmd, args, createSpawnOptions(cmd, args, envOverride));
+    result = spawnSync(command, commandArgs, createSpawnOptions(command, commandArgs, envOverride));
   } catch (err) {
     console.error(`Failed to launch ${cmd}:`, err);
     process.exit(1);

--- a/src/node-host/invoke.sanitize-env.test.ts
+++ b/src/node-host/invoke.sanitize-env.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
+import {
+  decodeCapturedOutputBuffer,
+  parseWindowsCodePage,
+} from "../process/windows-console-encoding.js";
 import { withEnv } from "../test-utils/env.js";
-import { decodeCapturedOutputBuffer, parseWindowsCodePage, sanitizeEnv } from "./invoke.js";
+import { sanitizeEnv } from "./invoke.js";
 import { buildNodeInvokeResultParams } from "./runner.js";
 
 describe("node-host sanitizeEnv", () => {

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { GatewayClient } from "../gateway/client.js";
@@ -19,6 +19,10 @@ import {
   type ExecHostResponse,
 } from "../infra/exec-host.js";
 import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
+import {
+  decodeCapturedOutputBuffer,
+  resolveWindowsConsoleEncoding,
+} from "../process/windows-console-encoding.js";
 import { runBrowserProxyCommand } from "./invoke-browser.js";
 import { buildSystemRunApprovalPlan, handleSystemRunInvoke } from "./invoke-system-run.js";
 import type {
@@ -32,16 +36,6 @@ import type {
 const OUTPUT_CAP = 200_000;
 const OUTPUT_EVENT_TAIL = 20_000;
 const DEFAULT_NODE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
-  65001: "utf-8",
-  54936: "gb18030",
-  936: "gbk",
-  950: "big5",
-  932: "shift_jis",
-  949: "euc-kr",
-  1252: "windows-1252",
-};
-let cachedWindowsConsoleEncoding: string | null | undefined;
 
 const execHostEnforced = process.env.OPENCLAW_NODE_EXEC_HOST?.trim().toLowerCase() === "app";
 const execHostFallbackAllowed =
@@ -101,65 +95,6 @@ function truncateOutput(raw: string, maxChars: number): { text: string; truncate
     return { text: raw, truncated: false };
   }
   return { text: `... (truncated) ${raw.slice(raw.length - maxChars)}`, truncated: true };
-}
-
-export function parseWindowsCodePage(raw: string): number | null {
-  if (!raw) {
-    return null;
-  }
-  const match = raw.match(/\b(\d{3,5})\b/);
-  if (!match?.[1]) {
-    return null;
-  }
-  const codePage = Number.parseInt(match[1], 10);
-  if (!Number.isFinite(codePage) || codePage <= 0) {
-    return null;
-  }
-  return codePage;
-}
-
-function resolveWindowsConsoleEncoding(): string | null {
-  if (process.platform !== "win32") {
-    return null;
-  }
-  if (cachedWindowsConsoleEncoding !== undefined) {
-    return cachedWindowsConsoleEncoding;
-  }
-  try {
-    const result = spawnSync("cmd.exe", ["/d", "/s", "/c", "chcp"], {
-      windowsHide: true,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-    const codePage = parseWindowsCodePage(raw);
-    cachedWindowsConsoleEncoding =
-      codePage !== null ? (WINDOWS_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
-  } catch {
-    cachedWindowsConsoleEncoding = null;
-  }
-  return cachedWindowsConsoleEncoding;
-}
-
-export function decodeCapturedOutputBuffer(params: {
-  buffer: Buffer;
-  platform?: NodeJS.Platform;
-  windowsEncoding?: string | null;
-}): string {
-  const utf8 = params.buffer.toString("utf8");
-  const platform = params.platform ?? process.platform;
-  if (platform !== "win32") {
-    return utf8;
-  }
-  const encoding = params.windowsEncoding ?? resolveWindowsConsoleEncoding();
-  if (!encoding || encoding.toLowerCase() === "utf-8") {
-    return utf8;
-  }
-  try {
-    return new TextDecoder(encoding).decode(params.buffer);
-  } catch {
-    return utf8;
-  }
 }
 
 function redactExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -8,6 +8,7 @@ import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
 import { logDebug, logError } from "../logger.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
 import { resolveWindowsCommandShim } from "./windows-command.js";
+import { resolveWindowsConsoleEncoding } from "./windows-console-encoding.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -224,6 +225,15 @@ export async function runCommandWithTimeout(
   const finalArgv = process.platform === "win32" ? (resolveNpmArgvForWindows(argv) ?? argv) : argv;
   const resolvedCommand = finalArgv !== argv ? (finalArgv[0] ?? "") : resolveCommand(argv[0] ?? "");
   const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
+  const windowsEncoding = resolveWindowsConsoleEncoding();
+  const stdoutDecoder =
+    process.platform === "win32" && windowsEncoding && windowsEncoding.toLowerCase() !== "utf-8"
+      ? new TextDecoder(windowsEncoding)
+      : null;
+  const stderrDecoder =
+    process.platform === "win32" && windowsEncoding && windowsEncoding.toLowerCase() !== "utf-8"
+      ? new TextDecoder(windowsEncoding)
+      : null;
   const child = spawn(
     useCmdWrapper ? (process.env.ComSpec ?? "cmd.exe") : resolvedCommand,
     useCmdWrapper
@@ -290,11 +300,13 @@ export async function runCommandWithTimeout(
     }
 
     child.stdout?.on("data", (d) => {
-      stdout += d.toString();
+      const chunk = d as Buffer;
+      stdout += stdoutDecoder ? stdoutDecoder.decode(chunk, { stream: true }) : chunk.toString();
       armNoOutputTimer();
     });
     child.stderr?.on("data", (d) => {
-      stderr += d.toString();
+      const chunk = d as Buffer;
+      stderr += stderrDecoder ? stderrDecoder.decode(chunk, { stream: true }) : chunk.toString();
       armNoOutputTimer();
     });
     child.on("error", (err) => {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -2,6 +2,7 @@ import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_pr
 import { killProcessTree } from "../../kill-tree.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
 import { resolveWindowsCommandShim } from "../../windows-command.js";
+import { resolveWindowsConsoleEncoding } from "../../windows-console-encoding.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
 
@@ -100,15 +101,33 @@ export async function createChildAdapter(params: {
       }
     : undefined;
 
+  const windowsEncoding = resolveWindowsConsoleEncoding();
+  const stdoutDecoder =
+    process.platform === "win32" && windowsEncoding && windowsEncoding.toLowerCase() !== "utf-8"
+      ? new TextDecoder(windowsEncoding)
+      : null;
+  const stderrDecoder =
+    process.platform === "win32" && windowsEncoding && windowsEncoding.toLowerCase() !== "utf-8"
+      ? new TextDecoder(windowsEncoding)
+      : null;
+
   const onStdout = (listener: (chunk: string) => void) => {
     child.stdout.on("data", (chunk) => {
-      listener(chunk.toString());
+      if (stdoutDecoder) {
+        listener(stdoutDecoder.decode(chunk as Buffer, { stream: true }));
+        return;
+      }
+      listener((chunk as Buffer).toString());
     });
   };
 
   const onStderr = (listener: (chunk: string) => void) => {
     child.stderr.on("data", (chunk) => {
-      listener(chunk.toString());
+      if (stderrDecoder) {
+        listener(stderrDecoder.decode(chunk as Buffer, { stream: true }));
+        return;
+      }
+      listener((chunk as Buffer).toString());
     });
   };
 

--- a/src/process/windows-console-encoding.ts
+++ b/src/process/windows-console-encoding.ts
@@ -1,0 +1,72 @@
+import { spawnSync } from "node:child_process";
+
+const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
+  65001: "utf-8",
+  54936: "gb18030",
+  936: "gbk",
+  950: "big5",
+  932: "shift_jis",
+  949: "euc-kr",
+  1252: "windows-1252",
+};
+
+let cachedWindowsConsoleEncoding: string | null | undefined;
+
+export function parseWindowsCodePage(raw: string): number | null {
+  if (!raw) {
+    return null;
+  }
+  const match = raw.match(/\b(\d{3,5})\b/);
+  if (!match?.[1]) {
+    return null;
+  }
+  const codePage = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(codePage) || codePage <= 0) {
+    return null;
+  }
+  return codePage;
+}
+
+export function resolveWindowsConsoleEncoding(): string | null {
+  if (process.platform !== "win32") {
+    return null;
+  }
+  if (cachedWindowsConsoleEncoding !== undefined) {
+    return cachedWindowsConsoleEncoding;
+  }
+  try {
+    const result = spawnSync("cmd.exe", ["/d", "/s", "/c", "chcp"], {
+      windowsHide: true,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+    const codePage = parseWindowsCodePage(raw);
+    cachedWindowsConsoleEncoding =
+      codePage !== null ? (WINDOWS_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
+  } catch {
+    cachedWindowsConsoleEncoding = null;
+  }
+  return cachedWindowsConsoleEncoding;
+}
+
+export function decodeCapturedOutputBuffer(params: {
+  buffer: Buffer;
+  platform?: NodeJS.Platform;
+  windowsEncoding?: string | null;
+}): string {
+  const utf8 = params.buffer.toString("utf8");
+  const platform = params.platform ?? process.platform;
+  if (platform !== "win32") {
+    return utf8;
+  }
+  const encoding = params.windowsEncoding ?? resolveWindowsConsoleEncoding();
+  if (!encoding || encoding.toLowerCase() === "utf-8") {
+    return utf8;
+  }
+  try {
+    return new TextDecoder(encoding).decode(params.buffer);
+  } catch {
+    return utf8;
+  }
+}


### PR DESCRIPTION
Add a shared Windows console encoding helper that detects the active code page via chcp and decodes captured output with TextDecoder (e.g. CP936/GBK, GB18030). Use that decoder for streamed stdout/stderr in the supervisor child adapter so Windows commands no longer appear garbled when they emit non‑UTF8 text. Apply the same decoding in runCommandWithTimeout() for non‑supervisor spawn paths. Refactor node-host to reuse the shared decoder and update tests accordingly. Harden Windows spawning in scripts/ui.js by avoiding shell: true for resolved absolute paths and routing .cmd/.bat through an explicit cmd.exe /c wrapper.