### PR TITLE
fix(agents): handle stop_reason 'sensitive' gracefully (#43607)

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -116,6 +116,13 @@ const OVERLOAD_FAILOVER_BACKOFF_POLICY: BackoffPolicy = {
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)";
 
+// Detect model safety-filter rejections (stop_reason: sensitive).
+// This is NOT a timeout — it is a content policy block that requires a user-facing message.
+// Matches both bare text ("stop_reason: sensitive") and JSON-stringified variants
+// ('"stop_reason":"sensitive"') since describeUnknownError uses JSON.stringify.
+const SENSITIVE_STOP_REASON_RE =
+  /\bunhandled\s+stop[_ ]reason:\s*"?sensitive"?\b|\bstop[_ ]reason"?:\s*"?sensitive"?\b|\breason"?:\s*"?sensitive"?\b/i;
+
 function scrubAnthropicRefusalMagic(prompt: string): string {
   if (!prompt.includes(ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL)) {
     return prompt;
@@ -1268,6 +1275,33 @@ export async function runEmbeddedPiAgent(
             if (await maybeRefreshRuntimeAuthForAuthError(errorText, runtimeAuthRetry)) {
               authRetryPending = true;
               continue;
+            }
+            // Handle sensitive stop_reason (content safety filter) with a user-friendly message
+            if (SENSITIVE_STOP_REASON_RE.test(errorText)) {
+              return {
+                payloads: [
+                  {
+                    text:
+                      "I can't respond to that - the content was flagged by the model's safety filter. " +
+                      "Please rephrase or try a different topic.",
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: buildErrorAgentMeta({
+                    sessionId: sessionIdUsed,
+                    provider,
+                    model: model.id,
+                    usageAccumulator,
+                    lastRunPromptUsage,
+                    lastAssistant,
+                    lastTurnTotal,
+                  }),
+                  systemPromptReport: attempt.systemPromptReport,
+                  error: { kind: "sensitive", message: errorText },
+                },
+              };
             }
             // Handle role ordering errors with a user-friendly message
             if (/incorrect role information|roles must alternate/i.test(errorText)) {

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -41,7 +41,8 @@ export type EmbeddedPiRunMeta = {
       | "compaction_failure"
       | "role_ordering"
       | "image_size"
-      | "retry_limit";
+      | "retry_limit"
+      | "sensitive";
     message: string;
   };
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */


### PR DESCRIPTION
## Summary
- handle `Unhandled stop reason: sensitive` in the embedded runner as a graceful user-facing reply instead of rethrowing, so the agent turn completes without crashing
- add a regression test in `usage-reporting.test.ts` that verifies the sensitive stop-reason prompt error returns the safety-filter guidance message
- extend failover timeout hint parsing/tests to recognize `stop reason: sensitive` variants and avoid leaving these unclassified in failover error helpers

## Verification
- `pnpm test src/agents/pi-embedded-runner/usage-reporting.test.ts`
- `pnpm test src/agents/failover-error.test.ts` *(currently fails in this repo with `TypeError: getOAuthProviders is not a function` before tests execute)*
- `pnpm build`