### PR TITLE
fix(gateway): fall back to PowerShell when wmic is unavailable on Win…

### DIFF
--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -248,9 +248,7 @@ async function resolveWindowsImageName(pid: number): Promise<string | undefined>
   return undefined;
 }
 
-async function resolveWindowsCommandLineViaPowerShell(
-  pid: number,
-): Promise<string | undefined> {
+async function resolveWindowsCommandLineViaPowerShell(pid: number): Promise<string | undefined> {
   const res = await runCommandSafe([
     "powershell",
     "-NoProfile",
@@ -282,10 +280,10 @@ async function resolveWindowsCommandLine(pid: number): Promise<string | undefine
         continue;
       }
       const value = line.slice("commandline=".length).trim();
-      if (value) {
-        return value;
-      }
+      return value || undefined;
     }
+    // wmic succeeded but produced no commandline — don't fallback.
+    return undefined;
   }
   // Fallback to PowerShell Get-CimInstance when wmic is unavailable.
   return resolveWindowsCommandLineViaPowerShell(pid);

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -248,7 +248,24 @@ async function resolveWindowsImageName(pid: number): Promise<string | undefined>
   return undefined;
 }
 
+async function resolveWindowsCommandLineViaPowerShell(
+  pid: number,
+): Promise<string | undefined> {
+  const res = await runCommandSafe([
+    "powershell",
+    "-NoProfile",
+    "-Command",
+    `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").CommandLine`,
+  ]);
+  if (res.code !== 0) {
+    return undefined;
+  }
+  const value = res.stdout.trim();
+  return value || undefined;
+}
+
 async function resolveWindowsCommandLine(pid: number): Promise<string | undefined> {
+  // Try wmic first (fast, but deprecated/removed on modern Windows 11+).
   const res = await runCommandSafe([
     "wmic",
     "process",
@@ -258,18 +275,20 @@ async function resolveWindowsCommandLine(pid: number): Promise<string | undefine
     "CommandLine",
     "/value",
   ]);
-  if (res.code !== 0) {
-    return undefined;
-  }
-  for (const rawLine of res.stdout.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line.toLowerCase().startsWith("commandline=")) {
-      continue;
+  if (res.code === 0) {
+    for (const rawLine of res.stdout.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line.toLowerCase().startsWith("commandline=")) {
+        continue;
+      }
+      const value = line.slice("commandline=".length).trim();
+      if (value) {
+        return value;
+      }
     }
-    const value = line.slice("commandline=".length).trim();
-    return value || undefined;
   }
-  return undefined;
+  // Fallback to PowerShell Get-CimInstance when wmic is unavailable.
+  return resolveWindowsCommandLineViaPowerShell(pid);
 }
 
 async function readWindowsListeners(


### PR DESCRIPTION

  ## Summary

  - `openclaw gateway restart` always times out (60s) on Windows machines where `wmic` has been removed (Windows 11+), even though the gateway        
  restarts successfully
  - Fix: fall back to PowerShell `Get-CimInstance Win32_Process` when `wmic` fails, restoring correct process classification on modern Windows        

  ## Root Cause

  Microsoft deprecated and removed `wmic.exe` on modern Windows (11+). This causes `resolveWindowsCommandLine()` in `src/infra/ports-inspect.ts` to   
  silently fail, returning no command line for port listeners. The restart health check then only sees `"node.exe"` (the image name from `tasklist`), 
  which `classifyPortListener()` cannot identify as a gateway process — it requires `"openclaw"` in the command string. This results in:

  ownsPort = false → healthy = false → 60s timeout loop → false failure report

  The gateway is actually running and healthy the entire time.

  ## Fix

  When `wmic` returns a non-zero exit code or produces no output, fall back to `powershell -NoProfile -Command "(Get-CimInstance Win32_Process -Filter
   'ProcessId=<pid>').CommandLine"` to retrieve the full command line. This is the Microsoft-recommended replacement for `wmic process get
  CommandLine`.

  ## Related

  - #32620 — same class of bug on Linux when `lsof` is missing (open)
  - #32613 — fix PR for the Linux variant (open, not yet merged)

  ## Test plan

  - [x] Verified on Windows machine without `wmic`: health check now correctly identifies the gateway process via PowerShell fallback
  - [x] When `wmic` is available, behavior is unchanged (wmic path taken first)
  - [x] When both `wmic` and `powershell` fail, returns `undefined` gracefully (same as before)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)