### PR TITLE
fix(session): guard parent fork totalTokens lookup

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import { buildModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import * as sessionsConfig from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import {
@@ -373,6 +374,79 @@ describe("initSessionState thread forking", () => {
       ? await fs.realpath(parsedHeader.parentSession)
       : undefined;
     expect(actualParentSession).toBe(expectedParentSession);
+  });
+
+  it("uses a stable parent entry reference during parent-fork initialization", async () => {
+    const root = await makeCaseDir("openclaw-thread-session-stable-parent-ref-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+
+    const parentSessionId = "parent-stable-ref";
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    const header = {
+      type: "session",
+      version: 3,
+      id: parentSessionId,
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    };
+    const message = {
+      type: "message",
+      id: "m1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "Parent prompt" },
+    };
+    await fs.writeFile(
+      parentSessionFile,
+      `${JSON.stringify(header)}\n${JSON.stringify(message)}\n`,
+      "utf-8",
+    );
+
+    const parentSessionKey = "agent:main:slack:channel:c1";
+    const unstableParentStore = {} as Record<string, SessionEntry>;
+    let parentReads = 0;
+    Object.defineProperty(unstableParentStore, parentSessionKey, {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        parentReads += 1;
+        if (parentReads === 1) {
+          return {
+            sessionId: parentSessionId,
+            sessionFile: parentSessionFile,
+            updatedAt: Date.now(),
+          };
+        }
+        return undefined;
+      },
+    });
+
+    const loadStoreSpy = vi
+      .spyOn(sessionsConfig, "loadSessionStore")
+      .mockReturnValue(unstableParentStore);
+
+    try {
+      const cfg = {
+        session: { store: path.join(root, "sessions.json") },
+      } as OpenClawConfig;
+      const threadSessionKey = "agent:main:slack:channel:c1:thread:stable";
+      const result = await initSessionState({
+        ctx: {
+          Body: "Thread reply",
+          SessionKey: threadSessionKey,
+          ParentSessionKey: parentSessionKey,
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.sessionKey).toBe(threadSessionKey);
+      expect(result.sessionEntry.forkedFromParent).toBe(true);
+      expect(parentReads).toBe(1);
+    } finally {
+      loadStoreSpy.mockRestore();
+    }
   });
 
   it("records topic-specific session files when MessageThreadId is present", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -478,14 +478,13 @@ export async function initSessionState(params: {
     sessionEntry.displayName = threadLabel;
   }
   const parentSessionKey = ctx.ParentSessionKey?.trim();
+  const parentSessionEntry =
+    parentSessionKey && parentSessionKey !== sessionKey
+      ? sessionStore[parentSessionKey]
+      : undefined;
   const alreadyForked = sessionEntry.forkedFromParent === true;
-  if (
-    parentSessionKey &&
-    parentSessionKey !== sessionKey &&
-    sessionStore[parentSessionKey] &&
-    !alreadyForked
-  ) {
-    const parentTokens = sessionStore[parentSessionKey].totalTokens ?? 0;
+  if (parentSessionKey && parentSessionEntry && !alreadyForked) {
+    const parentTokens = parentSessionEntry.totalTokens ?? 0;
     if (parentForkMaxTokens > 0 && parentTokens > parentForkMaxTokens) {
       // Parent context is too large — forking would create a thread session
       // that immediately overflows the model's context window. Start fresh
@@ -501,7 +500,7 @@ export async function initSessionState(params: {
           `parentTokens=${parentTokens}`,
       );
       const forked = forkSessionFromParent({
-        parentEntry: sessionStore[parentSessionKey],
+        parentEntry: parentSessionEntry,
         agentId,
         sessionsDir: path.dirname(storePath),
       });


### PR DESCRIPTION
## Summary

- Problem: `initSessionState` could throw `TypeError: Cannot read properties of undefined (reading 'totalTokens')` in parent-fork initialization when parent session entry lookup was unstable across repeated reads.
- Why it matters: this can crash agent turns (reported on Codex OAuth lane), causing user-visible delivery failures before fallback handling.
- What changed: captured `parentSessionEntry` once and reused it for token check + fork call; added regression test that simulates a parent store getter returning entry once then `undefined`.
- What did NOT change (scope boundary): no model/provider logic changes, no fallback policy changes, no config/schema/API changes, no network/auth behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42248
- Related: None

## User-visible / Behavior Changes

Codex OAuth lane (and any parent-fork path using this code) no longer crashes from transient/missing parent entry during `totalTokens` read in session initialization.  
No command/config UX changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node + Vitest local run
- Model/provider: N/A for unit regression; issue context is `openai-codex/gpt-5.3-codex` OAuth lane
- Integration/channel (if any): session parent-fork path (lane/session orchestration)
- Relevant config (redacted): default session config with session store

### Steps

1. Simulate parent session entry lookup that returns valid entry on first read and `undefined` on second read.
2. Call `initSessionState` with `ParentSessionKey` set.
3. Verify initialization succeeds and parent lookup is read once.

### Expected

- No throw when parent metadata is unstable.
- Session initialization completes and marks parent fork state as expected.

### Actual

- Regression test passes.
- Targeted suite passes with no failures.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression test:
- `src/auto-reply/reply/session.test.ts`  
  `uses a stable parent entry reference during parent-fork initialization`

Run:
- `COREPACK_HOME=/tmp/corepack corepack pnpm exec vitest run src/auto-reply/reply/session.test.ts`
- Result: `1 passed`, `51 tests passed`.

## Human Verification (required)

- Verified scenarios:
  - Parent-fork init uses a stable parent entry reference.
  - Parent lookup accessed once in unstable getter simulation.
  - Targeted session test file remains green.
- Edge cases checked:
  - Parent entry missing after initial read no longer causes `totalTokens` dereference crash.
- What you did **not** verify:
  - Full end-to-end Slack bridge runtime path with live OAuth session.
  - Full `pnpm build && pnpm check && pnpm test` across entire monorepo in this environment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore:
  - `src/auto-reply/reply/session.ts`
  - `src/auto-reply/reply/session.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected behavior in thread parent-fork initialization.
  - Reappearance of `reading 'totalTokens'` errors in session init lanes.

## Risks and Mitigations

- Risk: parent-fork behavior could change subtly if downstream code relied on multiple live store reads.
  - Mitigation: logic is functionally equivalent except for stabilized reference; regression test explicitly covers unstable-read case.

## AI Assistance Disclosure

- AI-assisted: Yes (Codex)
- Testing level: Targeted test run (`src/auto-reply/reply/session.test.ts`)
- I reviewed and understand all code changes
