### PR TITLE
fix(install): remove redundant --probe flag

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2195,7 +2195,7 @@ refresh_gateway_service_if_loaded() {
         return 0
     fi
 
-    run_quiet_step "Probing gateway service" "$claw" gateway status --probe --deep || true
+    run_quiet_step "Probing gateway service" "$claw" gateway status --deep || true
 }
 
 # Main installation flow


### PR DESCRIPTION
The 'gateway status' command does not support an explicit '--probe' flag (probing is default unless '--no-probe' is passed). This redundant flag caused an error during the post-install/upgrade phase.