### PR TITLE
fix(agents): skip tool calls without valid name on model switch

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -572,7 +572,7 @@ describe("convertMessagesToInputItems", () => {
     // Paired tool result should also be skipped when tool call was skipped due to empty name
     const msg1 = assistantMsg([], [{ id: "call123", name: "", args: { query: "test" } }]);
     const msg2 = {
-      role: "tool_result" as const,
+      role: "toolResult" as const,
       toolCallId: "call123",
       content: [{ type: "output_text", output: "result" }],
     };

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -561,6 +561,25 @@ describe("convertMessagesToInputItems", () => {
     expect(items).toEqual([]);
   });
 
+  it("drops assistant tool calls with empty names (model switch scenario)", () => {
+    // This happens during model switching (e.g., Gemini -> Grok -> Gemini)
+    const msg = assistantMsg([], [{ id: "call123", name: "", args: { path: "/tmp/a" } }]);
+    const items = convertMessagesToInputItems([msg] as Parameters<typeof convertMessagesToInputItems>[0]);
+    expect(items).toEqual([]);
+  });
+
+  it("drops tool results for skipped empty-name tool calls", () => {
+    // Paired tool result should also be skipped when tool call was skipped due to empty name
+    const msg1 = assistantMsg([], [{ id: "call123", name: "", args: { query: "test" } }]);
+    const msg2 = {
+      role: "tool_result" as const,
+      toolCallId: "call123",
+      content: [{ type: "output_text", output: "result" }],
+    };
+    const items = convertMessagesToInputItems([msg1, msg2] as Parameters<typeof convertMessagesToInputItems>[0]);
+    expect(items).toEqual([]);
+  });
+
   it("skips thinking blocks in assistant messages", () => {
     const msg = {
       role: "assistant" as const,

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -368,6 +368,8 @@ export function convertMessagesToInputItems(
           pushAssistantText();
           const callIdRaw = toNonEmptyString(block.id);
           const toolName = toNonEmptyString(block.name);
+          // Skip tool calls without valid name - this can happen when switching models
+          // and the context contains function_response from a different model format
           if (!callIdRaw || !toolName) {
             continue;
           }

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -415,6 +415,10 @@ export function convertMessagesToInputItems(
     const parts = Array.isArray(m.content) ? contentToOpenAIParts(m.content, modelOverride) : [];
     const textOutput = contentToText(m.content);
     const imageParts = parts.filter((part) => part.type === "input_image");
+    // Skip if callId is empty (no corresponding function_call)
+    if (!callId) {
+      continue;
+    }
     items.push({
       type: "function_call_output",
       call_id: callId,

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -417,6 +417,7 @@ export function convertMessagesToInputItems(
       continue;
     }
     const [callId] = toolCallId.split("|", 2);
+    const skippedCallIds = new Set<string>();
     const parts = Array.isArray(m.content) ? contentToOpenAIParts(m.content, modelOverride) : [];
     const textOutput = contentToText(m.content);
     const imageParts = parts.filter((part) => part.type === "input_image");

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -422,7 +422,9 @@ export function convertMessagesToInputItems(
     const textOutput = contentToText(m.content);
     const imageParts = parts.filter((part) => part.type === "input_image");
     // Skip if callId was skipped in function_call (model switch scenario)
+    // and remove it so later valid calls with same ID are not blocked
     if (skippedCallIds.has(callId)) {
+      skippedCallIds.delete(callId);
       continue;
     }
     items.push({

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -292,6 +292,7 @@ export function convertMessagesToInputItems(
   modelOverride?: ReplayModelInfo,
 ): InputItem[] {
   const items: InputItem[] = [];
+  const skippedCallIds = new Set<string>();
 
   for (const msg of messages) {
     const m = msg as AnyMessage & {
@@ -417,7 +418,6 @@ export function convertMessagesToInputItems(
       continue;
     }
     const [callId] = toolCallId.split("|", 2);
-    const skippedCallIds = new Set<string>();
     const parts = Array.isArray(m.content) ? contentToOpenAIParts(m.content, modelOverride) : [];
     const textOutput = contentToText(m.content);
     const imageParts = parts.filter((part) => part.type === "input_image");

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -292,7 +292,7 @@ export function convertMessagesToInputItems(
   modelOverride?: ReplayModelInfo,
 ): InputItem[] {
   const items: InputItem[] = [];
-  const skippedCallIds = new Set<string>();
+  const skippedCallIds = new Map<string, boolean>(); // callId -> whether paired function_call existed
 
   for (const msg of messages) {
     const m = msg as AnyMessage & {
@@ -375,11 +375,12 @@ export function convertMessagesToInputItems(
             // Track skipped callId so function_call_output can skip it too
             if (callIdRaw) {
               const [skippedId] = callIdRaw.split("|", 2);
-              skippedCallIds.add(skippedId);
+              skippedCallIds.set(skippedId, false); // false = no function_call
             }
             continue;
           }
           const [callId, itemId] = callIdRaw.split("|", 2);
+          skippedCallIds.set(callId, true); // true = has function_call
           items.push({
             type: "function_call",
             ...(itemId ? { id: itemId } : {}),
@@ -423,7 +424,8 @@ export function convertMessagesToInputItems(
     const imageParts = parts.filter((part) => part.type === "input_image");
     // Skip if callId was skipped in function_call (model switch scenario)
     // and remove it so later valid calls with same ID are not blocked
-    if (skippedCallIds.has(callId)) {
+    // Skip only if no valid function_call existed for this callId
+    if (skippedCallIds.get(callId) === false) {
       skippedCallIds.delete(callId);
       continue;
     }

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -371,6 +371,11 @@ export function convertMessagesToInputItems(
           // Skip tool calls without valid name - this can happen when switching models
           // and the context contains function_response from a different model format
           if (!callIdRaw || !toolName) {
+            // Track skipped callId so function_call_output can skip it too
+            if (callIdRaw) {
+              const [skippedId] = callIdRaw.split("|", 2);
+              skippedCallIds.add(skippedId);
+            }
             continue;
           }
           const [callId, itemId] = callIdRaw.split("|", 2);
@@ -415,8 +420,8 @@ export function convertMessagesToInputItems(
     const parts = Array.isArray(m.content) ? contentToOpenAIParts(m.content, modelOverride) : [];
     const textOutput = contentToText(m.content);
     const imageParts = parts.filter((part) => part.type === "input_image");
-    // Skip if callId is empty (no corresponding function_call)
-    if (!callId) {
+    // Skip if callId was skipped in function_call (model switch scenario)
+    if (skippedCallIds.has(callId)) {
       continue;
     }
     items.push({


### PR DESCRIPTION
## Summary
Fixes #43930

### Problem
When switching between models (e.g., Gemini → Grok → Gemini), the context may contain function_response entries that were valid for the previous model but cause errors for Gemini API with:
```
INVALID_ARGUMENT: Name cannot be empty
GenerateContentRequest.contents[N].parts[0].function_response.name: Name cannot be empty
```

### Root Cause
When switching models mid-session, the conversation history contains tool calls from the previous model. These may have different format requirements. Gemini API requires function_response.name to be non-empty, but other models may allow empty names.

### Solution
Skip tool calls without valid name during message conversion in convertMessagesToInputItems(). This prevents the INVALID_ARGUMENT error from Gemini API.

### Related
- PR #41173 added stripRuntimeModelState() for session reset
- This is a different scenario (model switch vs session reset) that needs separate handling

### Test
1. Configure Gemini Latest Flash
2. Switch to Grok mid-session
3. Switch back to Gemini Latest Flash
4. Send a message - should work without error