### PR TITLE
fix(build): use Git Bash wrapper for A2UI bundling on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "build:docker": "node scripts/tsdown-build.mjs && node scripts/copy-plugin-sdk-root-alias.mjs && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",
     "build:strict-smoke": "pnpm canvas:a2ui:bundle && node scripts/tsdown-build.mjs && node scripts/copy-plugin-sdk-root-alias.mjs && pnpm build:plugin-sdk:dts",
-    "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
+    "canvas:a2ui:bundle": "node scripts/bundle-a2ui.mjs",
     "check": "pnpm check:host-env-policy:swift && pnpm format:check && pnpm tsgo && pnpm lint && pnpm lint:tmp:no-random-messaging && pnpm lint:tmp:channel-agnostic-boundaries && pnpm lint:tmp:no-raw-channel-fetch && pnpm lint:agent:ingress-owner && pnpm lint:plugins:no-register-http-handler && pnpm lint:plugins:no-monolithic-plugin-sdk-entry-imports && pnpm lint:webhook:no-low-level-body-read && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope",
     "check:docs": "pnpm format:docs:check && pnpm lint:docs && pnpm docs:check-links",
     "check:host-env-policy:swift": "node scripts/generate-host-env-security-policy-swift.mjs --check",

--- a/scripts/bundle-a2ui.mjs
+++ b/scripts/bundle-a2ui.mjs
@@ -1,6 +1,6 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -12,7 +12,8 @@ function resolveWindowsBash() {
     process.env.GIT_BASH_PATH,
     process.env.ProgramW6432 && path.join(process.env.ProgramW6432, "Git", "bin", "bash.exe"),
     process.env.ProgramFiles && path.join(process.env.ProgramFiles, "Git", "bin", "bash.exe"),
-    process.env.ProgramFiles && path.join(process.env.ProgramFiles, "Git", "usr", "bin", "bash.exe"),
+    process.env.ProgramFiles &&
+      path.join(process.env.ProgramFiles, "Git", "usr", "bin", "bash.exe"),
     process.env["ProgramFiles(x86)"] &&
       path.join(process.env["ProgramFiles(x86)"], "Git", "bin", "bash.exe"),
     process.env["ProgramFiles(x86)"] &&
@@ -28,10 +29,7 @@ function resolveWindowsBash() {
   return null;
 }
 
-const shell =
-  process.platform === "win32"
-    ? resolveWindowsBash() ?? "bash"
-    : "bash";
+const shell = process.platform === "win32" ? (resolveWindowsBash() ?? "bash") : "bash";
 
 const result = spawnSync(shell, [scriptPath], {
   cwd: rootDir,

--- a/scripts/bundle-a2ui.mjs
+++ b/scripts/bundle-a2ui.mjs
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const scriptPath = path.join(rootDir, "scripts", "bundle-a2ui.sh");
+
+function resolveWindowsBash() {
+  const candidates = [
+    process.env.OPENCLAW_GIT_BASH,
+    process.env.GIT_BASH_PATH,
+    process.env.ProgramW6432 && path.join(process.env.ProgramW6432, "Git", "bin", "bash.exe"),
+    process.env.ProgramFiles && path.join(process.env.ProgramFiles, "Git", "bin", "bash.exe"),
+    process.env.ProgramFiles && path.join(process.env.ProgramFiles, "Git", "usr", "bin", "bash.exe"),
+    process.env["ProgramFiles(x86)"] &&
+      path.join(process.env["ProgramFiles(x86)"], "Git", "bin", "bash.exe"),
+    process.env["ProgramFiles(x86)"] &&
+      path.join(process.env["ProgramFiles(x86)"], "Git", "usr", "bin", "bash.exe"),
+  ].filter((value) => typeof value === "string" && value.length > 0);
+
+  for (const candidate of candidates) {
+    if (candidate && fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+const shell =
+  process.platform === "win32"
+    ? resolveWindowsBash() ?? "bash"
+    : "bash";
+
+const result = spawnSync(shell, [scriptPath], {
+  cwd: rootDir,
+  stdio: "inherit",
+  env: process.env,
+});
+
+if (result.error) {
+  if (process.platform === "win32") {
+    console.error(
+      "A2UI bundling requires Git Bash on Windows. Set OPENCLAW_GIT_BASH to bash.exe if Git is installed in a non-standard location.",
+    );
+  }
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

- Problem: `pnpm canvas:a2ui:bundle` depended on `bash` resolving correctly on Windows, which often hits the System32 WSL stub or no executable at all.
- Why it matters: native Windows builds fail before TypeScript compilation, and that breaks both contributor workflows and the build path used by `build` / `build:strict-smoke`.
- What changed: replaced the package script entry point with a Node wrapper that locates Git Bash on Windows and then runs the existing `bundle-a2ui.sh` through a real `bash` executable.
- What did NOT change (scope boundary): the actual bundling logic in `bundle-a2ui.sh` is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #43891

## User-visible / Behavior Changes

- Native Windows users can run the A2UI bundle step without depending on `bash` resolving to the WSL stub or on `sh.exe` being present on PATH.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No, existing script is still invoked; only the launcher changed)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm canvas:a2ui:bundle` on native Windows.
2. Before the patch, the build depended on direct shell resolution and could fail before the bundle script ran.
3. Apply the Node wrapper and rerun both the bundle step and the strict smoke build.

### Expected

- The A2UI bundle step should succeed on native Windows when Git Bash is installed in a standard location.

### Actual

- `pnpm canvas:a2ui:bundle` and `pnpm build:strict-smoke` both complete successfully with the wrapper in place.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm canvas:a2ui:bundle` and `pnpm build:strict-smoke` on Windows.
- What I did not verify: Git Bash installed in non-standard locations beyond the documented environment variables and common Program Files paths.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (Optional only: `OPENCLAW_GIT_BASH` if Git Bash is installed in a custom location)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- Revert `package.json` and `scripts/bundle-a2ui.mjs`.
- Known bad symptoms reviewers should watch for: wrapper failing to locate Git Bash in unusual custom installations.