### PR TITLE
community: add spawn-interceptor plugin for ACP task lifecycle tracking

### DIFF
--- a/community/plugins/spawn-interceptor/README.md
+++ b/community/plugins/spawn-interceptor/README.md
@@ -1,0 +1,40 @@
+# spawn-interceptor — Community ACP Task Tracking Plugin
+
+A zero-config OpenClaw plugin that automatically tracks `sessions_spawn` calls and detects task completion through a 3-layer defense system.
+
+## Why?
+
+OpenClaw's ACP runtime has no native completion notification mechanism (see [#40272](https://github.com/openclaw/openclaw/issues/40272)). This plugin fills that gap without requiring any core modifications.
+
+### Key Discoveries
+
+1. **`subagent_ended` hook does NOT fire for ACP runtime** — ACP sessions are managed by the `acpx` binary, separate from OpenClaw's hook system
+2. **Prompt injection doesn't work for oneshot ACP** — Agents ignore injected instructions after completing their primary task
+3. **`~/.acpx/sessions/index.json` is the source of truth** for ACP session lifecycle
+
+## How It Works
+
+| Layer | Mechanism | Latency | Coverage |
+|-------|-----------|---------|----------|
+| L1 | `subagent_ended` hook | <1s | `runtime=subagent` |
+| L2 | ACP Session Poller (`~/.acpx/sessions/index.json`) | ~15s | `runtime=acp` |
+| L3 | Stale Reaper | 30min | All (safety net) |
+
+## Install
+
+```bash
+cp -r community/plugins/spawn-interceptor ~/.openclaw/extensions/
+# Restart Gateway
+```
+
+## Output
+
+All events are written to `~/.openclaw/shared-context/monitor-tasks/task-log.jsonl` as JSONL.
+
+## Full Documentation
+
+See the [openclaw-multiagent-framework](https://github.com/lanyasheng/openclaw-multiagent-framework) repository for architecture docs, protocol specs, and integration guides.
+
+## License
+
+MIT

--- a/community/plugins/spawn-interceptor/index.js
+++ b/community/plugins/spawn-interceptor/index.js
@@ -1,5 +1,5 @@
 /**
- * spawn-interceptor v2.4 — OpenClaw plugin for automatic ACP task tracking.
+ * spawn-interceptor v2.5 — OpenClaw plugin for automatic ACP task tracking.
  *
  * Completion detection (layered, in priority order):
  *   1. subagent_ended hook — works for runtime=subagent only
@@ -11,21 +11,24 @@
  * The poller reads the index.json to find closed sessions, then matches them to pending
  * tasks by creation time proximity.
  *
- * v2.4 fixes:
- *   - Stale reaper no longer re-logs tasks that were already completed/failed/timed out
- *   - Pending file is atomically saved after every state change
+ * v2.5 fixes (review feedback):
+ *   - subagent_ended now matches by targetSessionKey instead of first-match-by-type
+ *   - ACP poller consumes matched closed sessions to prevent double-matching
+ *   - Fallback "no open sessions" status changed from completed to assumed_complete
+ *   - Added unregister() for proper timer cleanup on plugin hot-reload
+ *   - Version synced between package.json and index.js
  */
 
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
+import fs from "fs";
+import path from "path";
+import os from "os";
 
-const SHARED_CTX = path.join(os.homedir(), '.openclaw', 'shared-context');
-const TASK_LOG = path.join(SHARED_CTX, 'monitor-tasks', 'task-log.jsonl');
-const PENDING_FILE = path.join(SHARED_CTX, 'monitor-tasks', '.pending-tasks.json');
-const ACPX_SESSIONS_DIR = path.join(os.homedir(), '.acpx', 'sessions');
-const ACPX_INDEX = path.join(ACPX_SESSIONS_DIR, 'index.json');
-const COMPLETION_SESSION = 'agent:main:completion-relay';
+const SHARED_CTX = path.join(os.homedir(), ".openclaw", "shared-context");
+const TASK_LOG = path.join(SHARED_CTX, "monitor-tasks", "task-log.jsonl");
+const PENDING_FILE = path.join(SHARED_CTX, "monitor-tasks", ".pending-tasks.json");
+const ACPX_SESSIONS_DIR = path.join(os.homedir(), ".acpx", "sessions");
+const ACPX_INDEX = path.join(ACPX_SESSIONS_DIR, "index.json");
+const COMPLETION_SESSION = "agent:main:completion-relay";
 
 const STALE_TIMEOUT_MS = 30 * 60 * 1000;
 const REAPER_INTERVAL_MS = 5 * 60 * 1000;
@@ -39,24 +42,28 @@ let pluginLogger = null;
 function loadPending() {
   try {
     if (fs.existsSync(PENDING_FILE)) {
-      const data = JSON.parse(fs.readFileSync(PENDING_FILE, 'utf-8'));
+      const data = JSON.parse(fs.readFileSync(PENDING_FILE, "utf-8"));
       pendingTasks = new Map(Object.entries(data));
     }
-  } catch { /* start fresh */ }
+  } catch {
+    /* start fresh */
+  }
 }
 
 function savePending() {
   try {
     const dir = path.dirname(PENDING_FILE);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    const tmp = PENDING_FILE + '.tmp';
+    const tmp = PENDING_FILE + ".tmp";
     fs.writeFileSync(tmp, JSON.stringify(Object.fromEntries(pendingTasks), null, 2));
     fs.renameSync(tmp, PENDING_FILE);
-  } catch { /* non-fatal */ }
+  } catch {
+    /* non-fatal */
+  }
 }
 
 function genId() {
-  const ts = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14);
+  const ts = new Date().toISOString().replace(/[-:T]/g, "").slice(0, 14);
   const r = Math.random().toString(36).slice(2, 8);
   return `tsk_${ts}_${r}`;
 }
