### PR TITLE
fix(telegram): suppress exact NO_REPLY payloads in outbound adapter

### DIFF
--- a/src/channels/plugins/outbound/telegram.test.ts
+++ b/src/channels/plugins/outbound/telegram.test.ts
@@ -58,6 +58,22 @@ describe("telegramOutbound", () => {
     );
   });
 
+  it("suppresses exact NO_REPLY token for sendText", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-text-3", chatId: "123" });
+    const sendText = telegramOutbound.sendText;
+    expect(sendText).toBeDefined();
+
+    const result = await sendText!({
+      cfg: {},
+      to: "123",
+      text: "NO_REPLY",
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "telegram", messageId: "suppressed", chatId: "123" });
+  });
+
   it("passes media options for sendMedia", async () => {
     const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-media-1", chatId: "123" });
     const sendMedia = telegramOutbound.sendMedia;
@@ -84,6 +100,23 @@ describe("telegramOutbound", () => {
       }),
     );
     expect(result).toEqual({ channel: "telegram", messageId: "tg-media-1", chatId: "123" });
+  });
+
+  it("suppresses exact NO_REPLY token payloads without media", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-silent", chatId: "123" });
+    const sendPayload = telegramOutbound.sendPayload;
+    expect(sendPayload).toBeDefined();
+
+    const result = await sendPayload!({
+      cfg: {},
+      to: "123",
+      text: "",
+      payload: { text: " NO_REPLY " },
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "telegram", messageId: "suppressed", chatId: "123" });
   });
 
   it("sends payload media list and applies buttons only to first message", async () => {

--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -1,3 +1,4 @@
+import { isSilentReplyText } from "../../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../../auto-reply/types.js";
 import type { OutboundSendDeps } from "../../../infra/outbound/deliver.js";
 import type { TelegramInlineButtons } from "../../../telegram/button-types.js";
@@ -66,6 +67,9 @@ export async function sendTelegramPayloadMessages(params: {
   };
 
   if (mediaUrls.length === 0) {
+    if (isSilentReplyText(text)) {
+      return { messageId: "suppressed", chatId: params.to };
+    }
     return await params.send(params.to, text, {
       ...payloadOpts,
       buttons: telegramData?.buttons,
@@ -92,6 +96,9 @@ export const telegramOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId }) => {
+    if (isSilentReplyText(text)) {
+      return { channel: "telegram", messageId: "suppressed", chatId: to };
+    }
     const { send, baseOpts } = resolveTelegramSendContext({
       cfg,
       deps,


### PR DESCRIPTION
## Problem

Telegram outbound delivery can leak exact `NO_REPLY` payloads into chats, especially from isolated cron announce flows that should remain silent.

The outbound adapter currently forwards exact silent tokens as normal text sends.

## Fix

Add a hard suppression guard in the Telegram outbound adapter:

- `sendText`: suppress exact `NO_REPLY`
- `sendPayload`: suppress exact `NO_REPLY` when there is no media

This keeps silent runs silent while preserving normal mixed-content replies and media sends.

## Tests

Added regression coverage for:
- suppressing exact `NO_REPLY` in `sendText`
- suppressing exact `NO_REPLY` payloads without media in `sendPayload`

Closes #44213
