### PR TITLE
fix(msteams): persist conversation reference during DM pairing

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -152,4 +152,110 @@ describe("msteams monitor handler authz", () => {
 
     expect(conversationStore.upsert).not.toHaveBeenCalled();
   });
+
+  it("persists conversation reference on first DM during pairing", async () => {
+    const upsertPairingRequest = vi.fn(async () => ({ id: "user-aad", channel: "msteams" }));
+    setMSTeamsRuntime({
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        debounce: {
+          resolveInboundDebounceMs: () => 0,
+          createInboundDebouncer: <T>(params: {
+            onFlush: (entries: T[]) => Promise<void>;
+          }): { enqueue: (entry: T) => Promise<void> } => ({
+            enqueue: async (entry: T) => {
+              await params.onFlush([entry]);
+            },
+          }),
+        },
+        pairing: {
+          readAllowFromStore: vi.fn(async () => []),
+          upsertPairingRequest,
+        },
+        text: {
+          hasControlCommand: () => false,
+        },
+      },
+    } as unknown as PluginRuntime);
+
+    const conversationStore = {
+      upsert: vi.fn(async () => undefined),
+    };
+
+    const deps: MSTeamsMessageHandlerDeps = {
+      cfg: {
+        channels: {
+          msteams: {
+            dmPolicy: "pairing",
+            allowFrom: [],
+          },
+        },
+      } as OpenClawConfig,
+      runtime: { error: vi.fn() } as unknown as RuntimeEnv,
+      appId: "test-app",
+      adapter: {} as MSTeamsMessageHandlerDeps["adapter"],
+      tokenProvider: {
+        getAccessToken: vi.fn(async () => "token"),
+      },
+      textLimit: 4000,
+      mediaMaxBytes: 1024 * 1024,
+      conversationStore:
+        conversationStore as unknown as MSTeamsMessageHandlerDeps["conversationStore"],
+      pollStore: {
+        recordVote: vi.fn(async () => null),
+      } as unknown as MSTeamsMessageHandlerDeps["pollStore"],
+      log: {
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+      } as unknown as MSTeamsMessageHandlerDeps["log"],
+    };
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler({
+      activity: {
+        id: "dm-1",
+        type: "message",
+        text: "hello",
+        from: {
+          id: "user-id",
+          aadObjectId: "user-aad",
+          name: "New User",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "19:user-id_bot-id@unq.gbl.spaces",
+          conversationType: "personal",
+        },
+        channelData: {},
+        channelId: "msteams",
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+        locale: "en-US",
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
+    expect(upsertPairingRequest).toHaveBeenCalledWith({
+      channel: "msteams",
+      accountId: "default",
+      id: "user-aad",
+      meta: { name: "New User" },
+    });
+    // Conversation reference must be persisted so --notify works after approval.
+    expect(conversationStore.upsert).toHaveBeenCalledWith(
+      "19:user-id_bot-id@unq.gbl.spaces",
+      expect.objectContaining({
+        user: { id: "user-id", name: "New User", aadObjectId: "user-aad" },
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+        conversation: expect.objectContaining({
+          id: "19:user-id_bot-id@unq.gbl.spaces",
+          conversationType: "personal",
+        }),
+      }),
+    );
+  });
 });

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -210,6 +210,29 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         allowNameMatching: isDangerousNameMatchingEnabled(msteamsCfg),
       });
       if (access.decision === "pairing") {
+        // Persist conversation reference before returning so that
+        // `--notify` can reach the user after pairing is approved.
+        const agent = activity.recipient;
+        const pairingRef: StoredConversationReference = {
+          activityId: activity.id,
+          user: { id: from.id, name: from.name, aadObjectId: from.aadObjectId },
+          agent,
+          bot: agent ? { id: agent.id, name: agent.name } : undefined,
+          conversation: {
+            id: conversationId,
+            conversationType,
+            tenantId: conversation?.tenantId,
+          },
+          channelId: activity.channelId,
+          serviceUrl: activity.serviceUrl,
+          locale: activity.locale,
+        };
+        conversationStore.upsert(conversationId, pairingRef).catch((err) => {
+          log.debug?.("failed to save pairing conversation reference", {
+            error: formatUnknownError(err),
+          });
+        });
+
         const request = await pairing.upsertPairingRequest({
           id: senderId,
           meta: { name: senderName },


### PR DESCRIPTION
## Summary

When `dmPolicy=pairing` is set for MS Teams, the first DM from an unknown user triggers `upsertPairingRequest` but returns early **before** `conversationStore.upsert()` is called. This means the conversation reference is never persisted, so `--notify` cannot deliver messages to the user after their pairing request is approved.

This PR moves `conversationStore.upsert()` into the pairing block so the reference is saved immediately upon first contact.

## Repro Steps

1. Configure MS Teams extension with `dmPolicy: "pairing"`
2. Have an unpaired user send a DM to the bot
3. Approve the pairing request via `openclaw pair approve`
4. Attempt `openclaw notify` to reach the user → **fails** because no conversation reference was stored

## Root Cause

In `message-handler.ts`, when `access.decision === "pairing"`, the handler calls `pairing.upsertPairingRequest(…)` and then returns. The `conversationStore.upsert()` call that persists the Teams conversation reference only happens later in the happy-path flow (after `decision === "allow"`). Since the pairing branch returns early, the reference is lost.

## Behaviour Changes

| Scenario | Before | After |
|----------|--------|-------|
| First DM with `dmPolicy=pairing` | Conversation reference **not** saved | Conversation reference **saved** before early return |
| `--notify` after pairing approval | Fails (no stored reference) | Works (reference persisted at first contact) |
| Existing allowed-user DMs | No change | No change |
| Group messages | No change | No change |

## Tests

Added regression test in `message-handler.authz.test.ts`:
- **"persists conversation reference on first DM during pairing"** — sends a personal DM with `dmPolicy=pairing`, asserts both `upsertPairingRequest` and `conversationStore.upsert` are called with correct arguments.

All 3 tests in the authz suite pass. TypeScript compiles cleanly (only pre-existing `extensions/tlon` errors from unrelated missing deps).

## Sign-Off

- [x] Regression test added
- [x] `scripts/committer` lint + commit passed
- [x] `tsc --noEmit` clean (excluding pre-existing tlon errors)
- [x] vitest suite green (3/3)

lobster-biscuit
