### PR TITLE
Fix ACP Discord thread delivery routing

### DIFF
--- a/extensions/discord/src/subagent-hooks.test.ts
+++ b/extensions/discord/src/subagent-hooks.test.ts
@@ -409,10 +409,12 @@ describe("discord subagent hook handlers", () => {
   });
 
   it("keeps original routing when delivery target is ambiguous", () => {
-    hookMocks.listThreadBindingsBySessionKey.mockReturnValueOnce([
-      { accountId: "work", threadId: "777" },
-      { accountId: "work", threadId: "888" },
-    ]);
+    hookMocks.listThreadBindingsBySessionKey
+      .mockReturnValueOnce([
+        { accountId: "work", threadId: "777" },
+        { accountId: "work", threadId: "888" },
+      ])
+      .mockReturnValueOnce([]);
     const handlers = registerHandlersForTest();
     const handler = getRequiredHandler(handlers, "subagent_delivery_target");
 

--- a/extensions/discord/src/subagent-hooks.test.ts
+++ b/extensions/discord/src/subagent-hooks.test.ts
@@ -321,9 +321,9 @@ describe("discord subagent hook handlers", () => {
   });
 
   it("resolves delivery target from matching bound thread", () => {
-    hookMocks.listThreadBindingsBySessionKey.mockReturnValueOnce([
-      { accountId: "work", threadId: "777" },
-    ]);
+    hookMocks.listThreadBindingsBySessionKey
+      .mockReturnValueOnce([{ accountId: "work", threadId: "777" }])
+      .mockReturnValueOnce([]);
     const handlers = registerHandlersForTest();
     const handler = getRequiredHandler(handlers, "subagent_delivery_target");
 
@@ -344,10 +344,15 @@ describe("discord subagent hook handlers", () => {
       {},
     );
 
-    expect(hookMocks.listThreadBindingsBySessionKey).toHaveBeenCalledWith({
+    expect(hookMocks.listThreadBindingsBySessionKey).toHaveBeenNthCalledWith(1, {
       targetSessionKey: "agent:main:subagent:child",
       accountId: "work",
       targetKind: "subagent",
+    });
+    expect(hookMocks.listThreadBindingsBySessionKey).toHaveBeenNthCalledWith(2, {
+      targetSessionKey: "agent:main:subagent:child",
+      accountId: "work",
+      targetKind: "acp",
     });
     expect(result).toEqual({
       origin: {
@@ -355,6 +360,50 @@ describe("discord subagent hook handlers", () => {
         accountId: "work",
         to: "channel:777",
         threadId: "777",
+      },
+    });
+  });
+
+  it("resolves delivery target from acp thread bindings", () => {
+    hookMocks.listThreadBindingsBySessionKey
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([{ accountId: "work", threadId: "999" }]);
+    const handlers = registerHandlersForTest();
+    const handler = getRequiredHandler(handlers, "subagent_delivery_target");
+
+    const result = handler(
+      {
+        childSessionKey: "agent:main:acp:child",
+        requesterSessionKey: "agent:main:main",
+        requesterOrigin: {
+          channel: "discord",
+          accountId: "work",
+          to: "channel:123",
+          threadId: "999",
+        },
+        childRunId: "run-1",
+        spawnMode: "session",
+        expectsCompletionMessage: true,
+      },
+      {},
+    );
+
+    expect(hookMocks.listThreadBindingsBySessionKey).toHaveBeenNthCalledWith(1, {
+      targetSessionKey: "agent:main:acp:child",
+      accountId: "work",
+      targetKind: "subagent",
+    });
+    expect(hookMocks.listThreadBindingsBySessionKey).toHaveBeenNthCalledWith(2, {
+      targetSessionKey: "agent:main:acp:child",
+      accountId: "work",
+      targetKind: "acp",
+    });
+    expect(result).toEqual({
+      origin: {
+        channel: "discord",
+        accountId: "work",
+        to: "channel:999",
+        threadId: "999",
       },
     });
   });

--- a/extensions/discord/src/subagent-hooks.ts
+++ b/extensions/discord/src/subagent-hooks.ts
@@ -113,11 +113,22 @@ export function registerDiscordSubagentHooks(api: OpenClawPluginApi) {
       event.requesterOrigin?.threadId != null && event.requesterOrigin.threadId !== ""
         ? String(event.requesterOrigin.threadId).trim()
         : "";
-    const bindings = listThreadBindingsBySessionKey({
-      targetSessionKey: event.childSessionKey,
-      ...(requesterAccountId ? { accountId: requesterAccountId } : {}),
-      targetKind: "subagent",
-    });
+    const bindingTargetKinds = ["subagent", "acp"] as const;
+    const seenBindingKeys = new Set<string>();
+    const bindings = bindingTargetKinds.flatMap((targetKind) =>
+      listThreadBindingsBySessionKey({
+        targetSessionKey: event.childSessionKey,
+        ...(requesterAccountId ? { accountId: requesterAccountId } : {}),
+        targetKind,
+      }).filter((entry) => {
+        const key = `${entry.accountId}:${entry.threadId}`;
+        if (seenBindingKeys.has(key)) {
+          return false;
+        }
+        seenBindingKeys.add(key);
+        return true;
+      }),
+    );
     if (bindings.length === 0) {
       return;
     }

--- a/src/discord/monitor/reply-delivery.test.ts
+++ b/src/discord/monitor/reply-delivery.test.ts
@@ -37,6 +37,7 @@ describe("deliverDiscordReply", () => {
       webhookId: string;
       webhookToken: string;
       introText: string;
+      targetKind: "subagent" | "acp";
     }> = {},
   ) => {
     const threadBindings = createThreadBindingManager({
@@ -434,6 +435,36 @@ describe("deliverDiscordReply", () => {
         accountId: "default",
         threadId: "thread-1",
         replyTo: "reply-1",
+      }),
+    );
+    expect(sendMessageDiscordMock).not.toHaveBeenCalled();
+  });
+
+  it("uses thread-id fallback when the binding is owned by a different session key", async () => {
+    const threadBindings = await createBoundThreadBindings({
+      targetKind: "acp",
+      targetSessionKey: "agent:main:acp:child",
+      label: "codex-acp",
+    });
+
+    await deliverDiscordReply({
+      replies: [{ text: "Hello from ACP" }],
+      target: "channel:thread-1",
+      token: "token",
+      runtime,
+      cfg,
+      textLimit: 2000,
+      sessionKey: "agent:main:discord:parent",
+      threadBindings,
+    });
+
+    expect(sendWebhookMessageDiscordMock).toHaveBeenCalledTimes(1);
+    expect(sendWebhookMessageDiscordMock).toHaveBeenCalledWith(
+      "Hello from ACP",
+      expect.objectContaining({
+        webhookId: "wh_1",
+        webhookToken: "tok_1",
+        threadId: "thread-1",
       }),
     );
     expect(sendMessageDiscordMock).not.toHaveBeenCalled();

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -24,6 +24,7 @@ export type DiscordThreadBindingLookupRecord = {
 
 export type DiscordThreadBindingLookup = {
   listBySessionKey: (targetSessionKey: string) => DiscordThreadBindingLookupRecord[];
+  getByThreadId?: (threadId: string) => DiscordThreadBindingLookupRecord | undefined;
   touchThread?: (params: { threadId: string; at?: number; persist?: boolean }) => unknown;
 };
 
@@ -89,18 +90,21 @@ function resolveBoundThreadBinding(params: {
   target: string;
 }): DiscordThreadBindingLookupRecord | undefined {
   const sessionKey = params.sessionKey?.trim();
-  if (!params.threadBindings || !sessionKey) {
-    return undefined;
-  }
-  const bindings = params.threadBindings.listBySessionKey(sessionKey);
-  if (bindings.length === 0) {
-    return undefined;
-  }
   const targetChannelId = resolveTargetChannelId(params.target);
-  if (!targetChannelId) {
+  if (!params.threadBindings || !targetChannelId) {
     return undefined;
   }
-  return bindings.find((entry) => entry.threadId === targetChannelId);
+  if (sessionKey) {
+    const bindings = params.threadBindings.listBySessionKey(sessionKey);
+    const matched = bindings.find((entry) => entry.threadId === targetChannelId);
+    if (matched) {
+      return matched;
+    }
+  }
+  if ("getByThreadId" in params.threadBindings && typeof params.threadBindings.getByThreadId === "function") {
+    return params.threadBindings.getByThreadId(targetChannelId) ?? undefined;
+  }
+  return undefined;
 }
 
 function resolveBindingPersona(

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -101,7 +101,10 @@ function resolveBoundThreadBinding(params: {
       return matched;
     }
   }
-  if ("getByThreadId" in params.threadBindings && typeof params.threadBindings.getByThreadId === "function") {
+  if (
+    "getByThreadId" in params.threadBindings &&
+    typeof params.threadBindings.getByThreadId === "function"
+  ) {
     return params.threadBindings.getByThreadId(targetChannelId) ?? undefined;
   }
   return undefined;

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -91,15 +91,13 @@ function resolveBoundThreadBinding(params: {
 }): DiscordThreadBindingLookupRecord | undefined {
   const sessionKey = params.sessionKey?.trim();
   const targetChannelId = resolveTargetChannelId(params.target);
-  if (!params.threadBindings || !targetChannelId) {
+  if (!params.threadBindings || !targetChannelId || !sessionKey) {
     return undefined;
   }
-  if (sessionKey) {
-    const bindings = params.threadBindings.listBySessionKey(sessionKey);
-    const matched = bindings.find((entry) => entry.threadId === targetChannelId);
-    if (matched) {
-      return matched;
-    }
+  const bindings = params.threadBindings.listBySessionKey(sessionKey);
+  const matched = bindings.find((entry) => entry.threadId === targetChannelId);
+  if (matched) {
+    return matched;
   }
   if (
     "getByThreadId" in params.threadBindings &&


### PR DESCRIPTION
## Summary

This PR fixes Discord thread delivery for ACP-backed child sessions.

When an ACP session is spawned into a Discord thread, OpenClaw can correctly create the thread binding and the ACP child can produce output, but completion/progress delivery can still miss the bound thread because two Discord-specific lookup paths were still subagent-only.

## Root cause

There were two mismatches in the Discord thread delivery path:

1. `extensions/discord/src/subagent-hooks.ts`
   - `subagent_delivery_target` only queried thread bindings with `targetKind: "subagent"`
   - ACP thread bindings are stored with `targetKind: "acp"`
   - Result: Discord delivery target resolution could miss valid ACP thread bindings

2. `src/discord/monitor/reply-delivery.ts`
   - `resolveBoundThreadBinding(...)` only looked up bindings by `sessionKey`
   - In ACP thread-bound flows, the binding may be attached to the ACP child session key, while outbound reply delivery can be invoked with the parent Discord session key
   - Result: webhook/thread delivery could fail to resolve the bound thread even when the thread ID already matched a valid binding

## Fix

This PR makes two targeted changes:

- Query both `targetKind: "subagent"` and `targetKind: "acp"` in the Discord `subagent_delivery_target` hook
- Add a fallback in `resolveBoundThreadBinding(...)` to resolve by `threadId` when the session-key lookup does not find a matching binding

The fallback keeps the existing behavior for the normal case and only activates when the direct session-key lookup misses.

## Tests

Added/updated tests for both sides of the fix:

- `extensions/discord/src/subagent-hooks.test.ts`
  - verifies the hook still resolves normal subagent bindings
  - verifies ACP bindings are also accepted

- `src/discord/monitor/reply-delivery.test.ts`
  - verifies webhook delivery still works for the original bound-session case
  - verifies thread delivery still resolves when the binding is owned by a different session key but the target thread ID matches

## Validation performed locally

Ran targeted tests:

- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/discord/src/subagent-hooks.test.ts`
- `pnpm exec vitest run --config vitest.channels.config.ts src/discord/monitor/reply-delivery.test.ts`

Both passed.

## User-visible impact

This restores the expected behavior where ACP child-session output and completion notices are delivered into the bound Discord thread instead of silently missing the thread due to ACP/subagent binding mismatches.
