### PR TITLE
fix(windows): bootstrap UTF-8 before running gateway task script

### DIFF
--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -61,6 +61,7 @@ describe("installScheduledTask", () => {
       });
 
       const script = await fs.readFile(scriptPath, "utf8");
+      expect(script).toContain("chcp 65001>nul");
       expect(script).toContain('cd /d "C:\\temp\\poc&calc"');
       expect(script).toContain(
         'node gateway.js --display-name "safe&whoami" --percent "%%TEMP%%" --bang "^!token^!"',
@@ -149,6 +150,47 @@ describe("installScheduledTask", () => {
       const script = await fs.readFile(scriptPath, "utf8");
       expect(script).not.toContain('set "PATH=');
       expect(script).toContain('set "OPENCLAW_GATEWAY_PORT=18789"');
+    });
+  });
+
+  it("bootstraps UTF-8 before emitting non-ASCII paths into the task script", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      const { scriptPath } = await installScheduledTask({
+        env,
+        stdout: new PassThrough(),
+        programArguments: [
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\Users\\幻14\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+          "gateway",
+          "run",
+        ],
+        workingDirectory: "C:\\Users\\幻14\\projects\\openclaw",
+        environment: {
+          OPENCLAW_PROFILE_LABEL: "杭州-默认",
+        },
+      });
+
+      const script = await fs.readFile(scriptPath, "utf8");
+      expect(script).toContain("@echo off\r\nchcp 65001>nul\r\n");
+      expect(script).toContain("cd /d C:\\Users\\幻14\\projects\\openclaw");
+      expect(script).toContain(
+        '"C:\\Program Files\\nodejs\\node.exe" C:\\Users\\幻14\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js gateway run',
+      );
+      expect(script).toContain('set "OPENCLAW_PROFILE_LABEL=杭州-默认"');
+
+      const parsed = await readScheduledTaskCommand(env);
+      expect(parsed).toMatchObject({
+        programArguments: [
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\Users\\幻14\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+          "gateway",
+          "run",
+        ],
+        workingDirectory: "C:\\Users\\幻14\\projects\\openclaw",
+        environment: {
+          OPENCLAW_PROFILE_LABEL: "杭州-默认",
+        },
+      });
     });
   });
 });

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -184,6 +184,29 @@ describe("readScheduledTaskCommand", () => {
     );
   });
 
+  it("skips the UTF-8 code page bootstrap line before parsing the real command", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "chcp 65001>nul",
+          '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\幻14\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js" gateway run',
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: [
+            "C:\\Program Files\\nodejs\\node.exe",
+            "C:\\Users\\幻14\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+            "gateway",
+            "run",
+          ],
+        });
+      },
+    );
+  });
+
   it("returns null when script does not exist", async () => {
     await withScheduledTaskScript({}, async (env) => {
       const result = await readScheduledTaskCommand(env);

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -37,6 +37,10 @@ export function resolveTaskScriptPath(env: GatewayServiceEnv): string {
   return path.join(stateDir, scriptName);
 }
 
+function isCmdUtf8BootstrapLine(value: string): boolean {
+  return /^@?chcp(?:\.com|\.exe)?\s+65001(?:\s*>\s*nul)?$/i.test(value.trim());
+}
+
 // `/TR` is parsed by schtasks itself, while the generated `gateway.cmd` line is parsed by cmd.exe.
 // Keep their quoting strategies separate so each parser gets the encoding it expects.
 function quoteSchtasksArg(value: string): string {
@@ -77,6 +81,9 @@ export async function readScheduledTaskCommand(
       }
       const lower = line.toLowerCase();
       if (line.startsWith("@echo")) {
+        continue;
+      }
+      if (isCmdUtf8BootstrapLine(line)) {
         continue;
       }
       if (lower.startsWith("rem ")) {
@@ -186,7 +193,7 @@ function buildTaskScript({
   workingDirectory,
   environment,
 }: GatewayServiceRenderArgs): string {
-  const lines: string[] = ["@echo off"];
+  const lines: string[] = ["@echo off", "chcp 65001>nul"];
   const trimmedDescription = description?.trim();
   if (trimmedDescription) {
     assertNoCmdLineBreak(trimmedDescription, "Task description");


### PR DESCRIPTION
## Summary
- prepend `chcp 65001>nul` to generated Windows gateway task scripts so `cmd.exe` reads non-ASCII paths correctly
- teach scheduled-task command parsing to ignore the UTF-8 bootstrap line
- add regression coverage for Chinese-path task scripts

## Testing
- pnpm exec vitest run --config vitest.unit.config.ts src/daemon/schtasks.install.test.ts src/daemon/schtasks.test.ts src/daemon/cmd-argv.test.ts
- pnpm exec oxfmt --check src/daemon/schtasks.ts src/daemon/schtasks.install.test.ts src/daemon/schtasks.test.ts

Closes #43943
