### PR TITLE
feat(feishu): fix board tool SDK paths and add create_whiteboard action

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
+import { registerFeishuSheetsTools } from "./src/sheets.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
@@ -59,6 +60,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuSheetsTools(api);
   },
 };
 

--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -1,6 +1,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/feishu";
 import { registerFeishuBitableTools } from "./src/bitable.js";
+import { registerFeishuBoardTools } from "./src/board.js";
 import { feishuPlugin } from "./src/channel.js";
 import { registerFeishuChatTools } from "./src/chat.js";
 import { registerFeishuDocTools } from "./src/docx.js";
@@ -61,6 +62,7 @@ const plugin = {
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
     registerFeishuSheetsTools(api);
+    registerFeishuBoardTools(api);
   },
 };
 

--- a/extensions/feishu/src/board-schema.ts
+++ b/extensions/feishu/src/board-schema.ts
@@ -1,0 +1,100 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+const BOARD_ACTION_VALUES = [
+  "create_whiteboard",
+  "create_node",
+  "create_plantuml",
+  "list_nodes",
+  "get_theme",
+  "update_theme",
+  "download_image",
+] as const;
+
+const THEME_VALUES = [
+  "classic",
+  "minimalist_gray",
+  "retro",
+  "vibrant_color",
+  "minimalist_blue",
+  "default",
+] as const;
+
+const NODE_TYPE_VALUES = [
+  "image",
+  "text_shape",
+  "group",
+  "composite_shape",
+  "svg",
+  "connector",
+  "table",
+  "life_line",
+  "activation",
+  "section",
+  "table_uml",
+  "table_er",
+  "sticky_note",
+  "mind_map",
+  "paint",
+  "combined_fragment",
+] as const;
+
+export const FeishuBoardSchema = Type.Object({
+  action: Type.Unsafe<(typeof BOARD_ACTION_VALUES)[number]>({
+    type: "string",
+    enum: [...BOARD_ACTION_VALUES],
+    description:
+      "Action to run: create_whiteboard | create_node | create_plantuml | list_nodes | get_theme | update_theme | download_image",
+  }),
+  whiteboard_id: Type.Optional(
+    Type.String({
+      description: "Whiteboard ID (required for all actions except create_whiteboard)",
+    }),
+  ),
+  title: Type.Optional(
+    Type.String({
+      description: "Whiteboard title (optional, for create_whiteboard)",
+    }),
+  ),
+  folder_token: Type.Optional(
+    Type.String({
+      description: "Folder token to create whiteboard in (optional, for create_whiteboard)",
+    }),
+  ),
+  nodes: Type.Optional(
+    Type.Array(
+      Type.Object({
+        type: Type.Unsafe<(typeof NODE_TYPE_VALUES)[number]>({
+          type: "string",
+          enum: [...NODE_TYPE_VALUES],
+          description: "Node type",
+        }),
+        x: Type.Optional(Type.Number({ description: "X position" })),
+        y: Type.Optional(Type.Number({ description: "Y position" })),
+        width: Type.Optional(Type.Number({ description: "Node width" })),
+        height: Type.Optional(Type.Number({ description: "Node height" })),
+        text: Type.Optional(Type.String({ description: "Node text content" })),
+        parent_id: Type.Optional(Type.String({ description: "Parent node ID" })),
+      }),
+      { description: "Array of nodes to create (required for create_node)" },
+    ),
+  ),
+  plant_uml_code: Type.Optional(
+    Type.String({
+      description:
+        "PlantUML code for creating diagrams such as mind maps, flowcharts, sequence diagrams (required for create_plantuml)",
+    }),
+  ),
+  style_type: Type.Optional(Type.Number({ description: "PlantUML style type (optional)" })),
+  syntax_type: Type.Optional(Type.Number({ description: "PlantUML syntax type (optional)" })),
+  diagram_type: Type.Optional(Type.Number({ description: "PlantUML diagram type (optional)" })),
+  theme: Type.Optional(
+    Type.Unsafe<(typeof THEME_VALUES)[number]>({
+      type: "string",
+      enum: [...THEME_VALUES],
+      description:
+        "Whiteboard theme (required for update_theme): classic | minimalist_gray | retro | vibrant_color | minimalist_blue | default",
+    }),
+  ),
+});
+
+export type FeishuBoardParams = Static<typeof FeishuBoardSchema>;

