### PR TITLE
Gateway: support auth token from trusted proxy headers

### DIFF
--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -52,21 +52,17 @@ function trimToUndefined(value: string | undefined): string | undefined {
 
 /**
  * Extract token from WebSocket upgrade request headers.
- * This allows nginx proxy to inject X-OpenClaw-Token header for browser clients
- * that cannot send custom WebSocket headers.
+ * This allows a trusted reverse proxy to inject X-OpenClaw-Token header
+ * for browser clients that cannot send custom WebSocket headers.
+ *
+ * Note: Only X-OpenClaw-Token is extracted, not Authorization: Bearer.
+ * The standard Authorization header may contain unrelated OAuth/OIDC tokens
+ * that would cause spurious rate-limit hits if treated as gateway auth.
  */
 function extractHeaderToken(req: IncomingMessage): string | undefined {
   const headerToken = req.headers["x-openclaw-token"];
   if (typeof headerToken === "string" && headerToken.trim()) {
     return headerToken.trim();
-  }
-  // Also check Authorization: Bearer header
-  const auth = req.headers.authorization;
-  if (typeof auth === "string" && auth.toLowerCase().startsWith("bearer ")) {
-    const token = auth.slice(7).trim();
-    if (token) {
-      return token;
-    }
   }
   return undefined;
 }
@@ -104,6 +100,19 @@ function resolveBootstrapTokenCandidate(
   return trimToUndefined(connectAuth?.bootstrapToken);
 }
 
+/**
+ * Resolve auth state for a WebSocket connect handshake.
+ *
+ * When the request comes from a trusted proxy (gateway.trustedProxies),
+ * extracts X-OpenClaw-Token header and uses it as shared auth. This enables
+ * browser clients behind a reverse proxy to authenticate without device pairing
+ * when gateway.controlUi.dangerouslyDisableDeviceAuth is enabled.
+ *
+ * Limitations:
+ * - Header token is only used as shared auth, not as device token candidate.
+ *   Browser clients authing solely via header need dangerouslyDisableDeviceAuth: true
+ *   or must pass primary auth (token/password) via authorizeWsControlUiGatewayConnect.
+ */
 export async function resolveConnectAuthState(params: {
   resolvedAuth: ResolvedGatewayAuth;
   connectAuth: HandshakeConnectAuth | null | undefined;

--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -11,6 +11,7 @@ import {
   type GatewayAuthResult,
   type ResolvedGatewayAuth,
 } from "../../auth.js";
+import { isTrustedProxyAddress } from "../../net.js";
 
 type HandshakeConnectAuth = {
   token?: string;
@@ -49,10 +50,32 @@ function trimToUndefined(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+/**
+ * Extract token from WebSocket upgrade request headers.
+ * This allows nginx proxy to inject X-OpenClaw-Token header for browser clients
+ * that cannot send custom WebSocket headers.
+ */
+function extractHeaderToken(req: IncomingMessage): string | undefined {
+  const headerToken = req.headers["x-openclaw-token"];
+  if (typeof headerToken === "string" && headerToken.trim()) {
+    return headerToken.trim();
+  }
+  // Also check Authorization: Bearer header
+  const auth = req.headers.authorization;
+  if (typeof auth === "string" && auth.toLowerCase().startsWith("bearer ")) {
+    const token = auth.slice(7).trim();
+    if (token) {
+      return token;
+    }
+  }
+  return undefined;
+}
+
 function resolveSharedConnectAuth(
   connectAuth: HandshakeConnectAuth | null | undefined,
+  headerToken?: string,
 ): { token?: string; password?: string } | undefined {
-  const token = trimToUndefined(connectAuth?.token);
+  const token = trimToUndefined(connectAuth?.token) ?? headerToken;
   const password = trimToUndefined(connectAuth?.password);
   if (!token && !password) {
     return undefined;
@@ -91,7 +114,15 @@ export async function resolveConnectAuthState(params: {
   rateLimiter?: AuthRateLimiter;
   clientIp?: string;
 }): Promise<ConnectAuthState> {
-  const sharedConnectAuth = resolveSharedConnectAuth(params.connectAuth);
+  // Check if request comes from a trusted proxy - if so, we can use header token
+  const remoteAddr = params.req.socket?.remoteAddress;
+  const isFromTrustedProxy = isTrustedProxyAddress(remoteAddr, params.trustedProxies);
+
+  // Extract token from HTTP headers (for browser clients behind trusted proxy)
+  // Only use header token when request comes from a trusted proxy to prevent spoofing
+  const headerToken = isFromTrustedProxy ? extractHeaderToken(params.req) : undefined;
+
+  const sharedConnectAuth = resolveSharedConnectAuth(params.connectAuth, headerToken);
   const sharedAuthProvided = Boolean(sharedConnectAuth);
   const bootstrapTokenCandidate = params.hasDeviceIdentity
     ? resolveBootstrapTokenCandidate(params.connectAuth)


### PR DESCRIPTION
## Summary

Browser clients cannot send custom headers during WebSocket connections, which prevents them from authenticating via `X-OpenClaw-Token` header when connecting through a reverse proxy like nginx.

This change allows the gateway to extract the auth token from HTTP upgrade request headers when the connection comes from a trusted proxy IP. The proxy injects the `X-OpenClaw-Token` (or `Authorization: Bearer`) header, which is then used to satisfy `sharedAuthOk` for the device identity bypass when `dangerouslyDisableDeviceAuth` is configured.

## Security model

- Only trusted proxies (defined in `gateway.trustedProxies` config) can have their headers honored
- IP-based validation prevents header spoofing from untrusted sources
- Works with the existing `dangerouslyDisableDeviceAuth` + `sharedAuthOk` flow

## Use case

When running OpenClaw behind nginx/Caddy/traefik with `dangerouslyDisableDeviceAuth: true`:

1. Browser connects to `wss://gateway.example.com`
2. Nginx proxies to gateway and injects `X-OpenClaw-Token: <token>` header
3. Gateway sees connection from trusted proxy IP
4. Gateway extracts token from header and uses it for auth
5. Browser client can connect without device pairing

## Testing

- Tested with nginx proxy injecting `X-OpenClaw-Token` header
- Verified browser clients from remote network can now connect when:
  - `gateway.controlUi.dangerouslyDisableDeviceAuth: true`
  - `gateway.trustedProxies` includes proxy IP
  - nginx sets `X-OpenClaw-Token` header with valid gateway token

🤖 Generated with [Claude Code](https://claude.com/claude-code)