### PR TITLE
fix: restore export-html template placeholders and prevent reformatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto eol=lf
 CLAUDE.md -text
 src/gateway/server-methods/CLAUDE.md -text
+src/auto-reply/reply/export-html/template.html -text

--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -1,88 +1,54 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Session Export</title>
-    <style>
-      {{CSS}}
-    </style>
-  </head>
-  <body>
-    <button id="hamburger" title="Open sidebar">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
-        <circle cx="6" cy="6" r="2.5" />
-        <circle cx="6" cy="18" r="2.5" />
-        <circle cx="18" cy="12" r="2.5" />
-        <rect x="5" y="6" width="2" height="12" />
-        <path d="M6 12h10c1 0 2 0 2-2V8" />
-      </svg>
-    </button>
-    <div id="sidebar-overlay"></div>
-    <div id="app">
-      <aside id="sidebar">
-        <div class="sidebar-header">
-          <div class="sidebar-controls">
-            <input type="text" class="sidebar-search" id="tree-search" placeholder="Search..." />
-          </div>
-          <div class="sidebar-filters">
-            <button class="filter-btn active" data-filter="default" title="Hide settings entries">
-              Default
-            </button>
-            <button class="filter-btn" data-filter="no-tools" title="Default minus tool results">
-              No-tools
-            </button>
-            <button class="filter-btn" data-filter="user-only" title="Only user messages">
-              User
-            </button>
-            <button class="filter-btn" data-filter="labeled-only" title="Only labeled entries">
-              Labeled
-            </button>
-            <button class="filter-btn" data-filter="all" title="Show everything">All</button>
-            <button class="sidebar-close" id="sidebar-close" title="Close">✕</button>
-          </div>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Session Export</title>
+  <style>
+{{CSS}}
+  </style>
+</head>
+<body>
+  <button id="hamburger" title="Open sidebar"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="12" r="2.5"/><rect x="5" y="6" width="2" height="12"/><path d="M6 12h10c1 0 2 0 2-2V8"/></svg></button>
+  <div id="sidebar-overlay"></div>
+  <div id="app">
+    <aside id="sidebar">
+      <div class="sidebar-header">
+        <div class="sidebar-controls">
+          <input type="text" class="sidebar-search" id="tree-search" placeholder="Search...">
         </div>
-        <div class="tree-container" id="tree-container"></div>
-        <div class="tree-status" id="tree-status"></div>
-      </aside>
-      <main id="content">
-        <div id="header-container"></div>
-        <div id="messages"></div>
-      </main>
-      <div id="image-modal" class="image-modal">
-        <img id="modal-image" src="" alt="" />
+        <div class="sidebar-filters">
+          <button class="filter-btn active" data-filter="default" title="Hide settings entries">Default</button>
+          <button class="filter-btn" data-filter="no-tools" title="Default minus tool results">No-tools</button>
+          <button class="filter-btn" data-filter="user-only" title="Only user messages">User</button>
+          <button class="filter-btn" data-filter="labeled-only" title="Only labeled entries">Labeled</button>
+          <button class="filter-btn" data-filter="all" title="Show everything">All</button>
+          <button class="sidebar-close" id="sidebar-close" title="Close">✕</button>
+        </div>
       </div>
+      <div class="tree-container" id="tree-container"></div>
+      <div class="tree-status" id="tree-status"></div>
+    </aside>
+    <main id="content">
+      <div id="header-container"></div>
+      <div id="messages"></div>
+    </main>
+    <div id="image-modal" class="image-modal">
+      <img id="modal-image" src="" alt="">
     </div>
+  </div>
 
-    <script id="session-data" type="application/json">
-      {{SESSION_DATA}}
-    </script>
+  <script id="session-data" type="application/json">{{SESSION_DATA}}</script>
 
-    <!-- Vendored libraries -->
-    <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
-    </script>
+  <!-- Vendored libraries -->
+  <script>{{MARKED_JS}}</script>
 
-    <!-- highlight.js -->
-    <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
-    </script>
+  <!-- highlight.js -->
+  <script>{{HIGHLIGHT_JS}}</script>
 
-    <!-- Main application code -->
-    <script>
-      {
-        {
-          JS;
-        }
-      }
-    </script>
-  </body>
+  <!-- Main application code -->
+  <script>
+{{JS}}
+  </script>
+</body>
 </html>


### PR DESCRIPTION
This PR fixes the export-html template that was broken by a formatter.

**What was broken:**
- The template placeholders , , and  were being split into multiple lines by the formatter
- This caused the export-html functionality to fail because the placeholders couldn't be recognized

**What this PR does:**
1. Restores the original template.html with correct placeholder formatting
2. Adds  to  to prevent future reformatting
3. Keeps the existing ignore in  as an extra layer of protection

Closes #43616, #43620