### PR TITLE
fix(slack): ignore edit/delete events for AI re-trigger

### DIFF
--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -108,12 +108,12 @@ describe("registerSlackMessageEvents", () => {
       calls: 0,
     },
     {
-      name: "blocks message_changed system events when dmPolicy is disabled",
+      name: "ignores message_changed system events regardless of dmPolicy (disabled)",
       input: { overrides: { dmPolicy: "disabled" }, event: makeChangedEvent() },
       calls: 0,
     },
     {
-      name: "blocks message_changed system events for unauthorized senders in allowlist mode",
+      name: "ignores message_changed system events regardless of dmPolicy (allowlist)",
       input: {
         overrides: { dmPolicy: "allowlist", allowFrom: ["U2"] },
         event: makeChangedEvent({ user: "U1" }),
@@ -121,12 +121,11 @@ describe("registerSlackMessageEvents", () => {
       calls: 0,
     },
     {
-      name: "ignores message_deleted system events",
+      name: "ignores message_deleted system events regardless of channel auth config",
       input: {
         overrides: {
           dmPolicy: "open",
           channelType: "channel",
-          channelUsers: ["U_OWNER"],
         },
         event: makeDeletedEvent({ channel: "C1", user: "U_ATTACKER" }),
       },

--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -103,9 +103,9 @@ async function runMessageCase(input: MessageCase = {}): Promise<void> {
 describe("registerSlackMessageEvents", () => {
   const cases: Array<{ name: string; input: MessageCase; calls: number }> = [
     {
-      name: "enqueues message_changed system events when dmPolicy is open",
+      name: "ignores message_changed system events when dmPolicy is open",
       input: { overrides: { dmPolicy: "open" }, event: makeChangedEvent() },
-      calls: 1,
+      calls: 0,
     },
     {
       name: "blocks message_changed system events when dmPolicy is disabled",
@@ -205,7 +205,7 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
-  it("applies subtype system-event handling for channel messages", async () => {
+  it("ignores message_changed subtype events for channel messages", async () => {
     messageQueueMock.mockClear();
     messageAllowMock.mockReset().mockResolvedValue([]);
     const { handler, handleSlackMessage } = createMessageHandlers({
@@ -226,7 +226,7 @@ describe("registerSlackMessageEvents", () => {
     });
 
     expect(handleSlackMessage).not.toHaveBeenCalled();
-    expect(messageQueueMock).toHaveBeenCalledTimes(1);
+    expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
   it("skips app_mention events for DM channel ids even with contradictory channel_type", async () => {

--- a/src/slack/monitor/events/messages.test.ts
+++ b/src/slack/monitor/events/messages.test.ts
@@ -121,7 +121,7 @@ describe("registerSlackMessageEvents", () => {
       calls: 0,
     },
     {
-      name: "blocks message_deleted system events for users outside channel users allowlist",
+      name: "ignores message_deleted system events",
       input: {
         overrides: {
           dmPolicy: "open",

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -23,7 +23,10 @@ export function registerSlackMessageEvents(params: {
       const message = event as SlackMessageEvent;
       const subtypeHandler = resolveSlackMessageSubtypeHandler(message);
       if (subtypeHandler) {
-        if (subtypeHandler.eventKind === "message_changed") {
+        if (
+          subtypeHandler.eventKind === "message_changed" ||
+          subtypeHandler.eventKind === "message_deleted"
+        ) {
           return;
         }
         const channelId = subtypeHandler.resolveChannelId(message);

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -23,6 +23,9 @@ export function registerSlackMessageEvents(params: {
       const message = event as SlackMessageEvent;
       const subtypeHandler = resolveSlackMessageSubtypeHandler(message);
       if (subtypeHandler) {
+        if (subtypeHandler.eventKind === "message_changed") {
+          return;
+        }
         const channelId = subtypeHandler.resolveChannelId(message);
         const ingressContext = await authorizeAndResolveSlackSystemEventContext({
           ctx,


### PR DESCRIPTION
## Summary

Fix Slack duplicate re-engagement caused by `message_changed` and `message_deleted` subtype events.

Today these subtype events can enqueue system context back into the same routed session. In real Slack usage this can cause the agent to re-enter the conversation and produce duplicate replies after a user edits a message (and potentially after deletes as well).

This PR makes Slack treat these two subtype events as non-triggering events by returning early instead of routing them into system-event handling.

`thread_broadcast` is intentionally left unchanged.

## What changed

- ignore Slack `message_changed` events in `registerSlackMessageEvents`
- ignore Slack `message_deleted` events in `registerSlackMessageEvents`
- update tests to assert these events are ignored

## Why this is still needed

There was a prior PR in this area (#28916), but the underlying behavior is still present in current release flows and still reproducible in practice. This PR reapplies the fix against current `main`.

## Repro

1. Talk to the bot in Slack
2. Edit a prior message
3. Before this fix: the session can be re-stimulated and emit a duplicate reply
4. After this fix: edit/delete events are ignored for AI turn triggering

## Validation

- `pnpm test -- --run src/slack/monitor/events/messages.test.ts`
- All tests passing

## Scope boundary

- does **not** change regular Slack message handling
- does **not** change `thread_broadcast`
- does **not** change outbound delivery behavior
