### PR TITLE
fix(plugins): skip node_modules and other heavy dirs in plugin discovery scan

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -393,4 +393,54 @@ describe("discoverOpenClawPlugins", () => {
     });
     expect(third.candidates.some((candidate) => candidate.idHint === "cached")).toBe(false);
   });
+
+  it("skips node_modules and other heavy directories inside plugin roots", async () => {
+    const stateDir = makeTempDir();
+    const workspaceDir = path.join(stateDir, "workspace");
+
+    const extensionsDir = path.join(stateDir, "extensions");
+    fs.mkdirSync(extensionsDir, { recursive: true });
+
+    // Create a legitimate plugin
+    const realPlugin = path.join(extensionsDir, "real-plugin");
+    fs.mkdirSync(realPlugin, { recursive: true });
+    fs.writeFileSync(path.join(realPlugin, "index.ts"), "export default function () {}", "utf-8");
+
+    // Create directories that should be ignored — each containing a fake
+    // "plugin" that must NOT be discovered
+    for (const ignored of [
+      "node_modules",
+      ".git",
+      "dist",
+      ".venv",
+      "__pycache__",
+      "browser_data",
+    ]) {
+      const fakeDir = path.join(extensionsDir, ignored, "fake-pkg");
+      fs.mkdirSync(fakeDir, { recursive: true });
+      fs.writeFileSync(path.join(fakeDir, "index.ts"), "export default function () {}", "utf-8");
+      writePluginPackageManifest({
+        packageDir: fakeDir,
+        packageName: `@fake/${ignored}`,
+        extensions: ["index.ts"],
+      });
+    }
+
+    const { candidates } = await discoverWithStateDir(stateDir, { workspaceDir });
+
+    // The real plugin should be discovered
+    expect(candidates.some((c) => c.idHint === "real-plugin")).toBe(true);
+
+    // None of the packages inside ignored directories should appear
+    for (const ignored of [
+      "node_modules",
+      ".git",
+      "dist",
+      ".venv",
+      "__pycache__",
+      "browser_data",
+    ]) {
+      expect(candidates.some((c) => c.source.includes(`/${ignored}/`))).toBe(false);
+    }
+  });
 });

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -406,8 +406,9 @@ describe("discoverOpenClawPlugins", () => {
     fs.mkdirSync(realPlugin, { recursive: true });
     fs.writeFileSync(path.join(realPlugin, "index.ts"), "export default function () {}", "utf-8");
 
-    // Create directories that should be ignored — each containing a fake
-    // "plugin" that must NOT be discovered
+    // Place index.ts directly inside each ignored directory so
+    // discoverInDirectory would find it via DEFAULT_PLUGIN_ENTRY_CANDIDATES
+    // if shouldIgnoreScannedDirectory did not filter the directory out.
     for (const ignored of [
       "node_modules",
       ".git",
@@ -416,14 +417,9 @@ describe("discoverOpenClawPlugins", () => {
       "__pycache__",
       "browser_data",
     ]) {
-      const fakeDir = path.join(extensionsDir, ignored, "fake-pkg");
+      const fakeDir = path.join(extensionsDir, ignored);
       fs.mkdirSync(fakeDir, { recursive: true });
       fs.writeFileSync(path.join(fakeDir, "index.ts"), "export default function () {}", "utf-8");
-      writePluginPackageManifest({
-        packageDir: fakeDir,
-        packageName: `@fake/${ignored}`,
-        extensions: ["index.ts"],
-      });
     }
 
     const { candidates } = await discoverWithStateDir(stateDir, { workspaceDir });

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -280,9 +280,38 @@ function isExtensionFile(filePath: string): boolean {
   return !filePath.endsWith(".d.ts");
 }
 
+/**
+ * Directories that should never be descended into during plugin/skill discovery.
+ * These contain dependency trees, build artifacts, or VCS metadata that are not
+ * valid plugin sources and can hold thousands of files — exhausting file
+ * descriptors on macOS and causing `spawn EBADF` gateway failures.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/2532
+ *      https://github.com/openclaw/openclaw/issues/11181
+ */
+const IGNORED_SCAN_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  ".venv",
+  "venv",
+  "__pycache__",
+  ".mypy_cache",
+  ".pytest_cache",
+  ".cache",
+  ".tox",
+  "site-packages",
+  ".pnpm-store",
+  "browser_data",
+]);
+
 function shouldIgnoreScannedDirectory(dirName: string): boolean {
   const normalized = dirName.trim().toLowerCase();
   if (!normalized) {
+    return true;
+  }
+  if (IGNORED_SCAN_DIRS.has(normalized)) {
     return true;
   }
   if (normalized.endsWith(".bak")) {


### PR DESCRIPTION
Fixes #43813.

## Problem

`shouldIgnoreScannedDirectory()` in plugin discovery only skips `.bak`/`.backup-`/`.disabled` directories. When a workspace skill contains `node_modules` (e.g. a LanceDB plugin with 5,000+ files), discovery descends into every subdirectory, exhausting file descriptors on macOS and causing `spawn EBADF` on all exec calls.

Measured on 2026.3.11 (macOS arm64): **12,232 open FDs** at gateway startup, dropping to **1,231** after manually removing `node_modules`.

The skills watcher (`DEFAULT_SKILLS_WATCH_IGNORED`) and memory watcher (`IGNORED_MEMORY_WATCH_DIR_NAMES`) already skip these directories — but the plugin discovery scanner does not.

## Fix

Add `IGNORED_SCAN_DIRS` set to `shouldIgnoreScannedDirectory()`, aligned with the existing watcher ignore patterns. 2 files changed, 67 insertions.

## Tests

Added integration test verifying that fake plugins inside `node_modules/`, `.git/`, `.venv/`, etc. are not discovered, while legitimate sibling plugins still are.

```
pnpm lint    → 0 warnings, 0 errors
pnpm tsgo    → passed
pnpm vitest run src/plugins/discovery.test.ts → 14 passed
```

Previously: #2532, #8869, #11181

---

🤖 AI-assisted (Cursor + Claude). Tested on a production OpenClaw 2026.3.11 gateway with real FD exhaustion. The author understands the change.

Made with [Cursor](https://cursor.com)