### PR TITLE
fix(gateway): resolve invalid unicode escape sequence in error message

### DIFF
--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -132,7 +132,8 @@ export async function resolveGatewayRuntimeConfig(params: {
   }
   if (!isLoopbackHost(bindHost) && !hasSharedSecret && authMode !== "trusted-proxy") {
     throw new Error(
-      `refusing to bind gateway to ${bindHost}:${params.port} without auth (set gateway.auth.token/password, or set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD)`,
+      'refusing to bind gateway to ' + bindHost + ':' + params.port + 
+      ' without auth (set gateway.auth.token/password, or set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD)',
     );
   }
   if (


### PR DESCRIPTION
## Problem
CI build failing with error:
```
[PARSE_ERROR] Error: Invalid Unicode escape sequence
🭯─[ src/gateway/server-runtime-config.ts:135:197 ]
  135 │ `refusing to bind gateway to ${bindHost}:${params.port} without auth...
```

## Solution
- Replace template string with string concatenation
- Avoids Unicode escape sequence parsing issues in rolldown/tsdown

## Testing
- ✅ Local build passes
- ✅ No functional changes

## Related
- Fixes CI build error in GitHub Actions