### PR TITLE
fix(docker): isolate IPC namespace for both services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+    ipc: private
     init: true
     restart: unless-stopped
     command:
@@ -68,6 +69,7 @@ services:
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+    ipc: private
     stdin_open: true
     tty: true
     init: true


### PR DESCRIPTION
## Summary

Add `ipc: private` to both `openclaw-gateway` and `openclaw-cli` services in `docker-compose.yml` to explicitly isolate the IPC namespace.

## Problem

Without an explicit `ipc` setting, Docker's default IPC namespace behavior depends on the Engine version:
- **Docker < 20.10**: the default is `shareable`, which allows other containers to join the namespace via `ipc: container:<name>`, exposing System V shared memory segments, semaphores, and POSIX message queues.
- **Docker >= 20.10**: the default is already `private`, but this is not guaranteed by the Compose spec and could change.

Setting `ipc: private` explicitly makes the security posture auditable and version-independent.

## Changes

- Add `ipc: private` to `openclaw-gateway` service
- Add `ipc: private` to `openclaw-cli` service
- 2 lines added, 0 lines modified

## Context

This complements the existing security hardening on `openclaw-cli`:
- `cap_drop: [NET_RAW, NET_ADMIN]`
- `security_opt: [no-new-privileges:true]`

Adding explicit IPC isolation provides defense-in-depth with zero functional impact — neither service uses inter-process shared memory.
