### PR TITLE
Increase agent-to-agent ping-pong cap

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -98,7 +98,7 @@ Behavior:
 - After the primary run completes, OpenClaw runs a **reply-back loop**:
   - Round 2+ alternates between requester and target agents.
   - Reply exactly `REPLY_SKIP` to stop the ping‑pong.
-  - Max turns is `session.agentToAgent.maxPingPongTurns` (0–5, default 5).
+  - Max turns is `session.agentToAgent.maxPingPongTurns` (0–20, default 5).
 - Once the loop ends, OpenClaw runs the **agent‑to‑agent announce step** (target agent only):
   - Reply exactly `ANNOUNCE_SKIP` to stay silent.
   - Any other reply is sent to the target channel.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1497,7 +1497,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
       maxAgeHours: 0, // default hard max age in hours (`0` disables)
     },
     mainKey: "main", // legacy (runtime always uses "main")
-    agentToAgent: { maxPingPongTurns: 5 },
+    agentToAgent: { maxPingPongTurns: 5 }, // 0–20, default 5
     sendPolicy: {
       rules: [{ action: "deny", match: { channel: "discord", chatType: "group" } }],
       default: "allow",

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -502,7 +502,7 @@ Notes:
   - `attachAs.mountPath` is a reserved hint for future mount implementations.
 - `sessions_spawn` is non-blocking and returns `status: "accepted"` immediately.
 - ACP `streamTo: "parent"` responses may include `streamLogPath` (session-scoped `*.acp-stream.jsonl`) for tailing progress history.
-- `sessions_send` runs a reply‑back ping‑pong (reply `REPLY_SKIP` to stop; max turns via `session.agentToAgent.maxPingPongTurns`, 0–5).
+- `sessions_send` runs a reply‑back ping‑pong (reply `REPLY_SKIP` to stop; max turns via `session.agentToAgent.maxPingPongTurns`, 0–20).
 - After the ping‑pong, the target agent runs an **announce step**; reply `ANNOUNCE_SKIP` to suppress the announcement.
 - Sandbox clamp: when the current session is sandboxed and `agents.defaults.sandbox.sessionToolsVisibility: "spawned"`, OpenClaw clamps `tools.sessions.visibility` to `tree`.
 

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -8,7 +8,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 const ANNOUNCE_SKIP_TOKEN = "ANNOUNCE_SKIP";
 const REPLY_SKIP_TOKEN = "REPLY_SKIP";
 const DEFAULT_PING_PONG_TURNS = 5;
-const MAX_PING_PONG_TURNS = 5;
+const MAX_PING_PONG_TURNS = 20;
 
 export type AnnounceTarget = {
   channel: string;

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -57,7 +57,7 @@ export const SessionSchema = z
     sendPolicy: SessionSendPolicySchema.optional(),
     agentToAgent: z
       .object({
-        maxPingPongTurns: z.number().int().min(0).max(5).optional(),
+        maxPingPongTurns: z.number().int().min(0).max(20).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:
Closes #43972
- Problem: `session.agentToAgent.maxPingPongTurns` 在 schema 和 runtime 都被硬限制为 0–5，无法支持需要更长往返对话的多代理场景。
- Why it matters: 多代理协作（规划、反思、协调）往往需要 10+ 轮对话，5 的上限会让对话被迫提前终止，降低协作质量。
- What changed: 将配置 schema 的上限从 5 提升到 20，同步更新 runtime clamp（0–20）以及所有相关文档说明为「0–20，默认 5」。
- What did NOT change (scope boundary): 未修改默认值（仍为 5），未改动 ping‑pong 控制流、`REPLY_SKIP` 语义或任何 Web/UI/网关逻辑。

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43972
- Related #

## User-visible / Behavior Changes

- `session.agentToAgent.maxPingPongTurns` 的可配置范围从 `0–5` 扩大为 `0–20`，默认值仍为 5。
- runtime 对 ping‑pong 回合数的硬上限从 5 提升到 20：
  - 配置在 0–5 范围内时，行为与之前完全一致；
  - 显式配置为 6–20 时，ping‑pong 循环最多可以运行到对应回合数。
- 所有英文文档中对该字段的说明统一为「0–20，默认 5」，与实际行为对齐。

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) **No**
- Secrets/tokens handling changed? (`Yes/No`) **No**
- New/changed network calls? (`Yes/No`) **No**
- Command/tool execution surface changed? (`Yes/No`) **No**
- Data access scope changed? (`Yes/No`) **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: 本地开发环境（例如 Windows 10 / macOS）
- Runtime/container: Node v24.14.0（agent 环境 Node 20.x 仅用于静态检查）
- Model/provider: N/A（纯配置 + 内部工具逻辑）
- Integration/channel (if any): N/A
- Relevant config (redacted):

```json5
{
  "session": {
    "agentToAgent": {
      "maxPingPongTurns": 12
    }
  }
}
