### PR TITLE
fix(telegram): preserve explicit proxy fetch transport

### DIFF
--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -179,18 +179,20 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   if (finalFetch) {
     const baseFetch = finalFetch;
     finalFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-      return Promise.resolve(baseFetch(input, init)).catch((err: unknown) => {
-        try {
-          tagTelegramNetworkError(err, {
-            method: extractTelegramApiMethod(input),
-            url: readRequestUrl(input),
-          });
-        } catch {
-          // Tagging is best-effort; preserve the original fetch failure if the
-          // error object cannot accept extra metadata.
-        }
-        throw err;
-      });
+      return Promise.resolve((baseFetch as unknown as typeof fetch)(input, init)).catch(
+        (err: unknown) => {
+          try {
+            tagTelegramNetworkError(err, {
+              method: extractTelegramApiMethod(input),
+              url: readRequestUrl(input),
+            });
+          } catch {
+            // Tagging is best-effort; preserve the original fetch failure if the
+            // error object cannot accept extra metadata.
+          }
+          throw err;
+        },
+      );
     }) as unknown as NonNullable<ApiClientOptions["fetch"]>;
   }
 

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -8,7 +8,6 @@ import {
   resolveTelegramAutoSelectFamilyDecision,
   resolveTelegramDnsResultOrderDecision,
 } from "./network-config.js";
-import { getProxyUrlFromFetch } from "./proxy.js";
 
 const log = createSubsystemLogger("telegram/network");
 
@@ -344,28 +343,26 @@ export function resolveTelegramFetch(
     dnsDecision,
   });
 
-  const explicitProxyUrl = proxyFetch ? getProxyUrlFromFetch(proxyFetch) : undefined;
   const undiciSourceFetch = resolveWrappedFetch(undiciFetch as unknown as typeof fetch);
-  const sourceFetch = explicitProxyUrl
-    ? undiciSourceFetch
-    : proxyFetch
-      ? resolveWrappedFetch(proxyFetch)
-      : undiciSourceFetch;
+  const sourceFetch = proxyFetch ? resolveWrappedFetch(proxyFetch) : undiciSourceFetch;
 
   // Preserve fully caller-owned custom fetch implementations.
-  // OpenClaw proxy fetches are metadata-tagged and continue into resolver-scoped policy.
-  if (proxyFetch && !explicitProxyUrl) {
+  // For explicit OpenClaw proxy fetches, keep the original proxyFetch transport path
+  // instead of rebuilding a fresh undici ProxyAgent dispatcher. In some proxy setups
+  // (observed on Telegram media downloads after v2026.3.11), reconstructing the
+  // explicit proxy route can regress file fetches even though the original proxy fetch
+  // remains healthy.
+  if (proxyFetch) {
     return sourceFetch;
   }
 
   const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
-  const useEnvProxy = !explicitProxyUrl && hasEnvHttpProxyForTelegramApi();
+  const useEnvProxy = hasEnvHttpProxyForTelegramApi();
   const defaultDispatcherResolution = createTelegramDispatcher({
     autoSelectFamily: autoSelectDecision.value,
     dnsResultOrder,
     useEnvProxy,
     forceIpv4: false,
-    proxyUrl: explicitProxyUrl,
   });
   const defaultDispatcher = defaultDispatcherResolution.dispatcher;
   const shouldBypassEnvProxy = shouldBypassEnvProxyForTelegramApi();
@@ -383,7 +380,6 @@ export function resolveTelegramFetch(
         dnsResultOrder: "ipv4first",
         useEnvProxy: stickyShouldUseEnvProxy,
         forceIpv4: true,
-        proxyUrl: explicitProxyUrl,
       }).dispatcher;
     }
     return stickyIpv4Dispatcher;
@@ -398,7 +394,7 @@ export function resolveTelegramFetch(
       stickyIpv4FallbackEnabled ? resolveStickyIpv4Dispatcher() : defaultDispatcher,
     );
     try {
-      return await sourceFetch(input, initialInit);
+      return await sourceFetch(input, initialInit as RequestInit);
     } catch (err) {
       if (shouldRetryWithIpv4Fallback(err)) {
         // Preserve caller-owned dispatchers on retry.
@@ -416,7 +412,10 @@ export function resolveTelegramFetch(
             `fetch fallback: enabling sticky IPv4-only dispatcher (codes=${formatErrorCodes(err)})`,
           );
         }
-        return sourceFetch(input, withDispatcherIfMissing(init, resolveStickyIpv4Dispatcher()));
+        return sourceFetch(
+          input,
+          withDispatcherIfMissing(init, resolveStickyIpv4Dispatcher()) as RequestInit,
+        );
       }
       throw err;
     }


### PR DESCRIPTION
## Summary
- preserve the original explicit `proxyFetch` transport path for Telegram fetches instead of rebuilding a fresh undici `ProxyAgent` dispatcher
- avoid Telegram media download regressions seen after the 2026.3.11 network-layer refactor when `channels.telegram.proxy` is configured
- keep the fix narrow to explicit OpenClaw proxy fetches; env-proxy and direct paths stay unchanged

## Problem
On a proxy-dependent Telegram setup, text Bot API calls still worked after upgrading to 2026.3.11, but media downloads (`https://api.telegram.org/file/...`) started failing consistently with:

- `MediaFetchError: Failed to fetch media`
- `TypeError: fetch failed`

This reproduced on voice messages while the same machine+proxy setup had worked before the upgrade.

## Root cause hypothesis
The 2026.3.11 Telegram network refactor started extracting the proxy URL from OpenClaw's explicit `proxyFetch` and rebuilding a new undici `ProxyAgent` dispatcher for Telegram requests. In this environment that new explicit-proxy dispatcher path regressed Telegram media downloads, while the original `proxyFetch` transport path remained healthy.

## Fix
When Telegram already receives an explicit OpenClaw `proxyFetch`, keep using that fetch implementation directly instead of reconstructing a new explicit-proxy dispatcher.

## Validation
- `pnpm run build` ✅
- manual regression check on a real Telegram bot setup behind explicit `channels.telegram.proxy`:
  - before fix: repeated voice downloads failed at `api.telegram.org/file/...`
  - after fix: voice download + transcription succeeded again

Fixes #41569
