### PR TITLE
fix: treat transient network errors as retryable for failover

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -589,6 +589,17 @@ describe("isTransientNetworkErrorMessage", () => {
     expect(isTransientNetworkErrorMessage("billing error")).toBe(false);
     expect(isTransientNetworkErrorMessage("")).toBe(false);
   });
+
+  it("does not match user cancellation / AbortError", () => {
+    // "aborted" must not be classified as transient network — it would cause
+    // cancelled runs to retry instead of terminating immediately.
+    expect(isTransientNetworkErrorMessage("aborted")).toBe(false);
+    expect(isTransientNetworkErrorMessage("The operation was aborted")).toBe(false);
+    expect(isTransientNetworkErrorMessage("AbortError: signal is aborted without reason")).toBe(
+      false,
+    );
+    expect(isTransientNetworkErrorMessage("Operation aborted")).toBe(false);
+  });
 });
 
 describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -14,6 +14,7 @@ import {
   isLikelyContextOverflowError,
   isTimeoutErrorMessage,
   isTransientHttpError,
+  isTransientNetworkErrorMessage,
   parseImageDimensionError,
   parseImageSizeError,
 } from "./pi-embedded-helpers.js";
@@ -567,6 +568,29 @@ describe("image dimension errors", () => {
   });
 });
 
