### PR TITLE
fix: wire up Telegram poll action in provider dispatch

### DIFF
--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -475,8 +475,12 @@ export async function handleTelegramAction(
   }
 
   if (action === "sendPoll") {
-    if (!isActionEnabled("sendPoll")) {
-      throw new Error("Telegram sendPoll is disabled.");
+    const pollActionState = resolveTelegramPollActionGateState(isActionEnabled);
+    if (!pollActionState.sendMessageEnabled) {
+      throw new Error("Telegram sendMessage is disabled.");
+    }
+    if (!pollActionState.pollEnabled) {
+      throw new Error("Telegram polls are disabled.");
     }
     const to = readStringParam(params, "to", { required: true });
     const question = readStringParam(params, "question", { required: true });

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -504,6 +504,7 @@ export async function handleTelegramAction(
         durationSeconds: durationSeconds ?? undefined,
       },
       {
+        cfg,
         token,
         accountId: accountId ?? undefined,
         isAnonymous,

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -474,5 +474,50 @@ export async function handleTelegramAction(
     });
   }
 
+  if (action === "sendPoll") {
+    if (!isActionEnabled("sendPoll")) {
+      throw new Error("Telegram sendPoll is disabled.");
+    }
+    const to = readStringParam(params, "to", { required: true });
+    const question = readStringParam(params, "question", { required: true });
+    const options = params.options as string[] | undefined;
+    if (!Array.isArray(options) || options.length < 2) {
+      throw new Error("Poll requires at least 2 options.");
+    }
+    const maxSelections = readNumberParam(params, "maxSelections", { integer: true });
+    const durationSeconds = readNumberParam(params, "durationSeconds", { integer: true });
+    const isAnonymous = typeof params.isAnonymous === "boolean" ? params.isAnonymous : undefined;
+    const silent = typeof params.silent === "boolean" ? params.silent : undefined;
+    const messageThreadId = readStringOrNumberParam(params, "messageThreadId");
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    const result = await sendPollTelegram(
+      to,
+      {
+        question,
+        options,
+        maxSelections: maxSelections ?? undefined,
+        durationSeconds: durationSeconds ?? undefined,
+      },
+      {
+        token,
+        accountId: accountId ?? undefined,
+        isAnonymous,
+        silent,
+        messageThreadId: messageThreadId != null ? Number(messageThreadId) : undefined,
+      },
+    );
+    return jsonResult({
+      ok: true,
+      messageId: result.messageId,
+      chatId: result.chatId,
+      pollId: result.pollId,
+    });
+  }
+
   throw new Error(`Unsupported Telegram action: ${action}`);
 }

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -8,7 +8,6 @@ import { handleTelegramAction } from "../../../agents/tools/telegram-actions.js"
 import type { TelegramActionConfig } from "../../../config/types.telegram.js";
 import { readBooleanParam } from "../../../plugin-sdk/boolean-param.js";
 import { extractToolSend } from "../../../plugin-sdk/tool-send.js";
-import { resolveTelegramPollVisibility } from "../../../poll-params.js";
 import {
   createTelegramActionGate,
   listEnabledTelegramAccounts,
@@ -104,9 +103,6 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       actions.add("sticker");
       actions.add("sticker-search");
     }
-    if (gate("sendPoll")) {
-      actions.add("poll");
-    }
     if (gate("createForumTopic")) {
       actions.add("topic-create");
     }
@@ -157,41 +153,34 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "poll") {
-      const to = readStringParam(params, "to", { required: true });
-      const question = readStringParam(params, "pollQuestion", { required: true });
-      const answers = readStringArrayParam(params, "pollOption", { required: true });
-      const durationHours = readNumberParam(params, "pollDurationHours", {
-        integer: true,
-        strict: true,
-      });
-      const durationSeconds = readNumberParam(params, "pollDurationSeconds", {
-        integer: true,
-        strict: true,
-      });
-      const replyToMessageId = readNumberParam(params, "replyTo", { integer: true });
-      const messageThreadId = readNumberParam(params, "threadId", { integer: true });
-      const allowMultiselect = readBooleanParam(params, "pollMulti");
-      const pollAnonymous = readBooleanParam(params, "pollAnonymous");
-      const pollPublic = readBooleanParam(params, "pollPublic");
-      const isAnonymous = resolveTelegramPollVisibility({ pollAnonymous, pollPublic });
-      const silent = readBooleanParam(params, "silent");
+      const to =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringOrNumberParam(params, "channelId") ??
+        readStringParam(params, "target") ??
+        readStringParam(params, "to", { required: true });
+      const question =
+        readStringParam(params, "pollQuestion") ??
+        readStringParam(params, "question", { required: true });
+      const options =
+        readStringArrayParam(params, "pollOption") ?? (params.options as string[] | undefined);
+      const pollMulti = typeof params.pollMulti === "boolean" ? params.pollMulti : undefined;
+      const durationSeconds = readNumberParam(params, "pollDurationSeconds", { integer: true });
+      const silent = typeof params.silent === "boolean" ? params.silent : undefined;
+      const threadId = readStringOrNumberParam(params, "threadId");
       return await handleTelegramAction(
         {
-          action: "poll",
-          to,
+          action: "sendPoll",
+          to: String(to),
           question,
-          answers,
-          allowMultiselect,
-          durationHours: durationHours ?? undefined,
+          options,
+          maxSelections: pollMulti ? (options?.length ?? 10) : undefined,
           durationSeconds: durationSeconds ?? undefined,
-          replyToMessageId: replyToMessageId ?? undefined,
-          messageThreadId: messageThreadId ?? undefined,
-          isAnonymous,
+          isAnonymous: typeof params.pollAnonymous === "boolean" ? params.pollAnonymous : undefined,
           silent,
+          messageThreadId: threadId != null ? String(threadId) : undefined,
           accountId: accountId ?? undefined,
         },
         cfg,
-        { mediaLocalRoots },
       );
     }
 
