### PR TITLE
feat(compaction): include sessionFile in after_compaction hooks

### DIFF
--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -69,8 +69,10 @@ Scope intent:
 - `channels.bluebubbles.password`
 - `channels.bluebubbles.accounts.*.password`
 - `channels.feishu.appSecret`
+- `channels.feishu.encryptKey`
 - `channels.feishu.verificationToken`
 - `channels.feishu.accounts.*.appSecret`
+- `channels.feishu.accounts.*.encryptKey`
 - `channels.feishu.accounts.*.verificationToken`
 - `channels.msteams.appPassword`
 - `channels.mattermost.botToken`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -129,6 +129,13 @@
       "optIn": true
     },
     {
+      "id": "channels.feishu.accounts.*.encryptKey",
+      "configFile": "openclaw.json",
+      "path": "channels.feishu.accounts.*.encryptKey",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "channels.feishu.accounts.*.verificationToken",
       "configFile": "openclaw.json",
       "path": "channels.feishu.accounts.*.verificationToken",
@@ -139,6 +146,13 @@
       "id": "channels.feishu.appSecret",
       "configFile": "openclaw.json",
       "path": "channels.feishu.appSecret",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.feishu.encryptKey",
+      "configFile": "openclaw.json",
+      "path": "channels.feishu.encryptKey",
       "secretShape": "secret_input",
       "optIn": true
     },

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -381,6 +381,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
         messageCount: 1,
         tokenCount: 10,
         compactedCount: 1,
+        sessionFile: "/tmp/session.jsonl",
       },
       expect.objectContaining({ sessionKey: "agent:main:session-1", messageProvider: "telegram" }),
     );
@@ -404,7 +405,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       expect.objectContaining({ sessionKey: "session-1" }),
     );
     expect(hookRunner.runAfterCompaction).toHaveBeenCalledWith(
-      expect.any(Object),
+      expect.objectContaining({ sessionFile: "/tmp/session.jsonl" }),
       expect.objectContaining({ sessionKey: "session-1" }),
     );
   });

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -868,6 +868,7 @@ export async function compactEmbeddedPiSessionDirect(
                 messageCount: messageCountAfter,
                 tokenCount: tokensAfter,
                 compactedCount,
+                sessionFile: params.sessionFile,
               },
               {
                 sessionId: params.sessionId,


### PR DESCRIPTION
## Summary

- Problem: `PluginHookAfterCompactionEvent` already documented `sessionFile`, but the direct compaction path did not include it in the plugin hook payload.
- Why it matters: plugins that want to inspect the persisted transcript after compaction had to reconstruct the path from outside the event.
- What changed: direct compaction now forwards `params.sessionFile` to `hookRunner.runAfterCompaction`, and the hook tests assert the field.
- What did NOT change (scope boundary): no compaction summary logic, transcript persistence behavior, or before-compaction payloads changed.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Plugins listening to direct `after_compaction` hooks now receive `sessionFile` consistently.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A (mocked test)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Trigger direct compaction with plugin hooks enabled and a known `sessionFile`.
2. Inspect the `after_compaction` payload before this change.
3. Apply the patch and rerun the focused hook tests.

### Expected

- `after_compaction` should include the same transcript path already available to the compaction routine.

### Actual

- The hook payload now includes `sessionFile`, and the focused tests pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the two focused Vitest cases that assert the direct `after_compaction` payload and the session-key fallback path.
- Edge cases checked: verified the `sessionId` fallback case still receives the same session file path.
- What you did **not** verify: the unrelated Windows path assertion in `bootstraps runtime plugins with the resolved workspace` remains outside this PR's scope.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the additive hook field wiring.
- Files/config to restore: `src/agents/pi-embedded-runner/compact.ts`, `src/agents/pi-embedded-runner/compact.hooks.test.ts`
- Known bad symptoms reviewers should watch for: none expected beyond additive event shape changes.

## Risks and Mitigations

- Risk: plugin consumers may start depending on `sessionFile` in code paths that still do not provide it.
- Mitigation: this PR only wires an already-available path in the direct compaction path and keeps the field optional.