### PR TITLE
fix(errors): classify connection errors as retryable failover reason

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -108,6 +108,19 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("API provider");
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
+  it("returns a friendly message for connection errors", () => {
+    const msg = makeAssistantError("Connection error.");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The AI service encountered a connection error. Please try again in a moment.",
+    );
+  });
+  it("returns a friendly message for APIConnectionError", () => {
+    const msg = makeAssistantError("APIConnectionError: Connection error.");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The AI service encountered a connection error. Please try again in a moment.",
+    );
+  });
+
   it("returns a friendly message for rate limit errors", () => {
     const msg = makeAssistantError("429 rate limit reached");
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");

--- a/src/agents/pi-embedded-helpers.isconnectionerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isconnectionerrormessage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isConnectionErrorMessage } from "./pi-embedded-helpers.js";
+
+describe("isConnectionErrorMessage", () => {
+  it("returns true for Anthropic SDK APIConnectionError message", () => {
+    expect(isConnectionErrorMessage("Connection error.")).toBe(true);
+  });
+
+  it("returns true for common connection failure patterns", () => {
+    expect(isConnectionErrorMessage("socket hang up")).toBe(true);
+    expect(isConnectionErrorMessage("connect ECONNREFUSED 127.0.0.1:443")).toBe(true);
+    expect(isConnectionErrorMessage("read ECONNRESET")).toBe(true);
+    expect(isConnectionErrorMessage("getaddrinfo ENOTFOUND api.anthropic.com")).toBe(true);
+    expect(isConnectionErrorMessage("fetch failed")).toBe(true);
+    expect(isConnectionErrorMessage("network error")).toBe(true);
+    expect(isConnectionErrorMessage("DNS lookup failed")).toBe(true);
+    expect(isConnectionErrorMessage("APIConnectionError: Connection error.")).toBe(true);
+  });
+
+  it("returns false for non-connection errors", () => {
+    expect(isConnectionErrorMessage("rate limit exceeded")).toBe(false);
+    expect(isConnectionErrorMessage("invalid api key")).toBe(false);
+    expect(isConnectionErrorMessage("timeout")).toBe(false);
+    expect(isConnectionErrorMessage("overloaded")).toBe(false);
+    expect(isConnectionErrorMessage("402 Payment Required")).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-helpers.isconnectionerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isconnectionerrormessage.test.ts
@@ -14,6 +14,8 @@ describe("isConnectionErrorMessage", () => {
     expect(isConnectionErrorMessage("fetch failed")).toBe(true);
     expect(isConnectionErrorMessage("network error")).toBe(true);
     expect(isConnectionErrorMessage("DNS lookup failed")).toBe(true);
+    expect(isConnectionErrorMessage("getaddrinfo EAI_AGAIN api.anthropic.com")).toBe(true);
+    expect(isConnectionErrorMessage("network request failed")).toBe(true);
     expect(isConnectionErrorMessage("APIConnectionError: Connection error.")).toBe(true);
   });
 

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -28,6 +28,7 @@ export {
   isCloudflareOrHtmlErrorPage,
   isCloudCodeAssistFormatError,
   isCompactionFailureError,
+  isConnectionErrorMessage,
   isContextOverflowError,
   isLikelyContextOverflowError,
   isFailoverAssistantError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -7,6 +7,7 @@ import {
   isAuthErrorMessage,
   isAuthPermanentErrorMessage,
   isBillingErrorMessage,
+  isConnectionErrorMessage,
   isOverloadedErrorMessage,
   isPeriodicUsageLimitErrorMessage,
   isRateLimitErrorMessage,
@@ -19,6 +20,7 @@ export {
   isAuthErrorMessage,
   isAuthPermanentErrorMessage,
   isBillingErrorMessage,
+  isConnectionErrorMessage,
   isOverloadedErrorMessage,
   isRateLimitErrorMessage,
   isTimeoutErrorMessage,
@@ -700,6 +702,10 @@ export function formatAssistantErrorText(
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
+  if (isConnectionErrorMessage(raw)) {
+    return "The AI service encountered a connection error. Please try again in a moment.";
+  }
+
   const transientCopy = formatRateLimitOrOverloadedErrorCopy(raw);
   if (transientCopy) {
     return transientCopy;
@@ -977,6 +983,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isBillingErrorMessage(raw)) {
     return "billing";
+  }
+  if (isConnectionErrorMessage(raw)) {
+    return "timeout";
   }
   if (isTimeoutErrorMessage(raw)) {
     return "timeout";

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -98,8 +98,10 @@ const ERROR_PATTERNS = {
     "socket hang up",
     /\beconn(?:refused|reset|aborted)\b/i,
     /\benotfound\b/i,
+    /\beai_again\b/i,
     "fetch failed",
     "network error",
+    "network request failed",
     "dns lookup failed",
   ],
 } as const;

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -92,6 +92,16 @@ const ERROR_PATTERNS = {
     "invalid request format",
     /tool call id was.*must be/i,
   ],
+  connection: [
+    "connection error",
+    "apiconnectionerror",
+    "socket hang up",
+    /\beconn(?:refused|reset|aborted)\b/i,
+    /\benotfound\b/i,
+    "fetch failed",
+    "network error",
+    "dns lookup failed",
+  ],
 } as const;
 
 const BILLING_ERROR_HEAD_RE =
@@ -159,4 +169,8 @@ export function isAuthErrorMessage(raw: string): boolean {
 
 export function isOverloadedErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.overloaded);
+}
+
+export function isConnectionErrorMessage(raw: string): boolean {
+  return matchesErrorPatterns(raw, ERROR_PATTERNS.connection);
 }


### PR DESCRIPTION
## Summary

Rebased successor of #15163 (stale due to merge conflicts with the `failover-matches.ts` refactor).

Connection-level failures (`ECONNREFUSED`, `ECONNRESET`, `ENOTFOUND`, `socket hang up`, `fetch failed`, `APIConnectionError`, `dns lookup failed`, etc.) were previously unclassified — they leaked raw error text to channels and were not retried by the failover mechanism.

This PR:
- Adds a `connection` error pattern set to `failover-matches.ts` (aligned with the refactored architecture that moved patterns out of `errors.ts`)
- Exposes `isConnectionErrorMessage()` for connection-specific detection
- Wires it into `formatAssistantErrorText()` to return a friendly user-facing message instead of raw error text
- Wires it into `classifyFailoverReason()` mapped to `"timeout"` (retryable), so the failover mechanism can retry on a different provider

### What changed vs #15163
The original PR defined patterns inline in `errors.ts`. Since then, main refactored all error patterns into `failover-matches.ts`. This PR follows the new architecture — the `connection` pattern set and `isConnectionErrorMessage()` live in `failover-matches.ts` alongside the existing pattern categories.

## Test plan
- [x] New `isConnectionErrorMessage` test suite (3 tests: SDK message, common patterns, negative cases)
- [x] New `formatAssistantErrorText` tests for connection error messages (2 tests)
- [x] All existing tests pass

Fixes #15083
Supersedes #15163

🤖 Generated with [Claude Code](https://claude.com/claude-code)