### PR TITLE
Cron: scope isolated subagent waits to current run window (fix #43850)

### DIFF
--- a/scripts/restart-gateway.sh
+++ b/scripts/restart-gateway.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+
+# Safe gateway restart script
+# This script restarts the gateway process safely without killing the script itself
+# It reads config from ~/.openclaw/openclaw.json or uses env var defaults
+
+set -eu
+
+# Configuration file path
+OPENCLAW_CONFIG="${OPENCLAW_CONFIG:-$HOME/.openclaw/openclaw.json}"
+
+# Get port and bind from config file or environment variables
+if [ -f "$OPENCLAW_CONFIG" ]; then
+  GATEWAY_PORT="$(node -e "console.log(require('$OPENCLAW_CONFIG').gateway?.port || '18789')" 2>/dev/null)"
+  GATEWAY_BIND="$(node -e "console.log(require('$OPENCLAW_CONFIG').gateway?.bind || 'loopback')" 2>/dev/null)"
+else
+  GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+  GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-loopback}"
+fi
+
+# Log file path (default to ~/.openclaw/logs/gateway-restart.log)
+LOG_PATH="${OPENCLAW_GATEWAY_RESTART_LOG:-$HOME/.openclaw/logs/gateway-restart.log}"
+
+# Ensure log directory exists
+LOG_DIR="$(dirname "${LOG_PATH}")"
+mkdir -p "${LOG_DIR}" 2>/dev/null || true
+
+# Log restart request with POSIX-compatible timestamp
+# Use date -u + for cross-platform compatibility (works on both GNU and BSD date)
+printf "%s\n" "==> openclaw gateway restart requested at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+# Kill only the gateway process, NOT the script itself
+# Use -x to match exact command name and avoid matching the script's own command line
+pkill -9 -f -x "openclaw-gateway" || true
+
+sleep 2
+
+# Start gateway in background with proper env var forwarding
+# Forward all necessary env vars to the detached shell
+nohup env \
+  LOG_PATH="${LOG_PATH}" \
+  GATEWAY_PORT="${GATEWAY_PORT}" \
+  GATEWAY_BIND="${GATEWAY_BIND}" \
+sh -c '
+  {
+    # Log restart completion with POSIX-compatible timestamp
+    printf "%s\n" "==> openclaw gateway restarted at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+    # Start gateway with config-provided or defaulted port/bind
+    openclaw gateway run --bind "${GATEWAY_BIND}" --port "${GATEWAY_PORT}" --force
+  } >> "${LOG_PATH}" 2>&1
+' >/dev/null 2>&1 &
+
+printf "%s\n" "Gateway restart scheduled; see ${LOG_PATH} for details."

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../agents/subagent-registry.js", () => ({
   countActiveDescendantRuns: vi.fn().mockReturnValue(0),
