### PR TITLE
fix(cron): suppress stale descendant subagent fallback summaries

### DIFF
--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -149,7 +149,7 @@ describe("readDescendantSubagentFallbackReply", () => {
     expect(result).toBe("live transcript text");
   });
 
-  it("joins replies from multiple descendants", async () => {
+  it("returns only the freshest descendant reply", async () => {
     vi.mocked(listDescendantRunsForRequester).mockReturnValue([
       {
         runId: "run-1",
@@ -160,7 +160,7 @@ describe("readDescendantSubagentFallbackReply", () => {
         cleanup: "keep",
         createdAt: 1000,
         endedAt: 2000,
-        frozenResultText: "first child output",
+        frozenResultText: "stale child output",
       },
       {
         runId: "run-2",
@@ -171,7 +171,7 @@ describe("readDescendantSubagentFallbackReply", () => {
         cleanup: "keep",
         createdAt: 1000,
         endedAt: 3000,
-        frozenResultText: "second child output",
+        frozenResultText: "fresh child output",
       },
     ]);
     vi.mocked(readLatestAssistantReply).mockResolvedValue(undefined);
@@ -179,7 +179,44 @@ describe("readDescendantSubagentFallbackReply", () => {
       sessionKey: "test-session",
       runStartedAt,
     });
-    expect(result).toBe("first child output\n\nsecond child output");
+    expect(result).toBe("fresh child output");
+  });
+
+  it("falls back to next freshest usable reply when newest is silent", async () => {
+    vi.mocked(listDescendantRunsForRequester).mockReturnValue([
+      {
+        runId: "run-1",
+        childSessionKey: "child-1",
+        requesterSessionKey: "test-session",
+        requesterDisplayKey: "test-session",
+        task: "task-1",
+        cleanup: "keep",
+        createdAt: 1000,
+        endedAt: 2000,
+        frozenResultText: "older usable output",
+      },
+      {
+        runId: "run-2",
+        childSessionKey: "child-2",
+        requesterSessionKey: "test-session",
+        requesterDisplayKey: "test-session",
+        task: "task-2",
+        cleanup: "keep",
+        createdAt: 1000,
+        endedAt: 3000,
+      },
+    ]);
+    vi.mocked(readLatestAssistantReply).mockImplementation(async (params) => {
+      if (params.sessionKey === "child-2") {
+        return "NO_REPLY";
+      }
+      return undefined;
+    });
+    const result = await readDescendantSubagentFallbackReply({
+      sessionKey: "test-session",
+      runStartedAt,
+    });
+    expect(result).toBe("older usable output");
   });
 
   it("skips SILENT_REPLY_TOKEN descendants", async () => {

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -67,11 +67,23 @@ export async function readDescendantSubagentFallbackReply(params: {
         entry.endedAt >= params.runStartedAt &&
         entry.childSessionKey.trim().length > 0,
     )
-    .toSorted((a, b) => (b.endedAt ?? 0) - (a.endedAt ?? 0));
+    .toSorted((a, b) => {
+      const diff = (b.endedAt ?? 0) - (a.endedAt ?? 0);
+      // Secondary tie-breaker: when endedAt timestamps are equal, prefer the
+      // run that was created later (higher createdAt → more recent attempt).
+      if (diff !== 0) {
+        return diff;
+      }
+      return (b.createdAt ?? 0) - (a.createdAt ?? 0);
+    });
   if (descendants.length === 0) {
     return undefined;
   }
 
+  // Build a map of childSessionKey → latest run.  Because `descendants` is
+  // sorted descending by endedAt (with createdAt as tie-breaker), the first
+  // occurrence for each child key is guaranteed to be the newest run.
+  // Skipping duplicates via `has()` is therefore correct.
   const latestByChild = new Map<string, (typeof descendants)[number]>();
   for (const entry of descendants) {
     const childKey = entry.childSessionKey.trim();
@@ -81,9 +93,9 @@ export async function readDescendantSubagentFallbackReply(params: {
     latestByChild.set(childKey, entry);
   }
 
-  const latestRuns = [...latestByChild.values()].toSorted(
-    (a, b) => (b.endedAt ?? 0) - (a.endedAt ?? 0),
-  );
+  // Map preserves insertion order which mirrors the descending endedAt sort
+  // above, so no additional sort is needed.
+  const latestRuns = [...latestByChild.values()];
   for (const entry of latestRuns) {
     let reply = (await readLatestAssistantReply({ sessionKey: entry.childSessionKey }))?.trim();
     // Fall back to the registry's frozen result text when the session transcript
@@ -92,6 +104,12 @@ export async function readDescendantSubagentFallbackReply(params: {
       reply = entry.frozenResultText.trim();
     }
     if (!reply || reply.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
+      continue;
+    }
+    // Skip interim acknowledgements that don't carry real content — these are
+    // status messages like "on it" or "working on it" that the subagent emitted
+    // before producing its actual result.
+    if (isLikelyInterimCronMessage(reply)) {
       continue;
     }
     // Fallback mode should surface the freshest settled descendant result only.

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -67,7 +67,7 @@ export async function readDescendantSubagentFallbackReply(params: {
         entry.endedAt >= params.runStartedAt &&
         entry.childSessionKey.trim().length > 0,
     )
-    .toSorted((a, b) => (a.endedAt ?? 0) - (b.endedAt ?? 0));
+    .toSorted((a, b) => (b.endedAt ?? 0) - (a.endedAt ?? 0));
   if (descendants.length === 0) {
     return undefined;
   }
@@ -75,19 +75,15 @@ export async function readDescendantSubagentFallbackReply(params: {
   const latestByChild = new Map<string, (typeof descendants)[number]>();
   for (const entry of descendants) {
     const childKey = entry.childSessionKey.trim();
-    if (!childKey) {
+    if (!childKey || latestByChild.has(childKey)) {
       continue;
     }
-    const current = latestByChild.get(childKey);
-    if (!current || (entry.endedAt ?? 0) >= (current.endedAt ?? 0)) {
-      latestByChild.set(childKey, entry);
-    }
+    latestByChild.set(childKey, entry);
   }
 
-  const replies: string[] = [];
-  const latestRuns = [...latestByChild.values()]
-    .toSorted((a, b) => (a.endedAt ?? 0) - (b.endedAt ?? 0))
-    .slice(-4);
+  const latestRuns = [...latestByChild.values()].toSorted(
+    (a, b) => (b.endedAt ?? 0) - (a.endedAt ?? 0),
+  );
   for (const entry of latestRuns) {
     let reply = (await readLatestAssistantReply({ sessionKey: entry.childSessionKey }))?.trim();
     // Fall back to the registry's frozen result text when the session transcript
@@ -98,15 +94,13 @@ export async function readDescendantSubagentFallbackReply(params: {
     if (!reply || reply.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
       continue;
     }
-    replies.push(reply);
+    // Fallback mode should surface the freshest settled descendant result only.
+    // Older descendant summaries are easily stale/obsolete and can pollute
+    // current-status reminders when multiple subagents were used in one workflow.
+    return reply;
   }
-  if (replies.length === 0) {
-    return undefined;
-  }
-  if (replies.length === 1) {
-    return replies[0];
-  }
-  return replies.join("\n\n");
+
+  return undefined;
 }
 
 /**

--- a/src/shared/global-singleton.ts
+++ b/src/shared/global-singleton.ts
@@ -2,7 +2,7 @@ export function resolveGlobalSingleton<T>(key: symbol, create: () => T): T {
   const globalStore = globalThis as Record<PropertyKey, unknown>;
   const existing = globalStore[key] as T | undefined;
   if (Object.prototype.hasOwnProperty.call(globalStore, key)) {
-    return existing;
+    return existing as T;
   }
   const created = create();
   globalStore[key] = created;


### PR DESCRIPTION
## Summary
- stop concatenating multiple descendant fallback replies
- choose only the freshest settled descendant reply for cron isolated-agent fallback
- add regression coverage for stale vs fresh descendant replies

## Testing
- pnpm test -- src/cron/isolated-agent/subagent-followup.test.ts