### PR TITLE
fix(docker): clean up stale containers before gateway start

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -477,7 +477,7 @@ echo "==> Cleaning up stale containers"
 # Remove leftover containers and orphan networks from previous runs.
 # Abnormal exits (kill -9, power loss, OOM-kill) bypass --rm cleanup, leaving
 # ghost containers that cause port/name conflicts on the next start.
-docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans 2>/dev/null || true
+docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans || true
 
 echo ""
 echo "==> Starting gateway"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -473,6 +473,13 @@ echo "  ${COMPOSE_HINT} run --rm openclaw-cli channels add --channel discord --t
 echo "Docs: https://docs.openclaw.ai/channels"
 
 echo ""
+echo "==> Cleaning up stale containers"
+# Remove leftover containers and orphan networks from previous runs.
+# Abnormal exits (kill -9, power loss, OOM-kill) bypass --rm cleanup, leaving
+# ghost containers that cause port/name conflicts on the next start.
+docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans 2>/dev/null || true
+
+echo ""
 echo "==> Starting gateway"
 docker compose "${COMPOSE_ARGS[@]}" up -d openclaw-gateway
 


### PR DESCRIPTION
## Summary

Add a cleanup step to `docker-setup.sh` that removes stale containers and orphan networks before starting the gateway.

## Problem

`docker-setup.sh` uses `docker compose run --rm` extensively, but `--rm` only removes containers on **normal** exit. Abnormal terminations — `kill -9`, power loss, OOM-kill — leave ghost containers behind. On the next run, these cause:

- **Port conflicts**: the old container still holds port 18789/18790
- **Name conflicts**: Compose refuses to create a container with a duplicate name
- **Orphan networks**: stale bridge networks accumulate

## Changes

- Add `docker compose down --remove-orphans` before the "Starting gateway" step in `docker-setup.sh`
- The command is guarded with `|| true` so it never blocks a fresh first-time setup (where nothing exists to tear down)
- 7 lines added, 0 lines modified

## Testing

- Verified on macOS with Docker Desktop: `docker compose down --remove-orphans` correctly removes leftover containers and networks, then `up -d` succeeds cleanly
- On a fresh setup with no prior containers, the `down` command exits silently (no error)
