### PR TITLE
fix(whatsapp): widen reconnect-window retries

### DIFF
--- a/src/web/auto-reply/deliver-reply.test.ts
+++ b/src/web/auto-reply/deliver-reply.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { logVerbose } from "../../globals.js";
 import { sleep } from "../../utils.js";
 import { loadWebMedia } from "../media.js";
@@ -84,6 +84,10 @@ async function expectReplySuppressed(replyResult: { text: string; isReasoning?: 
 }
 
 describe("deliverWebReply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("suppresses payloads flagged as reasoning", async () => {
     await expectReplySuppressed({ text: "Reasoning:\n_hidden_", isReasoning: true });
   });
@@ -145,7 +149,7 @@ describe("deliverWebReply", () => {
       });
 
       expect(msg.reply).toHaveBeenCalledTimes(2);
-      expect(sleep).toHaveBeenCalledWith(500);
+      expect(sleep).toHaveBeenCalledWith(1000);
     },
   );
 
@@ -199,7 +203,59 @@ describe("deliverWebReply", () => {
     });
 
     expect(msg.sendMedia).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledWith(500);
+    expect(sleep).toHaveBeenCalledWith(1000);
+  });
+
+  it("keeps retrying transient text failures until the fifth attempt", async () => {
+    const msg = makeMsg();
+    const replyMock = msg.reply as unknown as {
+      mockRejectedValueOnce: (v: unknown) => unknown;
+      mockResolvedValueOnce: (v: unknown) => unknown;
+    };
+    replyMock.mockRejectedValueOnce(new Error("Connection Closed"));
+    replyMock.mockRejectedValueOnce(new Error("Connection Closed"));
+    replyMock.mockRejectedValueOnce(new Error("Connection Closed"));
+    replyMock.mockRejectedValueOnce(new Error("Connection Closed"));
+    replyMock.mockResolvedValueOnce(undefined);
+
+    await deliverWebReply({
+      replyResult: { text: "hi" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.reply).toHaveBeenCalledTimes(5);
+    expect(sleep).toHaveBeenNthCalledWith(1, 1000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 2000);
+    expect(sleep).toHaveBeenNthCalledWith(3, 3000);
+    expect(sleep).toHaveBeenNthCalledWith(4, 4000);
+  });
+
+  it("throws after exhausting transient text retries", async () => {
+    const msg = makeMsg();
+    (msg.reply as unknown as { mockRejectedValue: (v: unknown) => void }).mockRejectedValue(
+      new Error("Connection Closed"),
+    );
+
+    await expect(
+      deliverWebReply({
+        replyResult: { text: "hi" },
+        msg,
+        maxMediaBytes: 1024 * 1024,
+        textLimit: 200,
+        replyLogger,
+        skipLog: true,
+      }),
+    ).rejects.toThrow("Connection Closed");
+
+    expect(msg.reply).toHaveBeenCalledTimes(5);
+    expect(sleep).toHaveBeenNthCalledWith(1, 1000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 2000);
+    expect(sleep).toHaveBeenNthCalledWith(3, 3000);
+    expect(sleep).toHaveBeenNthCalledWith(4, 4000);
   });
 
   it("falls back to text-only when the first media send fails", async () => {

--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -13,6 +13,8 @@ import type { WebInboundMsg } from "./types.js";
 import { elide } from "./util.js";
 
 const REASONING_PREFIX = "reasoning:";
+const SEND_RETRY_MAX_ATTEMPTS = 5;
+const SEND_RETRY_BACKOFF_MS = 1000;
 
 function shouldSuppressReasoningReply(payload: ReplyPayload): boolean {
   if (payload.isReasoning === true) {
@@ -58,7 +60,11 @@ export async function deliverWebReply(params: {
       ? [replyResult.mediaUrl]
       : [];
 
-  const sendWithRetry = async (fn: () => Promise<unknown>, label: string, maxAttempts = 3) => {
+  const sendWithRetry = async (
+    fn: () => Promise<unknown>,
+    label: string,
+    maxAttempts = SEND_RETRY_MAX_ATTEMPTS,
+  ) => {
     let lastErr: unknown;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
@@ -71,7 +77,7 @@ export async function deliverWebReply(params: {
         if (!shouldRetry || isLast) {
           throw err;
         }
-        const backoffMs = 500 * attempt;
+        const backoffMs = SEND_RETRY_BACKOFF_MS * attempt;
         logVerbose(
           `Retrying ${label} to ${msg.from} after failure (${attempt}/${maxAttempts - 1}) in ${backoffMs}ms: ${errText}`,
         );

--- a/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/src/web/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -9,8 +9,9 @@ let capturedDispatchParams: unknown;
 let sessionDir: string | undefined;
 let sessionStorePath: string;
 let backgroundTasks: Set<Promise<unknown>>;
-const { deliverWebReplyMock } = vi.hoisted(() => ({
+const { deliverWebReplyMock, enqueueSystemEventMock } = vi.hoisted(() => ({
   deliverWebReplyMock: vi.fn(async () => {}),
+  enqueueSystemEventMock: vi.fn(),
 }));
 
 const defaultReplyLogger = {
@@ -106,6 +107,10 @@ vi.mock("../deliver-reply.js", () => ({
   deliverWebReply: deliverWebReplyMock,
 }));
 
+vi.mock("../../../infra/system-events.js", () => ({
+  enqueueSystemEvent: enqueueSystemEventMock,
+}));
+
 import { updateLastRouteInBackground } from "./last-route.js";
 import { processMessage } from "./process-message.js";
 
@@ -115,6 +120,7 @@ describe("web processMessage inbound contract", () => {
     capturedDispatchParams = undefined;
     backgroundTasks = new Set();
     deliverWebReplyMock.mockClear();
+    enqueueSystemEventMock.mockClear();
     sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-process-message-"));
     sessionStorePath = path.join(sessionDir, "sessions.json");
   });
@@ -298,6 +304,23 @@ describe("web processMessage inbound contract", () => {
     await deliver?.({ text: "final payload" }, { kind: "final" });
     expect(deliverWebReplyMock).toHaveBeenCalledTimes(1);
     expect(rememberSentText).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces WhatsApp delivery failures as system events", async () => {
+    await processMessage(createWhatsAppDirectStreamingArgs());
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const onError = (capturedDispatchParams as any)?.dispatcherOptions?.onError as
+      | ((err: unknown, info: { kind: "tool" | "block" | "final" }) => void)
+      | undefined;
+    expect(onError).toBeTypeOf("function");
+
+    onError?.(new Error("Connection Closed"), { kind: "final" });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "WhatsApp auto-reply delivery failed to +1555: Connection Closed",
+      { sessionKey: "agent:main:whatsapp:direct:+1555" },
+    );
   });
 
   it("forces disableBlockStreaming for WhatsApp dispatch", async () => {

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -17,6 +17,7 @@ import type { loadConfig } from "../../../config/config.js";
 import { resolveMarkdownTableMode } from "../../../config/markdown-tables.js";
 import { recordSessionMetaFromInbound } from "../../../config/sessions.js";
 import { logVerbose, shouldLogVerbose } from "../../../globals.js";
+import { enqueueSystemEvent } from "../../../infra/system-events.js";
 import type { getChildLogger } from "../../../logging.js";
 import { getAgentScopedMediaLocalRoots } from "../../../media/local-roots.js";
 import {
@@ -443,9 +444,12 @@ export async function processMessage(params: {
             : info.kind === "block"
               ? "block update"
               : "auto-reply";
-        whatsappOutboundLog.error(
-          `Failed sending web ${label} to ${params.msg.from ?? conversationId}: ${formatError(err)}`,
-        );
+        const errorText = formatError(err);
+        const target = params.msg.from ?? conversationId;
+        whatsappOutboundLog.error(`Failed sending web ${label} to ${target}: ${errorText}`);
+        enqueueSystemEvent(`WhatsApp ${label} delivery failed to ${target}: ${errorText}`, {
+          sessionKey: params.route.sessionKey,
+        });
       },
       onReplyStart: params.msg.sendComposing,
     },


### PR DESCRIPTION
## Summary

Fixes #14827.

When WhatsApp Web is reconnecting after a transient 408/503-style disconnect, replies could exhaust their retry budget before the socket was usable again. The delivery failure was then only logged by the dispatcher, so the agent had no structured signal that the message never reached the user.

## What changed

### 1) Widen the WhatsApp send retry window
In `src/web/auto-reply/deliver-reply.ts`:

- increase default retry attempts from **3 → 5**
- increase linear backoff from **500ms × attempt → 1000ms × attempt**

That extends the retry window enough to cover the typical 3–5s reconnect gap without introducing a broader outbound queue.

### 2) Surface delivery failures to the agent
In `src/web/auto-reply/monitor/process-message.ts`:

- keep the existing outbound error log
- additionally enqueue a **system event** when WhatsApp final delivery fails

That means the failure is no longer silent from the agent/session perspective.

## Why this scope

This is the smallest safe fix I could make with high confidence:

- it improves the common reconnect-window case directly
- it avoids introducing a new queue / flush lifecycle in the WhatsApp transport path
- it makes unrecovered failures visible instead of silently dropping them

Tradeoff: this does **not** add a durable outbound queue. If the reconnect gap exceeds the wider retry window, delivery can still fail — but now it is surfaced instead of disappearing silently.

## Tests

- `pnpm exec vitest run src/web/auto-reply/deliver-reply.test.ts src/web/auto-reply/monitor/process-message.inbound-contract.test.ts`
- `pnpm exec tsc --noEmit`
