### PR TITLE
PDF: add explicit extraction modes

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -881,6 +881,7 @@ Time format in system prompt. Default: `auto` (OS preference).
       },
       pdfMaxBytesMb: 10,
       pdfMaxPages: 20,
+      pdfExtractionMode: "local",
       thinkingDefault: "low",
       verboseDefault: "off",
       elevatedDefault: "on",
@@ -904,6 +905,9 @@ Time format in system prompt. Default: `auto` (OS preference).
   - If omitted, the PDF tool falls back to `imageModel`, then to best-effort provider defaults.
 - `pdfMaxBytesMb`: default PDF size limit for the `pdf` tool when `maxBytesMb` is not passed at call time.
 - `pdfMaxPages`: default maximum pages considered by extraction fallback mode in the `pdf` tool.
+- `pdfExtractionMode`: optional default extraction override for the `pdf` tool (`"local"`, `"ocr"`, or `"auto"`).
+  - When unset, the tool preserves its current native-versus-fallback routing behavior.
+  - When set, the tool opts matching calls out of native PDF mode and forces extraction.
 - `model.primary`: format `provider/model` (e.g. `anthropic/claude-opus-4-6`). If you omit the provider, OpenClaw assumes `anthropic` (deprecated).
 - `models`: the configured model catalog and allowlist for `/model`. Each entry can include `alias` (shortcut) and `params` (provider-specific, for example `temperature`, `maxTokens`, `cacheRetention`, `context1m`).
 - `params` merge precedence (config): `agents.defaults.models["provider/model"].params` is the base, then `agents.list[].params` (matching agent id) overrides by key.

--- a/docs/tools/pdf.md
+++ b/docs/tools/pdf.md
@@ -33,6 +33,7 @@ If no usable model can be resolved, the `pdf` tool is not exposed.
 - `pdfs` (`string[]`): multiple PDF paths or URLs, up to 10 total
 - `prompt` (`string`): analysis prompt, default `Analyze this PDF document.`
 - `pages` (`string`): page filter like `1-5` or `1,3,7-9`
+- `extractionMode` (`"local" | "ocr" | "auto"`): optional extraction override
 - `model` (`string`): optional model override (`provider/model`)
 - `maxBytesMb` (`number`): per-PDF size cap in MB
 
@@ -65,15 +66,19 @@ The tool sends raw PDF bytes directly to provider APIs.
 Native mode limits:
 
 - `pages` is not supported. If set, the tool returns an error.
+- Explicit `extractionMode` opts out of native PDF mode and uses extraction instead.
 
 ### Extraction fallback mode
 
-Fallback mode is used for non-native providers.
+Fallback mode is used for non-native providers and for any call with explicit `extractionMode`.
 
 Flow:
 
 1. Extract text from selected pages (up to `agents.defaults.pdfMaxPages`, default `20`).
-2. If extracted text length is below `200` chars, render selected pages to PNG images and include them.
+2. Behavior then depends on `extractionMode`:
+   - unset or `"local"`: if text is weak, render selected pages to PNG images and include them
+   - `"ocr"`: call Mistral OCR and use OCR text as the extraction result
+   - `"auto"`: if local text is weak, try Mistral OCR first, then fall back to PNG images if OCR is unavailable or fails
 3. Send extracted content plus prompt to the selected model.
 
 Fallback details:
@@ -81,6 +86,7 @@ Fallback details:
 - Page image extraction uses a pixel budget of `4,000,000`.
 - If the target model does not support image input and there is no extractable text, the tool errors.
 - Extraction fallback requires `pdfjs-dist` (and `@napi-rs/canvas` for image rendering).
+- `extractionMode: "ocr"` and `"auto"` use Mistral OCR and send PDF bytes to Mistral when OCR runs.
 
 ## Config
 
@@ -94,10 +100,20 @@ Fallback details:
       },
       pdfMaxBytesMb: 10,
       pdfMaxPages: 20,
