### PR TITLE
fix(sandbox): prune should also remove workspace directory

### DIFF
--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -37,13 +37,13 @@ x-i18n:
 </p>
 
 <Columns>
-  <Card title="入门指南" href="/start/getting-started" icon="rocket">
+  <Card title="入门指南" href="/zh-CN/start/getting-started" icon="rocket">
     安装 OpenClaw 并在几分钟内启动 Gateway 网关。
   </Card>
-  <Card title="运行向导" href="/start/wizard" icon="sparkles">
+  <Card title="运行向导" href="/zh-CN/start/wizard" icon="sparkles">
     通过 `openclaw onboard` 和配对流程进行引导式设置。
   </Card>
-  <Card title="打开控制界面" href="/web/control-ui" icon="layout-dashboard">
+  <Card title="打开控制界面" href="/zh-CN/web/control-ui" icon="layout-dashboard">
     启动浏览器仪表板，管理聊天、配置和会话。
   </Card>
 </Columns>
@@ -108,14 +108,14 @@ Gateway 网关是会话、路由和渠道连接的唯一事实来源。
   </Step>
 </Steps>
 
-需要完整的安装和开发环境设置？请参阅[快速开始](/start/quickstart)。
+需要完整的安装和开发环境设置？请参阅[快速开始](/zh-CN/start/quickstart)。
 
 ## 仪表板
 
 Gateway 网关启动后，打开浏览器控制界面。
 
 - 本地默认地址：http://127.0.0.1:18789/
-- 远程访问：[Web 界面](/web)和 [Tailscale](/gateway/tailscale)
+- 远程访问：[Web 界面](/zh-CN/web)和 [Tailscale](/zh-CN/gateway/tailscale)
 
 <p align="center">
   <img src="/whatsapp-openclaw.jpg" alt="OpenClaw" width="420" />
@@ -145,16 +145,16 @@ Gateway 网关启动后，打开浏览器控制界面。
 ## 从这里开始
 
 <Columns>
-  <Card title="文档中心" href="/start/hubs" icon="book-open">
+  <Card title="文档中心" href="/zh-CN/start/hubs" icon="book-open">
     所有文档和指南，按用例分类。
   </Card>
-  <Card title="配置" href="/gateway/configuration" icon="settings">
+  <Card title="配置" href="/zh-CN/gateway/configuration" icon="settings">
     核心 Gateway 网关设置、令牌和提供商配置。
   </Card>
-  <Card title="远程访问" href="/gateway/remote" icon="globe">
+  <Card title="远程访问" href="/zh-CN/gateway/remote" icon="globe">
     SSH 和 tailnet 访问模式。
   </Card>
-  <Card title="渠道" href="/channels/telegram" icon="message-square">
+  <Card title="渠道" href="/zh-CN/channels/telegram" icon="message-square">
     WhatsApp、Telegram、Discord 等渠道的具体设置。
   </Card>
   <Card title="节点" href="/nodes" icon="smartphone">
@@ -168,19 +168,19 @@ Gateway 网关启动后，打开浏览器控制界面。
 ## 了解更多
 
 <Columns>
-  <Card title="完整功能列表" href="/concepts/features" icon="list">
+  <Card title="完整功能列表" href="/zh-CN/concepts/features" icon="list">
     全部渠道、路由和媒体功能。
   </Card>
-  <Card title="多智能体路由" href="/concepts/multi-agent" icon="route">
+  <Card title="多智能体路由" href="/zh-CN/concepts/multi-agent" icon="route">
     工作区隔离和按智能体的会话管理。
   </Card>
-  <Card title="安全" href="/gateway/security" icon="shield">
+  <Card title="安全" href="/zh-CN/gateway/security" icon="shield">
     令牌、白名单和安全控制。
   </Card>
-  <Card title="故障排除" href="/gateway/troubleshooting" icon="wrench">
+  <Card title="故障排除" href="/zh-CN/gateway/troubleshooting" icon="wrench">
     Gateway 网关诊断和常见错误。
   </Card>
-  <Card title="关于与致谢" href="/reference/credits" icon="info">
+  <Card title="关于与致谢" href="/zh-CN/reference/credits" icon="info">
     项目起源、贡献者和许可证。
   </Card>
 </Columns>

