### PR TITLE
fix(cron-cli): handle object model in printCronList

### DIFF
--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -152,6 +152,29 @@ describe("printCronList", () => {
     expect(dataLine).toContain("opus");
   });
 
+  it("handles payload.model as {primary, fallbacks} object without crashing (#44084)", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const job = createBaseJob({
+      id: "object-model-job",
+      name: "Object Model",
+      agentId: "ops",
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "hello",
+        model: {
+          primary: "openai-codex/gpt-5.1-codex-mini",
+          fallbacks: ["anthropic/claude-haiku-4-5"],
+        } as unknown as string,
+      },
+    });
+
+    expect(() => printCronList([job], runtime)).not.toThrow();
+    const dataLine = logs[1] ?? "";
+    // Model column is truncated to 20 chars, so we check for the prefix
+    expect(dataLine).toContain("openai-codex/gpt-");
+  });
+
   it("shows exact label for cron schedules with stagger disabled", () => {
     const { logs, runtime } = createRuntimeLogCapture();
     const job = createBaseJob({

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -222,13 +222,17 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);
     const agentLabel = pad(truncate(job.agentId ?? "-", CRON_AGENT_PAD), CRON_AGENT_PAD);
-    const modelLabel = pad(
-      truncate(
-        (job.payload.kind === "agentTurn" ? job.payload.model : undefined) ?? "-",
-        CRON_MODEL_PAD,
-      ),
-      CRON_MODEL_PAD,
-    );
+    const rawModel = job.payload.kind === "agentTurn" ? job.payload.model : undefined;
+    const modelStr =
+      typeof rawModel === "string"
+        ? rawModel
+        : rawModel && typeof rawModel === "object" && "primary" in rawModel
+          ? (() => {
+              const p = (rawModel as { primary?: unknown }).primary;
+              return typeof p === "string" ? p : "-";
+            })()
+          : "-";
+    const modelLabel = pad(truncate(modelStr, CRON_MODEL_PAD), CRON_MODEL_PAD);
 
     const coloredStatus = (() => {
       if (statusRaw === "ok") {


### PR DESCRIPTION
## Problem

`openclaw cron list` crashes with `TypeError: value.slice is not a function` when any cron job has `payload.model` stored as a `{primary, fallbacks}` object instead of a plain string.

This happens after running `openclaw doctor --fix`, which normalizes cron payload model fields to the object format.

## Root Cause

`src/cli/cron-cli/shared.ts`, `printCronList()` passes `job.payload.model` directly to `truncate()`, which calls `value.slice()`. When the model is an object (`{primary, fallbacks}`), `.slice()` doesn't exist.

The `?? "-"` guard only catches `undefined`/`null`, not objects.

## Fix

Resolve `model` to a string before passing to `truncate()`:
- If it's a string, use it directly
- If it's an object with `.primary`, extract the primary string
- Otherwise, fall back to "-"

## Test

Added a test case that creates a job with an object model and verifies `printCronList` doesn't throw.

Fixes #44084