+      pdfExtractionMode: "local",
     },
   },
 }
 ```
+
+`pdfExtractionMode` behavior:
+
+- unset: preserve current tool behavior, including native PDF mode for Anthropic/Google
+- `"local"`: force extraction mode without OCR
+- `"ocr"`: force Mistral OCR extraction
+- `"auto"`: force extraction mode and try OCR only when local text is weak
+
+Setting `agents.defaults.pdfExtractionMode` globally opts matching `pdf` calls out of native PDF mode.
 
 See [Configuration Reference](/gateway/configuration-reference) for full field details.
 
@@ -109,6 +125,8 @@ Common `details` fields:
 
 - `model`: resolved model ref (`provider/model`)
 - `native`: `true` for native provider mode, `false` for fallback
+- `extractionMode`: present when an explicit extraction mode is active
+- `ocrProvider`: present when OCR runs (`"mistral"`)
 - `attempts`: fallback attempts that failed before success
 
 Path fields:
@@ -123,6 +141,7 @@ Path fields:
 - Too many PDFs: returns structured error in `details.error = "too_many_pdfs"`
 - Unsupported reference scheme: returns `details.error = "unsupported_pdf_reference"`
 - Native mode with `pages`: throws clear `pages is not supported with native PDF providers` error
+- Explicit `extractionMode: "ocr"` without Mistral auth: throws a clear OCR auth error
 
 ## Examples
 

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -11,6 +11,10 @@ type PdfInput = {
   filename?: string;
 };
 
+type MistralOcrPage = {
+  markdown?: string;
+};
+
 // ---------------------------------------------------------------------------
 // Anthropic – native PDF via Messages API
 // ---------------------------------------------------------------------------
@@ -175,4 +179,75 @@ export async function geminiAnalyzePdf(params: {
   }
 
   return text.trim();
+}
+
+export async function mistralOcrPdf(params: {
+  apiKey: string;
+  pdf: PdfInput;
+  pageNumbers?: number[];
+  modelId?: string;
+  baseUrl?: string;
+}): Promise<string> {
+  const apiKey = normalizeSecretInput(params.apiKey);
+  if (!apiKey) {
+    throw new Error("Mistral OCR: apiKey required");
+  }
+
+  const trimmedBaseUrl = (params.baseUrl ?? "https://api.mistral.ai").replace(/\/+$/, "");
+  const url = /\/v1$/i.test(trimmedBaseUrl) ? `${trimmedBaseUrl}/ocr` : `${trimmedBaseUrl}/v1/ocr`;
+  const zeroBasedPages =
+    params.pageNumbers
+      ?.map((page) => Math.floor(page) - 1)
+      .filter((page) => Number.isFinite(page) && page >= 0) ?? [];
+  const pages =
+    zeroBasedPages.length > 0 ? Array.from(new Set(zeroBasedPages)).toSorted((a, b) => a - b) : [];
+
+  const body: Record<string, unknown> = {
+    model: params.modelId?.trim() || "mistral-ocr-latest",
+    document: {
+      type: "document_url",
+      document_url: `data:application/pdf;base64,${params.pdf.base64}`,
+    },
+    include_image_base64: false,
+  };
+  if (pages.length > 0) {
+    body.pages = pages;
+  }
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const responseBody = await res.text().catch(() => "");
+    throw new Error(
+      `Mistral OCR request failed (${res.status} ${res.statusText})${responseBody ? `: ${responseBody.slice(0, 400)}` : ""}`,
+    );
+  }
+
+  const json = (await res.json().catch(() => null)) as unknown;
+  if (!isRecord(json)) {
+    throw new Error("Mistral OCR response was not JSON.");
+  }
+
+  const responsePages = json.pages as MistralOcrPage[] | undefined;
+  if (!Array.isArray(responsePages)) {
+    throw new Error("Mistral OCR response missing pages array.");
+  }
+
+  const text = responsePages
+    .map((page) => (typeof page?.markdown === "string" ? page.markdown : ""))
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+  if (!text) {
+    throw new Error("Mistral OCR returned no text.");
+  }
+
+  return text;
 }

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -201,6 +201,9 @@ export async function mistralOcrPdf(params: {
       .filter((page) => Number.isFinite(page) && page >= 0) ?? [];
   const pages =
     zeroBasedPages.length > 0 ? Array.from(new Set(zeroBasedPages)).toSorted((a, b) => a - b) : [];
+  if (params.pageNumbers !== undefined && pages.length === 0) {
+    throw new Error("Mistral OCR: no valid pages selected.");
+  }
 
   const body: Record<string, unknown> = {
     model: params.modelId?.trim() || "mistral-ocr-latest",

--- a/src/agents/tools/pdf-tool.helpers.ts
+++ b/src/agents/tools/pdf-tool.helpers.ts
@@ -7,6 +7,8 @@ import {
 import { extractAssistantText } from "../pi-embedded-utils.js";
 
 export type PdfModelConfig = { primary?: string; fallbacks?: string[] };
+export const PDF_EXTRACTION_MODES = ["local", "ocr", "auto"] as const;
+export type PdfExtractionMode = (typeof PDF_EXTRACTION_MODES)[number];
 
 /**
  * Providers known to support native PDF document input.
@@ -92,6 +94,19 @@ export function coercePdfModelConfig(cfg?: OpenClawConfig): PdfModelConfig {
     modelConfig.fallbacks = fallbacks;
   }
   return modelConfig;
+}
+
+export function coercePdfExtractionMode(value: unknown): PdfExtractionMode | undefined {
+  if (value === "local" || value === "ocr" || value === "auto") {
+    return value;
+  }
+  return undefined;
+}
+
+export function coerceConfiguredPdfExtractionMode(
+  cfg?: OpenClawConfig,
+): PdfExtractionMode | undefined {
+  return coercePdfExtractionMode(cfg?.agents?.defaults?.pdfExtractionMode);
 }
 
 export function resolvePdfToolMaxTokens(

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  coerceConfiguredPdfExtractionMode,
   coercePdfAssistantText,
   coercePdfModelConfig,
   parsePageRange,
@@ -97,12 +98,29 @@ function makeGeminiAnalyzeParams(
   };
 }
 
+function makeMistralOcrParams(
+  overrides: Partial<{
+    apiKey: string;
+    pdf: { base64: string; filename: string };
+    pageNumbers: number[];
+    modelId: string;
+    baseUrl: string;
+  }> = {},
+) {
+  return {
+    apiKey: "test-key", // pragma: allowlist secret
+    pdf: TEST_PDF_INPUT,
+    ...overrides,
+  };
+}
+
 function resetAuthEnv() {
   vi.stubEnv("OPENAI_API_KEY", "");
   vi.stubEnv("ANTHROPIC_API_KEY", "");
   vi.stubEnv("ANTHROPIC_OAUTH_TOKEN", "");
   vi.stubEnv("GEMINI_API_KEY", "");
   vi.stubEnv("GOOGLE_API_KEY", "");
+  vi.stubEnv("MISTRAL_API_KEY", "");
   vi.stubEnv("MINIMAX_API_KEY", "");
   vi.stubEnv("ZAI_API_KEY", "");
   vi.stubEnv("Z_AI_API_KEY", "");
@@ -508,6 +526,364 @@ describe("createPdfTool", () => {
     });
   });
 
+  it("forces local extraction mode for native-capable providers and allows pages", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, { provider: "anthropic", input: ["text", "document"] });
+
+      const nativeProviders = await import("./pdf-native-providers.js");
+      const nativeSpy = vi
+        .spyOn(nativeProviders, "anthropicAnalyzePdf")
+        .mockResolvedValue("unused");
+
+      const extractModule = await import("../../media/pdf-extract.js");
+      const extractSpy = vi.spyOn(extractModule, "extractPdfContent").mockResolvedValue({
+        text: "Extracted content",
+        images: [],
+      });
+
+      const piAi = await import("@mariozechner/pi-ai");
+      vi.mocked(piAi.complete).mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "local summary" }],
+      } as never);
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            pdfModel: { primary: ANTHROPIC_PDF_MODEL },
+            pdfExtractionMode: "local",
+          },
+        },
+      };
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+        pages: "1-2",
+      });
+
+      expect(nativeSpy).not.toHaveBeenCalled();
+      expect(extractSpy).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "local summary" }],
+        details: { native: false, model: ANTHROPIC_PDF_MODEL, extractionMode: "local" },
+      });
+    });
+  });
+
+  it("uses OCR extraction mode when explicitly requested", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("MISTRAL_API_KEY", "mistral-test-key");
+      await stubPdfToolInfra(agentDir, { provider: "anthropic", input: ["text", "document"] });
+
+      const nativeProviders = await import("./pdf-native-providers.js");
+      vi.spyOn(nativeProviders, "anthropicAnalyzePdf").mockResolvedValue("unused");
+      const ocrSpy = vi.spyOn(nativeProviders, "mistralOcrPdf").mockResolvedValue("OCR content");
+
+      const extractModule = await import("../../media/pdf-extract.js");
+      const extractSpy = vi.spyOn(extractModule, "extractPdfContent");
+
+      const piAi = await import("@mariozechner/pi-ai");
+      vi.mocked(piAi.complete).mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "ocr summary" }],
+      } as never);
+
+      const cfg = withPdfModel(ANTHROPIC_PDF_MODEL);
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+        pages: "1-2",
+        extractionMode: "ocr",
+      });
+
+      expect(extractSpy).not.toHaveBeenCalled();
+      expect(ocrSpy).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "ocr summary" }],
+        details: {
+          native: false,
+          model: ANTHROPIC_PDF_MODEL,
+          extractionMode: "ocr",
+          ocrProvider: "mistral",
+        },
+      });
+    });
+  });
+
+  it("errors in OCR extraction mode when Mistral auth is unavailable", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const piAi = await import("@mariozechner/pi-ai");
+      vi.mocked(piAi.complete).mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "unused" }],
+      } as never);
+
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", {
+          prompt: "summarize",
+          pdf: "/tmp/doc.pdf",
+          extractionMode: "ocr",
+        }),
+      ).rejects.toThrow('PDF extractionMode "ocr" requires Mistral auth.');
+    });
+  });
+
+  it("errors in OCR extraction mode when OCR fails", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("MISTRAL_API_KEY", "mistral-test-key");
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const nativeProviders = await import("./pdf-native-providers.js");
+      vi.spyOn(nativeProviders, "mistralOcrPdf").mockRejectedValue(
+        new Error("Mistral OCR returned no text."),
+      );
+
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", {
+          prompt: "summarize",
+          pdf: "/tmp/doc.pdf",
+          extractionMode: "ocr",
+        }),
+      ).rejects.toThrow("Mistral OCR returned no text.");
+    });
+  });
+
+  it("skips OCR in auto mode when local text is already strong", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("MISTRAL_API_KEY", "mistral-test-key");
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const extractModule = await import("../../media/pdf-extract.js");
+      const extractSpy = vi.spyOn(extractModule, "extractPdfContent").mockResolvedValue({
+        text: "A".repeat(240),
+        images: [],
+      });
+
+      const nativeProviders = await import("./pdf-native-providers.js");
+      const ocrSpy = vi.spyOn(nativeProviders, "mistralOcrPdf");
+
+      const piAi = await import("@mariozechner/pi-ai");
+      vi.mocked(piAi.complete).mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "local summary" }],
+      } as never);
+
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+        extractionMode: "auto",
+      });
+
+      expect(extractSpy).toHaveBeenCalledTimes(1);
+      expect(extractSpy.mock.calls[0]?.[0]).toMatchObject({ skipImageExtraction: true });
+      expect(ocrSpy).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "local summary" }],
+        details: { native: false, model: OPENAI_PDF_MODEL, extractionMode: "auto" },
+      });
+      expect((result.details as Record<string, unknown>).ocrProvider).toBeUndefined();
+    });
+  });
+
+  it("uses auto extraction mode only when local text is weak", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("MISTRAL_API_KEY", "mistral-test-key");
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const extractModule = await import("../../media/pdf-extract.js");
+      const extractSpy = vi
+        .spyOn(extractModule, "extractPdfContent")
+        .mockResolvedValueOnce({ text: "too short", images: [] })
+        .mockResolvedValueOnce({ text: "unused", images: [] });
+
+      const nativeProviders = await import("./pdf-native-providers.js");
+      const ocrSpy = vi.spyOn(nativeProviders, "mistralOcrPdf").mockResolvedValue("OCR content");
+
+      const piAi = await import("@mariozechner/pi-ai");
+      vi.mocked(piAi.complete).mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "auto summary" }],
+      } as never);
+
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+        extractionMode: "auto",
+      });
+
+      expect(extractSpy).toHaveBeenCalledTimes(1);
+      expect(extractSpy.mock.calls[0]?.[0]).toMatchObject({ skipImageExtraction: true });
+      expect(ocrSpy).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "auto summary" }],
+        details: {
+          native: false,
+          model: OPENAI_PDF_MODEL,
+          extractionMode: "auto",
+          ocrProvider: "mistral",
+        },
+      });
+    });
+  });
+
+  it("falls back to local image extraction in auto mode when Mistral auth is unavailable", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const extractModule = await import("../../media/pdf-extract.js");
+      const extractSpy = vi
+        .spyOn(extractModule, "extractPdfContent")
+        .mockResolvedValueOnce({ text: "too short", images: [] })
+        .mockResolvedValueOnce({
+          text: "too short",
+          images: [{ type: "image", data: "abc", mimeType: "image/png" }],
+        });
+
+      const nativeProviders = await import("./pdf-native-providers.js");
+      const ocrSpy = vi.spyOn(nativeProviders, "mistralOcrPdf");
+
+      const piAi = await import("@mariozechner/pi-ai");
+      vi.mocked(piAi.complete).mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "fallback summary" }],
+      } as never);
+
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+        extractionMode: "auto",
+      });
+
+      expect(extractSpy).toHaveBeenCalledTimes(2);
+      expect(extractSpy.mock.calls[0]?.[0]).toMatchObject({ skipImageExtraction: true });
+      expect(ocrSpy).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "fallback summary" }],
+        details: { native: false, model: OPENAI_PDF_MODEL, extractionMode: "auto" },
+      });
+    });
+  });
+
+  it("falls back to local image extraction in auto mode when OCR fails", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("MISTRAL_API_KEY", "mistral-test-key");
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const extractModule = await import("../../media/pdf-extract.js");
+      const extractSpy = vi
+        .spyOn(extractModule, "extractPdfContent")
+        .mockResolvedValueOnce({ text: "too short", images: [] })
+        .mockResolvedValueOnce({
+          text: "too short",
+          images: [{ type: "image", data: "abc", mimeType: "image/png" }],
+        });
+
+      const nativeProviders = await import("./pdf-native-providers.js");
+      const ocrSpy = vi
+        .spyOn(nativeProviders, "mistralOcrPdf")
+        .mockRejectedValue(new Error("bad OCR"));
+
+      const piAi = await import("@mariozechner/pi-ai");
+      vi.mocked(piAi.complete).mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "fallback summary" }],
+      } as never);
+
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+        extractionMode: "auto",
+      });
+
+      expect(extractSpy).toHaveBeenCalledTimes(2);
+      expect(extractSpy.mock.calls[0]?.[0]).toMatchObject({ skipImageExtraction: true });
+      expect(extractSpy.mock.calls[1]?.[0]).not.toHaveProperty("skipImageExtraction", true);
+      expect(ocrSpy).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "fallback summary" }],
+        details: { native: false, model: OPENAI_PDF_MODEL, extractionMode: "auto" },
+      });
+      expect((result.details as Record<string, unknown>).ocrProvider).toBeUndefined();
+    });
+  });
+
+  it("per-call extractionMode overrides configured extraction mode", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("MISTRAL_API_KEY", "mistral-test-key");
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const extractModule = await import("../../media/pdf-extract.js");
+      const extractSpy = vi.spyOn(extractModule, "extractPdfContent").mockResolvedValue({
+        text: "Extracted content",
+        images: [],
+      });
+
+      const nativeProviders = await import("./pdf-native-providers.js");
+      const ocrSpy = vi.spyOn(nativeProviders, "mistralOcrPdf").mockResolvedValue("unused");
+
+      const piAi = await import("@mariozechner/pi-ai");
+      vi.mocked(piAi.complete).mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "local summary" }],
+      } as never);
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            pdfModel: { primary: OPENAI_PDF_MODEL },
+            pdfExtractionMode: "ocr",
+          },
+        },
+      };
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+        extractionMode: "local",
+      });
+
+      expect(extractSpy).toHaveBeenCalledTimes(1);
+      expect(ocrSpy).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "local summary" }],
+        details: { native: false, model: OPENAI_PDF_MODEL, extractionMode: "local" },
+      });
+    });
+  });
+
   it("tool parameters have correct schema shape", async () => {
     await withAnthropicPdfTool(async (tool) => {
       const schema = tool.parameters;
@@ -518,6 +894,7 @@ describe("createPdfTool", () => {
       expect(props.pdf).toBeDefined();
       expect(props.pdfs).toBeDefined();
       expect(props.pages).toBeDefined();
+      expect(props.extractionMode).toBeDefined();
       expect(props.model).toBeDefined();
       expect(props.maxBytesMb).toBeDefined();
     });
@@ -731,6 +1108,67 @@ describe("native PDF provider API calls", () => {
     expect(url).toContain("/v1beta/models/");
     expect(url).not.toContain("/v1beta/v1beta");
   });
+
+  it("mistralOcrPdf sends expected request with zero-based pages", async () => {
+    const { mistralOcrPdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        pages: [{ markdown: "Page 1" }, { markdown: "Page 2" }],
+      }),
+    });
+
+    const result = await mistralOcrPdf(
+      makeMistralOcrParams({
+        pageNumbers: [1, 3, 3],
+        baseUrl: "https://api.mistral.ai/v1/",
+      }),
+    );
+
+    expect(result).toBe("Page 1\n\nPage 2");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.mistral.ai/v1/ocr");
+    const body = JSON.parse(opts.body);
+    expect(body.model).toBe("mistral-ocr-latest");
+    expect(body.document.type).toBe("document_url");
+    expect(body.document.document_url).toContain("data:application/pdf;base64,");
+    expect(body.include_image_base64).toBe(false);
+    expect(body.pages).toEqual([0, 2]);
+  });
+
+  it("mistralOcrPdf throws on API error", async () => {
+    const { mistralOcrPdf } = await import("./pdf-native-providers.js");
+    mockFetchResponse({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      text: async () => "bad key",
+    });
+
+    await expect(mistralOcrPdf(makeMistralOcrParams())).rejects.toThrow(
+      "Mistral OCR request failed",
+    );
+  });
+
+  it("mistralOcrPdf throws when response has no markdown text", async () => {
+    const { mistralOcrPdf } = await import("./pdf-native-providers.js");
+    mockFetchResponse({
+      ok: true,
+      json: async () => ({ pages: [{ markdown: "   " }] }),
+    });
+
+    await expect(mistralOcrPdf(makeMistralOcrParams())).rejects.toThrow(
+      "Mistral OCR returned no text",
+    );
+  });
+
+  it("mistralOcrPdf requires apiKey", async () => {
+    const { mistralOcrPdf } = await import("./pdf-native-providers.js");
+    await expect(mistralOcrPdf(makeMistralOcrParams({ apiKey: "" }))).rejects.toThrow(
+      "apiKey required",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -759,6 +1197,17 @@ describe("pdf-tool.helpers", () => {
       primary: "anthropic/claude-opus-4-6",
       fallbacks: ["google/gemini-2.5-pro"],
     });
+  });
+
+  it("coerceConfiguredPdfExtractionMode reads configured extraction mode", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          pdfExtractionMode: "auto",
+        },
+      },
+    };
+    expect(coerceConfiguredPdfExtractionMode(cfg)).toBe("auto");
   });
 
   it("coercePdfAssistantText returns trimmed text", () => {

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -640,6 +640,28 @@ describe("createPdfTool", () => {
     });
   });
 
+  it("surfaces auth resolution errors in OCR extraction mode", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const modelAuth = await import("../model-auth.js");
+      vi.spyOn(modelAuth, "resolveApiKeyForProvider").mockRejectedValue(
+        new Error("auth store exploded"),
+      );
+
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", {
+          prompt: "summarize",
+          pdf: "/tmp/doc.pdf",
+          extractionMode: "ocr",
+        }),
+      ).rejects.toThrow("auth store exploded");
+    });
+  });
+
   it("errors in OCR extraction mode when OCR fails", async () => {
     await withTempAgentDir(async (agentDir) => {
       vi.stubEnv("MISTRAL_API_KEY", "mistral-test-key");
@@ -783,6 +805,55 @@ describe("createPdfTool", () => {
 
       expect(extractSpy).toHaveBeenCalledTimes(2);
       expect(extractSpy.mock.calls[0]?.[0]).toMatchObject({ skipImageExtraction: true });
+      expect(extractSpy.mock.calls[1]?.[0]).toMatchObject({ preExtractedText: "too short" });
+      expect(ocrSpy).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "fallback summary" }],
+        details: { native: false, model: OPENAI_PDF_MODEL, extractionMode: "auto" },
+      });
+    });
+  });
+
+  it("falls back to local extraction in auto mode when auth resolution fails", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const extractModule = await import("../../media/pdf-extract.js");
+      const extractSpy = vi
+        .spyOn(extractModule, "extractPdfContent")
+        .mockResolvedValueOnce({ text: "too short", images: [] })
+        .mockResolvedValueOnce({
+          text: "too short",
+          images: [{ type: "image", data: "abc", mimeType: "image/png" }],
+        });
+
+      const modelAuth = await import("../model-auth.js");
+      vi.spyOn(modelAuth, "resolveApiKeyForProvider").mockRejectedValue(
+        new Error("auth store exploded"),
+      );
+
+      const nativeProviders = await import("./pdf-native-providers.js");
+      const ocrSpy = vi.spyOn(nativeProviders, "mistralOcrPdf");
+
+      const piAi = await import("@mariozechner/pi-ai");
+      vi.mocked(piAi.complete).mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "fallback summary" }],
+      } as never);
+
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+        extractionMode: "auto",
+      });
+
+      expect(extractSpy).toHaveBeenCalledTimes(2);
+      expect(extractSpy.mock.calls[0]?.[0]).toMatchObject({ skipImageExtraction: true });
+      expect(extractSpy.mock.calls[1]?.[0]).toMatchObject({ preExtractedText: "too short" });
       expect(ocrSpy).not.toHaveBeenCalled();
       expect(result).toMatchObject({
         content: [{ type: "text", text: "fallback summary" }],
@@ -828,13 +899,85 @@ describe("createPdfTool", () => {
 
       expect(extractSpy).toHaveBeenCalledTimes(2);
       expect(extractSpy.mock.calls[0]?.[0]).toMatchObject({ skipImageExtraction: true });
-      expect(extractSpy.mock.calls[1]?.[0]).not.toHaveProperty("skipImageExtraction", true);
+      expect(extractSpy.mock.calls[1]?.[0]).toMatchObject({ preExtractedText: "too short" });
       expect(ocrSpy).toHaveBeenCalledTimes(1);
       expect(result).toMatchObject({
         content: [{ type: "text", text: "fallback summary" }],
         details: { native: false, model: OPENAI_PDF_MODEL, extractionMode: "auto" },
       });
       expect((result.details as Record<string, unknown>).ocrProvider).toBeUndefined();
+    });
+  });
+
+  it("errors in OCR extraction mode when selected pages normalize to none", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("MISTRAL_API_KEY", "mistral-test-key");
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const fetchMock = vi.fn();
+      global.fetch = Object.assign(fetchMock, { preconnect: vi.fn() }) as typeof global.fetch;
+
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { pdfModel: { primary: OPENAI_PDF_MODEL }, pdfMaxPages: 5 } },
+      };
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", {
+          prompt: "summarize",
+          pdf: "/tmp/doc.pdf",
+          pages: "8-9",
+          extractionMode: "ocr",
+        }),
+      ).rejects.toThrow("Mistral OCR: no valid pages selected.");
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("falls back in auto mode when selected pages normalize to none for OCR", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("MISTRAL_API_KEY", "mistral-test-key");
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const extractModule = await import("../../media/pdf-extract.js");
+      const extractSpy = vi
+        .spyOn(extractModule, "extractPdfContent")
+        .mockResolvedValueOnce({ text: "too short", images: [] })
+        .mockResolvedValueOnce({
+          text: "too short",
+          images: [{ type: "image", data: "abc", mimeType: "image/png" }],
+        });
+
+      const fetchMock = vi.fn();
+      global.fetch = Object.assign(fetchMock, { preconnect: vi.fn() }) as typeof global.fetch;
+
+      const piAi = await import("@mariozechner/pi-ai");
+      vi.mocked(piAi.complete).mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "fallback summary" }],
+      } as never);
+
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { pdfModel: { primary: OPENAI_PDF_MODEL }, pdfMaxPages: 5 } },
+      };
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+        pages: "8-9",
+        extractionMode: "auto",
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(extractSpy).toHaveBeenCalledTimes(2);
+      expect(extractSpy.mock.calls[1]?.[0]).toMatchObject({ preExtractedText: "too short" });
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "fallback summary" }],
+        details: { native: false, model: OPENAI_PDF_MODEL, extractionMode: "auto" },
+      });
     });
   });
 
@@ -1135,6 +1278,34 @@ describe("native PDF provider API calls", () => {
     expect(body.document.document_url).toContain("data:application/pdf;base64,");
     expect(body.include_image_base64).toBe(false);
     expect(body.pages).toEqual([0, 2]);
+  });
+
+  it("mistralOcrPdf omits pages when pageNumbers is undefined", async () => {
+    const { mistralOcrPdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        pages: [{ markdown: "Page 1" }],
+      }),
+    });
+
+    const result = await mistralOcrPdf(makeMistralOcrParams());
+
+    expect(result).toBe("Page 1");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).not.toHaveProperty("pages");
+  });
+
+  it("mistralOcrPdf rejects empty normalized page filters before fetch", async () => {
+    const { mistralOcrPdf } = await import("./pdf-native-providers.js");
+    const fetchMock = vi.fn();
+    global.fetch = Object.assign(fetchMock, { preconnect: vi.fn() }) as typeof global.fetch;
+
+    await expect(mistralOcrPdf(makeMistralOcrParams({ pageNumbers: [] }))).rejects.toThrow(
+      "Mistral OCR: no valid pages selected.",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("mistralOcrPdf throws on API error", async () => {

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -54,6 +54,7 @@ const ANTHROPIC_PDF_FALLBACK = "anthropic/claude-opus-4-5";
 
 const PDF_MIN_TEXT_CHARS = 200;
 const PDF_MAX_PIXELS = 4_000_000;
+const MISTRAL_MISSING_AUTH_ERROR = 'No API key found for provider "mistral".';
 
 function resolveProviderBaseUrl(
   cfg: OpenClawConfig | undefined,
@@ -77,6 +78,10 @@ function resolveProviderBaseUrl(
     }
   }
   return undefined;
+}
+
+function isMissingMistralAuthError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes(MISTRAL_MISSING_AUTH_ERROR);
 }
 
 // ---------------------------------------------------------------------------
@@ -557,32 +562,31 @@ export function createPdfTool(options?: {
       let mistralAuthPromise: Promise<{
         apiKey: string;
         baseUrl?: string;
-      } | null> | null = null;
+      }> | null = null;
 
-      const resolveMistralAuth = async (): Promise<{
+      const resolveRequiredMistralAuth = async (): Promise<{
         apiKey: string;
         baseUrl?: string;
-      } | null> => {
+      }> => {
         if (!mistralAuthPromise) {
           mistralAuthPromise = (async () => {
-            try {
-              const auth = await resolveApiKeyForProvider({
-                provider: "mistral",
-                cfg: options?.config,
-                agentDir,
-              });
-              const apiKey = auth.apiKey?.trim();
-              if (!apiKey) {
-                return null;
-              }
-              return {
-                apiKey,
-                baseUrl: resolveProviderBaseUrl(options?.config, "mistral"),
-              };
-            } catch {
-              return null;
+            const auth = await resolveApiKeyForProvider({
+              provider: "mistral",
+              cfg: options?.config,
+              agentDir,
+            });
+            const apiKey = auth.apiKey?.trim();
+            if (!apiKey) {
+              throw new Error(MISTRAL_MISSING_AUTH_ERROR);
             }
-          })();
+            return {
+              apiKey,
+              baseUrl: resolveProviderBaseUrl(options?.config, "mistral"),
+            };
+          })().catch((error) => {
+            mistralAuthPromise = null;
+            throw error;
+          });
         }
         return mistralAuthPromise;
       };
@@ -591,9 +595,16 @@ export function createPdfTool(options?: {
         const extractedAll: PdfExtractedContent[] = [];
         for (const pdf of loadedPdfs) {
           if (extractionMode === "ocr") {
-            const mistralAuth = await resolveMistralAuth();
-            if (!mistralAuth) {
-              throw new Error('PDF extractionMode "ocr" requires Mistral auth.');
+            let mistralAuth;
+            try {
+              mistralAuth = await resolveRequiredMistralAuth();
+            } catch (error) {
+              if (isMissingMistralAuthError(error)) {
+                throw new Error('PDF extractionMode "ocr" requires Mistral auth.', {
+                  cause: error,
+                });
+              }
+              throw error;
             }
             const text = await mistralOcrPdf({
               apiKey: mistralAuth.apiKey,
@@ -623,7 +634,12 @@ export function createPdfTool(options?: {
               continue;
             }
 
-            const mistralAuth = await resolveMistralAuth();
+            let mistralAuth: { apiKey: string; baseUrl?: string } | null = null;
+            try {
+              mistralAuth = await resolveRequiredMistralAuth();
+            } catch {
+              mistralAuth = null;
+            }
             if (mistralAuth) {
               try {
                 const text = await mistralOcrPdf({
@@ -642,6 +658,17 @@ export function createPdfTool(options?: {
                 // Auto mode preserves today's local fallback path when OCR is unavailable.
               }
             }
+
+            const extracted = await extractPdfContent({
+              buffer: pdf.buffer,
+              maxPages: configuredMaxPages,
+              maxPixels: PDF_MAX_PIXELS,
+              minTextChars: PDF_MIN_TEXT_CHARS,
+              pageNumbers,
+              preExtractedText: localTextOnly.text,
+            });
+            extractedAll.push(extracted);
+            continue;
           }
 
           const extracted = await extractPdfContent({

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -4,6 +4,9 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { extractPdfContent, type PdfExtractedContent } from "../../media/pdf-extract.js";
 import { resolveUserPath } from "../../utils.js";
 import { loadWebMediaRaw } from "../../web/media.js";
+import { resolveApiKeyForProvider } from "../model-auth.js";
+import { normalizeProviderId } from "../model-selection.js";
+import { optionalStringEnum } from "../schema/typebox.js";
 import {
   coerceImageModelConfig,
   type ImageModelConfig,
@@ -18,11 +21,14 @@ import {
   resolvePromptAndModelOverride,
 } from "./media-tool-shared.js";
 import { hasAuthForProvider, resolveDefaultModelRef } from "./model-config.helpers.js";
-import { anthropicAnalyzePdf, geminiAnalyzePdf } from "./pdf-native-providers.js";
+import { anthropicAnalyzePdf, geminiAnalyzePdf, mistralOcrPdf } from "./pdf-native-providers.js";
 import {
+  coerceConfiguredPdfExtractionMode,
+  coercePdfExtractionMode,
   coercePdfAssistantText,
   coercePdfModelConfig,
   parsePageRange,
+  PDF_EXTRACTION_MODES,
   providerSupportsNativePdf,
   resolvePdfToolMaxTokens,
 } from "./pdf-tool.helpers.js";
@@ -48,6 +54,30 @@ const ANTHROPIC_PDF_FALLBACK = "anthropic/claude-opus-4-5";
 
 const PDF_MIN_TEXT_CHARS = 200;
 const PDF_MAX_PIXELS = 4_000_000;
+
+function resolveProviderBaseUrl(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): string | undefined {
+  const providers = cfg?.models?.providers;
+  if (!providers || typeof providers !== "object") {
+    return undefined;
+  }
+  const direct = providers[provider] as { baseUrl?: unknown } | undefined;
+  if (typeof direct?.baseUrl === "string" && direct.baseUrl.trim()) {
+    return direct.baseUrl.trim();
+  }
+  const target = normalizeProviderId(provider);
+  for (const [providerKey, providerConfig] of Object.entries(providers)) {
+    if (normalizeProviderId(providerKey) !== target) {
+      continue;
+    }
+    if (typeof providerConfig?.baseUrl === "string" && providerConfig.baseUrl.trim()) {
+      return providerConfig.baseUrl.trim();
+    }
+  }
+  return undefined;
+}
 
 // ---------------------------------------------------------------------------
 // Model resolution (mirrors image tool pattern)
@@ -173,6 +203,7 @@ async function runPdfPrompt(params: {
   prompt: string;
   pdfBuffers: Array<{ base64: string; filename: string }>;
   pageNumbers?: number[];
+  allowNativePdf: boolean;
   getExtractions: () => Promise<PdfExtractedContent[]>;
 }): Promise<{
   text: string;
@@ -207,7 +238,7 @@ async function runPdfPrompt(params: {
         authStorage,
       });
 
-      if (providerSupportsNativePdf(provider)) {
+      if (params.allowNativePdf && providerSupportsNativePdf(provider)) {
         if (params.pageNumbers && params.pageNumbers.length > 0) {
           throw new Error(
             `pages is not supported with native PDF providers (${provider}/${modelId}). Remove pages, or use a non-native model for page filtering.`,
@@ -326,6 +357,7 @@ export function createPdfTool(options?: {
     typeof maxPagesDefault === "number" && Number.isFinite(maxPagesDefault)
       ? Math.floor(maxPagesDefault)
       : DEFAULT_MAX_PAGES;
+  const configuredExtractionMode = coerceConfiguredPdfExtractionMode(options?.config);
 
   const localRoots = resolveMediaToolLocalRoots(options?.workspaceDir, {
     workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
@@ -351,6 +383,10 @@ export function createPdfTool(options?: {
           description: 'Page range to process, e.g. "1-5", "1,3,5-7". Defaults to all pages.',
         }),
       ),
+      extractionMode: optionalStringEnum(PDF_EXTRACTION_MODES, {
+        description:
+          'Optional extraction mode override: "local", "ocr", or "auto". When set, this opts out of native PDF mode.',
+      }),
       model: Type.Optional(Type.String()),
       maxBytesMb: Type.Optional(Type.Number()),
     }),
@@ -407,6 +443,12 @@ export function createPdfTool(options?: {
       // Parse page range
       const pagesRaw =
         typeof record.pages === "string" && record.pages.trim() ? record.pages.trim() : undefined;
+      const extractionModeArg = coercePdfExtractionMode(record.extractionMode);
+      if (record.extractionMode !== undefined && !extractionModeArg) {
+        throw new Error('Invalid extractionMode. Expected one of: "local", "ocr", "auto".');
+      }
+      const extractionMode = extractionModeArg ?? configuredExtractionMode;
+      const allowNativePdf = extractionMode === undefined;
 
       const sandboxConfig: SandboxedBridgeMediaPathConfig | null =
         options?.sandbox && options.sandbox.root.trim()
@@ -510,10 +552,98 @@ export function createPdfTool(options?: {
       }
 
       const pageNumbers = pagesRaw ? parsePageRange(pagesRaw, configuredMaxPages) : undefined;
+      let ocrProviderUsed = false;
+
+      let mistralAuthPromise: Promise<{
+        apiKey: string;
+        baseUrl?: string;
+      } | null> | null = null;
+
+      const resolveMistralAuth = async (): Promise<{
+        apiKey: string;
+        baseUrl?: string;
+      } | null> => {
+        if (!mistralAuthPromise) {
+          mistralAuthPromise = (async () => {
+            try {
+              const auth = await resolveApiKeyForProvider({
+                provider: "mistral",
+                cfg: options?.config,
+                agentDir,
+              });
+              const apiKey = auth.apiKey?.trim();
+              if (!apiKey) {
+                return null;
+              }
+              return {
+                apiKey,
+                baseUrl: resolveProviderBaseUrl(options?.config, "mistral"),
+              };
+            } catch {
+              return null;
+            }
+          })();
+        }
+        return mistralAuthPromise;
+      };
 
       const getExtractions = async (): Promise<PdfExtractedContent[]> => {
         const extractedAll: PdfExtractedContent[] = [];
         for (const pdf of loadedPdfs) {
+          if (extractionMode === "ocr") {
+            const mistralAuth = await resolveMistralAuth();
+            if (!mistralAuth) {
+              throw new Error('PDF extractionMode "ocr" requires Mistral auth.');
+            }
+            const text = await mistralOcrPdf({
+              apiKey: mistralAuth.apiKey,
+              baseUrl: mistralAuth.baseUrl,
+              pdf: {
+                base64: pdf.base64,
+                filename: pdf.filename,
+              },
+              pageNumbers,
+            });
+            extractedAll.push({ text, images: [] });
+            ocrProviderUsed = true;
+            continue;
+          }
+
+          if (extractionMode === "auto") {
+            const localTextOnly = await extractPdfContent({
+              buffer: pdf.buffer,
+              maxPages: configuredMaxPages,
+              maxPixels: PDF_MAX_PIXELS,
+              minTextChars: PDF_MIN_TEXT_CHARS,
+              pageNumbers,
+              skipImageExtraction: true,
+            });
+            if (localTextOnly.text.trim().length >= PDF_MIN_TEXT_CHARS) {
+              extractedAll.push(localTextOnly);
+              continue;
+            }
+
+            const mistralAuth = await resolveMistralAuth();
+            if (mistralAuth) {
+              try {
+                const text = await mistralOcrPdf({
+                  apiKey: mistralAuth.apiKey,
+                  baseUrl: mistralAuth.baseUrl,
+                  pdf: {
+                    base64: pdf.base64,
+                    filename: pdf.filename,
+                  },
+                  pageNumbers,
+                });
+                extractedAll.push({ text, images: [] });
+                ocrProviderUsed = true;
+                continue;
+              } catch {
+                // Auto mode preserves today's local fallback path when OCR is unavailable.
+              }
+            }
+          }
+
           const extracted = await extractPdfContent({
             buffer: pdf.buffer,
             maxPages: configuredMaxPages,
@@ -534,6 +664,7 @@ export function createPdfTool(options?: {
         prompt: promptRaw,
         pdfBuffers: loadedPdfs.map((p) => ({ base64: p.base64, filename: p.filename })),
         pageNumbers,
+        allowNativePdf,
         getExtractions,
       });
 
@@ -552,7 +683,12 @@ export function createPdfTool(options?: {
               })),
             };
 
-      return buildTextToolResult(result, { native: result.native, ...pdfDetails });
+      return buildTextToolResult(result, {
+        native: result.native,
+        ...(extractionMode ? { extractionMode } : {}),
+        ...(ocrProviderUsed ? { ocrProvider: "mistral" } : {}),
+        ...pdfDetails,
+      });
     },
   };
 }

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -116,7 +116,7 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
-  it("accepts pdf default model and limits", () => {
+  it("accepts pdf default model, limits, and extraction mode", () => {
     const res = validateConfigObject({
       agents: {
         defaults: {
@@ -126,6 +126,7 @@ describe("config schema regressions", () => {
           },
           pdfMaxBytesMb: 12,
           pdfMaxPages: 25,
+          pdfExtractionMode: "auto",
         },
       },
     });
@@ -140,13 +141,20 @@ describe("config schema regressions", () => {
           pdfModel: { primary: "openai/gpt-5-mini" },
           pdfMaxBytesMb: 0,
           pdfMaxPages: 0,
+          pdfExtractionMode: "bogus",
         },
       },
     });
 
     expect(res.ok).toBe(false);
     if (!res.ok) {
-      expect(res.issues.some((issue) => issue.path.includes("agents.defaults.pdfMax"))).toBe(true);
+      expect(
+        res.issues.some(
+          (issue) =>
+            issue.path.includes("agents.defaults.pdfMax") ||
+            issue.path === "agents.defaults.pdfExtractionMode",
+        ),
+      ).toBe(true);
     }
   });
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1008,6 +1008,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Maximum PDF file size in megabytes for the PDF tool (default: 10).",
   "agents.defaults.pdfMaxPages":
     "Maximum number of PDF pages to process for the PDF tool (default: 20).",
+  "agents.defaults.pdfExtractionMode":
+    'Optional default extraction mode for the PDF tool: "local", "ocr", or "auto". When set, this opts out of native PDF mode and forces extraction for matching calls.',
   "agents.defaults.imageMaxDimensionPx":
     "Max image side length in pixels when sanitizing transcript/tool-result image payloads (default: 1200).",
   "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -453,6 +453,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.pdfModel.fallbacks": "PDF Model Fallbacks",
   "agents.defaults.pdfMaxBytesMb": "PDF Max Size (MB)",
   "agents.defaults.pdfMaxPages": "PDF Max Pages",
+  "agents.defaults.pdfExtractionMode": "PDF Extraction Mode",
   "agents.defaults.imageMaxDimensionPx": "Image Max Dimension (px)",
   "agents.defaults.humanDelay.mode": "Human Delay Mode",
   "agents.defaults.humanDelay.minMs": "Human Delay Min (ms)",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -128,6 +128,8 @@ export type AgentDefaultsConfig = {
   pdfMaxBytesMb?: number;
   /** Maximum number of PDF pages to process (default: 20). */
   pdfMaxPages?: number;
+  /** Explicit PDF extraction mode override: local, ocr, or auto. */
+  pdfExtractionMode?: "local" | "ocr" | "auto";
   /** Model catalog with optional aliases (full provider/model keys). */
   models?: Record<string, AgentModelEntryConfig>;
   /** Agent working directory (preferred). Used as the default cwd for agent runs. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -21,6 +21,9 @@ export const AgentDefaultsSchema = z
     pdfModel: AgentModelSchema.optional(),
     pdfMaxBytesMb: z.number().positive().optional(),
     pdfMaxPages: z.number().int().positive().optional(),
+    pdfExtractionMode: z
+      .union([z.literal("local"), z.literal("ocr"), z.literal("auto")])
+      .optional(),
     models: z
       .record(
         z.string(),

--- a/src/media/pdf-extract.ts
+++ b/src/media/pdf-extract.ts
@@ -45,9 +45,18 @@ export async function extractPdfContent(params: {
   maxPixels: number;
   minTextChars: number;
   pageNumbers?: number[];
+  skipImageExtraction?: boolean;
   onImageExtractionError?: (error: unknown) => void;
 }): Promise<PdfExtractedContent> {
-  const { buffer, maxPages, maxPixels, minTextChars, pageNumbers, onImageExtractionError } = params;
+  const {
+    buffer,
+    maxPages,
+    maxPixels,
+    minTextChars,
+    pageNumbers,
+    skipImageExtraction,
+    onImageExtractionError,
+  } = params;
   const { getDocument } = await loadPdfJsModule();
   const pdf = await getDocument({ data: new Uint8Array(buffer), disableWorker: true }).promise;
 
@@ -70,6 +79,9 @@ export async function extractPdfContent(params: {
 
   const text = textParts.join("\n\n");
   if (text.trim().length >= minTextChars) {
+    return { text, images: [] };
+  }
+  if (skipImageExtraction) {
     return { text, images: [] };
   }
 

--- a/src/media/pdf-extract.ts
+++ b/src/media/pdf-extract.ts
@@ -45,6 +45,7 @@ export async function extractPdfContent(params: {
   maxPixels: number;
   minTextChars: number;
   pageNumbers?: number[];
+  preExtractedText?: string;
   skipImageExtraction?: boolean;
   onImageExtractionError?: (error: unknown) => void;
 }): Promise<PdfExtractedContent> {
@@ -54,6 +55,7 @@ export async function extractPdfContent(params: {
     maxPixels,
     minTextChars,
     pageNumbers,
+    preExtractedText,
     skipImageExtraction,
     onImageExtractionError,
   } = params;
@@ -64,20 +66,23 @@ export async function extractPdfContent(params: {
     ? pageNumbers.filter((p) => p >= 1 && p <= pdf.numPages).slice(0, maxPages)
     : Array.from({ length: Math.min(pdf.numPages, maxPages) }, (_, i) => i + 1);
 
-  const textParts: string[] = [];
-  for (const pageNum of effectivePages) {
-    const page = await pdf.getPage(pageNum);
-    const textContent = await page.getTextContent();
-    const pageText = textContent.items
-      .map((item) => ("str" in item ? String(item.str) : ""))
-      .filter(Boolean)
-      .join(" ");
-    if (pageText) {
-      textParts.push(pageText);
+  let text = preExtractedText ?? "";
+  if (preExtractedText === undefined) {
+    const textParts: string[] = [];
+    for (const pageNum of effectivePages) {
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+      const pageText = textContent.items
+        .map((item) => ("str" in item ? String(item.str) : ""))
+        .filter(Boolean)
+        .join(" ");
+      if (pageText) {
+        textParts.push(pageText);
+      }
     }
+    text = textParts.join("\n\n");
   }
 
-  const text = textParts.join("\n\n");
   if (text.trim().length >= minTextChars) {
     return { text, images: [] };
   }


### PR DESCRIPTION
## Summary

- Problem: The previous PDF OCR proposal hid OCR behind a weak-text fallback, which made behavior hard to predict and mixed two different parsing strategies under one heuristic.
- Why it matters: OCR changes latency, privacy, and behavior, so callers need explicit control over when the tool stays native, when it parses locally, and when it uses remote OCR.
- What changed: Added explicit `pdf.extractionMode` (`local|ocr|auto`) plus `agents.defaults.pdfExtractionMode`, preserved current behavior when unset, and added a Mistral OCR path for explicit OCR/auto extraction.
- What did NOT change (scope boundary): No generic OCR abstraction, no new tool surface beyond the `pdf` parameter/config addition, and no change to default native PDF behavior when extraction mode is omitted.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #35771

## User-visible / Behavior Changes

- Added `pdf.extractionMode` with `"local" | "ocr" | "auto"`.
- Added `agents.defaults.pdfExtractionMode` with the same values.
- When extraction mode is unset, the tool preserves current behavior: Anthropic/Google keep native PDF mode, non-native providers keep extraction fallback mode.
- Any explicit extraction mode opts out of native PDF mode and forces extraction, including on Anthropic/Google models.
- `details.extractionMode` is returned when an explicit extraction mode is active.
- `details.ocrProvider = "mistral"` is returned when OCR actually runs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
  - Yes.
- Secrets/tokens handling changed? (`Yes/No`)
  - No.
- New/changed network calls? (`Yes/No`)
  - Yes.
- Command/tool execution surface changed? (`Yes/No`)
  - No.
- Data access scope changed? (`Yes/No`)
  - Yes.
- If any `Yes`, explain risk + mitigation:
  - Risk: Explicit `ocr` and `auto` modes can send PDF bytes to Mistral.
  - Mitigation: OCR is opt-in, default behavior is unchanged when extraction mode is unset, and output metadata reports when OCR ran.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: Anthropic, Google, OpenAI fallback path, Mistral OCR path in tests
- Integration/channel (if any): agent `pdf` tool
- Relevant config (redacted):
  - `agents.defaults.pdfModel`
  - `agents.defaults.pdfExtractionMode`

### Steps

1. Run the focused PDF/config test suite.
2. Run TypeScript checks and type-aware lint on the touched files.
3. Verify formatting on the touched files.

### Expected

- Unset mode preserves existing native/fallback routing.
- Explicit `local`, `ocr`, and `auto` follow their documented extraction behavior.
- OCR metadata is only present when OCR actually runs.

### Actual

- Matches expected in focused verification.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Executed:

- `pnpm exec vitest run src/agents/tools/pdf-tool.test.ts src/config/config.schema-regressions.test.ts`
- `pnpm tsgo`
- `pnpm exec oxlint --type-aware src/agents/tools/pdf-tool.ts src/agents/tools/pdf-native-providers.ts src/agents/tools/pdf-tool.helpers.ts src/agents/tools/pdf-tool.test.ts src/config/config.schema-regressions.test.ts src/config/types.agent-defaults.ts src/config/zod-schema.agent-defaults.ts src/config/schema.help.ts src/config/schema.labels.ts src/media/pdf-extract.ts`
- `pnpm exec oxfmt --check src/agents/tools/pdf-tool.ts src/agents/tools/pdf-native-providers.ts src/agents/tools/pdf-tool.helpers.ts src/agents/tools/pdf-tool.test.ts src/config/config.schema-regressions.test.ts src/config/types.agent-defaults.ts src/config/zod-schema.agent-defaults.ts src/config/schema.help.ts src/config/schema.labels.ts src/media/pdf-extract.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Unset mode preserves native Anthropic/Google routing.
  - Explicit `local` mode forces extraction and allows `pages` on native-capable providers.
  - Explicit `ocr` mode forces Mistral OCR and errors on missing auth or OCR failure.
  - `auto` mode uses local text first, then OCR only for weak text, then PNG fallback if OCR is unavailable/fails.
  - Output metadata reports `extractionMode` only when explicit and `ocrProvider` only when OCR runs.
