### PR TITLE
feat(compaction): expose summary in after_compaction hooks

### DIFF
--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -69,8 +69,10 @@ Scope intent:
 - `channels.bluebubbles.password`
 - `channels.bluebubbles.accounts.*.password`
 - `channels.feishu.appSecret`
+- `channels.feishu.encryptKey`
 - `channels.feishu.verificationToken`
 - `channels.feishu.accounts.*.appSecret`
+- `channels.feishu.accounts.*.encryptKey`
 - `channels.feishu.accounts.*.verificationToken`
 - `channels.msteams.appPassword`
 - `channels.mattermost.botToken`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -129,6 +129,13 @@
       "optIn": true
     },
     {
+      "id": "channels.feishu.accounts.*.encryptKey",
+      "configFile": "openclaw.json",
+      "path": "channels.feishu.accounts.*.encryptKey",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "channels.feishu.accounts.*.verificationToken",
       "configFile": "openclaw.json",
       "path": "channels.feishu.accounts.*.verificationToken",
@@ -139,6 +146,13 @@
       "id": "channels.feishu.appSecret",
       "configFile": "openclaw.json",
       "path": "channels.feishu.appSecret",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.feishu.encryptKey",
+      "configFile": "openclaw.json",
+      "path": "channels.feishu.encryptKey",
       "secretShape": "secret_input",
       "optIn": true
     },

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -377,11 +377,12 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       expect.objectContaining({ sessionKey: "agent:main:session-1", messageProvider: "telegram" }),
     );
     expect(hookRunner.runAfterCompaction).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         messageCount: 1,
         tokenCount: 10,
         compactedCount: 1,
-      },
+        summary: "summary",
+      }),
       expect.objectContaining({ sessionKey: "agent:main:session-1", messageProvider: "telegram" }),
     );
   });
@@ -516,6 +517,7 @@ describe("compactEmbeddedPiSession hooks (ownsCompaction engine)", () => {
         messageCount: -1,
         compactedCount: -1,
         tokenCount: 50,
+        summary: "engine-summary",
         sessionFile: "/tmp/session.jsonl",
       },
       expect.objectContaining({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -868,6 +868,7 @@ export async function compactEmbeddedPiSessionDirect(
                 messageCount: messageCountAfter,
                 tokenCount: tokensAfter,
                 compactedCount,
+                summary: typeof result.summary === "string" ? result.summary : undefined,
               },
               {
                 sessionId: params.sessionId,
@@ -1003,6 +1004,7 @@ export async function compactEmbeddedPiSession(
                 messageCount: -1,
                 compactedCount: -1,
                 tokenCount: result.result?.tokensAfter,
+                summary: result.result?.summary,
                 sessionFile: params.sessionFile,
               },
               hookCtx,

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -208,12 +208,13 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
       }),
     );
     expect(mockedGlobalHookRunner.runAfterCompaction).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         messageCount: -1,
         compactedCount: -1,
         tokenCount: 50,
+        summary: "engine-owned compaction",
         sessionFile: "/tmp/session.json",
-      },
+      }),
       expect.objectContaining({
         sessionKey: "test-key",
       }),

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1105,6 +1105,7 @@ export async function runEmbeddedPiAgent(
                       messageCount: -1,
                       compactedCount: -1,
                       tokenCount: compactResult.result?.tokensAfter,
+                      summary: compactResult.result?.summary,
                       sessionFile: params.sessionFile,
                     },
                     hookCtx,

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -80,6 +80,12 @@ export function handleAutoCompactionEnd(
           {
             messageCount: ctx.params.session.messages?.length ?? 0,
             compactedCount: ctx.getCompactionCount(),
+            summary:
+              evt.result && typeof evt.result === "object" && "summary" in evt.result
+                ? typeof evt.result.summary === "string"
+                  ? evt.result.summary
+                  : undefined
+                : undefined,
           },
           {},
         )

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -549,6 +549,7 @@ export type PluginHookAfterCompactionEvent = {
   messageCount: number;
   tokenCount?: number;
   compactedCount: number;
+  summary?: string;
   /** Path to the session JSONL transcript. All pre-compaction messages are
    *  preserved on disk, so plugins can read and process them asynchronously
    *  without blocking the compaction pipeline. */

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -110,10 +110,11 @@ describe("compaction hook wiring", () => {
       [unknown]
     >;
     const event = afterCalls[0]?.[0] as
-      | { messageCount?: number; compactedCount?: number }
+      | { messageCount?: number; compactedCount?: number; summary?: string }
       | undefined;
     expect(event?.messageCount).toBe(2);
     expect(event?.compactedCount).toBe(1);
+    expect(event?.summary).toBe("compacted");
     expect(ctx.incrementCompactionCount).toHaveBeenCalledTimes(1);
     expect(ctx.maybeResolveCompactionWait).toHaveBeenCalledTimes(1);
     expect(emitAgentEvent).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary

- Problem: `after_compaction` hooks only exposed counts, even in code paths that already had the actual compaction summary string available.
- Why it matters: plugin consumers had to infer summary meaning from metadata or reread other state instead of receiving the final summary directly.
- What changed: added optional `summary` to `PluginHookAfterCompactionEvent` and populated it in direct compaction, engine-owned compaction, overflow recovery, and wired auto-compaction forwarding where a summary already exists.
- What did NOT change (scope boundary): no compaction algorithms, retry behavior, or transcript persistence changed.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Plugins listening to `after_compaction` can now receive the actual summary string, not just counts, in the code paths where a summary already exists.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A (mocked tests)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Trigger compaction through direct, engine-owned, overflow-recovery, and wired auto-compaction paths with hooks enabled.
2. Inspect `after_compaction` payloads before this change.
3. Apply the patch and rerun the focused summary-related tests.

### Expected

- `after_compaction` should expose `summary` whenever the compaction result already contains one.

### Actual

- The updated hook payload now includes `summary` consistently across the affected paths, and the focused tests pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran focused Vitest cases covering direct compaction, engine-owned compaction, overflow recovery, and wired hook forwarding.
- Edge cases checked: verified the field remains optional and only appears where a string summary exists.
- What you did **not** verify: the unrelated Windows path assertion in `compact.hooks.test.ts` is still outside this PR’s scope and was not part of the focused runs.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the additive hook field wiring.
- Files/config to restore: `src/plugins/types.ts`, `src/agents/pi-embedded-runner/compact.ts`, `src/agents/pi-embedded-runner/run.ts`, `src/agents/pi-embedded-subscribe.handlers.compaction.ts`
- Known bad symptoms reviewers should watch for: plugin consumers receiving a larger event payload than before.

## Risks and Mitigations

- Risk: plugin consumers may begin relying on `summary` in paths where no summary exists.
- Mitigation: the field is optional, and this PR only sets it when a string summary is already present in the underlying compaction result.