### PR TITLE
feat(tts): add CLI provider support

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -185,6 +185,14 @@ Use any command-line TTS tool. The CLI provider is useful for local TTS engines 
 - `{{TtsOutputPath}}` — Full path where audio output should be written
 - `{{TtsOutputFormat}}` — Output format (`pcm` for telephony, `opus` for voice note, `mp3` otherwise)
 
+**Environment variables:**
+
+- `TTS_TEXT` — The text to convert (same as `{{TtsText}}`)
+- `TTS_OUTPUT_PATH` — Output path (same as `{{TtsOutputPath}}`)
+- `TTS_OUTPUT_FORMAT` — Output format (same as `{{TtsOutputFormat}}`)
+
+Use environment variables instead of template variables if your CLI tool is a Windows batch wrapper (`.cmd`/`.bat`), since special characters like `&`, `%`, `|`, or newlines in user text can cause argument parsing failures. For example, text containing `R&D` would fail when passed via `{{TtsText}}` but works via `TTS_TEXT` env var.
+
 If the CLI command exits with non-zero code, OpenClaw automatically falls back to the next configured provider. You may need to enlarge `timeoutMs` if local CLI is slow.
 
 ### Custom limits + prefs path

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -17,6 +17,7 @@ It works anywhere OpenClaw can send audio; Telegram gets a round voice-note bubb
 - **ElevenLabs** (primary or fallback provider)
 - **OpenAI** (primary or fallback provider; also used for summaries)
 - **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when no API keys)
+- **CLI** (custom local TTS via command-line tool)
 
 ### Edge TTS notes
 
@@ -37,7 +38,7 @@ If you want OpenAI or ElevenLabs:
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
 - `OPENAI_API_KEY`
 
-Edge TTS does **not** require an API key. If no API keys are found, OpenClaw defaults
+Edge TTS and CLI do **not** require an API key. If no API keys are found, OpenClaw defaults
 to Edge TTS (unless disabled via `messages.tts.edge.enabled=false`).
 
 If multiple providers are configured, the selected provider is used first and the others are fallback options.
@@ -153,6 +154,39 @@ Full schema is in [Gateway configuration](/gateway/configuration).
 }
 ```
 
+### CLI provider (custom local TTS)
+
+Use any command-line TTS tool. The CLI provider is useful for local TTS engines like macOS `say` and `mlx-audio`, Linux `espeak`, or custom scripts.
+
+```json5
+{
+  messages: {
+    tts: {
+      provider: "cli",
+      cli: {
+        command: "/path/to/my-local-tts",
+        args: [
+          "--output_path",
+          "{{TtsOutputPath}}",
+          "--output_format",
+          "{{TtsOutputFormat}}",
+          "--text",
+          "{{TtsText}}",
+        ],
+      },
+    },
+  },
+}
+```
+
+**Template variables:**
+
+- `{{TtsText}}` — The text to convert to speech
+- `{{TtsOutputPath}}` — Full path where audio output should be written
+- `{{TtsOutputFormat}}` — Output format (`pcm` for telephony, `opus` for voice note, `mp3` otherwise)
+
+If the CLI command exit with non-zero code, OpenClaw automatically falls back to the next configured provider. You may need to enlarge `timeoutMs` if local CLI is slow.
+
 ### Custom limits + prefs path
 
 ```json5
@@ -205,7 +239,7 @@ Then run:
   - `tagged` only sends audio when the reply includes `[[tts]]` tags.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
