### PR TITLE
feat(secrets): add AWS Secrets Manager provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@discordjs/voice':
         specifier: ^0.19.1
         version: 0.19.1(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@google-cloud/secret-manager':
+        specifier: ^6.1.1
+        version: 6.1.1
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.41.1)
@@ -1370,14 +1373,9 @@ packages:
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
-  '@exodus/bytes@1.15.0':
-    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@noble/hashes': ^1.8.0 || ^2.0.0
-    peerDependenciesMeta:
-      '@noble/hashes':
-        optional: true
+  '@google-cloud/secret-manager@6.1.1':
+    resolution: {integrity: sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==}
+    engines: {node: '>=18'}
 
   '@google/genai@1.44.0':
     resolution: {integrity: sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==}
@@ -3468,6 +3466,10 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -4426,6 +4428,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -4780,6 +4785,10 @@ packages:
     resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
     engines: {node: '>=18'}
 
+  google-gax@5.0.6:
+    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
+    engines: {node: '>=18'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
@@ -4877,6 +4886,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -5611,6 +5624,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -5937,6 +5954,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
   protobufjs@6.8.8:
     resolution: {integrity: sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==}
     hasBin: true
@@ -6123,6 +6144,10 @@ packages:
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
     engines: {node: '>=18'}
 
   retry@0.12.0:
@@ -6419,6 +6444,12 @@ packages:
     resolution: {integrity: sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==}
     engines: {node: '>=18'}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
@@ -6470,6 +6501,9 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -6490,6 +6524,10 @@ packages:
 
   tar@7.5.11:
     resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+    engines: {node: '>=18'}
+
+  teeny-request@10.1.0:
+    resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -8638,9 +8676,11 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
-    optionalDependencies:
-      '@noble/hashes': 2.0.1
+  '@google-cloud/secret-manager@6.1.1':
+    dependencies:
+      google-gax: 5.0.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@google/genai@1.44.0':
     dependencies:
@@ -11000,6 +11040,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tootallnate/once@2.0.0': {}
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@twurple/api-call@8.0.3':
@@ -11462,7 +11504,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   agent-base@7.1.4: {}
 
@@ -12045,6 +12086,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
 
   ecc-jsbn@0.1.2:
@@ -12515,6 +12563,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      duplexify: 4.1.3
+      google-auth-library: 10.6.1
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.5.4
+      retry-request: 8.0.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
@@ -12631,6 +12695,14 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -12650,7 +12722,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -13424,6 +13495,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@3.0.0: {}
+
   object-inspect@1.13.4: {}
 
   object-path@0.11.8: {}
@@ -13836,6 +13909,10 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.5.4
+
   protobufjs@6.8.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -14035,7 +14112,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   readdirp@5.0.0: {}
 
@@ -14087,6 +14163,13 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   retry@0.12.0: {}
 
@@ -14471,6 +14554,12 @@ snapshots:
 
   steno@4.0.2: {}
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   streamx@2.23.0:
     dependencies:
       events-universal: 1.0.1
@@ -14510,7 +14599,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -14534,6 +14622,8 @@ snapshots:
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  stubs@3.0.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -14566,6 +14656,15 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  teeny-request@10.1.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   teex@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,6 @@ importers:
       '@discordjs/voice':
         specifier: ^0.19.1
         version: 0.19.1(@discordjs/opus@0.10.0)(opusscript@0.1.1)
-      '@google-cloud/secret-manager':
-        specifier: ^6.1.1
-        version: 6.1.1
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.41.1)
@@ -1373,9 +1370,14 @@ packages:
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
-  '@google-cloud/secret-manager@6.1.1':
-    resolution: {integrity: sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==}
-    engines: {node: '>=18'}
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@google/genai@1.44.0':
     resolution: {integrity: sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==}
@@ -3466,10 +3468,6 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
-    engines: {node: '>= 10'}
-
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -4428,9 +4426,6 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  duplexify@4.1.3:
-    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
-
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -4785,10 +4780,6 @@ packages:
     resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
     engines: {node: '>=18'}
 
