### PR TITLE
fix(agents): recognize Codex/OpenAI server_error in failover classifier (#43591)

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -13,7 +13,8 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
-    // Transient server errors (502/503/504) should trigger failover as timeout.
+    // Transient server errors (500/502/503/504) should trigger failover as timeout.
+    expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -163,7 +163,7 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) {
     return "timeout";
   }
-  if (status === 502 || status === 503 || status === 504) {
+  if (status === 500 || status === 502 || status === 503 || status === 504) {
     return "timeout";
   }
   if (status === 400) {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -447,4 +447,14 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+  it("classifies Codex/OpenAI server_error payloads as timeout", () => {
+    expect(
+      classifyFailoverReason(
+        'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred"}}',
+      ),
+    ).toBe("timeout");
+  });
+  it("classifies plain server_error text as timeout", () => {
+    expect(classifyFailoverReason("server_error")).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -754,6 +754,18 @@ function isJsonApiInternalServerError(raw: string): boolean {
   return value.includes('"type":"api_error"') && value.includes("internal server error");
 }
 
+export function isOpenAiServerError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const value = raw.toLowerCase();
+  return (
+    value.includes('"type":"server_error"') ||
+    value.includes('"code":"server_error"') ||
+    /\bserver_error\b/.test(value)
+  );
+}
+
 export function parseImageDimensionError(raw: string): {
   maxDimensionPx?: number;
   messageIndex?: number;
@@ -863,6 +875,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     return "timeout";
   }
   if (isJsonApiInternalServerError(raw)) {
+    return "timeout";
+  }
+  if (isOpenAiServerError(raw)) {
     return "timeout";
   }
   if (isRateLimitErrorMessage(raw)) {


### PR DESCRIPTION
## Summary
- add `isOpenAiServerError(raw)` in `src/agents/pi-embedded-helpers/errors.ts` to recognize Codex/OpenAI `server_error` payloads and classify them as `timeout`
- include HTTP `500` in `resolveFailoverReasonFromError()` timeout status mapping in `src/agents/failover-error.ts`
- add regression tests for Codex/OpenAI `server_error`, plain `server_error` text, and HTTP 500 failover classification

## Verification
- `pnpm test -- --reporter=dot src/agents/failover-error.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` *(fails in current branch due unrelated existing runtime error: `(0 , __vite_ssr_import_0__.getOAuthProviders) is not a function` while loading `src/agents/auth-profiles/oauth.ts`)*
- `pnpm build`
- lsp diagnostics clean for changed files
