### PR TITLE
fix(agents): exclude synthetic assistant transcript mirrors from Anthropic replay

### DIFF
--- a/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
+++ b/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
@@ -7,8 +7,8 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { validateAnthropicTurns } from "./pi-embedded-helpers.js";
+import { isAnthropicBedrockModel } from "./pi-embedded-runner/anthropic-stream-wrappers.js";
 import { sanitizeSessionHistory } from "./pi-embedded-runner/google.js";
-import { isAnthropicApi } from "./transcript-policy.js";
 
 const ZERO_USAGE: Usage = {
   input: 0,
@@ -133,10 +133,21 @@ async function getReplayableMessagesForTarget(
     sessionManager: reopened,
     sessionId: "test-session",
   });
-  const validated = isAnthropicApi(target.modelApi, target.provider)
+  const validated = shouldValidateAnthropicReplayTarget(target)
     ? validateAnthropicTurns(replayable)
     : replayable;
   return validated.filter(isLlmMessage);
+}
+
+function shouldValidateAnthropicReplayTarget(target: {
+  modelApi: string;
+  provider: string;
+  modelId: string;
+}): boolean {
+  if (target.provider === "anthropic" || target.modelApi === "anthropic-messages") {
+    return true;
+  }
+  return target.modelApi === "bedrock-converse-stream" && isAnthropicBedrockModel(target.modelId);
 }
 
 describe("anthropic thinking replay", () => {
@@ -266,8 +277,9 @@ describe("anthropic thinking replay", () => {
     });
   });
 
-  it("drops delivery-mirror assistant entries for bedrock anthropic-compatible replay", async () => {
-    const sessionFile = path.join(tempRoot, `session-${Date.now()}-bedrock.jsonl`);
+  it("drops delivery-mirror assistant entries for bedrock claude replay", async () => {
+    const sessionFile = path.join(tempRoot, `session-${Date.now()}-bedrock-claude.jsonl`);
+    const modelId = "anthropic.claude-3-7-sonnet-20250219-v1:0";
 
     const sessionManager = SessionManager.open(sessionFile);
     sessionManager.appendMessage({
@@ -278,8 +290,8 @@ describe("anthropic thinking replay", () => {
     sessionManager.appendMessage({
       role: "assistant",
       api: "bedrock-converse-stream",
-      provider: "bedrock",
-      model: "claude-sonnet-4-6",
+      provider: "amazon-bedrock",
+      model: modelId,
       usage: ZERO_USAGE,
       stopReason: "stop",
       timestamp: Date.now(),
@@ -303,8 +315,8 @@ describe("anthropic thinking replay", () => {
 
     const replayable = await getReplayableMessagesForTarget(sessionFile, {
       modelApi: "bedrock-converse-stream",
-      provider: "bedrock",
-      modelId: "claude-sonnet-4-6",
+      provider: "amazon-bedrock",
+      modelId,
     });
 
     expect(replayable.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
@@ -316,6 +328,62 @@ describe("anthropic thinking replay", () => {
           message.model === "delivery-mirror",
       ),
     ).toBe(false);
+  });
+
+  it("keeps delivery-mirror assistant entries for non-anthropic bedrock replay", async () => {
+    const sessionFile = path.join(tempRoot, `session-${Date.now()}-bedrock-nova.jsonl`);
+    const modelId = "amazon.nova-pro-v1:0";
+
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage({
+      role: "user",
+      content: "hello",
+      timestamp: Date.now(),
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      api: "bedrock-converse-stream",
+      provider: "amazon-bedrock",
+      model: modelId,
+      usage: ZERO_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "nova reply" }],
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      usage: ZERO_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "persisted outbound reply" }],
+    });
+    sessionManager.appendMessage({
+      role: "user",
+      content: "continue",
+      timestamp: Date.now(),
+    });
+
+    const replayable = await getReplayableMessagesForTarget(sessionFile, {
+      modelApi: "bedrock-converse-stream",
+      provider: "amazon-bedrock",
+      modelId,
+    });
+
+    expect(replayable.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+      "user",
+    ]);
+    expect(replayable[2]).toMatchObject({
+      role: "assistant",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      content: [{ type: "text", text: "persisted outbound reply" }],
+    });
   });
 
   it("keeps delivery-mirror assistant entries for non-anthropic replay", async () => {

--- a/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
+++ b/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
@@ -56,6 +56,16 @@ function isLlmMessage(message: AgentMessage): message is Message {
   );
 }
 
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof Error && error.name === "AbortError") ||
+    (typeof error === "object" &&
+      error !== null &&
+      "name" in error &&
+      (error as { name?: unknown }).name === "AbortError")
+  );
+}
+
 async function captureAnthropicPayload(messages: Message[]) {
   const controller = new AbortController();
   controller.abort();
@@ -74,7 +84,14 @@ async function captureAnthropicPayload(messages: Message[]) {
       },
     },
   );
-  await stream.result();
+  try {
+    // The stream is pre-aborted on purpose; this test only needs the constructed payload from onPayload.
+    await stream.result();
+  } catch (error) {
+    if (!isAbortError(error)) {
+      throw error;
+    }
+  }
   return payload;
 }
 
@@ -87,6 +104,21 @@ function getPayloadAssistantMessages(payload: Record<string, unknown> | undefine
       (message as { role?: unknown }).role === "assistant" &&
       Array.isArray((message as { content?: unknown }).content),
   );
+}
+
+async function getReplayableMessages(sessionFile: string) {
+  const reopened = SessionManager.open(sessionFile);
+  const context = reopened.buildSessionContext();
+  return validateAnthropicTurns(
+    await sanitizeSessionHistory({
+      messages: context.messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      sessionManager: reopened,
+      sessionId: "test-session",
+    }),
+  ).filter(isLlmMessage);
 }
 
 describe("anthropic thinking replay", () => {
@@ -141,18 +173,7 @@ describe("anthropic thinking replay", () => {
       timestamp: Date.now(),
     });
 
-    const reopened = SessionManager.open(sessionFile);
-    const context = reopened.buildSessionContext();
-    const replayable = validateAnthropicTurns(
-      await sanitizeSessionHistory({
-        messages: context.messages,
-        modelApi: "anthropic-messages",
-        provider: "anthropic",
-        modelId: "claude-sonnet-4-6",
-        sessionManager: reopened,
-        sessionId: "test-session",
-      }),
-    ).filter(isLlmMessage);
+    const replayable = await getReplayableMessages(sessionFile);
 
     expect(replayable.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
     const payload = await captureAnthropicPayload(replayable);
@@ -174,5 +195,56 @@ describe("anthropic thinking replay", () => {
         text: "final answer",
       },
     ]);
+  });
+
+  it("keeps gateway-injected assistant entries in replay history", async () => {
+    const sessionFile = path.join(tempRoot, `session-${Date.now()}-gateway.jsonl`);
+
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage({
+      role: "user",
+      content: "hello",
+      timestamp: Date.now(),
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      usage: ZERO_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "partial reply" }],
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "gateway-injected",
+      usage: ZERO_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "resume from here" }],
+    });
+    sessionManager.appendMessage({
+      role: "user",
+      content: "continue",
+      timestamp: Date.now(),
+    });
+
+    const replayable = await getReplayableMessages(sessionFile);
+
+    expect(replayable.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+      "user",
+    ]);
+    expect(replayable[2]).toMatchObject({
+      role: "assistant",
+      provider: "openclaw",
+      model: "gateway-injected",
+      content: [{ type: "text", text: "resume from here" }],
+    });
   });
 });

