### PR TITLE
fix(cli): ignore invalid canonical session ids

### DIFF
--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -4,11 +4,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { runCliAgent } from "./cli-runner.js";
-import {
-  parseCliJson,
-  parseCliJsonl,
-  resolveCliNoOutputTimeoutMs,
-} from "./cli-runner/helpers.js";
+import { parseCliJson, parseCliJsonl, resolveCliNoOutputTimeoutMs } from "./cli-runner/helpers.js";
 
 const supervisorSpawnMock = vi.fn();
 const enqueueSystemEventMock = vi.fn();

--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { runCliAgent } from "./cli-runner.js";
-import { resolveCliNoOutputTimeoutMs } from "./cli-runner/helpers.js";
+import {
+  parseCliJson,
+  parseCliJsonl,
+  resolveCliNoOutputTimeoutMs,
+} from "./cli-runner/helpers.js";
 
 const supervisorSpawnMock = vi.fn();
 const enqueueSystemEventMock = vi.fn();
@@ -313,5 +317,44 @@ describe("resolveCliNoOutputTimeoutMs", () => {
       useResume: true,
     });
     expect(timeoutMs).toBe(42_000);
+  });
+});
+
+describe("CLI session id parsing", () => {
+  it("ignores non-UUID canonical session ids from JSON output", () => {
+    const parsed = parseCliJson(
+      JSON.stringify({
+        message: "rate limited",
+        session_id: "rate-limited",
+      }),
+      { command: "claude" },
+    );
+
+    expect(parsed?.sessionId).toBeUndefined();
+  });
+
+  it("preserves UUID canonical session ids from JSON output", () => {
+    const sessionId = "550e8400-e29b-41d4-a716-446655440000";
+    const parsed = parseCliJson(
+      JSON.stringify({
+        message: "ok",
+        session_id: sessionId,
+      }),
+      { command: "claude" },
+    );
+
+    expect(parsed?.sessionId).toBe(sessionId);
+  });
+
+  it("keeps JSONL thread_id fallback when canonical session ids are invalid", () => {
+    const parsed = parseCliJsonl(
+      [
+        JSON.stringify({ session_id: "rate-limited" }),
+        JSON.stringify({ thread_id: "thread-123", item: { type: "message", text: "ok" } }),
+      ].join("\n"),
+      { command: "codex" },
+    );
+
+    expect(parsed?.sessionId).toBe("thread-123");
   });
 });

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -158,6 +158,9 @@ function collectText(value: unknown): string {
   return "";
 }
 
+const UUID_SESSION_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 function pickSessionId(
   parsed: Record<string, unknown>,
   backend: CliBackendConfig,
@@ -171,7 +174,11 @@ function pickSessionId(
   for (const field of fields) {
     const value = parsed[field];
     if (typeof value === "string" && value.trim()) {
-      return value.trim();
+      const trimmed = value.trim();
+      if (!UUID_SESSION_ID_RE.test(trimmed)) {
+        continue;
+      }
+      return trimmed;
     }
   }
   return undefined;


### PR DESCRIPTION
## Summary
- ignore non-UUID canonical CLI session ids before persisting them for resume
- keep valid UUID session ids unchanged
- preserve the existing `thread_id` JSONL fallback for Codex-style backends

## Problem
`pickSessionId()` accepted any non-empty value from canonical fields like `session_id`, so Claude CLI responses such as `session_id: "rate-limited"` were being persisted and later passed into `--resume`. Claude expects a UUID there and crashes on the next turn.

## What Changed
- `pickSessionId()` now accepts only UUID-shaped values from canonical session id fields
- invalid canonical values are ignored so parsing can continue
- the existing `thread_id` fallback in `parseCliJsonl()` remains unchanged

## Testing
- `G:\Rust\openclaw\node_modules\.bin\vitest.cmd run src/agents/cli-runner.test.ts --reporter=dot`
- `G:\Rust\openclaw\node_modules\.bin\vitest.cmd run src/agents/claude-cli-runner.test.ts --reporter=dot`

## Linked Issue
- Closes #43288

## Transparency
- AI-assisted: implemented with Codex
