### PR TITLE
fix: restore Telegram route inheritance for Webchat replies

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -937,6 +937,49 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
+  it("chat.send does not inherit Telegram routes for webchat clients when the session key is not Telegram", async () => {
+    createTranscriptFixture("openclaw-chat-send-webchat-telegram-mismatch-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:6812765697",
+        accountId: "default",
+      },
+      lastChannel: "telegram",
+      lastTo: "telegram:6812765697",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-webchat-telegram-mismatch",
+      client: {
+        connect: {
+          client: {
+            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            id: "openclaw-webchat",
+          },
+        },
+      } as unknown,
+      sessionKey: "agent:main:discord:direct:6812765697",
+      deliver: true,
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        ExplicitDeliverRoute: false,
+        AccountId: undefined,
+      }),
+    );
+  });
+
   it("chat.send still inherits external routes for UI clients on channel-scoped sessions", async () => {
     createTranscriptFixture("openclaw-chat-send-ui-channel-scoped-inherit-");
     mockState.finalText = "ok";

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -894,6 +894,49 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
+  it("chat.send inherits Telegram routes for webchat clients on Telegram channel-scoped sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-webchat-telegram-inherit-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:6812765697",
+        accountId: "default",
+      },
+      lastChannel: "telegram",
+      lastTo: "telegram:6812765697",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-webchat-telegram-inherit",
+      client: {
+        connect: {
+          client: {
+            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            id: "openclaw-webchat",
+          },
+        },
+      } as unknown,
+      sessionKey: "agent:main:telegram:direct:6812765697",
+      deliver: true,
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:6812765697",
+        ExplicitDeliverRoute: true,
+        AccountId: "default",
+      }),
+    );
+  });
+
   it("chat.send still inherits external routes for UI clients on channel-scoped sessions", async () => {
     createTranscriptFixture("openclaw-chat-send-ui-channel-scoped-inherit-");
     mockState.finalText = "ok";

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -195,6 +195,7 @@ function resolveChatSendOriginatingRoute(params: {
     (isFromGatewayCliClient || !hasClientMetadata);
   const canInheritWebchatTelegramRoute = Boolean(
     isFromWebchatClient &&
+    sessionChannelHint === "telegram" &&
     routeChannelCandidate === "telegram" &&
     !isChannelAgnosticSessionScope &&
     (isChannelScopedSession || hasLegacyChannelPeerShape),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -193,16 +193,26 @@ function resolveChatSendOriginatingRoute(params: {
     isConfiguredMainSessionScope &&
     params.hasConnectedClient &&
     (isFromGatewayCliClient || !hasClientMetadata);
+  const canInheritWebchatTelegramRoute = Boolean(
+    isFromWebchatClient &&
+    routeChannelCandidate === "telegram" &&
+    !isChannelAgnosticSessionScope &&
+    (isChannelScopedSession || hasLegacyChannelPeerShape),
+  );
 
-  // Webchat clients never inherit external delivery routes. Configured-main
+  // Webchat clients stay internal by default. The one exception here is
+  // Telegram channel-scoped sessions, where Webchat should be able to mirror
+  // replies back into the originating Telegram conversation. Configured-main
   // sessions are stricter than channel-scoped sessions: only CLI callers, or
   // legacy callers with no client metadata, may inherit the last external route.
   const canInheritDeliverableRoute = Boolean(
-    !isFromWebchatClient &&
     sessionChannelHint &&
     sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
-    ((!isChannelAgnosticSessionScope && (isChannelScopedSession || hasLegacyChannelPeerShape)) ||
-      canInheritConfiguredMainRoute),
+    (canInheritWebchatTelegramRoute ||
+      (!isFromWebchatClient &&
+        ((!isChannelAgnosticSessionScope &&
+          (isChannelScopedSession || hasLegacyChannelPeerShape)) ||
+          canInheritConfiguredMainRoute))),
   );
   const hasDeliverableRoute =
     canInheritDeliverableRoute &&


### PR DESCRIPTION
## Summary

- Problem: Webchat replies in Telegram-scoped sessions stay on the internal Webchat surface instead of routing back to Telegram.
- Why it matters: Telegram inbound messages appear in Webchat, but Webchat replies do not go back out to Telegram in the same conversation.
- What changed: Webchat now inherits the external route for Telegram channel-scoped sessions while keeping the existing internal-only behavior for other Webchat surfaces.
- What did NOT change (scope boundary): this PR does not broaden Webchat route inheritance for all channels, and it does not change Telegram transport logic.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #43993

## User-visible / Behavior Changes

- Replies sent from Webchat in Telegram-scoped sessions can route back to the originating Telegram conversation again.
- Existing Webchat internal-only behavior for non-Telegram sessions stays unchanged.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: local macOS dev environment
- Runtime/container: Node.js dev environment
- Model/provider: not required for routing tests
- Integration/channel (if any): Webchat + Telegram route inheritance
- Relevant config (redacted): not required

### Steps

1. Open a Telegram-scoped session in Webchat.
2. Send a reply from Webchat with `deliver: true`.
3. Observe the routing context passed into the agent dispatch path.

### Expected

- The reply keeps the Telegram route (`OriginatingChannel`, `OriginatingTo`, `AccountId`) for Telegram-scoped sessions.

### Actual

- Before this change, Webchat forced those replies back to the internal Webchat surface even for Telegram channel-scoped sessions.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`
- Edge cases checked: Telegram Webchat route inheritance, existing non-Telegram Webchat internal-only behavior, broader gateway chat flows
- What you did **not** verify: a live Webchat-to-Telegram round-trip against a real Telegram bot after this patch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `src/gateway/server-methods/chat.ts`
- Known bad symptoms reviewers should watch for: Webchat unexpectedly inheriting routes for non-Telegram channel-scoped sessions

## Risks and Mitigations

- Risk: route inheritance could become broader than intended for Webchat.
  - Mitigation: the code change is gated to Telegram channel-scoped sessions only, and the existing non-Telegram Webchat block remains covered by tests.
