### PR TITLE
fix(google-gemini-cli-auth): align loadCodeAssist metadata and improve package discovery

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -239,17 +239,6 @@ describe("loginGeminiCliOAuth", () => {
     "GOOGLE_CLOUD_PROJECT_ID",
   ] as const;
 
-  function getExpectedPlatform(): "WINDOWS" | "MACOS" | "PLATFORM_UNSPECIFIED" {
-    if (process.platform === "win32") {
-      return "WINDOWS";
-    }
-    if (process.platform === "darwin") {
-      return "MACOS";
-    }
-    // Matches updated resolvePlatform() which uses PLATFORM_UNSPECIFIED for Linux
-    return "PLATFORM_UNSPECIFIED";
-  }
-
   function getRequestUrl(input: string | URL | Request): string {
     return typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
   }
@@ -373,16 +362,16 @@ describe("loginGeminiCliOAuth", () => {
     const clientMetadata = getHeaderValue(firstHeaders, "Client-Metadata");
     expect(clientMetadata).toBeDefined();
     expect(JSON.parse(clientMetadata as string)).toEqual({
-      ideType: "ANTIGRAVITY",
-      platform: getExpectedPlatform(),
+      ideType: "IDE_UNSPECIFIED",
+      platform: "PLATFORM_UNSPECIFIED",
       pluginType: "GEMINI",
     });
 
     const body = JSON.parse(String(loadRequests[0]?.init?.body));
     expect(body).toEqual({
       metadata: {
-        ideType: "ANTIGRAVITY",
-        platform: getExpectedPlatform(),
+        ideType: "IDE_UNSPECIFIED",
+        platform: "PLATFORM_UNSPECIFIED",
         pluginType: "GEMINI",
       },
     });

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { createServer } from "node:http";
+import { createRequire } from "node:module";
 import { delimiter, dirname, join } from "node:path";
 import { fetchWithSsrFGuard, isWSL2Sync } from "openclaw/plugin-sdk/google-gemini-cli-auth";
 
@@ -146,6 +147,16 @@ function resolveGeminiCliDirs(geminiPath: string, resolvedPath: string): string[
     join(dirname(binDir), "lib", "node_modules", "@google", "gemini-cli"),
   ];
 
+  try {
+    const require = createRequire(import.meta.url);
+    const geminiCliPackageJson = require.resolve("@google/gemini-cli/package.json");
+    const packageRoot = dirname(geminiCliPackageJson);
+    candidates.unshift(packageRoot); // for nested dependencies
+    candidates.unshift(dirname(dirname(dirname(packageRoot)))); // for sibling dependencies (global npm/pnpm)
+  } catch {
+    // ignore
+  }
+
   const deduped: string[] = [];
   const seen = new Set<string>();
   for (const candidate of candidates) {
@@ -222,18 +233,6 @@ function generatePkce(): { verifier: string; challenge: string } {
   const verifier = randomBytes(32).toString("hex");
   const challenge = createHash("sha256").update(verifier).digest("base64url");
   return { verifier, challenge };
-}
-
-function resolvePlatform(): "WINDOWS" | "MACOS" | "PLATFORM_UNSPECIFIED" {
-  if (process.platform === "win32") {
-    return "WINDOWS";
-  }
-  if (process.platform === "darwin") {
-    return "MACOS";
-  }
-  // Google's loadCodeAssist API rejects "LINUX" as an invalid Platform enum value.
-  // Use "PLATFORM_UNSPECIFIED" for Linux and other platforms to match the pi-ai runtime.
-  return "PLATFORM_UNSPECIFIED";
 }
 
 async function fetchWithTimeout(
@@ -466,10 +465,9 @@ async function getUserEmail(accessToken: string): Promise<string | undefined> {
 
 async function discoverProject(accessToken: string): Promise<string> {
   const envProject = process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT_ID;
-  const platform = resolvePlatform();
   const metadata = {
-    ideType: "ANTIGRAVITY",
-    platform,
+    ideType: "IDE_UNSPECIFIED",
+    platform: "PLATFORM_UNSPECIFIED",
     pluginType: "GEMINI",
   };
   const headers = {

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -153,8 +153,9 @@ function resolveGeminiCliDirs(geminiPath: string, resolvedPath: string): string[
     const packageRoot = dirname(geminiCliPackageJson);
     candidates.unshift(dirname(dirname(dirname(packageRoot)))); // for sibling dependencies (global npm/pnpm)
     candidates.unshift(packageRoot); // for nested dependencies (prioritize this)
-  } catch {
-    // ignore
+  } catch (err) {
+    // Best-effort discovery step. Node.js native resolution may fail in certain environments.
+    // If it fails, we intentionally ignore the error and fall back to the existing heuristic paths below.
   }
 
   const deduped: string[] = [];

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -151,8 +151,8 @@ function resolveGeminiCliDirs(geminiPath: string, resolvedPath: string): string[
     const require = createRequire(import.meta.url);
     const geminiCliPackageJson = require.resolve("@google/gemini-cli/package.json");
     const packageRoot = dirname(geminiCliPackageJson);
-    candidates.unshift(packageRoot); // for nested dependencies
     candidates.unshift(dirname(dirname(dirname(packageRoot)))); // for sibling dependencies (global npm/pnpm)
+    candidates.unshift(packageRoot); // for nested dependencies (prioritize this)
   } catch {
     // ignore
   }


### PR DESCRIPTION
Fixes #41224.

### How this fixes the issue:

1. **Metadata Alignment:**
   The `loadCodeAssist` API was returning a `400 Bad Request` because it did not recognize the non-standard `ideType: "ANTIGRAVITY"` or specific platform strings like `LINUX`. This PR switches these to `IDE_UNSPECIFIED` and `PLATFORM_UNSPECIFIED`, which aligns with the internal defaults used by the Gemini CLI and ensures the backend accepts the request metadata.

2. **Improved Package Discovery:**
   The previous logic relied on heuristic path guessing which often fails in environments using `pnpm` (due to its content-addressable symlink structure) or non-standard global NPM layouts.
   - We now use `require.resolve("@google/gemini-cli/package.json")` to leverage Node's native resolution to find the exact package root.
   - We've updated `resolveGeminiCliDirs` to include both the package root and its grandparent in the search candidates, ensuring the logic can find the `gemini-cli-core` dependency whether it's nested or a sibling (common in global installs).

3. **Cleanup:**
   Removed the unused `resolvePlatform` helper and updated the test suite in `oauth.test.ts` to verify the new metadata constants.