### PR TITLE
fix(session): updateLastRoute must preserve activity timestamp for idle reset

### DIFF
--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -915,14 +915,14 @@ export async function updateLastRoute(params: {
         })
       : null;
     const basePatch: Partial<SessionEntry> = {
-      updatedAt: Math.max(existing?.updatedAt ?? 0, now),
+      updatedAt: existing?.updatedAt ?? now,
       deliveryContext: normalized.deliveryContext,
       lastChannel: normalized.lastChannel,
       lastTo: normalized.lastTo,
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    const next = mergeSessionEntry(
+    const next = mergeSessionEntryPreserveActivity(
       existing,
       metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
     );


### PR DESCRIPTION
## Summary

- **Problem:** `updateLastRoute()` unconditionally refreshes `updatedAt` to `Date.now()` via both its `basePatch` (`Math.max(existing?.updatedAt ?? 0, now)`) and the default `mergeSessionEntry()` (which includes `Date.now()` in `resolveMergedUpdatedAt`). Since `recordInboundSession()` calls `updateLastRoute()` **before** `initSessionState()` evaluates session freshness, the session always appears freshly active — making idle-based session resets impossible via inbound messages.
- **Why it matters:** `recordSessionMetaFromInbound` was already fixed to use `mergeSessionEntryPreserveActivity` (with the comment *"Inbound metadata updates must not refresh activity timestamps; idle reset evaluation relies on updatedAt from actual session turns"*), but `updateLastRoute` was missed — so the bug persists for any channel that updates delivery routing on inbound (Discord, Telegram, etc.).
- **What changed:** `updateLastRoute` now uses `mergeSessionEntryPreserveActivity` instead of `mergeSessionEntry`, and its `basePatch.updatedAt` preserves the existing timestamp (`existing?.updatedAt ?? now`) instead of always advancing to `now`.
- **What did NOT change:** actual session turn activity (via `initSessionState` / `updateSessionStore`) still updates `updatedAt` normally. Only the pre-evaluation inbound routing metadata path is affected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

Idle-based session resets now work correctly for inbound messages on all channels. Previously, sending a message after the idle threshold would never trigger a session reset because `updateLastRoute` silently refreshed the session timestamp before freshness was evaluated.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node / pnpm, source-based install
- Integration/channel: Discord group channel

### Steps

1. Set `resetByType.group.idleMinutes` to 1 in `openclaw.json`
2. Wait > 1 minute after the last message in a Discord group channel
3. Send a message in that channel
4. Check `sessions.json` — the session ID should remain unchanged (bug) or change to a new UUID (fix)

### Expected

- Session ID changes to a new UUID after the idle threshold is exceeded

### Actual

- **Before fix:** Session ID stays the same; `updatedAt` is refreshed to `Date.now()` by `updateLastRoute` before freshness evaluation
- **After fix:** Session ID changes; idle reset triggers correctly

## Evidence

- [x] Verified on local Discord instance: session `f4029f14` (stale) was NOT reset on upstream `main` (bug reproduced), then session WAS reset to `2d86fbc3` after applying this fix

## Human Verification (required)

- Verified scenarios: reproduced the bug on latest `main`, applied the two-line fix, rebuilt, restarted gateway, and confirmed session reset works via Discord message to #obico channel
- Edge cases checked: confirmed `recordSessionMetaFromInbound` already uses `mergeSessionEntryPreserveActivity` — this change makes `updateLastRoute` consistent
- What I did **not** verify: other channels beyond Discord (Telegram, Slack, etc.), though the code path is shared

## AI/Vibe-Coded PR

- [x] AI-assisted (Claude Code)
- [x] Fully tested on local instance
- [x] I understand what the code does

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR
- Files to restore: `src/config/sessions/store.ts`
- Known bad symptoms: session resets triggering unexpectedly if some caller relied on `updateLastRoute` to keep sessions alive

## Risks and Mitigations

- Risk: callers that intentionally relied on `updateLastRoute` refreshing `updatedAt` would no longer get that behavior
  - Mitigation: `updateLastRoute` is a delivery-routing metadata update, not a session activity signal. The existing comment on `recordSessionMetaFromInbound` confirms this is the intended semantic.