@@ -64,7 +71,7 @@ function genId() {
 function appendLog(entry) {
   const dir = path.dirname(TASK_LOG);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.appendFileSync(TASK_LOG, JSON.stringify(entry) + '\n');
+  fs.appendFileSync(TASK_LOG, JSON.stringify(entry) + "\n");
 }
 
 function relay(taskId) {
@@ -86,9 +93,9 @@ function reapStaleTasks() {
         runtime: task.runtime,
         task: task.task,
         spawnedAt: task.spawnedAt,
-        status: 'timeout',
+        status: "timeout",
         completedAt: new Date().toISOString(),
-        completionSource: 'stale_reaper',
+        completionSource: "stale_reaper",
         reason: `no completion detected within ${STALE_TIMEOUT_MS / 60000}min`,
       });
       reaped++;
@@ -97,19 +104,24 @@ function reapStaleTasks() {
 
   if (reaped > 0) {
     savePending();
-    if (pluginLogger) pluginLogger.info(`spawn-interceptor: reaped ${reaped} stale task(s), ${pendingTasks.size} still pending`);
+    if (pluginLogger)
+      pluginLogger.info(
+        `spawn-interceptor: reaped ${reaped} stale task(s), ${pendingTasks.size} still pending`,
+      );
   }
 }
 
 function pollAcpSessions() {
-  const acpPending = [...pendingTasks.entries()].filter(([, t]) => t.runtime === 'acp');
+  const acpPending = [...pendingTasks.entries()].filter(([, t]) => t.runtime === "acp");
   if (acpPending.length === 0) return;
 
   let index;
   try {
     if (!fs.existsSync(ACPX_INDEX)) return;
-    index = JSON.parse(fs.readFileSync(ACPX_INDEX, 'utf-8'));
-  } catch { return; }
+    index = JSON.parse(fs.readFileSync(ACPX_INDEX, "utf-8"));
+  } catch {
+    return;
+  }
 
   const entries = index.entries || [];
   if (entries.length === 0) return;
@@ -129,18 +141,25 @@ function pollAcpSessions() {
     }
   }
 
