### PR TITLE
feat(feishu): add feishu_sheets tool for reading spreadsheet data

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
+import { registerFeishuSheetsTools } from "./src/sheets.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
@@ -59,6 +60,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuSheetsTools(api);
   },
 };
 

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -92,6 +92,7 @@ const FeishuToolsConfigSchema = z
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
+    sheets: z.boolean().optional(), // Spreadsheet read operations (default: true)
   })
   .strict()
   .optional();

--- a/extensions/feishu/src/sheets-schema.ts
+++ b/extensions/feishu/src/sheets-schema.ts
@@ -1,0 +1,33 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+const SHEETS_ACTION_VALUES = ["get_meta", "read_range", "list_sheets"] as const;
+
+export const FeishuSheetsSchema = Type.Object({
+  action: Type.Unsafe<(typeof SHEETS_ACTION_VALUES)[number]>({
+    type: "string",
+    enum: [...SHEETS_ACTION_VALUES],
+    description: "Action to run: get_meta | read_range | list_sheets",
+  }),
+  spreadsheet_token: Type.String({
+    description:
+      "Spreadsheet token (the part after /sheets/ in the URL, e.g. from https://xxx.feishu.cn/sheets/{token})",
+  }),
+  sheet_id: Type.Optional(
+    Type.String({
+      description: "Sheet tab ID (required for read_range — identifies which sheet tab to read)",
+    }),
+  ),
+  range: Type.Optional(
+    Type.String({
+      description:
+        'Cell range in A1 notation, e.g. "A1:Z100". If omitted, reads all data in the sheet.',
+    }),
+  ),
+  page_size: Type.Optional(
+    Type.Number({
+      description: "Max rows to return (default 100). Used to limit read_range results.",
+    }),
+  ),
+});
+
+export type FeishuSheetsParams = Static<typeof FeishuSheetsSchema>;

--- a/extensions/feishu/src/sheets.ts
+++ b/extensions/feishu/src/sheets.ts
@@ -20,7 +20,7 @@ async function getMeta(client: Lark.Client, params: FeishuSheetsParams) {
 
   return {
     title: res.data?.spreadsheet?.title,
-    spreadsheet_token: res.data?.spreadsheet?.spreadsheet_token,
+    spreadsheet_token: res.data?.spreadsheet?.token,
     url: res.data?.spreadsheet?.url,
   };
 }

