### PR TITLE
fix(config): use passthrough for plugin entry schema to accept provider-specific keys

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -352,6 +352,25 @@ describe("config strict validation", () => {
     });
   });
 
+  it("accepts plugin entries with extra provider-specific keys (#43551)", () => {
+    const res = validateConfigObject({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        enabled: true,
+        entries: {
+          "openclaw-mem0": {
+            enabled: true,
+            mode: "qdrant",
+            userId: "test-user",
+            autoRecall: true,
+            oss: { apiUrl: "http://localhost:6333" },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it("still marks literal gateway.bind host aliases as legacy", async () => {
     await withTempHome(async (home) => {
       await writeOpenClawConfig(home, {

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -369,6 +369,15 @@ describe("config strict validation", () => {
       },
     });
     expect(res.ok).toBe(true);
+    if (res.ok) {
+      const entry = res.config.plugins?.entries?.["openclaw-mem0"] as Record<string, unknown>;
+      expect(entry.enabled).toBe(true);
+      // Passthrough keys must be preserved (not stripped) so plugins can read them.
+      expect(entry.mode).toBe("qdrant");
+      expect(entry.userId).toBe("test-user");
+      expect(entry.autoRecall).toBe(true);
+      expect(entry.oss).toEqual({ apiUrl: "http://localhost:6333" });
+    }
   });
 
   it("still marks literal gateway.bind host aliases as legacy", async () => {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -151,7 +151,7 @@ const PluginEntrySchema = z
     enabled: z.boolean().optional(),
     config: z.record(z.string(), z.unknown()).optional(),
   })
-  .strict();
+  .passthrough();
 
 export const OpenClawSchema = z
   .object({


### PR DESCRIPTION
## Summary

- Fix `PluginEntrySchema` using `.strict()` which rejects all keys except `enabled` and `config` in `plugins.entries.<id>`, causing gateway crash on startup
- Change to `.passthrough()` so provider-specific config keys (e.g. `mode`, `userId`, `autoRecall`, `oss`) are accepted without validation error
- Add test verifying plugin entries with extra provider-specific keys pass validation

## Root Cause

The Zod schema for plugin entries (`PluginEntrySchema`) used `.strict()` mode, which rejects any unrecognized keys. When users configure plugin-specific settings directly in `plugins.entries.<plugin-id>`, the strict validation throws "Unrecognized keys" and the gateway exits with code 1.

## Fix

Replace `.strict()` with `.passthrough()` on `PluginEntrySchema`. This preserves unknown keys in the parsed output instead of rejecting them, allowing plugins to define their own configuration keys.

Users can also nest config under the `config` sub-key (which already works), but top-level keys should not crash the gateway.

Fixes #43551

## Test plan

- [x] New test: "accepts plugin entries with extra provider-specific keys (#43551)" in `config-misc.test.ts`
- [x] All existing config validation tests pass
- [x] Full test suite passes (1 pre-existing failure in `commands.test.ts` unrelated to this change)
- [x] Build succeeds