### PR TITLE
fix(signal): preserve original filename for local outbound attachments

### DIFF
--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveUserPath } from "../utils.js";
 import { loadWebMedia } from "../web/media.js";
@@ -14,7 +15,7 @@ function isRemoteMediaUrl(mediaUrl: string): boolean {
 
 /**
  * Resolves a local media URL or path to an absolute filesystem path.
- * Handles file:// URLs, ~ expansion, and plain absolute/relative paths.
+ * Handles file:// URLs, ~ expansion, and plain paths (including relative).
  * Consistent with the resolution logic in loadWebMediaInternal.
  */
 function resolveLocalOutboundPath(mediaUrl: string): string {
@@ -28,7 +29,9 @@ function resolveLocalOutboundPath(mediaUrl: string): string {
   if (mediaUrl.startsWith("~")) {
     return resolveUserPath(mediaUrl);
   }
-  return mediaUrl;
+  // Resolve relative paths to absolute so downstream processes (e.g. signal-cli)
+  // can locate the file regardless of their working directory.
+  return path.resolve(mediaUrl);
 }
 
 export async function resolveOutboundAttachmentFromUrl(
@@ -49,10 +52,22 @@ export async function resolveOutboundAttachmentFromUrl(
   // of re-saving with a UUID-based name. Re-saving would discard the human-readable
   // filename, causing outbound attachments (e.g. Signal) to arrive as UUID blobs.
   if (!isRemoteMediaUrl(trimmed)) {
-    return {
-      path: resolveLocalOutboundPath(trimmed),
-      contentType: media.contentType,
-    };
+    const resolvedPath = resolveLocalOutboundPath(trimmed);
+    // If the file fits within the limit (no optimization was needed), short-circuit.
+    // If loadWebMedia had to optimize the image to fit, media.buffer already contains
+    // the correctly sized result — persist that instead of returning the oversized original.
+    if (media.buffer.byteLength <= maxBytes) {
+      return { path: resolvedPath, contentType: media.contentType };
+    }
+    // Fallback: file needed optimization; persist the optimized buffer.
+    const saved = await saveMediaBuffer(
+      media.buffer,
+      media.contentType ?? undefined,
+      "outbound",
+      maxBytes,
+      media.fileName ?? undefined,
+    );
+    return { path: saved.path, contentType: saved.contentType };
   }
 
   // Remote media: buffer is downloaded; persist to temp store.

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -15,23 +15,27 @@ function isRemoteMediaUrl(mediaUrl: string): boolean {
 
 /**
  * Resolves a local media URL or path to an absolute filesystem path.
- * Handles file:// URLs, ~ expansion, and plain paths (including relative).
+ * Handles MEDIA: prefix (used by agent tools), file:// URLs, ~ expansion,
+ * and plain paths (including relative).
  * Consistent with the resolution logic in loadWebMediaInternal.
  */
 function resolveLocalOutboundPath(mediaUrl: string): string {
-  if (mediaUrl.startsWith("file://")) {
+  // Strip the MEDIA: prefix that agent tools (e.g. TTS) prepend to media paths.
+  // loadWebMedia strips it internally; we must do the same before resolving the path.
+  const stripped = mediaUrl.replace(/^\s*MEDIA\s*:\s*/i, "");
+  if (stripped.startsWith("file://")) {
     try {
-      return fileURLToPath(mediaUrl);
+      return fileURLToPath(stripped);
     } catch {
       // Fall through: return as-is if URL is malformed
     }
   }
-  if (mediaUrl.startsWith("~")) {
-    return resolveUserPath(mediaUrl);
+  if (stripped.startsWith("~")) {
+    return resolveUserPath(stripped);
   }
   // Resolve relative paths to absolute so downstream processes (e.g. signal-cli)
   // can locate the file regardless of their working directory.
-  return path.resolve(mediaUrl);
+  return path.resolve(stripped);
 }
 
 export async function resolveOutboundAttachmentFromUrl(

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -43,7 +43,11 @@ export async function resolveOutboundAttachmentFromUrl(
   maxBytes: number,
   options?: { localRoots?: readonly string[] },
 ): Promise<{ path: string; contentType?: string }> {
-  const trimmed = mediaUrl.trim();
+  // Strip the MEDIA: prefix before any further processing so that isRemoteMediaUrl
+  // and loadWebMedia both see the bare URL/path. Without this, a MEDIA:-prefixed
+  // remote URL (e.g. "MEDIA:https://...") would fail the isRemoteMediaUrl check
+  // and enter the local-file path, producing a path.resolve("https://...") garbage path.
+  const trimmed = mediaUrl.trim().replace(/^\s*MEDIA\s*:\s*/i, "");
   const media = await loadWebMedia(
     trimmed,
     buildOutboundMediaLoadOptions({

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -1,9 +1,11 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveUserPath } from "../utils.js";
-import { loadWebMedia } from "../web/media.js";
 import { buildOutboundMediaLoadOptions } from "./load-options.js";
 import { saveMediaBuffer } from "./store.js";
+import { loadWebMedia } from "./web-media.js";
+
+const MEDIA_PREFIX_RE = /^MEDIA:/i;
 
 /**
  * Returns true for remote URLs (http/https) or data: URIs.
@@ -15,14 +17,11 @@ function isRemoteMediaUrl(mediaUrl: string): boolean {
 
 /**
  * Resolves a local media URL or path to an absolute filesystem path.
- * Handles MEDIA: prefix (used by agent tools), file:// URLs, ~ expansion,
- * and plain paths (including relative).
+ * Handles file:// URLs, ~ expansion, and plain paths (including relative).
  * Consistent with the resolution logic in loadWebMediaInternal.
  */
 function resolveLocalOutboundPath(mediaUrl: string): string {
-  // Strip the MEDIA: prefix that agent tools (e.g. TTS) prepend to media paths.
-  // loadWebMedia strips it internally; we must do the same before resolving the path.
-  const stripped = mediaUrl.replace(/^\s*MEDIA\s*:\s*/i, "");
+  const stripped = mediaUrl.replace(MEDIA_PREFIX_RE, "");
   if (stripped.startsWith("file://")) {
     try {
       return fileURLToPath(stripped);
@@ -43,11 +42,8 @@ export async function resolveOutboundAttachmentFromUrl(
   maxBytes: number,
   options?: { localRoots?: readonly string[] },
 ): Promise<{ path: string; contentType?: string }> {
-  // Strip the MEDIA: prefix before any further processing so that isRemoteMediaUrl
-  // and loadWebMedia both see the bare URL/path. Without this, a MEDIA:-prefixed
-  // remote URL (e.g. "MEDIA:https://...") would fail the isRemoteMediaUrl check
-  // and enter the local-file path, producing a path.resolve("https://...") garbage path.
-  const trimmed = mediaUrl.trim().replace(/^\s*MEDIA\s*:\s*/i, "");
+  // Strip MEDIA: prefix (used by agent tools like TTS to tag media paths).
+  const trimmed = mediaUrl.trim().replace(MEDIA_PREFIX_RE, "");
   const media = await loadWebMedia(
     trimmed,
     buildOutboundMediaLoadOptions({

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
-import { loadWebMedia } from "../web/media.js";
 import { resolveUserPath } from "../utils.js";
+import { loadWebMedia } from "../web/media.js";
 import { buildOutboundMediaLoadOptions } from "./load-options.js";
 import { saveMediaBuffer } from "./store.js";
 

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -1,24 +1,68 @@
+import { fileURLToPath } from "node:url";
 import { loadWebMedia } from "../web/media.js";
+import { resolveUserPath } from "../utils.js";
 import { buildOutboundMediaLoadOptions } from "./load-options.js";
 import { saveMediaBuffer } from "./store.js";
+
+/**
+ * Returns true for remote URLs (http/https) or data: URIs.
+ * Local file paths and file:// URLs are considered local.
+ */
+function isRemoteMediaUrl(mediaUrl: string): boolean {
+  return /^https?:\/\//i.test(mediaUrl) || /^data:/i.test(mediaUrl);
+}
+
+/**
+ * Resolves a local media URL or path to an absolute filesystem path.
+ * Handles file:// URLs, ~ expansion, and plain absolute/relative paths.
+ * Consistent with the resolution logic in loadWebMediaInternal.
+ */
+function resolveLocalOutboundPath(mediaUrl: string): string {
+  if (mediaUrl.startsWith("file://")) {
+    try {
+      return fileURLToPath(mediaUrl);
+    } catch {
+      // Fall through: return as-is if URL is malformed
+    }
+  }
+  if (mediaUrl.startsWith("~")) {
+    return resolveUserPath(mediaUrl);
+  }
+  return mediaUrl;
+}
 
 export async function resolveOutboundAttachmentFromUrl(
   mediaUrl: string,
   maxBytes: number,
   options?: { localRoots?: readonly string[] },
 ): Promise<{ path: string; contentType?: string }> {
+  const trimmed = mediaUrl.trim();
   const media = await loadWebMedia(
-    mediaUrl,
+    trimmed,
     buildOutboundMediaLoadOptions({
       maxBytes,
       mediaLocalRoots: options?.localRoots,
     }),
   );
+
+  // For local files already on disk, return the original path directly instead
+  // of re-saving with a UUID-based name. Re-saving would discard the human-readable
+  // filename, causing outbound attachments (e.g. Signal) to arrive as UUID blobs.
+  if (!isRemoteMediaUrl(trimmed)) {
+    return {
+      path: resolveLocalOutboundPath(trimmed),
+      contentType: media.contentType,
+    };
+  }
+
+  // Remote media: buffer is downloaded; persist to temp store.
+  // Pass fileName so the store can embed the original name (e.g. "report.pdf---<uuid>.pdf").
   const saved = await saveMediaBuffer(
     media.buffer,
     media.contentType ?? undefined,
     "outbound",
     maxBytes,
+    media.fileName ?? undefined,
   );
   return { path: saved.path, contentType: saved.contentType };
 }


### PR DESCRIPTION
## Problem

When sending a local file as an attachment via Signal (or iMessage), the outbound attachment arrived with a UUID-based filename (e.g. `a3f8c2d1.jpg`) instead of the original human-readable name (e.g. `photo.jpg`).

The root cause: `resolveOutboundAttachmentFromUrl` always called `saveMediaBuffer`, which re-saved the file under a new UUID-based name regardless of whether the source was already on disk.

## Fix

Detect whether the media URL is remote (http/https or data:) or local, and take different paths:

- **Local paths / file:// URLs**: return the resolved filesystem path directly, without copying or renaming. `loadWebMedia` is still called for content-type detection.
- **Remote URLs**: keep the existing behavior (download buffer + `saveMediaBuffer`). Also forward `media.fileName` to the store so it can embed the original name in the UUID pattern (`filename---<uuid>.ext`).

Additionally:
- Trims whitespace from `mediaUrl` consistently with callers in `signal/send.ts` and `loadWebMediaInternal`.
- Uses `fileURLToPath` (node:url) and `resolveUserPath` (existing util) for path resolution — no new dependencies.

## Testing

Verified with a local patch applied to the installed OpenClaw dist: outbound Signal attachments now preserve their original filenames end-to-end.