### PR TITLE
fix(tts): preserve instructions for custom OpenAI-compatible endpoints

### DIFF
--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -391,9 +391,16 @@ export function isValidOpenAIModel(model: string, baseUrl?: string): boolean {
 export function resolveOpenAITtsInstructions(
   model: string,
   instructions?: string,
+  baseUrl?: string,
 ): string | undefined {
   const next = trimToUndefined(instructions);
-  return next && model.includes("gpt-4o-mini-tts") ? next : undefined;
+  if (!next) {
+    return undefined;
+  }
+  if (baseUrl != null && isCustomOpenAIEndpoint(baseUrl)) {
+    return next;
+  }
+  return model.includes("gpt-4o-mini-tts") ? next : undefined;
 }
 
 export function isValidOpenAIVoice(voice: string, baseUrl?: string): voice is OpenAiTtsVoice {
@@ -639,7 +646,7 @@ export async function openaiTTS(params: {
 }): Promise<Buffer> {
   const { text, apiKey, baseUrl, model, voice, speed, instructions, responseFormat, timeoutMs } =
     params;
-  const effectiveInstructions = resolveOpenAITtsInstructions(model, instructions);
+  const effectiveInstructions = resolveOpenAITtsInstructions(model, instructions, baseUrl);
 
   if (!isValidOpenAIModel(model, baseUrl)) {
     throw new Error(`Invalid model: ${model}`);

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -172,7 +172,7 @@ describe("tts", () => {
   });
 
   describe("resolveOpenAITtsInstructions", () => {
-    it("keeps instructions only for gpt-4o-mini-tts variants", () => {
+    it("keeps instructions for gpt-4o-mini-tts variants and custom endpoints", () => {
       expect(resolveOpenAITtsInstructions("gpt-4o-mini-tts", " Speak warmly ")).toBe(
         "Speak warmly",
       );
@@ -181,6 +181,12 @@ describe("tts", () => {
       );
       expect(resolveOpenAITtsInstructions("tts-1", "Speak warmly")).toBeUndefined();
       expect(resolveOpenAITtsInstructions("tts-1-hd", "Speak warmly")).toBeUndefined();
+      expect(
+        resolveOpenAITtsInstructions("tts-1", " Speak warmly ", "http://127.0.0.1:8880/v1"),
+      ).toBe("Speak warmly");
+      withEnv({ OPENAI_TTS_BASE_URL: "http://127.0.0.1:8880/v1" }, () => {
+        expect(resolveOpenAITtsInstructions("tts-1", "Speak warmly")).toBeUndefined();
+      });
       expect(resolveOpenAITtsInstructions("gpt-4o-mini-tts", "   ")).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Summary

This preserves TTS `instructions` for custom OpenAI-compatible endpoints while keeping the current upstream restriction for the default OpenAI API.

Today `resolveOpenAITtsInstructions()` only forwards instructions for `gpt-4o-mini-tts` model names. That is reasonable for the default OpenAI endpoint, but it is too strict for custom OpenAI-compatible TTS backends, which may support `instructions` on different model names.

This change keeps the existing behavior for the default OpenAI API and only passes `instructions` through when the caller explicitly uses a non-default OpenAI-compatible `baseUrl`.

This is useful for promptable TTS styles such as angry, gentle, playful, tender, or serious delivery instructions on OpenAI-compatible backends.

It also helps OpenClaw keep one OpenAI-compatible TTS request shape for a wider range of local or self-hosted backends, instead of pushing users toward provider-specific request formats when they want to run custom models.

## Why

This fixes a regression for custom OpenAI-compatible TTS deployments where:
- the backend accepts the OpenAI `/audio/speech` shape
- the configured model name is not `gpt-4o-mini-tts`
- `instructions` are part of the desired speaking-style control

Without this change, OpenClaw silently drops those instructions before making the TTS request.

## Changes

- update `resolveOpenAITtsInstructions()` to preserve instructions when an explicit custom OpenAI-compatible `baseUrl` is provided
- keep the current upstream gating for the default OpenAI endpoint
- add test coverage for:
  - default OpenAI endpoint + `tts-1` => instructions omitted
  - custom OpenAI-compatible endpoint + `tts-1` => instructions preserved
  - env-only custom endpoint state does not implicitly relax the default path

## Testing

AI-assisted: yes  
Built and tested in: Codex App  
Model: GPT-5.4  
Reasoning effort: High  
Testing: focused local test

- `pnpm exec vitest run src/tts/tts.test.ts`
- `codex review --base origin/main`

I ran `codex review --base origin/main` locally on the isolated branch and addressed the one review finding before opening this draft PR.
