### PR TITLE
fix(feishu): do not treat @all as a bot mention

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -53,6 +53,12 @@ function makeShareChatEvent(content: unknown) {
 describe("parseFeishuMessageEvent – mentionedBot", () => {
   const BOT_OPEN_ID = "ou_bot_123";
 
+  it("returns mentionedBot=false for @all group notifications", () => {
+    const event = makeEvent("group", [], "@_all hello everyone");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
   it("returns mentionedBot=false when there are no mentions", () => {
     const event = makeEvent("group", []);
     const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -453,9 +453,6 @@ function formatSubMessageContent(content: string, contentType: string): string {
 
 function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boolean {
   if (!botOpenId) return false;
-  // Check for @all (@_all in Feishu) — treat as mentioning every bot
-  const rawContent = event.message.content ?? "";
-  if (rawContent.includes("@_all")) return true;
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
     // Rely on Feishu mention IDs; display names can vary by alias/context.


### PR DESCRIPTION
## Summary

Fixes #37706

When a user sends `@all` in a Feishu group chat, Feishu embeds `@_all` in the raw message content. The previous code in `checkBotMentioned` explicitly treated this as a bot mention, causing the bot to process every group-wide notification unintentionally.

## Root Cause

`extensions/feishu/src/bot.ts` had an early-return that checked for `@_all` in the raw message content and immediately returned `true`:

`	s
// Check for @all (@_all in Feishu) ??treat as mentioning every bot
const rawContent = event.message.content ?? "";
if (rawContent.includes("@_all")) return true;
`

## Fix

Removed the `@_all` early-return. The bot now only activates when explicitly mentioned by its `open_id` in the mentions array (or in rich-text post content), consistent with the rest of the function's logic.

## Testing

- [x] Added test `returns mentionedBot=false for @all group notifications` in `extensions/feishu/src/bot.checkBotMentioned.test.ts`