### PR TITLE
fix(cron): preserve telegram direct-thread context in inferred delivery targets

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -343,6 +343,19 @@ describe("cron tool", () => {
     });
   });
 
+  it("converts telegram direct thread session keys into topic-qualified delivery targets", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-telegram-direct-thread",
+        agentSessionKey: "agent:velizar:telegram:direct:834275911:thread:834275911:197918",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "834275911:topic:197918",
+    });
+  });
+
   it("infers delivery when delivery is null", async () => {
     expect(
       await executeAddAndReadDelivery({

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -154,11 +154,26 @@ function stripThreadSuffixFromSessionKey(sessionKey: string): string {
   return parent ? parent : sessionKey;
 }
 
+function extractTelegramDirectThreadTarget(sessionKey: string): string | null {
+  const normalized = sessionKey.trim().toLowerCase();
+  const match = /^agent:[^:]+:telegram:direct:([^:]+):thread:[^:]+:(\d+)$/.exec(normalized);
+  if (!match) {
+    return null;
+  }
+  const chatId = match[1]?.trim();
+  const threadId = match[2]?.trim();
+  if (!chatId || !threadId) {
+    return null;
+  }
+  return `${chatId}:topic:${threadId}`;
+}
+
 function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | null {
   const rawSessionKey = agentSessionKey?.trim();
   if (!rawSessionKey) {
     return null;
   }
+  const telegramThreadTarget = extractTelegramDirectThreadTarget(rawSessionKey);
   const parsed = parseAgentSessionKey(stripThreadSuffixFromSessionKey(rawSessionKey));
   if (!parsed || !parsed.rest) {
     return null;
@@ -200,7 +215,8 @@ function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | n
     channel = parts[0]?.trim().toLowerCase() as CronMessageChannel;
   }
 
-  const delivery: CronDelivery = { mode: "announce", to: peerId };
+  const resolvedPeerId = channel === "telegram" && telegramThreadTarget ? telegramThreadTarget : peerId;
+  const delivery: CronDelivery = { mode: "announce", to: resolvedPeerId };
   if (channel) {
     delivery.channel = channel;
   }


### PR DESCRIPTION
## Problem

Cron reminder auto-inference drops Telegram direct-chat thread context when the source session key uses `:thread:`.

As a result, reminders created from threaded Telegram direct chats are persisted with a plain DM target and get delivered outside the originating thread.

## Fix

Preserve Telegram direct-thread context during cron delivery inference by converting:

- session-key form: `...:thread:<chatId>:<threadId>`
- delivery-target form: `<chatId>:topic:<threadId>`

This keeps Telegram threaded DM reminders routed back to the correct thread.

## Tests

Added regression coverage for Telegram direct-thread session keys so inferred delivery preserves the topic-qualified target.

Closes #44270