--- a/extensions/feishu/src/board.ts
+++ b/extensions/feishu/src/board.ts
@@ -169,19 +169,10 @@ async function downloadImage(client: Lark.Client, params: FeishuBoardParams) {
     throw new Error(res.msg);
   }
 
-  // The downloadAsImage endpoint returns binary image data in res.data.
-  // Convert to base64 if we got a Buffer, otherwise return as-is.
-  let imageData: string | undefined;
-  if (Buffer.isBuffer(res.data)) {
-    imageData = res.data.toString("base64");
-  } else if (res.data?.image) {
-    imageData = res.data.image;
-  }
-
   return {
     whiteboard_id: params.whiteboard_id,
-    image_base64: imageData,
-    downloaded: !!imageData,
+    image_data: res.data,
+    downloaded: true,
   };
 }
 

--- a/extensions/feishu/src/board.ts
+++ b/extensions/feishu/src/board.ts
@@ -2,15 +2,12 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuBoardSchema, type FeishuBoardParams } from "./board-schema.js";
-import { createFeishuClient } from "./client.js";
-import { resolveToolsConfig } from "./tools-config.js";
-
-function json(data: unknown) {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
-    details: data,
-  };
-}
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+import {
+  jsonToolResult,
+  toolExecutionErrorResult,
+  unknownToolActionResult,
+} from "./tool-result.js";
 
 async function createWhiteboard(client: Lark.Client, params: FeishuBoardParams) {
   // The Lark SDK doesn't expose whiteboard.create; use raw HTTP request.
@@ -172,9 +169,19 @@ async function downloadImage(client: Lark.Client, params: FeishuBoardParams) {
     throw new Error(res.msg);
   }
 
+  // The downloadAsImage endpoint returns binary image data in res.data.
+  // Convert to base64 if we got a Buffer, otherwise return as-is.
+  let imageData: string | undefined;
+  if (Buffer.isBuffer(res.data)) {
+    imageData = res.data.toString("base64");
+  } else if (res.data?.image) {
+    imageData = res.data.image;
+  }
+
   return {
     whiteboard_id: params.whiteboard_id,
-    downloaded: true,
+    image_base64: imageData,
+    downloaded: !!imageData,
   };
 }
 
