### PR TITLE
docs: add @civic/openclaw-google to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -21,6 +21,19 @@ OpenClaw checks ClawHub first and falls back to npm automatically.
 
 ## Listed plugins
 
+### Civic Google
+
+Zero-config Google Workspace OAuth for OpenClaw. Civic handles credentials,
+token refresh, and least-privilege scope selection automatically — no
+`gog auth add` or Google Cloud project needed.
+
+- **npm:** `@civic/openclaw-google`
+- **repo:** [github.com/civicteam/openclaw-google](https://github.com/civicteam/openclaw-google)
+
+```bash
+openclaw plugins install @civic/openclaw-google
+```
+
 ### Codex App Server Bridge
 
 Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to


### PR DESCRIPTION
## Summary

- Adds `@civic/openclaw-google` to the community plugins listing in `docs/plugins/community.md`
- Entry follows the required candidate format (name, description, npm, repo, install)
- Placed in alphabetical order (C before W, ahead of WeChat)

## Notes

- `gog` (gogcli) is OpenClaw's built-in Google CLI integration — it's the standard tool the agent uses for Gmail, Calendar, Drive, etc.
- Normally, deployers need to run `gog auth add`, manage OAuth credentials, handle token refresh, and decide which Google scopes to request. This plugin removes all of that: Civic AuthZ handles the full OAuth lifecycle (token storage, refresh, scope management), and the plugin injects a fresh token before each `gog` call transparently.
- Least-privilege by design: Civic requests only the scopes the agent actually needs for the specific `gog` subcommand being called (`gmail.readonly` for search, `gmail.compose` for drafts, etc.) — no over-permissioned buckets.
- Docs-only change; no runtime behavior modified
- AI-assisted PR