### PR TITLE
fix(shared): narrow global singleton lookup after hasOwnProperty guard

### DIFF
--- a/src/shared/global-singleton.ts
+++ b/src/shared/global-singleton.ts
@@ -1,8 +1,7 @@
 export function resolveGlobalSingleton<T>(key: symbol, create: () => T): T {
   const globalStore = globalThis as Record<PropertyKey, unknown>;
-  const existing = globalStore[key] as T | undefined;
   if (Object.prototype.hasOwnProperty.call(globalStore, key)) {
-    return existing;
+    return globalStore[key] as T;
   }
   const created = create();
   globalStore[key] = created;


### PR DESCRIPTION
## Problem

`resolveGlobalSingleton()` stored the keyed global value in a local variable typed as `T | undefined` and then returned it after a `hasOwnProperty` guard.

TypeScript does not narrow that local variable based on the later property-existence check, so this now fails with:

```ts
src/shared/global-singleton.ts(5,5): error TS2322: Type 'T | undefined' is not assignable to type 'T'.
```

This is currently breaking shared check/build jobs across unrelated PRs.

## Fix

Return `globalStore[key] as T` directly inside the `hasOwnProperty` branch so the type matches the runtime guarantee.

## Scope

Small type-only fix in `src/shared/global-singleton.ts`.
