### PR TITLE
fix: auto-close browser tabs when embedded run ends

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -78,8 +78,12 @@ export function createOpenClawTools(
      */
     spawnWorkspaceDir?: string;
     /** When provided, browser tabs opened during the run are tracked here for cleanup.
-     *  Maps targetId → baseUrl so cleanup can close against the correct endpoint. */
-    openedBrowserTabTracker?: Map<string, string | undefined>;
+     *  Maps targetId → { baseUrl, profile } so cleanup can close against the correct
+     *  endpoint and browser profile. */
+    openedBrowserTabTracker?: Map<
+      string,
+      { baseUrl: string | undefined; profile: string | undefined }
+    >;
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -77,6 +77,8 @@ export function createOpenClawTools(
      * subagents inherit the real workspace path instead of the sandbox copy.
      */
     spawnWorkspaceDir?: string;
+    /** When provided, targetIds of browser tabs opened during the run are tracked here for cleanup. */
+    openedBrowserTabTracker?: Set<string>;
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
@@ -140,6 +142,7 @@ export function createOpenClawTools(
       sandboxBridgeUrl: options?.sandboxBrowserBridgeUrl,
       allowHostControl: options?.allowHostBrowserControl,
       agentSessionKey: options?.agentSessionKey,
+      openedTabTracker: options?.openedBrowserTabTracker,
     }),
     createCanvasTool({ config: options?.config }),
     createNodesTool({

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -77,8 +77,9 @@ export function createOpenClawTools(
      * subagents inherit the real workspace path instead of the sandbox copy.
      */
     spawnWorkspaceDir?: string;
-    /** When provided, targetIds of browser tabs opened during the run are tracked here for cleanup. */
-    openedBrowserTabTracker?: Set<string>;
+    /** When provided, browser tabs opened during the run are tracked here for cleanup.
+     *  Maps targetId → baseUrl so cleanup can close against the correct endpoint. */
+    openedBrowserTabTracker?: Map<string, string | undefined>;
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -9,6 +9,7 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { browserCloseTab } from "../../../browser/client.js";
+import { untrackSessionBrowserTab } from "../../../browser/session-tab-registry.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
@@ -2036,6 +2037,15 @@ export async function runEmbeddedAttempt(
           for (const [targetId, { baseUrl, profile }] of openedBrowserTabs) {
             browserCloseTab(baseUrl, targetId, { profile: profile ?? undefined }).catch((err) => {
               log.debug(`failed to close browser tab ${targetId}: ${String(err)}`);
+            });
+            // Also remove from the session-level tab registry so that
+            // closeTrackedBrowserTabsForSessions won't retry these stale IDs
+            // on session reset/delete.
+            untrackSessionBrowserTab({
+              sessionKey: params.sessionKey,
+              targetId,
+              baseUrl,
+              profile,
             });
           }
           openedBrowserTabs.clear();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -850,10 +850,14 @@ export async function runEmbeddedAttempt(
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
     // Track browser tabs opened during this run for automatic cleanup.
-    // Maps targetId → baseUrl so we close against the correct endpoint
-    // (host vs sandbox browser). Node-proxy tabs are excluded since
-    // their sandbox process is torn down independently.
-    const openedBrowserTabs = new Map<string, string | undefined>();
+    // Maps targetId → { baseUrl, profile } so we close against the correct
+    // endpoint (host vs sandbox browser) and browser profile.
+    // Node-proxy tabs store undefined baseUrl — their sandbox process is
+    // torn down independently, so cleanup is best-effort.
+    const openedBrowserTabs = new Map<
+      string,
+      { baseUrl: string | undefined; profile: string | undefined }
+    >();
     const toolsRaw = params.disableTools
       ? []
       : createOpenClawCodingTools({
@@ -2023,14 +2027,14 @@ export async function runEmbeddedAttempt(
         params.abortSignal?.removeEventListener?.("abort", onAbort);
 
         // Close browser tabs opened during this run to prevent leaked headless tabs.
-        // Each entry maps targetId → baseUrl so we close against the correct endpoint
-        // (host browser vs sandbox browser).
+        // Each entry maps targetId → { baseUrl, profile } so we close against the
+        // correct endpoint (host vs sandbox) and browser profile.
         if (openedBrowserTabs.size > 0) {
           log.debug(
             `closing ${openedBrowserTabs.size} browser tab(s) opened during run: runId=${params.runId}`,
           );
-          for (const [targetId, baseUrl] of openedBrowserTabs) {
-            browserCloseTab(baseUrl, targetId).catch((err) => {
+          for (const [targetId, { baseUrl, profile }] of openedBrowserTabs) {
+            browserCloseTab(baseUrl, targetId, { profile: profile ?? undefined }).catch((err) => {
               log.debug(`failed to close browser tab ${targetId}: ${String(err)}`);
             });
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -8,6 +8,7 @@ import {
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
+import { browserCloseTab } from "../../../browser/client.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
@@ -848,9 +849,11 @@ export async function runEmbeddedAttempt(
     });
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
+    const openedBrowserTabs = new Set<string>();
     const toolsRaw = params.disableTools
       ? []
       : createOpenClawCodingTools({
+          openedBrowserTabTracker: openedBrowserTabs,
           agentId: sessionAgentId,
           exec: {
             ...params.execOverrides,
@@ -1790,6 +1793,7 @@ export async function runEmbeddedAttempt(
           } else {
             await abortable(activeSession.prompt(effectivePrompt));
           }
+
         } catch (err) {
           promptError = err;
           promptErrorSource = "prompt";
@@ -2014,6 +2018,19 @@ export async function runEmbeddedAttempt(
         }
         clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
         params.abortSignal?.removeEventListener?.("abort", onAbort);
+
+        // Close browser tabs opened during this run to prevent leaked headless tabs
+        if (openedBrowserTabs.size > 0) {
+          log.debug(
+            `closing ${openedBrowserTabs.size} browser tab(s) opened during run: runId=${params.runId}`,
+          );
+          for (const targetId of openedBrowserTabs) {
+            browserCloseTab(undefined, targetId).catch((err) => {
+              log.debug(`failed to close browser tab ${targetId}: ${String(err)}`);
+            });
+          }
+          openedBrowserTabs.clear();
+        }
       }
 
       const lastAssistant = messagesSnapshot

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -849,7 +849,11 @@ export async function runEmbeddedAttempt(
     });
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
-    const openedBrowserTabs = new Set<string>();
+    // Track browser tabs opened during this run for automatic cleanup.
+    // Maps targetId → baseUrl so we close against the correct endpoint
+    // (host vs sandbox browser). Node-proxy tabs are excluded since
+    // their sandbox process is torn down independently.
+    const openedBrowserTabs = new Map<string, string | undefined>();
     const toolsRaw = params.disableTools
       ? []
       : createOpenClawCodingTools({
@@ -1793,7 +1797,6 @@ export async function runEmbeddedAttempt(
           } else {
             await abortable(activeSession.prompt(effectivePrompt));
           }
-
         } catch (err) {
           promptError = err;
           promptErrorSource = "prompt";
@@ -2019,13 +2022,15 @@ export async function runEmbeddedAttempt(
         clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
         params.abortSignal?.removeEventListener?.("abort", onAbort);
 
-        // Close browser tabs opened during this run to prevent leaked headless tabs
+        // Close browser tabs opened during this run to prevent leaked headless tabs.
+        // Each entry maps targetId → baseUrl so we close against the correct endpoint
+        // (host browser vs sandbox browser).
         if (openedBrowserTabs.size > 0) {
           log.debug(
             `closing ${openedBrowserTabs.size} browser tab(s) opened during run: runId=${params.runId}`,
           );
-          for (const targetId of openedBrowserTabs) {
-            browserCloseTab(undefined, targetId).catch((err) => {
+          for (const [targetId, baseUrl] of openedBrowserTabs) {
+            browserCloseTab(baseUrl, targetId).catch((err) => {
               log.debug(`failed to close browser tab ${targetId}: ${String(err)}`);
             });
           }

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -267,8 +267,9 @@ export function createOpenClawCodingTools(options?: {
   disableMessageTool?: boolean;
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
-  /** When provided, targetIds of browser tabs opened during the run are tracked here for cleanup. */
-  openedBrowserTabTracker?: Set<string>;
+  /** When provided, browser tabs opened during the run are tracked here for cleanup.
+   *  Maps targetId → baseUrl so cleanup can close against the correct endpoint. */
+  openedBrowserTabTracker?: Map<string, string | undefined>;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -268,8 +268,12 @@ export function createOpenClawCodingTools(options?: {
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
   /** When provided, browser tabs opened during the run are tracked here for cleanup.
-   *  Maps targetId → baseUrl so cleanup can close against the correct endpoint. */
-  openedBrowserTabTracker?: Map<string, string | undefined>;
+   *  Maps targetId → { baseUrl, profile } so cleanup can close against the correct
+   *  endpoint and browser profile. */
+  openedBrowserTabTracker?: Map<
+    string,
+    { baseUrl: string | undefined; profile: string | undefined }
+  >;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -267,6 +267,8 @@ export function createOpenClawCodingTools(options?: {
   disableMessageTool?: boolean;
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
+  /** When provided, targetIds of browser tabs opened during the run are tracked here for cleanup. */
+  openedBrowserTabTracker?: Set<string>;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
@@ -530,6 +532,7 @@ export function createOpenClawCodingTools(options?: {
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
       sessionId: options?.sessionId,
+      openedBrowserTabTracker: options?.openedBrowserTabTracker,
     }),
   ];
   const toolsForMemoryFlush =

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -282,6 +282,8 @@ export function createBrowserTool(opts?: {
   sandboxBridgeUrl?: string;
   allowHostControl?: boolean;
   agentSessionKey?: string;
+  /** When provided, targetIds of tabs opened via this tool are tracked here for cleanup. */
+  openedTabTracker?: Set<string>;
 }): AnyAgentTool {
   const targetDefault = opts?.sandboxBridgeUrl ? "sandbox" : "host";
   const hostHint =
@@ -423,16 +425,27 @@ export function createBrowserTool(opts?: {
               profile,
               body: { url: targetUrl },
             });
+            // Track opened tab for automatic cleanup when the run ends
+            const tid = (result as { targetId?: string })?.targetId;
+            if (tid && opts?.openedTabTracker) {
+              opts.openedTabTracker.add(tid);
+            }
             return jsonResult(result);
           }
-          const opened = await browserOpenTab(baseUrl, targetUrl, { profile });
-          trackSessionBrowserTab({
-            sessionKey: opts?.agentSessionKey,
-            targetId: opened.targetId,
-            baseUrl,
-            profile,
-          });
-          return jsonResult(opened);
+          {
+            const tab = await browserOpenTab(baseUrl, targetUrl, { profile });
+            trackSessionBrowserTab({
+              sessionKey: opts?.agentSessionKey,
+              targetId: tab.targetId,
+              baseUrl,
+              profile,
+            });
+            // Track opened tab for automatic cleanup when the run ends
+            if (tab.targetId && opts?.openedTabTracker) {
+              opts.openedTabTracker.add(tab.targetId);
+            }
+            return jsonResult(tab);
+          }
         }
         case "focus": {
           const targetId = readStringParam(params, "targetId", {
@@ -465,6 +478,10 @@ export function createBrowserTool(opts?: {
                   profile,
                   body: { kind: "close" },
                 });
+            // Remove from tracker so it won't be double-closed on run cleanup
+            if (targetId) {
+              opts?.openedTabTracker?.delete(targetId);
+            }
             return jsonResult(result);
           }
           if (targetId) {
@@ -475,6 +492,8 @@ export function createBrowserTool(opts?: {
               baseUrl,
               profile,
             });
+            // Remove from tracker so it won't be double-closed on run cleanup
+            opts?.openedTabTracker?.delete(targetId);
           } else {
             await browserAct(baseUrl, { kind: "close" }, { profile });
           }

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -282,8 +282,9 @@ export function createBrowserTool(opts?: {
   sandboxBridgeUrl?: string;
   allowHostControl?: boolean;
   agentSessionKey?: string;
-  /** When provided, targetIds of tabs opened via this tool are tracked here for cleanup. */
-  openedTabTracker?: Set<string>;
+  /** When provided, tabs opened via this tool are tracked here for cleanup.
+   *  Maps targetId → baseUrl so cleanup can close against the correct endpoint. */
+  openedTabTracker?: Map<string, string | undefined>;
 }): AnyAgentTool {
   const targetDefault = opts?.sandboxBridgeUrl ? "sandbox" : "host";
   const hostHint =
@@ -425,10 +426,11 @@ export function createBrowserTool(opts?: {
               profile,
               body: { url: targetUrl },
             });
-            // Track opened tab for automatic cleanup when the run ends
+            // Track opened tab (with baseUrl) for automatic cleanup when the run ends.
+            // Node-proxy tabs are excluded — their sandbox process is torn down independently.
             const tid = (result as { targetId?: string })?.targetId;
             if (tid && opts?.openedTabTracker) {
-              opts.openedTabTracker.add(tid);
+              opts.openedTabTracker.set(tid, undefined);
             }
             return jsonResult(result);
           }
@@ -440,9 +442,9 @@ export function createBrowserTool(opts?: {
               baseUrl,
               profile,
             });
-            // Track opened tab for automatic cleanup when the run ends
+            // Track opened tab (with baseUrl) for automatic cleanup when the run ends
             if (tab.targetId && opts?.openedTabTracker) {
-              opts.openedTabTracker.add(tab.targetId);
+              opts.openedTabTracker.set(tab.targetId, baseUrl);
             }
             return jsonResult(tab);
           }
@@ -478,7 +480,10 @@ export function createBrowserTool(opts?: {
                   profile,
                   body: { kind: "close" },
                 });
-            // Remove from tracker so it won't be double-closed on run cleanup
+            // Remove from tracker so it won't be double-closed on run cleanup.
+            // When no targetId is provided (active-tab close), the tab stays in
+            // the tracker and will produce a harmless failed cleanup attempt
+            // (errors are swallowed in the finally block).
             if (targetId) {
               opts?.openedTabTracker?.delete(targetId);
             }
@@ -495,6 +500,9 @@ export function createBrowserTool(opts?: {
             // Remove from tracker so it won't be double-closed on run cleanup
             opts?.openedTabTracker?.delete(targetId);
           } else {
+            // Active-tab close without explicit targetId. The closed tab stays
+            // in the tracker — cleanup will attempt to close it again, but
+            // the error is silently swallowed (tab not found).
             await browserAct(baseUrl, { kind: "close" }, { profile });
           }
           return jsonResult({ ok: true });

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -283,8 +283,9 @@ export function createBrowserTool(opts?: {
   allowHostControl?: boolean;
   agentSessionKey?: string;
   /** When provided, tabs opened via this tool are tracked here for cleanup.
-   *  Maps targetId → baseUrl so cleanup can close against the correct endpoint. */
-  openedTabTracker?: Map<string, string | undefined>;
+   *  Maps targetId → { baseUrl, profile } so cleanup can close against the
+   *  correct endpoint and browser profile. */
+  openedTabTracker?: Map<string, { baseUrl: string | undefined; profile: string | undefined }>;
 }): AnyAgentTool {
   const targetDefault = opts?.sandboxBridgeUrl ? "sandbox" : "host";
   const hostHint =
@@ -426,11 +427,12 @@ export function createBrowserTool(opts?: {
               profile,
               body: { url: targetUrl },
             });
-            // Track opened tab (with baseUrl) for automatic cleanup when the run ends.
-            // Node-proxy tabs are excluded — their sandbox process is torn down independently.
+            // Track opened tab for automatic cleanup when the run ends.
+            // Node-proxy tabs store undefined baseUrl — their sandbox process
+            // is torn down independently, so cleanup is best-effort.
             const tid = (result as { targetId?: string })?.targetId;
             if (tid && opts?.openedTabTracker) {
-              opts.openedTabTracker.set(tid, undefined);
+              opts.openedTabTracker.set(tid, { baseUrl: undefined, profile });
             }
             return jsonResult(result);
           }
@@ -442,9 +444,9 @@ export function createBrowserTool(opts?: {
               baseUrl,
               profile,
             });
-            // Track opened tab (with baseUrl) for automatic cleanup when the run ends
+            // Track opened tab (with baseUrl and profile) for automatic cleanup when the run ends
             if (tab.targetId && opts?.openedTabTracker) {
-              opts.openedTabTracker.set(tab.targetId, baseUrl);
+              opts.openedTabTracker.set(tab.targetId, { baseUrl, profile });
             }
             return jsonResult(tab);
           }


### PR DESCRIPTION
## Summary
- Track browser tab `targetId`s opened via the `browser` tool in a `Set<string>` passed through the tool chain (`createBrowserTool` → `createOpenClawTools` → `createOpenClawCodingTools` → `runEmbeddedAttempt`)
- Close all remaining tracked tabs in the run's `finally` block to prevent leaked headless Chromium processes
- Remove tabs from the tracker when explicitly closed by the agent (prevents double-close)

## Context
Browser tabs opened during agent runs were never cleaned up. Over time, leaked headless Chromium tabs accumulated and consumed significant CPU (observed 42% CPU from ~20 leaked tabs over 2 days).

🤖 Generated with [Claude Code](https://claude.com/claude-code)