### PR TITLE
feat(acp): add remote runtime backend plugin

### DIFF
--- a/extensions/acp-remote/index.ts
+++ b/extensions/acp-remote/index.ts
@@ -1,0 +1,19 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/acp";
+import { createAcpRemotePluginConfigSchema } from "./src/config.js";
+import { createAcpRemoteRuntimeService } from "./src/service.js";
+
+const plugin = {
+  id: "acp-remote",
+  name: "ACP Remote Runtime",
+  description: "ACP runtime backend powered by a remote HTTP gateway.",
+  configSchema: createAcpRemotePluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    api.registerService(
+      createAcpRemoteRuntimeService({
+        pluginConfig: api.pluginConfig,
+      }),
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/acp-remote/openclaw.plugin.json
+++ b/extensions/acp-remote/openclaw.plugin.json
@@ -9,6 +9,9 @@
       "url": {
         "type": "string"
       },
+      "defaultCwd": {
+        "type": "string"
+      },
       "headers": {
         "type": "object",
         "additionalProperties": {
@@ -35,6 +38,10 @@
     "url": {
       "label": "Gateway URL",
       "help": "HTTP endpoint that accepts ACP JSON-RPC requests over Streamable HTTP and returns JSON or SSE responses."
+    },
+    "defaultCwd": {
+      "label": "Default Working Directory",
+      "help": "Optional absolute path to use on the remote host when callers omit cwd. If unset, the remote gateway falls back to its home directory."
     },
     "headers": {
       "label": "HTTP Headers",

--- a/extensions/acp-remote/openclaw.plugin.json
+++ b/extensions/acp-remote/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "acp-remote",
   "name": "ACP Remote Runtime",
-  "description": "ACP runtime backend that connects OpenClaw to a remote ACP gateway over newline-delimited JSON-RPC HTTP streams.",
+  "description": "ACP runtime backend that connects OpenClaw to a remote ACP gateway over Streamable HTTP.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -23,9 +23,6 @@
         "type": "number",
         "minimum": 0
       },
-      "requiredDraftRevision": {
-        "type": "string"
-      },
       "protocolVersion": {
         "type": "integer",
         "minimum": 1,
@@ -37,7 +34,7 @@
   "uiHints": {
     "url": {
       "label": "Gateway URL",
-      "help": "HTTP endpoint that accepts newline-delimited ACP JSON-RPC requests and streams newline-delimited responses."
+      "help": "HTTP endpoint that accepts ACP JSON-RPC requests over Streamable HTTP and returns JSON or SSE responses."
     },
     "headers": {
       "label": "HTTP Headers",
@@ -52,11 +49,6 @@
     "retryDelayMs": {
       "label": "Prompt Retry Delay Ms",
       "help": "Delay before reissuing a dropped prompt request with the same OpenClaw request id.",
-      "advanced": true
-    },
-    "requiredDraftRevision": {
-      "label": "Required Draft Revision",
-      "help": "Compatibility revision that the remote gateway must echo during initialize.",
       "advanced": true
     },
     "protocolVersion": {

--- a/extensions/acp-remote/openclaw.plugin.json
+++ b/extensions/acp-remote/openclaw.plugin.json
@@ -1,0 +1,68 @@
+{
+  "id": "acp-remote",
+  "name": "ACP Remote Runtime",
+  "description": "ACP runtime backend that connects OpenClaw to a remote ACP gateway over newline-delimited JSON-RPC HTTP streams.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "url": {
+        "type": "string"
+      },
+      "headers": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "timeoutSeconds": {
+        "type": "number",
+        "minimum": 0.001
+      },
+      "retryDelayMs": {
+        "type": "number",
+        "minimum": 0
+      },
+      "requiredDraftRevision": {
+        "type": "string"
+      },
+      "protocolVersion": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 65535
+      }
+    },
+    "required": ["url"]
+  },
+  "uiHints": {
+    "url": {
+      "label": "Gateway URL",
+      "help": "HTTP endpoint that accepts newline-delimited ACP JSON-RPC requests and streams newline-delimited responses."
+    },
+    "headers": {
+      "label": "HTTP Headers",
+      "help": "Optional static headers to include on each gateway request, for example Authorization.",
+      "advanced": true
+    },
+    "timeoutSeconds": {
+      "label": "Request Timeout Seconds",
+      "help": "Timeout applied to initialize, session setup, control, and prompt requests.",
+      "advanced": true
+    },
+    "retryDelayMs": {
+      "label": "Prompt Retry Delay Ms",
+      "help": "Delay before reissuing a dropped prompt request with the same OpenClaw request id.",
+      "advanced": true
+    },
+    "requiredDraftRevision": {
+      "label": "Required Draft Revision",
+      "help": "Compatibility revision that the remote gateway must echo during initialize.",
+      "advanced": true
+    },
+    "protocolVersion": {
+      "label": "ACP Protocol Version",
+      "help": "ACP protocol version to negotiate with the remote gateway.",
+      "advanced": true
+    }
+  }
+}

--- a/extensions/acp-remote/openclaw.plugin.json
+++ b/extensions/acp-remote/openclaw.plugin.json
@@ -41,7 +41,7 @@
     },
     "defaultCwd": {
       "label": "Default Working Directory",
-      "help": "Optional absolute path to use on the remote host when callers omit cwd. If unset, the remote gateway falls back to its home directory."
+      "help": "Optional absolute path to use on the remote host when callers omit cwd. If unset, the remote gateway uses its own default working directory."
     },
     "headers": {
       "label": "HTTP Headers",

--- a/extensions/acp-remote/package.json
+++ b/extensions/acp-remote/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@openclaw/acp-remote",
+  "version": "2026.3.9",
+  "description": "OpenClaw remote ACP runtime backend over HTTP",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/acp-remote/src/config.test.ts
+++ b/extensions/acp-remote/src/config.test.ts
@@ -23,6 +23,7 @@ describe("acp-remote plugin config parsing", () => {
     const resolved = resolveAcpRemotePluginConfig({
       rawConfig: {
         url: "http://127.0.0.1:8787/acp",
+        defaultCwd: "/srv/openclaw",
         headers: {
           Authorization: "Bearer test",
         },
@@ -32,6 +33,7 @@ describe("acp-remote plugin config parsing", () => {
       },
     });
 
+    expect(resolved.defaultCwd).toBe("/srv/openclaw");
     expect(resolved.headers).toEqual({
       Authorization: "Bearer test",
     });
@@ -51,6 +53,17 @@ describe("acp-remote plugin config parsing", () => {
         },
       }),
     ).toThrow("headers must be an object of string values");
+  });
+
+  it("rejects relative defaultCwd values", () => {
+    expect(() =>
+      resolveAcpRemotePluginConfig({
+        rawConfig: {
+          url: "http://127.0.0.1:8787/acp",
+          defaultCwd: "relative/path",
+        },
+      }),
+    ).toThrow("defaultCwd must be an absolute path");
   });
 
   it("schema rejects malformed URLs", () => {

--- a/extensions/acp-remote/src/config.test.ts
+++ b/extensions/acp-remote/src/config.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACP_REMOTE_DRAFT_REVISION,
+  ACP_REMOTE_PROTOCOL_VERSION,
+  createAcpRemotePluginConfigSchema,
+  resolveAcpRemotePluginConfig,
+} from "./config.js";
+
+describe("acp-remote plugin config parsing", () => {
+  it("requires a valid absolute URL", () => {
+    const resolved = resolveAcpRemotePluginConfig({
+      rawConfig: {
+        url: "http://127.0.0.1:8787/acp",
+      },
+    });
+
+    expect(resolved.url).toBe("http://127.0.0.1:8787/acp");
+    expect(resolved.timeoutMs).toBe(30_000);
+    expect(resolved.retryDelayMs).toBe(150);
+    expect(resolved.requiredDraftRevision).toBe(ACP_REMOTE_DRAFT_REVISION);
+    expect(resolved.protocolVersion).toBe(ACP_REMOTE_PROTOCOL_VERSION);
+  });
+
+  it("preserves optional headers and timing overrides", () => {
+    const resolved = resolveAcpRemotePluginConfig({
+      rawConfig: {
+        url: "http://127.0.0.1:8787/acp",
+        headers: {
+          Authorization: "Bearer test",
+        },
+        timeoutSeconds: 12.5,
+        retryDelayMs: 5,
+        requiredDraftRevision: "draft-x",
+        protocolVersion: 7,
+      },
+    });
+
+    expect(resolved.headers).toEqual({
+      Authorization: "Bearer test",
+    });
+    expect(resolved.timeoutMs).toBe(12_500);
+    expect(resolved.retryDelayMs).toBe(5);
+    expect(resolved.requiredDraftRevision).toBe("draft-x");
+    expect(resolved.protocolVersion).toBe(7);
+  });
+
+  it("rejects invalid headers", () => {
+    expect(() =>
+      resolveAcpRemotePluginConfig({
+        rawConfig: {
+          url: "http://127.0.0.1:8787/acp",
+          headers: {
+            Authorization: 1,
+          },
+        },
+      }),
+    ).toThrow("headers must be an object of string values");
+  });
+
+  it("schema rejects malformed URLs", () => {
+    const schema = createAcpRemotePluginConfigSchema();
+    if (!schema.safeParse) {
+      throw new Error("acp-remote config schema missing safeParse");
+    }
+    const parsed = schema.safeParse({
+      url: "relative/path",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects unknown config keys", () => {
+    expect(() =>
+      resolveAcpRemotePluginConfig({
+        rawConfig: {
+          url: "http://127.0.0.1:8787/acp",
+          transport: "sse",
+        },
+      }),
+    ).toThrow("unknown config key: transport");
+  });
+});

--- a/extensions/acp-remote/src/config.test.ts
+++ b/extensions/acp-remote/src/config.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  ACP_REMOTE_DRAFT_REVISION,
   ACP_REMOTE_PROTOCOL_VERSION,
   createAcpRemotePluginConfigSchema,
   resolveAcpRemotePluginConfig,
@@ -17,7 +16,6 @@ describe("acp-remote plugin config parsing", () => {
     expect(resolved.url).toBe("http://127.0.0.1:8787/acp");
     expect(resolved.timeoutMs).toBe(30_000);
     expect(resolved.retryDelayMs).toBe(150);
-    expect(resolved.requiredDraftRevision).toBe(ACP_REMOTE_DRAFT_REVISION);
     expect(resolved.protocolVersion).toBe(ACP_REMOTE_PROTOCOL_VERSION);
   });
 
@@ -30,7 +28,6 @@ describe("acp-remote plugin config parsing", () => {
         },
         timeoutSeconds: 12.5,
         retryDelayMs: 5,
-        requiredDraftRevision: "draft-x",
         protocolVersion: 7,
       },
     });
@@ -40,7 +37,6 @@ describe("acp-remote plugin config parsing", () => {
     });
     expect(resolved.timeoutMs).toBe(12_500);
     expect(resolved.retryDelayMs).toBe(5);
-    expect(resolved.requiredDraftRevision).toBe("draft-x");
     expect(resolved.protocolVersion).toBe(7);
   });
 

--- a/extensions/acp-remote/src/config.ts
+++ b/extensions/acp-remote/src/config.ts
@@ -1,9 +1,11 @@
+import { isAbsolute } from "node:path";
 import type { OpenClawPluginConfigSchema } from "openclaw/plugin-sdk/acp";
 
 export const ACP_REMOTE_PROTOCOL_VERSION = 1;
 
 export type AcpRemotePluginConfig = {
   url?: string;
+  defaultCwd?: string;
   headers?: Record<string, string>;
   timeoutSeconds?: number;
   retryDelayMs?: number;
@@ -12,6 +14,7 @@ export type AcpRemotePluginConfig = {
 
 export type ResolvedAcpRemotePluginConfig = {
   url: string;
+  defaultCwd?: string;
   headers: Record<string, string>;
   timeoutMs: number;
   retryDelayMs: number;
@@ -54,6 +57,7 @@ function parseAcpRemotePluginConfig(value: unknown): ParseResult {
 
   const allowedKeys = new Set([
     "url",
+    "defaultCwd",
     "headers",
     "timeoutSeconds",
     "retryDelayMs",
@@ -73,6 +77,16 @@ function parseAcpRemotePluginConfig(value: unknown): ParseResult {
     new URL(url);
   } catch {
     return { ok: false, message: "url must be a valid absolute URL" };
+  }
+
+  const defaultCwd = normalizeText(value.defaultCwd);
+  if (value.defaultCwd !== undefined) {
+    if (!defaultCwd) {
+      return { ok: false, message: "defaultCwd must be a non-empty string" };
+    }
+    if (!isAbsolute(defaultCwd)) {
+      return { ok: false, message: "defaultCwd must be an absolute path" };
+    }
   }
 
   const headers = value.headers;
@@ -108,6 +122,7 @@ function parseAcpRemotePluginConfig(value: unknown): ParseResult {
     ok: true,
     value: {
       url,
+      defaultCwd,
       headers: headers as Record<string, string> | undefined,
       timeoutSeconds: typeof timeoutSeconds === "number" ? timeoutSeconds : undefined,
       retryDelayMs: typeof retryDelayMs === "number" ? retryDelayMs : undefined,
@@ -141,6 +156,7 @@ export function createAcpRemotePluginConfigSchema(): OpenClawPluginConfigSchema 
       required: ["url"],
       properties: {
         url: { type: "string" },
+        defaultCwd: { type: "string" },
         headers: {
           type: "object",
           additionalProperties: { type: "string" },
@@ -167,6 +183,7 @@ export function resolveAcpRemotePluginConfig(params: {
   const normalized = parsed.value ?? {};
   return {
     url: new URL(normalized.url ?? "").toString(),
+    defaultCwd: normalized.defaultCwd,
     headers: { ...(normalized.headers ?? {}) },
     timeoutMs: Math.round((normalized.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000),
     retryDelayMs: Math.max(0, Math.round(normalized.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS)),

--- a/extensions/acp-remote/src/config.ts
+++ b/extensions/acp-remote/src/config.ts
@@ -1,6 +1,5 @@
 import type { OpenClawPluginConfigSchema } from "openclaw/plugin-sdk/acp";
 
-export const ACP_REMOTE_DRAFT_REVISION = "openclaw-ndjson-http-v1";
 export const ACP_REMOTE_PROTOCOL_VERSION = 1;
 
 export type AcpRemotePluginConfig = {
@@ -8,7 +7,6 @@ export type AcpRemotePluginConfig = {
   headers?: Record<string, string>;
   timeoutSeconds?: number;
   retryDelayMs?: number;
-  requiredDraftRevision?: string;
   protocolVersion?: number;
 };
 
@@ -17,7 +15,6 @@ export type ResolvedAcpRemotePluginConfig = {
   headers: Record<string, string>;
   timeoutMs: number;
   retryDelayMs: number;
-  requiredDraftRevision: string;
   protocolVersion: number;
 };
 
@@ -60,7 +57,6 @@ function parseAcpRemotePluginConfig(value: unknown): ParseResult {
     "headers",
     "timeoutSeconds",
     "retryDelayMs",
-    "requiredDraftRevision",
     "protocolVersion",
   ]);
   for (const key of Object.keys(value)) {
@@ -100,11 +96,6 @@ function parseAcpRemotePluginConfig(value: unknown): ParseResult {
     return { ok: false, message: "retryDelayMs must be a non-negative number" };
   }
 
-  const requiredDraftRevision = normalizeText(value.requiredDraftRevision);
-  if (value.requiredDraftRevision !== undefined && !requiredDraftRevision) {
-    return { ok: false, message: "requiredDraftRevision must be a non-empty string" };
-  }
-
   const protocolVersion = value.protocolVersion;
   if (
     protocolVersion !== undefined &&
@@ -120,7 +111,6 @@ function parseAcpRemotePluginConfig(value: unknown): ParseResult {
       headers: headers as Record<string, string> | undefined,
       timeoutSeconds: typeof timeoutSeconds === "number" ? timeoutSeconds : undefined,
       retryDelayMs: typeof retryDelayMs === "number" ? retryDelayMs : undefined,
-      requiredDraftRevision,
       protocolVersion: typeof protocolVersion === "number" ? protocolVersion : undefined,
     },
   };
@@ -157,7 +147,6 @@ export function createAcpRemotePluginConfigSchema(): OpenClawPluginConfigSchema 
         },
         timeoutSeconds: { type: "number", minimum: 0.001 },
         retryDelayMs: { type: "number", minimum: 0 },
-        requiredDraftRevision: { type: "string" },
         protocolVersion: {
           type: "integer",
           minimum: 1,
@@ -181,7 +170,6 @@ export function resolveAcpRemotePluginConfig(params: {
     headers: { ...(normalized.headers ?? {}) },
     timeoutMs: Math.round((normalized.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000),
     retryDelayMs: Math.max(0, Math.round(normalized.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS)),
-    requiredDraftRevision: normalized.requiredDraftRevision ?? ACP_REMOTE_DRAFT_REVISION,
     protocolVersion: normalized.protocolVersion ?? ACP_REMOTE_PROTOCOL_VERSION,
   };
 }

--- a/extensions/acp-remote/src/config.ts
+++ b/extensions/acp-remote/src/config.ts
@@ -1,0 +1,187 @@
+import type { OpenClawPluginConfigSchema } from "openclaw/plugin-sdk/acp";
+
+export const ACP_REMOTE_DRAFT_REVISION = "openclaw-ndjson-http-v1";
+export const ACP_REMOTE_PROTOCOL_VERSION = 1;
+
+export type AcpRemotePluginConfig = {
+  url?: string;
+  headers?: Record<string, string>;
+  timeoutSeconds?: number;
+  retryDelayMs?: number;
+  requiredDraftRevision?: string;
+  protocolVersion?: number;
+};
+
+export type ResolvedAcpRemotePluginConfig = {
+  url: string;
+  headers: Record<string, string>;
+  timeoutMs: number;
+  retryDelayMs: number;
+  requiredDraftRevision: string;
+  protocolVersion: number;
+};
+
+const DEFAULT_TIMEOUT_SECONDS = 30;
+const DEFAULT_RETRY_DELAY_MS = 150;
+
+type ParseResult =
+  | { ok: true; value: AcpRemotePluginConfig | undefined }
+  | { ok: false; message: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function isStringMap(value: unknown): value is Record<string, string> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function parseAcpRemotePluginConfig(value: unknown): ParseResult {
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+  if (!isRecord(value)) {
+    return { ok: false, message: "expected config object" };
+  }
+
+  const allowedKeys = new Set([
+    "url",
+    "headers",
+    "timeoutSeconds",
+    "retryDelayMs",
+    "requiredDraftRevision",
+    "protocolVersion",
+  ]);
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      return { ok: false, message: `unknown config key: ${key}` };
+    }
+  }
+
+  const url = normalizeText(value.url);
+  if (!url) {
+    return { ok: false, message: "url must be a non-empty string" };
+  }
+  try {
+    new URL(url);
+  } catch {
+    return { ok: false, message: "url must be a valid absolute URL" };
+  }
+
+  const headers = value.headers;
+  if (headers !== undefined && !isStringMap(headers)) {
+    return { ok: false, message: "headers must be an object of string values" };
+  }
+
+  const timeoutSeconds = value.timeoutSeconds;
+  if (
+    timeoutSeconds !== undefined &&
+    (typeof timeoutSeconds !== "number" || !Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0)
+  ) {
+    return { ok: false, message: "timeoutSeconds must be a positive number" };
+  }
+
+  const retryDelayMs = value.retryDelayMs;
+  if (
+    retryDelayMs !== undefined &&
+    (typeof retryDelayMs !== "number" || !Number.isFinite(retryDelayMs) || retryDelayMs < 0)
+  ) {
+    return { ok: false, message: "retryDelayMs must be a non-negative number" };
+  }
+
+  const requiredDraftRevision = normalizeText(value.requiredDraftRevision);
+  if (value.requiredDraftRevision !== undefined && !requiredDraftRevision) {
+    return { ok: false, message: "requiredDraftRevision must be a non-empty string" };
+  }
+
+  const protocolVersion = value.protocolVersion;
+  if (
+    protocolVersion !== undefined &&
+    (!Number.isInteger(protocolVersion) || protocolVersion < 1 || protocolVersion > 65_535)
+  ) {
+    return { ok: false, message: "protocolVersion must be an integer between 1 and 65535" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      url,
+      headers: headers as Record<string, string> | undefined,
+      timeoutSeconds: typeof timeoutSeconds === "number" ? timeoutSeconds : undefined,
+      retryDelayMs: typeof retryDelayMs === "number" ? retryDelayMs : undefined,
+      requiredDraftRevision,
+      protocolVersion: typeof protocolVersion === "number" ? protocolVersion : undefined,
+    },
+  };
+}
+
+export function createAcpRemotePluginConfigSchema(): OpenClawPluginConfigSchema {
+  return {
+    safeParse(value: unknown):
+      | { success: true; data?: unknown }
+      | {
+          success: false;
+          error: { issues: Array<{ path: Array<string | number>; message: string }> };
+        } {
+      const parsed = parseAcpRemotePluginConfig(value);
+      if (parsed.ok) {
+        return { success: true, data: parsed.value };
+      }
+      return {
+        success: false,
+        error: {
+          issues: [{ path: [], message: parsed.message }],
+        },
+      };
+    },
+    jsonSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["url"],
+      properties: {
+        url: { type: "string" },
+        headers: {
+          type: "object",
+          additionalProperties: { type: "string" },
+        },
+        timeoutSeconds: { type: "number", minimum: 0.001 },
+        retryDelayMs: { type: "number", minimum: 0 },
+        requiredDraftRevision: { type: "string" },
+        protocolVersion: {
+          type: "integer",
+          minimum: 1,
+          maximum: 65_535,
+        },
+      },
+    },
+  };
+}
+
+export function resolveAcpRemotePluginConfig(params: {
+  rawConfig: unknown;
+}): ResolvedAcpRemotePluginConfig {
+  const parsed = parseAcpRemotePluginConfig(params.rawConfig);
+  if (!parsed.ok) {
+    throw new Error(parsed.message);
+  }
+  const normalized = parsed.value ?? {};
+  return {
+    url: new URL(normalized.url ?? "").toString(),
+    headers: { ...(normalized.headers ?? {}) },
+    timeoutMs: Math.round((normalized.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000),
+    retryDelayMs: Math.max(0, Math.round(normalized.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS)),
+    requiredDraftRevision: normalized.requiredDraftRevision ?? ACP_REMOTE_DRAFT_REVISION,
+    protocolVersion: normalized.protocolVersion ?? ACP_REMOTE_PROTOCOL_VERSION,
+  };
+}

--- a/extensions/acp-remote/src/config.ts
+++ b/extensions/acp-remote/src/config.ts
@@ -47,6 +47,10 @@ function isStringMap(value: unknown): value is Record<string, string> {
   return Object.values(value).every((entry) => typeof entry === "string");
 }
 
+function normalizeFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
 function parseAcpRemotePluginConfig(value: unknown): ParseResult {
   if (value === undefined) {
     return { ok: true, value: undefined };
@@ -94,28 +98,26 @@ function parseAcpRemotePluginConfig(value: unknown): ParseResult {
     return { ok: false, message: "headers must be an object of string values" };
   }
 
-  const timeoutSeconds = value.timeoutSeconds;
-  if (
-    timeoutSeconds !== undefined &&
-    (typeof timeoutSeconds !== "number" || !Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0)
-  ) {
+  const timeoutSeconds = normalizeFiniteNumber(value.timeoutSeconds);
+  if (value.timeoutSeconds !== undefined && (timeoutSeconds === undefined || timeoutSeconds <= 0)) {
     return { ok: false, message: "timeoutSeconds must be a positive number" };
   }
 
-  const retryDelayMs = value.retryDelayMs;
-  if (
-    retryDelayMs !== undefined &&
-    (typeof retryDelayMs !== "number" || !Number.isFinite(retryDelayMs) || retryDelayMs < 0)
-  ) {
+  const retryDelayMs = normalizeFiniteNumber(value.retryDelayMs);
+  if (value.retryDelayMs !== undefined && (retryDelayMs === undefined || retryDelayMs < 0)) {
     return { ok: false, message: "retryDelayMs must be a non-negative number" };
   }
 
-  const protocolVersion = value.protocolVersion;
-  if (
-    protocolVersion !== undefined &&
-    (!Number.isInteger(protocolVersion) || protocolVersion < 1 || protocolVersion > 65_535)
-  ) {
-    return { ok: false, message: "protocolVersion must be an integer between 1 and 65535" };
+  const protocolVersion = normalizeFiniteNumber(value.protocolVersion);
+  if (value.protocolVersion !== undefined) {
+    if (
+      protocolVersion === undefined ||
+      !Number.isInteger(protocolVersion) ||
+      protocolVersion < 1 ||
+      protocolVersion > 65_535
+    ) {
+      return { ok: false, message: "protocolVersion must be an integer between 1 and 65535" };
+    }
   }
 
   return {
@@ -124,9 +126,9 @@ function parseAcpRemotePluginConfig(value: unknown): ParseResult {
       url,
       defaultCwd,
       headers: headers as Record<string, string> | undefined,
-      timeoutSeconds: typeof timeoutSeconds === "number" ? timeoutSeconds : undefined,
-      retryDelayMs: typeof retryDelayMs === "number" ? retryDelayMs : undefined,
-      protocolVersion: typeof protocolVersion === "number" ? protocolVersion : undefined,
+      timeoutSeconds,
+      retryDelayMs,
+      protocolVersion,
     },
   };
 }

--- a/extensions/acp-remote/src/runtime.test.ts
+++ b/extensions/acp-remote/src/runtime.test.ts
@@ -90,6 +90,13 @@ class MockAcpRemoteGateway {
       }
       beginSse();
       const session = this.sessions.get(sessionId);
+      const requestedCwd =
+        typeof request.params?.cwd === "string" && request.params.cwd.trim()
+          ? request.params.cwd.trim()
+          : undefined;
+      if (session && requestedCwd) {
+        session.cwd = requestedCwd;
+      }
       if (session?.history.length) {
         for (const notification of session.history) {
           writeSse(notification);
@@ -99,6 +106,7 @@ class MockAcpRemoteGateway {
         jsonrpc: "2.0",
         id: request.id,
         result: {
+          cwd: session?.cwd,
           modes: session?.currentModeId
             ? {
                 currentModeId: session.currentModeId,
@@ -124,8 +132,13 @@ class MockAcpRemoteGateway {
 
     if (request.method === "session/new") {
       const sessionId = String(request.params?._meta?.openclawSessionId ?? "");
+      const cwd =
+        typeof request.params?.cwd === "string" && request.params.cwd.trim()
+          ? request.params.cwd.trim()
+          : this.fallbackCwd;
       this.newCalls.push(sessionId);
       this.sessions.set(sessionId, {
+        cwd,
         currentModeId: undefined,
         configOptions: {},
         history: [],
@@ -135,6 +148,7 @@ class MockAcpRemoteGateway {
         id: request.id,
         result: {
           sessionId,
+          cwd,
         },
       });
       return;
@@ -312,9 +326,11 @@ class MockAcpRemoteGateway {
   protocolVersion = ACP_REMOTE_PROTOCOL_VERSION;
   loadSession = true;
   dropFirstPromptAttempt = false;
+  fallbackCwd = "/home/remote";
   readonly sessions = new Map<
     string,
     {
+      cwd: string;
       currentModeId?: string;
       configOptions: Record<string, string>;
       history: unknown[];
@@ -372,12 +388,18 @@ afterEach(async () => {
   }
 });
 
-async function createRuntime(params: { gateway?: MockAcpRemoteGateway } = {}) {
+async function createRuntime(
+  params: {
+    gateway?: MockAcpRemoteGateway;
+    config?: { defaultCwd?: string };
+  } = {},
+) {
   const gateway = params.gateway ?? new MockAcpRemoteGateway();
   const url = await gateway.start();
   servers.push(gateway);
   const runtime = new AcpRemoteRuntime({
     url,
+    defaultCwd: params.config?.defaultCwd,
     headers: {},
     timeoutMs: 5_000,
     retryDelayMs: 1,
@@ -448,6 +470,85 @@ describe("AcpRemoteRuntime", () => {
     expect(gateway.loadCalls).toEqual(["agent:codex:acp:stable", "agent:codex:acp:stable"]);
     expect(gateway.newCalls).toEqual(["agent:codex:acp:stable"]);
     expect(new Set(clientIds)).toEqual(new Set([decoded?.clientId]));
+  });
+
+  it("uses configured defaultCwd when callers omit cwd", async () => {
+    const { runtime, gateway } = await createRuntime({
+      config: {
+        defaultCwd: "/srv/openclaw",
+      },
+    });
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:default-cwd",
+      agent: "codex",
+      mode: "persistent",
+    });
+    const decoded = decodeAcpRemoteHandleState(handle.runtimeSessionName);
+    const sessionLoadRequest = gateway.requests.find(
+      (entry) => entry.request.method === "session/load",
+    );
+    const sessionNewRequest = gateway.requests.find(
+      (entry) => entry.request.method === "session/new",
+    );
+
+    expect(sessionLoadRequest?.request.params?.cwd).toBeUndefined();
+    expect(sessionNewRequest?.request.params?.cwd).toBe("/srv/openclaw");
+    expect(handle.cwd).toBe("/srv/openclaw");
+    expect(decoded?.cwd).toBe("/srv/openclaw");
+  });
+
+  it("omits cwd on the wire and uses the remote fallback when no cwd is configured", async () => {
+    const { runtime, gateway } = await createRuntime();
+
+    const first = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:remote-fallback",
+      agent: "codex",
+      mode: "persistent",
+    });
+    const second = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:remote-fallback",
+      agent: "codex",
+      mode: "persistent",
+    });
+    const sessionRequests = gateway.requests.filter((entry) =>
+      ["session/new", "session/load"].includes(String(entry.request.method)),
+    );
+
+    expect(sessionRequests.every((entry) => entry.request.params?.cwd === undefined)).toBe(true);
+    expect(first.cwd).toBe(gateway.fallbackCwd);
+    expect(second.cwd).toBe(gateway.fallbackCwd);
+    expect(decodeAcpRemoteHandleState(second.runtimeSessionName)?.cwd).toBe(gateway.fallbackCwd);
+  });
+
+  it("preserves an existing remote cwd on load when callers omit cwd", async () => {
+    const gateway = new MockAcpRemoteGateway();
+    gateway.sessions.set("agent:codex:acp:preserve-cwd", {
+      cwd: "/srv/existing-session",
+      currentModeId: undefined,
+      configOptions: {},
+      history: [],
+    });
+    const { runtime } = await createRuntime({
+      gateway,
+      config: {
+        defaultCwd: "/srv/openclaw",
+      },
+    });
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:preserve-cwd",
+      agent: "codex",
+      mode: "persistent",
+    });
+    const loadRequest = gateway.requests.find((entry) => entry.request.method === "session/load");
+
+    expect(loadRequest?.request.params?.cwd).toBeUndefined();
+    expect(gateway.newCalls).toEqual([]);
+    expect(handle.cwd).toBe("/srv/existing-session");
+    expect(decodeAcpRemoteHandleState(handle.runtimeSessionName)?.cwd).toBe(
+      "/srv/existing-session",
+    );
   });
 
   it("uses Streamable HTTP headers and omits private transport markers", async () => {

--- a/extensions/acp-remote/src/runtime.test.ts
+++ b/extensions/acp-remote/src/runtime.test.ts
@@ -551,6 +551,52 @@ describe("AcpRemoteRuntime", () => {
     );
   });
 
+  it("reopens an existing remote session from a fresh runtime instance without replaying cwd", async () => {
+    const gateway = new MockAcpRemoteGateway();
+    const url = await gateway.start();
+    servers.push(gateway);
+    const runtimeA = new AcpRemoteRuntime({
+      url,
+      headers: {},
+      timeoutMs: 5_000,
+      retryDelayMs: 1,
+      protocolVersion: ACP_REMOTE_PROTOCOL_VERSION,
+    });
+
+    const first = await runtimeA.ensureSession({
+      sessionKey: "agent:codex:acp:fresh-runtime-reopen",
+      agent: "codex",
+      mode: "persistent",
+    });
+    const requestsAfterCreate = gateway.requests.length;
+    const runtimeB = new AcpRemoteRuntime({
+      url,
+      headers: {},
+      timeoutMs: 5_000,
+      retryDelayMs: 1,
+      protocolVersion: ACP_REMOTE_PROTOCOL_VERSION,
+    });
+
+    const reopened = await runtimeB.ensureSession({
+      sessionKey: "agent:codex:acp:fresh-runtime-reopen",
+      agent: "codex",
+      mode: "persistent",
+    });
+    const reopenRequests = gateway.requests.slice(requestsAfterCreate);
+    const sessionLoadRequest = reopenRequests.find(
+      (entry) => entry.request.method === "session/load",
+    );
+    const sessionNewRequest = reopenRequests.find(
+      (entry) => entry.request.method === "session/new",
+    );
+
+    expect(first.cwd).toBe(gateway.fallbackCwd);
+    expect(sessionLoadRequest?.request.params?.cwd).toBeUndefined();
+    expect(sessionNewRequest).toBeUndefined();
+    expect(reopened.cwd).toBe(gateway.fallbackCwd);
+    expect(decodeAcpRemoteHandleState(reopened.runtimeSessionName)?.cwd).toBe(gateway.fallbackCwd);
+  });
+
   it("uses Streamable HTTP headers and omits private transport markers", async () => {
     const { runtime, gateway } = await createRuntime();
 

--- a/extensions/acp-remote/src/runtime.test.ts
+++ b/extensions/acp-remote/src/runtime.test.ts
@@ -1,0 +1,492 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { runAcpRuntimeAdapterContract } from "../../../src/acp/runtime/adapter-contract.testkit.js";
+import { ACP_REMOTE_DRAFT_REVISION } from "./config.js";
+import { AcpRemoteRuntime, decodeAcpRemoteHandleState } from "./runtime.js";
+
+type RpcRequest = {
+  id?: string | number | null;
+  method?: string;
+  params?: Record<string, unknown>;
+};
+
+class MockAcpRemoteGateway {
+  private readonly server = createServer(async (req, res) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const requestLine = Buffer.concat(chunks).toString("utf8").trim().split("\n")[0] ?? "";
+    const request = JSON.parse(requestLine || "{}") as RpcRequest;
+
+    const send = (message: unknown) => {
+      res.write(`${JSON.stringify(message)}\n`);
+    };
+
+    const ok = () => {
+      res.writeHead(200, { "content-type": "application/x-ndjson" });
+    };
+
+    if (request.method === "initialize") {
+      ok();
+      send({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          protocolVersion: request.params?.protocolVersion ?? 1,
+          agentCapabilities: {
+            loadSession: true,
+            promptCapabilities: {
+              image: false,
+              audio: false,
+              embeddedContext: false,
+            },
+            mcpCapabilities: {
+              http: false,
+              sse: false,
+            },
+            sessionCapabilities: {},
+          },
+          authMethods: [],
+          agentInfo: {
+            name: "mock-acp-gateway",
+            version: "test",
+          },
+          _meta: {
+            openclawDraftRevision: this.draftRevision,
+          },
+        },
+      });
+      res.end();
+      return;
+    }
+
+    if (request.method === "session/load") {
+      ok();
+      const sessionId = String(request.params?.sessionId ?? "");
+      this.loadCalls.push(sessionId);
+      if (!this.sessions.has(sessionId)) {
+        send({
+          jsonrpc: "2.0",
+          id: request.id,
+          error: {
+            code: "session_not_found",
+            message: `session ${sessionId} not found`,
+            data: {
+              reason: "session_not_found",
+            },
+          },
+        });
+        res.end();
+        return;
+      }
+      send({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          modes: this.sessions.get(sessionId)?.currentModeId
+            ? {
+                currentModeId: this.sessions.get(sessionId)?.currentModeId,
+                availableModes: [{ id: "contract", name: "Contract" }],
+              }
+            : undefined,
+          configOptions: Object.entries(this.sessions.get(sessionId)?.configOptions ?? {}).map(
+            ([id, currentValue]) => ({
+              type: "select",
+              id,
+              name: id,
+              currentValue,
+              options: [],
+            }),
+          ),
+        },
+      });
+      res.end();
+      return;
+    }
+
+    if (request.method === "session/new") {
+      ok();
+      const sessionId = String(request.params?._meta?.openclawSessionId ?? "");
+      this.newCalls.push(sessionId);
+      this.sessions.set(sessionId, {
+        currentModeId: undefined,
+        configOptions: {},
+      });
+      send({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          sessionId,
+        },
+      });
+      res.end();
+      return;
+    }
+
+    if (request.method === "session/set_mode") {
+      ok();
+      const sessionId = String(request.params?.sessionId ?? "");
+      const modeId = String(request.params?.modeId ?? "");
+      this.setModeCalls.push({ sessionId, modeId });
+      const session = this.sessions.get(sessionId);
+      if (session) {
+        session.currentModeId = modeId;
+      }
+      send({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {},
+      });
+      res.end();
+      return;
+    }
+
+    if (request.method === "session/set_config_option") {
+      ok();
+      const sessionId = String(request.params?.sessionId ?? "");
+      const configId = String(request.params?.configId ?? "");
+      const value = String(request.params?.value ?? "");
+      this.setConfigCalls.push({ sessionId, configId, value });
+      const session = this.sessions.get(sessionId);
+      if (session) {
+        session.configOptions[configId] = value;
+      }
+      send({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          configOptions: [
+            {
+              type: "select",
+              id: configId,
+              name: configId,
+              currentValue: value,
+              options: [],
+            },
+          ],
+        },
+      });
+      res.end();
+      return;
+    }
+
+    if (request.method === "session/close") {
+      ok();
+      const sessionId = String(request.params?.sessionId ?? "");
+      this.closeCalls.push(sessionId);
+      this.sessions.delete(sessionId);
+      send({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {},
+      });
+      res.end();
+      return;
+    }
+
+    if (request.method === "session/cancel") {
+      ok();
+      const sessionId = String(request.params?.sessionId ?? "");
+      this.cancelCalls.push(sessionId);
+      res.end();
+      return;
+    }
+
+    if (request.method === "session/prompt") {
+      ok();
+      const sessionId = String(request.params?.sessionId ?? "");
+      const prompt = request.params?.prompt;
+      const text =
+        Array.isArray(prompt) && prompt[0] && typeof prompt[0] === "object"
+          ? String((prompt[0] as { text?: unknown }).text ?? "")
+          : "";
+      const requestId = String(request.params?._meta?.openclawRequestId ?? request.id ?? "");
+      const attempt = (this.promptAttempts.get(requestId) ?? 0) + 1;
+      this.promptAttempts.set(requestId, attempt);
+
+      const stored =
+        this.promptResults.get(requestId) ??
+        (() => {
+          const result = {
+            notifications: [
+              {
+                jsonrpc: "2.0",
+                method: "session/update",
+                params: {
+                  sessionId,
+                  update: {
+                    sessionUpdate: "agent_thought_chunk",
+                    content: {
+                      type: "text",
+                      text: "thinking",
+                    },
+                  },
+                },
+              },
+              {
+                jsonrpc: "2.0",
+                method: "session/update",
+                params: {
+                  sessionId,
+                  update: {
+                    sessionUpdate: "tool_call",
+                    toolCallId: "tool-1",
+                    title: "inspect",
+                    status: "in_progress",
+                  },
+                },
+              },
+              {
+                jsonrpc: "2.0",
+                method: "session/update",
+                params: {
+                  sessionId,
+                  update: {
+                    sessionUpdate: "agent_message_chunk",
+                    content: {
+                      type: "text",
+                      text: `echo:${text}`,
+                    },
+                  },
+                },
+              },
+            ],
+            terminal: {
+              jsonrpc: "2.0",
+              id: request.id,
+              result: {
+                stopReason: "end_turn",
+              },
+            },
+          };
+          this.promptResults.set(requestId, result);
+          return result;
+        })();
+
+      for (const notification of stored.notifications) {
+        send(notification);
+      }
+      if (this.dropFirstPromptAttempt && attempt === 1) {
+        res.end();
+        return;
+      }
+      send(stored.terminal);
+      res.end();
+      return;
+    }
+
+    ok();
+    send({
+      jsonrpc: "2.0",
+      id: request.id,
+      error: {
+        code: -32_600,
+        message: `unsupported method: ${String(request.method)}`,
+      },
+    });
+    res.end();
+  });
+
+  draftRevision = ACP_REMOTE_DRAFT_REVISION;
+  dropFirstPromptAttempt = false;
+  readonly sessions = new Map<
+    string,
+    {
+      currentModeId?: string;
+      configOptions: Record<string, string>;
+    }
+  >();
+  readonly promptAttempts = new Map<string, number>();
+  readonly promptResults = new Map<
+    string,
+    {
+      notifications: unknown[];
+      terminal: unknown;
+    }
+  >();
+  readonly loadCalls: string[] = [];
+  readonly newCalls: string[] = [];
+  readonly cancelCalls: string[] = [];
+  readonly closeCalls: string[] = [];
+  readonly setModeCalls: Array<{ sessionId: string; modeId: string }> = [];
+  readonly setConfigCalls: Array<{ sessionId: string; configId: string; value: string }> = [];
+
+  async start(): Promise<string> {
+    await new Promise<void>((resolve, reject) => {
+      this.server.once("error", reject);
+      this.server.listen(0, "127.0.0.1", () => {
+        this.server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = this.server.address() as AddressInfo;
+    return `http://127.0.0.1:${address.port}/acp`;
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+const servers: MockAcpRemoteGateway[] = [];
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    const server = servers.pop();
+    if (server) {
+      await server.stop();
+    }
+  }
+});
+
+async function createRuntime(
+  params: {
+    gateway?: MockAcpRemoteGateway;
+    requiredDraftRevision?: string;
+  } = {},
+) {
+  const gateway = params.gateway ?? new MockAcpRemoteGateway();
+  const url = await gateway.start();
+  servers.push(gateway);
+  const runtime = new AcpRemoteRuntime({
+    url,
+    headers: {},
+    timeoutMs: 5_000,
+    retryDelayMs: 1,
+    requiredDraftRevision: params.requiredDraftRevision ?? ACP_REMOTE_DRAFT_REVISION,
+    protocolVersion: 1,
+  });
+  return { runtime, gateway };
+}
+
+describe("AcpRemoteRuntime", () => {
+  it("passes the shared ACP adapter contract suite", async () => {
+    const { runtime, gateway } = await createRuntime();
+
+    await runAcpRuntimeAdapterContract({
+      createRuntime: async () => runtime,
+      agentId: "codex",
+      successPrompt: "contract-pass",
+      includeControlChecks: true,
+    });
+
+    expect(gateway.newCalls.length).toBe(1);
+    expect(gateway.setModeCalls).toEqual([
+      expect.objectContaining({
+        modeId: "contract",
+      }),
+    ]);
+    expect(gateway.setConfigCalls).toEqual([
+      expect.objectContaining({
+        configId: "contract_key",
+        value: "contract_value",
+      }),
+    ]);
+    expect(gateway.cancelCalls.length).toBeGreaterThanOrEqual(1);
+    expect(gateway.closeCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reopens sessions by stable OpenClaw session key", async () => {
+    const { runtime, gateway } = await createRuntime();
+
+    const first = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:stable",
+      agent: "codex",
+      mode: "persistent",
+      cwd: "/tmp/workspace",
+    });
+    const decoded = decodeAcpRemoteHandleState(first.runtimeSessionName);
+
+    expect(first.backendSessionId).toBe("agent:codex:acp:stable");
+    expect(decoded?.sessionId).toBe("agent:codex:acp:stable");
+    expect(gateway.newCalls).toEqual(["agent:codex:acp:stable"]);
+
+    await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:stable",
+      agent: "codex",
+      mode: "persistent",
+      cwd: "/tmp/workspace",
+    });
+
+    expect(gateway.loadCalls).toEqual(["agent:codex:acp:stable", "agent:codex:acp:stable"]);
+    expect(gateway.newCalls).toEqual(["agent:codex:acp:stable"]);
+  });
+
+  it("retries dropped prompt streams and suppresses replay duplicates", async () => {
+    const gateway = new MockAcpRemoteGateway();
+    gateway.dropFirstPromptAttempt = true;
+    const { runtime } = await createRuntime({ gateway });
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:retry",
+      agent: "codex",
+      mode: "persistent",
+      cwd: "/tmp/workspace",
+    });
+
+    const events = [];
+    for await (const event of runtime.runTurn({
+      handle,
+      text: "retry-me",
+      mode: "prompt",
+      requestId: "req-retry",
+    })) {
+      events.push(event);
+    }
+
+    expect(gateway.promptAttempts.get("req-retry")).toBe(2);
+    expect(events.filter((event) => event.type === "text_delta")).toEqual([
+      {
+        type: "text_delta",
+        text: "thinking",
+        stream: "thought",
+        tag: "agent_thought_chunk",
+      },
+      {
+        type: "text_delta",
+        text: "echo:retry-me",
+        stream: "output",
+        tag: "agent_message_chunk",
+      },
+    ]);
+    expect(events.filter((event) => event.type === "tool_call")).toEqual([
+      {
+        type: "tool_call",
+        text: "inspect (in_progress)",
+        tag: "tool_call",
+        toolCallId: "tool-1",
+        status: "in_progress",
+        title: "inspect",
+      },
+    ]);
+    expect(events.at(-1)).toEqual({
+      type: "done",
+      stopReason: "end_turn",
+    });
+  });
+
+  it("fails probe when the remote draft revision is incompatible", async () => {
+    const gateway = new MockAcpRemoteGateway();
+    gateway.draftRevision = "wrong-draft";
+    const { runtime } = await createRuntime({ gateway });
+
+    await runtime.probeAvailability();
+
+    expect(runtime.isHealthy()).toBe(false);
+    await expect(runtime.doctor()).resolves.toEqual(
+      expect.objectContaining({
+        ok: false,
+      }),
+    );
+  });
+});

--- a/extensions/acp-remote/src/runtime.test.ts
+++ b/extensions/acp-remote/src/runtime.test.ts
@@ -1,8 +1,9 @@
 import { createServer } from "node:http";
+import type { IncomingHttpHeaders } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 import { runAcpRuntimeAdapterContract } from "../../../src/acp/runtime/adapter-contract.testkit.js";
-import { ACP_REMOTE_DRAFT_REVISION } from "./config.js";
+import { ACP_REMOTE_PROTOCOL_VERSION } from "./config.js";
 import { AcpRemoteRuntime, decodeAcpRemoteHandleState } from "./runtime.js";
 
 type RpcRequest = {
@@ -11,32 +12,44 @@ type RpcRequest = {
   params?: Record<string, unknown>;
 };
 
+type CapturedRequest = {
+  headers: IncomingHttpHeaders;
+  request: RpcRequest;
+};
+
 class MockAcpRemoteGateway {
   private readonly server = createServer(async (req, res) => {
     const chunks: Buffer[] = [];
     for await (const chunk of req) {
       chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     }
-    const requestLine = Buffer.concat(chunks).toString("utf8").trim().split("\n")[0] ?? "";
-    const request = JSON.parse(requestLine || "{}") as RpcRequest;
+    const request = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}") as RpcRequest;
+    this.requests.push({
+      headers: req.headers,
+      request,
+    });
 
-    const send = (message: unknown) => {
-      res.write(`${JSON.stringify(message)}\n`);
+    const writeJson = (message: unknown) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(message));
     };
 
-    const ok = () => {
-      res.writeHead(200, { "content-type": "application/x-ndjson" });
+    const beginSse = () => {
+      res.writeHead(200, { "content-type": "text/event-stream; charset=utf-8" });
+    };
+
+    const writeSse = (message: unknown) => {
+      res.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
     };
 
     if (request.method === "initialize") {
-      ok();
-      send({
+      writeJson({
         jsonrpc: "2.0",
         id: request.id,
         result: {
-          protocolVersion: request.params?.protocolVersion ?? 1,
+          protocolVersion: this.protocolVersion,
           agentCapabilities: {
-            loadSession: true,
+            loadSession: this.loadSession,
             promptCapabilities: {
               image: false,
               audio: false,
@@ -53,21 +66,16 @@ class MockAcpRemoteGateway {
             name: "mock-acp-gateway",
             version: "test",
           },
-          _meta: {
-            openclawDraftRevision: this.draftRevision,
-          },
         },
       });
-      res.end();
       return;
     }
 
     if (request.method === "session/load") {
-      ok();
       const sessionId = String(request.params?.sessionId ?? "");
       this.loadCalls.push(sessionId);
       if (!this.sessions.has(sessionId)) {
-        send({
+        writeJson({
           jsonrpc: "2.0",
           id: request.id,
           error: {
@@ -78,28 +86,36 @@ class MockAcpRemoteGateway {
             },
           },
         });
-        res.end();
         return;
       }
-      send({
+      beginSse();
+      const session = this.sessions.get(sessionId);
+      if (session?.history.length) {
+        for (const notification of session.history) {
+          writeSse(notification);
+        }
+      }
+      writeSse({
         jsonrpc: "2.0",
         id: request.id,
         result: {
-          modes: this.sessions.get(sessionId)?.currentModeId
+          modes: session?.currentModeId
             ? {
-                currentModeId: this.sessions.get(sessionId)?.currentModeId,
-                availableModes: [{ id: "contract", name: "Contract" }],
+                currentModeId: session.currentModeId,
+                availableModes: [
+                  { id: "prompt", name: "Prompt" },
+                  { id: "steer", name: "Steer" },
+                  { id: "contract", name: "Contract" },
+                ],
               }
             : undefined,
-          configOptions: Object.entries(this.sessions.get(sessionId)?.configOptions ?? {}).map(
-            ([id, currentValue]) => ({
-              type: "select",
-              id,
-              name: id,
-              currentValue,
-              options: [],
-            }),
-          ),
+          configOptions: Object.entries(session?.configOptions ?? {}).map(([id, currentValue]) => ({
+            type: "select",
+            id,
+            name: id,
+            currentValue,
+            options: [],
+          })),
         },
       });
       res.end();
@@ -107,26 +123,24 @@ class MockAcpRemoteGateway {
     }
 
     if (request.method === "session/new") {
-      ok();
       const sessionId = String(request.params?._meta?.openclawSessionId ?? "");
       this.newCalls.push(sessionId);
       this.sessions.set(sessionId, {
         currentModeId: undefined,
         configOptions: {},
+        history: [],
       });
-      send({
+      writeJson({
         jsonrpc: "2.0",
         id: request.id,
         result: {
           sessionId,
         },
       });
-      res.end();
       return;
     }
 
     if (request.method === "session/set_mode") {
-      ok();
       const sessionId = String(request.params?.sessionId ?? "");
       const modeId = String(request.params?.modeId ?? "");
       this.setModeCalls.push({ sessionId, modeId });
@@ -134,17 +148,24 @@ class MockAcpRemoteGateway {
       if (session) {
         session.currentModeId = modeId;
       }
-      send({
+      writeJson({
         jsonrpc: "2.0",
         id: request.id,
-        result: {},
+        result: {
+          modes: {
+            currentModeId: modeId,
+            availableModes: [
+              { id: "prompt", name: "Prompt" },
+              { id: "steer", name: "Steer" },
+              { id: "contract", name: "Contract" },
+            ],
+          },
+        },
       });
-      res.end();
       return;
     }
 
     if (request.method === "session/set_config_option") {
-      ok();
       const sessionId = String(request.params?.sessionId ?? "");
       const configId = String(request.params?.configId ?? "");
       const value = String(request.params?.value ?? "");
@@ -153,7 +174,7 @@ class MockAcpRemoteGateway {
       if (session) {
         session.configOptions[configId] = value;
       }
-      send({
+      writeJson({
         jsonrpc: "2.0",
         id: request.id,
         result: {
@@ -168,34 +189,31 @@ class MockAcpRemoteGateway {
           ],
         },
       });
-      res.end();
       return;
     }
 
     if (request.method === "session/close") {
-      ok();
       const sessionId = String(request.params?.sessionId ?? "");
       this.closeCalls.push(sessionId);
       this.sessions.delete(sessionId);
-      send({
+      writeJson({
         jsonrpc: "2.0",
         id: request.id,
         result: {},
       });
-      res.end();
       return;
     }
 
     if (request.method === "session/cancel") {
-      ok();
       const sessionId = String(request.params?.sessionId ?? "");
       this.cancelCalls.push(sessionId);
+      res.writeHead(202);
       res.end();
       return;
     }
 
     if (request.method === "session/prompt") {
-      ok();
+      beginSse();
       const sessionId = String(request.params?.sessionId ?? "");
       const prompt = request.params?.prompt;
       const text =
@@ -265,20 +283,23 @@ class MockAcpRemoteGateway {
           return result;
         })();
 
+      const session = this.sessions.get(sessionId);
+      if (session) {
+        session.history.push(...stored.notifications);
+      }
       for (const notification of stored.notifications) {
-        send(notification);
+        writeSse(notification);
       }
       if (this.dropFirstPromptAttempt && attempt === 1) {
         res.end();
         return;
       }
-      send(stored.terminal);
+      writeSse(stored.terminal);
       res.end();
       return;
     }
 
-    ok();
-    send({
+    writeJson({
       jsonrpc: "2.0",
       id: request.id,
       error: {
@@ -286,18 +307,20 @@ class MockAcpRemoteGateway {
         message: `unsupported method: ${String(request.method)}`,
       },
     });
-    res.end();
   });
 
-  draftRevision = ACP_REMOTE_DRAFT_REVISION;
+  protocolVersion = ACP_REMOTE_PROTOCOL_VERSION;
+  loadSession = true;
   dropFirstPromptAttempt = false;
   readonly sessions = new Map<
     string,
     {
       currentModeId?: string;
       configOptions: Record<string, string>;
+      history: unknown[];
     }
   >();
+  readonly requests: CapturedRequest[] = [];
   readonly promptAttempts = new Map<string, number>();
   readonly promptResults = new Map<
     string,
@@ -349,12 +372,7 @@ afterEach(async () => {
   }
 });
 
-async function createRuntime(
-  params: {
-    gateway?: MockAcpRemoteGateway;
-    requiredDraftRevision?: string;
-  } = {},
-) {
+async function createRuntime(params: { gateway?: MockAcpRemoteGateway } = {}) {
   const gateway = params.gateway ?? new MockAcpRemoteGateway();
   const url = await gateway.start();
   servers.push(gateway);
@@ -363,8 +381,7 @@ async function createRuntime(
     headers: {},
     timeoutMs: 5_000,
     retryDelayMs: 1,
-    requiredDraftRevision: params.requiredDraftRevision ?? ACP_REMOTE_DRAFT_REVISION,
-    protocolVersion: 1,
+    protocolVersion: ACP_REMOTE_PROTOCOL_VERSION,
   });
   return { runtime, gateway };
 }
@@ -396,14 +413,14 @@ describe("AcpRemoteRuntime", () => {
     expect(gateway.closeCalls.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("reopens sessions by stable OpenClaw session key", async () => {
+  it("reopens sessions with a stable lease identity derived from the session key", async () => {
     const { runtime, gateway } = await createRuntime();
 
     const first = await runtime.ensureSession({
       sessionKey: "agent:codex:acp:stable",
       agent: "codex",
       mode: "persistent",
-      cwd: "/tmp/workspace",
+      cwd: "/home/test/workspace",
     });
     const decoded = decodeAcpRemoteHandleState(first.runtimeSessionName);
 
@@ -415,11 +432,60 @@ describe("AcpRemoteRuntime", () => {
       sessionKey: "agent:codex:acp:stable",
       agent: "codex",
       mode: "persistent",
-      cwd: "/tmp/workspace",
+      cwd: "/home/test/workspace",
     });
+
+    const loadRequests = gateway.requests.filter(
+      (entry) => entry.request.method === "session/load" || entry.request.method === "session/new",
+    );
+    const clientIds = loadRequests.map((entry) =>
+      String(
+        (entry.request.params?._meta as { openclawClientId?: unknown } | undefined)
+          ?.openclawClientId ?? "",
+      ),
+    );
 
     expect(gateway.loadCalls).toEqual(["agent:codex:acp:stable", "agent:codex:acp:stable"]);
     expect(gateway.newCalls).toEqual(["agent:codex:acp:stable"]);
+    expect(new Set(clientIds)).toEqual(new Set([decoded?.clientId]));
+  });
+
+  it("uses Streamable HTTP headers and omits private transport markers", async () => {
+    const { runtime, gateway } = await createRuntime();
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:transport",
+      agent: "codex",
+      mode: "persistent",
+      cwd: "/home/test/workspace",
+    });
+    await runtime.setMode({ handle, mode: "steer" });
+    await runtime.setConfigOption({ handle, key: "verbosity", value: "verbose" });
+    await runtime.cancel({ handle, reason: "transport-check" });
+
+    const initializeRequest = gateway.requests.find(
+      (entry) => entry.request.method === "initialize",
+    );
+    const promptOrControlRequests = gateway.requests.filter((entry) =>
+      [
+        "session/new",
+        "session/load",
+        "session/set_mode",
+        "session/set_config_option",
+        "session/cancel",
+      ].includes(String(entry.request.method)),
+    );
+
+    expect(initializeRequest?.headers.accept).toContain("application/json");
+    expect(initializeRequest?.headers.accept).toContain("text/event-stream");
+    expect(initializeRequest?.headers["content-type"]).toContain("application/json");
+    expect(initializeRequest?.request.params?._meta).toBeUndefined();
+
+    for (const entry of promptOrControlRequests) {
+      const meta = (entry.request.params?._meta as Record<string, unknown> | undefined) ?? {};
+      expect(meta.openclawDraftRevision).toBeUndefined();
+      expect(meta.openclawTransport).toBeUndefined();
+    }
   });
 
   it("retries dropped prompt streams and suppresses replay duplicates", async () => {
@@ -431,7 +497,7 @@ describe("AcpRemoteRuntime", () => {
       sessionKey: "agent:codex:acp:retry",
       agent: "codex",
       mode: "persistent",
-      cwd: "/tmp/workspace",
+      cwd: "/home/test/workspace",
     });
 
     const events = [];
@@ -475,9 +541,9 @@ describe("AcpRemoteRuntime", () => {
     });
   });
 
-  it("fails probe when the remote draft revision is incompatible", async () => {
+  it("fails probe when the remote endpoint does not advertise session/load support", async () => {
     const gateway = new MockAcpRemoteGateway();
-    gateway.draftRevision = "wrong-draft";
+    gateway.loadSession = false;
     const { runtime } = await createRuntime({ gateway });
 
     await runtime.probeAvailability();

--- a/extensions/acp-remote/src/runtime.test.ts
+++ b/extensions/acp-remote/src/runtime.test.ts
@@ -17,6 +17,18 @@ type CapturedRequest = {
   request: RpcRequest;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readMetaValue(params: Record<string, unknown> | undefined, key: string): unknown {
+  const meta = params?._meta;
+  if (!isRecord(meta)) {
+    return undefined;
+  }
+  return meta[key];
+}
+
 class MockAcpRemoteGateway {
   private readonly server = createServer(async (req, res) => {
     const chunks: Buffer[] = [];
@@ -131,7 +143,7 @@ class MockAcpRemoteGateway {
     }
 
     if (request.method === "session/new") {
-      const sessionId = String(request.params?._meta?.openclawSessionId ?? "");
+      const sessionId = String(readMetaValue(request.params, "openclawSessionId") ?? "");
       const cwd =
         typeof request.params?.cwd === "string" && request.params.cwd.trim()
           ? request.params.cwd.trim()
@@ -234,7 +246,9 @@ class MockAcpRemoteGateway {
         Array.isArray(prompt) && prompt[0] && typeof prompt[0] === "object"
           ? String((prompt[0] as { text?: unknown }).text ?? "")
           : "";
-      const requestId = String(request.params?._meta?.openclawRequestId ?? request.id ?? "");
+      const requestId = String(
+        readMetaValue(request.params, "openclawRequestId") ?? request.id ?? "",
+      );
       const attempt = (this.promptAttempts.get(requestId) ?? 0) + 1;
       this.promptAttempts.set(requestId, attempt);
 

--- a/extensions/acp-remote/src/runtime.ts
+++ b/extensions/acp-remote/src/runtime.ts
@@ -50,13 +50,13 @@ type AcpRemoteHandleState = {
   sessionId: string;
   sessionKey: string;
   clientId: string;
-  cwd: string;
+  cwd?: string;
   mode: AcpRuntimeEnsureInput["mode"];
 };
 
 type AcpRemoteSessionState = {
   clientId: string;
-  cwd: string;
+  cwd?: string;
   mode: AcpRuntimeEnsureInput["mode"];
   currentModeId?: string;
   configOptions: Record<string, string>;
@@ -139,7 +139,7 @@ export function decodeAcpRemoteHandleState(
     const clientId = normalizeText(parsed.clientId);
     const cwd = normalizeText(parsed.cwd);
     const mode = parsed.mode;
-    if (!sessionId || !sessionKey || !clientId || !cwd) {
+    if (!sessionId || !sessionKey || !clientId) {
       return null;
     }
     if (mode !== "persistent" && mode !== "oneshot") {
@@ -174,6 +174,24 @@ function sleep(ms: number): Promise<void> {
 function buildStableClientId(sessionKey: string): string {
   const digest = createHash("sha256").update(sessionKey).digest("hex").slice(0, 24);
   return `openclaw:${digest}`;
+}
+
+function buildSessionInitParams(params: {
+  sessionId?: string;
+  cwd?: string;
+  clientId: string;
+  sessionKey: string;
+}): Record<string, unknown> {
+  return {
+    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+    ...(params.cwd ? { cwd: params.cwd } : {}),
+    mcpServers: [],
+    _meta: {
+      openclawClientId: params.clientId,
+      openclawSessionId: params.sessionKey,
+      openclawSessionKey: params.sessionKey,
+    },
+  };
 }
 
 function isAbortLikeError(error: unknown): boolean {
@@ -225,6 +243,13 @@ function readCurrentModeId(value: unknown): string | undefined {
     return undefined;
   }
   return normalizeText(value.currentModeId);
+}
+
+function readSessionCwd(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return normalizeText(value.cwd);
 }
 
 function readConfigOptionValues(value: unknown): Record<string, string> {
@@ -332,6 +357,7 @@ export class AcpRemoteRuntime implements AcpRuntime {
     const sessionState = this.sessionStateBySessionId.get(state.sessionId);
     const currentModeId = sessionState?.currentModeId;
     const configOptions = sessionState?.configOptions ?? {};
+    const cwd = sessionState?.cwd ?? state.cwd;
     return {
       summary: currentModeId
         ? `remote ACP session ready (${currentModeId})`
@@ -339,8 +365,8 @@ export class AcpRemoteRuntime implements AcpRuntime {
       backendSessionId: state.sessionId,
       details: {
         url: this.config.url,
-        cwd: sessionState?.cwd ?? state.cwd,
         clientId: sessionState?.clientId ?? state.clientId,
+        ...(cwd ? { cwd } : {}),
         ...(currentModeId ? { currentModeId } : {}),
         ...(Object.keys(configOptions).length > 0 ? { configOptions } : {}),
       },
@@ -353,50 +379,46 @@ export class AcpRemoteRuntime implements AcpRuntime {
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
-    const cwd = normalizeText(input.cwd) ?? process.cwd();
     const sessionId = sessionKey;
     const existing = this.sessionStateBySessionId.get(sessionId);
     const clientId = existing?.clientId ?? buildStableClientId(sessionKey);
+    const explicitCwd = normalizeText(input.cwd);
+    let effectiveCwd = existing?.cwd;
 
     try {
       const result = await this.request<Record<string, unknown> | null>({
         method: "session/load",
         id: `load:${sessionId}`,
-        params: {
+        params: buildSessionInitParams({
           sessionId,
-          cwd,
-          mcpServers: [],
-          _meta: this.buildMeta({
-            openclawClientId: clientId,
-            openclawSessionId: sessionId,
-            openclawSessionKey: sessionKey,
-          }),
-        },
+          cwd: explicitCwd,
+          clientId,
+          sessionKey,
+        }),
       });
+      const loadedCwd = readSessionCwd(result) ?? existing?.cwd ?? explicitCwd;
       this.upsertSessionState(sessionId, {
         clientId,
-        cwd,
+        cwd: loadedCwd,
         mode: input.mode,
       });
       this.applyRemoteSessionMetadata(sessionId, result);
+      effectiveCwd = this.sessionStateBySessionId.get(sessionId)?.cwd ?? loadedCwd;
     } catch (error) {
       if (!this.isMissingSessionError(error)) {
         throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", toMessageText(error), {
           cause: error,
         });
       }
+      const createCwd = explicitCwd ?? this.config.defaultCwd;
       const result = await this.request<Record<string, unknown>>({
         method: "session/new",
         id: `new:${sessionId}`,
-        params: {
-          cwd,
-          mcpServers: [],
-          _meta: this.buildMeta({
-            openclawClientId: clientId,
-            openclawSessionId: sessionId,
-            openclawSessionKey: sessionKey,
-          }),
-        },
+        params: buildSessionInitParams({
+          cwd: createCwd,
+          clientId,
+          sessionKey,
+        }),
       });
       const returnedSessionId = normalizeText(result.sessionId);
       if (!returnedSessionId) {
@@ -411,12 +433,21 @@ export class AcpRemoteRuntime implements AcpRuntime {
           `ACP remote session/new returned sessionId "${returnedSessionId}" but OpenClaw requires stable sessionId "${sessionId}".`,
         );
       }
+      const createdCwd = readSessionCwd(result) ?? createCwd;
       this.upsertSessionState(sessionId, {
         clientId,
-        cwd,
+        cwd: createdCwd,
         mode: input.mode,
       });
       this.applyRemoteSessionMetadata(sessionId, result);
+      effectiveCwd = this.sessionStateBySessionId.get(sessionId)?.cwd ?? createdCwd;
+    }
+
+    if (!effectiveCwd) {
+      throw new AcpRuntimeError(
+        "ACP_SESSION_INIT_FAILED",
+        "ACP remote session did not resolve an effective working directory.",
+      );
     }
 
     return {
@@ -426,10 +457,10 @@ export class AcpRemoteRuntime implements AcpRuntime {
         sessionId,
         sessionKey,
         clientId,
-        cwd,
+        ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
         mode: input.mode,
       }),
-      cwd,
+      ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
       backendSessionId: sessionId,
     };
   }
@@ -708,12 +739,12 @@ export class AcpRemoteRuntime implements AcpRuntime {
 
   private upsertSessionState(
     sessionId: string,
-    patch: Pick<AcpRemoteSessionState, "clientId" | "cwd" | "mode">,
+    patch: Pick<AcpRemoteSessionState, "clientId" | "mode"> & { cwd?: string },
   ): void {
     const current = this.sessionStateBySessionId.get(sessionId);
     this.sessionStateBySessionId.set(sessionId, {
       clientId: patch.clientId,
-      cwd: patch.cwd,
+      cwd: patch.cwd ?? current?.cwd,
       mode: patch.mode,
       currentModeId: current?.currentModeId,
       configOptions: { ...(current?.configOptions ?? {}) },
@@ -724,6 +755,10 @@ export class AcpRemoteRuntime implements AcpRuntime {
     const state = this.sessionStateBySessionId.get(sessionId);
     if (!state || !isRecord(value)) {
       return;
+    }
+    const resolvedCwd = normalizeText(value.cwd);
+    if (resolvedCwd) {
+      state.cwd = resolvedCwd;
     }
     const currentModeId =
       readCurrentModeId(value.modes) ?? readCurrentModeId(value.currentMode) ?? state.currentModeId;

--- a/extensions/acp-remote/src/runtime.ts
+++ b/extensions/acp-remote/src/runtime.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 import type {
   AcpRuntime,
   AcpRuntimeCapabilities,
@@ -171,6 +171,11 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function buildStableClientId(sessionKey: string): string {
+  const digest = createHash("sha256").update(sessionKey).digest("hex").slice(0, 24);
+  return `openclaw:${digest}`;
+}
+
 function isAbortLikeError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
@@ -246,6 +251,23 @@ function normalizeStopReason(value: unknown): string | undefined {
   return normalizeText(value);
 }
 
+function normalizeContentType(value: string | null): string {
+  return value?.split(";")[0]?.trim().toLowerCase() ?? "";
+}
+
+function parseJsonRpcPayload(value: unknown, method: string): JsonRpcMessage[] {
+  if (Array.isArray(value)) {
+    if (!value.every(isRecord)) {
+      throw new Error(`ACP remote ${method} returned a non-object JSON-RPC payload.`);
+    }
+    return value as JsonRpcMessage[];
+  }
+  if (!isRecord(value)) {
+    throw new Error(`ACP remote ${method} returned a non-object JSON-RPC payload.`);
+  }
+  return [value as JsonRpcMessage];
+}
+
 function serializeNotification(message: JsonRpcNotification): string {
   return JSON.stringify(message);
 }
@@ -284,10 +306,7 @@ export class AcpRemoteRuntime implements AcpRuntime {
       return {
         ok: state.loadSession,
         message: `ACP remote gateway ready at ${this.config.url}`,
-        details: [
-          `protocolVersion=${state.protocolVersion}`,
-          `draftRevision=${this.config.requiredDraftRevision}`,
-        ],
+        details: [`protocolVersion=${state.protocolVersion}`, "transport=streamable-http"],
       };
     } catch (error) {
       return {
@@ -337,7 +356,7 @@ export class AcpRemoteRuntime implements AcpRuntime {
     const cwd = normalizeText(input.cwd) ?? process.cwd();
     const sessionId = sessionKey;
     const existing = this.sessionStateBySessionId.get(sessionId);
-    const clientId = existing?.clientId ?? randomUUID();
+    const clientId = existing?.clientId ?? buildStableClientId(sessionKey);
 
     try {
       const result = await this.request<Record<string, unknown> | null>({
@@ -625,11 +644,7 @@ export class AcpRemoteRuntime implements AcpRuntime {
   }
 
   private buildMeta(extra: Record<string, unknown>): Record<string, unknown> {
-    return {
-      openclawDraftRevision: this.config.requiredDraftRevision,
-      openclawTransport: "ndjson-http-response-stream",
-      ...extra,
-    };
+    return { ...extra };
   }
 
   private async initializeRemote(
@@ -651,7 +666,6 @@ export class AcpRemoteRuntime implements AcpRuntime {
           terminal: false,
         },
         clientInfo: ACP_REMOTE_CLIENT_INFO,
-        _meta: this.buildMeta({}),
       },
     });
 
@@ -660,15 +674,6 @@ export class AcpRemoteRuntime implements AcpRuntime {
       throw new AcpRuntimeError(
         "ACP_BACKEND_UNAVAILABLE",
         `ACP remote protocol mismatch: expected ${this.config.protocolVersion}, got ${protocolVersion ?? "unknown"}.`,
-      );
-    }
-
-    const responseMeta = isRecord(result._meta) ? result._meta : {};
-    const returnedDraftRevision = normalizeText(responseMeta.openclawDraftRevision);
-    if (returnedDraftRevision !== this.config.requiredDraftRevision) {
-      throw new AcpRuntimeError(
-        "ACP_BACKEND_UNAVAILABLE",
-        `ACP remote draft revision mismatch: expected ${this.config.requiredDraftRevision}, got ${returnedDraftRevision ?? "unknown"}.`,
       );
     }
 
@@ -846,16 +851,16 @@ export class AcpRemoteRuntime implements AcpRuntime {
     const response = await fetch(this.config.url, {
       method: "POST",
       headers: {
-        accept: "application/x-ndjson",
-        "content-type": "application/x-ndjson",
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
         ...this.config.headers,
       },
-      body: `${JSON.stringify({
+      body: JSON.stringify({
         jsonrpc: "2.0",
         id: params.id,
         method: params.method,
         params: params.params,
-      })}\n`,
+      }),
       signal,
     });
 
@@ -870,32 +875,62 @@ export class AcpRemoteRuntime implements AcpRuntime {
       throw new MissingTerminalResponseError(params.method);
     }
 
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    while (true) {
-      const chunk = await reader.read();
-      if (chunk.done) {
-        break;
-      }
-      buffer += decoder.decode(chunk.value, { stream: true });
+    const contentType = normalizeContentType(response.headers.get("content-type"));
+    if (contentType === "text/event-stream") {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      const emitEvent = async function* (rawEvent: string): AsyncIterable<JsonRpcMessage> {
+        const dataLines: string[] = [];
+        for (const rawLine of rawEvent.split("\n")) {
+          const line = rawLine.trimEnd();
+          if (!line || line.startsWith(":")) {
+            continue;
+          }
+          if (line.startsWith("data:")) {
+            dataLines.push(line.slice(5).trimStart());
+          }
+        }
+        if (dataLines.length === 0) {
+          return;
+        }
+        const payload = JSON.parse(dataLines.join("\n")) as unknown;
+        for (const message of parseJsonRpcPayload(payload, params.method)) {
+          yield message;
+        }
+      };
+
       while (true) {
-        const newlineIndex = buffer.indexOf("\n");
-        if (newlineIndex === -1) {
+        const chunk = await reader.read();
+        if (chunk.done) {
           break;
         }
-        const line = buffer.slice(0, newlineIndex).trim();
-        buffer = buffer.slice(newlineIndex + 1);
-        if (!line) {
-          continue;
+        buffer += decoder.decode(chunk.value, { stream: true }).replaceAll("\r\n", "\n");
+        while (true) {
+          const eventEnd = buffer.indexOf("\n\n");
+          if (eventEnd === -1) {
+            break;
+          }
+          const rawEvent = buffer.slice(0, eventEnd);
+          buffer = buffer.slice(eventEnd + 2);
+          yield* emitEvent(rawEvent);
         }
-        yield JSON.parse(line) as JsonRpcMessage;
       }
+
+      const tail = `${buffer}${decoder.decode()}`.replaceAll("\r\n", "\n").trim();
+      if (tail) {
+        yield* emitEvent(tail);
+      }
+      return;
     }
 
-    const finalChunk = `${buffer}${decoder.decode()}`.trim();
-    if (finalChunk) {
-      yield JSON.parse(finalChunk) as JsonRpcMessage;
+    const text = await response.text();
+    if (!text.trim()) {
+      return;
+    }
+    const payload = JSON.parse(text) as unknown;
+    for (const message of parseJsonRpcPayload(payload, params.method)) {
+      yield message;
     }
   }
 
@@ -937,15 +972,15 @@ export class AcpRemoteRuntime implements AcpRuntime {
     const response = await fetch(this.config.url, {
       method: "POST",
       headers: {
-        accept: "application/x-ndjson",
-        "content-type": "application/x-ndjson",
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
         ...this.config.headers,
       },
-      body: `${JSON.stringify({
+      body: JSON.stringify({
         jsonrpc: "2.0",
         method: params.method,
         params: params.params,
-      })}\n`,
+      }),
       signal,
     });
 
@@ -955,6 +990,9 @@ export class AcpRemoteRuntime implements AcpRuntime {
         response.status,
         `ACP remote ${params.method} failed with HTTP ${response.status}${text ? `: ${text.trim()}` : ""}`,
       );
+    }
+    if (response.status === 202 || response.status === 204) {
+      return;
     }
     await response.text().catch(() => "");
   }

--- a/extensions/acp-remote/src/runtime.ts
+++ b/extensions/acp-remote/src/runtime.ts
@@ -1,0 +1,961 @@
+import { randomUUID } from "node:crypto";
+import type {
+  AcpRuntime,
+  AcpRuntimeCapabilities,
+  AcpRuntimeDoctorReport,
+  AcpRuntimeEnsureInput,
+  AcpRuntimeEvent,
+  AcpRuntimeHandle,
+  AcpRuntimeStatus,
+  AcpRuntimeTurnInput,
+  PluginLogger,
+} from "openclaw/plugin-sdk/acp";
+import { AcpRuntimeError } from "openclaw/plugin-sdk/acp";
+import type { ResolvedAcpRemotePluginConfig } from "./config.js";
+
+export const ACP_REMOTE_BACKEND_ID = "acp-remote";
+
+const ACP_REMOTE_CLIENT_INFO = {
+  name: "openclaw",
+  version: "acp-remote",
+};
+const ACP_REMOTE_HANDLE_PREFIX = "acp-remote:v1:";
+const ACP_REMOTE_CAPABILITIES: AcpRuntimeCapabilities = {
+  controls: ["session/set_config_option", "session/set_mode", "session/status"],
+};
+
+type JsonRpcId = string | number;
+type JsonRpcNotification = {
+  jsonrpc?: string;
+  method: string;
+  params?: unknown;
+};
+type JsonRpcSuccess = {
+  jsonrpc?: string;
+  id: JsonRpcId;
+  result: unknown;
+};
+type JsonRpcFailure = {
+  jsonrpc?: string;
+  id: JsonRpcId | null;
+  error: {
+    code?: string | number;
+    message?: string;
+    data?: unknown;
+  };
+};
+type JsonRpcMessage = JsonRpcNotification | JsonRpcSuccess | JsonRpcFailure;
+
+type AcpRemoteHandleState = {
+  sessionId: string;
+  sessionKey: string;
+  clientId: string;
+  cwd: string;
+  mode: AcpRuntimeEnsureInput["mode"];
+};
+
+type AcpRemoteSessionState = {
+  clientId: string;
+  cwd: string;
+  mode: AcpRuntimeEnsureInput["mode"];
+  currentModeId?: string;
+  configOptions: Record<string, string>;
+};
+
+type AcpRemoteInitializeState = {
+  protocolVersion: number;
+  loadSession: boolean;
+};
+
+class RemoteRpcError extends Error {
+  readonly code?: string | number;
+  readonly data?: unknown;
+
+  constructor(message: string, options?: { code?: string | number; data?: unknown }) {
+    super(message);
+    this.name = "RemoteRpcError";
+    this.code = options?.code;
+    this.data = options?.data;
+  }
+}
+
+class RemoteHttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "RemoteHttpError";
+    this.status = status;
+  }
+}
+
+class MissingTerminalResponseError extends Error {
+  constructor(method: string) {
+    super(`ACP remote ${method} ended without a terminal response.`);
+    this.name = "MissingTerminalResponseError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function normalizeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function encodeAcpRemoteHandleState(state: AcpRemoteHandleState): string {
+  const payload = Buffer.from(JSON.stringify(state), "utf8").toString("base64url");
+  return `${ACP_REMOTE_HANDLE_PREFIX}${payload}`;
+}
+
+export function decodeAcpRemoteHandleState(
+  runtimeSessionName: string,
+): AcpRemoteHandleState | null {
+  const trimmed = runtimeSessionName.trim();
+  if (!trimmed.startsWith(ACP_REMOTE_HANDLE_PREFIX)) {
+    return null;
+  }
+  const encoded = trimmed.slice(ACP_REMOTE_HANDLE_PREFIX.length);
+  if (!encoded) {
+    return null;
+  }
+  try {
+    const raw = Buffer.from(encoded, "base64url").toString("utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) {
+      return null;
+    }
+    const sessionId = normalizeText(parsed.sessionId);
+    const sessionKey = normalizeText(parsed.sessionKey);
+    const clientId = normalizeText(parsed.clientId);
+    const cwd = normalizeText(parsed.cwd);
+    const mode = parsed.mode;
+    if (!sessionId || !sessionKey || !clientId || !cwd) {
+      return null;
+    }
+    if (mode !== "persistent" && mode !== "oneshot") {
+      return null;
+    }
+    return {
+      sessionId,
+      sessionKey,
+      clientId,
+      cwd,
+      mode,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function toMessageText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value instanceof Error) {
+    return value.message;
+  }
+  return String(value);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isAbortLikeError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.name === "AbortError" || /aborted/i.test(error.message);
+}
+
+function buildTimeoutSignal(base: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+  if (typeof AbortSignal.timeout === "function") {
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    if (base && typeof AbortSignal.any === "function") {
+      return AbortSignal.any([base, timeoutSignal]);
+    }
+    return base ?? timeoutSignal;
+  }
+  return base ?? new AbortController().signal;
+}
+
+function isJsonRpcNotification(message: JsonRpcMessage): message is JsonRpcNotification {
+  return typeof (message as JsonRpcNotification).method === "string";
+}
+
+function isJsonRpcFailure(message: JsonRpcMessage): message is JsonRpcFailure {
+  return isRecord(message) && "error" in message;
+}
+
+function isJsonRpcSuccess(message: JsonRpcMessage): message is JsonRpcSuccess {
+  return isRecord(message) && "result" in message && "id" in message;
+}
+
+function idsEqual(left: unknown, right: JsonRpcId): boolean {
+  return left === right;
+}
+
+function extractChunkText(content: unknown): string | undefined {
+  if (!isRecord(content)) {
+    return undefined;
+  }
+  if (content.type === "text") {
+    return normalizeText(content.text);
+  }
+  return undefined;
+}
+
+function readCurrentModeId(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return normalizeText(value.currentModeId);
+}
+
+function readConfigOptionValues(value: unknown): Record<string, string> {
+  if (!Array.isArray(value)) {
+    return {};
+  }
+  const entries: Array<[string, string]> = [];
+  for (const option of value) {
+    if (!isRecord(option)) {
+      continue;
+    }
+    const id = normalizeText(option.id);
+    const currentValue = isRecord(option)
+      ? normalizeText((option as { currentValue?: unknown }).currentValue)
+      : undefined;
+    if (id && currentValue) {
+      entries.push([id, currentValue]);
+    }
+  }
+  return Object.fromEntries(entries);
+}
+
+function normalizeStopReason(value: unknown): string | undefined {
+  return normalizeText(value);
+}
+
+function serializeNotification(message: JsonRpcNotification): string {
+  return JSON.stringify(message);
+}
+
+export class AcpRemoteRuntime implements AcpRuntime {
+  private healthy = false;
+  private readonly logger?: PluginLogger;
+  private initializeState: AcpRemoteInitializeState | null = null;
+  private readonly sessionStateBySessionId = new Map<string, AcpRemoteSessionState>();
+
+  constructor(
+    private readonly config: ResolvedAcpRemotePluginConfig,
+    options?: {
+      logger?: PluginLogger;
+    },
+  ) {
+    this.logger = options?.logger;
+  }
+
+  isHealthy(): boolean {
+    return this.healthy;
+  }
+
+  async probeAvailability(): Promise<void> {
+    try {
+      await this.initializeRemote({ force: true });
+      this.healthy = true;
+    } catch {
+      this.healthy = false;
+    }
+  }
+
+  async doctor(): Promise<AcpRuntimeDoctorReport> {
+    try {
+      const state = await this.initializeRemote({ force: true });
+      return {
+        ok: state.loadSession,
+        message: `ACP remote gateway ready at ${this.config.url}`,
+        details: [
+          `protocolVersion=${state.protocolVersion}`,
+          `draftRevision=${this.config.requiredDraftRevision}`,
+        ],
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        code: "ACP_BACKEND_UNAVAILABLE",
+        message: `ACP remote gateway probe failed: ${toMessageText(error)}`,
+        installCommand: "Ensure the acp-gateway service is reachable and protocol-compatible.",
+      };
+    }
+  }
+
+  async getCapabilities(): Promise<AcpRuntimeCapabilities> {
+    await this.initializeRemote();
+    return ACP_REMOTE_CAPABILITIES;
+  }
+
+  async getStatus(input: {
+    handle: AcpRuntimeHandle;
+    signal?: AbortSignal;
+  }): Promise<AcpRuntimeStatus> {
+    await this.initializeRemote();
+    const state = this.resolveHandleState(input.handle);
+    const sessionState = this.sessionStateBySessionId.get(state.sessionId);
+    const currentModeId = sessionState?.currentModeId;
+    const configOptions = sessionState?.configOptions ?? {};
+    return {
+      summary: currentModeId
+        ? `remote ACP session ready (${currentModeId})`
+        : "remote ACP session ready",
+      backendSessionId: state.sessionId,
+      details: {
+        url: this.config.url,
+        cwd: sessionState?.cwd ?? state.cwd,
+        clientId: sessionState?.clientId ?? state.clientId,
+        ...(currentModeId ? { currentModeId } : {}),
+        ...(Object.keys(configOptions).length > 0 ? { configOptions } : {}),
+      },
+    };
+  }
+
+  async ensureSession(input: AcpRuntimeEnsureInput): Promise<AcpRuntimeHandle> {
+    await this.initializeRemote();
+    const sessionKey = normalizeText(input.sessionKey);
+    if (!sessionKey) {
+      throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
+    }
+    const cwd = normalizeText(input.cwd) ?? process.cwd();
+    const sessionId = sessionKey;
+    const existing = this.sessionStateBySessionId.get(sessionId);
+    const clientId = existing?.clientId ?? randomUUID();
+
+    try {
+      const result = await this.request<Record<string, unknown> | null>({
+        method: "session/load",
+        id: `load:${sessionId}`,
+        params: {
+          sessionId,
+          cwd,
+          mcpServers: [],
+          _meta: this.buildMeta({
+            openclawClientId: clientId,
+            openclawSessionId: sessionId,
+            openclawSessionKey: sessionKey,
+          }),
+        },
+      });
+      this.upsertSessionState(sessionId, {
+        clientId,
+        cwd,
+        mode: input.mode,
+      });
+      this.applyRemoteSessionMetadata(sessionId, result);
+    } catch (error) {
+      if (!this.isMissingSessionError(error)) {
+        throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", toMessageText(error), {
+          cause: error,
+        });
+      }
+      const result = await this.request<Record<string, unknown>>({
+        method: "session/new",
+        id: `new:${sessionId}`,
+        params: {
+          cwd,
+          mcpServers: [],
+          _meta: this.buildMeta({
+            openclawClientId: clientId,
+            openclawSessionId: sessionId,
+            openclawSessionKey: sessionKey,
+          }),
+        },
+      });
+      const returnedSessionId = normalizeText(result.sessionId);
+      if (!returnedSessionId) {
+        throw new AcpRuntimeError(
+          "ACP_SESSION_INIT_FAILED",
+          "ACP remote session/new did not return a sessionId.",
+        );
+      }
+      if (returnedSessionId !== sessionId) {
+        throw new AcpRuntimeError(
+          "ACP_SESSION_INIT_FAILED",
+          `ACP remote session/new returned sessionId "${returnedSessionId}" but OpenClaw requires stable sessionId "${sessionId}".`,
+        );
+      }
+      this.upsertSessionState(sessionId, {
+        clientId,
+        cwd,
+        mode: input.mode,
+      });
+      this.applyRemoteSessionMetadata(sessionId, result);
+    }
+
+    return {
+      sessionKey,
+      backend: ACP_REMOTE_BACKEND_ID,
+      runtimeSessionName: encodeAcpRemoteHandleState({
+        sessionId,
+        sessionKey,
+        clientId,
+        cwd,
+        mode: input.mode,
+      }),
+      cwd,
+      backendSessionId: sessionId,
+    };
+  }
+
+  async *runTurn(input: AcpRuntimeTurnInput): AsyncIterable<AcpRuntimeEvent> {
+    await this.initializeRemote();
+    const state = this.resolveHandleState(input.handle);
+    this.upsertSessionState(state.sessionId, {
+      clientId: state.clientId,
+      cwd: state.cwd,
+      mode: state.mode,
+    });
+
+    const cancelOnAbort = async () => {
+      await this.cancel({
+        handle: input.handle,
+        reason: "abort-signal",
+      }).catch((error) => {
+        this.logger?.warn?.(`acp-remote abort-cancel failed: ${toMessageText(error)}`);
+      });
+    };
+    const onAbort = () => {
+      void cancelOnAbort();
+    };
+
+    if (input.signal?.aborted) {
+      await cancelOnAbort();
+      return;
+    }
+    if (input.signal) {
+      input.signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    const seenNotifications: string[] = [];
+    try {
+      for (let attempt = 1; attempt <= 2; attempt += 1) {
+        let replayCursor = 0;
+        let dedupingReplay = attempt > 1;
+        try {
+          for await (const message of this.streamRpc({
+            method: "session/prompt",
+            id: input.requestId,
+            params: {
+              sessionId: state.sessionId,
+              prompt: [{ type: "text", text: input.text }],
+              _meta: this.buildMeta({
+                openclawClientId: state.clientId,
+                openclawRequestId: input.requestId,
+              }),
+            },
+            signal: input.signal,
+          })) {
+            if (isJsonRpcNotification(message)) {
+              if (dedupingReplay) {
+                const serialized = serializeNotification(message);
+                if (
+                  replayCursor < seenNotifications.length &&
+                  seenNotifications[replayCursor] === serialized
+                ) {
+                  replayCursor += 1;
+                  continue;
+                }
+                dedupingReplay = false;
+                seenNotifications.push(serialized);
+              } else {
+                seenNotifications.push(serializeNotification(message));
+              }
+              for (const event of this.translateNotification(message, state.sessionId)) {
+                yield event;
+              }
+              continue;
+            }
+            if (!idsEqual((message as JsonRpcSuccess | JsonRpcFailure).id, input.requestId)) {
+              continue;
+            }
+            if (isJsonRpcFailure(message)) {
+              yield {
+                type: "error",
+                message:
+                  normalizeText(message.error.message) ?? "ACP remote prompt request failed.",
+                code:
+                  typeof message.error.code === "number" || typeof message.error.code === "string"
+                    ? String(message.error.code)
+                    : undefined,
+              };
+              return;
+            }
+            if (isJsonRpcSuccess(message)) {
+              const result = isRecord(message.result) ? message.result : {};
+              const stopReason = normalizeStopReason(result.stopReason);
+              if (!stopReason) {
+                yield {
+                  type: "error",
+                  message: "ACP remote prompt response did not include stopReason.",
+                };
+                return;
+              }
+              yield {
+                type: "done",
+                stopReason,
+              };
+              return;
+            }
+          }
+          throw new MissingTerminalResponseError("session/prompt");
+        } catch (error) {
+          if (input.signal?.aborted || isAbortLikeError(error)) {
+            return;
+          }
+          const retryable = attempt < 2 && this.isRetryablePromptError(error);
+          if (retryable) {
+            this.logger?.warn?.(
+              `acp-remote prompt transport dropped; retrying request ${input.requestId}`,
+            );
+            if (this.config.retryDelayMs > 0) {
+              await sleep(this.config.retryDelayMs);
+            }
+            continue;
+          }
+          yield {
+            type: "error",
+            message: toMessageText(error),
+          };
+          return;
+        }
+      }
+    } finally {
+      if (input.signal) {
+        input.signal.removeEventListener("abort", onAbort);
+      }
+    }
+  }
+
+  async setMode(input: { handle: AcpRuntimeHandle; mode: string }): Promise<void> {
+    await this.initializeRemote();
+    const state = this.resolveHandleState(input.handle);
+    await this.request({
+      method: "session/set_mode",
+      id: `set-mode:${state.sessionId}:${input.mode}`,
+      params: {
+        sessionId: state.sessionId,
+        modeId: input.mode,
+        _meta: this.buildMeta({
+          openclawClientId: state.clientId,
+        }),
+      },
+    });
+    const current = this.sessionStateBySessionId.get(state.sessionId);
+    if (current) {
+      current.currentModeId = input.mode;
+    }
+  }
+
+  async setConfigOption(input: {
+    handle: AcpRuntimeHandle;
+    key: string;
+    value: string;
+  }): Promise<void> {
+    await this.initializeRemote();
+    const state = this.resolveHandleState(input.handle);
+    const result = await this.request<Record<string, unknown> | null>({
+      method: "session/set_config_option",
+      id: `set-config:${state.sessionId}:${input.key}`,
+      params: {
+        sessionId: state.sessionId,
+        configId: input.key,
+        value: input.value,
+        _meta: this.buildMeta({
+          openclawClientId: state.clientId,
+        }),
+      },
+    });
+    const current = this.sessionStateBySessionId.get(state.sessionId);
+    if (current) {
+      current.configOptions[input.key] = input.value;
+    }
+    this.applyRemoteSessionMetadata(state.sessionId, result);
+  }
+
+  async cancel(input: { handle: AcpRuntimeHandle; reason?: string }): Promise<void> {
+    const state = this.resolveHandleState(input.handle);
+    await this.notify({
+      method: "session/cancel",
+      params: {
+        sessionId: state.sessionId,
+        _meta: this.buildMeta({
+          openclawClientId: state.clientId,
+          ...(normalizeText(input.reason) ? { reason: normalizeText(input.reason) } : {}),
+        }),
+      },
+    }).catch((error) => {
+      this.logger?.warn?.(`acp-remote cancel failed: ${toMessageText(error)}`);
+    });
+  }
+
+  async close(input: { handle: AcpRuntimeHandle; reason: string }): Promise<void> {
+    const state = this.resolveHandleState(input.handle);
+    await this.request({
+      method: "session/close",
+      id: `close:${state.sessionId}`,
+      params: {
+        sessionId: state.sessionId,
+        _meta: this.buildMeta({
+          openclawClientId: state.clientId,
+          reason: input.reason,
+        }),
+      },
+    }).catch((error) => {
+      this.logger?.warn?.(`acp-remote close failed: ${toMessageText(error)}`);
+    });
+    this.sessionStateBySessionId.delete(state.sessionId);
+  }
+
+  private buildMeta(extra: Record<string, unknown>): Record<string, unknown> {
+    return {
+      openclawDraftRevision: this.config.requiredDraftRevision,
+      openclawTransport: "ndjson-http-response-stream",
+      ...extra,
+    };
+  }
+
+  private async initializeRemote(
+    params: { force?: boolean } = {},
+  ): Promise<AcpRemoteInitializeState> {
+    if (!params.force && this.initializeState) {
+      return this.initializeState;
+    }
+    const result = await this.request<Record<string, unknown>>({
+      method: "initialize",
+      id: `initialize:${this.config.protocolVersion}`,
+      params: {
+        protocolVersion: this.config.protocolVersion,
+        clientCapabilities: {
+          fs: {
+            readTextFile: false,
+            writeTextFile: false,
+          },
+          terminal: false,
+        },
+        clientInfo: ACP_REMOTE_CLIENT_INFO,
+        _meta: this.buildMeta({}),
+      },
+    });
+
+    const protocolVersion = normalizeNumber(result.protocolVersion);
+    if (protocolVersion !== this.config.protocolVersion) {
+      throw new AcpRuntimeError(
+        "ACP_BACKEND_UNAVAILABLE",
+        `ACP remote protocol mismatch: expected ${this.config.protocolVersion}, got ${protocolVersion ?? "unknown"}.`,
+      );
+    }
+
+    const responseMeta = isRecord(result._meta) ? result._meta : {};
+    const returnedDraftRevision = normalizeText(responseMeta.openclawDraftRevision);
+    if (returnedDraftRevision !== this.config.requiredDraftRevision) {
+      throw new AcpRuntimeError(
+        "ACP_BACKEND_UNAVAILABLE",
+        `ACP remote draft revision mismatch: expected ${this.config.requiredDraftRevision}, got ${returnedDraftRevision ?? "unknown"}.`,
+      );
+    }
+
+    const loadSession = Boolean(
+      isRecord(result.agentCapabilities) && result.agentCapabilities.loadSession === true,
+    );
+    if (!loadSession) {
+      throw new AcpRuntimeError(
+        "ACP_BACKEND_UNAVAILABLE",
+        "ACP remote gateway must advertise loadSession support.",
+      );
+    }
+
+    const state = {
+      protocolVersion,
+      loadSession,
+    };
+    this.initializeState = state;
+    return state;
+  }
+
+  private resolveHandleState(handle: AcpRuntimeHandle): AcpRemoteHandleState {
+    const decoded = decodeAcpRemoteHandleState(handle.runtimeSessionName);
+    if (!decoded) {
+      throw new AcpRuntimeError(
+        "ACP_SESSION_INIT_FAILED",
+        "Invalid acp-remote runtime handle state.",
+      );
+    }
+    return decoded;
+  }
+
+  private upsertSessionState(
+    sessionId: string,
+    patch: Pick<AcpRemoteSessionState, "clientId" | "cwd" | "mode">,
+  ): void {
+    const current = this.sessionStateBySessionId.get(sessionId);
+    this.sessionStateBySessionId.set(sessionId, {
+      clientId: patch.clientId,
+      cwd: patch.cwd,
+      mode: patch.mode,
+      currentModeId: current?.currentModeId,
+      configOptions: { ...(current?.configOptions ?? {}) },
+    });
+  }
+
+  private applyRemoteSessionMetadata(sessionId: string, value: unknown): void {
+    const state = this.sessionStateBySessionId.get(sessionId);
+    if (!state || !isRecord(value)) {
+      return;
+    }
+    const currentModeId =
+      readCurrentModeId(value.modes) ?? readCurrentModeId(value.currentMode) ?? state.currentModeId;
+    if (currentModeId) {
+      state.currentModeId = currentModeId;
+    }
+    state.configOptions = {
+      ...state.configOptions,
+      ...readConfigOptionValues(value.configOptions),
+    };
+  }
+
+  private translateNotification(
+    message: JsonRpcNotification,
+    sessionId: string,
+  ): AcpRuntimeEvent[] {
+    if (message.method !== "session/update" || !isRecord(message.params)) {
+      return [];
+    }
+    if (normalizeText(message.params.sessionId) !== sessionId) {
+      return [];
+    }
+    const update = isRecord(message.params.update) ? message.params.update : null;
+    if (!update) {
+      return [];
+    }
+    const tag = normalizeText(update.sessionUpdate);
+    if (!tag) {
+      return [];
+    }
+
+    if (tag === "agent_message_chunk" || tag === "agent_thought_chunk") {
+      const text = extractChunkText(update.content);
+      if (!text) {
+        return [];
+      }
+      return [
+        {
+          type: "text_delta",
+          text,
+          stream: tag === "agent_thought_chunk" ? "thought" : "output",
+          tag,
+        },
+      ];
+    }
+
+    if (tag === "tool_call" || tag === "tool_call_update") {
+      const title = normalizeText(update.title) ?? normalizeText(update.toolCallId) ?? "tool";
+      const status = normalizeText(update.status);
+      const text = status ? `${title} (${status})` : title;
+      return [
+        {
+          type: "tool_call",
+          text,
+          tag,
+          toolCallId: normalizeText(update.toolCallId),
+          status,
+          title,
+        },
+      ];
+    }
+
+    if (tag === "current_mode_update") {
+      const currentModeId = normalizeText(update.currentModeId);
+      const state = this.sessionStateBySessionId.get(sessionId);
+      if (state && currentModeId) {
+        state.currentModeId = currentModeId;
+      }
+      return currentModeId
+        ? [
+            {
+              type: "status",
+              text: currentModeId,
+              tag,
+            },
+          ]
+        : [];
+    }
+
+    if (tag === "config_option_update") {
+      const state = this.sessionStateBySessionId.get(sessionId);
+      if (state) {
+        state.configOptions = {
+          ...state.configOptions,
+          ...readConfigOptionValues(update.configOptions),
+        };
+      }
+    }
+
+    return [];
+  }
+
+  private isMissingSessionError(error: unknown): boolean {
+    if (!(error instanceof RemoteRpcError)) {
+      return false;
+    }
+    if (error.code === 404 || error.code === -32004 || error.code === "session_not_found") {
+      return true;
+    }
+    const reason =
+      isRecord(error.data) && typeof error.data.reason === "string" ? error.data.reason : undefined;
+    if (reason === "session_not_found") {
+      return true;
+    }
+    return /session.*not found|unknown session|missing session|does not exist/i.test(error.message);
+  }
+
+  private isRetryablePromptError(error: unknown): boolean {
+    if (error instanceof RemoteRpcError) {
+      return false;
+    }
+    if (error instanceof RemoteHttpError) {
+      return error.status >= 500;
+    }
+    return error instanceof MissingTerminalResponseError || error instanceof Error;
+  }
+
+  private async *streamRpc(params: {
+    method: string;
+    id: JsonRpcId;
+    params: Record<string, unknown>;
+    signal?: AbortSignal;
+  }): AsyncIterable<JsonRpcMessage> {
+    const signal = buildTimeoutSignal(params.signal, this.config.timeoutMs);
+    const response = await fetch(this.config.url, {
+      method: "POST",
+      headers: {
+        accept: "application/x-ndjson",
+        "content-type": "application/x-ndjson",
+        ...this.config.headers,
+      },
+      body: `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: params.id,
+        method: params.method,
+        params: params.params,
+      })}\n`,
+      signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new RemoteHttpError(
+        response.status,
+        `ACP remote ${params.method} failed with HTTP ${response.status}${text ? `: ${text.trim()}` : ""}`,
+      );
+    }
+    if (!response.body) {
+      throw new MissingTerminalResponseError(params.method);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        break;
+      }
+      buffer += decoder.decode(chunk.value, { stream: true });
+      while (true) {
+        const newlineIndex = buffer.indexOf("\n");
+        if (newlineIndex === -1) {
+          break;
+        }
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
+        if (!line) {
+          continue;
+        }
+        yield JSON.parse(line) as JsonRpcMessage;
+      }
+    }
+
+    const finalChunk = `${buffer}${decoder.decode()}`.trim();
+    if (finalChunk) {
+      yield JSON.parse(finalChunk) as JsonRpcMessage;
+    }
+  }
+
+  private async request<T>(params: {
+    method: string;
+    id: JsonRpcId;
+    params: Record<string, unknown>;
+    signal?: AbortSignal;
+  }): Promise<T> {
+    for await (const message of this.streamRpc(params)) {
+      if (isJsonRpcNotification(message)) {
+        continue;
+      }
+      if (!idsEqual((message as JsonRpcSuccess | JsonRpcFailure).id, params.id)) {
+        continue;
+      }
+      if (isJsonRpcFailure(message)) {
+        throw new RemoteRpcError(
+          normalizeText(message.error.message) ?? `ACP remote ${params.method} failed.`,
+          {
+            code: message.error.code,
+            data: message.error.data,
+          },
+        );
+      }
+      if (isJsonRpcSuccess(message)) {
+        return message.result as T;
+      }
+    }
+    throw new MissingTerminalResponseError(params.method);
+  }
+
+  private async notify(params: {
+    method: string;
+    params: Record<string, unknown>;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const signal = buildTimeoutSignal(params.signal, this.config.timeoutMs);
+    const response = await fetch(this.config.url, {
+      method: "POST",
+      headers: {
+        accept: "application/x-ndjson",
+        "content-type": "application/x-ndjson",
+        ...this.config.headers,
+      },
+      body: `${JSON.stringify({
+        jsonrpc: "2.0",
+        method: params.method,
+        params: params.params,
+      })}\n`,
+      signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new RemoteHttpError(
+        response.status,
+        `ACP remote ${params.method} failed with HTTP ${response.status}${text ? `: ${text.trim()}` : ""}`,
+      );
+    }
+    await response.text().catch(() => "");
+  }
+}

--- a/extensions/acp-remote/src/service.test.ts
+++ b/extensions/acp-remote/src/service.test.ts
@@ -1,0 +1,111 @@
+import type { AcpRuntime, OpenClawPluginServiceContext } from "openclaw/plugin-sdk/acp";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AcpRuntimeError } from "../../../src/acp/runtime/errors.js";
+import {
+  __testing,
+  getAcpRuntimeBackend,
+  requireAcpRuntimeBackend,
+} from "../../../src/acp/runtime/registry.js";
+import { createAcpRemoteRuntimeService } from "./service.js";
+
+type RuntimeStub = AcpRuntime & {
+  probeAvailability(): Promise<void>;
+  isHealthy(): boolean;
+};
+
+function createRuntimeStub(healthy: boolean): {
+  runtime: RuntimeStub;
+  probeAvailabilitySpy: ReturnType<typeof vi.fn>;
+  isHealthySpy: ReturnType<typeof vi.fn>;
+} {
+  const probeAvailabilitySpy = vi.fn(async () => {});
+  const isHealthySpy = vi.fn(() => healthy);
+  return {
+    runtime: {
+      ensureSession: vi.fn(async (input) => ({
+        sessionKey: input.sessionKey,
+        backend: "acp-remote",
+        runtimeSessionName: input.sessionKey,
+        backendSessionId: input.sessionKey,
+      })),
+      runTurn: vi.fn(async function* () {
+        yield { type: "done" as const };
+      }),
+      cancel: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      async probeAvailability() {
+        await probeAvailabilitySpy();
+      },
+      isHealthy() {
+        return isHealthySpy();
+      },
+    },
+    probeAvailabilitySpy,
+    isHealthySpy,
+  };
+}
+
+function createServiceContext(
+  overrides: Partial<OpenClawPluginServiceContext> = {},
+): OpenClawPluginServiceContext {
+  return {
+    config: {},
+    workspaceDir: "/tmp/workspace",
+    stateDir: "/tmp/state",
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    ...overrides,
+  };
+}
+
+describe("createAcpRemoteRuntimeService", () => {
+  beforeEach(() => {
+    __testing.resetAcpRuntimeBackendsForTests();
+  });
+
+  it("registers and unregisters the acp-remote backend", async () => {
+    const { runtime, probeAvailabilitySpy } = createRuntimeStub(true);
+    const service = createAcpRemoteRuntimeService({
+      pluginConfig: {
+        url: "http://127.0.0.1:8787/acp",
+      },
+      runtimeFactory: () => runtime,
+    });
+    const context = createServiceContext();
+
+    await service.start(context);
+    expect(getAcpRuntimeBackend("acp-remote")?.runtime).toBe(runtime);
+
+    await vi.waitFor(() => {
+      expect(probeAvailabilitySpy).toHaveBeenCalledOnce();
+    });
+
+    await service.stop?.(context);
+    expect(getAcpRuntimeBackend("acp-remote")).toBeNull();
+  });
+
+  it("marks backend unavailable when runtime health check fails", async () => {
+    const { runtime } = createRuntimeStub(false);
+    const service = createAcpRemoteRuntimeService({
+      pluginConfig: {
+        url: "http://127.0.0.1:8787/acp",
+      },
+      runtimeFactory: () => runtime,
+    });
+    const context = createServiceContext();
+
+    await service.start(context);
+
+    expect(() => requireAcpRuntimeBackend("acp-remote")).toThrowError(AcpRuntimeError);
+    try {
+      requireAcpRuntimeBackend("acp-remote");
+      throw new Error("expected ACP backend lookup to fail");
+    } catch (error) {
+      expect((error as AcpRuntimeError).code).toBe("ACP_BACKEND_UNAVAILABLE");
+    }
+  });
+});

--- a/extensions/acp-remote/src/service.ts
+++ b/extensions/acp-remote/src/service.ts
@@ -1,0 +1,86 @@
+import type {
+  AcpRuntime,
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
+  PluginLogger,
+} from "openclaw/plugin-sdk/acp";
+import { registerAcpRuntimeBackend, unregisterAcpRuntimeBackend } from "openclaw/plugin-sdk/acp";
+import { resolveAcpRemotePluginConfig, type ResolvedAcpRemotePluginConfig } from "./config.js";
+import { ACP_REMOTE_BACKEND_ID, AcpRemoteRuntime } from "./runtime.js";
+
+type AcpRemoteRuntimeLike = AcpRuntime & {
+  probeAvailability(): Promise<void>;
+  isHealthy(): boolean;
+};
+
+type AcpRemoteRuntimeFactoryParams = {
+  pluginConfig: ResolvedAcpRemotePluginConfig;
+  logger?: PluginLogger;
+};
+
+type CreateAcpRemoteRuntimeServiceParams = {
+  pluginConfig?: unknown;
+  runtimeFactory?: (params: AcpRemoteRuntimeFactoryParams) => AcpRemoteRuntimeLike;
+};
+
+function createDefaultRuntime(params: AcpRemoteRuntimeFactoryParams): AcpRemoteRuntimeLike {
+  return new AcpRemoteRuntime(params.pluginConfig, {
+    logger: params.logger,
+  });
+}
+
+export function createAcpRemoteRuntimeService(
+  params: CreateAcpRemoteRuntimeServiceParams = {},
+): OpenClawPluginService {
+  let runtime: AcpRemoteRuntimeLike | null = null;
+  let lifecycleRevision = 0;
+
+  return {
+    id: "acp-remote-runtime",
+    async start(ctx: OpenClawPluginServiceContext): Promise<void> {
+      const pluginConfig = resolveAcpRemotePluginConfig({
+        rawConfig: params.pluginConfig,
+      });
+      const runtimeFactory = params.runtimeFactory ?? createDefaultRuntime;
+      runtime = runtimeFactory({
+        pluginConfig,
+        logger: ctx.logger,
+      });
+
+      registerAcpRuntimeBackend({
+        id: ACP_REMOTE_BACKEND_ID,
+        runtime,
+        healthy: () => runtime?.isHealthy() ?? false,
+      });
+      ctx.logger.info(`acp-remote runtime backend registered (url: ${pluginConfig.url})`);
+
+      lifecycleRevision += 1;
+      const currentRevision = lifecycleRevision;
+      void (async () => {
+        try {
+          await runtime?.probeAvailability();
+          if (currentRevision !== lifecycleRevision) {
+            return;
+          }
+          if (runtime?.isHealthy()) {
+            ctx.logger.info("acp-remote runtime backend ready");
+          } else {
+            ctx.logger.warn("acp-remote runtime backend probe failed");
+          }
+        } catch (error) {
+          if (currentRevision !== lifecycleRevision) {
+            return;
+          }
+          ctx.logger.warn(
+            `acp-remote runtime setup failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      })();
+    },
+    async stop(_ctx: OpenClawPluginServiceContext): Promise<void> {
+      lifecycleRevision += 1;
+      unregisterAcpRuntimeBackend(ACP_REMOTE_BACKEND_ID);
+      runtime = null;
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,10 @@
       "types": "./dist/plugin-sdk/acpx.d.ts",
       "default": "./dist/plugin-sdk/acpx.js"
     },
+    "./plugin-sdk/acp": {
+      "types": "./dist/plugin-sdk/acp.d.ts",
+      "default": "./dist/plugin-sdk/acp.js"
+    },
     "./plugin-sdk/bluebubbles": {
       "types": "./dist/plugin-sdk/bluebubbles.d.ts",
       "default": "./dist/plugin-sdk/bluebubbles.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,8 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
+  extensions/acp-remote: {}
+
   extensions/acpx:
     dependencies:
       acpx:

--- a/scripts/check-plugin-sdk-exports.mjs
+++ b/scripts/check-plugin-sdk-exports.mjs
@@ -52,6 +52,7 @@ const requiredSubpathEntries = [
   "whatsapp",
   "line",
   "msteams",
+  "acp",
   "acpx",
   "bluebubbles",
   "copilot-proxy",

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -43,6 +43,8 @@ const requiredPathGroups = [
   "dist/plugin-sdk/line.d.ts",
   "dist/plugin-sdk/msteams.js",
   "dist/plugin-sdk/msteams.d.ts",
+  "dist/plugin-sdk/acp.js",
+  "dist/plugin-sdk/acp.d.ts",
   "dist/plugin-sdk/acpx.js",
   "dist/plugin-sdk/acpx.d.ts",
   "dist/plugin-sdk/bluebubbles.js",

--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -18,6 +18,7 @@ const entrypoints = [
   "whatsapp",
   "line",
   "msteams",
+  "acp",
   "acpx",
   "bluebubbles",
   "copilot-proxy",

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -242,7 +242,7 @@ export class AcpSessionManager {
       const effectiveCwd = normalizeText(handle.cwd) ?? requestedCwd;
       const effectiveRuntimeOptions = normalizeRuntimeOptions({
         ...initialRuntimeOptions,
-        ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
+        ...(requestedCwd && effectiveCwd ? { cwd: effectiveCwd } : {}),
       });
 
       const identityNow = Date.now();
@@ -897,14 +897,15 @@ export class AcpSessionManager {
       params.meta.agent?.trim() || resolveAcpAgentFromSessionKey(params.sessionKey, "main");
     const mode = params.meta.mode;
     const runtimeOptions = resolveRuntimeOptionsFromMeta(params.meta);
-    const cwd = runtimeOptions.cwd ?? normalizeText(params.meta.cwd);
+    const requestedCwd = runtimeOptions.cwd;
+    const currentCwd = requestedCwd ?? normalizeText(params.meta.cwd);
     const configuredBackend = (params.meta.backend || params.cfg.acp?.backend || "").trim();
     const cached = this.getCachedRuntimeState(params.sessionKey);
     if (cached) {
       const backendMatches = !configuredBackend || cached.backend === configuredBackend;
       const agentMatches = cached.agent === agent;
       const modeMatches = cached.mode === mode;
-      const cwdMatches = (cached.cwd ?? "") === (cwd ?? "");
+      const cwdMatches = (cached.cwd ?? "") === (currentCwd ?? "");
       if (backendMatches && agentMatches && modeMatches && cwdMatches) {
         return {
           runtime: cached.runtime,
@@ -928,7 +929,7 @@ export class AcpSessionManager {
           sessionKey: params.sessionKey,
           agent,
           mode,
-          cwd,
+          cwd: requestedCwd,
         }),
       fallbackCode: "ACP_SESSION_INIT_FAILED",
       fallbackMessage: "Could not initialize ACP session runtime.",
@@ -937,10 +938,11 @@ export class AcpSessionManager {
     const previousMeta = params.meta;
     const previousIdentity = resolveSessionIdentityFromMeta(previousMeta);
     const now = Date.now();
-    const effectiveCwd = normalizeText(ensured.cwd) ?? cwd;
+    const effectiveCwd =
+      normalizeText(ensured.cwd) ?? requestedCwd ?? normalizeText(params.meta.cwd);
     const nextRuntimeOptions = normalizeRuntimeOptions({
       ...runtimeOptions,
-      ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
+      ...(requestedCwd && effectiveCwd ? { cwd: effectiveCwd } : {}),
     });
     const nextIdentity =
       mergeSessionIdentity({
@@ -1027,6 +1029,7 @@ export class AcpSessionManager {
         if (!base) {
           return null;
         }
+        const nextCwd = normalized.cwd ?? base.cwd;
         return {
           backend: base.backend,
           agent: base.agent,
@@ -1034,7 +1037,7 @@ export class AcpSessionManager {
           ...(base.identity ? { identity: base.identity } : {}),
           mode: base.mode,
           runtimeOptions: hasOptions ? normalized : undefined,
-          cwd: normalized.cwd,
+          ...(nextCwd ? { cwd: nextCwd } : {}),
           state: base.state,
           lastActivityAt: Date.now(),
           ...(base.lastError ? { lastError: base.lastError } : {}),
@@ -1047,7 +1050,8 @@ export class AcpSessionManager {
     if (!cached) {
       return;
     }
-    if ((cached.cwd ?? "") !== (normalized.cwd ?? "")) {
+    const nextCwd = normalized.cwd ?? cached.cwd;
+    if ((cached.cwd ?? "") !== (nextCwd ?? "")) {
       this.clearCachedRuntimeState(params.sessionKey);
       return;
     }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -54,10 +54,16 @@ function createRuntime(): {
   setConfigOption: ReturnType<typeof vi.fn>;
 } {
   const ensureSession = vi.fn(
-    async (input: { sessionKey: string; agent: string; mode: "persistent" | "oneshot" }) => ({
+    async (input: {
+      sessionKey: string;
+      agent: string;
+      mode: "persistent" | "oneshot";
+      cwd?: string;
+    }) => ({
       sessionKey: input.sessionKey,
       backend: "acpx",
       runtimeSessionName: `${input.sessionKey}:${input.mode}:runtime`,
+      cwd: input.cwd,
     }),
   );
   const runTurn = vi.fn(async function* () {
@@ -330,6 +336,139 @@ describe("AcpSessionManager", () => {
     });
 
     expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps learned cwd out of explicit runtime input across initialize and restart", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.ensureSession.mockImplementation(
+      async (input: {
+        sessionKey: string;
+        agent: string;
+        mode: "persistent" | "oneshot";
+        cwd?: string;
+      }) => ({
+        sessionKey: input.sessionKey,
+        backend: "acpx",
+        runtimeSessionName: `${input.sessionKey}:${input.mode}:${runtimeState.ensureSession.mock.calls.length}`,
+        cwd: input.cwd ?? "/srv/remote-session",
+      }),
+    );
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+
+    let storedMeta: SessionAcpMeta | undefined;
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      if (!storedMeta) {
+        return null;
+      }
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: storedMeta,
+      };
+    });
+    hoisted.upsertAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        sessionKey: string;
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta } | undefined,
+        ) => SessionAcpMeta | null | undefined;
+      };
+      const entry = storedMeta
+        ? {
+            sessionId: "session-1",
+            updatedAt: Date.now(),
+            acp: storedMeta,
+          }
+        : undefined;
+      const next = params.mutate(storedMeta, entry);
+      if (!next) {
+        storedMeta = undefined;
+        return null;
+      }
+      storedMeta = next;
+      return {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        acp: next,
+      };
+    });
+
+    const managerA = new AcpSessionManager();
+    const initialized = await managerA.initializeSession({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    expect(initialized.meta.cwd).toBe("/srv/remote-session");
+    expect(initialized.meta.runtimeOptions?.cwd).toBeUndefined();
+    expect(runtimeState.ensureSession).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        sessionKey: "agent:codex:acp:session-1",
+        cwd: undefined,
+      }),
+    );
+
+    const managerB = new AcpSessionManager();
+    await managerB.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "after restart",
+      mode: "prompt",
+      requestId: "r2",
+    });
+
+    expect(storedMeta?.cwd).toBe("/srv/remote-session");
+    expect(storedMeta?.runtimeOptions?.cwd).toBeUndefined();
+    expect(runtimeState.ensureSession).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        sessionKey: "agent:codex:acp:session-1",
+        cwd: undefined,
+      }),
+    );
+  });
+
+  it("replays explicit cwd on restart", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-explicit",
+      storeSessionKey: "agent:codex:acp:session-explicit",
+      acp: {
+        ...readySessionMeta(),
+        cwd: "/workspace/explicit",
+        runtimeOptions: {
+          cwd: "/workspace/explicit",
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-explicit",
+      text: "resume explicit cwd",
+      mode: "prompt",
+      requestId: "r-explicit",
+    });
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:codex:acp:session-explicit",
+        cwd: "/workspace/explicit",
+      }),
+    );
   });
 
   it("enforces acp.maxConcurrentSessions when opening new runtime handles", async () => {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1203,7 +1203,7 @@ describe("AcpSessionManager", () => {
     hoisted.requireAcpRuntimeBackendMock.mockImplementation(() => {
       throw new AcpRuntimeError(
         "ACP_BACKEND_MISSING",
-        "ACP runtime backend is not configured. Install and enable the acpx runtime plugin.",
+        "ACP runtime backend is not configured. Install and enable an ACP runtime plugin.",
       );
     });
 
@@ -1231,7 +1231,7 @@ describe("AcpSessionManager", () => {
     hoisted.requireAcpRuntimeBackendMock.mockImplementation(() => {
       throw new AcpRuntimeError(
         "ACP_BACKEND_MISSING",
-        "ACP runtime backend is not configured. Install and enable the acpx runtime plugin.",
+        "ACP runtime backend is not configured. Install and enable an ACP runtime plugin.",
       );
     });
     hoisted.upsertAcpSessionMetaMock.mockRejectedValueOnce(new Error("disk locked"));

--- a/src/acp/control-plane/runtime-options.ts
+++ b/src/acp/control-plane/runtime-options.ts
@@ -266,14 +266,7 @@ export function mergeRuntimeOptions(params: {
 }
 
 export function resolveRuntimeOptionsFromMeta(meta: SessionAcpMeta): AcpSessionRuntimeOptions {
-  const normalized = normalizeRuntimeOptions(meta.runtimeOptions);
-  if (normalized.cwd || !meta.cwd) {
-    return normalized;
-  }
-  return normalizeRuntimeOptions({
-    ...normalized,
-    cwd: meta.cwd,
-  });
+  return normalizeRuntimeOptions(meta.runtimeOptions);
 }
 
 export function runtimeOptionsEqual(

--- a/src/acp/runtime/registry.ts
+++ b/src/acp/runtime/registry.ts
@@ -90,7 +90,7 @@ export function requireAcpRuntimeBackend(id?: string): AcpRuntimeBackend {
   if (!backend) {
     throw new AcpRuntimeError(
       "ACP_BACKEND_MISSING",
-      "ACP runtime backend is not configured. Install and enable the acpx runtime plugin.",
+      "ACP runtime backend is not configured. Install and enable an ACP runtime plugin.",
     );
   }
   if (!isBackendHealthy(backend)) {

--- a/src/acp/session.test.ts
+++ b/src/acp/session.test.ts
@@ -55,6 +55,33 @@ describe("acp session manager", () => {
     expect(store.hasSession("existing")).toBe(true);
   });
 
+  it("preserves the stored cwd when refreshing an existing session without a new cwd", () => {
+    store.createSession({
+      sessionId: "existing",
+      sessionKey: "acp:one",
+      cwd: "/tmp/one",
+    });
+    advance(500);
+
+    const refreshed = store.createSession({
+      sessionId: "existing",
+      sessionKey: "acp:two",
+    });
+
+    expect(refreshed.sessionKey).toBe("acp:two");
+    expect(refreshed.cwd).toBe("/tmp/one");
+    expect(refreshed.lastTouchedAt).toBe(1_500);
+  });
+
+  it("rejects new sessions that omit cwd", () => {
+    expect(() =>
+      store.createSession({
+        sessionId: "missing-cwd",
+        sessionKey: "acp:missing-cwd",
+      }),
+    ).toThrow(/missing a working directory/i);
+  });
+
   it("reaps idle sessions before enforcing the max session cap", () => {
     const boundedStore = createInMemorySessionStore({
       maxSessions: 1,

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { AcpSession } from "./types.js";
 
 export type AcpSessionStore = {
-  createSession: (params: { sessionKey: string; cwd: string; sessionId?: string }) => AcpSession;
+  createSession: (params: { sessionKey: string; cwd?: string; sessionId?: string }) => AcpSession;
   hasSession: (sessionId: string) => boolean;
   getSession: (sessionId: string) => AcpSession | undefined;
   getSessionByRunId: (runId: string) => AcpSession | undefined;
@@ -83,9 +83,14 @@ export function createInMemorySessionStore(options: AcpSessionStoreOptions = {})
     const existingSession = sessions.get(sessionId);
     if (existingSession) {
       existingSession.sessionKey = params.sessionKey;
-      existingSession.cwd = params.cwd;
+      if (params.cwd !== undefined) {
+        existingSession.cwd = params.cwd;
+      }
       touchSession(existingSession, nowMs);
       return existingSession;
+    }
+    if (params.cwd === undefined) {
+      throw new Error(`ACP session ${sessionId} is missing a working directory.`);
     }
     reapIdleSessions(nowMs);
     if (sessions.size >= maxSessions && !evictOldestIdleSession()) {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -824,7 +824,7 @@ describe("/acp command", () => {
     hoisted.requireAcpRuntimeBackendMock.mockImplementation(() => {
       throw new AcpRuntimeError(
         "ACP_BACKEND_MISSING",
-        "ACP runtime backend is not configured. Install and enable the acpx runtime plugin.",
+        "ACP runtime backend is not configured. Install and enable an ACP runtime plugin.",
       );
     });
 

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1491,7 +1491,7 @@ describe("dispatchReplyFromConfig", () => {
     acpMocks.requireAcpRuntimeBackend.mockImplementation(() => {
       throw new AcpRuntimeError(
         "ACP_BACKEND_MISSING",
-        "ACP runtime backend is not configured. Install and enable the acpx runtime plugin.",
+        "ACP runtime backend is not configured. Install and enable an ACP runtime plugin.",
       );
     });
 
@@ -1516,7 +1516,7 @@ describe("dispatchReplyFromConfig", () => {
     const finalPayload = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock
       .calls[0]?.[0] as ReplyPayload | undefined;
     expect(finalPayload?.text).toContain("ACP error (ACP_BACKEND_MISSING)");
-    expect(finalPayload?.text).toContain("Install and enable the acpx runtime plugin");
+    expect(finalPayload?.text).toContain("Install and enable an ACP runtime plugin");
   });
 
   it("deduplicates inbound messages by MessageSid and origin", async () => {

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -204,6 +204,22 @@ describe("applyPluginAutoEnable", () => {
     expect(result.config.plugins?.entries?.acpx?.enabled).toBeUndefined();
   });
 
+  it("auto-enables acp-remote when ACP is configured for the remote backend", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        acp: {
+          enabled: true,
+          backend: "acp-remote",
+        },
+      },
+      env: {},
+    });
+
+    expect(result.config.plugins?.entries?.["acp-remote"]?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.acpx?.enabled).toBeUndefined();
+    expect(result.changes.join("\n")).toContain("ACP runtime configured, enabled automatically.");
+  });
+
   it("skips when plugins are globally disabled", () => {
     const result = applyPluginAutoEnable({
       config: {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -357,10 +357,19 @@ function resolveConfiguredPlugins(
   const backendRaw =
     typeof cfg.acp?.backend === "string" ? cfg.acp.backend.trim().toLowerCase() : "";
   const acpConfigured =
-    cfg.acp?.enabled === true || cfg.acp?.dispatch?.enabled === true || backendRaw === "acpx";
+    cfg.acp?.enabled === true ||
+    cfg.acp?.dispatch?.enabled === true ||
+    backendRaw === "acpx" ||
+    backendRaw === "acp-remote";
   if (acpConfigured && (!backendRaw || backendRaw === "acpx")) {
     changes.push({
       pluginId: "acpx",
+      reason: "ACP runtime configured",
+    });
+  }
+  if (acpConfigured && backendRaw === "acp-remote") {
+    changes.push({
+      pluginId: "acp-remote",
       reason: "ACP runtime configured",
     });
   }

--- a/src/plugin-sdk/acp.ts
+++ b/src/plugin-sdk/acp.ts
@@ -1,0 +1,34 @@
+// Generic ACP plugin-sdk surface for ACP runtime backends.
+// Keep this additive and aligned with the bundled acpx surface.
+
+export type { AcpRuntimeErrorCode } from "../acp/runtime/errors.js";
+export { AcpRuntimeError } from "../acp/runtime/errors.js";
+export { registerAcpRuntimeBackend, unregisterAcpRuntimeBackend } from "../acp/runtime/registry.js";
+export type {
+  AcpRuntime,
+  AcpRuntimeCapabilities,
+  AcpRuntimeDoctorReport,
+  AcpRuntimeEnsureInput,
+  AcpRuntimeEvent,
+  AcpRuntimeHandle,
+  AcpRuntimeStatus,
+  AcpRuntimeTurnInput,
+  AcpSessionUpdateTag,
+} from "../acp/runtime/types.js";
+export type {
+  OpenClawPluginApi,
+  OpenClawPluginConfigSchema,
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
+  PluginLogger,
+} from "../plugins/types.js";
+export type {
+  WindowsSpawnProgram,
+  WindowsSpawnProgramCandidate,
+  WindowsSpawnResolution,
+} from "./windows-spawn.js";
+export {
+  applyWindowsSpawnProgramPolicy,
+  materializeWindowsSpawnProgram,
+  resolveWindowsSpawnProgramCandidate,
+} from "./windows-spawn.js";

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -50,6 +50,12 @@ const bundledExtensionSubpathLoaders = [
 ] as const;
 
 describe("plugin-sdk subpath exports", () => {
+  it("exports generic ACP helpers", async () => {
+    const acpSdk = await import("openclaw/plugin-sdk/acp");
+    expect(typeof acpSdk.AcpRuntimeError).toBe("function");
+    expect(typeof acpSdk.registerAcpRuntimeBackend).toBe("function");
+  });
+
   it("exports compat helpers", () => {
     expect(typeof compatSdk.emptyPluginConfigSchema).toBe("function");
     expect(typeof compatSdk.resolveControlCommandGate).toBe("function");

--- a/tsconfig.plugin-sdk.dts.json
+++ b/tsconfig.plugin-sdk.dts.json
@@ -22,6 +22,7 @@
     "src/plugin-sdk/whatsapp.ts",
     "src/plugin-sdk/line.ts",
     "src/plugin-sdk/msteams.ts",
+    "src/plugin-sdk/acp.ts",
     "src/plugin-sdk/account-id.ts",
     "src/plugin-sdk/keyed-async-queue.ts",
     "src/plugin-sdk/acpx.ts",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -52,6 +52,7 @@ const pluginSdkEntrypoints = [
   "whatsapp",
   "line",
   "msteams",
+  "acp",
   "acpx",
   "bluebubbles",
   "copilot-proxy",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ const pluginSdkSubpaths = [
   "whatsapp",
   "line",
   "msteams",
+  "acp",
   "acpx",
   "bluebubbles",
   "copilot-proxy",


### PR DESCRIPTION
## Summary
- add a separate `acp-remote` ACP runtime backend that connects OpenClaw to a remote ACP gateway over Streamable HTTP
- expose the minimal additive ACP plugin-sdk/runtime registration surface needed to support remote backends cleanly
- preserve existing ACP manager behavior for remote sessions: session lifecycle, prompt streaming, mode/config controls, and handle persistence
- auto-enable the backend when configured
- preserve omitted `cwd` semantics on reopen/reload
- add config/runtime/service/manager/plugin-sdk coverage for the new backend

## Context
This change follows ACP rather than introducing a custom remote protocol.

Relevant ACP references:
- Protocol overview: https://agentclientprotocol.com/protocol/overview
- Session setup: https://agentclientprotocol.com/protocol/session-setup
- Schema / JSON-RPC surface: https://agentclientprotocol.com/protocol/schema
- Transports (including Streamable HTTP draft): https://agentclientprotocol.com/protocol/transports

Scope is intentionally limited to the OpenClaw side:
- `acpx` remains the local CLI-backed backend
- `acp-remote` adds a separate remote backend
- gateway concerns such as supervision, persistence, replay, lease semantics, and recovery stay in the companion repo: https://github.com/jorgensandhaug/acp-gateway

## Verification
- `pnpm build:strict-smoke`
- `pnpm exec vitest run extensions/acp-remote/src/config.test.ts extensions/acp-remote/src/runtime.test.ts extensions/acp-remote/src/service.test.ts src/acp/control-plane/manager.test.ts src/acp/session.test.ts src/auto-reply/reply/commands-acp.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/config/plugin-auto-enable.test.ts src/plugin-sdk/subpaths.test.ts`

## Notes
- targeted local verification passed for the ACP-remote change surface
- full CI on this draft PR is the authoritative signal