### PR TITLE
fix(plugins): suppress provenance warning for plugins in plugins.allow

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -825,7 +825,7 @@ describe("loadOpenClawPlugins", () => {
     ).toBe(true);
   });
 
-  it("warns when loaded non-bundled plugin has no install/load-path provenance", () => {
+  it("suppresses provenance warning for plugins explicitly listed in plugins.allow", () => {
     useNoBundledPlugins();
     const stateDir = makeTempDir();
     withEnv({ OPENCLAW_STATE_DIR: stateDir, CLAWDBOT_STATE_DIR: undefined }, () => {
@@ -845,6 +845,41 @@ describe("loadOpenClawPlugins", () => {
         config: {
           plugins: {
             allow: ["rogue"],
+          },
+        },
+      });
+
+      const rogue = registry.plugins.find((entry) => entry.id === "rogue");
+      expect(rogue?.status).toBe("loaded");
+      expect(
+        warnings.some(
+          (msg) =>
+            msg.includes("rogue") && msg.includes("loaded without install/load-path provenance"),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it("warns when loaded non-bundled plugin has no install/load-path provenance and is not in allow list", () => {
+    useNoBundledPlugins();
+    const stateDir = makeTempDir();
+    withEnv({ OPENCLAW_STATE_DIR: stateDir, CLAWDBOT_STATE_DIR: undefined }, () => {
+      const globalDir = path.join(stateDir, "extensions", "rogue");
+      fs.mkdirSync(globalDir, { recursive: true });
+      writePlugin({
+        id: "rogue",
+        body: `module.exports = { id: "rogue", register() {} };`,
+        dir: globalDir,
+        filename: "index.cjs",
+      });
+
+      const warnings: string[] = [];
+      const registry = loadOpenClawPlugins({
+        cache: false,
+        logger: createWarningLogger(warnings),
+        config: {
+          plugins: {
+            enabled: true,
           },
         },
       });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -338,10 +338,15 @@ function warnWhenAllowlistIsOpen(params: {
 function warnAboutUntrackedLoadedPlugins(params: {
   registry: PluginRegistry;
   provenance: PluginProvenanceIndex;
+  allow: string[];
   logger: PluginLogger;
 }) {
+  const allowSet = new Set(params.allow);
   for (const plugin of params.registry.plugins) {
     if (plugin.status !== "loaded" || plugin.origin === "bundled") {
+      continue;
+    }
+    if (allowSet.has(plugin.id)) {
       continue;
     }
     if (
@@ -684,6 +689,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   warnAboutUntrackedLoadedPlugins({
     registry,
     provenance,
+    allow: normalized.allow,
     logger,
   });
 


### PR DESCRIPTION
## Summary

- Suppress the "loaded without install/load-path provenance" warning for plugins that are explicitly listed in `plugins.allow`
- When a user explicitly trusts a plugin via `plugins.allow`, the provenance warning is redundant and confusing

Closes #43655

## Changes

- `src/plugins/loader.ts`: Added `allow` parameter to `warnAboutUntrackedLoadedPlugins()` and skip warning for plugins in the allow list
- `src/plugins/loader.test.ts`: Updated existing test to verify warning is suppressed for allowed plugins; added new test to verify warning still fires for non-allowed plugins

## Test plan

- [x] Existing test updated: allowed plugin no longer triggers provenance warning
- [x] New test added: non-allowed plugin still triggers provenance warning
- [x] All 29 loader tests pass (`pnpm vitest run src/plugins/loader.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)