### PR TITLE
fix(gateway): refresh service file with new version after update

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -216,6 +216,12 @@ describe("update-cli", () => {
 
   const runRestartFallbackScenario = async (params: { daemonInstall: "ok" | "fail" }) => {
     vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
+    // Mock runCommandWithTimeout to fail so refreshGatewayServiceEnv falls back to runDaemonInstall
+    vi.mocked(runCommandWithTimeout).mockResolvedValue({
+      stdout: "",
+      stderr: "install failed",
+      code: 1,
+    });
     if (params.daemonInstall === "fail") {
       vi.mocked(runDaemonInstall).mockRejectedValueOnce(new Error("refresh failed"));
     } else {
@@ -227,6 +233,7 @@ describe("update-cli", () => {
 
     await updateCommand({});
 
+    // Verify fallback was attempted
     expect(runDaemonInstall).toHaveBeenCalledWith({
       force: true,
       json: undefined,

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -221,6 +221,9 @@ describe("update-cli", () => {
       stdout: "",
       stderr: "install failed",
       code: 1,
+      signal: null,
+      killed: false,
+      termination: "exit",
     });
     if (params.daemonInstall === "fail") {
       vi.mocked(runDaemonInstall).mockRejectedValueOnce(new Error("refresh failed"));

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -107,14 +107,6 @@ function resolveGatewayInstallEntrypointCandidates(root?: string): string[] {
   ];
 }
 
-function formatCommandFailure(stdout: string, stderr: string): string {
-  const detail = (stderr || stdout).trim();
-  if (!detail) {
-    return "command returned a non-zero exit code";
-  }
-  return detail.split("\n").slice(-3).join("\n");
-}
-
 type UpdateDryRunPreview = {
   dryRun: true;
   root: string;
@@ -183,6 +175,8 @@ async function refreshGatewayServiceEnv(params: {
     args.push("--json");
   }
 
+  // Try to regenerate the service file using the updated binary first.
+  // This ensures OPENCLAW_SERVICE_VERSION in the service file matches the new version.
   for (const candidate of resolveGatewayInstallEntrypointCandidates(params.result.root)) {
     if (!(await pathExists(candidate))) {
       continue;
@@ -193,11 +187,13 @@ async function refreshGatewayServiceEnv(params: {
     if (res.code === 0) {
       return;
     }
-    throw new Error(
-      `updated install refresh failed (${candidate}): ${formatCommandFailure(res.stdout, res.stderr)}`,
-    );
+    // Don't throw here - fall through to runDaemonInstall as a fallback.
+    // This ensures the service file still gets regenerated even if the updated
+    // binary's install command fails (e.g., due to runtime/dependency issues).
   }
 
+  // Fallback: use the current CLI to regenerate the service file.
+  // This will read the new VERSION from the updated package.json.
   await runDaemonInstall({ force: true, json: params.jsonMode || undefined });
 }
 
@@ -526,10 +522,17 @@ async function maybeRestartService(params: {
             jsonMode: Boolean(params.opts.json),
           });
         } catch (err) {
+          // Service env refresh failed, but we should still proceed with restart.
+          // The user may need to manually reinstall the service if version is stale.
           if (!params.opts.json) {
             defaultRuntime.log(
               theme.warn(
-                `Failed to refresh gateway service environment from updated install: ${String(err)}`,
+                `Failed to refresh gateway service environment: ${err instanceof Error ? err.message : String(err)}. The dashboard may show an outdated version.`,
+              ),
+            );
+            defaultRuntime.log(
+              theme.muted(
+                `Tip: Run \`${replaceCliName(formatCliCommand("openclaw gateway install --force"), CLI_NAME)}\` to refresh the service file.`,
               ),
             );
           }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

修复了 │
◇  Doctor warnings ──────────────────────────────────────╮
│                                                        │
│  - State dir migration skipped: target already exists  │
│    (/Users/fang/.openclaw). Remove or merge manually.  │
│                                                        │
├────────────────────────────────────────────────────────╯
Updating OpenClaw...


Update Result: OK
  Root: /Users/fang/openclaw
  Before: 2026.3.11
  After: 2026.3.11

Steps:
  ✓ clean check (50ms)
  ✓ git checkout main (42ms)
  ✓ upstream check (19ms)
  ✓ git fetch (5.12s)
  ✓ git rev-parse @{upstream} (63ms)
  ✓ git rev-list (154ms)
  ✓ preflight worktree (2.57s)
  ✓ preflight checkout (62a71361) (304ms)
  ✓ preflight deps install (62a71361) (13.28s)
  ✓ preflight build (62a71361) (29.39s)
  ✓ preflight lint (62a71361) (9.95s)
  ✓ preflight cleanup (8.15s)
  ✓ git rebase (169ms)
  ✓ deps install (2.58s)
  ✓ build (28.84s)
  ✓ ui:build (3.38s)
  ✓ openclaw doctor (16.67s)
  ✓ git rev-parse HEAD (after) (27ms)

Total time: 120.86s

Updating plugins...
No plugin updates needed.

Restarting service...
Daemon restart completed.

Update done! Check the changelog or just trust me, it's good. 后网关仪表板显示旧版本号的问题。

## Root Cause

systemd/launchd/Windows 任务计划程序的服务文件在安装时会固化 `OPENCLAW_SERVICE_VERSION` 环境变量。更新命令虽然更新了二进制文件，但不会可靠地重新生成服务文件，导致仪表板读取的仍是旧版本号。

## Fix

修改了 `src/cli/update-cli/update-command.ts`:

1. **`refreshGatewayServiceEnv` 函数**: 当更新后的二进制运行 `gateway install --force` 失败时，不再抛出错误，而是回退到 `runDaemonInstall`，确保服务文件始终使用新版本号重新生成。

2. **`maybeRestartService` 函数**: 添加了错误处理，即使服务环境刷新完全失败，仍继续执行重启流程，并提示用户如何手动刷新服务文件。

## Testing

- 更新了 `src/cli/update-cli.test.ts` 中的测试用例，正确模拟 `runCommandWithTimeout` 失败的场景。
- 所有现有测试通过。

## Platforms Fixed

- macOS (LaunchAgent)
- Linux (systemd)
- Windows (Scheduled Task)

所有平台都使用相同的 `buildServiceEnvironment` 函数来设置 `OPENCLAW_SERVICE_VERSION`，因此修复适用于所有安装方式。

Closes #30689
EOF
)