-- `provider`: `"elevenlabs"`, `"openai"`, or `"edge"` (fallback is automatic).
+- `provider`: `"elevenlabs"`, `"openai"`, `"edge"`, or `"cli"` (fallback is automatic).
 - If `provider` is **unset**, OpenClaw prefers `openai` (if key), then `elevenlabs` (if key),
   otherwise `edge`.
 - `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
@@ -236,6 +270,8 @@ Then run:
 - `edge.saveSubtitles`: write JSON subtitles alongside the audio file.
 - `edge.proxy`: proxy URL for Edge TTS requests.
 - `edge.timeoutMs`: request timeout override (ms).
+- `cli.command`: CLI binary path or name (searched in PATH).
+- `cli.args`: CLI arguments with template variables (`{{TtsText}}`, `{{TtsOutputPath}}`, `{{TtsOutputFormat}}`).
 
 ## Model-driven overrides (default on)
 
@@ -260,7 +296,7 @@ Here you go.
 
 Available directive keys (when enabled):
 
-- `provider` (`openai` | `elevenlabs` | `edge`, requires `allowProvider: true`)
+- `provider` (`openai` | `elevenlabs` | `edge` | `cli`, requires `allowProvider: true`)
 - `voice` (OpenAI voice) or `voiceId` (ElevenLabs)
 - `model` (OpenAI TTS model or ElevenLabs model id)
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -272,6 +272,7 @@ Then run:
 - `edge.timeoutMs`: request timeout override (ms).
 - `cli.command`: CLI binary path or name (searched in PATH).
 - `cli.args`: CLI arguments with template variables (`{{TtsText}}`, `{{TtsOutputPath}}`, `{{TtsOutputFormat}}`).
+- `cli.sampleRate`: PCM sample rate (Hz) produced by the CLI command for telephony paths (default: `22050`). Must match the actual output of your CLI tool when used in voice-call integrations.
 
 ## Model-driven overrides (default on)
 

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -185,7 +185,7 @@ Use any command-line TTS tool. The CLI provider is useful for local TTS engines 
 - `{{TtsOutputPath}}` — Full path where audio output should be written
 - `{{TtsOutputFormat}}` — Output format (`pcm` for telephony, `opus` for voice note, `mp3` otherwise)
 
-If the CLI command exit with non-zero code, OpenClaw automatically falls back to the next configured provider. You may need to enlarge `timeoutMs` if local CLI is slow.
+If the CLI command exits with non-zero code, OpenClaw automatically falls back to the next configured provider. You may need to enlarge `timeoutMs` if local CLI is slow.
 
 ### Custom limits + prefs path
 

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -134,6 +134,21 @@
       "label": "ElevenLabs Base URL",
       "advanced": true
     },
+    "tts.cli.command": {
+      "label": "CLI TTS Command",
+      "help": "Command to run for CLI-based TTS (e.g., say, espeak)",
+      "advanced": true
+    },
+    "tts.cli.args": {
+      "label": "CLI TTS Arguments",
+      "help": "Arguments to pass to the CLI TTS command",
+      "advanced": true
+    },
+    "tts.cli.sampleRate": {
+      "label": "CLI TTS Sample Rate",
+      "help": "Sample rate for CLI TTS output in Hz",
+      "advanced": true
+    },
     "publicUrl": {
       "label": "Public Webhook URL",
       "advanced": true
@@ -421,7 +436,7 @@
           },
           "provider": {
             "type": "string",
-            "enum": ["openai", "elevenlabs", "edge"]
+            "enum": ["openai", "elevenlabs", "edge", "cli"]
           },
           "summaryModel": {
             "type": "string"
@@ -565,6 +580,26 @@
                 "type": "integer",
                 "minimum": 1000,
                 "maximum": 120000
+              }
+            }
+          },
+          "cli": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "command": {
+                "type": "string",
+                "minLength": 1
+              },
+              "args": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sampleRate": {
+                "type": "integer",
+                "minimum": 1
               }
             }
           },

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -162,6 +162,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
       const hasOpenAI = Boolean(resolveTtsApiKey(config, "openai"));
       const hasElevenLabs = Boolean(resolveTtsApiKey(config, "elevenlabs"));
       const hasEdge = isTtsProviderConfigured(config, "edge");
+      const hasCli = isTtsProviderConfigured(config, "cli");
       return {
         shouldContinue: false,
         reply: {
@@ -171,13 +172,19 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
             `OpenAI key: ${hasOpenAI ? "✅" : "❌"}\n` +
             `ElevenLabs key: ${hasElevenLabs ? "✅" : "❌"}\n` +
             `Edge enabled: ${hasEdge ? "✅" : "❌"}\n` +
-            `Usage: /tts provider openai | elevenlabs | edge`,
+            `CLI configured: ${hasCli ? "✅" : "❌"}\n` +
+            `Usage: /tts provider openai | elevenlabs | edge | cli`,
         },
       };
     }
 
     const requested = args.trim().toLowerCase();
-    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge") {
+    if (
+      requested !== "openai" &&
+      requested !== "elevenlabs" &&
+      requested !== "edge" &&
+      requested !== "cli"
+    ) {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -179,6 +179,10 @@ export type MsgContext = {
    * Used for hook confirmation messages like "Session context saved to memory".
    */
   HookMessages?: string[];
+  /** TTS template variables */
+  TtsText?: string;
+  TtsOutputPath?: string;
+  TtsOutputFormat?: string;
 };
 
 export type FinalizedMsgContext = Omit<MsgContext, "CommandAuthorized"> & {

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -179,10 +179,6 @@ export type MsgContext = {
    * Used for hook confirmation messages like "Session context saved to memory".
    */
   HookMessages?: string[];
-  /** TTS template variables */
-  TtsText?: string;
-  TtsOutputPath?: string;
-  TtsOutputFormat?: string;
 };
 
 export type FinalizedMsgContext = Omit<MsgContext, "CommandAuthorized"> & {

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,6 +1,6 @@
 import type { SecretInput } from "./types.secrets.js";
 
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "cli";
 
 export type TtsMode = "final" | "all";
 
@@ -75,6 +75,13 @@ export type TtsConfig = {
     saveSubtitles?: boolean;
     proxy?: string;
     timeoutMs?: number;
+  };
+  /** CLI provider configuration. */
+  cli?: {
+    /** CLI binary path or name (searched in PATH). */
+    command: string;
+    /** CLI arguments with template variables. */
+    args?: string[];
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -82,6 +82,8 @@ export type TtsConfig = {
     command: string;
     /** CLI arguments with template variables. */
     args?: string[];
+    /** PCM sample rate produced by the CLI command (Hz). Used for telephony paths. */
+    sampleRate?: number;
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -428,6 +428,7 @@ export const TtsConfigSchema = z
       .object({
         command: z.string().min(1),
         args: z.array(z.string()).optional(),
+        sampleRate: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -355,7 +355,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "cli"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -421,6 +421,13 @@ export const TtsConfigSchema = z
         saveSubtitles: z.boolean().optional(),
         proxy: z.string().optional(),
         timeoutMs: z.number().int().min(1000).max(120000).optional(),
+      })
+      .strict()
+      .optional(),
+    cli: z
+      .object({
+        command: z.string().min(1),
+        args: z.array(z.string()).optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -39,6 +39,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         hasOpenAIKey: Boolean(resolveTtsApiKey(config, "openai")),
         hasElevenLabsKey: Boolean(resolveTtsApiKey(config, "elevenlabs")),
         edgeEnabled: isTtsProviderConfigured(config, "edge"),
+        cliEnabled: isTtsProviderConfigured(config, "cli"),
       });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
@@ -100,13 +101,18 @@ export const ttsHandlers: GatewayRequestHandlers = {
   },
   "tts.setProvider": async ({ params, respond }) => {
     const provider = typeof params.provider === "string" ? params.provider.trim() : "";
-    if (provider !== "openai" && provider !== "elevenlabs" && provider !== "edge") {
+    if (
+      provider !== "openai" &&
+      provider !== "elevenlabs" &&
+      provider !== "edge" &&
+      provider !== "cli"
+    ) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          "Invalid provider. Use openai, elevenlabs, or edge.",
+          "Invalid provider. Use openai, elevenlabs, edge, or cli.",
         ),
       );
       return;
@@ -145,6 +151,12 @@ export const ttsHandlers: GatewayRequestHandlers = {
             id: "edge",
             name: "Edge TTS",
             configured: isTtsProviderConfigured(config, "edge"),
+            models: [],
+          },
+          {
+            id: "cli",
+            name: "CLI",
+            configured: isTtsProviderConfigured(config, "cli"),
             models: [],
           },
         ],

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -112,6 +112,7 @@ describe("cliTTS", () => {
       expect.any(Array),
       expect.objectContaining({
         env: expect.objectContaining({
+          TTS_TEXT: "Hello",
           TTS_OUTPUT_PATH: "/tmp/out.opus",
           TTS_OUTPUT_FORMAT: "opus",
         }),

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -142,6 +142,27 @@ describe("cliTTS", () => {
     ).rejects.toThrow("CLI TTS failed (exit code 1): Command not found");
   });
 
+  it("throws error when process is killed by signal", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: null,
+      stdout: "",
+      stderr: "",
+      signal: "SIGTERM",
+      killed: true,
+      termination: "timeout",
+    });
+
+    await expect(
+      cliTTS({
+        text: "Hello",
+        outputPath: "/tmp/out.mp3",
+        config: { command: "slow-tts" },
+        outputFormat: "mp3",
+        timeoutMs: 100,
+      }),
+    ).rejects.toThrow("CLI TTS failed (killed by signal SIGTERM)");
+  });
+
   it("throws error when output file is not created", async () => {
     mocks.runCommandWithTimeout.mockResolvedValue({
       code: 0,

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -103,7 +103,7 @@ describe("cliTTS", () => {
         outputFormat: "mp3",
         timeoutMs: 30000,
       }),
-    ).rejects.toThrow("CLI TTS failed with exit code 1: Command not found");
+    ).rejects.toThrow("CLI TTS failed (exit code 1): Command not found");
   });
 
   it("throws error when output file is not created", async () => {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  runCommandWithTimeout: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: mocks.runCommandWithTimeout,
+}));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: mocks.existsSync,
+  };
+});
+
+const { cliTTS } = await import("./tts-core.js");
+
+describe("cliTTS", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders template variables correctly", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mocks.existsSync.mockReturnValue(true);
+
+    const config = {
+      command: "say",
+      args: ["-o", "{{TtsOutputPath}}", "{{TtsText}}", "-f", "{{TtsOutputFormat}}"],
+    };
+
+    await cliTTS({
+      text: "Hello world",
+      outputPath: "/tmp/test.mp3",
+      config,
+      outputFormat: "mp3",
+      timeoutMs: 30000,
+    });
+
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(
+      ["say", "-o", "/tmp/test.mp3", "Hello world", "-f", "mp3"],
+      expect.objectContaining({ timeoutMs: 30000 }),
+    );
+  });
+
+  it("passes environment variables correctly", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mocks.existsSync.mockReturnValue(true);
+
+    const config = {
+      command: "say",
+      args: ["{{TtsText}}"],
+    };
+
+    await cliTTS({
+      text: "Hello",
+      outputPath: "/tmp/out.opus",
+      config,
+      outputFormat: "opus",
+      timeoutMs: 30000,
+    });
+
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          TTS_OUTPUT_PATH: "/tmp/out.opus",
+          TTS_OUTPUT_FORMAT: "opus",
+        }),
+      }),
+    );
+  });
+
+  it("throws error when command returns non-zero code", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 1,
+      stdout: "",
+      stderr: "Command not found",
+    });
+
+    const config = {
+      command: "invalid-command",
+      args: ["{{TtsText}}"],
+    };
+
+    await expect(
+      cliTTS({
+        text: "Hello",
+        outputPath: "/tmp/out.mp3",
+        config,
+        outputFormat: "mp3",
+        timeoutMs: 30000,
+      }),
+    ).rejects.toThrow("CLI TTS failed with exit code 1: Command not found");
+  });
+
+  it("throws error when output file is not created", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mocks.existsSync.mockReturnValue(false);
+
+    const config = {
+      command: "say",
+      args: ["{{TtsText}}"],
+    };
+
+    await expect(
+      cliTTS({
+        text: "Hello",
+        outputPath: "/tmp/missing.mp3",
+        config,
+        outputFormat: "mp3",
+        timeoutMs: 30000,
+      }),
+    ).rejects.toThrow("CLI TTS did not produce output file: /tmp/missing.mp3");
+  });
+
+  it("handles special characters in text safely", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mocks.existsSync.mockReturnValue(true);
+
+    const config = {
+      command: "echo",
+      args: ["{{TtsText}}"],
+    };
+
+    const dangerousText = "Hello'; rm -rf /; echo 'injection";
+
+    await cliTTS({
+      text: dangerousText,
+      outputPath: "/tmp/out.mp3",
+      config,
+      outputFormat: "mp3",
+      timeoutMs: 30000,
+    });
+
+    // Verify the dangerous text is passed as-is (templating doesn't execute it)
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(
+      ["echo", dangerousText],
+      expect.any(Object),
+    );
+  });
+
+  it("handles empty args array", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mocks.existsSync.mockReturnValue(true);
+
+    const config = {
+      command: "say",
+      args: [],
+    };
+
+    await cliTTS({
+      text: "Hello",
+      outputPath: "/tmp/out.mp3",
+      config,
+      outputFormat: "mp3",
+      timeoutMs: 30000,
+    });
+
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(["say"], expect.any(Object));
+  });
+
+  it("handles undefined args", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mocks.existsSync.mockReturnValue(true);
+
+    const config = {
+      command: "say",
+    };
+
+    await cliTTS({
+      text: "Hello",
+      outputPath: "/tmp/out.mp3",
+      config,
+      outputFormat: "mp3",
+      timeoutMs: 30000,
+    });
+
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(["say"], expect.any(Object));
+  });
+
+  it("preserves process.env in env", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mocks.existsSync.mockReturnValue(true);
+
+    const config = {
+      command: "say",
+      args: ["{{TtsText}}"],
+    };
+
+    await cliTTS({
+      text: "Hello",
+      outputPath: "/tmp/out.mp3",
+      config,
+      outputFormat: "mp3",
+      timeoutMs: 30000,
+    });
+
+    const callArgs = mocks.runCommandWithTimeout.mock.calls[0];
+    const envArg = callArgs?.[1]?.env as Record<string, string | undefined>;
+    expect(envArg).toHaveProperty("PATH");
+    expect(envArg).toHaveProperty("HOME");
+  });
+
+  it("handles multi-line text", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mocks.existsSync.mockReturnValue(true);
+
+    const config = {
+      command: "echo",
+      args: ["{{TtsText}}"],
+    };
+
+    const multiLineText = "Line 1\nLine 2\nLine 3";
+
+    await cliTTS({
+      text: multiLineText,
+      outputPath: "/tmp/out.mp3",
+      config,
+      outputFormat: "mp3",
+      timeoutMs: 30000,
+    });
+
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(
+      ["echo", multiLineText],
+      expect.any(Object),
+    );
+  });
+
+  it("handles pcm output format", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mocks.existsSync.mockReturnValue(true);
+
+    const config = {
+      command: "tts-cli",
+      args: ["--format", "{{TtsOutputFormat}}", "--output", "{{TtsOutputPath}}"],
+    };
+
+    await cliTTS({
+      text: "Hello",
+      outputPath: "/tmp/out.wav",
+      config,
+      outputFormat: "pcm",
+      timeoutMs: 30000,
+    });
+
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(
+      ["tts-cli", "--format", "pcm", "--output", "/tmp/out.wav"],
+      expect.any(Object),
+    );
+  });
+});

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -51,6 +51,42 @@ describe("cliTTS", () => {
     );
   });
 
+  it("preserves unrecognized template variables", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mocks.existsSync.mockReturnValue(true);
+
+    const config = {
+      command: "custom-tool",
+      args: ["--text", "{{TtsText}}", "--custom", "{{UnknownVar}}", "--typo", "{{TtsOutPutPath}}"],
+    };
+
+    await cliTTS({
+      text: "Hello",
+      outputPath: "/tmp/out.mp3",
+      config,
+      outputFormat: "mp3",
+      timeoutMs: 30000,
+    });
+
+    // Unknown vars should be preserved, not collapsed to empty strings
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(
+      [
+        "custom-tool",
+        "--text",
+        "Hello",
+        "--custom",
+        "{{UnknownVar}}",
+        "--typo",
+        "{{TtsOutPutPath}}",
+      ],
+      expect.any(Object),
+    );
+  });
+
   it("passes environment variables correctly", async () => {
     mocks.runCommandWithTimeout.mockResolvedValue({
       code: 0,

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -231,7 +231,6 @@ describe("cliTTS", () => {
     const callArgs = mocks.runCommandWithTimeout.mock.calls[0];
     const envArg = callArgs?.[1]?.env as Record<string, string | undefined>;
     expect(envArg).toHaveProperty("PATH");
-    expect(envArg).toHaveProperty("HOME");
   });
 
   it("handles multi-line text", async () => {

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -725,6 +725,7 @@ export async function cliTTS(params: {
     ...process.env,
     TTS_OUTPUT_PATH: outputPath,
     TTS_OUTPUT_FORMAT: outputFormat,
+    TTS_TEXT: text,
   };
 
   const result = await runCommandWithTimeout([config.command, ...resolvedArgs], { timeoutMs, env });
@@ -734,7 +735,8 @@ export async function cliTTS(params: {
       result.code === null
         ? `killed by signal ${result.signal ?? "unknown"}`
         : `exit code ${result.code}`;
-    throw new Error(`CLI TTS failed (${reason}): ${result.stderr || result.stdout}`);
+    const details = result.stderr || result.stdout;
+    throw new Error(`CLI TTS failed (${reason})${details ? `: ${details}` : ""}`);
   }
 
   if (!existsSync(outputPath)) {

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -11,7 +11,6 @@ import {
 } from "../agents/model-selection.js";
 import { createConfiguredOllamaStreamFn } from "../agents/ollama-stream.js";
 import { resolveModel } from "../agents/pi-embedded-runner/model.js";
-import { applyTemplate } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import type {
@@ -714,18 +713,19 @@ export async function cliTTS(params: {
 }): Promise<void> {
   const { text, outputPath, config, outputFormat, timeoutMs } = params;
 
-  const templateCtx = {
+  const TTS_TEMPLATE_VARS: Record<string, string> = {
     TtsText: text,
     TtsOutputPath: outputPath,
     TtsOutputFormat: outputFormat,
   };
+  const resolvedArgs = (config.args ?? []).map((arg) =>
+    arg.replace(/{{\s*(\w+)\s*}}/g, (match, key) => TTS_TEMPLATE_VARS[key] ?? match),
+  );
   const env = {
     ...process.env,
     TTS_OUTPUT_PATH: outputPath,
     TTS_OUTPUT_FORMAT: outputFormat,
   };
-
-  const resolvedArgs = (config.args ?? []).map((arg) => applyTemplate(arg, templateCtx));
 
   const result = await runCommandWithTimeout([config.command, ...resolvedArgs], { timeoutMs, env });
 

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -730,9 +730,11 @@ export async function cliTTS(params: {
   const result = await runCommandWithTimeout([config.command, ...resolvedArgs], { timeoutMs, env });
 
   if (result.code !== 0) {
-    throw new Error(
-      `CLI TTS failed with exit code ${result.code}: ${result.stderr || result.stdout}`,
-    );
+    const reason =
+      result.code === null
+        ? `killed by signal ${result.signal ?? "unknown"}`
+        : `exit code ${result.code}`;
+    throw new Error(`CLI TTS failed (${reason}): ${result.stderr || result.stdout}`);
   }
 
   if (!existsSync(outputPath)) {

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -1,4 +1,4 @@
-import { rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
 import { EdgeTTS } from "node-edge-tts";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
@@ -11,7 +11,9 @@ import {
 } from "../agents/model-selection.js";
 import { createConfiguredOllamaStreamFn } from "../agents/ollama-stream.js";
 import { resolveModel } from "../agents/pi-embedded-runner/model.js";
+import { applyTemplate } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { runCommandWithTimeout } from "../process/exec.js";
 import type {
   ResolvedTtsConfig,
   ResolvedTtsModelOverrides,
@@ -151,7 +153,12 @@ export function parseTtsDirectives(
             if (!policy.allowProvider) {
               break;
             }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
+            if (
+              rawValue === "openai" ||
+              rawValue === "elevenlabs" ||
+              rawValue === "edge" ||
+              rawValue === "cli"
+            ) {
               overrides.provider = rawValue;
             } else {
               warnings.push(`unsupported provider "${rawValue}"`);
@@ -696,4 +703,39 @@ export async function edgeTTS(params: {
     timeout: config.timeoutMs ?? timeoutMs,
   });
   await tts.ttsPromise(text, outputPath);
+}
+
+export async function cliTTS(params: {
+  text: string;
+  outputPath: string;
+  config: ResolvedTtsConfig["cli"];
+  outputFormat: "mp3" | "opus" | "pcm";
+  timeoutMs: number;
+}): Promise<void> {
+  const { text, outputPath, config, outputFormat, timeoutMs } = params;
+
+  const templateCtx = {
+    TtsText: text,
+    TtsOutputPath: outputPath,
+    TtsOutputFormat: outputFormat,
+  };
+  const env = {
+    ...process.env,
+    TTS_OUTPUT_PATH: outputPath,
+    TTS_OUTPUT_FORMAT: outputFormat,
+  };
+
+  const resolvedArgs = (config.args ?? []).map((arg) => applyTemplate(arg, templateCtx));
+
+  const result = await runCommandWithTimeout([config.command, ...resolvedArgs], { timeoutMs, env });
+
+  if (result.code !== 0) {
+    throw new Error(
+      `CLI TTS failed with exit code ${result.code}: ${result.stderr || result.stdout}`,
+    );
+  }
+
+  if (!existsSync(outputPath)) {
+    throw new Error(`CLI TTS did not produce output file: ${outputPath}`);
+  }
 }

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -45,7 +45,8 @@ vi.mock("../agents/custom-api-registry.js", () => ({
   ensureCustomApiRegistered: vi.fn(),
 }));
 
-const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider } = tts;
+const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider, isTtsProviderConfigured } =
+  tts;
 
 const {
   isValidVoiceId,
@@ -661,6 +662,58 @@ describe("tts", () => {
         expect(result.mediaUrl).toBeDefined();
         expect(fetchMock).toHaveBeenCalledTimes(1);
       });
+    });
+  });
+
+  describe("CLI TTS provider", () => {
+    it("resolves CLI config with defaults", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: {
+          tts: {
+            provider: "cli",
+            cli: {
+              command: "say",
+              args: ["-o", "{{TtsOutputPath}}", "{{TtsText}}"],
+            },
+          },
+        },
+      };
+      const config = resolveTtsConfig(cfg);
+
+      expect(config.provider).toBe("cli");
+      expect(config.cli.command).toBe("say");
+      expect(config.cli.args).toEqual(["-o", "{{TtsOutputPath}}", "{{TtsText}}"]);
+    });
+
+    it("is configured when command is set", () => {
+      const cfg: OpenClawConfig = {
+        messages: {
+          tts: {
+            cli: {
+              command: "say",
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const config = resolveTtsConfig(cfg);
+      expect(isTtsProviderConfigured(config, "cli")).toBe(true);
+    });
+
+    it("is not configured when command is empty", () => {
+      const cfg: OpenClawConfig = {
+        messages: { tts: {} },
+      } as OpenClawConfig;
+      const config = resolveTtsConfig(cfg);
+      expect(isTtsProviderConfigured(config, "cli")).toBe(false);
+    });
+
+    it("accepts cli as provider override in directives", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "Hello [[tts:provider=cli]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.provider).toBe("cli");
     });
   });
 });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -329,7 +329,7 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
     },
     cli: {
       command: raw.cli?.command?.trim() ?? "",
-      args: raw.cli?.args ?? [],
+      args: raw.cli?.args,
       sampleRate: raw.cli?.sampleRate,
     },
     prefsPath: raw.prefsPath,

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -692,7 +692,11 @@ export async function textToSpeech(params: {
             timeoutMs: config.timeoutMs,
           });
         } catch (err) {
-          scheduleCleanup(tempDir);
+          try {
+            rmSync(tempDir, { recursive: true, force: true });
+          } catch {
+            // ignore cleanup errors
+          }
           throw err;
         }
 
@@ -842,7 +846,11 @@ export async function textToSpeechTelephony(params: {
             sampleRate: sampleRate,
           };
         } catch (err) {
-          scheduleCleanup(tempDir);
+          try {
+            rmSync(tempDir, { recursive: true, force: true });
+          } catch {
+            // ignore cleanup errors
+          }
           throw err;
         }
       }

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -681,13 +681,18 @@ export async function textToSpeech(params: {
         const extension = output.extension;
         const audioPath = path.join(tempDir, `voice-${Date.now()}${extension}`);
 
-        await cliTTS({
-          text: params.text,
-          config: config.cli,
-          outputFormat: outputFormat,
-          outputPath: audioPath,
-          timeoutMs: config.timeoutMs,
-        });
+        try {
+          await cliTTS({
+            text: params.text,
+            config: config.cli,
+            outputFormat: outputFormat,
+            outputPath: audioPath,
+            timeoutMs: config.timeoutMs,
+          });
+        } catch (err) {
+          scheduleCleanup(tempDir);
+          throw err;
+        }
 
         scheduleCleanup(tempDir);
         const voiceCompatible = isVoiceCompatibleAudio({ fileName: audioPath });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -138,6 +138,7 @@ export type ResolvedTtsConfig = {
   cli: {
     command: string;
     args?: string[];
+    sampleRate?: number;
   };
   prefsPath?: string;
   maxTextLength: number;
@@ -329,6 +330,7 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
     cli: {
       command: raw.cli?.command?.trim() ?? "",
       args: raw.cli?.args ?? [],
+      sampleRate: raw.cli?.sampleRate,
     },
     prefsPath: raw.prefsPath,
     maxTextLength: raw.maxTextLength ?? DEFAULT_MAX_TEXT_LENGTH,
@@ -810,8 +812,9 @@ export async function textToSpeechTelephony(params: {
           continue;
         }
 
-        const output = TELEPHONY_OUTPUT.cli;
-        const extension = `.${output.format}`;
+        const outputFormat = TELEPHONY_OUTPUT.cli.format;
+        const sampleRate = config.cli.sampleRate;
+        const extension = `.${outputFormat}`;
 
         const tempRoot = resolvePreferredOpenClawTmpDir();
         mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
@@ -823,7 +826,7 @@ export async function textToSpeechTelephony(params: {
             text: params.text,
             config: config.cli,
             outputPath: audioPath,
-            outputFormat: output.format,
+            outputFormat: outputFormat,
             timeoutMs: config.timeoutMs,
           });
 
@@ -835,8 +838,8 @@ export async function textToSpeechTelephony(params: {
             audioBuffer,
             latencyMs: Date.now() - providerStart,
             provider,
-            outputFormat: output.format,
-            sampleRate: output.sampleRate,
+            outputFormat: outputFormat,
+            sampleRate: sampleRate,
           };
         } catch (err) {
           scheduleCleanup(tempDir);

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -813,7 +813,7 @@ export async function textToSpeechTelephony(params: {
         }
 
         const outputFormat = TELEPHONY_OUTPUT.cli.format;
-        const sampleRate = config.cli.sampleRate;
+        const sampleRate = config.cli.sampleRate ?? 22050;
         const extension = `.${outputFormat}`;
 
         const tempRoot = resolvePreferredOpenClawTmpDir();

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -88,7 +88,7 @@ const DEFAULT_OUTPUT = {
 const TELEPHONY_OUTPUT = {
   openai: { format: "pcm" as const, sampleRate: 24000 },
   elevenlabs: { format: "pcm_22050", sampleRate: 22050 },
-  cli: { format: "pcm" as const, sampleRate: 22050 },
+  cli: { format: "pcm" as const },
 };
 
 const TTS_AUTO_MODES = new Set<TtsAutoMode>(["off", "always", "inbound", "tagged"]);

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -29,6 +29,7 @@ import { isVoiceCompatibleAudio } from "../media/audio.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
   DEFAULT_OPENAI_BASE_URL,
+  cliTTS,
   edgeTTS,
   elevenLabsTTS,
   inferEdgeExtension,
@@ -71,6 +72,7 @@ const TELEGRAM_OUTPUT = {
   // ElevenLabs output formats use codec_sample_rate_bitrate naming.
   // Opus @ 48kHz/64kbps is a good voice-note tradeoff for Telegram.
   elevenlabs: "opus_48000_64",
+  cli: "opus" as const,
   extension: ".opus",
   voiceCompatible: true,
 };
@@ -78,6 +80,7 @@ const TELEGRAM_OUTPUT = {
 const DEFAULT_OUTPUT = {
   openai: "mp3" as const,
   elevenlabs: "mp3_44100_128",
+  cli: "mp3" as const,
   extension: ".mp3",
   voiceCompatible: false,
 };
@@ -85,6 +88,7 @@ const DEFAULT_OUTPUT = {
 const TELEPHONY_OUTPUT = {
   openai: { format: "pcm" as const, sampleRate: 24000 },
   elevenlabs: { format: "pcm_22050", sampleRate: 22050 },
+  cli: { format: "pcm" as const, sampleRate: 22050 },
 };
 
 const TTS_AUTO_MODES = new Set<TtsAutoMode>(["off", "always", "inbound", "tagged"]);
@@ -130,6 +134,10 @@ export type ResolvedTtsConfig = {
     saveSubtitles: boolean;
     proxy?: string;
     timeoutMs?: number;
+  };
+  cli: {
+    command: string;
+    args?: string[];
   };
   prefsPath?: string;
   maxTextLength: number;
@@ -317,6 +325,10 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       saveSubtitles: raw.edge?.saveSubtitles ?? false,
       proxy: raw.edge?.proxy?.trim() || undefined,
       timeoutMs: raw.edge?.timeoutMs,
+    },
+    cli: {
+      command: raw.cli?.command?.trim() ?? "",
+      args: raw.cli?.args ?? [],
     },
     prefsPath: raw.prefsPath,
     maxTextLength: raw.maxTextLength ?? DEFAULT_MAX_TEXT_LENGTH,
@@ -526,7 +538,7 @@ export function resolveTtsApiKey(
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge"] as const;
+export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge", "cli"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
@@ -535,6 +547,9 @@ export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
 export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: TtsProvider): boolean {
   if (provider === "edge") {
     return config.edge.enabled;
+  }
+  if (provider === "cli") {
+    return Boolean(config.cli?.command);
   }
   return Boolean(resolveTtsApiKey(config, provider));
 }
@@ -653,6 +668,40 @@ export async function textToSpeech(params: {
         };
       }
 
+      if (provider === "cli") {
+        if (!config.cli.command) {
+          errors.push("cli: not configured");
+          continue;
+        }
+
+        const tempRoot = resolvePreferredOpenClawTmpDir();
+        mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+        const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
+        const outputFormat = output.cli;
+        const extension = output.extension;
+        const audioPath = path.join(tempDir, `voice-${Date.now()}${extension}`);
+
+        await cliTTS({
+          text: params.text,
+          config: config.cli,
+          outputFormat: outputFormat,
+          outputPath: audioPath,
+          timeoutMs: config.timeoutMs,
+        });
+
+        scheduleCleanup(tempDir);
+        const voiceCompatible = isVoiceCompatibleAudio({ fileName: audioPath });
+
+        return {
+          success: true,
+          audioPath,
+          latencyMs: Date.now() - providerStart,
+          provider,
+          outputFormat: outputFormat,
+          voiceCompatible,
+        };
+      }
+
       const apiKey = resolveTtsApiKey(config, provider);
       if (!apiKey) {
         errors.push(`${provider}: no API key`);
@@ -748,6 +797,46 @@ export async function textToSpeechTelephony(params: {
       if (provider === "edge") {
         errors.push("edge: unsupported for telephony");
         continue;
+      }
+
+      if (provider === "cli") {
+        if (!config.cli.command) {
+          errors.push("cli: not configured");
+          continue;
+        }
+
+        const output = TELEPHONY_OUTPUT.cli;
+        const extension = `.${output.format}`;
+
+        const tempRoot = resolvePreferredOpenClawTmpDir();
+        mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+        const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
+        const audioPath = path.join(tempDir, `voice-${Date.now()}${extension}`);
+
+        try {
+          await cliTTS({
+            text: params.text,
+            config: config.cli,
+            outputPath: audioPath,
+            outputFormat: output.format,
+            timeoutMs: config.timeoutMs,
+          });
+
+          const audioBuffer = readFileSync(audioPath);
+          scheduleCleanup(tempDir);
+
+          return {
+            success: true,
+            audioBuffer,
+            latencyMs: Date.now() - providerStart,
+            provider,
+            outputFormat: output.format,
+            sampleRate: output.sampleRate,
+          };
+        } catch (err) {
+          scheduleCleanup(tempDir);
+          throw err;
+        }
       }
 
       const apiKey = resolveTtsApiKey(config, provider);


### PR DESCRIPTION
## Summary

- Problem: Users could not use local CLI TTS tools (say, espeak, piper, mlx-audio, etc.) and had to rely on cloud providers (OpenAI, ElevenLabs) which send data to external services
- Why it matters: Local TTS keeps sensitive text/audio on-device, improving privacy and reducing latency for offline usage. And can custom voices requires no API key.
- What changed: Added CLI provider with template variable support, env var passing, and comprehensive tests
- What did NOT change: Existing cloud providers (OpenAI, ElevenLabs, Edge) remain unchanged and functional

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New TTS provider option: `"cli"`
- New config section `messages.tts.cli` with `command` and optional `args`
- Template variables available in args: `{{TtsText}}`, `{{TtsOutputPath}}`, `{{TtsOutputFormat}}`
- Environment variables passed to CLI: `TTS_OUTPUT_PATH`, `TTS_OUTPUT_FORMAT`
- CLI provider appears in TTS provider list and fallback chain

Example:
```json5
{
  messages: {
    tts: {
      provider: "cli",
      cli: {
        command: "/path/to/my-local-tts",
        "args": [
          "--output_path", "{{TtsOutputPath}}",
          "--output_format", "{{TtsOutputFormat}}",
          "--text", "{{TtsText}}"
        ]
      },
    },
  },
}
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - **Risk**: User-configured CLI commands are executed via `runCommandWithTimeout`
  - **Mitigation**: 
    - Uses existing hardened exec utility with timeout and proper escaping
    - Template substitution only replaces variables, does not execute shell interpolation
    - Opt-in feature - only executes if user explicitly configures `messages.tts.provider: "cli"`
    - Output file path is validated to exist after execution

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: N/A (local TTS)
- Integration/channel (if any): Telegram
- Relevant config (redacted): See configuration example above