--- a/extensions/feishu/src/sheets.ts
+++ b/extensions/feishu/src/sheets.ts
@@ -1,0 +1,149 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { FeishuSheetsSchema, type FeishuSheetsParams } from "./sheets-schema.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+import {
+  jsonToolResult,
+  toolExecutionErrorResult,
+  unknownToolActionResult,
+} from "./tool-result.js";
+
+async function getMeta(client: Lark.Client, params: FeishuSheetsParams) {
+  const res = await client.sheets.spreadsheet.get({
+    path: { spreadsheet_token: params.spreadsheet_token },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    title: res.data?.spreadsheet?.title,
+    spreadsheet_token: res.data?.spreadsheet?.spreadsheet_token,
+    url: res.data?.spreadsheet?.url,
+  };
+}
+
+async function listSheets(client: Lark.Client, params: FeishuSheetsParams) {
+  // The Lark SDK type definitions may not expose this method fully, so we cast to any.
+  const res = await (client as any).sheets.spreadsheetSheet.query({
+    path: { spreadsheet_token: params.spreadsheet_token },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  const sheets = res.data?.sheets ?? [];
+  return {
+    spreadsheet_token: params.spreadsheet_token,
+    sheets: sheets.map((sheet: any) => ({
+      sheet_id: sheet.sheet_id,
+      title: sheet.title,
+      index: sheet.index,
+      row_count: sheet.grid_properties?.row_count,
+      column_count: sheet.grid_properties?.column_count,
+    })),
+  };
+}
+
+async function readRange(client: Lark.Client, params: FeishuSheetsParams) {
+  if (!params.sheet_id) {
+    throw new Error("sheet_id is required for read_range");
+  }
+
+  const range = params.range ? `${params.sheet_id}!${params.range}` : params.sheet_id;
+
+  // The Lark SDK type definitions don't fully expose the sheets v2 values API.
+  // Use client.request() (raw HTTP) if available, otherwise fall back to SDK path.
+  let valuesRes: any;
+  if (typeof (client as any).request === "function") {
+    valuesRes = await (client as any).request({
+      method: "GET",
+      url: `/open-apis/sheets/v2/spreadsheets/${params.spreadsheet_token}/values/${encodeURIComponent(range)}`,
+      params: { valueRenderOption: "ToString" },
+    });
+  } else {
+    valuesRes = await (client as any).sheets.spreadsheet.values.get({
+      path: { spreadsheet_token: params.spreadsheet_token },
+      params: { range },
+    });
+  }
+
+  // The v2 API returns data under data.valueRange
+  const valueRange = valuesRes?.data?.valueRange ?? valuesRes?.data;
+  const values: unknown[][] = valueRange?.values ?? [];
+
+  // Apply page_size limit (default 100)
+  const maxRows = params.page_size ?? 100;
+  const limitedValues = values.slice(0, maxRows);
+
+  return {
+    spreadsheet_token: params.spreadsheet_token,
+    sheet_id: params.sheet_id,
+    range: valueRange?.range ?? range,
+    total_rows: values.length,
+    returned_rows: limitedValues.length,
+    values: limitedValues,
+  };
+}
+
+export function registerFeishuSheetsTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_sheets: No config available, skipping sheets tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_sheets: No Feishu accounts configured, skipping sheets tools");
+    return;
+  }
+
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  if (!toolsCfg.sheets) {
+    api.logger.debug?.("feishu_sheets: sheets tool disabled in config");
+    return;
+  }
+
+  type FeishuSheetsExecuteParams = FeishuSheetsParams & { accountId?: string };
+
+  api.registerTool(
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_sheets",
+        label: "Feishu Sheets",
+        description:
+          "Read Feishu spreadsheet (电子表格) data. Actions: get_meta, list_sheets, read_range",
+        parameters: FeishuSheetsSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuSheetsExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            switch (p.action) {
+              case "get_meta":
+                return jsonToolResult(await getMeta(client, p));
+              case "list_sheets":
+                return jsonToolResult(await listSheets(client, p));
+              case "read_range":
+                return jsonToolResult(await readRange(client, p));
+              default:
+                return unknownToolActionResult((p as { action?: unknown }).action);
+            }
+          } catch (err) {
+            return toolExecutionErrorResult(err);
+          }
+        },
+      };
+    },
+    { name: "feishu_sheets" },
+  );
+
+  api.logger.info?.("feishu_sheets: Registered feishu_sheets tool");
+}

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -56,6 +56,9 @@ export function resolveAnyEnabledFeishuToolsConfig(
     drive: false,
     perm: false,
     scopes: false,
+    calendar: false,
+    board: false,
+    sheets: false,
   };
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);
@@ -65,6 +68,9 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.drive = merged.drive || cfg.drive;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
+    merged.calendar = merged.calendar || cfg.calendar;
+    merged.board = merged.board || cfg.board;
+    merged.sheets = merged.sheets || cfg.sheets;
   }
   return merged;
 }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -2,7 +2,7 @@ import type { FeishuToolsConfig } from "./types.js";
 
 /**
  * Default tool configuration.
- * - doc, chat, wiki, drive, scopes: enabled by default
+ * - doc, chat, wiki, drive, scopes, calendar, board, sheets: enabled by default
  * - perm: disabled by default (sensitive operation)
  */
 export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
@@ -12,6 +12,9 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  calendar: true,
+  board: true,
+  sheets: true,
 };
 
 /**

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -93,6 +93,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  sheets?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -93,6 +93,8 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  calendar?: boolean;
+  board?: boolean;
   sheets?: boolean;
 };
 


### PR DESCRIPTION
## Summary

- Add `feishu_sheets` tool with three actions: `get_meta` (spreadsheet metadata), `list_sheets` (enumerate sheet tabs), and `read_range` (read cell values in A1 notation)
- Wire the tool into the feishu extension config system (`FeishuToolsConfig`, `DEFAULT_TOOLS_CONFIG`, `FeishuToolsConfigSchema`, `resolveAnyEnabledFeishuToolsConfig`)
- Register the tool in the feishu plugin entry point

## Details

The sheets tool uses the Lark SDK `sheets.spreadsheet.get` for metadata, `sheets.spreadsheetSheet.query` for tab enumeration, and the v2 values API for reading cell data. It includes a `page_size` parameter (default 100) to limit returned rows and falls back to the SDK's internal path if `client.request()` is unavailable.

Follows the same registration pattern as the existing bitable, drive, and calendar tools.

## Test plan

- [x] Existing `tools-config.test.ts` passes (sheets defaults to enabled)
- [x] Existing `config-schema.test.ts` passes (strict schema accepts `sheets` key)
- [x] Type checking passes (`tsgo --noEmit`)
- [x] Formatting passes (`oxfmt --check`)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)