--- a/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
+++ b/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
@@ -107,18 +107,36 @@ function getPayloadAssistantMessages(payload: Record<string, unknown> | undefine
 }
 
 async function getReplayableMessages(sessionFile: string) {
+  return getReplayableMessagesForTarget(sessionFile, {
+    modelApi: "anthropic-messages",
+    provider: "anthropic",
+    modelId: "claude-sonnet-4-6",
+  });
+}
+
+async function getReplayableMessagesForTarget(
+  sessionFile: string,
+  target: {
+    modelApi: string;
+    provider: string;
+    modelId: string;
+  },
+) {
   const reopened = SessionManager.open(sessionFile);
   const context = reopened.buildSessionContext();
-  return validateAnthropicTurns(
-    await sanitizeSessionHistory({
-      messages: context.messages,
-      modelApi: "anthropic-messages",
-      provider: "anthropic",
-      modelId: "claude-sonnet-4-6",
-      sessionManager: reopened,
-      sessionId: "test-session",
-    }),
-  ).filter(isLlmMessage);
+  const replayable = await sanitizeSessionHistory({
+    messages: context.messages,
+    modelApi: target.modelApi,
+    provider: target.provider,
+    modelId: target.modelId,
+    sessionManager: reopened,
+    sessionId: "test-session",
+  });
+  const validated =
+    target.provider === "anthropic" || target.modelApi === "anthropic-messages"
+      ? validateAnthropicTurns(replayable)
+      : replayable;
+  return validated.filter(isLlmMessage);
 }
 
 describe("anthropic thinking replay", () => {
@@ -245,6 +263,46 @@ describe("anthropic thinking replay", () => {
       provider: "openclaw",
       model: "gateway-injected",
       content: [{ type: "text", text: "resume from here" }],
+    });
+  });
+
+  it("keeps delivery-mirror assistant entries for non-anthropic replay", async () => {
+    const sessionFile = path.join(tempRoot, `session-${Date.now()}-openai.jsonl`);
+
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage({
+      role: "user",
+      content: "hello",
+      timestamp: Date.now(),
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      usage: ZERO_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "persisted outbound reply" }],
+    });
+    sessionManager.appendMessage({
+      role: "user",
+      content: "continue",
+      timestamp: Date.now(),
+    });
+
+    const replayable = await getReplayableMessagesForTarget(sessionFile, {
+      modelApi: "openai-responses",
+      provider: "openai",
+      modelId: "gpt-5.2",
+    });
+
+    expect(replayable.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+    expect(replayable[1]).toMatchObject({
+      role: "assistant",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      content: [{ type: "text", text: "persisted outbound reply" }],
     });
   });
 });

--- a/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
+++ b/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
@@ -266,6 +266,58 @@ describe("anthropic thinking replay", () => {
     });
   });
 
