### PR TITLE
fix(agents): preserve threaded delivery route for subagent completion

### DIFF
--- a/src/agents/subagent-announce.resolve-origin.test.ts
+++ b/src/agents/subagent-announce.resolve-origin.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import type { DeliveryContext } from "../utils/delivery-context.js";
+import type { DeliveryContextSessionSource } from "../utils/delivery-context.js";
+import { resolveAnnounceOrigin } from "./subagent-announce.js";
+
+describe("resolveAnnounceOrigin thread routing", () => {
+  it("preserves session entry threadId when requester has to but no threadId", () => {
+    // Feishu scenario: completion comes back with channel/to but no explicit threadId.
+    // The entry has a persisted threadId from the original message.
+    // Expected: threadId should be preserved from entry.
+    const entry: DeliveryContextSessionSource = {
+      lastChannel: "feishu",
+      lastTo: "channel:C123",
+      lastAccountId: "acc1",
+      lastThreadId: "thread-456",
+    };
+
+    const requesterOrigin: DeliveryContext = {
+      channel: "feishu",
+      to: "channel:C123",
+      accountId: "acc1",
+      // threadId is intentionally absent
+    };
+
+    const result = resolveAnnounceOrigin(entry, requesterOrigin);
+
+    expect(result?.threadId).toBe("thread-456");
+  });
+
+  it("preserves requester threadId when explicitly provided", () => {
+    // When requester explicitly provides a threadId, it should take priority.
+    const entry: DeliveryContextSessionSource = {
+      lastChannel: "feishu",
+      lastTo: "channel:C123",
+      lastAccountId: "acc1",
+      lastThreadId: "thread-456",
+    };
+
+    const requesterOrigin: DeliveryContext = {
+      channel: "feishu",
+      to: "channel:C123",
+      accountId: "acc1",
+      threadId: "thread-789",
+    };
+
+    const result = resolveAnnounceOrigin(entry, requesterOrigin);
+
+    expect(result?.threadId).toBe("thread-789");
+  });
+
+  it("uses entry threadId when requester has no to field", () => {
+    // When requester doesn't override the 'to' field, entry's threadId should be preserved.
+    const entry: DeliveryContextSessionSource = {
+      lastChannel: "feishu",
+      lastTo: "channel:C123",
+      lastAccountId: "acc1",
+      lastThreadId: "thread-456",
+    };
+
+    const requesterOrigin: DeliveryContext = {
+      channel: "feishu",
+      accountId: "acc1",
+      // No 'to' field
+    };
+
+    const result = resolveAnnounceOrigin(entry, requesterOrigin);
+
+    expect(result?.threadId).toBe("thread-456");
+  });
+
+  it("handles missing entry gracefully", () => {
+    // When there's no persisted entry, use requester's threadId.
+    const requesterOrigin: DeliveryContext = {
+      channel: "feishu",
+      to: "channel:C123",
+      accountId: "acc1",
+      threadId: "thread-789",
+    };
+
+    const result = resolveAnnounceOrigin(undefined, requesterOrigin);
+
+    expect(result?.threadId).toBe("thread-789");
+    expect(result?.channel).toBe("feishu");
+  });
+
+  it("handles missing requester gracefully", () => {
+    // When there's no requester origin, use entry's threadId.
+    const entry: DeliveryContextSessionSource = {
+      lastChannel: "feishu",
+      lastTo: "channel:C123",
+      lastAccountId: "acc1",
+      lastThreadId: "thread-456",
+    };
+
+    const result = resolveAnnounceOrigin(entry, undefined);
+
+    expect(result?.threadId).toBe("thread-456");
+    expect(result?.channel).toBe("feishu");
+  });
+
+  it("prefers requester channel over entry channel, and uses requester's to/threadId when channels conflict", () => {
+    // When channels conflict (feishu vs whatsapp), the merge function keeps route fields
+    // paired to the primary (requester) channel and doesn't cross fields between channels.
+    // Since requester has no 'to', the result will have no 'to' (not fallback to entry's).
+    const entry: DeliveryContextSessionSource = {
+      lastChannel: "whatsapp",
+      lastTo: "channel:C123",
+      lastAccountId: "acc1",
+      lastThreadId: "thread-456",
+    };
+
+    const requesterOrigin: DeliveryContext = {
+      channel: "feishu",
+      accountId: "acc1",
+      // No 'to' field
+    };
+
+    const result = resolveAnnounceOrigin(entry, requesterOrigin);
+
+    // Channel comes from requester (feishu), but since channels conflict,
+    // 'to' and 'threadId' are not crossed from entry (whatsapp).
+    expect(result?.channel).toBe("feishu");
+    expect(result?.to).toBeUndefined();
+    expect(result?.threadId).toBeUndefined();
+  });
+
+  it("does not reuse entry threadId when same channel but different to", () => {
+    // Regression test: same channel + different 'to' + missing requester threadId
+    // should NOT reuse entry's threadId, as it belongs to a different conversation.
+    const entry: DeliveryContextSessionSource = {
+      lastChannel: "feishu",
+      lastTo: "channel:C123",
+      lastAccountId: "acc1",
+      lastThreadId: "thread-456",
+    };
+
+    const requesterOrigin: DeliveryContext = {
+      channel: "feishu",
+      to: "channel:C999", // Different destination
+      accountId: "acc1",
+      // threadId is intentionally absent
+    };
+
+    const result = resolveAnnounceOrigin(entry, requesterOrigin);
+
+    // Should use requester's 'to' but NOT entry's threadId (different conversation).
+    expect(result?.channel).toBe("feishu");
+    expect(result?.to).toBe("channel:C999");
+    expect(result?.threadId).toBeUndefined();
+  });
+});

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -475,7 +475,7 @@ async function buildCompactAnnounceStatsLine(params: {
 
 type DeliveryContextSource = Parameters<typeof deliveryContextFromSession>[0];
 
-function resolveAnnounceOrigin(
+export function resolveAnnounceOrigin(
   entry?: DeliveryContextSource,
   requesterOrigin?: DeliveryContext,
 ): DeliveryContext | undefined {
@@ -498,16 +498,23 @@ function resolveAnnounceOrigin(
   // requesterOrigin (captured at spawn time) reflects the channel the user is
   // actually on and must take priority over the session entry, which may carry
   // stale lastChannel / lastTo values from a previous channel interaction.
-  const entryForMerge =
+  // Preserve the entry's threadId when the requester doesn't explicitly override it,
+  // since absence of threadId in requesterOrigin does not mean "don't thread".
+  // However, if the same channel has a different 'to' destination, do not reuse
+  // the entry's threadId, as it belongs to a different conversation.
+  const sameChannelDifferentTo =
+    normalizedRequester?.channel &&
+    normalizedEntry?.channel &&
+    normalizedRequester.channel === normalizedEntry.channel &&
     normalizedRequester?.to &&
-    normalizedRequester.threadId == null &&
-    normalizedEntry?.threadId != null
-      ? (() => {
-          const { threadId: _ignore, ...rest } = normalizedEntry;
-          return rest;
-        })()
-      : normalizedEntry;
-  return mergeDeliveryContext(normalizedRequester, entryForMerge);
+    normalizedEntry?.to &&
+    normalizedRequester.to !== normalizedEntry.to;
+  if (sameChannelDifferentTo) {
+    // Remove threadId from entry to prevent cross-conversation reuse.
+    const entryWithoutThreadId = { ...normalizedEntry, threadId: undefined };
+    return mergeDeliveryContext(normalizedRequester, entryWithoutThreadId);
+  }
+  return mergeDeliveryContext(normalizedRequester, normalizedEntry);
 }
 
 async function resolveSubagentCompletionOrigin(params: {


### PR DESCRIPTION
## Summary
Fix threaded delivery routing for sub-agent completion announcements.

When a requester origin included `to` but omitted `threadId`, the announce origin merge logic discarded the persisted session-entry thread route. That caused threaded completion messages to fall back to the main timeline instead of the originating thread.

## What changed
- remove the special-case logic that stripped `threadId` from the persisted announce route
- let `mergeDeliveryContext()` preserve the session-entry thread route as fallback
- export `resolveAnnounceOrigin()` for focused unit testing
- add regression tests covering threaded route preservation and channel-conflict behavior

## Why
Absence of `threadId` in `requesterOrigin` does not mean “do not thread”. It only means the requester did not explicitly override the thread route. The persisted session-entry thread route should remain available as fallback.

## Testing
- `pnpm test src/agents/subagent-announce.resolve-origin.test.ts`
- `pnpm test src/agents/subagent-announce*.test.ts --run`