### PR TITLE
URGENT: fix heartbeat suppressing all user messages during heartbeat execution

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -865,4 +865,39 @@ describe("agent event handler", () => {
     // Should NOT be suppressed - primary has isHeartbeat=false
     expect(chatBroadcastCalls(broadcast)).toHaveLength(1);
   });
+
+  // Verify fallback behavior: when primary is undefined but sourceRunId is heartbeat, suppress
+  it("suppresses when primary is undefined but sourceRunId isHeartbeat=true", () => {
+    const { broadcast, chatRunState, handler } = createHarness({
+      now: 2_000,
+      resolveSessionKeyForRun: (runId) => {
+        if (runId === "source-run") {
+          return "session-source";
+        }
+        return undefined;
+      },
+    });
+    // Only register source-run as heartbeat (primary is NOT registered)
+    registerAgentRunContext("source-run", {
+      sessionKey: "session-source",
+      isHeartbeat: true,
+      verboseLevel: "off",
+    });
+    // Chat-link: source-run -> client-run (client has no context)
+    chatRunState.registry.add("source-run", {
+      sessionKey: "session-source",
+      clientRunId: "client-run",
+    });
+
+    handler({
+      runId: "source-run",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "HEARTBEAT_OK" },
+    });
+
+    // Should be suppressed - primary undefined, sourceRunId is heartbeat
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
+  });
 });

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -821,4 +821,48 @@ describe("agent event handler", () => {
       "Disk usage crossed 95 percent on /data and needs cleanup now.",
     );
   });
+
+  // Regression test: when primary run has isHeartbeat=false (interactive user),
+  // suppress should be false even if sourceRunId has isHeartbeat=true.
+  // This was the bug - old code would fall through to sourceRunId check.
+  it("does NOT suppress when primary isHeartbeat=false but sourceRunId isHeartbeat=true", () => {
+    const { broadcast, chatRunState, handler } = createHarness({
+      now: 2_000,
+      resolveSessionKeyForRun: (runId) => {
+        if (runId === "source-run") {
+          return "session-source";
+        }
+        return undefined;
+      },
+    });
+    // Register client-run as interactive (isHeartbeat=false)
+    registerAgentRunContext("client-run", {
+      sessionKey: "session-client",
+      isHeartbeat: false,
+      verboseLevel: "off",
+    });
+    // Register source-run as heartbeat
+    registerAgentRunContext("source-run", {
+      sessionKey: "session-source",
+      isHeartbeat: true,
+      verboseLevel: "off",
+    });
+    // Chat-link: source-run -> client-run
+    chatRunState.registry.add("source-run", {
+      sessionKey: "session-source",
+      clientRunId: "client-run",
+    });
+
+    // Trigger with source-run (heartbeat source), client is client-run
+    handler({
+      runId: "source-run",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "HEARTBEAT_OK from heartbeat source" },
+    });
+
+    // Should NOT be suppressed - primary has isHeartbeat=false
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(1);
+  });
 });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -23,13 +23,25 @@ function resolveHeartbeatAckMaxChars(): number {
 function resolveHeartbeatContext(runId: string, sourceRunId?: string) {
   const primary = getAgentRunContext(runId);
 
-  // If primary run is NOT a heartbeat, this is an interactive user message
+  // Case 1: primary exists and is explicitly NOT a heartbeat → interactive user message
   // Don't hide output - user is actively communicating
-  if (!primary?.isHeartbeat) {
+  if (primary && primary.isHeartbeat === false) {
     return primary;
   }
 
-  // Primary IS a heartbeat - check sourceRunId for context
+  // Case 2: primary is undefined (unregistered) → check sourceRunId for heartbeat context
+  // This preserves existing behavior for chat-linked synthetic clientRunId scenarios
+  if (!primary) {
+    if (sourceRunId && sourceRunId !== runId) {
+      const source = getAgentRunContext(sourceRunId);
+      if (source?.isHeartbeat) {
+        return source;
+      }
+    }
+    return primary;
+  }
+
+  // Case 3: primary exists (isHeartbeat === true or undefined) → check sourceRunId
   if (sourceRunId && sourceRunId !== runId) {
     const source = getAgentRunContext(sourceRunId);
     if (source?.isHeartbeat) {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -29,19 +29,7 @@ function resolveHeartbeatContext(runId: string, sourceRunId?: string) {
     return primary;
   }
 
-  // Case 2: primary is undefined (unregistered) → check sourceRunId for heartbeat context
-  // This preserves existing behavior for chat-linked synthetic clientRunId scenarios
-  if (!primary) {
-    if (sourceRunId && sourceRunId !== runId) {
-      const source = getAgentRunContext(sourceRunId);
-      if (source?.isHeartbeat) {
-        return source;
-      }
-    }
-    return primary;
-  }
-
-  // Case 3: primary exists (isHeartbeat === true or undefined) → check sourceRunId
+  // For all other cases (primary undefined or heartbeat), check sourceRunId fallback
   if (sourceRunId && sourceRunId !== runId) {
     const source = getAgentRunContext(sourceRunId);
     if (source?.isHeartbeat) {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -22,9 +22,14 @@ function resolveHeartbeatAckMaxChars(): number {
 
 function resolveHeartbeatContext(runId: string, sourceRunId?: string) {
   const primary = getAgentRunContext(runId);
-  if (primary?.isHeartbeat) {
+
+  // If primary run is NOT a heartbeat, this is an interactive user message
+  // Don't hide output - user is actively communicating
+  if (!primary?.isHeartbeat) {
     return primary;
   }
+
+  // Primary IS a heartbeat - check sourceRunId for context
   if (sourceRunId && sourceRunId !== runId) {
     const source = getAgentRunContext(sourceRunId);
     if (source?.isHeartbeat) {


### PR DESCRIPTION
## Summary
**This is a critical bug fix** - user responses were being silently dropped during heartbeat execution.

### Problem
When user sends a message during heartbeat execution, the response was silently hidden/suppressed.

Example:
1. Heartbeat triggers a scheduled task (e.g., news digest scan)
2. User sees the activity and sends a message
3. Agent's response is silently dropped - user never sees it!

### Root Cause Analysis
In `resolveHeartbeatContext()`:
- It checked both `runId` and `sourceRunId` for heartbeat context
- Even when user initiated a NEW message (non-heartbeat run), the output was hidden because `sourceRunId` was a heartbeat

### Solution
Changed the logic in `resolveHeartbeatContext()`:
```typescript
// If primary run is NOT a heartbeat, this is an interactive user message
// Don't hide output - user is actively communicating
if (!primary?.isHeartbeat) {
  return primary;
}

// Only hide if primary run IS a heartbeat (user responded to heartbeat prompt)
```

### Scenarios After Fix
| Scenario | Before Fix | After Fix |
|----------|-----------|----------|
| User initiates new message during heartbeat | ❌ Hidden | ✅ Displayed |
| User responds to heartbeat prompt | ✅ Hidden | ✅ Hidden |
| Heartbeat "HEARTBEAT_OK" acknowledgment | ✅ Hidden | ✅ Hidden |

### Testing
After this fix:
- ✅ Interactive user messages during heartbeat will display correctly
- ✅ Heartbeat "HEARTBEAT_OK" acknowledgments will still be suppressed (as intended)