### PR TITLE
feat(telegram): add apiRoot config for custom Bot API endpoints

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -142,6 +142,8 @@ export type TelegramAccountConfig = {
   /** @deprecated Legacy key; migrated automatically to `streaming`. */
   streamMode?: "off" | "partial" | "block";
   mediaMaxMb?: number;
+  /** Custom Telegram Bot API root URL (e.g. a reverse proxy). Replaces https://api.telegram.org. */
+  apiRoot?: string;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;
   /** Retry policy for outbound Telegram API calls. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -191,6 +191,7 @@ export const TelegramAccountSchemaBase = z
     // Legacy key kept for automatic migration to `streaming`.
     streamMode: z.enum(["off", "partial", "block"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
+    apiRoot: z.string().url().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,
     network: z

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -191,7 +191,13 @@ export const TelegramAccountSchemaBase = z
     // Legacy key kept for automatic migration to `streaming`.
     streamMode: z.enum(["off", "partial", "block"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
-    apiRoot: z.string().url().optional(),
+    apiRoot: z
+      .string()
+      .url()
+      .refine((v) => !v.endsWith("/"), {
+        message: "apiRoot must not have a trailing slash",
+      })
+      .optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,
     network: z

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -198,11 +198,13 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
+  const apiRoot = telegramCfg?.apiRoot || undefined;
   const client: ApiClientOptions | undefined =
-    finalFetch || timeoutSeconds
+    finalFetch || timeoutSeconds || apiRoot
       ? {
           ...(finalFetch ? { fetch: finalFetch } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(apiRoot ? { apiRoot } : {}),
         }
       : undefined;
 

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -198,7 +198,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
-  const apiRoot = telegramCfg?.apiRoot || undefined;
+  const apiRoot = telegramCfg?.apiRoot;
   const client: ApiClientOptions | undefined =
     finalFetch || timeoutSeconds || apiRoot
       ? {


### PR DESCRIPTION
## Summary

- Adds `channels.telegram.apiRoot` config option to override the default Telegram Bot API URL (`https://api.telegram.org`)
- Useful for users behind firewalls who need to route through a reverse proxy
- Existing `proxy` (forward proxy) config is unchanged; `apiRoot` is an alternative for reverse proxy setups
- grammY already supports `apiRoot` natively; this just exposes it through the config

## Test plan

- [x] `pnpm build` passes
- [x] `src/config/schema.test.ts` passes (20/20)
- [x] Pre-existing telegram test failures unrelated to this change (verified by testing on clean main)
- [ ] Manual test: set `apiRoot` to a custom reverse proxy, verify bot connects and polls successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)