### PR TITLE
fix: classify HTTP 500 as transient in status-based failover classifier

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -69,8 +69,8 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 499 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
-    // Keep the status-only path behavior-preserving and conservative.
-    expect(resolveFailoverReasonFromError({ status: 500 })).toBeNull();
+    // 500 is now classified as timeout so failover skips the downed provider.
+    expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1399,6 +1399,69 @@ describe("runWithModelFallback", () => {
       });
     });
   });
+
+  describe("HTTP 500 cross-provider failover", () => {
+    it("falls back to cross-provider model on Anthropic HTTP 500", async () => {
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["together/Qwen3.5-397B", "anthropic/claude-sonnet-4-20250514"],
+            },
+          },
+        },
+      });
+      // Simulate Anthropic SDK APIError with status 500
+      const apiError = Object.assign(new Error("Internal server error"), {
+        status: 500,
+        name: "APIError",
+      });
+      const run = vi.fn().mockRejectedValueOnce(apiError).mockResolvedValueOnce("qwen-ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        run,
+      });
+
+      expect(result.result).toBe("qwen-ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-opus-4-6");
+      expect(run).toHaveBeenNthCalledWith(2, "together", "Qwen3.5-397B");
+      expect(result.attempts).toHaveLength(1);
+      expect(result.attempts[0]?.reason).toBe("timeout");
+    });
+
+    it("classifies Anthropic 500 as timeout reason in failover attempts", async () => {
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["together/Qwen3.5-397B"],
+            },
+          },
+        },
+      });
+      const apiError = Object.assign(new Error("Internal server error"), {
+        status: 500,
+        name: "APIError",
+      });
+      const run = vi.fn().mockRejectedValueOnce(apiError).mockResolvedValueOnce("fallback-ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        run,
+      });
+
+      expect(result.attempts[0]?.reason).toBe("timeout");
+      expect(result.attempts[0]?.status).toBe(500);
+    });
+  });
 });
 
 describe("runWithImageModelFallback", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -414,7 +414,12 @@ export function classifyFailoverReasonFromHttpStatus(
     }
     return "timeout";
   }
-  if (status === 502 || status === 504) {
+  // Treat 5xx gateway/server errors as transient timeout-class failures so
+  // the failover loop skips the downed provider and auth-profile cooldowns
+  // are recorded correctly (previously 500 was unclassified, causing the
+  // primary to be re-probed on every request during an outage instead of
+  // falling back immediately).
+  if (status === 500 || status === 502 || status === 504) {
     return "timeout";
   }
   if (status === 529) {


### PR DESCRIPTION
## Summary

- HTTP 500 was missing from `classifyFailoverReasonFromHttpStatus`, so Anthropic API outages (500 Internal Server Error) were not triggering automatic model failover
- Added `status === 500` to the status-based classifier alongside 502/504, classifying it as a "timeout" failover reason
- This ensures auth profile cooldowns are recorded correctly and the failover chain (e.g. Opus → Qwen 3.5 → Kimi → Sonnet) triggers immediately instead of re-probing the downed provider on every request

## Test plan

- [x] Updated existing `resolveFailoverReasonFromError({ status: 500 })` assertion from `null` to `"timeout"`
- [x] Added 2 new tests in `model-fallback.test.ts` for HTTP 500 cross-provider failover
- [x] All 120 tests pass (failover-error: 30, model-fallback: 46, error classification: 44)

🤖 Generated with [Claude Code](https://claude.com/claude-code)