### PR TITLE
fix(telegram): keep numeric chat ids for announce targets

### DIFF
--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -60,9 +60,12 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
     }
     return kind === "channel" ? `channel:${id}` : `group:${id}`;
   })();
-  const normalized = normalizedChannel
-    ? getChannelPlugin(normalizedChannel)?.messaging?.normalizeTarget?.(kindTarget)
-    : undefined;
+  const normalized =
+    normalizedChannel === "telegram"
+      ? id
+      : normalizedChannel
+        ? getChannelPlugin(normalizedChannel)?.messaging?.normalizeTarget?.(kindTarget)
+        : undefined;
   return {
     channel,
     to: normalized ?? kindTarget,


### PR DESCRIPTION
## Summary
- keep Telegram announce targets as raw numeric chat IDs in `resolveAnnounceTargetFromKey`
- preserve topic/thread IDs for Telegram group/topic delivery
- add a focused test covering plain group and topic session keys

## Problem
When `sessions_send` / nested announce delivery targeted a Telegram group session, `resolveAnnounceTargetFromKey(...)` routed the target through channel target normalization and produced values like `group:-1001720118846`.

Later, Telegram send-path validation rejected that target with:

`Telegram recipient must be a numeric chat ID`

This broke agent-to-agent announce delivery into Telegram groups, even though the underlying session key already contained the correct numeric chat ID.

## Fix
For Telegram, bypass messaging target normalization in `resolveAnnounceTargetFromKey(...)` and keep the resolved announce target as the raw numeric chat ID. Thread/topic IDs are still extracted and preserved separately.

## Repro
- create or reuse a Telegram group session key like `agent:main:telegram:group:-1001720118846`
- use `sessions_send` / nested announce flow targeting that session
- before this change, delivery attempts can fail with `Telegram recipient must be a numeric chat ID`

## Notes
I could not run the repo Vitest target in this environment because project dependencies are not installed in the cloned repo, but I added a focused unit test for the helper.
