### PR TITLE
fix(agents): improve subagent output extraction for edge cases

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -248,6 +248,8 @@ function extractSubagentOutputText(message: unknown): string {
   }
   const role = (message as { role?: unknown }).role;
   const content = (message as { content?: unknown }).content;
+
+  // Try assistant role first
   if (role === "assistant") {
     const assistantText = extractAssistantText(message);
     if (assistantText) {
@@ -261,10 +263,14 @@ function extractSubagentOutputText(message: unknown): string {
     }
     return "";
   }
+
+  // Try toolResult or tool role
   if (role === "toolResult" || role === "tool") {
     return extractToolResultText((message as ToolResultMessage).content);
   }
-  if (role == null) {
+
+  // Try user role as fallback - subagent results might be in user messages
+  if (role === "user") {
     if (typeof content === "string") {
       return sanitizeTextContent(content);
     }
@@ -272,6 +278,30 @@ function extractSubagentOutputText(message: unknown): string {
       return extractInlineTextContent(content);
     }
   }
+
+  // Handle null/undefined role - check all possible content fields
+  if (role == null) {
+    // Try all possible content fields
+    if (typeof content === "string") {
+      return sanitizeTextContent(content);
+    }
+    if (Array.isArray(content)) {
+      return extractInlineTextContent(content);
+    }
+
+    // Check for raw result field at message root
+    const rawResult = (message as { result?: unknown }).result;
+    if (typeof rawResult === "string") {
+      return sanitizeTextContent(rawResult);
+    }
+
+    // Check for output field at message root
+    const output = (message as { output?: unknown }).output;
+    if (typeof output === "string") {
+      return sanitizeTextContent(output);
+    }
+  }
+
   return "";
 }
 


### PR DESCRIPTION
## Summary
Fixes #43755

### Problem
When using `sessions_spawn` to call claude subagent, the result is captured by gateway but not delivered to parent session, showing `(no output)` instead of actual content.

### Root Cause
The `extractSubagentOutputText()` function may not handle all message formats correctly. When subagent results are stored in different formats (user role, or with different content fields), the extraction fails and returns empty string.

### Solution
Added more fallback handling in `extractSubagentOutputText()`:
- Try user role as fallback (results might be in user messages)
- Check for raw "result" field at message root
- Check for "output" field at message root
- Handle more edge cases

### Test
1. Use `sessions_spawn(agentId="claude", task="...")` in main session
2. Wait for subagent to complete
3. Parent session should receive actual result instead of `(no output)`