### PR TITLE
fix(doctor): repair cron migration warnings

### DIFF
--- a/src/commands/doctor-prompter.test.ts
+++ b/src/commands/doctor-prompter.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDoctorPrompter } from "./doctor-prompter.js";
+
+function setIsTty(value: boolean) {
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("createDoctorPrompter", () => {
+  const originalIsTty = process.stdin.isTTY;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: originalIsTty,
+    });
+  });
+
+  it("applies repair confirmations in non-interactive repair mode", async () => {
+    setIsTty(false);
+
+    const prompter = createDoctorPrompter({
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      } as never,
+      options: {
+        nonInteractive: true,
+        repair: true,
+      },
+    });
+
+    await expect(prompter.confirm({ message: "repair?", initialValue: false })).resolves.toBe(true);
+    await expect(
+      prompter.confirmRepair({ message: "repair?", initialValue: false }),
+    ).resolves.toBe(true);
+    await expect(
+      prompter.confirmSkipInNonInteractive({ message: "repair?", initialValue: false }),
+    ).resolves.toBe(true);
+    await expect(
+      prompter.confirmAggressive({ message: "repair?", initialValue: true }),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/commands/doctor-prompter.ts
+++ b/src/commands/doctor-prompter.ts
@@ -37,7 +37,7 @@ export function createDoctorPrompter(params: {
   const canPrompt = isTty && !yes && !nonInteractive;
   const confirmDefault = async (p: Parameters<typeof confirm>[0]) => {
     if (nonInteractive) {
-      return false;
+      return shouldRepair;
     }
     if (shouldRepair) {
       return true;
@@ -58,13 +58,13 @@ export function createDoctorPrompter(params: {
     confirm: confirmDefault,
     confirmRepair: async (p) => {
       if (nonInteractive) {
-        return false;
+        return shouldRepair;
       }
       return confirmDefault(p);
     },
     confirmAggressive: async (p) => {
       if (nonInteractive) {
-        return false;
+        return shouldRepair && shouldForce;
       }
       if (shouldRepair && shouldForce) {
         return true;
@@ -85,7 +85,7 @@ export function createDoctorPrompter(params: {
     },
     confirmSkipInNonInteractive: async (p) => {
       if (nonInteractive) {
-        return false;
+        return shouldRepair;
       }
       if (shouldRepair) {
         return true;

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -75,4 +75,32 @@ describe("normalizeStoredCronJobs", () => {
       channel: "slack",
     });
   });
+
+  it("does not flag already-normalized payload kinds", () => {
+    const jobs = [
+      {
+        id: "normalized-agent-turn",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: {
+          kind: "agentTurn",
+          message: "ping",
+        },
+      },
+      {
+        id: "normalized-system-event",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: {
+          kind: "systemEvent",
+          text: "pong",
+        },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(false);
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+    expect(jobs[0]?.payload).toMatchObject({ kind: "agentTurn", message: "ping" });
+    expect(jobs[1]?.payload).toMatchObject({ kind: "systemEvent", text: "pong" });
+  });
 });

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -98,8 +98,34 @@ describe("normalizeStoredCronJobs", () => {
 
     const result = normalizeStoredCronJobs(jobs);
 
-    expect(result.mutated).toBe(false);
     expect(result.issues.legacyPayloadKind).toBeUndefined();
+    expect(jobs[0]?.payload).toMatchObject({ kind: "agentTurn", message: "ping" });
+    expect(jobs[1]?.payload).toMatchObject({ kind: "systemEvent", text: "pong" });
+  });
+
+  it("normalizes whitespace-padded payload kinds", () => {
+    const jobs = [
+      {
+        id: "padded-agent-turn",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: {
+          kind: "  agentTurn  ",
+          message: "ping",
+        },
+      },
+      {
+        id: "padded-system-event",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: {
+          kind: "  systemEvent  ",
+          text: "pong",
+        },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.issues.legacyPayloadKind).toBe(2);
     expect(jobs[0]?.payload).toMatchObject({ kind: "agentTurn", message: "ping" });
     expect(jobs[1]?.payload).toMatchObject({ kind: "systemEvent", text: "pong" });
   });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,12 +28,13 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
-  if (raw === "agentturn") {
+  const kind = typeof payload.kind === "string" ? payload.kind.trim() : "";
+  const raw = kind.toLowerCase();
+  if (raw === "agentturn" && kind !== "agentTurn") {
     payload.kind = "agentTurn";
     return true;
   }
-  if (raw === "systemevent") {
+  if (raw === "systemevent" && kind !== "systemEvent") {
     payload.kind = "systemEvent";
     return true;
   }

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -30,11 +30,11 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 function normalizePayloadKind(payload: Record<string, unknown>) {
   const kind = typeof payload.kind === "string" ? payload.kind.trim() : "";
   const raw = kind.toLowerCase();
-  if (raw === "agentturn" && kind !== "agentTurn") {
+  if (raw === "agentturn" && payload.kind !== "agentTurn") {
     payload.kind = "agentTurn";
     return true;
   }
-  if (raw === "systemevent" && kind !== "systemEvent") {
+  if (raw === "systemevent" && payload.kind !== "systemEvent") {
     payload.kind = "systemEvent";
     return true;
   }


### PR DESCRIPTION
Fixes #43923

## Summary

- stop treating already-normalized cron payload kinds as legacy
- allow `doctor --fix --non-interactive` to execute repair confirmations
- add regression tests for both paths

## Root cause

Two issues combined to make `doctor` cron repair misleading:

1. `normalizeStoredCronJobs()` lowercased `payload.kind` before deciding whether it was legacy, so valid `agentTurn` / `systemEvent` values were still counted as needing normalization.
2. `createDoctorPrompter()` returned `false` for repair confirmations in non-interactive mode even when `repair` was enabled, so `openclaw doctor --fix --non-interactive` could not actually apply fixes.

## Testing

- Added regression tests for normalized payload kinds
- Added regression tests for non-interactive repair confirmations
- Local Vitest execution was not completed in this workspace because dev dependencies are not installed (`pnpm exec vitest` could not find `vitest`)