+describe("isTransientNetworkErrorMessage", () => {
+  it("matches network connection lost", () => {
+    expect(isTransientNetworkErrorMessage("Network connection lost.")).toBe(true);
+    expect(isTransientNetworkErrorMessage("Network connection lost")).toBe(true);
+  });
+
+  it("matches other transient network errors", () => {
+    expect(isTransientNetworkErrorMessage("fetch failed")).toBe(true);
+    expect(isTransientNetworkErrorMessage("socket hang up")).toBe(true);
+    expect(isTransientNetworkErrorMessage("ECONNRESET")).toBe(true);
+    expect(isTransientNetworkErrorMessage("ETIMEDOUT")).toBe(true);
+    expect(isTransientNetworkErrorMessage("ECONNREFUSED")).toBe(true);
+    expect(isTransientNetworkErrorMessage("ENOTFOUND")).toBe(true);
+  });
+
+  it("does not match non-network errors", () => {
+    expect(isTransientNetworkErrorMessage("invalid api key")).toBe(false);
+    expect(isTransientNetworkErrorMessage("rate limit exceeded")).toBe(false);
+    expect(isTransientNetworkErrorMessage("billing error")).toBe(false);
+    expect(isTransientNetworkErrorMessage("")).toBe(false);
+  });
+});
+
 describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => {
   it("reclassifies periodic usage limits as rate_limit", () => {
     const samples = [
@@ -772,6 +796,13 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("Your api key has been revoked")).toBe("auth_permanent");
     expect(classifyFailoverReason("key has been disabled")).toBe("auth_permanent");
     expect(classifyFailoverReason("account has been deactivated")).toBe("auth_permanent");
+  });
+  it("classifies transient network errors as timeout", () => {
+    expect(classifyFailoverReason("Network connection lost.")).toBe("timeout");
+    expect(classifyFailoverReason("Network connection lost")).toBe("timeout");
+    expect(classifyFailoverReason("fetch failed")).toBe("timeout");
+    expect(classifyFailoverReason("socket hang up")).toBe("timeout");
+    expect(classifyFailoverReason("ECONNRESET")).toBe("timeout");
   });
   it("classifies JSON api_error internal server failures as timeout", () => {
     expect(

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -39,6 +39,7 @@ export {
   isRateLimitAssistantError,
   isRateLimitErrorMessage,
   isTransientHttpError,
+  isTransientNetworkErrorMessage,
   isTimeoutErrorMessage,
   parseImageDimensionError,
   parseImageSizeError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -940,8 +940,11 @@ function isCliSessionExpiredErrorMessage(raw: string): boolean {
  * These surface when the underlying fetch/socket layer fails before an
  * HTTP status code is available.
  */
+// Note: intentionally excludes "aborted" — AbortError / user cancellation must
+// not be classified as a transient transport failure (it would cause cancelled
+// runs to retry instead of terminating immediately).
 const TRANSIENT_NETWORK_ERROR_RE =
-  /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|socket hang up|network socket disconnected|Network connection lost|\baborted\b|UND_ERR_CONNECT_TIMEOUT|request to .* failed, reason:/i;
+  /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|socket hang up|network socket disconnected|Network connection lost|UND_ERR_CONNECT_TIMEOUT|request to .* failed, reason:/i;
 
 export function isTransientNetworkErrorMessage(raw: string): boolean {
   if (!raw) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -934,6 +934,22 @@ function isCliSessionExpiredErrorMessage(raw: string): boolean {
   );
 }
 
+/**
+ * Checks for raw network-level failure strings that indicate a transient
+ * transport problem (DNS, TCP, TLS) rather than an HTTP-level error.
+ * These surface when the underlying fetch/socket layer fails before an
+ * HTTP status code is available.
+ */
+const TRANSIENT_NETWORK_ERROR_RE =
+  /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|socket hang up|network socket disconnected|Network connection lost|\baborted\b|UND_ERR_CONNECT_TIMEOUT|request to .* failed, reason:/i;
+
+export function isTransientNetworkErrorMessage(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  return TRANSIENT_NETWORK_ERROR_RE.test(raw);
+}
+
 export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isImageDimensionErrorMessage(raw)) {
     return null;
@@ -967,6 +983,10 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
       return "overloaded";
     }
     // Treat remaining transient 5xx provider failures as retryable transport issues.
+    return "timeout";
+  }
+  // Treat raw network-level failures as retryable transport issues
+  if (isTransientNetworkErrorMessage(raw)) {
     return "timeout";
   }
   if (isJsonApiInternalServerError(raw)) {

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -42,6 +42,9 @@ const ERROR_PATTERNS = {
     /without sending (?:any )?chunks?/i,
     /\bstop reason:\s*(?:abort|error|malformed_response)\b/i,
     /\breason:\s*(?:abort|error|malformed_response)\b/i,
+    // Ollama surfaces network-level failures (e.g. fetch timeout, ECONNRESET) as a generic
+    // "error" stop reason with no further error classification. This is intentionally broad
+    // to catch those cases as retryable transport failures.
     /\bunhandled stop reason:\s*(?:abort|error|malformed_response)\b/i,
   ],
   billing: [

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -109,6 +109,7 @@ const TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /gateway closed \(1006/i,
   /gateway timeout/i,
   /\b(econnreset|econnrefused|etimedout|enotfound|ehostunreach|network error)\b/i,
+  /\bfetch failed\b/i,
 ];
 
 const PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -12,6 +12,7 @@ import {
   isBillingErrorMessage,
   isLikelyContextOverflowError,
   isTransientHttpError,
+  isTransientNetworkErrorMessage,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -521,7 +522,9 @@ export async function runAgentTurnWithFallback(params: {
       const isCompactionFailure = !isBilling && isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
-      const isTransientHttp = isTransientHttpError(message);
+      // Transient transport errors: HTTP 5xx/provider errors OR raw network-level failures
+      const isTransientError =
+        isTransientHttpError(message) || isTransientNetworkErrorMessage(message);
 
       if (
         isCompactionFailure &&
@@ -593,7 +596,7 @@ export async function runAgentTurnWithFallback(params: {
         };
       }
 
-      if (isTransientHttp && !didRetryTransientHttpError) {
+      if (isTransientError && !didRetryTransientHttpError) {
         didRetryTransientHttpError = true;
         // Retry the full runWithModelFallback() cycle — transient errors
         // (502/521/etc.) typically affect the whole provider, so falling
@@ -609,7 +612,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
+      const safeMessage = isTransientError
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");


### PR DESCRIPTION
## Summary
- Add `isTransientNetworkErrorMessage()` to detect raw network-level failures (fetch failed, ECONNRESET, socket hang up, ETIMEDOUT, etc.)
- Classify network errors as `"timeout"` failover reason (same recovery path as HTTP 5xx)
- Add `"unhandled stop reason: error"` to timeout patterns — Ollama surfaces fetch-level failures as a generic "error" stop reason rather than "abort"
- Add `"fetch failed"` to subagent announce transient delivery error patterns
- Include network errors in agent-runner-execution transient error recovery path

## Context
When the primary Ollama provider was unreachable (e.g. host down), errors like "fetch failed" and "Network connection lost" were not recognized as failover-eligible. The model fallback system would not trigger, leaving the agent stuck instead of falling back to OpenRouter or other configured providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)