+  // Track consumed sessions so one closed session cannot match multiple tasks
+  const consumedSessionIds = new Set();
+
   for (const [taskId, task] of acpPending) {
     const spawnTs = new Date(task.spawnedAt).getTime();
 
     let matched = false;
     for (const session of closedSessions) {
+      if (consumedSessionIds.has(session.acpxRecordId)) continue;
+
       let sessionDetail = null;
       try {
         const fp = path.join(ACPX_SESSIONS_DIR, session.file);
         if (fs.existsSync(fp)) {
-          sessionDetail = JSON.parse(fs.readFileSync(fp, 'utf-8'));
+          sessionDetail = JSON.parse(fs.readFileSync(fp, "utf-8"));
         }
-      } catch { /* skip */ }
+      } catch {
+        /* skip */
+      }
 
       const sessionCreatedAt = sessionDetail
         ? new Date(sessionDetail.created_at).getTime()
@@ -150,9 +169,10 @@ function pollAcpSessions() {
 
       if (timeDiff < TIME_MATCH_WINDOW_MS) {
         const closedAt = sessionDetail?.closed_at || session.lastUsedAt || new Date().toISOString();
-        const sessionName = sessionDetail?.name || session.name || '?';
+        const sessionName = sessionDetail?.name || session.name || "?";
 
         pendingTasks.delete(taskId);
+        consumedSessionIds.add(session.acpxRecordId);
         appendLog({
           taskId,
           agentId: task.agentId,
@@ -160,9 +180,9 @@ function pollAcpSessions() {
           runtime: task.runtime,
           task: task.task,
           spawnedAt: task.spawnedAt,
-          status: 'completed',
+          status: "completed",
           completedAt: closedAt,
-          completionSource: 'acp_session_poller',
+          completionSource: "acp_session_poller",
           acpxSession: session.acpxRecordId,
           acpxSessionName: sessionName,
           reason: `acpx session closed (time match: ${Math.round(timeDiff / 1000)}s)`,
@@ -172,7 +192,9 @@ function pollAcpSessions() {
         completed++;
 
         if (pluginLogger) {
-          pluginLogger.info(`spawn-interceptor: ACP task ${taskId} → completed (acpx session ${session.acpxRecordId} closed, match=${Math.round(timeDiff / 1000)}s)`);
+          pluginLogger.info(
+            `spawn-interceptor: ACP task ${taskId} → completed (acpx session ${session.acpxRecordId} closed, match=${Math.round(timeDiff / 1000)}s)`,
+          );
         }
         break;
       }
@@ -189,16 +211,18 @@ function pollAcpSessions() {
           runtime: task.runtime,
           task: task.task,
           spawnedAt: task.spawnedAt,
-          status: 'completed',
+          status: "assumed_complete",
           completedAt: new Date().toISOString(),
-          completionSource: 'acp_session_poller',
-          reason: `no open ACP sessions remain (task age: ${Math.round(age / 1000)}s)`,
+          completionSource: "acp_session_poller",
+          reason: `no open ACP sessions remain (task age: ${Math.round(age / 1000)}s, heuristic — actual outcome unknown)`,
         });
 
         completed++;
 
         if (pluginLogger) {
-          pluginLogger.info(`spawn-interceptor: ACP task ${taskId} → completed (no open ACP sessions, age=${Math.round(age / 1000)}s)`);
+          pluginLogger.info(
+            `spawn-interceptor: ACP task ${taskId} → assumed_complete (no open ACP sessions, age=${Math.round(age / 1000)}s)`,
+          );
         }
       }
     }
@@ -207,79 +231,109 @@ function pollAcpSessions() {
   if (completed > 0) {
     savePending();
     if (pluginLogger) {
-      pluginLogger.info(`spawn-interceptor: ACP poller completed ${completed} task(s), ${pendingTasks.size} still pending`);
+      pluginLogger.info(
+        `spawn-interceptor: ACP poller completed ${completed} task(s), ${pendingTasks.size} still pending`,
+      );
     }
   }
 }
 
 const spawnInterceptorPlugin = {
-  id: 'spawn-interceptor',
-  name: 'Spawn Interceptor',
-  description: 'Auto-tracks sessions_spawn and detects ACP completion via session polling',
-  version: '2.4.0',
+  id: "spawn-interceptor",
+  name: "Spawn Interceptor",
+  description: "Auto-tracks sessions_spawn and detects ACP completion via session polling",
+  version: "2.5.0",
 
   register(api) {
     pluginLogger = api.logger;
-    api.logger.info('spawn-interceptor v2.4: registering (subagent_ended + ACP session poller + stale reaper)');
+    api.logger.info(
+      "spawn-interceptor v2.5: registering (subagent_ended + ACP session poller + stale reaper)",
+    );
 
     loadPending();
     if (pendingTasks.size > 0) {
-      api.logger.info(`spawn-interceptor: restored ${pendingTasks.size} pending task(s) from disk`);
+      api.logger.info(
+        `spawn-interceptor: restored ${pendingTasks.size} pending task(s) from disk`,
+      );
       reapStaleTasks();
       pollAcpSessions();
+    }
+
+    // Clear any pre-existing timers from a previous register() call (hot-reload)
+    if (reaperTimer) {
+      clearInterval(reaperTimer);
+      reaperTimer = null;
+    }
+    if (acpPollerTimer) {
+      clearInterval(acpPollerTimer);
+      acpPollerTimer = null;
     }
 
     reaperTimer = setInterval(reapStaleTasks, REAPER_INTERVAL_MS);
     acpPollerTimer = setInterval(pollAcpSessions, ACP_POLL_INTERVAL_MS);
 
-    api.on('before_tool_call', (event, ctx) => {
-      if (event.toolName !== 'sessions_spawn') return;
+    api.on("before_tool_call", (event, ctx) => {
+      if (event.toolName !== "sessions_spawn") return;
 
       const p = event.params || {};
       const id = genId();
-      const rt = p.runtime || 'subagent';
+      const rt = p.runtime || "subagent";
 
       const taskEntry = {
         taskId: id,
-        agentId: ctx.agentId || '?',
-        sessionKey: ctx.sessionKey || '',
+        agentId: ctx.agentId || "?",
+        sessionKey: ctx.sessionKey || "",
         runtime: rt,
-        task: String(p.task || '').slice(0, 200),
+        task: String(p.task || "").slice(0, 200),
         spawnedAt: new Date().toISOString(),
-        status: 'spawning',
+        status: "spawning",
       };
 
       appendLog(taskEntry);
       pendingTasks.set(id, taskEntry);
       savePending();
 
-      api.logger.info(`spawn-interceptor: tracked ${id} (runtime=${rt}, pending=${pendingTasks.size})`);
+      api.logger.info(
+        `spawn-interceptor: tracked ${id} (runtime=${rt}, pending=${pendingTasks.size})`,
+      );
 
-      if (rt === 'acp' && p.task) {
+      if (rt === "acp" && p.task) {
         return { params: { ...p, task: p.task + relay(id) } };
       }
     });
 
-    api.on('subagent_ended', (event, ctx) => {
-      const targetKey = event.targetSessionKey || '';
-      const reason = event.reason || '';
-      const outcome = event.outcome || '';
+    api.on("subagent_ended", (event, ctx) => {
+      const targetKey = event.targetSessionKey || "";
+      const reason = event.reason || "";
+      const outcome = event.outcome || "";
       const endedAt = new Date().toISOString();
 
       let matchedTaskId = null;
       let matchedTask = null;
 
+      // Match by targetSessionKey for precise identification.
+      // Falls back to first subagent task only when no session key is available.
       for (const [taskId, task] of pendingTasks.entries()) {
-        if (task.runtime === 'subagent') {
+        if (task.runtime !== "subagent") continue;
+        if (targetKey && task.spawnedSessionKey === targetKey) {
           matchedTaskId = taskId;
           matchedTask = task;
           break;
         }
       }
 
-      const completionStatus = (outcome === 'ok' || reason === 'subagent-complete')
-        ? 'completed'
-        : 'failed';
+      // Fallback: if no precise match and only one subagent pending, use it
+      if (!matchedTaskId) {
+        const subagentTasks = [...pendingTasks.entries()].filter(
+          ([, t]) => t.runtime === "subagent",
+        );
+        if (subagentTasks.length === 1) {
+          [matchedTaskId, matchedTask] = subagentTasks[0];
+        }
+      }
+
+      const completionStatus =
+        outcome === "ok" || reason === "subagent-complete" ? "completed" : "failed";
 
       if (matchedTaskId && matchedTask) {
         pendingTasks.delete(matchedTaskId);
@@ -294,29 +348,45 @@ const spawnInterceptorPlugin = {
           spawnedAt: matchedTask.spawnedAt,
           status: completionStatus,
           completedAt: endedAt,
-          completionSource: 'subagent_ended_hook',
+          completionSource: "subagent_ended_hook",
           reason,
           outcome,
           targetSessionKey: targetKey,
         });
 
-        api.logger.info(`spawn-interceptor: ${matchedTaskId} → ${completionStatus} (subagent_ended, pending=${pendingTasks.size})`);
+        api.logger.info(
+          `spawn-interceptor: ${matchedTaskId} → ${completionStatus} (subagent_ended, pending=${pendingTasks.size})`,
+        );
       } else {
         appendLog({
-          event: 'subagent_ended',
+          event: "subagent_ended",
           targetSessionKey: targetKey,
-          targetKind: event.targetKind || 'unknown',
+          targetKind: event.targetKind || "unknown",
           reason,
           outcome,
-          agentId: ctx.runId || '?',
+          agentId: ctx.runId || "?",
           endedAt,
           matchedTask: false,
         });
-        api.logger.info(`spawn-interceptor: subagent ended (${targetKey}, ${reason}) — no pending match`);
+        api.logger.info(
+          `spawn-interceptor: subagent ended (${targetKey}, ${reason}) — no pending match`,
+        );
       }
     });
 
-    api.logger.info('spawn-interceptor v2.4: all hooks registered, ACP poller interval=15s');
+    api.logger.info("spawn-interceptor v2.5: all hooks registered, ACP poller interval=15s");
+  },
+
+  unregister() {
+    if (reaperTimer) {
+      clearInterval(reaperTimer);
+      reaperTimer = null;
+    }
+    if (acpPollerTimer) {
+      clearInterval(acpPollerTimer);
+      acpPollerTimer = null;
+    }
+    pluginLogger = null;
   },
 };
 

--- a/community/plugins/spawn-interceptor/index.js
+++ b/community/plugins/spawn-interceptor/index.js
@@ -1,0 +1,323 @@
+/**
+ * spawn-interceptor v2.4 — OpenClaw plugin for automatic ACP task tracking.
+ *
+ * Completion detection (layered, in priority order):
+ *   1. subagent_ended hook — works for runtime=subagent only
+ *   2. ACP session poller — reads ~/.acpx/sessions/index.json for closed sessions
+ *   3. Stale reaper — marks tasks stuck > 30min as timeout (final safety net)
+ *
+ * Key insight: OpenClaw's subagent_ended hook does NOT fire for ACP runtime sessions.
+ * ACP sessions are managed by acpx, and their lifecycle is recorded in ~/.acpx/sessions/.
+ * The poller reads the index.json to find closed sessions, then matches them to pending
+ * tasks by creation time proximity.
+ *
+ * v2.4 fixes:
+ *   - Stale reaper no longer re-logs tasks that were already completed/failed/timed out
+ *   - Pending file is atomically saved after every state change
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const SHARED_CTX = path.join(os.homedir(), '.openclaw', 'shared-context');
+const TASK_LOG = path.join(SHARED_CTX, 'monitor-tasks', 'task-log.jsonl');
+const PENDING_FILE = path.join(SHARED_CTX, 'monitor-tasks', '.pending-tasks.json');
+const ACPX_SESSIONS_DIR = path.join(os.homedir(), '.acpx', 'sessions');
+const ACPX_INDEX = path.join(ACPX_SESSIONS_DIR, 'index.json');
+const COMPLETION_SESSION = 'agent:main:completion-relay';
+
+const STALE_TIMEOUT_MS = 30 * 60 * 1000;
+const REAPER_INTERVAL_MS = 5 * 60 * 1000;
+const ACP_POLL_INTERVAL_MS = 15 * 1000;
+
+let pendingTasks = new Map();
+let reaperTimer = null;
+let acpPollerTimer = null;
+let pluginLogger = null;
+
+function loadPending() {
+  try {
+    if (fs.existsSync(PENDING_FILE)) {
+      const data = JSON.parse(fs.readFileSync(PENDING_FILE, 'utf-8'));
+      pendingTasks = new Map(Object.entries(data));
+    }
+  } catch { /* start fresh */ }
+}
+
+function savePending() {
+  try {
+    const dir = path.dirname(PENDING_FILE);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const tmp = PENDING_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(Object.fromEntries(pendingTasks), null, 2));
+    fs.renameSync(tmp, PENDING_FILE);
+  } catch { /* non-fatal */ }
+}
+
+function genId() {
+  const ts = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14);
+  const r = Math.random().toString(36).slice(2, 8);
+  return `tsk_${ts}_${r}`;
+}
+
+function appendLog(entry) {
+  const dir = path.dirname(TASK_LOG);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(TASK_LOG, JSON.stringify(entry) + '\n');
+}
+
+function relay(taskId) {
+  return `\n\n---\n[COMPLETION RELAY — OPTIONAL]\nWhen done, call sessions_send with:\n  sessionKey: "${COMPLETION_SESSION}"\n  message: {"type":"acp_completion","taskId":"${taskId}","status":"completed or failed","summary":"one-sentence result"}\nThis is optional — completion is tracked automatically.\n---`;
+}
+
+function reapStaleTasks() {
+  const now = Date.now();
+  let reaped = 0;
+
+  for (const [taskId, task] of [...pendingTasks.entries()]) {
+    const spawnedAt = new Date(task.spawnedAt).getTime();
+    if (now - spawnedAt > STALE_TIMEOUT_MS) {
+      pendingTasks.delete(taskId);
+      appendLog({
+        taskId,
+        agentId: task.agentId,
+        sessionKey: task.sessionKey,
+        runtime: task.runtime,
+        task: task.task,
+        spawnedAt: task.spawnedAt,
+        status: 'timeout',
+        completedAt: new Date().toISOString(),
+        completionSource: 'stale_reaper',
+        reason: `no completion detected within ${STALE_TIMEOUT_MS / 60000}min`,
+      });
+      reaped++;
+    }
+  }
+
+  if (reaped > 0) {
+    savePending();
+    if (pluginLogger) pluginLogger.info(`spawn-interceptor: reaped ${reaped} stale task(s), ${pendingTasks.size} still pending`);
+  }
+}
+
+function pollAcpSessions() {
+  const acpPending = [...pendingTasks.entries()].filter(([, t]) => t.runtime === 'acp');
+  if (acpPending.length === 0) return;
+
+  let index;
+  try {
+    if (!fs.existsSync(ACPX_INDEX)) return;
+    index = JSON.parse(fs.readFileSync(ACPX_INDEX, 'utf-8'));
+  } catch { return; }
+
+  const entries = index.entries || [];
+  if (entries.length === 0) return;
+
+  const TIME_MATCH_WINDOW_MS = 60 * 1000;
+  const BATCH_CLEANUP_AGE_MS = 2 * 60 * 1000;
+  let completed = 0;
+
+  const closedSessions = [];
+  const openSessions = [];
+
+  for (const entry of entries) {
+    if (entry.closed) {
+      closedSessions.push(entry);
+    } else {
+      openSessions.push(entry);
+    }
+  }
+
+  for (const [taskId, task] of acpPending) {
+    const spawnTs = new Date(task.spawnedAt).getTime();
+
+    let matched = false;
+    for (const session of closedSessions) {
+      let sessionDetail = null;
+      try {
+        const fp = path.join(ACPX_SESSIONS_DIR, session.file);
+        if (fs.existsSync(fp)) {
+          sessionDetail = JSON.parse(fs.readFileSync(fp, 'utf-8'));
+        }
+      } catch { /* skip */ }
+
+      const sessionCreatedAt = sessionDetail
+        ? new Date(sessionDetail.created_at).getTime()
+        : new Date(session.lastUsedAt).getTime();
+
+      const timeDiff = Math.abs(sessionCreatedAt - spawnTs);
+
+      if (timeDiff < TIME_MATCH_WINDOW_MS) {
+        const closedAt = sessionDetail?.closed_at || session.lastUsedAt || new Date().toISOString();
+        const sessionName = sessionDetail?.name || session.name || '?';
+
+        pendingTasks.delete(taskId);
+        appendLog({
+          taskId,
+          agentId: task.agentId,
+          sessionKey: task.sessionKey,
+          runtime: task.runtime,
+          task: task.task,
+          spawnedAt: task.spawnedAt,
+          status: 'completed',
+          completedAt: closedAt,
+          completionSource: 'acp_session_poller',
+          acpxSession: session.acpxRecordId,
+          acpxSessionName: sessionName,
+          reason: `acpx session closed (time match: ${Math.round(timeDiff / 1000)}s)`,
+        });
+
+        matched = true;
+        completed++;
+
+        if (pluginLogger) {
+          pluginLogger.info(`spawn-interceptor: ACP task ${taskId} → completed (acpx session ${session.acpxRecordId} closed, match=${Math.round(timeDiff / 1000)}s)`);
+        }
+        break;
+      }
+    }
+
+    if (!matched) {
+      const age = Date.now() - spawnTs;
+      if (age > BATCH_CLEANUP_AGE_MS && openSessions.length === 0) {
+        pendingTasks.delete(taskId);
+        appendLog({
+          taskId,
+          agentId: task.agentId,
+          sessionKey: task.sessionKey,
+          runtime: task.runtime,
+          task: task.task,
+          spawnedAt: task.spawnedAt,
+          status: 'completed',
+          completedAt: new Date().toISOString(),
+          completionSource: 'acp_session_poller',
+          reason: `no open ACP sessions remain (task age: ${Math.round(age / 1000)}s)`,
+        });
+
+        completed++;
+
+        if (pluginLogger) {
+          pluginLogger.info(`spawn-interceptor: ACP task ${taskId} → completed (no open ACP sessions, age=${Math.round(age / 1000)}s)`);
+        }
+      }
+    }
+  }
+
+  if (completed > 0) {
+    savePending();
+    if (pluginLogger) {
+      pluginLogger.info(`spawn-interceptor: ACP poller completed ${completed} task(s), ${pendingTasks.size} still pending`);
+    }
+  }
+}
+
+const spawnInterceptorPlugin = {
+  id: 'spawn-interceptor',
+  name: 'Spawn Interceptor',
+  description: 'Auto-tracks sessions_spawn and detects ACP completion via session polling',
+  version: '2.4.0',
+
+  register(api) {
+    pluginLogger = api.logger;
+    api.logger.info('spawn-interceptor v2.4: registering (subagent_ended + ACP session poller + stale reaper)');
+
+    loadPending();
+    if (pendingTasks.size > 0) {
+      api.logger.info(`spawn-interceptor: restored ${pendingTasks.size} pending task(s) from disk`);
+      reapStaleTasks();
+      pollAcpSessions();
+    }
+
+    reaperTimer = setInterval(reapStaleTasks, REAPER_INTERVAL_MS);
+    acpPollerTimer = setInterval(pollAcpSessions, ACP_POLL_INTERVAL_MS);
+
+    api.on('before_tool_call', (event, ctx) => {
+      if (event.toolName !== 'sessions_spawn') return;
+
+      const p = event.params || {};
+      const id = genId();
+      const rt = p.runtime || 'subagent';
+
+      const taskEntry = {
+        taskId: id,
+        agentId: ctx.agentId || '?',
+        sessionKey: ctx.sessionKey || '',
+        runtime: rt,
+        task: String(p.task || '').slice(0, 200),
+        spawnedAt: new Date().toISOString(),
+        status: 'spawning',
+      };
+
+      appendLog(taskEntry);
+      pendingTasks.set(id, taskEntry);
+      savePending();
+
+      api.logger.info(`spawn-interceptor: tracked ${id} (runtime=${rt}, pending=${pendingTasks.size})`);
+
+      if (rt === 'acp' && p.task) {
+        return { params: { ...p, task: p.task + relay(id) } };
+      }
+    });
+
+    api.on('subagent_ended', (event, ctx) => {
+      const targetKey = event.targetSessionKey || '';
+      const reason = event.reason || '';
+      const outcome = event.outcome || '';
+      const endedAt = new Date().toISOString();
+
+      let matchedTaskId = null;
+      let matchedTask = null;
+
+      for (const [taskId, task] of pendingTasks.entries()) {
+        if (task.runtime === 'subagent') {
+          matchedTaskId = taskId;
+          matchedTask = task;
+          break;
+        }
+      }
+
+      const completionStatus = (outcome === 'ok' || reason === 'subagent-complete')
+        ? 'completed'
+        : 'failed';
+
+      if (matchedTaskId && matchedTask) {
+        pendingTasks.delete(matchedTaskId);
+        savePending();
+
+        appendLog({
+          taskId: matchedTaskId,
+          agentId: matchedTask.agentId,
+          sessionKey: matchedTask.sessionKey,
+          runtime: matchedTask.runtime,
+          task: matchedTask.task,
+          spawnedAt: matchedTask.spawnedAt,
+          status: completionStatus,
+          completedAt: endedAt,
+          completionSource: 'subagent_ended_hook',
+          reason,
+          outcome,
+          targetSessionKey: targetKey,
+        });
+
+        api.logger.info(`spawn-interceptor: ${matchedTaskId} → ${completionStatus} (subagent_ended, pending=${pendingTasks.size})`);
+      } else {
+        appendLog({
+          event: 'subagent_ended',
+          targetSessionKey: targetKey,
+          targetKind: event.targetKind || 'unknown',
+          reason,
+          outcome,
+          agentId: ctx.runId || '?',
+          endedAt,
+          matchedTask: false,
+        });
+        api.logger.info(`spawn-interceptor: subagent ended (${targetKey}, ${reason}) — no pending match`);
+      }
+    });
+
+    api.logger.info('spawn-interceptor v2.4: all hooks registered, ACP poller interval=15s');
+  },
+};
+
+export default spawnInterceptorPlugin;

--- a/community/plugins/spawn-interceptor/index.js
+++ b/community/plugins/spawn-interceptor/index.js
@@ -1,5 +1,5 @@
 /**
- * spawn-interceptor v2.5 — OpenClaw plugin for automatic ACP task tracking.
+ * spawn-interceptor v2.5.1 — OpenClaw plugin for automatic ACP task tracking.
  *
  * Completion detection (layered, in priority order):
  *   1. subagent_ended hook — works for runtime=subagent only
@@ -17,6 +17,9 @@
  *   - Fallback "no open sessions" status changed from completed to assumed_complete
  *   - Added unregister() for proper timer cleanup on plugin hot-reload
  *   - Version synced between package.json and index.js
+ *
+ * v2.5.1 fixes:
+ *   - consumedAcpSessionIds persisted across poll iterations (previously recreated each tick)
  */
 
 import fs from "fs";
@@ -38,6 +41,7 @@ let pendingTasks = new Map();
 let reaperTimer = null;
 let acpPollerTimer = null;
 let pluginLogger = null;
+let consumedAcpSessionIds = new Set();
 
 function loadPending() {
   try {
@@ -141,15 +145,13 @@ function pollAcpSessions() {
     }
   }
 
-  // Track consumed sessions so one closed session cannot match multiple tasks
-  const consumedSessionIds = new Set();
 
   for (const [taskId, task] of acpPending) {
     const spawnTs = new Date(task.spawnedAt).getTime();
 
     let matched = false;
     for (const session of closedSessions) {
-      if (consumedSessionIds.has(session.acpxRecordId)) continue;
+      if (consumedAcpSessionIds.has(session.acpxRecordId)) continue;
 
       let sessionDetail = null;
       try {
@@ -172,7 +174,7 @@ function pollAcpSessions() {
         const sessionName = sessionDetail?.name || session.name || "?";
 
         pendingTasks.delete(taskId);
-        consumedSessionIds.add(session.acpxRecordId);
+        consumedAcpSessionIds.add(session.acpxRecordId);
         appendLog({
           taskId,
           agentId: task.agentId,
@@ -242,12 +244,12 @@ const spawnInterceptorPlugin = {
   id: "spawn-interceptor",
   name: "Spawn Interceptor",
   description: "Auto-tracks sessions_spawn and detects ACP completion via session polling",
-  version: "2.5.0",
+  version: "2.5.1",
 
   register(api) {
     pluginLogger = api.logger;
     api.logger.info(
-      "spawn-interceptor v2.5: registering (subagent_ended + ACP session poller + stale reaper)",
+      "spawn-interceptor v2.5.1: registering (subagent_ended + ACP session poller + stale reaper)",
     );
 
     loadPending();
@@ -374,7 +376,7 @@ const spawnInterceptorPlugin = {
       }
     });
 
-    api.logger.info("spawn-interceptor v2.5: all hooks registered, ACP poller interval=15s");
+    api.logger.info("spawn-interceptor v2.5.1: all hooks registered, ACP poller interval=15s");
   },
 
   unregister() {
@@ -386,6 +388,7 @@ const spawnInterceptorPlugin = {
       clearInterval(acpPollerTimer);
       acpPollerTimer = null;
     }
+    consumedAcpSessionIds.clear();
     pluginLogger = null;
   },
 };

--- a/community/plugins/spawn-interceptor/index.js
+++ b/community/plugins/spawn-interceptor/index.js
@@ -1,5 +1,5 @@
 /**
- * spawn-interceptor v2.5.1 — OpenClaw plugin for automatic ACP task tracking.
+ * spawn-interceptor v2.5.2 — OpenClaw plugin for automatic ACP task tracking.
  *
  * Completion detection (layered, in priority order):
  *   1. subagent_ended hook — works for runtime=subagent only
@@ -20,11 +20,15 @@
  *
  * v2.5.1 fixes:
  *   - consumedAcpSessionIds persisted across poll iterations (previously recreated each tick)
+ *
+ * v2.5.2 fixes:
+ *   - ACP matcher requires session creation time >= spawn time (minus 2s clock skew tolerance)
+ *     to prevent pre-existing closed sessions from matching newly spawned tasks
  */
 
 import fs from "fs";
-import path from "path";
 import os from "os";
+import path from "path";
 
 const SHARED_CTX = path.join(os.homedir(), ".openclaw", "shared-context");
 const TASK_LOG = path.join(SHARED_CTX, "monitor-tasks", "task-log.jsonl");
@@ -57,7 +61,9 @@ function loadPending() {
 function savePending() {
   try {
     const dir = path.dirname(PENDING_FILE);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
     const tmp = PENDING_FILE + ".tmp";
     fs.writeFileSync(tmp, JSON.stringify(Object.fromEntries(pendingTasks), null, 2));
     fs.renameSync(tmp, PENDING_FILE);
@@ -74,7 +80,9 @@ function genId() {
 
 function appendLog(entry) {
   const dir = path.dirname(TASK_LOG);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
   fs.appendFileSync(TASK_LOG, JSON.stringify(entry) + "\n");
 }
 
@@ -86,7 +94,7 @@ function reapStaleTasks() {
   const now = Date.now();
   let reaped = 0;
 
-  for (const [taskId, task] of [...pendingTasks.entries()]) {
+  for (const [taskId, task] of pendingTasks.entries()) {
     const spawnedAt = new Date(task.spawnedAt).getTime();
     if (now - spawnedAt > STALE_TIMEOUT_MS) {
       pendingTasks.delete(taskId);
@@ -108,27 +116,34 @@ function reapStaleTasks() {
 
   if (reaped > 0) {
     savePending();
-    if (pluginLogger)
+    if (pluginLogger) {
       pluginLogger.info(
         `spawn-interceptor: reaped ${reaped} stale task(s), ${pendingTasks.size} still pending`,
       );
+    }
   }
 }
 
 function pollAcpSessions() {
   const acpPending = [...pendingTasks.entries()].filter(([, t]) => t.runtime === "acp");
-  if (acpPending.length === 0) return;
+  if (acpPending.length === 0) {
+    return;
+  }
 
   let index;
   try {
-    if (!fs.existsSync(ACPX_INDEX)) return;
+    if (!fs.existsSync(ACPX_INDEX)) {
+      return;
+    }
     index = JSON.parse(fs.readFileSync(ACPX_INDEX, "utf-8"));
   } catch {
     return;
   }
 
   const entries = index.entries || [];
-  if (entries.length === 0) return;
+  if (entries.length === 0) {
+    return;
+  }
 
   const TIME_MATCH_WINDOW_MS = 60 * 1000;
   const BATCH_CLEANUP_AGE_MS = 2 * 60 * 1000;
@@ -145,13 +160,14 @@ function pollAcpSessions() {
     }
   }
 
-
   for (const [taskId, task] of acpPending) {
     const spawnTs = new Date(task.spawnedAt).getTime();
 
     let matched = false;
     for (const session of closedSessions) {
-      if (consumedAcpSessionIds.has(session.acpxRecordId)) continue;
+      if (consumedAcpSessionIds.has(session.acpxRecordId)) {
+        continue;
+      }
 
       let sessionDetail = null;
       try {
@@ -167,9 +183,9 @@ function pollAcpSessions() {
         ? new Date(sessionDetail.created_at).getTime()
         : new Date(session.lastUsedAt).getTime();
 
-      const timeDiff = Math.abs(sessionCreatedAt - spawnTs);
+      const timeDiff = sessionCreatedAt - spawnTs;
 
-      if (timeDiff < TIME_MATCH_WINDOW_MS) {
+      if (timeDiff >= -2000 && timeDiff < TIME_MATCH_WINDOW_MS) {
         const closedAt = sessionDetail?.closed_at || session.lastUsedAt || new Date().toISOString();
         const sessionName = sessionDetail?.name || session.name || "?";
 
@@ -244,19 +260,17 @@ const spawnInterceptorPlugin = {
   id: "spawn-interceptor",
   name: "Spawn Interceptor",
   description: "Auto-tracks sessions_spawn and detects ACP completion via session polling",
-  version: "2.5.1",
+  version: "2.5.2",
 
   register(api) {
     pluginLogger = api.logger;
     api.logger.info(
-      "spawn-interceptor v2.5.1: registering (subagent_ended + ACP session poller + stale reaper)",
+      "spawn-interceptor v2.5.2: registering (subagent_ended + ACP session poller + stale reaper)",
     );
 
     loadPending();
     if (pendingTasks.size > 0) {
-      api.logger.info(
-        `spawn-interceptor: restored ${pendingTasks.size} pending task(s) from disk`,
-      );
+      api.logger.info(`spawn-interceptor: restored ${pendingTasks.size} pending task(s) from disk`);
       reapStaleTasks();
       pollAcpSessions();
     }
@@ -275,7 +289,9 @@ const spawnInterceptorPlugin = {
     acpPollerTimer = setInterval(pollAcpSessions, ACP_POLL_INTERVAL_MS);
 
     api.on("before_tool_call", (event, ctx) => {
-      if (event.toolName !== "sessions_spawn") return;
+      if (event.toolName !== "sessions_spawn") {
+        return;
+      }
 
       const p = event.params || {};
       const id = genId();
@@ -316,7 +332,9 @@ const spawnInterceptorPlugin = {
       // Match by targetSessionKey for precise identification.
       // Falls back to first subagent task only when no session key is available.
       for (const [taskId, task] of pendingTasks.entries()) {
-        if (task.runtime !== "subagent") continue;
+        if (task.runtime !== "subagent") {
+          continue;
+        }
         if (targetKey && task.spawnedSessionKey === targetKey) {
           matchedTaskId = taskId;
           matchedTask = task;
@@ -376,7 +394,7 @@ const spawnInterceptorPlugin = {
       }
     });
 
-    api.logger.info("spawn-interceptor v2.5.1: all hooks registered, ACP poller interval=15s");
+    api.logger.info("spawn-interceptor v2.5.2: all hooks registered, ACP poller interval=15s");
   },
 
   unregister() {

--- a/community/plugins/spawn-interceptor/openclaw.plugin.json
+++ b/community/plugins/spawn-interceptor/openclaw.plugin.json
@@ -1,0 +1,14 @@
+{
+  "id": "spawn-interceptor",
+  "kind": "extension",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean"
+      }
+    },
+    "required": []
+  }
+}

--- a/community/plugins/spawn-interceptor/package.json
+++ b/community/plugins/spawn-interceptor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spawn-interceptor",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "type": "module",
   "description": "Auto-tracks sessions_spawn and detects ACP completion via session polling",
   "main": "index.js",

--- a/community/plugins/spawn-interceptor/package.json
+++ b/community/plugins/spawn-interceptor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spawn-interceptor",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "type": "module",
   "description": "Auto-tracks sessions_spawn and detects ACP completion via session polling",
   "main": "index.js",

--- a/community/plugins/spawn-interceptor/package.json
+++ b/community/plugins/spawn-interceptor/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "spawn-interceptor",
+  "version": "2.3.0",
+  "type": "module",
+  "description": "Auto-tracks sessions_spawn and detects ACP completion via session polling",
+  "main": "index.js",
+  "keywords": [
+    "openclaw",
+    "plugin",
+    "multi-agent",
+    "task-tracking",
+    "acp-completion"
+  ],
+  "license": "MIT",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/community/plugins/spawn-interceptor/package.json
+++ b/community/plugins/spawn-interceptor/package.json
@@ -1,17 +1,17 @@
 {
   "name": "spawn-interceptor",
-  "version": "2.5.1",
-  "type": "module",
+  "version": "2.5.2",
   "description": "Auto-tracks sessions_spawn and detects ACP completion via session polling",
-  "main": "index.js",
   "keywords": [
+    "acp-completion",
+    "multi-agent",
     "openclaw",
     "plugin",
-    "multi-agent",
-    "task-tracking",
-    "acp-completion"
+    "task-tracking"
   ],
   "license": "MIT",
+  "type": "module",
+  "main": "index.js",
   "openclaw": {
     "extensions": [
       "./index.js"


### PR DESCRIPTION
## Summary

Adds `spawn-interceptor` as a community plugin in `community/plugins/spawn-interceptor/`.

This plugin provides automatic ACP task lifecycle tracking — a workaround for #40272 (ACP sessions have no completion notification mechanism).

### What it does

- **Intercepts** every `sessions_spawn` call via the `before_tool_call` hook
- **Detects completion** through 3 layers:
  - L1: `subagent_ended` hook (for `runtime=subagent`, <1s)
  - L2: ACP Session Poller reading `~/.acpx/sessions/index.json` (for `runtime=acp`, ~15s)
  - L3: Stale Reaper (30min timeout, safety net for all runtimes)
- **Logs all events** to `task-log.jsonl` as JSONL for audit/monitoring

### Key insight

**`subagent_ended` does not fire for ACP runtime sessions.** ACP sessions are managed by `acpx`, and their lifecycle is tracked in `~/.acpx/sessions/` — completely separate from the hook system. The plugin works around this by polling the acpx session index.

### Why community/plugins/?

This is not a core change — it's a ~250-line plugin that uses existing public APIs (`before_tool_call`, `subagent_ended`). Placing it in `community/` makes it discoverable for users hitting #40272 while the core fix (PR #40273) is pending.

### Related

- Closes: N/A (complement to #40272)
- Related: #40273 (core fix for channel notification)
- Tested on: OpenClaw v2026.3.11, macOS

### Full docs

https://github.com/lanyasheng/openclaw-multiagent-framework
