### PR TITLE
Cron: preserve Telegram DM topic delivery inference

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -343,6 +343,19 @@ describe("cron tool", () => {
     });
   });
 
+  it("converts scoped telegram dm thread suffixes into topic delivery targets", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-telegram-dm-topic",
+        agentSessionKey: "agent:velizar:telegram:direct:834275911:thread:834275911:197918",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "834275911:topic:197918",
+    });
+  });
+
   it("infers delivery when delivery is null", async () => {
     expect(
       await executeAddAndReadDelivery({

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -144,14 +144,35 @@ async function buildReminderContextLines(params: {
   }
 }
 
-function stripThreadSuffixFromSessionKey(sessionKey: string): string {
+function splitThreadSuffixFromSessionKey(sessionKey: string): {
+  parentSessionKey: string;
+  threadSuffix?: string;
+} {
   const normalized = sessionKey.toLowerCase();
   const idx = normalized.lastIndexOf(":thread:");
   if (idx <= 0) {
-    return sessionKey;
+    return { parentSessionKey: sessionKey };
   }
-  const parent = sessionKey.slice(0, idx).trim();
-  return parent ? parent : sessionKey;
+  const parentSessionKey = sessionKey.slice(0, idx).trim();
+  const threadSuffix = sessionKey.slice(idx + ":thread:".length).trim();
+  if (!parentSessionKey) {
+    return { parentSessionKey: sessionKey };
+  }
+  return {
+    parentSessionKey,
+    threadSuffix: threadSuffix || undefined,
+  };
+}
+
+function resolveTelegramDmTopicTarget(peerId: string, threadSuffix?: string): string {
+  const trimmedPeerId = peerId.trim();
+  const trimmedThreadSuffix = threadSuffix?.trim();
+  if (!trimmedPeerId || !trimmedThreadSuffix) {
+    return trimmedPeerId;
+  }
+  const scopedMatch = /^-?\d+:(-?\d+)$/.exec(trimmedThreadSuffix);
+  const threadId = scopedMatch?.[1] ?? trimmedThreadSuffix;
+  return threadId ? `${trimmedPeerId}:topic:${threadId}` : trimmedPeerId;
 }
 
 function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | null {
@@ -159,7 +180,8 @@ function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | n
   if (!rawSessionKey) {
     return null;
   }
-  const parsed = parseAgentSessionKey(stripThreadSuffixFromSessionKey(rawSessionKey));
+  const { parentSessionKey, threadSuffix } = splitThreadSuffixFromSessionKey(rawSessionKey);
+  const parsed = parseAgentSessionKey(parentSessionKey);
   if (!parsed || !parsed.rest) {
     return null;
   }
@@ -179,8 +201,10 @@ function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | n
   // - <channel>:group:<peerId>
   // - <channel>:channel:<peerId>
   // Note: legacy keys may use "dm" instead of "direct".
-  // Threaded sessions append :thread:<id>, which we strip so delivery targets the parent peer.
-  // NOTE: Telegram forum topics encode as <chatId>:topic:<topicId> and should be preserved.
+  // Threaded sessions append :thread:<id>. Most channels should deliver to the
+  // parent peer, but Telegram DM topics need the thread converted into the
+  // delivery-target form <chatId>:topic:<topicId>.
+  // NOTE: Telegram forum topics already encode as <chatId>:topic:<topicId>.
   const markerIndex = parts.findIndex(
     (part) => part === "direct" || part === "dm" || part === "group" || part === "channel",
   );
@@ -200,7 +224,13 @@ function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | n
     channel = parts[0]?.trim().toLowerCase() as CronMessageChannel;
   }
 
-  const delivery: CronDelivery = { mode: "announce", to: peerId };
+  const peerKind = parts[markerIndex];
+  const normalizedPeerId =
+    channel === "telegram" && (peerKind === "direct" || peerKind === "dm")
+      ? resolveTelegramDmTopicTarget(peerId, threadSuffix)
+      : peerId;
+
+  const delivery: CronDelivery = { mode: "announce", to: normalizedPeerId };
   if (channel) {
     delivery.channel = channel;
   }

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -172,7 +172,7 @@ function resolveTelegramDmTopicTarget(peerId: string, threadSuffix?: string): st
   }
   const scopedMatch = /^-?\d+:(-?\d+)$/.exec(trimmedThreadSuffix);
   const threadId = scopedMatch?.[1] ?? trimmedThreadSuffix;
-  return threadId ? `${trimmedPeerId}:topic:${threadId}` : trimmedPeerId;
+  return `${trimmedPeerId}:topic:${threadId}`;
 }
 
 function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | null {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: cron auto-inference drops Telegram DM topic context when the source session key uses `:thread:`.
- Why it matters: reminders created from threaded Telegram direct chats get delivered back to the plain DM instead of the originating topic.
- What changed: cron delivery inference now preserves Telegram DM thread context by converting `:thread:` session suffixes into Telegram `:topic:` delivery targets.
- What changed: added a regression test covering scoped Telegram DM thread suffixes like `:thread:<chatId>:<threadId>`.
- What did NOT change (scope boundary): no changes to non-Telegram delivery inference, cron runtime dispatch, or Telegram send semantics outside this inference path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44270
- Related #44240

## User-visible / Behavior Changes

- Cron jobs created from threaded Telegram direct chats now persist `delivery.to` with the originating DM topic, so follow-up deliveries stay inside the same topic.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (WSL)
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): none required for the unit-level repro

### Steps

1. Use an agent session key shaped like `agent:velizar:telegram:direct:834275911:thread:834275911:197918`.
2. Create an isolated `agentTurn` cron job without explicitly setting `delivery.to`.
3. Inspect the inferred `delivery` payload passed to `cron.add`.

### Expected

- `delivery.to` preserves the DM topic as `834275911:topic:197918`.

### Actual

- Before this change, `delivery.to` was inferred as plain `834275911`, so the delivery escaped the originating topic.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm exec vitest run src/agents/tools/cron-tool.test.ts` and confirmed the new Telegram DM topic regression test passes alongside the existing cron inference coverage.
- Edge cases checked: preserved existing behavior for Slack threaded sessions and Telegram forum-topic inference in the same test file.
- What you did **not** verify: full repo test suite, live Telegram delivery against a running gateway, or non-unit reproduction on device.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit 6823ba374.
- Files/config to restore: `src/agents/tools/cron-tool.ts` and `src/agents/tools/cron-tool.test.ts`.
- Known bad symptoms reviewers should watch for: Telegram DM cron jobs inferring malformed `delivery.to` targets or non-Telegram threaded sessions unexpectedly changing inferred recipients.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Telegram DM thread suffix parsing could mis-handle unexpected scoped thread formats.
  - Mitigation: the parser keeps the existing parent-peer behavior unless the session is a Telegram DM, and the regression test covers the scoped thread form reported in #44270.

AI-assisted: yes (Codex).
Testing: targeted unit test coverage only.
