### PR TITLE
fix(exec-approvals): persist allow-always entries for bare basename commands

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -447,4 +447,67 @@ describe("resolveAllowAlwaysPatterns", () => {
       persistedPattern: benign,
     });
   });
+
+  it("persists resolved path for bare basename when segment lacks resolvedPath (#43988)", () => {
+    // Simulate the bug: segment was created without full PATH so resolvedPath is undefined.
+    // resolveAllowAlwaysPatterns must still persist the right path when env has PATH.
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const myId = makeExecutable(dir, "id");
+    const env = makePathEnv(dir);
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "id",
+          argv: ["id"],
+          // resolvedPath intentionally absent — as if PATH was unavailable at analysis time
+          resolution: { rawExecutable: "id", executableName: "id" },
+        },
+      ],
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(patterns).toEqual([myId]);
+  });
+
+  it("persists bare basename via full allow-always cycle (#43988)", () => {
+    // End-to-end: evaluateShellAllowlist segments feed resolveAllowAlwaysPatterns,
+    // then the persisted pattern satisfies a subsequent evaluateShellAllowlist call.
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const myJq = makeExecutable(dir, "jq");
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const first = evaluateShellAllowlist({
+      command: "jq -r .foo",
+      allowlist: [],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    const persisted = resolveAllowAlwaysPatterns({
+      segments: first.segments,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(persisted).toEqual([myJq]);
+
+    const second = evaluateShellAllowlist({
+      command: "jq -r .bar",
+      allowlist: persisted.map((p) => ({ pattern: p })),
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(true);
+  });
 });

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -459,7 +459,11 @@ function collectAllowAlwaysPatterns(params: {
     return;
   }
 
-  const candidatePath = resolveAllowlistCandidatePath(params.segment.resolution, params.cwd);
+  const candidatePath = resolveAllowlistCandidatePath(
+    params.segment.resolution,
+    params.cwd,
+    params.env,
+  );
   if (!candidatePath) {
     return;
   }

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -118,6 +118,7 @@ export function resolveCommandResolutionFromArgv(
 export function resolveAllowlistCandidatePath(
   resolution: CommandResolution | null,
   cwd?: string,
+  env?: NodeJS.ProcessEnv,
 ): string | undefined {
   if (!resolution) {
     return undefined;
@@ -131,7 +132,9 @@ export function resolveAllowlistCandidatePath(
   }
   const expanded = raw.startsWith("~") ? expandHomePrefix(raw) : raw;
   if (!expanded.includes("/") && !expanded.includes("\\")) {
-    return undefined;
+    // Bare basename: fall back to PATH lookup so "allow always" can persist the
+    // resolved absolute path even when the segment was analyzed without full PATH.
+    return resolveExecutableCandidatePath(expanded, { cwd, env });
   }
   if (path.isAbsolute(expanded)) {
     return expanded;


### PR DESCRIPTION
## Summary

- **Problem**: "Allow always" approvals for bare basename commands (e.g. `git`, `node` — no slashes) were never persisted. `resolveAllowlistCandidatePath` returned `undefined` for bare basenames, so `collectAllowAlwaysPatterns` bailed out and wrote nothing to the allowlist.
- **Why it matters**: Users who selected "allow always" for a common bare command had to re-approve it every session — the approval silently did nothing.
- **What changed**: `resolveAllowlistCandidatePath` now falls back to `resolveExecutableCandidatePath` (PATH lookup) for bare basenames, resolving to the full absolute path that can be persisted. The `env` parameter is threaded through `collectAllowAlwaysPatterns` → `resolveAllowlistCandidatePath` so the lookup uses the correct environment.
- **What did NOT change**: Allowlist file format, approval prompt UI, handling of absolute or relative paths, any other approval flow.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #

## User-visible / Behavior Changes

"Allow always" now correctly persists for bare basename commands. Previously these approvals were silently dropped; after this fix they resolve to the absolute executable path and are written to the allowlist as expected.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — bare basename "allow always" entries now persist, so previously-approved commands will not re-prompt. The resolved path is still the same absolute binary looked up via PATH; no escalation of privilege occurs.
- Data access scope changed? No

## Repro + Verification

### Steps

1. Run any bare basename command (e.g. `git status`) through the exec approval flow.
2. Select "Allow always".
3. Run the same command again in a new session.
4. **Before**: approval prompt re-appears. **After**: command runs without prompting.

### Evidence

- [x] Failing test/log before + passing after — new test suite `src/infra/exec-approvals-allow-always.test.ts` covers the bare-basename case explicitly (fails on `main`, passes on this branch).
