### PR TITLE
fix(memory): shouldSyncSessions skips sessions during full reindex

### DIFF
--- a/src/memory/manager-sync-ops.should-sync-sessions.test.ts
+++ b/src/memory/manager-sync-ops.should-sync-sessions.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { shouldSyncSessionsLogic } from "./should-sync-sessions.js";
+
+describe("shouldSyncSessions priority", () => {
+  it("returns true for full reindex even when reason is session-start (#44028)", () => {
+    // This was the bug: session-start reason returned false BEFORE
+    // needsFullReindex could return true, silently dropping session data
+    // from the rebuilt index.
+    expect(shouldSyncSessionsLogic(true, { reason: "session-start" }, true, false, 0)).toBe(true);
+  });
+
+  it("returns true for full reindex even when reason is watch", () => {
+    expect(shouldSyncSessionsLogic(true, { reason: "watch" }, true, false, 0)).toBe(true);
+  });
+
+  it("returns false for session-start without full reindex", () => {
+    expect(shouldSyncSessionsLogic(true, { reason: "session-start" }, false, true, 1)).toBe(false);
+  });
+
+  it("returns false for watch without full reindex", () => {
+    expect(shouldSyncSessionsLogic(true, { reason: "watch" }, false, true, 1)).toBe(false);
+  });
+
+  it("returns false when sessions source is not enabled", () => {
+    expect(shouldSyncSessionsLogic(false, { force: true }, true, true, 5)).toBe(false);
+  });
+
+  it("returns true when forced", () => {
+    expect(shouldSyncSessionsLogic(true, { force: true }, false, false, 0)).toBe(true);
+  });
+
+  it("returns true when dirty with pending files and no special reason", () => {
+    expect(shouldSyncSessionsLogic(true, { reason: "manual" }, false, true, 3)).toBe(true);
+  });
+
+  it("returns false when dirty but no pending files", () => {
+    expect(shouldSyncSessionsLogic(true, undefined, false, true, 0)).toBe(false);
+  });
+
+  it("returns true when sessionFiles contain non-empty paths", () => {
+    expect(shouldSyncSessionsLogic(true, { sessionFiles: ["a.jsonl"] }, false, false, 0)).toBe(
+      true,
+    );
+  });
+
+  it("returns false when sessionFiles are all blank", () => {
+    expect(shouldSyncSessionsLogic(true, { sessionFiles: ["", " "] }, false, false, 0)).toBe(false);
+  });
+});

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -47,6 +47,7 @@ import {
   listSessionFilesForAgent,
   sessionPathForFile,
 } from "./session-files.js";
+import { shouldSyncSessionsLogic } from "./should-sync-sessions.js";
 import { loadSqliteVecExtension } from "./sqlite-vec.js";
 import { requireNodeSqlite } from "./sqlite.js";
 import type { MemorySource, MemorySyncProgressUpdate } from "./types.js";
@@ -93,6 +94,8 @@ function shouldIgnoreMemoryWatchPath(watchPath: string): boolean {
   const parts = normalized.split(path.sep).map((segment) => segment.trim().toLowerCase());
   return parts.some((segment) => IGNORED_MEMORY_WATCH_DIR_NAMES.has(segment));
 }
+
+export { shouldSyncSessionsLogic } from "./should-sync-sessions.js";
 
 export abstract class MemoryManagerSyncOps {
   protected abstract readonly cfg: OpenClawConfig;
@@ -674,23 +677,13 @@ export abstract class MemoryManagerSyncOps {
     params?: { reason?: string; force?: boolean; sessionFiles?: string[] },
     needsFullReindex = false,
   ) {
-    if (!this.sources.has("sessions")) {
-      return false;
-    }
-    if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
-      return true;
-    }
-    if (params?.force) {
-      return true;
-    }
-    const reason = params?.reason;
-    if (reason === "session-start" || reason === "watch") {
-      return false;
-    }
-    if (needsFullReindex) {
-      return true;
-    }
-    return this.sessionsDirty && this.sessionsDirtyFiles.size > 0;
+    return shouldSyncSessionsLogic(
+      this.sources.has("sessions"),
+      params,
+      needsFullReindex,
+      this.sessionsDirty,
+      this.sessionsDirtyFiles.size,
+    );
   }
 
   private async syncMemoryFiles(params: {

--- a/src/memory/should-sync-sessions.ts
+++ b/src/memory/should-sync-sessions.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure decision logic for whether sessions should be synced during a memory
+ * index operation. Extracted to a standalone module so tests can import the
+ * real production logic without pulling in the full MemoryIndexManager class
+ * hierarchy (which triggers circular-dependency issues in test isolation).
+ */
+export function shouldSyncSessionsLogic(
+  hasSessions: boolean,
+  params: { reason?: string; force?: boolean; sessionFiles?: string[] } | undefined,
+  needsFullReindex: boolean,
+  sessionsDirty: boolean,
+  sessionsDirtyFilesCount: number,
+): boolean {
+  if (!hasSessions) {
+    return false;
+  }
+  if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
+    return true;
+  }
+  if (params?.force) {
+    return true;
+  }
+  // Full reindex must include sessions regardless of the trigger reason;
+  // otherwise a session-start or watch trigger that coincides with a
+  // config/model change silently drops session data from the new index.
+  if (needsFullReindex) {
+    return true;
+  }
+  const reason = params?.reason;
+  if (reason === "session-start" || reason === "watch") {
+    return false;
+  }
+  return sessionsDirty && sessionsDirtyFilesCount > 0;
+}


### PR DESCRIPTION
$## Summary\n\n`shouldSyncSessions()` checks the trigger reason (`session-start` / `watch`) **before** checking `needsFullReindex`. When a session-start event coincides with a config or model change that requires a full reindex, the method returns `false`, silently dropping all session data from the rebuilt index.\n\n## Fix\n\nReorder the priority checks so `needsFullReindex` is evaluated before the reason-based early return.\n\n## Tests\n\nAdded 8 unit tests covering all priority combinations, including the regression case where `reason=session-start` + `needsFullReindex=true` must return `true`.\n\nFixes #44028