### PR TITLE
fix: strip silent-reply token instead of discarding entire payload

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -1,7 +1,11 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { parseReplyDirectives } from "../../../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
+import {
+  isSilentReplyText,
+  stripTrailingSilentReplyToken,
+  SILENT_REPLY_TOKEN,
+} from "../../../auto-reply/tokens.js";
 import { formatToolAggregate } from "../../../auto-reply/tool-meta.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
@@ -339,8 +343,14 @@ export function buildEmbeddedRunPayloads(params: {
       if (!p.text && !p.mediaUrl && (!p.mediaUrls || p.mediaUrls.length === 0)) {
         return false;
       }
+      // If the text contains a silent-reply token, strip it instead of discarding
+      // the entire payload — the model may have appended real content before the token.
       if (p.text && isSilentReplyText(p.text, SILENT_REPLY_TOKEN)) {
-        return false;
+        const stripped = stripTrailingSilentReplyToken(p.text, SILENT_REPLY_TOKEN);
+        if (!stripped) {
+          return false;
+        }
+        p.text = stripped;
       }
       return true;
     });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -1,11 +1,7 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { parseReplyDirectives } from "../../../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
-import {
-  isSilentReplyText,
-  stripTrailingSilentReplyToken,
-  SILENT_REPLY_TOKEN,
-} from "../../../auto-reply/tokens.js";
+import { stripTrailingSilentReplyToken, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { formatToolAggregate } from "../../../auto-reply/tool-meta.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
@@ -339,18 +335,21 @@ export function buildEmbeddedRunPayloads(params: {
       replyToCurrent: item.replyToCurrent,
       audioAsVoice: item.audioAsVoice || Boolean(hasAudioAsVoiceTag && item.media?.length),
     }))
+    .map((p) => {
+      // Strip a trailing silent-reply token from text that contains real content
+      // (e.g. "Here is the answer NO_REPLY" → "Here is the answer").
+      // Returns undefined when the entire text is just the token.
+      if (p.text) {
+        const stripped = stripTrailingSilentReplyToken(p.text, SILENT_REPLY_TOKEN);
+        if (stripped !== p.text) {
+          return { ...p, text: stripped };
+        }
+      }
+      return p;
+    })
     .filter((p) => {
       if (!p.text && !p.mediaUrl && (!p.mediaUrls || p.mediaUrls.length === 0)) {
         return false;
-      }
-      // If the text contains a silent-reply token, strip it instead of discarding
-      // the entire payload — the model may have appended real content before the token.
-      if (p.text && isSilentReplyText(p.text, SILENT_REPLY_TOKEN)) {
-        const stripped = stripTrailingSilentReplyToken(p.text, SILENT_REPLY_TOKEN);
-        if (!stripped) {
-          return false;
-        }
-        p.text = stripped;
       }
       return true;
     });

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isSilentReplyPrefixText, isSilentReplyText, stripSilentToken } from "./tokens.js";
+import {
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  stripSilentToken,
+  stripTrailingSilentReplyToken,
+} from "./tokens.js";
 
 describe("isSilentReplyText", () => {
   it("returns true for exact token", () => {
@@ -70,6 +75,36 @@ describe("stripSilentToken", () => {
 
   it("works with custom token", () => {
     expect(stripSilentToken("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe("done");
+  });
+});
+
+describe("stripTrailingSilentReplyToken", () => {
+  it("strips trailing token from mixed content", () => {
+    expect(stripTrailingSilentReplyToken("Here is the answer NO_REPLY")).toBe("Here is the answer");
+    expect(stripTrailingSilentReplyToken("Done.\n\nNO_REPLY")).toBe("Done.");
+  });
+
+  it("returns undefined for token-only text", () => {
+    expect(stripTrailingSilentReplyToken("NO_REPLY")).toBeUndefined();
+    expect(stripTrailingSilentReplyToken("  NO_REPLY  ")).toBeUndefined();
+  });
+
+  it("returns undefined when token is at the start (prefix)", () => {
+    expect(stripTrailingSilentReplyToken("NO_REPLY but here is more")).toBeUndefined();
+  });
+
+  it("returns undefined for empty/undefined input", () => {
+    expect(stripTrailingSilentReplyToken(undefined)).toBeUndefined();
+    expect(stripTrailingSilentReplyToken("")).toBeUndefined();
+  });
+
+  it("returns text unchanged when no token present", () => {
+    expect(stripTrailingSilentReplyToken("just normal text")).toBe("just normal text");
+  });
+
+  it("works with custom token", () => {
+    expect(stripTrailingSilentReplyToken("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe("done");
+    expect(stripTrailingSilentReplyToken("HEARTBEAT_OK", "HEARTBEAT_OK")).toBeUndefined();
   });
 });
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -49,6 +49,27 @@ export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKE
   return text.replace(getSilentTrailingRegex(token), "").trim();
 }
 
+/**
+ * Strip a trailing silent-reply token from text that contains real content.
+ * Returns the cleaned text, or undefined if the entire text is just the token.
+ */
+export function stripTrailingSilentReplyToken(
+  text: string | undefined,
+  token: string = SILENT_REPLY_TOKEN,
+): string | undefined {
+  if (!text) {
+    return undefined;
+  }
+  const escaped = escapeRegExp(token);
+  const prefix = new RegExp(`^\\s*${escaped}(?=$|\\W)`);
+  if (prefix.test(text)) {
+    return undefined;
+  }
+  const suffix = new RegExp(`\\s*\\b${escaped}\\b\\W*$`);
+  const stripped = text.replace(suffix, "").trim();
+  return stripped || undefined;
+}
+
 export function isSilentReplyPrefixText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,


### PR DESCRIPTION
## Summary
- Add `stripTrailingSilentReplyToken()` utility that removes the token while preserving real content
- In `buildEmbeddedRunPayloads`, strip the token from the text instead of filtering out the entire payload
- Only suppress the message if it contains nothing but the token

## Context
When the model's response contained the silent-reply token alongside real content (e.g. `"Here's your answer... [TOKEN]"`), the entire message was discarded. The user received no reply despite the model having produced useful output. Now the token is stripped and the remaining text is delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)