### PR TITLE
fix(gateway): use launchctl stop instead of bootout to prevent Launch…

### DIFF
--- a/src/cli/gateway-cli/shared.ts
+++ b/src/cli/gateway-cli/shared.ts
@@ -69,7 +69,7 @@ export function renderGatewayServiceStopHints(env: NodeJS.ProcessEnv = process.e
     case "darwin":
       return [
         `Tip: ${formatCliCommand("moltbot gateway stop")}`,
-        `Or: launchctl bootout gui/$UID/${resolveGatewayLaunchAgentLabel(profile)}`,
+        `Or: launchctl stop gui/$UID/${resolveGatewayLaunchAgentLabel(profile)}`,
       ];
     case "linux":
       return [

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -209,7 +209,7 @@ export async function maybeRepairGatewayDaemon(params: {
   if (process.platform === "darwin") {
     const label = resolveGatewayLaunchAgentLabel(process.env.CLAWDBOT_PROFILE);
     note(
-      `LaunchAgent loaded; stopping requires "${formatCliCommand("moltbot gateway stop")}" or launchctl bootout gui/$UID/${label}.`,
+      `LaunchAgent loaded; stopping requires "${formatCliCommand("moltbot gateway stop")}" or launchctl stop gui/$UID/${label}.`,
       "Gateway",
     );
   }

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -357,9 +357,9 @@ export async function stopLaunchAgent({
 }): Promise<void> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  const res = await execLaunchctl(["stop", `${domain}/${label}`]);
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
-    throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
+    throw new Error(`launchctl stop failed: ${res.stderr || res.stdout}`.trim());
   }
   stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
 }


### PR DESCRIPTION
This fixes a service lifecycle issue in the gateway CLI on macOS.

Previously `launchctl bootout` was used in the stop logic, which stops
the service and unloads the LaunchAgent from launchd. Because of this,
running `gateway start` after `gateway stop` failed unless `gateway install`
was run again.

This change replaces `launchctl bootout` with `launchctl stop`, which
only stops the running process while keeping the LaunchAgent registered.
Now `gateway stop` followed by `gateway start` works as expected.