### PR TITLE
feat(acp): default streamTo to "parent" for ACP sessions

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -105,7 +105,8 @@ export function createSessionsSpawnTool(
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const streamTo =
+        params.streamTo === "parent" ? "parent" : runtime === "acp" ? "parent" : undefined;
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -106,7 +106,11 @@ export function createSessionsSpawnTool(
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
       const streamTo =
-        params.streamTo === "parent" ? "parent" : runtime === "acp" ? "parent" : undefined;
+        params.streamTo === "parent"
+          ? "parent"
+          : runtime === "acp" && opts?.agentSessionKey
+            ? "parent"
+            : undefined;
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"


### PR DESCRIPTION
## Problem

ACP sessions spawned via `sessions_spawn` currently require explicit `streamTo: "parent"` to receive completion notifications. Without it, results are silently lost from the caller's perspective — the parent session never gets notified when the ACP task finishes.

This is a common footgun: callers expect ACP run results to be reported back automatically (like subagent announce), but get nothing unless they remember to add `streamTo: "parent"` every time.

## Solution

Default `streamTo` to `"parent"` whenever `runtime="acp"`, ensuring ACP run results are always streamed back to the requester session. The caller can still explicitly set `streamTo` if needed.

## Changes

- `src/agents/tools/sessions-spawn-tool.ts`: When `runtime === "acp"` and `streamTo` is not explicitly set, default it to `"parent"` instead of `undefined`.

One-line change, no breaking behavior — callers who already pass `streamTo: "parent"` are unaffected.