+  listDescendantRunsForRequester: vi.fn().mockReturnValue([]),
 }));
 
 vi.mock("../../infra/outbound/deliver.js", () => ({
@@ -46,7 +47,10 @@ vi.mock("./subagent-followup.js", () => ({
 }));
 
 // Import after mocks
-import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
+import {
+  countActiveDescendantRuns,
+  listDescendantRunsForRequester,
+} from "../../agents/subagent-registry.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import { shouldEnqueueCronMainSummary } from "../heartbeat-policy.js";
 import { dispatchCronDelivery } from "./delivery-dispatch.js";
@@ -127,6 +131,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([]);
     vi.mocked(expectsSubagentFollowup).mockReturnValue(false);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
     vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
@@ -138,8 +143,20 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   });
 
   it("early return (active subagent) sets deliveryAttempted=true so timer skips enqueueSystemEvent", async () => {
-    // countActiveDescendantRuns returns >0 → enters wait block; still >0 after wait → early return
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(2);
+    // listDescendantRunsForRequester returns active descendants in the current window
+    const now = Date.now();
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([
+      {
+        runId: "run-1",
+        childSessionKey: "child-session",
+        requesterSessionKey: "agent:main",
+        requesterDisplayKey: "agent:main",
+        task: "task",
+        cleanup: "keep",
+        createdAt: now,
+        startedAt: now,
+      },
+    ]);
     vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
     vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
 
@@ -166,10 +183,22 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   });
 
   it("early return (stale interim suppression) sets deliveryAttempted=true so timer skips enqueueSystemEvent", async () => {
-    // First countActiveDescendantRuns call returns >0 (had descendants), second returns 0
-    vi.mocked(countActiveDescendantRuns)
-      .mockReturnValueOnce(2) // initial check → hadDescendants=true, enters wait block
-      .mockReturnValueOnce(0); // second check after wait → activeSubagentRuns=0
+    // First window-scoped active run count >0 (had descendants), after wait it becomes 0
+    const now = Date.now();
+    vi.mocked(listDescendantRunsForRequester)
+      .mockReturnValueOnce([
+        {
+          runId: "run-1",
+          childSessionKey: "child-session",
+          requesterSessionKey: "agent:main",
+          requesterDisplayKey: "agent:main",
+          task: "task",
+          cleanup: "keep",
+          createdAt: now,
+          startedAt: now,
+        },
+      ])
+      .mockReturnValueOnce([]);
     vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
     vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
     // synthesizedText matches initialSynthesizedText & isLikelyInterimCronMessage → stale interim
@@ -198,7 +227,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   });
 
   it("consolidates descendant output into the final direct delivery", async () => {
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([]);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
     vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(
       "Detailed child result, everything finished successfully.",
@@ -223,7 +252,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   });
 
   it("normal text delivery sends exactly once and sets deliveryAttempted=true", async () => {
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([]);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
 
     const params = makeBaseParams({ synthesizedText: "Morning briefing complete." });

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -47,10 +47,7 @@ vi.mock("./subagent-followup.js", () => ({
 }));
 
 // Import after mocks
-import {
-  countActiveDescendantRuns,
-  listDescendantRunsForRequester,
-} from "../../agents/subagent-registry.js";
+import { listDescendantRunsForRequester } from "../../agents/subagent-registry.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import { shouldEnqueueCronMainSummary } from "../heartbeat-policy.js";
 import { dispatchCronDelivery } from "./delivery-dispatch.js";
@@ -130,7 +127,6 @@ function makeBaseParams(overrides: { synthesizedText?: string; deliveryRequested
 describe("dispatchCronDelivery — double-announce guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(listDescendantRunsForRequester).mockReturnValue([]);
     vi.mocked(expectsSubagentFollowup).mockReturnValue(false);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
@@ -276,7 +272,6 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   });
 
   it("text delivery fires exactly once (no double-deliver)", async () => {
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
     vi.mocked(deliverOutboundPayloads).mockResolvedValue([{ ok: true } as never]);
 
@@ -292,7 +287,6 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
   it("retries transient direct announce failures before succeeding", async () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
     vi.mocked(deliverOutboundPayloads)
       .mockRejectedValueOnce(new Error("ECONNRESET while sending"))
@@ -309,7 +303,6 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
   it("does not retry permanent direct announce failures", async () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
     vi.mocked(deliverOutboundPayloads).mockRejectedValue(new Error("chat not found"));
 
@@ -338,7 +331,6 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   });
 
   it("text delivery always bypasses the write-ahead queue", async () => {
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
     vi.mocked(deliverOutboundPayloads).mockResolvedValue([{ ok: true } as never]);
 
@@ -360,7 +352,6 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   });
 
   it("structured/thread delivery also bypasses the write-ahead queue", async () => {
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
     vi.mocked(deliverOutboundPayloads).mockResolvedValue([{ ok: true } as never]);
 
@@ -376,7 +367,6 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   });
 
   it("transient retry delivers exactly once with skipQueue on both attempts", async () => {
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
 
     // First call throws a transient error, second call succeeds.

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -15,7 +15,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // --- Module mocks (must be hoisted before imports) ---
 
 vi.mock("../../agents/subagent-registry.js", () => ({
-  countActiveDescendantRuns: vi.fn().mockReturnValue(0),
   listDescendantRunsForRequester: vi.fn().mockReturnValue([]),
 }));
 
@@ -85,8 +84,13 @@ function makeWithRunSession() {
   });
 }
 
-function makeBaseParams(overrides: { synthesizedText?: string; deliveryRequested?: boolean }) {
+function makeBaseParams(overrides: {
+  synthesizedText?: string;
+  deliveryRequested?: boolean;
+  runStartedAt?: number;
+}) {
   const resolvedDelivery = makeResolvedDelivery();
+  const now = overrides.runStartedAt ?? Date.now();
   return {
     cfg: {} as never,
     cfgWithAgentDefaults: {} as never,
@@ -100,8 +104,8 @@ function makeBaseParams(overrides: { synthesizedText?: string; deliveryRequested
     agentId: "main",
     agentSessionKey: "agent:main",
     runSessionId: "run-123",
-    runStartedAt: Date.now(),
-    runEndedAt: Date.now(),
+    runStartedAt: now,
+    runEndedAt: now,
     timeoutMs: 30_000,
     resolvedDelivery,
     deliveryRequested: overrides.deliveryRequested ?? true,

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,4 +1,4 @@
-import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
+import { listDescendantRunsForRequester } from "../../agents/subagent-registry.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
@@ -315,7 +315,25 @@ export async function dispatchCronDelivery(
       return null;
     }
     const initialSynthesizedText = synthesizedText.trim();
-    let activeSubagentRuns = countActiveDescendantRuns(params.agentSessionKey);
+    const windowStart = params.runStartedAt;
+    const getActiveSubagentRunsInWindow = (): number => {
+      const runs = listDescendantRunsForRequester(params.agentSessionKey).filter((entry) => {
+        if (typeof entry.endedAt === "number") {
+          return false;
+        }
+        if (typeof windowStart !== "number" || !Number.isFinite(windowStart)) {
+          return true;
+        }
+        const timestamp =
+          typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
+            ? entry.startedAt
+            : entry.createdAt;
+        return Number.isFinite(timestamp) && timestamp >= windowStart;
+      });
+      return runs.length;
+    };
+
+    let activeSubagentRuns = getActiveSubagentRunsInWindow();
     const expectedSubagentFollowup = expectsSubagentFollowup(initialSynthesizedText);
     // Also check for already-completed descendants. If the subagent finished
     // before delivery-dispatch runs, activeSubagentRuns is 0 and
@@ -336,8 +354,9 @@ export async function dispatchCronDelivery(
         initialReply: initialSynthesizedText,
         timeoutMs: params.timeoutMs,
         observedActiveDescendants: activeSubagentRuns > 0 || expectedSubagentFollowup,
+        runStartedAt: params.runStartedAt,
       });
-      activeSubagentRuns = countActiveDescendantRuns(params.agentSessionKey);
+      activeSubagentRuns = getActiveSubagentRunsInWindow();
       if (!finalReply && activeSubagentRuns === 0) {
         finalReply = await readDescendantSubagentFallbackReply({
           sessionKey: params.agentSessionKey,

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -345,6 +345,35 @@ describe("waitForDescendantSubagentSummary", () => {
     expect(result).toBeUndefined();
   });
 
+  it("does not wait on stale active descendants outside the current run window", async () => {
+    vi.useFakeTimers();
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([
+      {
+        runId: "stale-run",
+        childSessionKey: "child-session",
+        requesterSessionKey: "cron-session",
+        requesterDisplayKey: "cron-session",
+        task: "old task",
+        cleanup: "keep",
+        createdAt: 1_000,
+        startedAt: 1_500,
+      },
+    ]);
+    vi.mocked(callGateway).mockResolvedValue({ status: "ok" });
+
+    const resultPromise = waitForDescendantSubagentSummary({
+      sessionKey: "cron-session",
+      initialReply: "on it",
+      timeoutMs: 30_000,
+      observedActiveDescendants: true,
+      runStartedAt: 5_000,
+    });
+
+    const result = await resolveAfterAdvancingTimers(resultPromise);
+    expect(result).toBeUndefined();
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
   it("returns synthesis even if initial reply was undefined", async () => {
     vi.mocked(listDescendantRunsForRequester)
       .mockReturnValueOnce([

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -109,6 +109,23 @@ export async function readDescendantSubagentFallbackReply(params: {
   return replies.join("\n\n");
 }
 
+function isInRunWindow(
+  entry: {
+    startedAt?: number;
+    createdAt: number;
+  },
+  runStartedAt?: number,
+): boolean {
+  if (typeof runStartedAt !== "number" || !Number.isFinite(runStartedAt)) {
+    return true;
+  }
+  const timestamp =
+    typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
+      ? entry.startedAt
+      : entry.createdAt;
+  return Number.isFinite(timestamp) && timestamp >= runStartedAt;
+}
+
 /**
  * Waits for descendant subagents to complete using a push-based approach:
  * each active descendant run is awaited via `agent.wait` (gateway RPC) instead
@@ -120,14 +137,16 @@ export async function waitForDescendantSubagentSummary(params: {
   initialReply?: string;
   timeoutMs: number;
   observedActiveDescendants?: boolean;
+  runStartedAt?: number;
 }): Promise<string | undefined> {
   const initialReply = params.initialReply?.trim();
   const deadline = Date.now() + Math.max(CRON_SUBAGENT_WAIT_MIN_MS, Math.floor(params.timeoutMs));
 
-  // Snapshot the currently active descendant run IDs.
+  // Snapshot the currently active descendant run IDs, scoped to the current cron run window
+  // when available so stale descendants from previous executions do not block the wait.
   const getActiveRuns = () =>
     listDescendantRunsForRequester(params.sessionKey).filter(
-      (entry) => typeof entry.endedAt !== "number",
+      (entry) => typeof entry.endedAt !== "number" && isInRunWindow(entry, params.runStartedAt),
     );
 
   const initialActiveRuns = getActiveRuns();


### PR DESCRIPTION
## Summary

- Problem: Isolated cron `agentTurn` runs can block on stale descendant subagent runs from previous executions, causing jobs to time out even when the current run's work is short.
- Why it matters: Scheduled proactive/heartbeat checks with `sessionTarget: "isolated"` can fail reliably and never deliver results, even though the underlying task completes quickly.
- What changed:
  - Scoped isolated descendant wait in `waitForDescendantSubagentSummary` to the current run window (`runStartedAt`) so only descendants started in this run are awaited.
  - Updated cron isolated delivery dispatch to count active descendants within the current run window using `listDescendantRunsForRequester`, and to pass `runStartedAt` through to the follow-up wait.
  - Extended unit tests to cover scenarios with only stale active descendants and to keep the double-announce guard behaviour intact.
- What did NOT change (scope boundary): Cron timeout policies and non-isolated cron delivery behaviour.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #43850

## User-visible / Behavior Changes

- Isolated cron `agentTurn` jobs no longer time out due to stale descendant subagent runs from previous executions; they only wait on descendants started in the current run window.
- When only stale active descendants exist, the job completes without blocking on them or silently suppressing delivery.

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux (dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A (unit tests only)
- Integration/channel: Cron isolated agent delivery path

### Steps

1. Add isolated cron scenarios with stale descendant runs in the registry.
2. Run unit tests that exercise isolated cron delivery and descendant follow-up.
3. Confirm that:
   - Stale-only descendants do not cause `agent.wait` to block.
   - Active descendants within the run window are still awaited.
   - Double-announce protection remains intact.

### Expected

- Cron isolated runs only wait on descendants started in the current run, and do not time out due to stale descendants.

### Actual

- With this patch, tests covering stale-only descendants and active-in-window descendants pass, and the double-announce guard behaviour is preserved.

## Evidence

- [x] Failing test/log before + passing after

  - `pnpm test src/cron/isolated-agent/subagent-followup.test.ts`
  - `pnpm test src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`

## Human Verification

- Verified scenarios:
  - Isolated descendant follow-up with active descendants in the current run window.
  - Isolated descendant follow-up with only stale active descendants before `runStartedAt`.
  - Cron isolated delivery paths with and without descendants, keeping the double-announce guard behaviour.
- Edge cases checked:
  - Missing `startedAt` falling back to `createdAt` for run-window checks.
  - Behaviour when `runStartedAt` is unavailable (non-cron callers).
- What you did **not** verify:
   - End-to-end live cron execution against real providers/channels.