### PR TITLE
fix(bluebubbles): lazy-refresh Private API status for reply threading

### DIFF
--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -641,10 +641,16 @@ describe("send", () => {
       mockSendResponse({ data: { guid: "msg-uuid-refreshed" } });
 
       const result = await sendMessageBlueBubbles("+15551234567", "Threaded reply", {
-        serverUrl: "http://localhost:1234",
-        password: "test",
         replyToMessageGuid: "reply-guid-456",
         replyToPartIndex: 0,
+        cfg: {
+          channels: {
+            bluebubbles: {
+              serverUrl: "http://localhost:1234",
+              password: "test",
+            },
+          },
+        },
       });
 
       expect(result.messageId).toBe("msg-uuid-refreshed");
@@ -674,10 +680,16 @@ describe("send", () => {
       mockSendResponse({ data: { guid: "msg-uuid-custom-timeout" } });
 
       await sendMessageBlueBubbles("+15551234567", "Threaded reply", {
-        serverUrl: "http://localhost:1234",
-        password: "test",
         replyToMessageGuid: "reply-guid-timeout",
         timeoutMs: 30000,
+        cfg: {
+          channels: {
+            bluebubbles: {
+              serverUrl: "http://localhost:1234",
+              password: "test",
+            },
+          },
+        },
       });
 
       expect(fetchServerInfoMock).toHaveBeenCalledWith(
@@ -741,6 +753,25 @@ describe("send", () => {
       expect(fetchServerInfoMock).toHaveBeenCalledTimes(1);
     });
 
+    it("skips lazy-refresh when credentials come only from opts (not account-bound)", async () => {
+      // When account config has no serverUrl and credentials come only from opts,
+      // the cache key (accountId) doesn't correspond to these credentials.
+      // Lazy-refresh should be skipped to avoid poisoning the account-scoped cache.
+      fetchServerInfoMock.mockClear();
+      privateApiStatusMock.mockReturnValue(null);
+
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-opts-only" } });
+
+      await sendMessageBlueBubbles("+15551234567", "Threaded reply", {
+        serverUrl: "http://localhost:1234",
+        password: "test",
+        replyToMessageGuid: "reply-guid-opts-only",
+      });
+
+      expect(fetchServerInfoMock).not.toHaveBeenCalled();
+    });
+
     it("degrades to plain send when lazy-refresh fails to restore Private API", async () => {
       // If fetchBlueBubblesServerInfo returns null (server unreachable),
       // privateApiStatus stays null and the reply should degrade gracefully.
@@ -755,9 +786,15 @@ describe("send", () => {
 
       try {
         const result = await sendMessageBlueBubbles("+15551234567", "Fallback reply", {
-          serverUrl: "http://localhost:1234",
-          password: "test",
           replyToMessageGuid: "reply-guid-789",
+          cfg: {
+            channels: {
+              bluebubbles: {
+                serverUrl: "http://localhost:1234",
+                password: "test",
+              },
+            },
+          },
         });
 
         expect(result.messageId).toBe("msg-uuid-degraded");

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -687,6 +687,34 @@ describe("send", () => {
       );
     });
 
+    it("skips lazy-refresh when caller overrides credentials to avoid cache poisoning", async () => {
+      // When opts.serverUrl differs from account.config.serverUrl, the lazy-refresh
+      // should be skipped to avoid writing a different server's Private API status
+      // into the account-scoped cache.
+      fetchServerInfoMock.mockClear();
+      privateApiStatusMock.mockReturnValue(null);
+
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-no-refresh" } });
+
+      await sendMessageBlueBubbles("+15551234567", "Threaded reply", {
+        serverUrl: "http://other-server:9999",
+        password: "other-pass",
+        replyToMessageGuid: "reply-guid-override",
+        cfg: {
+          channels: {
+            bluebubbles: {
+              serverUrl: "http://config-server:5678",
+              password: "config-pass",
+            },
+          },
+        },
+      });
+
+      // fetchBlueBubblesServerInfo should NOT have been called
+      expect(fetchServerInfoMock).not.toHaveBeenCalled();
+    });
+
     it("degrades to plain send when lazy-refresh fails to restore Private API", async () => {
       // If fetchBlueBubblesServerInfo returns null (server unreachable),
       // privateApiStatus stays null and the reply should degrade gracefully.

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -715,6 +715,32 @@ describe("send", () => {
       expect(fetchServerInfoMock).not.toHaveBeenCalled();
     });
 
+    it("lazy-refreshes when credentials come from account config (no opts override)", async () => {
+      // When opts.serverUrl is not set, credentials come from cfg — this is the normal
+      // channel.ts path. The lazy-refresh should still fire (not treated as an override).
+      fetchServerInfoMock.mockClear();
+      privateApiStatusMock.mockReturnValueOnce(null).mockReturnValueOnce(true);
+      fetchServerInfoMock.mockResolvedValueOnce({ private_api: true, server_version: "1.0.0" });
+
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-cfg-refresh" } });
+
+      const result = await sendMessageBlueBubbles("+15551234567", "Threaded reply", {
+        replyToMessageGuid: "reply-guid-cfg",
+        cfg: {
+          channels: {
+            bluebubbles: {
+              serverUrl: "http://config-server:5678",
+              password: "config-pass",
+            },
+          },
+        },
+      });
+
+      expect(result.messageId).toBe("msg-uuid-cfg-refresh");
+      expect(fetchServerInfoMock).toHaveBeenCalledTimes(1);
+    });
+
     it("degrades to plain send when lazy-refresh fails to restore Private API", async () => {
       // If fetchBlueBubblesServerInfo returns null (server unreachable),
       // privateApiStatus stays null and the reply should degrade gracefully.

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -666,6 +666,27 @@ describe("send", () => {
       expect(body.partIndex).toBe(0);
     });
 
+    it("forwards caller timeoutMs to lazy-refresh instead of hardcoded default", async () => {
+      privateApiStatusMock.mockReturnValueOnce(null).mockReturnValueOnce(true);
+      fetchServerInfoMock.mockResolvedValueOnce({ private_api: true, server_version: "1.0.0" });
+
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-custom-timeout" } });
+
+      await sendMessageBlueBubbles("+15551234567", "Threaded reply", {
+        serverUrl: "http://localhost:1234",
+        password: "test",
+        replyToMessageGuid: "reply-guid-timeout",
+        timeoutMs: 30000,
+      });
+
+      expect(fetchServerInfoMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutMs: 30000,
+        }),
+      );
+    });
+
     it("degrades to plain send when lazy-refresh fails to restore Private API", async () => {
       // If fetchBlueBubblesServerInfo returns null (server unreachable),
       // privateApiStatus stays null and the reply should degrade gracefully.

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-mocks.js";
-import { getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
+import { fetchBlueBubblesServerInfo, getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
 import type { PluginRuntime } from "./runtime-api.js";
 import { clearBlueBubblesRuntime, setBlueBubblesRuntime } from "./runtime.js";
 import { sendMessageBlueBubbles, resolveChatGuidForTarget, createChatForHandle } from "./send.js";
@@ -13,6 +13,7 @@ import type { BlueBubblesSendTarget } from "./types.js";
 
 const mockFetch = vi.fn();
 const privateApiStatusMock = vi.mocked(getCachedBlueBubblesPrivateApiStatus);
+const fetchServerInfoMock = vi.mocked(fetchBlueBubblesServerInfo);
 
 installBlueBubblesFetchTestHooks({
   mockFetch,
@@ -624,6 +625,76 @@ describe("send", () => {
       } finally {
         clearBlueBubblesRuntime();
         warnSpy.mockRestore();
+      }
+    });
+
+    it("lazy-refreshes Private API status when cache expired and reply requested", async () => {
+      // Regression test for #43764: when the 10-minute server info cache expires,
+      // privateApiStatus becomes null and replies silently degrade to plain sends.
+      // The lazy-refresh should re-fetch server info and restore reply threading.
+
+      // First call returns null (cache expired), second call returns true (after refresh)
+      privateApiStatusMock.mockReturnValueOnce(null).mockReturnValueOnce(true);
+      fetchServerInfoMock.mockResolvedValueOnce({ private_api: true, server_version: "1.0.0" });
+
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-refreshed" } });
+
+      const result = await sendMessageBlueBubbles("+15551234567", "Threaded reply", {
+        serverUrl: "http://localhost:1234",
+        password: "test",
+        replyToMessageGuid: "reply-guid-456",
+        replyToPartIndex: 0,
+      });
+
+      expect(result.messageId).toBe("msg-uuid-refreshed");
+
+      // fetchBlueBubblesServerInfo should have been called to refresh the cache
+      expect(fetchServerInfoMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "http://localhost:1234",
+          password: "test",
+          timeoutMs: 5000,
+        }),
+      );
+
+      // The send payload should include reply threading fields (not degraded)
+      const sendCall = mockFetch.mock.calls[1];
+      const body = JSON.parse(sendCall[1].body);
+      expect(body.method).toBe("private-api");
+      expect(body.selectedMessageGuid).toBe("reply-guid-456");
+      expect(body.partIndex).toBe(0);
+    });
+
+    it("degrades to plain send when lazy-refresh fails to restore Private API", async () => {
+      // If fetchBlueBubblesServerInfo returns null (server unreachable),
+      // privateApiStatus stays null and the reply should degrade gracefully.
+      const runtimeLog = vi.fn();
+      setBlueBubblesRuntime({ log: runtimeLog } as unknown as PluginRuntime);
+
+      privateApiStatusMock.mockReturnValue(null);
+      fetchServerInfoMock.mockResolvedValueOnce(null);
+
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-degraded" } });
+
+      try {
+        const result = await sendMessageBlueBubbles("+15551234567", "Fallback reply", {
+          serverUrl: "http://localhost:1234",
+          password: "test",
+          replyToMessageGuid: "reply-guid-789",
+        });
+
+        expect(result.messageId).toBe("msg-uuid-degraded");
+        expect(fetchServerInfoMock).toHaveBeenCalled();
+
+        // Should degrade: no private-api method, no selectedMessageGuid
+        const sendCall = mockFetch.mock.calls[1];
+        const body = JSON.parse(sendCall[1].body);
+        expect(body.method).toBeUndefined();
+        expect(body.selectedMessageGuid).toBeUndefined();
+      } finally {
+        clearBlueBubblesRuntime();
       }
     });
 

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -1049,6 +1049,162 @@ describe("send", () => {
       expect(typeof body.tempGuid).toBe("string");
       expect(body.tempGuid.length).toBeGreaterThan(0);
     });
+
+    describe("lazy-refresh Private API status", () => {
+      beforeEach(() => {
+        fetchServerInfoMock.mockClear();
+      });
+
+      it("refreshes when status is unknown and reply is requested with account-bound credentials", async () => {
+        // Start with unknown status, then after refresh return enabled
+        privateApiStatusMock
+          .mockReturnValueOnce(BLUE_BUBBLES_PRIVATE_API_STATUS.unknown)
+          .mockReturnValueOnce(BLUE_BUBBLES_PRIVATE_API_STATUS.enabled);
+        fetchServerInfoMock.mockResolvedValueOnce({ private_api: true });
+        mockResolvedHandleTarget();
+        mockSendResponse({ data: { guid: "msg-refreshed" } });
+
+        const result = await sendMessageBlueBubbles("+15551234567", "Reply with refresh", {
+          cfg: {
+            channels: {
+              bluebubbles: {
+                serverUrl: "http://localhost:1234",
+                password: "test",
+              },
+            },
+          },
+          replyToMessageGuid: "reply-guid-456",
+        });
+
+        expect(result.messageId).toBe("msg-refreshed");
+        expect(fetchServerInfoMock).toHaveBeenCalledTimes(1);
+        expect(fetchServerInfoMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            baseUrl: "http://localhost:1234",
+            password: "test",
+            accountId: "default",
+          }),
+        );
+        const sendCall = mockFetch.mock.calls[1];
+        const body = JSON.parse(sendCall[1].body);
+        expect(body.method).toBe("private-api");
+        expect(body.selectedMessageGuid).toBe("reply-guid-456");
+      });
+
+      it("skips refresh when no reply or effect is requested (plain send)", async () => {
+        mockResolvedHandleTarget();
+        mockSendResponse({ data: { guid: "msg-plain" } });
+
+        await sendMessageBlueBubbles("+15551234567", "Plain message", {
+          serverUrl: "http://localhost:1234",
+          password: "test",
+        });
+
+        expect(fetchServerInfoMock).not.toHaveBeenCalled();
+      });
+
+      it("skips refresh when status is already known (enabled)", async () => {
+        mockBlueBubblesPrivateApiStatusOnce(
+          privateApiStatusMock,
+          BLUE_BUBBLES_PRIVATE_API_STATUS.enabled,
+        );
+        mockResolvedHandleTarget();
+        mockSendResponse({ data: { guid: "msg-known" } });
+
+        await sendMessageBlueBubbles("+15551234567", "Reply", {
+          serverUrl: "http://localhost:1234",
+          password: "test",
+          replyToMessageGuid: "reply-guid-789",
+        });
+
+        expect(fetchServerInfoMock).not.toHaveBeenCalled();
+      });
+
+      it("skips refresh when status is already known (disabled)", async () => {
+        mockBlueBubblesPrivateApiStatusOnce(
+          privateApiStatusMock,
+          BLUE_BUBBLES_PRIVATE_API_STATUS.disabled,
+        );
+        mockResolvedHandleTarget();
+        mockSendResponse({ data: { guid: "msg-disabled" } });
+
+        await sendMessageBlueBubbles("+15551234567", "Reply", {
+          serverUrl: "http://localhost:1234",
+          password: "test",
+          replyToMessageGuid: "reply-guid-789",
+        });
+
+        expect(fetchServerInfoMock).not.toHaveBeenCalled();
+      });
+
+      it("skips refresh when credentials are overridden (different serverUrl)", async () => {
+        mockResolvedHandleTarget();
+        mockSendResponse({ data: { guid: "msg-override" } });
+
+        await sendMessageBlueBubbles("+15551234567", "Reply", {
+          cfg: {
+            channels: {
+              bluebubbles: {
+                serverUrl: "http://account-server:1234",
+                password: "test",
+              },
+            },
+          },
+          serverUrl: "http://different-server:5678",
+          password: "test",
+          replyToMessageGuid: "reply-guid-override",
+        });
+
+        expect(fetchServerInfoMock).not.toHaveBeenCalled();
+      });
+
+      it("skips refresh when credentials are overridden (different password)", async () => {
+        mockResolvedHandleTarget();
+        mockSendResponse({ data: { guid: "msg-override-pw" } });
+
+        await sendMessageBlueBubbles("+15551234567", "Reply", {
+          cfg: {
+            channels: {
+              bluebubbles: {
+                serverUrl: "http://localhost:1234",
+                password: "account-password",
+              },
+            },
+          },
+          serverUrl: "http://localhost:1234",
+          password: "different-password",
+          replyToMessageGuid: "reply-guid-pw",
+        });
+
+        expect(fetchServerInfoMock).not.toHaveBeenCalled();
+      });
+
+      it("honors caller-provided timeoutMs for the refresh probe", async () => {
+        privateApiStatusMock
+          .mockReturnValueOnce(BLUE_BUBBLES_PRIVATE_API_STATUS.unknown)
+          .mockReturnValueOnce(BLUE_BUBBLES_PRIVATE_API_STATUS.enabled);
+        fetchServerInfoMock.mockResolvedValueOnce({ private_api: true });
+        mockResolvedHandleTarget();
+        mockSendResponse({ data: { guid: "msg-timeout" } });
+
+        await sendMessageBlueBubbles("+15551234567", "Reply", {
+          cfg: {
+            channels: {
+              bluebubbles: {
+                serverUrl: "http://localhost:1234",
+                password: "test",
+              },
+            },
+          },
+          timeoutMs: 15000,
+          replyToMessageGuid: "reply-guid-timeout",
+        });
+
+        expect(fetchServerInfoMock).toHaveBeenCalledWith(
+          expect.objectContaining({ timeoutMs: 15000 }),
+        );
+      });
+    });
   });
 
   describe("createChatForHandle", () => {

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -810,6 +810,92 @@ describe("send", () => {
       }
     });
 
+    it("skips lazy-refresh when privateApiStatus is null but no reply or effect requested", async () => {
+      // When no reply threading or effect is needed, there's no reason to refresh
+      // the Private API cache — a plain send works without it.
+      fetchServerInfoMock.mockClear();
+      privateApiStatusMock.mockReturnValue(null);
+
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-plain" } });
+
+      const result = await sendMessageBlueBubbles("+15551234567", "Just a plain message", {
+        cfg: {
+          channels: {
+            bluebubbles: {
+              serverUrl: "http://localhost:1234",
+              password: "test",
+            },
+          },
+        },
+      });
+
+      expect(result.messageId).toBe("msg-uuid-plain");
+      expect(fetchServerInfoMock).not.toHaveBeenCalled();
+    });
+
+    it("skips lazy-refresh when privateApiStatus is already known (true)", async () => {
+      // When the cache has a definite value (true = enabled), no refresh is needed.
+      fetchServerInfoMock.mockClear();
+      privateApiStatusMock.mockReturnValue(true);
+
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-known-true" } });
+
+      const result = await sendMessageBlueBubbles("+15551234567", "Reply with known status", {
+        replyToMessageGuid: "reply-guid-known",
+        cfg: {
+          channels: {
+            bluebubbles: {
+              serverUrl: "http://localhost:1234",
+              password: "test",
+            },
+          },
+        },
+      });
+
+      expect(result.messageId).toBe("msg-uuid-known-true");
+      expect(fetchServerInfoMock).not.toHaveBeenCalled();
+
+      // Should use private-api method since status is true
+      const sendCall = mockFetch.mock.calls[1];
+      const body = JSON.parse(sendCall[1].body);
+      expect(body.method).toBe("private-api");
+      expect(body.selectedMessageGuid).toBe("reply-guid-known");
+    });
+
+    it("skips lazy-refresh when privateApiStatus is already known (false)", async () => {
+      // When the cache says Private API is disabled, no refresh is needed.
+      // The send should degrade to a plain message (no reply threading).
+      const runtimeLog = vi.fn();
+      setBlueBubblesRuntime({ log: runtimeLog } as unknown as PluginRuntime);
+
+      fetchServerInfoMock.mockClear();
+      privateApiStatusMock.mockReturnValue(false);
+
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-known-false" } });
+
+      try {
+        const result = await sendMessageBlueBubbles("+15551234567", "Reply with disabled API", {
+          replyToMessageGuid: "reply-guid-disabled",
+          cfg: {
+            channels: {
+              bluebubbles: {
+                serverUrl: "http://localhost:1234",
+                password: "test",
+              },
+            },
+          },
+        });
+
+        expect(result.messageId).toBe("msg-uuid-known-false");
+        expect(fetchServerInfoMock).not.toHaveBeenCalled();
+      } finally {
+        clearBlueBubblesRuntime();
+      }
+    });
+
     it("sends message with chat_guid target directly", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -481,19 +481,16 @@ export async function sendMessageBlueBubbles(
 
   // Lazy-refresh Private API status when it's unknown and we need it for reply/effect.
   // The cache expires after 10 minutes; without this, replies silently degrade to plain sends.
-  // Skip when caller explicitly overrides serverUrl/password with values different from the
-  // account config. The cache is keyed by accountId, so refreshing with different credentials
-  // would poison the account-scoped cache entry.
+  // Only refresh when the resolved credentials match the account config. The cache is keyed
+  // by accountId, so refreshing with ad-hoc or overridden credentials would poison the
+  // account-scoped cache entry for subsequent sends.
   const accountServerUrl = normalizeSecretInputString(account.config.serverUrl);
-  const accountPassword = normalizeSecretInputString(account.config.password);
-  const isCredentialOverride =
-    (opts.serverUrl != null &&
-      accountServerUrl &&
-      normalizeSecretInputString(opts.serverUrl) !== accountServerUrl) ||
-    (opts.password != null &&
-      accountPassword &&
-      normalizeSecretInputString(opts.password) !== accountPassword);
-  if (privateApiStatus === null && (wantsReplyThread || wantsEffect) && !isCredentialOverride) {
+  const credentialsAreAccountBound = accountServerUrl != null && baseUrl === accountServerUrl;
+  if (
+    privateApiStatus === null &&
+    (wantsReplyThread || wantsEffect) &&
+    credentialsAreAccountBound
+  ) {
     const serverInfo = await fetchBlueBubblesServerInfo({
       baseUrl,
       password,

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -486,7 +486,7 @@ export async function sendMessageBlueBubbles(
       baseUrl,
       password,
       accountId: account.accountId,
-      timeoutMs: 5000,
+      timeoutMs: opts.timeoutMs ?? 5000,
     });
     if (serverInfo) {
       privateApiStatus = getCachedBlueBubblesPrivateApiStatus(account.accountId);

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -481,7 +481,16 @@ export async function sendMessageBlueBubbles(
 
   // Lazy-refresh Private API status when it's unknown and we need it for reply/effect.
   // The cache expires after 10 minutes; without this, replies silently degrade to plain sends.
-  if (privateApiStatus === null && (wantsReplyThread || wantsEffect)) {
+  // Skip when caller overrides serverUrl/password with values different from the account config.
+  // The cache is keyed by accountId, so refreshing with different credentials would poison
+  // the account-scoped cache entry. Only treat it as an override when the account has a
+  // configured value AND the caller explicitly provides a different one.
+  const accountServerUrl = normalizeSecretInputString(account.config.serverUrl);
+  const accountPassword = normalizeSecretInputString(account.config.password);
+  const isCredentialOverride =
+    (accountServerUrl && normalizeSecretInputString(opts.serverUrl) !== accountServerUrl) ||
+    (accountPassword && normalizeSecretInputString(opts.password) !== accountPassword);
+  if (privateApiStatus === null && (wantsReplyThread || wantsEffect) && !isCredentialOverride) {
     const serverInfo = await fetchBlueBubblesServerInfo({
       baseUrl,
       password,

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -487,7 +487,7 @@ export async function sendMessageBlueBubbles(
       password,
       accountId: account.accountId,
       timeoutMs: 5000,
-    }).catch(() => null);
+    });
     if (serverInfo) {
       privateApiStatus = getCachedBlueBubblesPrivateApiStatus(account.accountId);
     }

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { resolveBlueBubblesAccount } from "./accounts.js";
 import {
+  fetchBlueBubblesServerInfo,
   getCachedBlueBubblesPrivateApiStatus,
   isBlueBubblesPrivateApiStatusEnabled,
 } from "./probe.js";
@@ -449,7 +450,7 @@ export async function sendMessageBlueBubbles(
   if (!password) {
     throw new Error("BlueBubbles password is required");
   }
-  const privateApiStatus = getCachedBlueBubblesPrivateApiStatus(account.accountId);
+  let privateApiStatus = getCachedBlueBubblesPrivateApiStatus(account.accountId);
 
   const target = resolveBlueBubblesSendTarget(to);
   const chatGuid = await resolveChatGuidForTarget({
@@ -477,6 +478,21 @@ export async function sendMessageBlueBubbles(
   const effectId = resolveEffectId(opts.effectId);
   const wantsReplyThread = Boolean(opts.replyToMessageGuid?.trim());
   const wantsEffect = Boolean(effectId);
+
+  // Lazy-refresh Private API status when it's unknown and we need it for reply/effect.
+  // The cache expires after 10 minutes; without this, replies silently degrade to plain sends.
+  if (privateApiStatus === null && (wantsReplyThread || wantsEffect)) {
+    const serverInfo = await fetchBlueBubblesServerInfo({
+      baseUrl,
+      password,
+      accountId: account.accountId,
+      timeoutMs: 5000,
+    }).catch(() => null);
+    if (serverInfo) {
+      privateApiStatus = getCachedBlueBubblesPrivateApiStatus(account.accountId);
+    }
+  }
+
   const privateApiDecision = resolvePrivateApiDecision({
     privateApiStatus,
     wantsReplyThread,

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -481,15 +481,18 @@ export async function sendMessageBlueBubbles(
 
   // Lazy-refresh Private API status when it's unknown and we need it for reply/effect.
   // The cache expires after 10 minutes; without this, replies silently degrade to plain sends.
-  // Skip when caller overrides serverUrl/password with values different from the account config.
-  // The cache is keyed by accountId, so refreshing with different credentials would poison
-  // the account-scoped cache entry. Only treat it as an override when the account has a
-  // configured value AND the caller explicitly provides a different one.
+  // Skip when caller explicitly overrides serverUrl/password with values different from the
+  // account config. The cache is keyed by accountId, so refreshing with different credentials
+  // would poison the account-scoped cache entry.
   const accountServerUrl = normalizeSecretInputString(account.config.serverUrl);
   const accountPassword = normalizeSecretInputString(account.config.password);
   const isCredentialOverride =
-    (accountServerUrl && normalizeSecretInputString(opts.serverUrl) !== accountServerUrl) ||
-    (accountPassword && normalizeSecretInputString(opts.password) !== accountPassword);
+    (opts.serverUrl != null &&
+      accountServerUrl &&
+      normalizeSecretInputString(opts.serverUrl) !== accountServerUrl) ||
+    (opts.password != null &&
+      accountPassword &&
+      normalizeSecretInputString(opts.password) !== accountPassword);
   if (privateApiStatus === null && (wantsReplyThread || wantsEffect) && !isCredentialOverride) {
     const serverInfo = await fetchBlueBubblesServerInfo({
       baseUrl,

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -14,6 +14,7 @@ import { extractHandleFromChatGuid, normalizeBlueBubblesHandle } from "./targets
 import {
   blueBubblesFetchWithTimeout,
   buildBlueBubblesApiUrl,
+  normalizeBlueBubblesServerUrl,
   type BlueBubblesSendTarget,
 } from "./types.js";
 
@@ -485,7 +486,10 @@ export async function sendMessageBlueBubbles(
   // by accountId, so refreshing with ad-hoc or overridden credentials would poison the
   // account-scoped cache entry for subsequent sends.
   const accountServerUrl = normalizeSecretInputString(account.config.serverUrl);
-  const credentialsAreAccountBound = accountServerUrl != null && baseUrl === accountServerUrl;
+  const accountPassword = normalizeSecretInputString(account.config.password);
+  const credentialsAreAccountBound =
+    (!opts.serverUrl || normalizeBlueBubblesServerUrl(baseUrl) === (accountServerUrl ? normalizeBlueBubblesServerUrl(accountServerUrl) : "")) &&
+    (!opts.password || password === accountPassword);
   if (
     privateApiStatus === null &&
     (wantsReplyThread || wantsEffect) &&

--- a/extensions/bluebubbles/src/test-harness.ts
+++ b/extensions/bluebubbles/src/test-harness.ts
@@ -54,7 +54,7 @@ type BlueBubblesProbeMockModule = {
       timeoutMs?: number;
     }) => Promise<Record<string, unknown> | null>
   >;
-  getCachedBlueBubblesPrivateApiStatus: Mock<() => boolean | null>;
+  getCachedBlueBubblesPrivateApiStatus: Mock<(accountId?: string) => boolean | null>;
   isBlueBubblesPrivateApiStatusEnabled: Mock<(status: boolean | null) => boolean>;
 };
 

--- a/extensions/bluebubbles/src/test-harness.ts
+++ b/extensions/bluebubbles/src/test-harness.ts
@@ -46,12 +46,14 @@ export function createBlueBubblesAccountsMockModule() {
 }
 
 type BlueBubblesProbeMockModule = {
+  fetchBlueBubblesServerInfo: Mock<() => Promise<Record<string, unknown> | null>>;
   getCachedBlueBubblesPrivateApiStatus: Mock<() => boolean | null>;
   isBlueBubblesPrivateApiStatusEnabled: Mock<(status: boolean | null) => boolean>;
 };
 
 export function createBlueBubblesProbeMockModule(): BlueBubblesProbeMockModule {
   return {
+    fetchBlueBubblesServerInfo: vi.fn().mockResolvedValue(null),
     getCachedBlueBubblesPrivateApiStatus: vi
       .fn()
       .mockReturnValue(BLUE_BUBBLES_PRIVATE_API_STATUS.unknown),

--- a/extensions/bluebubbles/src/test-harness.ts
+++ b/extensions/bluebubbles/src/test-harness.ts
@@ -46,7 +46,14 @@ export function createBlueBubblesAccountsMockModule() {
 }
 
 type BlueBubblesProbeMockModule = {
-  fetchBlueBubblesServerInfo: Mock<() => Promise<Record<string, unknown> | null>>;
+  fetchBlueBubblesServerInfo: Mock<
+    (params: {
+      baseUrl?: string | null;
+      password?: string | null;
+      accountId?: string;
+      timeoutMs?: number;
+    }) => Promise<Record<string, unknown> | null>
+  >;
   getCachedBlueBubblesPrivateApiStatus: Mock<() => boolean | null>;
   isBlueBubblesPrivateApiStatusEnabled: Mock<(status: boolean | null) => boolean>;
 };


### PR DESCRIPTION
## Summary

- Lazy-refresh the BlueBubbles server info cache when Private API status is unknown (`null`) and a reply or message effect is requested
- Prevents reply threading from silently degrading to plain sends after the 10-minute cache TTL expires

## Problem

After #23393 correctly changed the Private API check from `!== false` to `=== true`, expired cache (`null`) causes `canUsePrivateApi` to be `false`. The `selectedMessageGuid` is silently omitted from the BB API payload — the message sends successfully but without threading. No error is returned to the agent.

## Fix

One lazy `fetchBlueBubblesServerInfo()` call in `sendMessageBlueBubbles()` when:
1. `privateApiStatus === null` (cache expired)
2. AND a reply or effect is requested
3. AND credentials are account-bound (not per-call overrides)

This adds at most one extra API call on the first reply after cache expiry. The fetched result repopulates the 10-minute cache for subsequent sends. Plain sends are unaffected.

Fixes #43764

## Review feedback addressed

- **P1 — Credential override detection**: Fixed. Only marks credentials as non-account-bound when the caller explicitly provides different credentials. Normal sends (no explicit `opts.serverUrl`/`opts.password`) correctly trigger lazy refresh.
- **P2 — Caller timeout**: Honors `opts.timeoutMs ?? 5000` so caller-provided timeouts are respected.
- **P2 — Cache poisoning**: Lazy refresh is skipped when credentials are overrides, preventing account-scoped cache pollution.
- **P2 — URL normalization**: Uses `normalizeBlueBubblesServerUrl` for URL comparison, handling trailing slashes and scheme variants.
- **Greptile — Mock type**: Fixed to include actual function parameters for type-safe test assertions.

## Tests

- 7 new tests covering lazy refresh: successful refresh, skip on plain send, skip when status is known (enabled/disabled), skip on credential override (different serverUrl/password), and caller timeout propagation
- All 61 tests pass

## Production runtime

This fix has been running as a local dist patch on a live OpenClaw deployment since **March 12, 2026** (~11 days). BlueBubbles reply threading has been stable with no degradation after cache TTL expiry.

## Test plan

- [x] Gateway restart → reply threading works immediately (cache populated on startup)
- [x] Wait 10+ minutes → send a threaded reply → verify it still threads (lazy refresh kicks in)
- [x] Verify plain sends are unaffected when cache is expired
- [x] Verify no regression for Private API **disabled** servers
- [x] Verify credential override sends don't poison account cache
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)