### PR TITLE
fix(media-understanding): skip legacy Word docs from text extraction

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -970,6 +970,26 @@ describe("applyMediaUnderstanding", () => {
     expectFileNotApplied({ ctx, result, body: "<media:audio>" });
   });
 
+  it("skips legacy .doc attachments even when heuristics see UTF-16 tabular text", async () => {
+    const docLikeBytes = Buffer.concat([
+      Buffer.from([0xff, 0xfe]),
+      Buffer.from("WordDocument\t1Table\r\n", "utf16le"),
+      Buffer.from(Array.from({ length: 64 }, (_, index) => index)),
+    ]);
+    const filePath = await createTempMediaFile({
+      fileName: "incident.doc",
+      content: docLikeBytes,
+    });
+
+    const { ctx, result } = await applyWithDisabledMedia({
+      body: "<media:file>",
+      mediaPath: filePath,
+      mediaType: "application/msword",
+    });
+
+    expectFileNotApplied({ ctx, result, body: "<media:file>" });
+  });
+
   it("does not reclassify PDF attachments as text/plain", async () => {
     const pseudoPdf = Buffer.from("%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n", "utf8");
     const filePath = await createTempMediaFile({

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -388,8 +388,7 @@ async function extractFileBlocks(params: {
     const textSample = decodeTextSample(bufferResult?.buffer);
     // Do not coerce real PDFs into text/plain via printable-byte heuristics.
     // PDFs have a dedicated extraction path in extractFileContentFromSource.
-    const allowTextHeuristic =
-      normalizedRawMime !== "application/pdf" && !isBinaryMediaMime(normalizedRawMime);
+    const allowTextHeuristic = normalizedRawMime !== "application/pdf";
     const textLike =
       allowTextHeuristic && (Boolean(utf16Charset) || looksLikeUtf8Text(bufferResult?.buffer));
     const guessedDelimited = textLike ? guessDelimitedMime(textSample) : undefined;

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -312,6 +312,13 @@ function isBinaryMediaMime(mime?: string): boolean {
     return true;
   }
   if (
+    mime === "application/msword" ||
+    mime === "application/vnd.ms-word" ||
+    mime === "application/vnd.ms-office"
+  ) {
+    return true;
+  }
+  if (
     mime === "application/zip" ||
     mime === "application/x-zip-compressed" ||
     mime === "application/gzip" ||
@@ -385,7 +392,8 @@ async function extractFileBlocks(params: {
     const textSample = decodeTextSample(bufferResult?.buffer);
     // Do not coerce real PDFs into text/plain via printable-byte heuristics.
     // PDFs have a dedicated extraction path in extractFileContentFromSource.
-    const allowTextHeuristic = normalizedRawMime !== "application/pdf";
+    const allowTextHeuristic =
+      normalizedRawMime !== "application/pdf" && !isBinaryMediaMime(normalizedRawMime);
     const textLike =
       allowTextHeuristic && (Boolean(utf16Charset) || looksLikeUtf8Text(bufferResult?.buffer));
     const guessedDelimited = textLike ? guessDelimitedMime(textSample) : undefined;

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -311,11 +311,7 @@ function isBinaryMediaMime(mime?: string): boolean {
   if (mime === "application/octet-stream") {
     return true;
   }
-  if (
-    mime === "application/msword" ||
-    mime === "application/vnd.ms-word" ||
-    mime === "application/vnd.ms-office"
-  ) {
+  if (mime === "application/msword") {
     return true;
   }
   if (


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: legacy `.doc` attachments with MIME `application/msword` could pass through media-understanding text heuristics, be misclassified as text, and get inlined into prompt context.
- Why it matters: in long-running WhatsApp sessions this can inject binary garbage into model history, trigger `context_length_exceeded`, and leave the session unusable until reset.
- What changed: `src/media-understanding/apply.ts` now treats legacy Word MIME types as binary and skips text-heuristic coercion for already-binary MIME types; `src/media-understanding/apply.test.ts` adds a regression test for the UTF-16-plus-TSV false-positive path.
- What did NOT change (scope boundary): this PR does not add `.doc` extraction support, does not change session compaction/recovery behavior, and does not address the separate Brave Search API `422` country-validation bug.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Legacy Word `.doc` attachments are no longer auto-inlined into media-understanding file blocks through text MIME heuristics.
- Affected sessions avoid the specific binary-to-text prompt pollution path that could cause context overflow.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local fresh clone on branch `bugfix-msword-binary-guard`
- Model/provider: N/A for local regression test
- Integration/channel (if any): media-understanding attachment preprocessing; production incident observed on WhatsApp
- Relevant config (redacted): default file MIME allowlist path; no special override required for local regression

### Steps

1. Create or provide an attachment named `incident.doc` with MIME `application/msword` and bytes that look UTF-16/text-like near the start.
2. Pass that attachment through `applyMediaUnderstanding` with file-block extraction enabled and media features otherwise disabled.
3. Observe whether the attachment is converted into a `<file ...>` block and appended to the body.

### Expected

- Legacy `.doc` attachments are treated as binary and skipped by file-block text extraction.

### Actual

- Before this change, the `.doc`-like payload could be treated as text-like, relabeled, and inlined.
- After this change, the regression test confirms no `<file>` block is added.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
YYYY-MM-DDTHH:MM:SS.sssZ
error code: context_length_exceeded
message: Your input exceeds the context window of this model. Please adjust your input and try again.
```

```text
YYYY-MM-DD HH:MM:SS auto-reply sent
Context overflow: prompt too large for the model. Try /reset (or /new) to start a fresh session, or use a larger-context model.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the targeted regression test for legacy `.doc` MIME misclassification; verified the branch diff is limited to the guard and test; verified `pnpm build` succeeds in the corrected local environment.
- Edge cases checked: confirmed the guard is scoped to legacy Word binary MIME types; confirmed the existing PDF special-case remains intact in the same code path.
- What you did **not** verify: no live WhatsApp end-to-end retest; no production replay; no validation of `.docx` or other Office formats beyond the specific MIME guard added here.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore the previous MIME heuristic behavior.
- Files/config to restore: `src/media-understanding/apply.ts` and `src/media-understanding/apply.test.ts`
- Known bad symptoms reviewers should watch for: legacy `.doc` attachments unexpectedly no longer contribute extracted text; any regressions in non-binary text attachment extraction in the same code path.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some legitimate inputs mislabeled as `application/msword` will now be skipped instead of being coerced into text.
  - Mitigation: the changed behavior is limited to known legacy Word binary MIME types, which are unsafe to decode generically; dedicated extraction can be added later if needed.