-  google-gax@5.0.6:
-    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
-    engines: {node: '>=18'}
-
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
@@ -4886,10 +4877,6 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  http-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
-    engines: {node: '>= 6'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -5624,10 +5611,6 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -5954,10 +5937,6 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  proto3-json-serializer@3.0.4:
-    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
-    engines: {node: '>=18'}
-
   protobufjs@6.8.8:
     resolution: {integrity: sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==}
     hasBin: true
@@ -6144,10 +6123,6 @@ packages:
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
-  retry-request@8.0.2:
-    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
     engines: {node: '>=18'}
 
   retry@0.12.0:
@@ -6444,12 +6419,6 @@ packages:
     resolution: {integrity: sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==}
     engines: {node: '>=18'}
 
-  stream-events@1.0.5:
-    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
-
-  stream-shift@1.0.3:
-    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
-
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
@@ -6501,9 +6470,6 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
-  stubs@3.0.0:
-    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -6524,10 +6490,6 @@ packages:
 
   tar@7.5.11:
     resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
-    engines: {node: '>=18'}
-
-  teeny-request@10.1.0:
-    resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -8676,11 +8638,9 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@google-cloud/secret-manager@6.1.1':
-    dependencies:
-      google-gax: 5.0.6
-    transitivePeerDependencies:
-      - supports-color
+  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
 
   '@google/genai@1.44.0':
     dependencies:
@@ -11040,8 +11000,6 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tootallnate/once@2.0.0': {}
-
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@twurple/api-call@8.0.3':
@@ -11504,6 +11462,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   agent-base@7.1.4: {}
 
@@ -12086,13 +12045,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  duplexify@4.1.3:
-    dependencies:
-      end-of-stream: 1.4.5
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-      stream-shift: 1.0.3
-
   eastasianwidth@0.2.0: {}
 
   ecc-jsbn@0.1.2:
@@ -12563,22 +12515,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  google-gax@5.0.6:
-    dependencies:
-      '@grpc/grpc-js': 1.14.3
-      '@grpc/proto-loader': 0.8.0
-      duplexify: 4.1.3
-      google-auth-library: 10.6.1
-      google-logging-utils: 1.1.3
-      node-fetch: 3.3.2
-      object-hash: 3.0.0
-      proto3-json-serializer: 3.0.4
-      protobufjs: 7.5.4
-      retry-request: 8.0.2
-      rimraf: 5.0.10
-    transitivePeerDependencies:
-      - supports-color
-
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
@@ -12695,14 +12631,6 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@5.0.0:
-    dependencies:
-      '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -12722,6 +12650,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -13495,8 +13424,6 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  object-hash@3.0.0: {}
-
   object-inspect@1.13.4: {}
 
   object-path@0.11.8: {}
@@ -13909,10 +13836,6 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  proto3-json-serializer@3.0.4:
-    dependencies:
-      protobufjs: 7.5.4
-
   protobufjs@6.8.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -14112,6 +14035,7 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    optional: true
 
   readdirp@5.0.0: {}
 
@@ -14163,13 +14087,6 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
-
-  retry-request@8.0.2:
-    dependencies:
-      extend: 3.0.2
-      teeny-request: 10.1.0
-    transitivePeerDependencies:
-      - supports-color
 
   retry@0.12.0: {}
 
@@ -14554,12 +14471,6 @@ snapshots:
 
   steno@4.0.2: {}
 
-  stream-events@1.0.5:
-    dependencies:
-      stubs: 3.0.0
-
-  stream-shift@1.0.3: {}
-
   streamx@2.23.0:
     dependencies:
       events-universal: 1.0.1
@@ -14599,6 +14510,7 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -14622,8 +14534,6 @@ snapshots:
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
-
-  stubs@3.0.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -14656,15 +14566,6 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
-
-  teeny-request@10.1.0:
-    dependencies:
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      node-fetch: 3.3.2
-      stream-events: 1.0.5
-    transitivePeerDependencies:
-      - supports-color
 
   teex@1.0.1:
     dependencies:

--- a/src/config/aws-secret-provider.test.ts
+++ b/src/config/aws-secret-provider.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for AWS Secrets Manager provider.
+ *
+ * All tests use mocked SDK — no real AWS credentials needed.
+ */
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { clearSecretCache, type SecretProvider } from "./secret-resolution.js";
+
+// ---------------------------------------------------------------------------
+// Mock AWS SDK
+// ---------------------------------------------------------------------------
+
+const mockSend = vi.fn();
+
+function makeCmd(type: string) {
+  return class {
+    _type = type;
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  };
+}
+
+vi.mock("@aws-sdk/client-secrets-manager", () => {
+  class MockSecretsManagerClient {
+    send = mockSend;
+  }
+  return {
+    SecretsManagerClient: MockSecretsManagerClient,
+    GetSecretValueCommand: makeCmd("GetSecretValue"),
+    PutSecretValueCommand: makeCmd("PutSecretValue"),
+    CreateSecretCommand: makeCmd("CreateSecret"),
+    ListSecretsCommand: makeCmd("ListSecrets"),
+    DescribeSecretCommand: makeCmd("DescribeSecret"),
+    TagResourceCommand: makeCmd("TagResource"),
+  };
+});
+
+// Import after mocks
+import { AwsSecretProvider, clearAwsSecretCache } from "./aws-secret-provider.js";
+
+beforeEach(() => {
+  clearSecretCache();
+  clearAwsSecretCache();
+  mockSend.mockReset();
+});
+
+// ===========================================================================
+// Construction
+// ===========================================================================
+
+describe("AwsSecretProvider — construction", () => {
+  it("sets name to 'aws'", () => {
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    expect(provider.name).toBe("aws");
+  });
+
+  it("accepts region config", () => {
+    const provider = new AwsSecretProvider({ region: "eu-west-1" });
+    expect(provider).toBeDefined();
+  });
+
+  it("accepts optional config fields", () => {
+    const provider = new AwsSecretProvider({
+      region: "us-east-1",
+      profile: "openclaw",
+      roleArn: "arn:aws:iam::123456789012:role/openclaw",
+      externalId: "ext-123",
+      cacheTtlSeconds: 600,
+    });
+    expect(provider).toBeDefined();
+  });
+});
+
+// ===========================================================================
+// getSecret
+// ===========================================================================
+
+describe("AwsSecretProvider — getSecret", () => {
+  it("fetches a secret by name (string value)", async () => {
+    mockSend.mockResolvedValueOnce({ SecretString: "my-secret-value" });
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const value = await provider.getSecret("my-secret");
+    expect(value).toBe("my-secret-value");
+  });
+
+  it("fetches a secret by name (binary value)", async () => {
+    mockSend.mockResolvedValueOnce({
+      SecretBinary: Buffer.from("binary-secret", "utf-8"),
+    });
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const value = await provider.getSecret("my-binary-secret");
+    expect(value).toBe("binary-secret");
+  });
+
+  it("passes VersionId when version is provided", async () => {
+    mockSend.mockResolvedValueOnce({ SecretString: "versioned-value" });
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const value = await provider.getSecret("my-secret", "abc123");
+    expect(value).toBe("versioned-value");
+    // Verify the command was constructed with version params
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const cmd = mockSend.mock.calls[0][0];
+    expect(cmd.input).toEqual({
+      SecretId: "my-secret",
+      VersionId: "abc123",
+      VersionStage: "abc123",
+    });
+  });
+
+  it("throws on ResourceNotFoundException", async () => {
+    const err = new Error("Secret not found");
+    (err as { name: string }).name = "ResourceNotFoundException";
+    mockSend.mockRejectedValueOnce(err);
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    await expect(provider.getSecret("missing")).rejects.toThrow(/not found/i);
+  });
+
+  it("throws on AccessDeniedException", async () => {
+    const err = new Error("Access denied");
+    (err as { name: string }).name = "AccessDeniedException";
+    mockSend.mockRejectedValueOnce(err);
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    await expect(provider.getSecret("forbidden")).rejects.toThrow(/permission denied/i);
+  });
+
+  it("throws on DecryptionFailureException", async () => {
+    const err = new Error("Cannot decrypt");
+    (err as { name: string }).name = "DecryptionFailureException";
+    mockSend.mockRejectedValueOnce(err);
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    await expect(provider.getSecret("encrypted")).rejects.toThrow(/decrypt/i);
+  });
+
+  it("throws when secret has no value", async () => {
+    mockSend.mockResolvedValueOnce({});
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    await expect(provider.getSecret("empty")).rejects.toThrow(/no payload/i);
+  });
+
+  it("caches secret values", async () => {
+    mockSend.mockResolvedValueOnce({ SecretString: "cached-value" });
+    const provider = new AwsSecretProvider({ region: "us-east-1", cacheTtlSeconds: 300 });
+    const v1 = await provider.getSecret("cached-secret");
+    const v2 = await provider.getSecret("cached-secret");
+    expect(v1).toBe("cached-value");
+    expect(v2).toBe("cached-value");
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns stale cache on network error", async () => {
+    // First call succeeds
+    mockSend.mockResolvedValueOnce({ SecretString: "stale-value" });
+    const provider = new AwsSecretProvider({ region: "us-east-1", cacheTtlSeconds: 0 });
+    await provider.getSecret("flaky-secret");
+
+    // TTL=0 means expired immediately; next call fails
+    mockSend.mockRejectedValueOnce(new Error("Network timeout"));
+    const value = await provider.getSecret("flaky-secret");
+    expect(value).toBe("stale-value");
+  });
+});
+
+// ===========================================================================
+// setSecret
+// ===========================================================================
+
+describe("AwsSecretProvider — setSecret", () => {
+  it("creates and stores a secret", async () => {
+    mockSend.mockResolvedValueOnce({}); // PutSecretValue
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    await provider.setSecret("new-secret", "new-value");
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to create + put if ResourceNotFoundException on put", async () => {
+    const err = new Error("not found");
+    (err as { name: string }).name = "ResourceNotFoundException";
+    mockSend
+      .mockRejectedValueOnce(err) // PutSecretValue fails — doesn't exist
+      .mockResolvedValueOnce({}) // CreateSecret
+      .mockResolvedValueOnce({}); // PutSecretValue retry
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    await provider.setSecret("brand-new", "value");
+    expect(mockSend).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ===========================================================================
+// listSecrets
+// ===========================================================================
+
+describe("AwsSecretProvider — listSecrets", () => {
+  it("lists secrets", async () => {
+    mockSend.mockResolvedValueOnce({
+      SecretList: [{ Name: "secret-a" }, { Name: "secret-b" }],
+    });
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const names = await provider.listSecrets();
+    expect(names).toEqual(["secret-a", "secret-b"]);
+  });
+
+  it("handles pagination", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        SecretList: [{ Name: "a" }],
+        NextToken: "token1",
+      })
+      .mockResolvedValueOnce({
+        SecretList: [{ Name: "b" }],
+      });
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const names = await provider.listSecrets();
+    expect(names).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array when no secrets", async () => {
+    mockSend.mockResolvedValueOnce({ SecretList: [] });
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const names = await provider.listSecrets();
+    expect(names).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// testConnection
+// ===========================================================================
+
+describe("AwsSecretProvider — testConnection", () => {
+  it("returns ok on success", async () => {
+    mockSend.mockResolvedValueOnce({ SecretList: [] });
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const result = await provider.testConnection();
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("returns error on failure", async () => {
+    mockSend.mockRejectedValueOnce(new Error("boom"));
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const result = await provider.testConnection();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("boom");
+  });
+});
+
+// ===========================================================================
+// Integration with secret-resolution
+// ===========================================================================
+
+describe("AwsSecretProvider — integration with resolveConfigSecrets", () => {
+  it("resolves ${aws:name} references", async () => {
+    mockSend.mockResolvedValue({ SecretString: "resolved-aws-value" });
+    const { resolveConfigSecrets } = await import("./secret-resolution.js");
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const providers = new Map<string, SecretProvider>([["aws", provider]]);
+    const config = { key: "${aws:my-secret}" };
+    const result = await resolveConfigSecrets(config, undefined, providers);
+    expect(result).toEqual({ key: "resolved-aws-value" });
+  });
+
+  it("resolves versioned ${aws:name#version} references", async () => {
+    mockSend.mockResolvedValue({ SecretString: "v2-value" });
+    const { resolveConfigSecrets } = await import("./secret-resolution.js");
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const providers = new Map<string, SecretProvider>([["aws", provider]]);
+    const config = { key: "${aws:my-secret#v2}" };
+    const result = await resolveConfigSecrets(config, undefined, providers);
+    expect(result).toEqual({ key: "v2-value" });
+  });
+});
+
+// ===========================================================================
+// Rotation support
+// ===========================================================================
+
+describe("AwsSecretProvider — rotation", () => {
+  it("describeSecret returns rotation metadata", async () => {
+    mockSend.mockResolvedValueOnce({
+      Name: "my-secret",
+      LastRotatedDate: new Date("2026-01-15T00:00:00Z"),
+      RotationEnabled: true,
+      RotationRules: { AutomaticallyAfterDays: 30 },
+      Tags: [
+        { Key: "rotation-type", Value: "auto" },
+        { Key: "rotation-interval-days", Value: "30" },
+      ],
+    });
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const meta = await provider.describeSecret("my-secret");
+    expect(meta.lastRotatedDate).toEqual(new Date("2026-01-15T00:00:00Z"));
+    expect(meta.rotationEnabled).toBe(true);
+    expect(meta.tags).toBeDefined();
+  });
+
+  it("getTags returns secret tags", async () => {
+    mockSend.mockResolvedValueOnce({
+      Tags: [
+        { Key: "rotation-type", Value: "manual" },
+        { Key: "rotation-interval-days", Value: "90" },
+      ],
+    });
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const tags = await provider.getTags("my-secret");
+    expect(tags).toEqual({
+      "rotation-type": "manual",
+      "rotation-interval-days": "90",
+    });
+  });
+
+  it("setTags updates secret tags", async () => {
+    mockSend.mockResolvedValueOnce({}); // TagResource
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    await provider.setTags("my-secret", { "rotation-type": "auto" });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/config/aws-secret-provider.test.ts
+++ b/src/config/aws-secret-provider.test.ts
@@ -95,18 +95,30 @@ describe("AwsSecretProvider — getSecret", () => {
     expect(value).toBe("binary-secret");
   });
 
-  it("passes VersionId when version is provided", async () => {
+  it("passes VersionStage for staging label versions", async () => {
     mockSend.mockResolvedValueOnce({ SecretString: "versioned-value" });
     const provider = new AwsSecretProvider({ region: "us-east-1" });
-    const value = await provider.getSecret("my-secret", "abc123");
+    const value = await provider.getSecret("my-secret", "AWSCURRENT");
     expect(value).toBe("versioned-value");
-    // Verify the command was constructed with version params
     expect(mockSend).toHaveBeenCalledTimes(1);
     const cmd = mockSend.mock.calls[0][0];
     expect(cmd.input).toEqual({
       SecretId: "my-secret",
-      VersionId: "abc123",
-      VersionStage: "abc123",
+      VersionStage: "AWSCURRENT",
+    });
+  });
+
+  it("passes VersionId for UUID versions", async () => {
+    mockSend.mockResolvedValueOnce({ SecretString: "uuid-versioned-value" });
+    const provider = new AwsSecretProvider({ region: "us-east-1" });
+    const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    const value = await provider.getSecret("my-secret", uuid);
+    expect(value).toBe("uuid-versioned-value");
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const cmd = mockSend.mock.calls[0][0];
+    expect(cmd.input).toEqual({
+      SecretId: "my-secret",
+      VersionId: uuid,
     });
   });
 

--- a/src/config/aws-secret-provider.ts
+++ b/src/config/aws-secret-provider.ts
@@ -1,0 +1,301 @@
+/**
+ * AWS Secrets Manager provider for OpenClaw.
+ *
+ * SDK (`@aws-sdk/client-secrets-manager`) is lazy-loaded as an optional peer dependency.
+ * Authentication follows the AWS credential chain: env vars → shared credentials → IAM role → instance profile.
+ */
+
+import { type SecretProvider } from "./secret-resolution.js";
+
+// ---------------------------------------------------------------------------
+// Types (minimal — avoids importing SDK at module level)
+// ---------------------------------------------------------------------------
+
+interface AwsSmClient {
+  send(command: unknown): Promise<Record<string, unknown>>;
+}
+
+// Minimal shape of the lazy-loaded AWS SDK module
+interface AwsSdkModule {
+  SecretsManagerClient: new (opts: Record<string, unknown>) => AwsSmClient;
+  GetSecretValueCommand: new (params: Record<string, string>) => unknown;
+  PutSecretValueCommand: new (params: Record<string, string>) => unknown;
+  CreateSecretCommand: new (params: Record<string, string>) => unknown;
+  ListSecretsCommand: new (params: Record<string, unknown>) => unknown;
+  DescribeSecretCommand: new (params: Record<string, string>) => unknown;
+  TagResourceCommand: new (params: Record<string, unknown>) => unknown;
+}
+
+export interface AwsProviderConfig {
+  region: string;
+  cacheTtlSeconds?: number;
+  profile?: string;
+  credentialsFile?: string;
+  roleArn?: string;
+  externalId?: string;
+}
+
+export interface AwsSecretDescription {
+  name: string;
+  lastRotatedDate?: Date;
+  rotationEnabled?: boolean;
+  rotationRules?: { automaticallyAfterDays?: number };
+  tags: Record<string, string>;
+}
+
+// Cache for internal use (provider-level, separate from shared cache in secret-resolution.ts)
+type CacheEntry = { value: string; expiresAt: number };
+const localCache = new Map<string, CacheEntry>();
+
+/** Clear the provider-level cache (for testing). */
+export function clearAwsSecretCache(): void {
+  localCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// AwsSecretProvider
+// ---------------------------------------------------------------------------
+
+export class AwsSecretProvider implements SecretProvider {
+  public readonly name = "aws";
+  private readonly region: string;
+  private readonly cacheTtlMs: number;
+  private readonly profile?: string;
+  private readonly credentialsFile?: string;
+  private readonly roleArn?: string;
+  private readonly externalId?: string;
+
+  constructor(config: AwsProviderConfig) {
+    this.region = config.region;
+    this.cacheTtlMs = (config.cacheTtlSeconds ?? 300) * 1000;
+    this.profile = config.profile;
+    this.credentialsFile = config.credentialsFile;
+    this.roleArn = config.roleArn;
+    this.externalId = config.externalId;
+  }
+
+  // -------------------------------------------------------------------------
+  // SDK access (lazy-loaded)
+  // -------------------------------------------------------------------------
+
+  private clientInstance?: AwsSmClient;
+  private sdkModule?: AwsSdkModule;
+
+  private async getSdk(): Promise<AwsSdkModule> {
+    if (this.sdkModule) {
+      return this.sdkModule;
+    }
+    const pkg = "@aws-sdk/client-secrets-manager";
+    try {
+      this.sdkModule = (await import(pkg)) as AwsSdkModule;
+      return this.sdkModule;
+    } catch {
+      throw new Error(`Please install ${pkg}: pnpm add ${pkg}`);
+    }
+  }
+
+  private async getClient(): Promise<AwsSmClient> {
+    if (this.clientInstance) {
+      return this.clientInstance;
+    }
+    const sdk = await this.getSdk();
+    const opts: Record<string, unknown> = { region: this.region };
+
+    // Credential chain configuration
+    if (this.profile) {
+      opts.profile = this.profile;
+    }
+
+    this.clientInstance = new sdk.SecretsManagerClient(opts);
+    return this.clientInstance;
+  }
+
+  // -------------------------------------------------------------------------
+  // SecretProvider interface
+  // -------------------------------------------------------------------------
+
+  async getSecret(secretName: string, version?: string): Promise<string> {
+    // Check local cache
+    const ver = version ?? "latest";
+    const cacheKey = `aws:${secretName}#${ver}`;
+    const cached = localCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    const sdk = await this.getSdk();
+    const client = await this.getClient();
+
+    const params: Record<string, string> = { SecretId: secretName };
+    if (version) {
+      params.VersionId = version;
+      params.VersionStage = version;
+    }
+
+    let response: Record<string, unknown>;
+    try {
+      response = await client.send(new sdk.GetSecretValueCommand(params));
+    } catch (err: unknown) {
+      const errName = (err as Record<string, unknown>)?.name;
+
+      if (errName === "ResourceNotFoundException") {
+        throw new Error(`Secret '${secretName}' not found in region '${this.region}'`, {
+          cause: err,
+        });
+      }
+      if (errName === "AccessDeniedException") {
+        throw new Error(`Permission denied for secret '${secretName}'. Check IAM policy.`, {
+          cause: err,
+        });
+      }
+      if (errName === "DecryptionFailureException") {
+        throw new Error(`Cannot decrypt secret '${secretName}'. Check KMS permissions.`, {
+          cause: err,
+        });
+      }
+      if (errName === "InvalidRequestException") {
+        throw new Error(`Invalid request for secret '${secretName}': ${(err as Error).message}`, {
+          cause: err,
+        });
+      }
+
+      // Network / unknown error — stale-while-revalidate
+      if (cached) {
+        return cached.value;
+      }
+      throw err;
+    }
+
+    // Extract value
+    let value: string;
+    if (response.SecretString) {
+      value = response.SecretString as string;
+    } else if (response.SecretBinary) {
+      value = Buffer.from(response.SecretBinary as Uint8Array).toString("utf-8");
+    } else {
+      throw new Error(`Secret "${secretName}" has no payload data`);
+    }
+
+    localCache.set(cacheKey, { value, expiresAt: Date.now() + this.cacheTtlMs });
+    return value;
+  }
+
+  async setSecret(secretName: string, value: string): Promise<void> {
+    const sdk = await this.getSdk();
+    const client = await this.getClient();
+
+    try {
+      // Try PutSecretValue first (secret already exists)
+      await client.send(
+        new sdk.PutSecretValueCommand({
+          SecretId: secretName,
+          SecretString: value,
+        }),
+      );
+    } catch (err: unknown) {
+      if ((err as Record<string, unknown>)?.name === "ResourceNotFoundException") {
+        // Secret doesn't exist — create it, then put value
+        await client.send(
+          new sdk.CreateSecretCommand({
+            Name: secretName,
+            SecretString: value,
+          }),
+        );
+        // CreateSecret already stores the value, but if we want to be explicit:
+        await client.send(
+          new sdk.PutSecretValueCommand({
+            SecretId: secretName,
+            SecretString: value,
+          }),
+        );
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const sdk = await this.getSdk();
+    const client = await this.getClient();
+    const names: string[] = [];
+    let nextToken: string | undefined;
+
+    do {
+      const params: Record<string, unknown> = {};
+      if (nextToken) {
+        params.NextToken = nextToken;
+      }
+
+      const response = await client.send(new sdk.ListSecretsCommand(params));
+      const secretList = (response.SecretList ?? []) as Array<Record<string, unknown>>;
+      for (const secret of secretList) {
+        if (secret.Name) {
+          names.push(secret.Name as string);
+        }
+      }
+      nextToken = response.NextToken as string | undefined;
+    } while (nextToken);
+
+    return names;
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const sdk = await this.getSdk();
+      const client = await this.getClient();
+      await client.send(new sdk.ListSecretsCommand({ MaxResults: 1 }));
+      return { ok: true };
+    } catch (err: unknown) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Rotation / tag support (extends beyond base SecretProvider interface)
+  // -------------------------------------------------------------------------
+
+  async describeSecret(secretName: string): Promise<AwsSecretDescription> {
+    const sdk = await this.getSdk();
+    const client = await this.getClient();
+    const response = await client.send(new sdk.DescribeSecretCommand({ SecretId: secretName }));
+
+    const tags: Record<string, string> = {};
+    const tagList = (response.Tags ?? []) as Array<Record<string, unknown>>;
+    for (const tag of tagList) {
+      if (tag.Key && tag.Value !== undefined) {
+        tags[tag.Key as string] = tag.Value as string;
+      }
+    }
+
+    return {
+      name: (response.Name as string) ?? secretName,
+      lastRotatedDate: response.LastRotatedDate as Date | undefined,
+      rotationEnabled: response.RotationEnabled as boolean | undefined,
+      rotationRules: response.RotationRules
+        ? {
+            automaticallyAfterDays: (response.RotationRules as Record<string, unknown>)
+              .AutomaticallyAfterDays as number | undefined,
+          }
+        : undefined,
+      tags,
+    };
+  }
+
+  async getTags(secretName: string): Promise<Record<string, string>> {
+    const desc = await this.describeSecret(secretName);
+    return desc.tags;
+  }
+
+  async setTags(secretName: string, tags: Record<string, string>): Promise<void> {
+    const sdk = await this.getSdk();
+    const client = await this.getClient();
+    const tagList = Object.entries(tags).map(([Key, Value]) => ({ Key, Value }));
+
+    await client.send(
+      new sdk.TagResourceCommand({
+        SecretId: secretName,
+        Tags: tagList,
+      }),
+    );
+  }
+}

--- a/src/config/aws-secret-provider.ts
+++ b/src/config/aws-secret-provider.ts
@@ -128,8 +128,12 @@ export class AwsSecretProvider implements SecretProvider {
 
     const params: Record<string, string> = { SecretId: secretName };
     if (version) {
-      params.VersionId = version;
-      params.VersionStage = version;
+      // UUIDs go to VersionId; staging labels (AWSCURRENT/AWSPREVIOUS) go to VersionStage
+      if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(version)) {
+        params.VersionId = version;
+      } else {
+        params.VersionStage = version;
+      }
     }
 
     let response: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Adds `AwsSecretProvider` for resolving secrets from AWS Secrets Manager.

The AWS SDK (`@aws-sdk/client-secrets-manager`) is **lazy-loaded** as an optional peer dependency — no startup cost unless the provider is configured.

## Authentication
Standard AWS credential chain: env vars → shared credentials file → IAM role → EC2 instance profile.

## Features
- Version pinning: `${aws:my-secret#AWSCURRENT}`
- Profile selection and role ARN assumption
- External ID for cross-account access
- Configurable TTL caching (default 5 min)

## Config
```json
{
  "secrets": {
    "providers": {
      "aws": {
        "region": "us-east-1",
        "profile": "prod",
        "roleArn": "arn:aws:iam::123456789:role/openclaw"
      }
    }
  }
}
```

**Usage:** `${aws:my-secret-name}`

## Notes
Split from #24272 per @vincentkoc's request.