+  it("drops delivery-mirror assistant entries for anthropic-compatible replay providers", async () => {
+    const sessionFile = path.join(tempRoot, `session-${Date.now()}-bedrock.jsonl`);
+
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage({
+      role: "user",
+      content: "hello",
+      timestamp: Date.now(),
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      api: "anthropic-messages",
+      provider: "bedrock",
+      model: "claude-sonnet-4-6",
+      usage: ZERO_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "bedrock reply" }],
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      usage: ZERO_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "mirrored outbound reply" }],
+    });
+    sessionManager.appendMessage({
+      role: "user",
+      content: "continue",
+      timestamp: Date.now(),
+    });
+
+    const replayable = await getReplayableMessagesForTarget(sessionFile, {
+      modelApi: "anthropic-messages",
+      provider: "bedrock",
+      modelId: "claude-sonnet-4-6",
+    });
+
+    expect(replayable.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+    expect(
+      replayable.some(
+        (message) =>
+          message.role === "assistant" &&
+          message.provider === "openclaw" &&
+          message.model === "delivery-mirror",
+      ),
+    ).toBe(false);
+  });
+
   it("keeps delivery-mirror assistant entries for non-anthropic replay", async () => {
     const sessionFile = path.join(tempRoot, `session-${Date.now()}-openai.jsonl`);
 

--- a/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
+++ b/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
@@ -1,0 +1,178 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, Message, Model, Usage } from "@mariozechner/pi-ai";
+import { streamSimple } from "@mariozechner/pi-ai";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { validateAnthropicTurns } from "./pi-embedded-helpers.js";
+import { sanitizeSessionHistory } from "./pi-embedded-runner/google.js";
+
+const ZERO_USAGE: Usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+};
+
+const ANTHROPIC_MODEL: Model<"anthropic-messages"> = {
+  id: "claude-sonnet-4-6",
+  name: "Claude Sonnet 4.6",
+  api: "anthropic-messages",
+  provider: "anthropic",
+  baseUrl: "https://api.anthropic.com",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 4096,
+};
+
+let tempRoot: string;
+
+beforeAll(async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-anthropic-replay-"));
+});
+
+afterAll(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+function isLlmMessage(message: AgentMessage): message is Message {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "role" in message &&
+    (message.role === "user" || message.role === "assistant" || message.role === "toolResult")
+  );
+}
+
+async function captureAnthropicPayload(messages: Message[]) {
+  const controller = new AbortController();
+  controller.abort();
+  let payload: Record<string, unknown> | undefined;
+  const stream = streamSimple(
+    ANTHROPIC_MODEL,
+    {
+      systemPrompt: "system",
+      messages,
+    },
+    {
+      apiKey: "test",
+      signal: controller.signal,
+      onPayload: (nextPayload) => {
+        payload = nextPayload as Record<string, unknown>;
+      },
+    },
+  );
+  await stream.result();
+  return payload;
+}
+
+function getPayloadAssistantMessages(payload: Record<string, unknown> | undefined) {
+  const messages = Array.isArray(payload?.messages) ? payload.messages : [];
+  return messages.filter(
+    (message): message is { role: "assistant"; content: Array<Record<string, unknown>> } =>
+      !!message &&
+      typeof message === "object" &&
+      (message as { role?: unknown }).role === "assistant" &&
+      Array.isArray((message as { content?: unknown }).content),
+  );
+}
+
+describe("anthropic thinking replay", () => {
+  it("drops synthetic assistant transcript mirrors before replay so thinking signatures stay intact", async () => {
+    const sessionFile = path.join(tempRoot, `session-${Date.now()}.jsonl`);
+    const thinkingSignature = "sig-thinking-123";
+    const redactedSignature = "sig-redacted-456";
+    const signedAnthropicContent: AssistantMessage["content"] = [
+      {
+        type: "thinking",
+        thinking: "internal reasoning",
+        thinkingSignature,
+      },
+      {
+        type: "thinking",
+        thinking: "[Reasoning redacted]",
+        thinkingSignature: redactedSignature,
+        redacted: true,
+      },
+      { type: "text", text: "final answer" },
+    ];
+
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage({
+      role: "user",
+      content: "hello",
+      timestamp: Date.now(),
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      usage: ZERO_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: signedAnthropicContent,
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      usage: ZERO_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "final answer" }],
+    });
+    sessionManager.appendMessage({
+      role: "user",
+      content: "follow up",
+      timestamp: Date.now(),
+    });
+
+    const reopened = SessionManager.open(sessionFile);
+    const context = reopened.buildSessionContext();
+    const replayable = validateAnthropicTurns(
+      await sanitizeSessionHistory({
+        messages: context.messages,
+        modelApi: "anthropic-messages",
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-6",
+        sessionManager: reopened,
+        sessionId: "test-session",
+      }),
+    ).filter(isLlmMessage);
+
+    expect(replayable.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+    const payload = await captureAnthropicPayload(replayable);
+    const assistantMessages = getPayloadAssistantMessages(payload);
+
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0]?.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "internal reasoning",
+        signature: thinkingSignature,
+      },
+      {
+        type: "redacted_thinking",
+        data: redactedSignature,
+      },
+      {
+        type: "text",
+        text: "final answer",
+      },
+    ]);
+  });
+});

--- a/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
+++ b/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
@@ -8,6 +8,7 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { validateAnthropicTurns } from "./pi-embedded-helpers.js";
 import { sanitizeSessionHistory } from "./pi-embedded-runner/google.js";
