### PR TITLE
fix(gateway): honor dangerouslyDisableDeviceAuth in evaluateMissingDeviceIdentity

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -169,6 +169,42 @@ describe("ws connect policy", () => {
         isLocalClient: false,
       }).kind,
     ).toBe("allow");
+
+    // dangerouslyDisableDeviceAuth=true should allow device-identity bypass
+    // even without a shared token — auth will be checked by resolveConnectAuthDecision. (#43909)
+    const bypassPolicy = resolveControlUiAuthPolicy({
+      isControlUi: true,
+      controlUiConfig: { dangerouslyDisableDeviceAuth: true },
+      deviceRaw: null,
+    });
+    expect(
+      evaluateMissingDeviceIdentity({
+        hasDeviceIdentity: false,
+        role: "operator",
+        isControlUi: true,
+        controlUiAuthPolicy: bypassPolicy,
+        trustedProxyAuthOk: false,
+        sharedAuthOk: false,
+        authOk: true,
+        hasSharedAuth: false,
+        isLocalClient: false,
+      }).kind,
+    ).toBe("allow");
+
+    // Same bypass applies from a remote (non-localhost) connection (e.g. iframe at dev.coze.site).
+    expect(
+      evaluateMissingDeviceIdentity({
+        hasDeviceIdentity: false,
+        role: "operator",
+        isControlUi: true,
+        controlUiAuthPolicy: bypassPolicy,
+        trustedProxyAuthOk: false,
+        sharedAuthOk: true,
+        authOk: true,
+        hasSharedAuth: true,
+        isLocalClient: false,
+      }).kind,
+    ).toBe("allow");
   });
 
   test("pairing bypass requires control-ui bypass + shared auth (or trusted-proxy auth)", () => {

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -82,6 +82,11 @@ export function evaluateMissingDeviceIdentity(params: {
   if (params.isControlUi && params.trustedProxyAuthOk) {
     return { kind: "allow" };
   }
+  // dangerouslyDisableDeviceAuth bypasses device identity gating entirely.
+  // Shared-secret / token auth is still enforced separately via resolveConnectAuthDecision.
+  if (params.isControlUi && params.controlUiAuthPolicy.allowBypass) {
+    return { kind: "allow" };
+  }
   if (params.isControlUi && !params.controlUiAuthPolicy.allowBypass) {
     // Allow localhost Control UI connections when allowInsecureAuth is configured.
     // Localhost has no network interception risk, and browser SubtleCrypto


### PR DESCRIPTION
## Summary

Fixes #43909 — `gateway.controlUi.dangerouslyDisableDeviceAuth: true` was not actually bypassing device identity checks in `evaluateMissingDeviceIdentity`.

## Root Cause

`evaluateMissingDeviceIdentity` skipped the `reject-control-ui-insecure-auth` rejection block when `allowBypass === true`, but had no explicit `allow` path for that case. The function then fell through to `roleCanSkipDeviceIdentity(role, sharedAuthOk)`, which returns `false` when no shared token is provided (e.g. iframe environments like Coze that can't issue device crypto). This caused `reject-device-required` instead of the intended bypass.

## Fix

Add an explicit early return when `isControlUi && allowBypass === true`:

```ts
// dangerouslyDisableDeviceAuth bypasses device identity gating entirely.
// Shared-secret / token auth is still enforced separately via resolveConnectAuthDecision.
if (params.isControlUi && params.controlUiAuthPolicy.allowBypass) {
  return { kind: "allow" };
}
```

Token/password auth is still enforced after this check by `resolveConnectAuthDecision` — only device-identity crypto is bypassed.

## Tests

Two regression test cases added in `connect-policy.test.ts`:
- `dangerouslyDisableDeviceAuth=true` with `sharedAuthOk=false` (the exact failing case from #43909)
- `dangerouslyDisableDeviceAuth=true` with `sharedAuthOk=true` (remote iframe baseline)

All 4 existing tests continue to pass.

## Checklist

- [x] Regression tests added
- [x] All existing tests pass
- [x] No auth bypass introduced — token/password auth still checked downstream by `resolveConnectAuthDecision`