@@ -190,50 +197,54 @@ export function registerFeishuBoardTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.board) {
     api.logger.debug?.("feishu_board: board tool disabled in config");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  type FeishuBoardExecuteParams = FeishuBoardParams & { accountId?: string };
 
   api.registerTool(
-    {
-      name: "feishu_board",
-      label: "Feishu Board",
-      description:
-        "Feishu whiteboard/board operations. Actions: create_whiteboard (create a new whiteboard), create_node (create nodes in a whiteboard), create_plantuml (create PlantUML diagrams including mind maps, flowcharts, sequence diagrams), list_nodes (list all nodes), get_theme, update_theme, download_image",
-      parameters: FeishuBoardSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuBoardParams;
-        try {
-          const client = getClient();
-          switch (p.action) {
-            case "create_whiteboard":
-              return json(await createWhiteboard(client, p));
-            case "create_node":
-              return json(await createNode(client, p));
-            case "create_plantuml":
-              return json(await createPlantuml(client, p));
-            case "list_nodes":
-              return json(await listNodes(client, p));
-            case "get_theme":
-              return json(await getTheme(client, p));
-            case "update_theme":
-              return json(await updateTheme(client, p));
-            case "download_image":
-              return json(await downloadImage(client, p));
-            default:
-              return json({ error: `Unknown action: ${String(p.action)}` });
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_board",
+        label: "Feishu Board",
+        description:
+          "Feishu whiteboard/board operations. Actions: create_whiteboard (create a new whiteboard), create_node (create nodes in a whiteboard), create_plantuml (create PlantUML diagrams including mind maps, flowcharts, sequence diagrams), list_nodes (list all nodes), get_theme, update_theme, download_image",
+        parameters: FeishuBoardSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuBoardExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            switch (p.action) {
+              case "create_whiteboard":
+                return jsonToolResult(await createWhiteboard(client, p));
+              case "create_node":
+                return jsonToolResult(await createNode(client, p));
+              case "create_plantuml":
+                return jsonToolResult(await createPlantuml(client, p));
+              case "list_nodes":
+                return jsonToolResult(await listNodes(client, p));
+              case "get_theme":
+                return jsonToolResult(await getTheme(client, p));
+              case "update_theme":
+                return jsonToolResult(await updateTheme(client, p));
+              case "download_image":
+                return jsonToolResult(await downloadImage(client, p));
+              default:
+                return unknownToolActionResult((p as { action?: unknown }).action);
+            }
+          } catch (err) {
+            return toolExecutionErrorResult(err);
           }
-        } catch (err) {
-          return json({
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_board" },
   );

--- a/extensions/feishu/src/board.ts
+++ b/extensions/feishu/src/board.ts
@@ -1,0 +1,242 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { FeishuBoardSchema, type FeishuBoardParams } from "./board-schema.js";
+import { createFeishuClient } from "./client.js";
+import { resolveToolsConfig } from "./tools-config.js";
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+async function createWhiteboard(client: Lark.Client, params: FeishuBoardParams) {
+  // The Lark SDK doesn't expose whiteboard.create; use raw HTTP request.
+  const data: Record<string, unknown> = {};
+  if (params.title) {
+    data.title = params.title;
+  }
+  if (params.folder_token) {
+    data.folder_token = params.folder_token;
+  }
+
+  const res = await (client as any).request({
+    method: "POST",
+    url: "/open-apis/board/v1/whiteboards",
+    data,
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    whiteboard_id: res.data?.whiteboard?.id,
+    title: res.data?.whiteboard?.title,
+    url: res.data?.whiteboard?.url,
+  };
+}
+
+async function createNode(client: Lark.Client, params: FeishuBoardParams) {
+  if (!params.whiteboard_id) {
+    throw new Error("whiteboard_id is required for create_node");
+  }
+  if (!params.nodes || params.nodes.length === 0) {
+    throw new Error("nodes array is required for create_node");
+  }
+
+  const res = await (client as any).board.v1.whiteboardNode.create({
+    data: { nodes: params.nodes },
+    params: { user_id_type: "open_id" },
+    path: { whiteboard_id: params.whiteboard_id },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    whiteboard_id: params.whiteboard_id,
+    nodes: res.data?.nodes ?? [],
+  };
+}
+
+async function createPlantuml(client: Lark.Client, params: FeishuBoardParams) {
+  if (!params.whiteboard_id) {
+    throw new Error("whiteboard_id is required for create_plantuml");
+  }
+  if (!params.plant_uml_code) {
+    throw new Error("plant_uml_code is required for create_plantuml");
+  }
+
+  const data: Record<string, unknown> = {
+    plant_uml_code: params.plant_uml_code,
+  };
+  if (params.style_type !== undefined) {
+    data.style_type = params.style_type;
+  }
+  if (params.syntax_type !== undefined) {
+    data.syntax_type = params.syntax_type;
+  }
+  if (params.diagram_type !== undefined) {
+    data.diagram_type = params.diagram_type;
+  }
+
+  const res = await (client as any).board.v1.whiteboardNode.createPlantuml({
+    data,
+    path: { whiteboard_id: params.whiteboard_id },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    whiteboard_id: params.whiteboard_id,
+    nodes: res.data?.nodes ?? [],
+  };
+}
+
+async function listNodes(client: Lark.Client, params: FeishuBoardParams) {
+  if (!params.whiteboard_id) {
+    throw new Error("whiteboard_id is required for list_nodes");
+  }
+  const res = await (client as any).board.v1.whiteboardNode.list({
+    params: { user_id_type: "open_id" },
+    path: { whiteboard_id: params.whiteboard_id },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    whiteboard_id: params.whiteboard_id,
+    nodes: res.data?.nodes ?? [],
+  };
+}
+
+async function getTheme(client: Lark.Client, params: FeishuBoardParams) {
+  if (!params.whiteboard_id) {
+    throw new Error("whiteboard_id is required for get_theme");
+  }
+  const res = await (client as any).board.v1.whiteboard.theme({
+    path: { whiteboard_id: params.whiteboard_id },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    whiteboard_id: params.whiteboard_id,
+    theme: res.data?.theme,
+  };
+}
+
+async function updateTheme(client: Lark.Client, params: FeishuBoardParams) {
+  if (!params.whiteboard_id) {
+    throw new Error("whiteboard_id is required for update_theme");
+  }
+  if (!params.theme) {
+    throw new Error("theme is required for update_theme");
+  }
+
+  const res = await (client as any).board.v1.whiteboard.updateTheme({
+    data: { theme: params.theme },
+    path: { whiteboard_id: params.whiteboard_id },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    whiteboard_id: params.whiteboard_id,
+    theme: params.theme,
+    updated: true,
+  };
+}
+
+async function downloadImage(client: Lark.Client, params: FeishuBoardParams) {
+  if (!params.whiteboard_id) {
+    throw new Error("whiteboard_id is required for download_image");
+  }
+  const res = await (client as any).board.v1.whiteboard.downloadAsImage({
+    path: { whiteboard_id: params.whiteboard_id },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    whiteboard_id: params.whiteboard_id,
+    downloaded: true,
+  };
+}
+
+export function registerFeishuBoardTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_board: No config available, skipping board tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_board: No Feishu accounts configured, skipping board tools");
+    return;
+  }
+
+  const firstAccount = accounts[0];
+  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  if (!toolsCfg.board) {
+    api.logger.debug?.("feishu_board: board tool disabled in config");
+    return;
+  }
+
+  const getClient = () => createFeishuClient(firstAccount);
+
+  api.registerTool(
+    {
+      name: "feishu_board",
+      label: "Feishu Board",
+      description:
+        "Feishu whiteboard/board operations. Actions: create_whiteboard (create a new whiteboard), create_node (create nodes in a whiteboard), create_plantuml (create PlantUML diagrams including mind maps, flowcharts, sequence diagrams), list_nodes (list all nodes), get_theme, update_theme, download_image",
+      parameters: FeishuBoardSchema,
+      async execute(_toolCallId, params) {
+        const p = params as FeishuBoardParams;
+        try {
+          const client = getClient();
+          switch (p.action) {
+            case "create_whiteboard":
+              return json(await createWhiteboard(client, p));
+            case "create_node":
+              return json(await createNode(client, p));
+            case "create_plantuml":
+              return json(await createPlantuml(client, p));
+            case "list_nodes":
+              return json(await listNodes(client, p));
+            case "get_theme":
+              return json(await getTheme(client, p));
+            case "update_theme":
+              return json(await updateTheme(client, p));
+            case "download_image":
+              return json(await downloadImage(client, p));
+            default:
+              return json({ error: `Unknown action: ${String(p.action)}` });
+          }
+        } catch (err) {
+          return json({
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      },
+    },
+    { name: "feishu_board" },
+  );
+
+  api.logger.info?.("feishu_board: Registered feishu_board tool");
+}

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -92,6 +92,7 @@ const FeishuToolsConfigSchema = z
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
+    sheets: z.boolean().optional(), // Spreadsheet read operations (default: true)
   })
   .strict()
   .optional();

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -93,6 +93,7 @@ const FeishuToolsConfigSchema = z
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
     sheets: z.boolean().optional(), // Spreadsheet read operations (default: true)
+    board: z.boolean().optional(), // Whiteboard/board operations (default: true)
   })
   .strict()
   .optional();

--- a/extensions/feishu/src/sheets-schema.ts
+++ b/extensions/feishu/src/sheets-schema.ts
@@ -1,0 +1,33 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+const SHEETS_ACTION_VALUES = ["get_meta", "read_range", "list_sheets"] as const;
+
+export const FeishuSheetsSchema = Type.Object({
+  action: Type.Unsafe<(typeof SHEETS_ACTION_VALUES)[number]>({
+    type: "string",
+    enum: [...SHEETS_ACTION_VALUES],
+    description: "Action to run: get_meta | read_range | list_sheets",
+  }),
+  spreadsheet_token: Type.String({
+    description:
+      "Spreadsheet token (the part after /sheets/ in the URL, e.g. from https://xxx.feishu.cn/sheets/{token})",
+  }),
+  sheet_id: Type.Optional(
+    Type.String({
+      description: "Sheet tab ID (required for read_range — identifies which sheet tab to read)",
+    }),
+  ),
+  range: Type.Optional(
+    Type.String({
+      description:
+        'Cell range in A1 notation, e.g. "A1:Z100". If omitted, reads all data in the sheet.',
+    }),
+  ),
+  page_size: Type.Optional(
+    Type.Number({
+      description: "Max rows to return (default 100). Used to limit read_range results.",
+    }),
+  ),
+});
+
+export type FeishuSheetsParams = Static<typeof FeishuSheetsSchema>;

--- a/extensions/feishu/src/sheets.ts
+++ b/extensions/feishu/src/sheets.ts
@@ -1,19 +1,15 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
 import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuClient } from "./client.js";
 import { FeishuSheetsSchema, type FeishuSheetsParams } from "./sheets-schema.js";
-import { resolveToolsConfig } from "./tools-config.js";
-
-function json(data: unknown) {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
-    details: data,
-  };
-}
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+import {
+  jsonToolResult,
+  toolExecutionErrorResult,
+  unknownToolActionResult,
+} from "./tool-result.js";
 
 async function getMeta(client: Lark.Client, params: FeishuSheetsParams) {
-  // The Lark SDK sheets.spreadsheet.get retrieves spreadsheet metadata
   const res = await client.sheets.spreadsheet.get({
     path: { spreadsheet_token: params.spreadsheet_token },
   });
@@ -30,7 +26,6 @@ async function getMeta(client: Lark.Client, params: FeishuSheetsParams) {
 }
 
 async function listSheets(client: Lark.Client, params: FeishuSheetsParams) {
-  // Use spreadsheetSheet.query to get all sheet tabs in the spreadsheet.
   // The Lark SDK type definitions may not expose this method fully, so we cast to any.
   const res = await (client as any).sheets.spreadsheetSheet.query({
     path: { spreadsheet_token: params.spreadsheet_token },
@@ -60,18 +55,16 @@ async function readRange(client: Lark.Client, params: FeishuSheetsParams) {
 
   const range = params.range ? `${params.sheet_id}!${params.range}` : params.sheet_id;
 
-  // The Lark SDK type definitions don't fully expose the sheets v2 values API,
-  // so we cast to any. We try client.request() first (raw HTTP), then fall back
-  // to the SDK's internal path for reading spreadsheet values.
+  // The Lark SDK type definitions don't fully expose the sheets v2 values API.
+  // Use client.request() (raw HTTP) if available, otherwise fall back to SDK path.
   let valuesRes: any;
-  try {
+  if (typeof (client as any).request === "function") {
     valuesRes = await (client as any).request({
       method: "GET",
       url: `/open-apis/sheets/v2/spreadsheets/${params.spreadsheet_token}/values/${encodeURIComponent(range)}`,
       params: { valueRenderOption: "ToString" },
     });
-  } catch {
-    // Fallback: try the SDK path if .request() is not available
+  } else {
     valuesRes = await (client as any).sheets.spreadsheet.values.get({
       path: { spreadsheet_token: params.spreadsheet_token },
       params: { range },
@@ -108,42 +101,46 @@ export function registerFeishuSheetsTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.sheets) {
     api.logger.debug?.("feishu_sheets: sheets tool disabled in config");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  type FeishuSheetsExecuteParams = FeishuSheetsParams & { accountId?: string };
 
   api.registerTool(
-    {
-      name: "feishu_sheets",
-      label: "Feishu Sheets",
-      description:
-        "Read Feishu spreadsheet (电子表格) data. Actions: get_meta, list_sheets, read_range",
-      parameters: FeishuSheetsSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuSheetsParams;
-        try {
-          const client = getClient();
-          switch (p.action) {
-            case "get_meta":
-              return json(await getMeta(client, p));
-            case "list_sheets":
-              return json(await listSheets(client, p));
-            case "read_range":
-              return json(await readRange(client, p));
-            default:
-              return json({ error: `Unknown action: ${String(p.action)}` });
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_sheets",
+        label: "Feishu Sheets",
+        description:
+          "Read Feishu spreadsheet (电子表格) data. Actions: get_meta, list_sheets, read_range",
+        parameters: FeishuSheetsSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuSheetsExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            switch (p.action) {
+              case "get_meta":
+                return jsonToolResult(await getMeta(client, p));
+              case "list_sheets":
+                return jsonToolResult(await listSheets(client, p));
+              case "read_range":
+                return jsonToolResult(await readRange(client, p));
+              default:
+                return unknownToolActionResult((p as { action?: unknown }).action);
+            }
+          } catch (err) {
+            return toolExecutionErrorResult(err);
           }
-        } catch (err) {
-          return json({
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_sheets" },
   );

--- a/extensions/feishu/src/sheets.ts
+++ b/extensions/feishu/src/sheets.ts
@@ -1,0 +1,152 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
+import { FeishuSheetsSchema, type FeishuSheetsParams } from "./sheets-schema.js";
+import { resolveToolsConfig } from "./tools-config.js";
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+async function getMeta(client: Lark.Client, params: FeishuSheetsParams) {
+  // The Lark SDK sheets.spreadsheet.get retrieves spreadsheet metadata
+  const res = await client.sheets.spreadsheet.get({
+    path: { spreadsheet_token: params.spreadsheet_token },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    title: res.data?.spreadsheet?.title,
+    spreadsheet_token: res.data?.spreadsheet?.token,
+    url: res.data?.spreadsheet?.url,
+  };
+}
+
+async function listSheets(client: Lark.Client, params: FeishuSheetsParams) {
+  // Use spreadsheetSheet.query to get all sheet tabs in the spreadsheet.
+  // The Lark SDK type definitions may not expose this method fully, so we cast to any.
+  const res = await (client as any).sheets.spreadsheetSheet.query({
+    path: { spreadsheet_token: params.spreadsheet_token },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  const sheets = res.data?.sheets ?? [];
+  return {
+    spreadsheet_token: params.spreadsheet_token,
+    sheets: sheets.map((sheet: any) => ({
+      sheet_id: sheet.sheet_id,
+      title: sheet.title,
+      index: sheet.index,
+      row_count: sheet.grid_properties?.row_count,
+      column_count: sheet.grid_properties?.column_count,
+    })),
+  };
+}
+
+async function readRange(client: Lark.Client, params: FeishuSheetsParams) {
+  if (!params.sheet_id) {
+    throw new Error("sheet_id is required for read_range");
+  }
+
+  const range = params.range ? `${params.sheet_id}!${params.range}` : params.sheet_id;
+
+  // The Lark SDK type definitions don't fully expose the sheets v2 values API,
+  // so we cast to any. We try client.request() first (raw HTTP), then fall back
+  // to the SDK's internal path for reading spreadsheet values.
+  let valuesRes: any;
+  try {
+    valuesRes = await (client as any).request({
+      method: "GET",
+      url: `/open-apis/sheets/v2/spreadsheets/${params.spreadsheet_token}/values/${encodeURIComponent(range)}`,
+      params: { valueRenderOption: "ToString" },
+    });
+  } catch {
+    // Fallback: try the SDK path if .request() is not available
+    valuesRes = await (client as any).sheets.spreadsheet.values.get({
+      path: { spreadsheet_token: params.spreadsheet_token },
+      params: { range },
+    });
+  }
+
+  // The v2 API returns data under data.valueRange
+  const valueRange = valuesRes?.data?.valueRange ?? valuesRes?.data;
+  const values: unknown[][] = valueRange?.values ?? [];
+
+  // Apply page_size limit (default 100)
+  const maxRows = params.page_size ?? 100;
+  const limitedValues = values.slice(0, maxRows);
+
+  return {
+    spreadsheet_token: params.spreadsheet_token,
+    sheet_id: params.sheet_id,
+    range: valueRange?.range ?? range,
+    total_rows: values.length,
+    returned_rows: limitedValues.length,
+    values: limitedValues,
+  };
+}
+
+export function registerFeishuSheetsTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_sheets: No config available, skipping sheets tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_sheets: No Feishu accounts configured, skipping sheets tools");
+    return;
+  }
+
+  const firstAccount = accounts[0];
+  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  if (!toolsCfg.sheets) {
+    api.logger.debug?.("feishu_sheets: sheets tool disabled in config");
+    return;
+  }
+
+  const getClient = () => createFeishuClient(firstAccount);
+
+  api.registerTool(
+    {
+      name: "feishu_sheets",
+      label: "Feishu Sheets",
+      description:
+        "Read Feishu spreadsheet (电子表格) data. Actions: get_meta, list_sheets, read_range",
+      parameters: FeishuSheetsSchema,
+      async execute(_toolCallId, params) {
+        const p = params as FeishuSheetsParams;
+        try {
+          const client = getClient();
+          switch (p.action) {
+            case "get_meta":
+              return json(await getMeta(client, p));
+            case "list_sheets":
+              return json(await listSheets(client, p));
+            case "read_range":
+              return json(await readRange(client, p));
+            default:
+              return json({ error: `Unknown action: ${String(p.action)}` });
+          }
+        } catch (err) {
+          return json({
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      },
+    },
+    { name: "feishu_sheets" },
+  );
+
+  api.logger.info?.("feishu_sheets: Registered feishu_sheets tool");
+}

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -56,8 +56,9 @@ export function resolveAnyEnabledFeishuToolsConfig(
     drive: false,
     perm: false,
     scopes: false,
-    sheets: false,
+    calendar: false,
     board: false,
+    sheets: false,
   };
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);
@@ -67,8 +68,9 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.drive = merged.drive || cfg.drive;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
-    merged.sheets = merged.sheets || cfg.sheets;
+    merged.calendar = merged.calendar || cfg.calendar;
     merged.board = merged.board || cfg.board;
+    merged.sheets = merged.sheets || cfg.sheets;
   }
   return merged;
 }

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -56,6 +56,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     drive: false,
     perm: false,
     scopes: false,
+    sheets: false,
   };
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);
@@ -65,6 +66,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.drive = merged.drive || cfg.drive;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
+    merged.sheets = merged.sheets || cfg.sheets;
   }
   return merged;
 }

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -57,6 +57,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     perm: false,
     scopes: false,
     sheets: false,
+    board: false,
   };
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);
@@ -67,6 +68,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
     merged.sheets = merged.sheets || cfg.sheets;
+    merged.board = merged.board || cfg.board;
   }
   return merged;
 }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -2,7 +2,7 @@ import type { FeishuToolsConfig } from "./types.js";
 
 /**
  * Default tool configuration.
- * - doc, chat, wiki, drive, scopes, sheets: enabled by default
+ * - doc, chat, wiki, drive, scopes, calendar, board, sheets: enabled by default
  * - perm: disabled by default (sensitive operation)
  */
 export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
@@ -12,8 +12,9 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
-  sheets: true,
+  calendar: true,
   board: true,
+  sheets: true,
 };
 
 /**

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -2,7 +2,7 @@ import type { FeishuToolsConfig } from "./types.js";
 
 /**
  * Default tool configuration.
- * - doc, chat, wiki, drive, scopes: enabled by default
+ * - doc, chat, wiki, drive, scopes, sheets: enabled by default
  * - perm: disabled by default (sensitive operation)
  */
 export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
@@ -12,6 +12,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  sheets: true,
 };
 
 /**

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -13,6 +13,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   perm: false,
   scopes: true,
   sheets: true,
+  board: true,
 };
 
 /**

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -93,6 +93,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  calendar?: boolean;
   sheets?: boolean;
   board?: boolean;
 };

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -93,6 +93,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  sheets?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -94,6 +94,7 @@ export type FeishuToolsConfig = {
   perm?: boolean;
   scopes?: boolean;
   sheets?: boolean;
+  board?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {


### PR DESCRIPTION
## Summary

- **Bug fix**: All SDK calls in `board.ts` were missing `.v1` in the path — `client.board.whiteboard.*` and `client.board.whiteboardNode.*` should be `client.board.v1.whiteboard.*` and `client.board.v1.whiteboardNode.*`. Without `.v1`, all calls fail with "Cannot read properties of undefined".
- **New feature**: Added `create_whiteboard` action that creates a new whiteboard via raw HTTP request (`POST /open-apis/board/v1/whiteboards`) since the SDK doesn't expose this endpoint. Note: This endpoint may return 404 on Feishu until Feishu adds support.
- **Validation**: Added `whiteboard_id` validation to all actions that require it (`create_node`, `create_plantuml`, `list_nodes`, `get_theme`, `update_theme`, `download_image`).
- **Config wiring**: Added `board` to `FeishuToolsConfig` type, `DEFAULT_TOOLS_CONFIG`, `FeishuToolsConfigSchema`, and `resolveAnyEnabledFeishuToolsConfig`.

## Changed files

- `extensions/feishu/src/board.ts` — main implementation (bug fix + new feature + validation)
- `extensions/feishu/src/board-schema.ts` — schema with `create_whiteboard` action, optional `whiteboard_id`, `title`/`folder_token` params
- `extensions/feishu/src/types.ts` — added `board?: boolean` to `FeishuToolsConfig`
- `extensions/feishu/src/tools-config.ts` — added `board: true` to `DEFAULT_TOOLS_CONFIG`
- `extensions/feishu/src/tool-account.ts` — added `board` to merged config resolution
- `extensions/feishu/src/config-schema.ts` — added `board: z.boolean().optional()` to schema
- `extensions/feishu/index.ts` — registered `registerFeishuBoardTools`

## Test plan

- [x] Existing `tools-config.test.ts` passes (19 tests)
- [x] Existing `config-schema.test.ts` passes
- [x] TypeScript type check passes with no errors
- [x] Formatting check passes (`oxfmt --check`)
- [ ] Manual testing with Feishu whiteboard API

🤖 Generated with [Claude Code](https://claude.com/claude-code)