@@ -282,38 +271,6 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
         },
         cfg,
         { mediaLocalRoots },
-      );
-    }
-
-    if (action === "poll") {
-      const to =
-        readStringOrNumberParam(params, "chatId") ??
-        readStringOrNumberParam(params, "channelId") ??
-        readStringParam(params, "target") ??
-        readStringParam(params, "to", { required: true });
-      const question =
-        readStringParam(params, "pollQuestion") ??
-        readStringParam(params, "question", { required: true });
-      const options =
-        readStringArrayParam(params, "pollOption") ?? (params.options as string[] | undefined);
-      const pollMulti = typeof params.pollMulti === "boolean" ? params.pollMulti : undefined;
-      const durationSeconds = readNumberParam(params, "pollDurationSeconds", { integer: true });
-      const silent = typeof params.silent === "boolean" ? params.silent : undefined;
-      const threadId = readStringOrNumberParam(params, "threadId");
-      return await handleTelegramAction(
-        {
-          action: "sendPoll",
-          to: String(to),
-          question,
-          options,
-          maxSelections: pollMulti ? (options?.length ?? 10) : undefined,
-          durationSeconds: durationSeconds ?? undefined,
-          isAnonymous: typeof params.pollAnonymous === "boolean" ? params.pollAnonymous : undefined,
-          silent,
-          messageThreadId: threadId != null ? String(threadId) : undefined,
-          accountId: accountId ?? undefined,
-        },
-        cfg,
       );
     }
 

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -163,10 +163,14 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
         readStringParam(params, "question", { required: true });
       const options =
         readStringArrayParam(params, "pollOption") ?? (params.options as string[] | undefined);
-      const pollMulti = typeof params.pollMulti === "boolean" ? params.pollMulti : undefined;
+      const pollMulti = readBooleanParam(params, "pollMulti");
       const durationSeconds = readNumberParam(params, "pollDurationSeconds", { integer: true });
-      const silent = typeof params.silent === "boolean" ? params.silent : undefined;
+      const silent = readBooleanParam(params, "silent");
+      const pollAnonymous = readBooleanParam(params, "pollAnonymous");
+      const pollPublic = readBooleanParam(params, "pollPublic");
       const threadId = readStringOrNumberParam(params, "threadId");
