### PR TITLE
feat(feishu): add feishu_card tool for sending and updating interactive cards

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -1,6 +1,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/feishu";
 import { registerFeishuBitableTools } from "./src/bitable.js";
+import { registerFeishuCardTools } from "./src/card-tool.js";
 import { feishuPlugin } from "./src/channel.js";
 import { registerFeishuChatTools } from "./src/chat.js";
 import { registerFeishuDocTools } from "./src/docx.js";
@@ -59,6 +60,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuCardTools(api);
   },
 };
 

--- a/extensions/feishu/src/card-schema.ts
+++ b/extensions/feishu/src/card-schema.ts
@@ -1,0 +1,39 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+const CARD_ACTION_VALUES = ["send", "update"] as const;
+
+export const FeishuCardToolSchema = Type.Object({
+  action: Type.Unsafe<(typeof CARD_ACTION_VALUES)[number]>({
+    type: "string",
+    enum: [...CARD_ACTION_VALUES],
+    description: "Action to run: send | update",
+  }),
+  chat_id: Type.Optional(
+    Type.String({
+      description: "Chat ID to send the card to (required for send)",
+    }),
+  ),
+  message_id: Type.Optional(
+    Type.String({
+      description: "Message ID of the card to update (required for update)",
+    }),
+  ),
+  card: Type.Unsafe<Record<string, unknown>>({
+    type: "object",
+    description:
+      "Card JSON payload (Feishu interactive card schema 2.0). " +
+      "Must include a valid card structure with header and/or elements.",
+  }),
+  reply_to_message_id: Type.Optional(
+    Type.String({
+      description: "Message ID to reply to (optional, for send only)",
+    }),
+  ),
+  reply_in_thread: Type.Optional(
+    Type.Boolean({
+      description: "Whether to reply in a topic thread (optional, for send only)",
+    }),
+  ),
+});
+
+export type FeishuCardToolParams = Static<typeof FeishuCardToolSchema>;

--- a/extensions/feishu/src/card-tool.ts
+++ b/extensions/feishu/src/card-tool.ts
@@ -1,0 +1,97 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { FeishuCardToolSchema, type FeishuCardToolParams } from "./card-schema.js";
+import { resolveToolsConfig } from "./tools-config.js";
+import { sendCardFeishu, updateCardFeishu } from "./send.js";
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+export function registerFeishuCardTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_card: No config available, skipping card tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_card: No Feishu accounts configured, skipping card tools");
+    return;
+  }
+
+  const firstAccount = accounts[0];
+  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  if (!toolsCfg.card) {
+    api.logger.debug?.("feishu_card: card tool disabled in config");
+    return;
+  }
+
+  api.registerTool(
+    {
+      name: "feishu_card",
+      label: "Feishu Card",
+      description:
+        "Send or update Feishu interactive cards. " +
+        "Actions: send (send a card to a chat), update (update an existing card by message_id)",
+      parameters: FeishuCardToolSchema,
+      async execute(_toolCallId, params) {
+        const p = params as FeishuCardToolParams;
+        const cfg = api.config!;
+        const accountId = firstAccount.accountId;
+        try {
+          switch (p.action) {
+            case "send": {
+              if (!p.chat_id) {
+                return json({ error: "chat_id is required for send action" });
+              }
+              if (!p.card) {
+                return json({ error: "card is required" });
+              }
+              const result = await sendCardFeishu({
+                cfg,
+                to: p.chat_id,
+                card: p.card,
+                replyToMessageId: p.reply_to_message_id,
+                replyInThread: p.reply_in_thread,
+                accountId,
+              });
+              return json({
+                success: true,
+                message_id: result.messageId,
+              });
+            }
+            case "update": {
+              if (!p.message_id) {
+                return json({ error: "message_id is required for update action" });
+              }
+              if (!p.card) {
+                return json({ error: "card is required" });
+              }
+              await updateCardFeishu({
+                cfg,
+                messageId: p.message_id,
+                card: p.card,
+                accountId,
+              });
+              return json({
+                success: true,
+                message_id: p.message_id,
+              });
+            }
+            default:
+              return json({ error: `Unknown action: ${String(p.action)}` });
+          }
+        } catch (err) {
+          return json({ error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    },
+    { name: "feishu_card" },
+  );
+
+  api.logger.info?.("feishu_card: Registered feishu_card tool");
+}

--- a/extensions/feishu/src/card-tool.ts
+++ b/extensions/feishu/src/card-tool.ts
@@ -1,8 +1,8 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuCardToolSchema, type FeishuCardToolParams } from "./card-schema.js";
-import { resolveToolsConfig } from "./tools-config.js";
 import { sendCardFeishu, updateCardFeishu } from "./send.js";
+import { resolveToolsConfig } from "./tools-config.js";
 
 function json(data: unknown) {
   return {

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -56,6 +56,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     drive: false,
     perm: false,
     scopes: false,
+    card: false,
   };
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -2,7 +2,7 @@ import type { FeishuToolsConfig } from "./types.js";
 
 /**
  * Default tool configuration.
- * - doc, chat, wiki, drive, scopes: enabled by default
+ * - doc, chat, wiki, drive, scopes, card: enabled by default
  * - perm: disabled by default (sensitive operation)
  */
 export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
@@ -12,6 +12,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  card: true,
 };
 
 /**

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -79,6 +79,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  card?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {


### PR DESCRIPTION
## Motivation

Currently, agents that want to send Feishu interactive cards must use external scripts or raw API calls. There's no native tool for card operations, unlike `feishu_doc`, `feishu_chat`, `feishu_wiki`, etc.

## Changes

Add a new `feishu_card` tool with two actions:

### `feishu_card send`
- Send an interactive card (schema 2.0 JSON) to a specified chat
- Supports `reply_to_message_id` for reply threading
- Supports `reply_in_thread` for Feishu topic threads
- Returns the sent message's `message_id`

### `feishu_card update`
- Update an already-sent card by `message_id`
- Useful for dynamic card UIs (progress bars, status updates, form results, etc.)

## Implementation

- **`card-schema.ts`** — TypeBox schema defining tool parameters
- **`card-tool.ts`** — Tool registration following the same pattern as `feishu_chat`, `feishu_doc`, etc.
- Reuses existing `sendCardFeishu` and `updateCardFeishu` functions from `send.ts` — no new API logic
- Added `card` flag to `FeishuToolsConfig` (enabled by default, same as doc/chat/wiki/drive)
- Registered in `index.ts` alongside other Feishu tools

## Files Changed

| File | Change |
|------|--------|
| `extensions/feishu/src/card-schema.ts` | New — tool parameter schema |
| `extensions/feishu/src/card-tool.ts` | New — tool registration & dispatch |
| `extensions/feishu/src/types.ts` | Added `card?: boolean` to `FeishuToolsConfig` |
| `extensions/feishu/src/tools-config.ts` | Added `card: true` to defaults |
| `extensions/feishu/index.ts` | Import & register `registerFeishuCardTools` |

## Backward Compatibility

- New tool, no changes to existing behavior
- Tool can be disabled via `tools.card: false` in account config
- No changes to existing tools or card action handling