--- a/src/agents/sandbox/prune.ts
+++ b/src/agents/sandbox/prune.ts
@@ -1,7 +1,10 @@
+import fs from "node:fs/promises";
 import { stopBrowserBridgeServer } from "../../browser/bridge-server.js";
 import { defaultRuntime } from "../../runtime.js";
 import { BROWSER_BRIDGES } from "./browser-bridges.js";
 import { dockerContainerState, execDocker } from "./docker.js";
+import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js";
+import { DEFAULT_SANDBOX_WORKSPACE_ROOT } from "./constants.js";
 import {
   readBrowserRegistry,
   readRegistry,
@@ -16,7 +19,7 @@ let lastPruneAtMs = 0;
 
 type PruneableRegistryEntry = Pick<
   SandboxRegistryEntry,
-  "containerName" | "createdAtMs" | "lastUsedAtMs"
+  "containerName" | "sessionKey" | "createdAtMs" | "lastUsedAtMs"
 >;
 
 function shouldPruneSandboxEntry(cfg: SandboxConfig, now: number, entry: PruneableRegistryEntry) {
@@ -37,6 +40,7 @@ async function pruneSandboxRegistryEntries<TEntry extends PruneableRegistryEntry
   cfg: SandboxConfig;
   read: () => Promise<{ entries: TEntry[] }>;
   remove: (containerName: string) => Promise<void>;
+  workspaceRoot?: string;
   onRemoved?: (entry: TEntry) => Promise<void>;
 }) {
   const now = Date.now();
@@ -55,6 +59,16 @@ async function pruneSandboxRegistryEntries<TEntry extends PruneableRegistryEntry
     } catch {
       // ignore prune failures
     } finally {
+      // Remove workspace directory if sessionKey is available
+      if (entry.sessionKey && params.workspaceRoot && params.cfg.scope) {
+        try {
+          const scopeKey = resolveSandboxScopeKey(params.cfg.scope, entry.sessionKey);
+          const workspaceDir = resolveSandboxWorkspaceDir(params.workspaceRoot, scopeKey);
+          await fs.rm(workspaceDir, { force: true, recursive: true });
+        } catch {
+          // ignore workspace removal failures
+        }
+      }
       await params.remove(entry.containerName);
       await params.onRemoved?.(entry);
     }
@@ -62,14 +76,20 @@ async function pruneSandboxRegistryEntries<TEntry extends PruneableRegistryEntry
 }
 
 async function pruneSandboxContainers(cfg: SandboxConfig) {
+  const workspaceRoot = cfg.workspaceRoot ?? DEFAULT_SANDBOX_WORKSPACE_ROOT;
   await pruneSandboxRegistryEntries<SandboxRegistryEntry>({
     cfg,
     read: readRegistry,
     remove: removeRegistryEntry,
+    workspaceRoot,
   });
 }
 
 async function pruneSandboxBrowsers(cfg: SandboxConfig) {
+  // Note: We don't pass workspaceRoot to pruneSandboxRegistryEntries here
+  // because browser sandboxes share workspace directories with their parent
+  // container sandboxes. Deleting the workspace from browser prune could
+  // corrupt an active container's workspace.
   await pruneSandboxRegistryEntries<SandboxBrowserRegistryEntry>({
     cfg,
     read: readBrowserRegistry,


### PR DESCRIPTION
## Summary

Fix #43797 - Sandbox prune removes Docker containers but leaves workspace directories behind, causing disk space leak.

## Problem

When a sandbox is pruned (due to `idleHours` or `maxAgeDays` configuration), the workspace directory (`~/.openclaw/sandboxes/agent-<id>-<scope>`) was not being deleted. Only Docker containers were removed.

## Solution

Added logic to also remove the workspace directory after container removal:

1. Added `sessionKey` to the `PruneableRegistryEntry` type (already available in registry)
2. Added `workspaceRoot` parameter to `pruneSandboxRegistryEntries` function
3. After removing Docker container, also delete the workspace directory using `fs.rm()`

## Changes

- `src/agents/sandbox/prune.ts`: 
  - Added imports: `fs`, `resolveSandboxWorkspaceDir`, `DEFAULT_SANDBOX_WORKSPACE_ROOT`
  - Modified `PruneableRegistryEntry` to include `sessionKey`
  - Added workspace directory cleanup in prune logic

## Testing

The fix uses `fs.rm(workspaceDir, { force: true, recursive: true })` with try-catch to safely remove directories without failing the entire prune operation.