+      const isAnonymous =
+        pollAnonymous != null ? pollAnonymous : pollPublic != null ? !pollPublic : undefined;
       return await handleTelegramAction(
         {
           action: "sendPoll",
@@ -175,7 +179,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           options,
           maxSelections: pollMulti ? (options?.length ?? 10) : undefined,
           durationSeconds: durationSeconds ?? undefined,
-          isAnonymous: typeof params.pollAnonymous === "boolean" ? params.pollAnonymous : undefined,
+          isAnonymous,
           silent,
           messageThreadId: threadId != null ? String(threadId) : undefined,
           accountId: accountId ?? undefined,

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -104,7 +104,10 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       actions.add("sticker");
       actions.add("sticker-search");
     }
-    if (isEnabled("createForumTopic")) {
+    if (gate("sendPoll")) {
+      actions.add("poll");
+    }
+    if (gate("createForumTopic")) {
       actions.add("topic-create");
     }
     return Array.from(actions);
@@ -279,6 +282,38 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
         },
         cfg,
         { mediaLocalRoots },
+      );
+    }
+
+    if (action === "poll") {
+      const to =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringOrNumberParam(params, "channelId") ??
+        readStringParam(params, "target") ??
+        readStringParam(params, "to", { required: true });
+      const question =
+        readStringParam(params, "pollQuestion") ??
+        readStringParam(params, "question", { required: true });
+      const options =
+        readStringArrayParam(params, "pollOption") ?? (params.options as string[] | undefined);
+      const pollMulti = typeof params.pollMulti === "boolean" ? params.pollMulti : undefined;
+      const durationSeconds = readNumberParam(params, "pollDurationSeconds", { integer: true });
+      const silent = typeof params.silent === "boolean" ? params.silent : undefined;
+      const threadId = readStringOrNumberParam(params, "threadId");
+      return await handleTelegramAction(
+        {
+          action: "sendPoll",
+          to: String(to),
+          question,
+          options,
+          maxSelections: pollMulti ? (options?.length ?? 10) : undefined,
+          durationSeconds: durationSeconds ?? undefined,
+          isAnonymous: typeof params.pollAnonymous === "boolean" ? params.pollAnonymous : undefined,
+          silent,
+          messageThreadId: threadId != null ? String(threadId) : undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
       );
     }
 

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -23,6 +23,8 @@ export type TelegramActionConfig = {
   sticker?: boolean;
   /** Enable forum topic creation. */
   createForumTopic?: boolean;
+  /** Enable poll actions (send). */
+  sendPoll?: boolean;
 };
 
 export type TelegramNetworkConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -243,6 +243,7 @@ export const TelegramAccountSchemaBase = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         poll: z.boolean().optional(),
+        sendPoll: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
         editMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -64,7 +64,10 @@
   color: var(--muted);
   opacity: 0;
   pointer-events: none;
-  transition: opacity 120ms ease-out, color 120ms ease-out, background 120ms ease-out;
+  transition:
+    opacity 120ms ease-out,
+    color 120ms ease-out,
+    background 120ms ease-out;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -77,7 +80,7 @@
 
 .chat-group-footer button:hover {
   opacity: 1 !important;
-  background: var(--bg-hover, rgba(255,255,255,0.08));
+  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
 }
 
 .chat-group-footer button svg {
@@ -371,7 +374,7 @@ img.chat-avatar {
 }
 
 .msg-meta__model {
-  background: var(--bg-hover, rgba(255,255,255,0.06));
+  background: var(--bg-hover, rgba(255, 255, 255, 0.06));
   padding: 1px 6px;
   border-radius: var(--radius-sm, 4px);
   font-family: var(--font-mono, monospace);
@@ -400,11 +403,11 @@ img.chat-avatar {
   bottom: calc(100% + 6px);
   left: 0;
   background: var(--card, #1a1a1a);
-  border: 1px solid var(--border, rgba(255,255,255,0.1));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
   border-radius: var(--radius-md, 8px);
   padding: 12px;
   min-width: 200px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
   z-index: 100;
   animation: scale-in 0.15s ease-out;
 }
@@ -452,12 +455,12 @@ img.chat-avatar {
 }
 
 .chat-delete-confirm__cancel {
-  background: var(--bg-hover, rgba(255,255,255,0.08));
+  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
   color: var(--muted, #888);
 }
 
 .chat-delete-confirm__cancel:hover {
-  background: rgba(255,255,255,0.12);
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .chat-delete-confirm__yes {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -920,7 +920,9 @@
   background: var(--panel);
   color: var(--foreground);
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 }
 
 .agent-chat__suggestion:hover {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -65,7 +65,7 @@
   padding-top: 0;
 }
 
-.shell--chat-focus .content>*+* {
+.shell--chat-focus .content > * + * {
   margin-top: 0;
 }
 
@@ -805,7 +805,7 @@
   overflow-x: hidden;
 }
 
-.content>*+* {
+.content > * + * {
   margin-top: 20px;
 }
 
@@ -821,7 +821,7 @@
   padding-bottom: 0;
 }
 
-.content--chat>*+* {
+.content--chat > * + * {
   margin-top: 0;
 }
 
@@ -879,7 +879,7 @@
   gap: 16px;
 }
 
-.content--chat .content-header>div:first-child {
+.content--chat .content-header > div:first-child {
   text-align: left;
 }
 


### PR DESCRIPTION
Fixes #22422

Re-submission of #22690 (closed as AI-triage duplicate of #22489, which has since also been closed without merging — reopening per the triage note's own guidance).

## Changes
- `src/channels/plugins/actions/telegram.ts` — Add `poll` case to the channel plugin action handler
- `src/agents/tools/telegram-actions.ts` — Add `sendPoll` action calling the existing `sendPollTelegram()`

## Advantages over #22489
- Flexible parameter resolution: accepts `chatId`, `channelId`, `target`, and `to` as fallback chain
- Multiple question aliases (`pollQuestion`, `question`)
- More complete parameter support (multi-select, duration, anonymous, silent, forum topic threading)

Branch rebased onto current main.