### Steps

1. Configure CLI provider in `~/.openclaw/config.json` with macOS `say` command
2. Send message to any channel with TTS enabled
3. Observe audio generated via local `say` command

### Expected

- TTS audio generated via local CLI tool
- No network calls to external TTS services
- Template variables correctly substituted

### Actual

- TTS audio generated successfully via `say` command
- Unit tests pass (10 cliTTS tests, 56 total TTS tests)
- Lint and build pass

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before: N/A (new feature)
After: `src/tts/tts-core.test.ts` - 10 tests for cliTTS function

## Human Verification (required)

- Verified scenarios:
  - Template variable substitution ({{TtsText}}, {{TtsOutputPath}}, {{TtsOutputFormat}})
  - Environment variable passing (TTS_OUTPUT_PATH, TTS_OUTPUT_FORMAT)
  - Error handling for non-zero exit codes
  - Error handling for missing output files
  - Special character handling (command injection prevention)
  - Empty/undefined args handling
  - Multi-line text handling
  - All output formats (mp3, opus, pcm)
- Edge cases checked:
  - Dangerous text with shell metacharacters safely passed as-is
  - Empty args array vs undefined args
  - Non-existent CLI command returns proper error
- What you did **not** verify:
  - Integration with actual `espeak` or `piper` binaries (only mocked)
  - Windows-specific CLI behavior

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Change `messages.tts.provider` to `"openai"`, `"elevenlabs"`, or `"edge"`
- Files/config to restore: Remove `messages.tts.cli` section from config
- Known bad symptoms reviewers should watch for: CLI commands failing silently, output files not created

## Risks and Mitigations

- Risk: User misconfiguration could execute unexpected commands
  - Mitigation: Template substitution is literal replacement only (no shell evaluation), requires explicit opt-in via config
- Risk: Long-running CLI commands could hang TTS
  - Mitigation: Uses `runCommandWithTimeout` with configurable timeout (default 30s)
- Risk: CLI tools not in PATH
  - Mitigation: Error message propagated to user if command fails

None other than above.