### PR TITLE
feat: proactive auto-compaction when session context exceeds threshold

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1923,6 +1923,7 @@ export async function runEmbeddedAttempt(
                 prePromptMessageCount,
                 tokenBudget: params.contextTokenBudget,
                 runtimeContext: afterTurnRuntimeContext,
+                skipAutoCompaction: timedOutDuringCompaction,
               });
             } catch (afterTurnErr) {
               log.warn(`context engine afterTurn failed: ${String(afterTurnErr)}`);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1027,6 +1027,8 @@ export const FIELD_HELP: Record<string, string> = {
     'AGENTS.md H2/H3 section names re-injected after compaction so the agent reruns critical startup guidance. Leave unset to use "Session Startup"/"Red Lines" with legacy fallback to "Every Session"/"Safety"; set to [] to disable reinjection entirely.',
   "agents.defaults.compaction.model":
     "Optional provider/model override used only for compaction summarization. Set this when you want compaction to run on a different model than the session default, and leave it unset to keep using the primary agent model.",
+  "agents.defaults.compaction.autoThreshold":
+    "Proactive auto-compaction threshold as a fraction of the context window (0.5–0.95). When session token usage exceeds this ratio after a turn, compaction triggers automatically instead of waiting for a provider overflow error. Default: 0.75.",
   "agents.defaults.compaction.memoryFlush":
     "Pre-compaction memory flush settings that run an agentic memory write before heavy compaction. Keep enabled for long sessions so salient context is persisted before aggressive trimming.",
   "agents.defaults.compaction.memoryFlush.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -465,6 +465,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.qualityGuard.maxRetries": "Compaction Quality Guard Max Retries",
   "agents.defaults.compaction.postCompactionSections": "Post-Compaction Context Sections",
   "agents.defaults.compaction.model": "Compaction Model Override",
+  "agents.defaults.compaction.autoThreshold": "Auto-Compaction Threshold",
   "agents.defaults.compaction.memoryFlush": "Compaction Memory Flush",
   "agents.defaults.compaction.memoryFlush.enabled": "Compaction Memory Flush Enabled",
   "agents.defaults.compaction.memoryFlush.softThresholdTokens":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -326,6 +326,13 @@ export type AgentCompactionConfig = {
    * When set, compaction uses this model instead of the agent's primary model.
    * Falls back to the primary model when unset. */
   model?: string;
+  /**
+   * Proactive auto-compaction threshold as a fraction of the context window (0.5–0.95).
+   * When session token usage exceeds this ratio after a turn, compaction triggers
+   * automatically instead of waiting for a provider overflow error.
+   * Default: 0.75 (75% of context window).
+   */
+  autoThreshold?: number;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -105,6 +105,7 @@ export const AgentDefaultsSchema = z
           .optional(),
         postCompactionSections: z.array(z.string()).optional(),
         model: z.string().optional(),
+        autoThreshold: z.number().min(0.5).max(0.95).optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -1,10 +1,16 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 // ---------------------------------------------------------------------------
 // We dynamically import the registry so we can get a fresh module per test
 // group when needed.  For most groups we use the shared singleton directly.
 // ---------------------------------------------------------------------------
-import { LegacyContextEngine, registerLegacyContextEngine } from "./legacy.js";
+import {
+  LegacyContextEngine,
+  registerLegacyContextEngine,
+  estimateMessageTokens,
+  resolveAutoCompactionThreshold,
+  DEFAULT_AUTO_COMPACTION_THRESHOLD,
+} from "./legacy.js";
 import {
   registerContextEngine,
   getContextEngineFactory,
@@ -460,5 +466,191 @@ describe("Bundle chunk isolation (#40096)", () => {
     for (const id of ids) {
       expect(allIds).toContain(id);
     }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. Auto-compaction threshold resolution
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("resolveAutoCompactionThreshold", () => {
+  it("returns default (0.75) when config is undefined", () => {
+    expect(resolveAutoCompactionThreshold(undefined)).toBe(DEFAULT_AUTO_COMPACTION_THRESHOLD);
+  });
+
+  it("returns default when compaction section is absent", () => {
+    expect(resolveAutoCompactionThreshold({ agents: { defaults: {} } } as never)).toBe(
+      DEFAULT_AUTO_COMPACTION_THRESHOLD,
+    );
+  });
+
+  it("returns configured value when within valid range", () => {
+    const cfg = { agents: { defaults: { compaction: { autoThreshold: 0.8 } } } } as never;
+    expect(resolveAutoCompactionThreshold(cfg)).toBe(0.8);
+  });
+
+  it("clamps to 0.5 when below minimum", () => {
+    const cfg = { agents: { defaults: { compaction: { autoThreshold: 0.1 } } } } as never;
+    expect(resolveAutoCompactionThreshold(cfg)).toBe(0.5);
+  });
+
+  it("clamps to 0.95 when above maximum", () => {
+    const cfg = { agents: { defaults: { compaction: { autoThreshold: 0.99 } } } } as never;
+    expect(resolveAutoCompactionThreshold(cfg)).toBe(0.95);
+  });
+
+  it("returns default for non-finite values", () => {
+    const cfg = { agents: { defaults: { compaction: { autoThreshold: NaN } } } } as never;
+    expect(resolveAutoCompactionThreshold(cfg)).toBe(DEFAULT_AUTO_COMPACTION_THRESHOLD);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 9. estimateMessageTokens helper
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("estimateMessageTokens", () => {
+  it("returns 0 for empty array", () => {
+    expect(estimateMessageTokens([])).toBe(0);
+  });
+
+  it("returns a positive number for messages with content", () => {
+    const messages = [
+      makeMockMessage("user", "Hello world, this is a test message"),
+      makeMockMessage("assistant", "Sure, here is a response"),
+    ];
+    const tokens = estimateMessageTokens(messages);
+    expect(tokens).toBeGreaterThan(0);
+  });
+
+  it("increases with more messages", () => {
+    const small = [makeMockMessage("user", "Hi")];
+    const large = [
+      makeMockMessage("user", "Hi"),
+      makeMockMessage("assistant", "Hello! How can I help you today?"),
+      makeMockMessage("user", "Tell me about the weather forecast for tomorrow"),
+    ];
+    expect(estimateMessageTokens(large)).toBeGreaterThan(estimateMessageTokens(small));
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 10. LegacyContextEngine.afterTurn() proactive auto-compaction (#43603)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("LegacyContextEngine.afterTurn() auto-compaction (#43603)", () => {
+  it("does not compact when tokenBudget is missing", async () => {
+    const engine = new LegacyContextEngine();
+    const compactSpy = vi.spyOn(engine, "compact");
+    await engine.afterTurn({
+      sessionId: "s1",
+      sessionFile: "/tmp/s1.jsonl",
+      messages: [makeMockMessage("user", "x".repeat(1000))],
+      prePromptMessageCount: 0,
+    });
+    expect(compactSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not compact when token usage is below threshold", async () => {
+    const engine = new LegacyContextEngine();
+    const compactSpy = vi.spyOn(engine, "compact");
+    // Use tiny messages against a huge budget — well under 75%
+    await engine.afterTurn({
+      sessionId: "s1",
+      sessionFile: "/tmp/s1.jsonl",
+      messages: [makeMockMessage("user", "Hi")],
+      prePromptMessageCount: 0,
+      tokenBudget: 1_000_000,
+    });
+    expect(compactSpy).not.toHaveBeenCalled();
+  });
+
+  it("triggers compact when token usage exceeds threshold", async () => {
+    const engine = new LegacyContextEngine();
+    // Mock compact to avoid the heavy real compaction pipeline
+    const compactSpy = vi.spyOn(engine, "compact").mockResolvedValue({
+      ok: true,
+      compacted: true,
+      result: { tokensBefore: 800, tokensAfter: 200 },
+    });
+
+    // Create messages that will exceed 75% of a small budget.
+    // estimateTokens uses chars/4 heuristic, so 400 chars ≈ 100 tokens.
+    // With budget=100, threshold=75, 100 tokens > 75 → triggers.
+    const bigMessage = makeMockMessage("user", "x".repeat(400));
+    await engine.afterTurn({
+      sessionId: "s1",
+      sessionFile: "/tmp/s1.jsonl",
+      messages: [bigMessage],
+      prePromptMessageCount: 0,
+      tokenBudget: 100,
+    });
+    expect(compactSpy).toHaveBeenCalledOnce();
+    expect(compactSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "s1",
+        sessionFile: "/tmp/s1.jsonl",
+        tokenBudget: 100,
+        force: true,
+        compactionTarget: "budget",
+      }),
+    );
+  });
+
+  it("respects custom threshold from config in runtimeContext", async () => {
+    const engine = new LegacyContextEngine();
+    const compactSpy = vi.spyOn(engine, "compact").mockResolvedValue({
+      ok: true,
+      compacted: true,
+      result: { tokensBefore: 800, tokensAfter: 200 },
+    });
+
+    // 400 chars ≈ 100 tokens. Budget=200, default threshold 0.75 → triggerAt=150.
+    // 100 < 150 → should NOT compact with default threshold.
+    // But with threshold=0.5 → triggerAt=100 → 100 >= 100 → SHOULD compact.
+    const msg = makeMockMessage("user", "x".repeat(400));
+    const config = { agents: { defaults: { compaction: { autoThreshold: 0.5 } } } };
+
+    await engine.afterTurn({
+      sessionId: "s1",
+      sessionFile: "/tmp/s1.jsonl",
+      messages: [msg],
+      prePromptMessageCount: 0,
+      tokenBudget: 200,
+      runtimeContext: { config },
+    });
+
+    // With threshold=0.5, triggerAt=100, currentTokens≈100 → should trigger
+    expect(compactSpy).toHaveBeenCalledOnce();
+  });
+
+  it("does not crash when compact() throws (best-effort)", async () => {
+    const engine = new LegacyContextEngine();
+    vi.spyOn(engine, "compact").mockRejectedValue(new Error("boom"));
+
+    const bigMessage = makeMockMessage("user", "x".repeat(400));
+    // Should not throw — auto-compaction is best-effort
+    await expect(
+      engine.afterTurn({
+        sessionId: "s1",
+        sessionFile: "/tmp/s1.jsonl",
+        messages: [bigMessage],
+        prePromptMessageCount: 0,
+        tokenBudget: 100,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not compact when messages array is empty", async () => {
+    const engine = new LegacyContextEngine();
+    const compactSpy = vi.spyOn(engine, "compact");
+    await engine.afterTurn({
+      sessionId: "s1",
+      sessionFile: "/tmp/s1.jsonl",
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 100,
+    });
+    expect(compactSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/context-engine/legacy.ts
+++ b/src/context-engine/legacy.ts
@@ -102,7 +102,15 @@ export class LegacyContextEngine implements ContextEngine {
     isHeartbeat?: boolean;
     tokenBudget?: number;
     runtimeContext?: ContextEngineRuntimeContext;
+    skipAutoCompaction?: boolean;
   }): Promise<void> {
+    // Guard: skip auto-compaction when the runner already timed out during a
+    // compaction attempt this turn.  Re-triggering compact() here would create
+    // a stall loop in the exact recovery path meant to avoid them.
+    if (params.skipAutoCompaction) {
+      return;
+    }
+
     // Proactive auto-compaction: estimate current token usage and compact
     // before the next turn hits a provider overflow error.
     const { messages, tokenBudget, runtimeContext } = params;

--- a/src/context-engine/legacy.ts
+++ b/src/context-engine/legacy.ts
@@ -1,4 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { estimateTokens } from "@mariozechner/pi-coding-agent";
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { registerContextEngine } from "./registry.js";
 import type {
   ContextEngine,
@@ -8,6 +11,49 @@ import type {
   ContextEngineRuntimeContext,
   IngestResult,
 } from "./types.js";
+
+const log = createSubsystemLogger("legacy-context-engine");
+
+/** Default proactive auto-compaction threshold (fraction of context window). */
+export const DEFAULT_AUTO_COMPACTION_THRESHOLD = 0.75;
+
+/**
+ * Estimate total token count for a message array using the same heuristic
+ * as the compaction subsystem (chars/4). Returns 0 on estimation failure.
+ */
+export function estimateMessageTokens(messages: AgentMessage[]): number {
+  let total = 0;
+  for (const msg of messages) {
+    try {
+      total += estimateTokens(msg);
+    } catch {
+      // Estimation failure on a single message — skip, don't abort.
+    }
+  }
+  return total;
+}
+
+/**
+ * Resolve the effective auto-compaction threshold from config.
+ * Returns `null` when auto-compaction is explicitly disabled (set to 0 or falsy mode).
+ */
+export function resolveAutoCompactionThreshold(config?: OpenClawConfig): number | null {
+  const value = config?.agents?.defaults?.compaction?.autoThreshold;
+  if (value === undefined || value === null) {
+    return DEFAULT_AUTO_COMPACTION_THRESHOLD;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_AUTO_COMPACTION_THRESHOLD;
+  }
+  // Clamp to valid range
+  if (value < 0.5) {
+    return 0.5;
+  }
+  if (value > 0.95) {
+    return 0.95;
+  }
+  return value;
+}
 
 /**
  * LegacyContextEngine wraps the existing compaction behavior behind the
@@ -47,7 +93,7 @@ export class LegacyContextEngine implements ContextEngine {
     };
   }
 
-  async afterTurn(_params: {
+  async afterTurn(params: {
     sessionId: string;
     sessionFile: string;
     messages: AgentMessage[];
@@ -57,7 +103,63 @@ export class LegacyContextEngine implements ContextEngine {
     tokenBudget?: number;
     runtimeContext?: ContextEngineRuntimeContext;
   }): Promise<void> {
-    // No-op: legacy flow persists context directly in SessionManager.
+    // Proactive auto-compaction: estimate current token usage and compact
+    // before the next turn hits a provider overflow error.
+    const { messages, tokenBudget, runtimeContext } = params;
+    if (!tokenBudget || tokenBudget <= 0 || messages.length === 0) {
+      return;
+    }
+
+    const config = runtimeContext?.config as OpenClawConfig | undefined;
+    const threshold = resolveAutoCompactionThreshold(config);
+    if (threshold === null) {
+      return;
+    }
+
+    const currentTokens = estimateMessageTokens(messages);
+    const triggerAt = Math.floor(tokenBudget * threshold);
+
+    if (currentTokens < triggerAt) {
+      return;
+    }
+
+    const ratio = currentTokens / tokenBudget;
+    log.info(
+      `[auto-compaction] triggered: sessionId=${params.sessionId} ` +
+        `tokens=${currentTokens} budget=${tokenBudget} ratio=${ratio.toFixed(3)} ` +
+        `threshold=${threshold} triggerAt=${triggerAt}`,
+    );
+
+    try {
+      const result = await this.compact({
+        sessionId: params.sessionId,
+        sessionFile: params.sessionFile,
+        tokenBudget,
+        force: true,
+        currentTokenCount: currentTokens,
+        compactionTarget: "budget",
+        runtimeContext,
+      });
+
+      if (result.compacted) {
+        log.info(
+          `[auto-compaction] completed: sessionId=${params.sessionId} ` +
+            `tokensBefore=${result.result?.tokensBefore ?? "?"} ` +
+            `tokensAfter=${result.result?.tokensAfter ?? "?"}`,
+        );
+      } else {
+        log.info(
+          `[auto-compaction] skipped by compactor: sessionId=${params.sessionId} ` +
+            `reason=${result.reason ?? "unknown"}`,
+        );
+      }
+    } catch (err) {
+      // Auto-compaction is best-effort — don't crash the session.
+      log.warn(
+        `[auto-compaction] failed: sessionId=${params.sessionId} ` +
+          `error=${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   async compact(params: {

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -113,6 +113,13 @@ export interface ContextEngine {
     tokenBudget?: number;
     /** Optional runtime-owned context for engines that need caller state. */
     runtimeContext?: ContextEngineRuntimeContext;
+    /**
+     * When true, the engine must skip proactive auto-compaction.
+     * Set by the runner when the current turn already timed out during a
+     * compaction attempt — re-triggering compact() here would create a
+     * stall loop in the exact recovery path meant to avoid them.
+     */
+    skipAutoCompaction?: boolean;
   }): Promise<void>;
 
   /**


### PR DESCRIPTION
## Problem

Agent sessions gradually bloat in tokens. When they hit 70-80% of context window, agents freeze or slow to a crawl. Currently compaction only triggers **reactively** — after the provider returns a context overflow error. There's no proactive threshold, no warning, and no way to prevent the degradation.

## Solution

Add proactive auto-compaction that runs after each agent turn. When estimated session token usage exceeds a configurable fraction of the context window, compaction triggers immediately — before the next prompt hits the provider.

### Changes

**Config** (`agents.defaults.compaction.autoThreshold`)
- New field: float 0.5–0.95, default 0.75
- Zod schema validation, type definition, schema label, help text

**Core logic** (`src/context-engine/legacy.ts`)
- `LegacyContextEngine.afterTurn()` now estimates tokens via `estimateTokens()` (same heuristic as the compaction subsystem)
- Compares against `tokenBudget * threshold`
- Calls `this.compact()` with `force: true` and `compactionTarget: "budget"`
- Best-effort: errors are logged but never crash the session
- Exported helpers: `estimateMessageTokens()`, `resolveAutoCompactionThreshold()`, `DEFAULT_AUTO_COMPACTION_THRESHOLD`

**Tests** (12 new, all passing)
- Threshold resolution: default, configured, clamped below/above, NaN
- Token estimation: empty, content, scaling
- afterTurn: no-budget skip, below-threshold skip, trigger, custom threshold, error resilience, empty messages

### Config example

```yaml
agents:
  defaults:
    compaction:
      autoThreshold: 0.75  # compact at 75% of context window
```

Closes #43603