+import { isAnthropicApi } from "./transcript-policy.js";
 
 const ZERO_USAGE: Usage = {
   input: 0,
@@ -132,10 +133,9 @@ async function getReplayableMessagesForTarget(
     sessionManager: reopened,
     sessionId: "test-session",
   });
-  const validated =
-    target.provider === "anthropic" || target.modelApi === "anthropic-messages"
-      ? validateAnthropicTurns(replayable)
-      : replayable;
+  const validated = isAnthropicApi(target.modelApi, target.provider)
+    ? validateAnthropicTurns(replayable)
+    : replayable;
   return validated.filter(isLlmMessage);
 }
 
@@ -266,7 +266,7 @@ describe("anthropic thinking replay", () => {
     });
   });
 
-  it("drops delivery-mirror assistant entries for anthropic-compatible replay providers", async () => {
+  it("drops delivery-mirror assistant entries for bedrock anthropic-compatible replay", async () => {
     const sessionFile = path.join(tempRoot, `session-${Date.now()}-bedrock.jsonl`);
 
     const sessionManager = SessionManager.open(sessionFile);
@@ -277,7 +277,7 @@ describe("anthropic thinking replay", () => {
     });
     sessionManager.appendMessage({
       role: "assistant",
-      api: "anthropic-messages",
+      api: "bedrock-converse-stream",
       provider: "bedrock",
       model: "claude-sonnet-4-6",
       usage: ZERO_USAGE,
@@ -302,7 +302,7 @@ describe("anthropic thinking replay", () => {
     });
 
     const replayable = await getReplayableMessagesForTarget(sessionFile, {
-      modelApi: "anthropic-messages",
+      modelApi: "bedrock-converse-stream",
       provider: "bedrock",
       modelId: "claude-sonnet-4-6",
     });

--- a/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
+++ b/src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts
@@ -7,7 +7,6 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { validateAnthropicTurns } from "./pi-embedded-helpers.js";
-import { isAnthropicBedrockModel } from "./pi-embedded-runner/anthropic-stream-wrappers.js";
 import { sanitizeSessionHistory } from "./pi-embedded-runner/google.js";
 
 const ZERO_USAGE: Usage = {
@@ -144,14 +143,11 @@ function shouldValidateAnthropicReplayTarget(target: {
   provider: string;
   modelId: string;
 }): boolean {
-  if (target.provider === "anthropic" || target.modelApi === "anthropic-messages") {
-    return true;
-  }
-  return target.modelApi === "bedrock-converse-stream" && isAnthropicBedrockModel(target.modelId);
+  return target.provider === "anthropic" || target.modelApi === "anthropic-messages";
 }
 
 describe("anthropic thinking replay", () => {
-  it("drops synthetic assistant transcript mirrors before replay so thinking signatures stay intact", async () => {
+  it("drops duplicated delivery-mirror assistant shadows before replay so thinking signatures stay intact", async () => {
     const sessionFile = path.join(tempRoot, `session-${Date.now()}.jsonl`);
     const thinkingSignature = "sig-thinking-123";
     const redactedSignature = "sig-redacted-456";
@@ -277,78 +273,14 @@ describe("anthropic thinking replay", () => {
     });
   });
 
-  it("drops delivery-mirror assistant entries for bedrock claude replay", async () => {
-    const sessionFile = path.join(tempRoot, `session-${Date.now()}-bedrock-claude.jsonl`);
-    const modelId = "anthropic.claude-3-7-sonnet-20250219-v1:0";
+  it("keeps delivery-mirror assistant entries when they are the only assistant history", async () => {
+    const sessionFile = path.join(tempRoot, `session-${Date.now()}-mirror-only.jsonl`);
 
     const sessionManager = SessionManager.open(sessionFile);
     sessionManager.appendMessage({
       role: "user",
       content: "hello",
       timestamp: Date.now(),
-    });
-    sessionManager.appendMessage({
-      role: "assistant",
-      api: "bedrock-converse-stream",
-      provider: "amazon-bedrock",
-      model: modelId,
-      usage: ZERO_USAGE,
-      stopReason: "stop",
-      timestamp: Date.now(),
-      content: [{ type: "text", text: "bedrock reply" }],
-    });
-    sessionManager.appendMessage({
-      role: "assistant",
-      api: "openai-responses",
-      provider: "openclaw",
-      model: "delivery-mirror",
-      usage: ZERO_USAGE,
-      stopReason: "stop",
-      timestamp: Date.now(),
-      content: [{ type: "text", text: "mirrored outbound reply" }],
-    });
-    sessionManager.appendMessage({
-      role: "user",
-      content: "continue",
-      timestamp: Date.now(),
-    });
-
-    const replayable = await getReplayableMessagesForTarget(sessionFile, {
-      modelApi: "bedrock-converse-stream",
-      provider: "amazon-bedrock",
-      modelId,
-    });
-
-    expect(replayable.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
-    expect(
-      replayable.some(
-        (message) =>
-          message.role === "assistant" &&
-          message.provider === "openclaw" &&
-          message.model === "delivery-mirror",
-      ),
-    ).toBe(false);
-  });
-
-  it("keeps delivery-mirror assistant entries for non-anthropic bedrock replay", async () => {
-    const sessionFile = path.join(tempRoot, `session-${Date.now()}-bedrock-nova.jsonl`);
-    const modelId = "amazon.nova-pro-v1:0";
-
-    const sessionManager = SessionManager.open(sessionFile);
-    sessionManager.appendMessage({
-      role: "user",
-      content: "hello",
-      timestamp: Date.now(),
-    });
-    sessionManager.appendMessage({
-      role: "assistant",
-      api: "bedrock-converse-stream",
-      provider: "amazon-bedrock",
-      model: modelId,
-      usage: ZERO_USAGE,
-      stopReason: "stop",
-      timestamp: Date.now(),
-      content: [{ type: "text", text: "nova reply" }],
     });
     sessionManager.appendMessage({
       role: "assistant",
@@ -366,19 +298,10 @@ describe("anthropic thinking replay", () => {
       timestamp: Date.now(),
     });
 
-    const replayable = await getReplayableMessagesForTarget(sessionFile, {
-      modelApi: "bedrock-converse-stream",
-      provider: "amazon-bedrock",
-      modelId,
-    });
+    const replayable = await getReplayableMessages(sessionFile);
 
-    expect(replayable.map((message) => message.role)).toEqual([
-      "user",
-      "assistant",
-      "assistant",
-      "user",
-    ]);
-    expect(replayable[2]).toMatchObject({
+    expect(replayable.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+    expect(replayable[1]).toMatchObject({
       role: "assistant",
       provider: "openclaw",
       model: "delivery-mirror",

--- a/src/agents/pi-embedded-runner.thinking-signature-persistence.test.ts
+++ b/src/agents/pi-embedded-runner.thinking-signature-persistence.test.ts
@@ -1,0 +1,294 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AssistantMessage, Message, Usage } from "@mariozechner/pi-ai";
+import "./test-helpers/fast-coding-tools.js";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+type MockModelRef = { api: string; provider: string; id: string };
+type MockStreamContext = { messages?: Message[] };
+type MockAssistantMessage = AssistantMessage;
+
+function createMockUsage(input: number, output: number): Usage {
+  return {
+    input,
+    output,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: input + output,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+}
+
+const piAiMockState = vi.hoisted(() => ({
+  streamScenarios: new Map<
+    string,
+    Array<
+      (params: { model: MockModelRef; context: MockStreamContext }) => {
+        reason: "stop" | "error";
+        message: MockAssistantMessage;
+      }
+    >
+  >(),
+  capturedContexts: [] as Array<{ modelId: string; messages: Message[] }>,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+  return await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>(
+    "@mariozechner/pi-coding-agent",
+  );
+});
+
+vi.mock("@mariozechner/pi-ai", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
+
+  const buildAssistantMessage = (model: MockModelRef): MockAssistantMessage => ({
+    role: "assistant",
+    content: [{ type: "text", text: "ok" }],
+    stopReason: "stop",
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: createMockUsage(1, 1),
+    timestamp: Date.now(),
+  });
+
+  const buildAssistantErrorMessage = (model: MockModelRef): MockAssistantMessage => ({
+    role: "assistant",
+    content: [],
+    stopReason: "error",
+    errorMessage: "boom",
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: createMockUsage(0, 0),
+    timestamp: Date.now(),
+  });
+
+  return {
+    ...actual,
+    complete: async (model: MockModelRef) => buildAssistantMessage(model),
+    completeSimple: async (model: MockModelRef) => buildAssistantMessage(model),
+    streamSimple: (model: MockModelRef, context?: MockStreamContext) => {
+      const stream = actual.createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const messages = Array.isArray(context?.messages) ? context.messages : [];
+        piAiMockState.capturedContexts.push({ modelId: model.id, messages });
+        const scenario = piAiMockState.streamScenarios.get(model.id)?.shift();
+        if (scenario) {
+          const result = scenario({ model, context: { messages } });
+          if (result.reason === "error") {
+            stream.push({
+              type: "error",
+              reason: "error",
+              error: result.message,
+            });
+          } else {
+            stream.push({
+              type: "done",
+              reason: "stop",
+              message: result.message,
+            });
+          }
+          stream.end();
+          return;
+        }
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message:
+            model.id === "mock-error"
+              ? buildAssistantErrorMessage(model)
+              : buildAssistantMessage(model),
+        });
+        stream.end();
+      });
+      return stream;
+    },
+  };
+});
+
+let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;
+let tempRoot: string | undefined;
+let agentDir: string;
+let workspaceDir: string;
+let sessionCounter = 0;
+let runCounter = 0;
+
+beforeAll(async () => {
+  vi.useRealTimers();
+  ({ runEmbeddedPiAgent } = await import("./pi-embedded-runner/run.js"));
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-thinking-signature-"));
+  agentDir = path.join(tempRoot, "agent");
+  workspaceDir = path.join(tempRoot, "workspace");
+  await fs.mkdir(agentDir, { recursive: true });
+  await fs.mkdir(workspaceDir, { recursive: true });
+}, 180_000);
+
+afterEach(() => {
+  piAiMockState.streamScenarios.clear();
+  piAiMockState.capturedContexts.length = 0;
+});
+
+afterAll(async () => {
+  if (!tempRoot) {
+    return;
+  }
+  await fs.rm(tempRoot, { recursive: true, force: true });
+  tempRoot = undefined;
+});
+
+const makeAnthropicConfig = (modelId: string) =>
+  ({
+    models: {
+      providers: {
+        anthropic: {
+          api: "anthropic-messages",
+          apiKey: "sk-ant-test",
+          baseUrl: "https://example.com",
+          models: [
+            {
+              id: modelId,
+              name: `Mock ${modelId}`,
+              reasoning: true,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 16_000,
+              maxTokens: 2048,
+            },
+          ],
+        },
+      },
+    },
+  }) satisfies OpenClawConfig;
+
+const nextSessionFile = () => {
+  sessionCounter += 1;
+  return path.join(workspaceDir, `session-${sessionCounter}.jsonl`);
+};
+
+const nextRunId = (prefix: string) => `${prefix}-${++runCounter}`;
+
+const readSessionMessages = async (sessionFile: string) => {
+  const raw = await fs.readFile(sessionFile, "utf-8");
+  return raw
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { message?: { role?: string; content?: unknown } })
+    .filter((entry) => entry.message)
+    .map((entry) => entry.message) as Array<{ role?: string; content?: unknown }>;
+};
+
+function isAssistantMessage(message: Message | undefined): message is AssistantMessage {
+  return message?.role === "assistant";
+}
+
+function isAssistantWithArrayContent(
+  message: { role?: string; content?: unknown } | undefined,
+): message is { role: "assistant"; content: unknown[] } {
+  return message?.role === "assistant" && Array.isArray(message.content);
+}
+
+describe("runEmbeddedPiAgent anthropic thinking signature persistence", () => {
+  it("keeps thinking signatures and redacted markers through session replay", async () => {
+    const sessionFile = nextSessionFile();
+    const sessionKey = "agent:test:thinking-signature";
+    const modelId = "mock-anthropic-thinking";
+    const cfg = makeAnthropicConfig(modelId);
+    const thinkingSignature = "sig-thinking-123";
+    const redactedSignature = "sig-redacted-456";
+    const expectedContent: AssistantMessage["content"] = [
+      {
+        type: "thinking",
+        thinking: "internal reasoning",
+        thinkingSignature,
+      },
+      {
+        type: "thinking",
+        thinking: "[Reasoning redacted]",
+        thinkingSignature: redactedSignature,
+        redacted: true,
+      },
+      { type: "text", text: "first reply" },
+    ];
+
+    piAiMockState.streamScenarios.set(modelId, [
+      ({ model }) => ({
+        reason: "stop",
+        message: {
+          role: "assistant",
+          content: expectedContent,
+          stopReason: "stop",
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage: createMockUsage(1, 1),
+          timestamp: Date.now(),
+        },
+      }),
+      ({ model, context }) => {
+        const priorAssistant = (context.messages ?? []).findLast(isAssistantMessage);
+        expect(priorAssistant).toBeDefined();
+        expect(priorAssistant?.content).toEqual(expectedContent);
+        return {
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "second reply" }],
+            stopReason: "stop",
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: createMockUsage(1, 1),
+            timestamp: Date.now(),
+          },
+        };
+      },
+    ]);
+
+    await runEmbeddedPiAgent({
+      sessionId: "session:test",
+      sessionKey,
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "first prompt",
+      provider: "anthropic",
+      model: modelId,
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("anthropic-thinking-first"),
+      disableTools: true,
+      enqueue: async (task) => await task(),
+    });
+
+    const firstRunMessages = await readSessionMessages(sessionFile);
+    const persistedAssistant = firstRunMessages.find((message) =>
+      isAssistantWithArrayContent(message),
+    );
+    expect(persistedAssistant?.content).toEqual(expectedContent);
+
+    await runEmbeddedPiAgent({
+      sessionId: "session:test",
+      sessionKey,
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "second prompt",
+      provider: "anthropic",
+      model: modelId,
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("anthropic-thinking-second"),
+      disableTools: true,
+      enqueue: async (task) => await task(),
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -24,13 +24,14 @@ import {
   sanitizeToolUseResultPairing,
 } from "../session-transcript-repair.js";
 import type { TranscriptPolicy } from "../transcript-policy.js";
-import { isAnthropicApi, resolveTranscriptPolicy } from "../transcript-policy.js";
+import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import {
   makeZeroUsageSnapshot,
   normalizeUsage,
   type AssistantUsageSnapshot,
   type UsageLike,
 } from "../usage.js";
+import { isAnthropicBedrockModel } from "./anthropic-stream-wrappers.js";
 import { log } from "./logger.js";
 import { dropThinkingBlocks } from "./thinking.js";
 import { describeUnknownError } from "./utils.js";
@@ -165,8 +166,14 @@ function dropSyntheticAssistantTranscriptMessages(messages: AgentMessage[]): Age
 function shouldDropSyntheticAssistantTranscriptMessages(params: {
   modelApi?: string | null;
   provider?: string;
+  modelId?: string;
 }): boolean {
-  return isAnthropicApi(params.modelApi, params.provider);
+  if (params.provider === "anthropic" || params.modelApi === "anthropic-messages") {
+    return true;
+  }
+  return (
+    params.modelApi === "bedrock-converse-stream" && isAnthropicBedrockModel(params.modelId ?? "")
+  );
 }
 
 function parseMessageTimestamp(value: unknown): number | null {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -140,6 +140,27 @@ function annotateInterSessionUserMessages(messages: AgentMessage[]): AgentMessag
   return touched ? out : messages;
 }
 
+function isSyntheticAssistantTranscriptMessage(message: AgentMessage): boolean {
+  if (!message || typeof message !== "object" || message.role !== "assistant") {
+    return false;
+  }
+  const provider = (message as { provider?: unknown }).provider;
+  return provider === "openclaw";
+}
+
+function dropSyntheticAssistantTranscriptMessages(messages: AgentMessage[]): AgentMessage[] {
+  let changed = false;
+  const out: AgentMessage[] = [];
+  for (const message of messages) {
+    if (isSyntheticAssistantTranscriptMessage(message)) {
+      changed = true;
+      continue;
+    }
+    out.push(message);
+  }
+  return changed ? out : messages;
+}
+
 function parseMessageTimestamp(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
@@ -537,8 +558,9 @@ export async function sanitizeSessionHistory(params: {
       modelId: params.modelId,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
+  const replayableMessages = dropSyntheticAssistantTranscriptMessages(withInterSessionMarkers);
   const sanitizedImages = await sanitizeSessionMessagesImages(
-    withInterSessionMarkers,
+    replayableMessages,
     "session:history",
     {
       sanitizeMode: policy.sanitizeMode,

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -24,7 +24,7 @@ import {
   sanitizeToolUseResultPairing,
 } from "../session-transcript-repair.js";
 import type { TranscriptPolicy } from "../transcript-policy.js";
-import { resolveTranscriptPolicy } from "../transcript-policy.js";
+import { isAnthropicApi, resolveTranscriptPolicy } from "../transcript-policy.js";
 import {
   makeZeroUsageSnapshot,
   normalizeUsage,
@@ -166,7 +166,7 @@ function shouldDropSyntheticAssistantTranscriptMessages(params: {
   modelApi?: string | null;
   provider?: string;
 }): boolean {
-  return params.provider === "anthropic" || params.modelApi === "anthropic-messages";
+  return isAnthropicApi(params.modelApi, params.provider);
 }
 
 function parseMessageTimestamp(value: unknown): number | null {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -166,10 +166,7 @@ function shouldDropSyntheticAssistantTranscriptMessages(params: {
   modelApi?: string | null;
   provider?: string;
 }): boolean {
-  if (params.provider) {
-    return params.provider === "anthropic";
-  }
-  return params.modelApi === "anthropic-messages";
+  return params.provider === "anthropic" || params.modelApi === "anthropic-messages";
 }
 
 function parseMessageTimestamp(value: unknown): number | null {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -145,7 +145,8 @@ function isSyntheticAssistantTranscriptMessage(message: AgentMessage): boolean {
     return false;
   }
   const provider = (message as { provider?: unknown }).provider;
-  return provider === "openclaw";
+  const model = (message as { model?: unknown }).model;
+  return provider === "openclaw" && model === "delivery-mirror";
 }
 
 function dropSyntheticAssistantTranscriptMessages(messages: AgentMessage[]): AgentMessage[] {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -162,6 +162,16 @@ function dropSyntheticAssistantTranscriptMessages(messages: AgentMessage[]): Age
   return changed ? out : messages;
 }
 
+function shouldDropSyntheticAssistantTranscriptMessages(params: {
+  modelApi?: string | null;
+  provider?: string;
+}): boolean {
+  if (params.provider) {
+    return params.provider === "anthropic";
+  }
+  return params.modelApi === "anthropic-messages";
+}
+
 function parseMessageTimestamp(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
@@ -559,7 +569,9 @@ export async function sanitizeSessionHistory(params: {
       modelId: params.modelId,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
-  const replayableMessages = dropSyntheticAssistantTranscriptMessages(withInterSessionMarkers);
+  const replayableMessages = shouldDropSyntheticAssistantTranscriptMessages(params)
+    ? dropSyntheticAssistantTranscriptMessages(withInterSessionMarkers)
+    : withInterSessionMarkers;
   const sanitizedImages = await sanitizeSessionMessagesImages(
     replayableMessages,
     "session:history",

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -14,6 +14,7 @@ import {
   downgradeOpenAIReasoningBlocks,
   isCompactionFailureError,
   isGoogleModelApi,
+  normalizeTextForComparison,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
 } from "../pi-embedded-helpers.js";
@@ -31,7 +32,6 @@ import {
   type AssistantUsageSnapshot,
   type UsageLike,
 } from "../usage.js";
-import { isAnthropicBedrockModel } from "./anthropic-stream-wrappers.js";
 import { log } from "./logger.js";
 import { dropThinkingBlocks } from "./thinking.js";
 import { describeUnknownError } from "./utils.js";
@@ -150,30 +150,61 @@ function isSyntheticAssistantTranscriptMessage(message: AgentMessage): boolean {
   return provider === "openclaw" && model === "delivery-mirror";
 }
 
+function getAssistantComparableText(message: AgentMessage): string | null {
+  if (!message || typeof message !== "object" || message.role !== "assistant") {
+    return null;
+  }
+  if (typeof message.content === "string") {
+    const normalized = normalizeTextForComparison(message.content);
+    return normalized || null;
+  }
+  if (!Array.isArray(message.content)) {
+    return null;
+  }
+  const text = message.content
+    .filter(
+      (block): block is { type: "text"; text: string } =>
+        !!block &&
+        typeof block === "object" &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string",
+    )
+    .map((block) => block.text)
+    .join("\n");
+  const normalized = normalizeTextForComparison(text);
+  return normalized || null;
+}
+
+function isDuplicateSyntheticAssistantTranscriptMessage(
+  message: AgentMessage,
+  previousMessage: AgentMessage | undefined,
+): boolean {
+  if (!isSyntheticAssistantTranscriptMessage(message)) {
+    return false;
+  }
+  if (!previousMessage || previousMessage.role !== "assistant") {
+    return false;
+  }
+  const previousProvider = (previousMessage as { provider?: unknown }).provider;
+  if (previousProvider === "openclaw") {
+    return false;
+  }
+  const mirrorText = getAssistantComparableText(message);
+  const previousText = getAssistantComparableText(previousMessage);
+  return Boolean(mirrorText && previousText && mirrorText === previousText);
+}
+
 function dropSyntheticAssistantTranscriptMessages(messages: AgentMessage[]): AgentMessage[] {
   let changed = false;
   const out: AgentMessage[] = [];
   for (const message of messages) {
-    if (isSyntheticAssistantTranscriptMessage(message)) {
+    if (isDuplicateSyntheticAssistantTranscriptMessage(message, out.at(-1))) {
       changed = true;
       continue;
     }
     out.push(message);
   }
   return changed ? out : messages;
-}
-
-function shouldDropSyntheticAssistantTranscriptMessages(params: {
-  modelApi?: string | null;
-  provider?: string;
-  modelId?: string;
-}): boolean {
-  if (params.provider === "anthropic" || params.modelApi === "anthropic-messages") {
-    return true;
-  }
-  return (
-    params.modelApi === "bedrock-converse-stream" && isAnthropicBedrockModel(params.modelId ?? "")
-  );
 }
 
 function parseMessageTimestamp(value: unknown): number | null {
@@ -573,9 +604,7 @@ export async function sanitizeSessionHistory(params: {
       modelId: params.modelId,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
-  const replayableMessages = shouldDropSyntheticAssistantTranscriptMessages(params)
-    ? dropSyntheticAssistantTranscriptMessages(withInterSessionMarkers)
-    : withInterSessionMarkers;
+  const replayableMessages = dropSyntheticAssistantTranscriptMessages(withInterSessionMarkers);
   const sanitizedImages = await sanitizeSessionMessagesImages(
     replayableMessages,
     "session:history",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -49,7 +49,7 @@ function isOpenAiProvider(provider?: string | null): boolean {
   return isOpenAiProviderFamily(provider);
 }
 
-export function isAnthropicApi(modelApi?: string | null, provider?: string | null): boolean {
+function isAnthropicApi(modelApi?: string | null, provider?: string | null): boolean {
   if (modelApi === "anthropic-messages" || modelApi === "bedrock-converse-stream") {
     return true;
   }

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -49,7 +49,7 @@ function isOpenAiProvider(provider?: string | null): boolean {
   return isOpenAiProviderFamily(provider);
 }
 
-function isAnthropicApi(modelApi?: string | null, provider?: string | null): boolean {
+export function isAnthropicApi(modelApi?: string | null, provider?: string | null): boolean {
   if (modelApi === "anthropic-messages" || modelApi === "bedrock-converse-stream") {
     return true;
   }


### PR DESCRIPTION
## Summary

Fixes Anthropic extended-thinking replay failures by deduplicating synthetic `delivery-mirror` assistant transcript turns only when they are true duplicates of an adjacent real assistant reply.

Although the issue initially appeared to be a persistence/signature-loss problem, the session JSONL round-trip already preserved thinking signatures correctly. The actual bug was in replay assembly: a synthetic OpenClaw `delivery-mirror` assistant turn could be replayed alongside the original assistant reply, which polluted replay history and caused Anthropic reasoning replay to reject it as modified thinking content.

## What changed

- replace target-based `delivery-mirror` removal with transcript-based deduplication
- keep the mirror marker narrow:
  - `role === "assistant"`
  - `provider === "openclaw"`
  - `model === "delivery-mirror"`
- only drop a mirror when it is a true adjacent duplicate:
  - it follows a real assistant turn
  - the previous assistant turn is not from `openclaw`
  - the normalized visible assistant text matches
- preserve `delivery-mirror` turns when they are the only persisted assistant history
- preserve non-mirror OpenClaw assistant transcript entries such as `gateway-injected`
- add regression coverage for:
  - session persistence fidelity of thinking / redacted-thinking content
  - final Anthropic replay payload assembly
  - dropping duplicated mirror turns that shadow a real assistant reply
  - preserving mirror-only assistant history
  - preserving `gateway-injected` assistant entries
  - intentional abort handling in the payload-capture test helper

## Why this fix is safe

This change is intentionally narrow.

It no longer relies on replay target heuristics to remove mirrored assistant history. Instead, it removes only transcript entries that are structurally identifiable as duplicate `delivery-mirror` shadows of an adjacent real assistant reply. Mirror-only assistant history remains intact.

## Validation

- `pnpm test src/agents/pi-embedded-runner.thinking-signature-persistence.test.ts src/agents/pi-embedded-runner.anthropic-thinking-replay.test.ts`
- `pnpm build`
- `pnpm check`

Closes #43691