- Edge cases checked:
  - Mistral page-number conversion from 1-based internal pages to 0-based OCR request pages.
  - Mistral base URL normalization for `/v1/ocr`.
  - Empty OCR markdown response handling.
  - Per-call extraction mode overriding configured extraction mode.
- What you did **not** verify:
  - Live end-to-end OCR against a real Mistral account in this PR iteration.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
  - Yes.
- Config/env changes? (`Yes/No`)
  - Yes.
- Migration needed? (`Yes/No`)
  - No.
- If yes, exact upgrade steps:
  - N/A.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove `extractionMode` from calls and unset `agents.defaults.pdfExtractionMode`.
- Files/config to restore:
  - `agents.defaults.pdfExtractionMode` in config.
- Known bad symptoms reviewers should watch for:
  - Unexpected OCR auth errors in explicit `ocr` mode.
  - Unexpected native-PDF bypass when a config default is set intentionally.

## Risks and Mitigations

- Risk: Explicit extraction mode on Anthropic/Google bypasses native PDF mode, which changes capability and latency characteristics.
  - Mitigation: This only happens when the caller or config explicitly requests extraction mode, and docs call it out clearly.
- Risk: OCR failures could confuse users if they expect silent fallback.
  - Mitigation: Only `auto` falls back silently; explicit `ocr` mode fails clearly by design.
