### PR TITLE
fix(agents): add opencode-go to resolveEnvApiKey candidates

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -292,6 +292,19 @@ describe("getApiKeyForModel", () => {
     });
   });
 
+  it("resolveEnvApiKey('opencode-go') returns OPENCODE_API_KEY when set", async () => {
+    const saved = process.env.OPENCODE_API_KEY;
+    try {
+      process.env.OPENCODE_API_KEY = "test-opencode-go-key";
+      const resolved = resolveEnvApiKey("opencode-go");
+      expect(resolved).not.toBeNull();
+      expect(resolved!.apiKey).toBe("test-opencode-go-key");
+    } finally {
+      if (saved === undefined) delete process.env.OPENCODE_API_KEY;
+      else process.env.OPENCODE_API_KEY = saved;
+    }
+  });
+
   it("resolveEnvApiKey('huggingface') returns HUGGINGFACE_HUB_TOKEN when set", async () => {
     await withEnvAsync(
       {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -275,6 +275,10 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return pick("OPENCODE_API_KEY") ?? pick("OPENCODE_ZEN_API_KEY");
   }
 
+  if (normalized === "opencode-go") {
+    return pick("OPENCODE_API_KEY");
+  }
+
   if (normalized === "qwen-portal") {
     return pick("QWEN_OAUTH_TOKEN") ?? pick("QWEN_PORTAL_API_KEY");
   }


### PR DESCRIPTION
## Summary
- add an explicit `opencode-go` branch in `resolveEnvApiKey` that reads `OPENCODE_API_KEY`
- keep existing envMap fallback unchanged
- add a regression test that verifies `resolveEnvApiKey('opencode-go')` returns the configured key