### PR TITLE
fix(config): preserve $schema on config hot-reload rewrite

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -317,6 +317,14 @@ function resolveGatewayMode(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function readConfigSchemaUri(value: unknown): string | undefined {
+  if (!isPlainObject(value) || typeof value.$schema !== "string") {
+    return undefined;
+  }
+  const trimmed = value.$schema.trim();
+  return trimmed.length > 0 ? value.$schema : undefined;
+}
+
 function cloneUnknown<T>(value: T): T {
   return structuredClone(value);
 }
@@ -1107,6 +1115,16 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           outputConfig = unsetResult.next;
         }
       }
+    }
+    const schemaUri =
+      readConfigSchemaUri(outputConfig) ??
+      readConfigSchemaUri(cfg) ??
+      readConfigSchemaUri(snapshot.parsed);
+    if (schemaUri) {
+      outputConfig = {
+        ...outputConfig,
+        $schema: schemaUri,
+      };
     }
     // Do NOT apply runtime defaults when writing — user config should only contain
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -126,6 +126,26 @@ describe("config io write", () => {
     });
   });
 
+  it("preserves $schema field on write", async () => {
+    await withTempHome("openclaw-config-io-", async (home) => {
+      const schemaUri = "https://openclaw.ai/config.json";
+      const { configPath, io, snapshot } = await writeConfigAndCreateIo({
+        home,
+        initialConfig: {
+          $schema: schemaUri,
+          gateway: { port: 18789 },
+        },
+      });
+
+      const persisted = await writeTokenAuthAndReadConfig({ io, snapshot, configPath });
+      expect(persisted.$schema).toBe(schemaUri);
+      expect(persisted.gateway).toEqual({
+        port: 18789,
+        auth: { mode: "token" },
+      });
+    });
+  });
+
   it('shows actionable guidance for dmPolicy="open" without wildcard allowFrom', async () => {
     await withTempHome("openclaw-config-io-", async (home) => {
       const io = createConfigIO({

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -26,6 +26,8 @@ import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
 export type OpenClawConfig = {
+  /** Optional JSON schema URI for editor tooling. */
+  $schema?: string;
   meta?: {
     /** Last OpenClaw version that wrote this config. */
     lastTouchedVersion?: string;


### PR DESCRIPTION
## Summary
- preserve the root `$schema` URI while writing config snapshots so hot-reload rewrites do not drop editor schema metadata
- add an io write test that verifies `$schema` survives a write round-trip while applying unrelated config changes
- add `$schema` to `OpenClawConfig` typings to keep write-path handling explicit and type-safe

## Testing
- pnpm test -- --reporter=dot src/config/io.write-config.test.ts src/config/config-misc.test.ts *(fails in this environment before test execution with `TypeError: getOAuthProviders is not a function` from `src/agents/auth-profiles/oauth.ts`)*