### PR TITLE
fix: guard followup-runner dedup behind cross-target check

### DIFF
--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -4,6 +4,7 @@
   "description": "OpenClaw Mattermost channel plugin",
   "type": "module",
   "dependencies": {
+    "@sinclair/typebox": "0.34.48",
     "ws": "^8.20.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
 
   extensions/mattermost:
     dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
       ws:
         specifier: ^8.20.0
         version: 8.20.0

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2,14 +2,20 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { FailoverError } from "./failover-error.js";
 import { isAnthropicBillingError } from "./live-auth-keys.js";
-import { runWithImageModelFallback, runWithModelFallback } from "./model-fallback.js";
+import {
+  runWithImageModelFallback,
+  runWithModelFallback,
+  _transientRetryInternals,
+  _testHooks,
+} from "./model-fallback.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
 const makeCfg = makeModelFallbackCfg;
@@ -81,6 +87,7 @@ async function expectFallsBackToHaiku(params: {
     cfg,
     provider: params.provider,
     model: params.model,
+    transientRetries: 0,
     run,
   });
 
@@ -333,6 +340,7 @@ describe("runWithModelFallback", () => {
       cfg,
       provider: "anthropic",
       model: "claude-haiku-3-5",
+      transientRetries: 0,
       run,
     });
 
@@ -752,6 +760,7 @@ describe("runWithModelFallback", () => {
       cfg,
       provider: "anthropic",
       model: "claude-sonnet-4",
+      transientRetries: 0,
       run,
     });
 
@@ -987,6 +996,7 @@ describe("runWithModelFallback", () => {
       cfg,
       provider: "openrouter",
       model: "meta-llama/llama-3.3-70b:free",
+      transientRetries: 0,
       run,
     });
 
@@ -1019,6 +1029,7 @@ describe("runWithModelFallback", () => {
         cfg,
         provider: "anthropic",
         model: "claude-sonnet-4-20250514", // Different from config primary
+        transientRetries: 0,
         run,
       });
 
@@ -1049,6 +1060,7 @@ describe("runWithModelFallback", () => {
         cfg,
         provider: "anthropic",
         model: "claude-opus-4-5", // Version difference from config
+        transientRetries: 0,
         run,
       });
 
@@ -1109,6 +1121,7 @@ describe("runWithModelFallback", () => {
         cfg,
         provider: "anthropic",
         model: "claude-opus-4-6", // Exact match
+        transientRetries: 0,
         run,
       });
 
@@ -1307,6 +1320,7 @@ describe("runWithModelFallback", () => {
         cfg,
         provider: "anthropic",
         model: "claude-opus-4-6",
+        transientRetries: 0,
         run,
         agentDir: tmpDir,
       });
@@ -1345,6 +1359,7 @@ describe("runWithModelFallback", () => {
         cfg,
         provider: "anthropic",
         model: "claude-opus-4-6",
+        transientRetries: 0,
         run,
         agentDir: dir,
       });
@@ -1397,6 +1412,271 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5", {
         allowTransientCooldownProbe: true,
       });
+    });
+  });
+
+  describe("transient error retry before failover", () => {
+    const originalSleep = _testHooks.sleep;
+    const sleepCalls: number[] = [];
+    beforeEach(() => {
+      sleepCalls.length = 0;
+      _testHooks.sleep = async (ms: number) => {
+        sleepCalls.push(ms);
+      };
+    });
+    afterEach(() => {
+      _testHooks.sleep = originalSleep;
+    });
+
+    it("retries same model on HTTP 408 timeout and succeeds on 2nd attempt", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("LLM request timed out", { reason: "timeout", status: 408 }),
+        )
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        transientRetries: 2,
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      // Should retry same model, not fall to the next candidate
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[0]).toEqual(["openai", "gpt-4.1-mini"]);
+      expect(run.mock.calls[1]).toEqual(["openai", "gpt-4.1-mini"]);
+      expect(result.provider).toBe("openai");
+      expect(result.model).toBe("gpt-4.1-mini");
+    });
+
+    it("retries same model on HTTP 429 rate limit and succeeds", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("Rate limit exceeded", { reason: "rate_limit", status: 429 }),
+        )
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        transientRetries: 2,
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[0]).toEqual(["openai", "gpt-4.1-mini"]);
+      expect(run.mock.calls[1]).toEqual(["openai", "gpt-4.1-mini"]);
+    });
+
+    it("retries same model on HTTP 503 overloaded and succeeds", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("Service overloaded", { reason: "overloaded", status: 503 }),
+        )
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        transientRetries: 2,
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[0]).toEqual(["openai", "gpt-4.1-mini"]);
+      expect(run.mock.calls[1]).toEqual(["openai", "gpt-4.1-mini"]);
+    });
+
+    it("exhausts transient retries then falls to next candidate", async () => {
+      const cfg = makeCfg();
+      const timeoutErr = new FailoverError("LLM request timed out", {
+        reason: "timeout",
+        status: 408,
+      });
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(timeoutErr) // 1st attempt
+        .mockRejectedValueOnce(timeoutErr) // 1st retry
+        .mockRejectedValueOnce(timeoutErr) // 2nd retry (exhausted)
+        .mockResolvedValueOnce("fallback ok"); // fallback candidate
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        transientRetries: 2,
+        run,
+      });
+
+      expect(result.result).toBe("fallback ok");
+      // 3 attempts on primary (1 + 2 retries), then 1 on fallback
+      expect(run).toHaveBeenCalledTimes(4);
+      expect(run.mock.calls[0]).toEqual(["openai", "gpt-4.1-mini"]);
+      expect(run.mock.calls[1]).toEqual(["openai", "gpt-4.1-mini"]);
+      expect(run.mock.calls[2]).toEqual(["openai", "gpt-4.1-mini"]);
+      expect(run.mock.calls[3]).toEqual(["anthropic", "claude-haiku-3-5"]);
+      expect(result.provider).toBe("anthropic");
+      expect(result.model).toBe("claude-haiku-3-5");
+    });
+
+    it("does not retry on permanent error (401 auth)", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("Invalid API key", { reason: "auth", status: 401 }),
+        )
+        .mockResolvedValueOnce("fallback ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        transientRetries: 2,
+        run,
+      });
+
+      expect(result.result).toBe("fallback ok");
+      // Should NOT retry — immediate failover
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[0]).toEqual(["openai", "gpt-4.1-mini"]);
+      expect(run.mock.calls[1]).toEqual(["anthropic", "claude-haiku-3-5"]);
+    });
+
+    it("does not retry on permanent error (404 model not found)", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("Model not found", { reason: "model_not_found", status: 404 }),
+        )
+        .mockResolvedValueOnce("fallback ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        transientRetries: 2,
+        run,
+      });
+
+      expect(result.result).toBe("fallback ok");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[0]).toEqual(["openai", "gpt-4.1-mini"]);
+      expect(run.mock.calls[1]).toEqual(["anthropic", "claude-haiku-3-5"]);
+    });
+
+    it("does not retry on format errors (400)", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("Invalid request format", { reason: "format", status: 400 }),
+        )
+        .mockResolvedValueOnce("fallback ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        transientRetries: 2,
+        run,
+      });
+
+      expect(result.result).toBe("fallback ok");
+      expect(run).toHaveBeenCalledTimes(2);
+    });
+
+    it("respects transientRetries: 0 to disable retries", async () => {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError("LLM request timed out", { reason: "timeout", status: 408 }),
+        )
+        .mockResolvedValueOnce("fallback ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        transientRetries: 0,
+        run,
+      });
+
+      expect(result.result).toBe("fallback ok");
+      // With retries disabled, should immediately fall to next candidate
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run.mock.calls[0]).toEqual(["openai", "gpt-4.1-mini"]);
+      expect(run.mock.calls[1]).toEqual(["anthropic", "claude-haiku-3-5"]);
+    });
+
+    it("uses default retry count when transientRetries is not specified", async () => {
+      expect(_transientRetryInternals.DEFAULT_TRANSIENT_RETRY_COUNT).toBe(2);
+    });
+
+    it("does not retry transient errors when there are no fallback candidates", async () => {
+      // Single model, no fallbacks — transient retry only applies when fallbacks exist
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-4.1-mini",
+              fallbacks: [],
+            },
+          },
+        },
+      });
+      const timeoutErr = new FailoverError("LLM request timed out", {
+        reason: "timeout",
+        status: 408,
+      });
+      const run = vi.fn().mockRejectedValueOnce(timeoutErr);
+
+      await expect(
+        runWithModelFallback({
+          cfg,
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          transientRetries: 2,
+          run,
+        }),
+      ).rejects.toThrow("LLM request timed out");
+
+      // Only 1 attempt — no retries when there are no fallback candidates
+      expect(run).toHaveBeenCalledTimes(1);
+    });
+
+    it("classifies timeout, rate_limit, and overloaded as transient", () => {
+      const { isTransientFailoverReason } = _transientRetryInternals;
+      expect(isTransientFailoverReason("timeout")).toBe(true);
+      expect(isTransientFailoverReason("rate_limit")).toBe(true);
+      expect(isTransientFailoverReason("overloaded")).toBe(true);
+    });
+
+    it("classifies auth, format, model_not_found, billing as non-transient", () => {
+      const { isTransientFailoverReason } = _transientRetryInternals;
+      expect(isTransientFailoverReason("auth")).toBe(false);
+      expect(isTransientFailoverReason("auth_permanent")).toBe(false);
+      expect(isTransientFailoverReason("format")).toBe(false);
+      expect(isTransientFailoverReason("model_not_found")).toBe(false);
+      expect(isTransientFailoverReason("billing")).toBe(false);
+      expect(isTransientFailoverReason("session_expired")).toBe(false);
+      expect(isTransientFailoverReason(null)).toBe(false);
+      expect(isTransientFailoverReason(undefined)).toBe(false);
     });
   });
 });

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1628,8 +1628,8 @@ describe("runWithModelFallback", () => {
       expect(_transientRetryInternals.DEFAULT_TRANSIENT_RETRY_COUNT).toBe(2);
     });
 
-    it("does not retry transient errors when there are no fallback candidates", async () => {
-      // Single model, no fallbacks — transient retry only applies when fallbacks exist
+    it("retries transient errors even when there are no fallback candidates", async () => {
+      // Single model, no fallbacks — transient retries still apply
       const cfg = makeCfg({
         agents: {
           defaults: {
@@ -1644,7 +1644,7 @@ describe("runWithModelFallback", () => {
         reason: "timeout",
         status: 408,
       });
-      const run = vi.fn().mockRejectedValueOnce(timeoutErr);
+      const run = vi.fn().mockRejectedValue(timeoutErr);
 
       await expect(
         runWithModelFallback({
@@ -1656,8 +1656,8 @@ describe("runWithModelFallback", () => {
         }),
       ).rejects.toThrow("LLM request timed out");
 
-      // Only 1 attempt — no retries when there are no fallback candidates
-      expect(run).toHaveBeenCalledTimes(1);
+      // 1 initial + 2 retries = 3 attempts total
+      expect(run).toHaveBeenCalledTimes(3);
     });
 
     it("classifies timeout, rate_limit, and overloaded as transient", () => {
@@ -1675,6 +1675,7 @@ describe("runWithModelFallback", () => {
       expect(isTransientFailoverReason("model_not_found")).toBe(false);
       expect(isTransientFailoverReason("billing")).toBe(false);
       expect(isTransientFailoverReason("session_expired")).toBe(false);
+      expect(isTransientFailoverReason("unknown")).toBe(false);
       expect(isTransientFailoverReason(null)).toBe(false);
       expect(isTransientFailoverReason(undefined)).toBe(false);
     });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -21,7 +21,6 @@ import {
 } from "./failover-error.js";
 import {
   shouldAllowCooldownProbeForReason,
-  shouldPreserveTransientCooldownProbeSlot,
   shouldUseTransientCooldownProbeSlot,
 } from "./failover-policy.js";
 import { logModelFallbackDecision } from "./model-fallback-observation.js";
@@ -38,6 +37,50 @@ import type { FailoverReason } from "./pi-embedded-helpers.js";
 import { isLikelyContextOverflowError } from "./pi-embedded-helpers.js";
 
 const log = createSubsystemLogger("model-fallback");
+
+/**
+ * Maximum number of retries for the same candidate on transient errors
+ * (e.g. HTTP 408 timeout, 429 rate-limit, 502/503/504 server errors)
+ * before falling over to the next candidate.
+ */
+const DEFAULT_TRANSIENT_RETRY_COUNT = 2;
+
+/** Backoff delays (ms) for successive transient retries on the same candidate. */
+const TRANSIENT_RETRY_BACKOFF_MS = [1_000, 2_000];
+
+/**
+ * Classify whether a failover reason represents a transient (retryable on
+ * same model) error vs. a permanent error that should immediately failover.
+ *
+ * Transient: timeout, rate_limit, overloaded, unknown
+ * Permanent: auth, auth_permanent, billing, format, model_not_found, session_expired
+ */
+function isTransientFailoverReason(reason: FailoverReason | null | undefined): boolean {
+  if (!reason) {
+    return false;
+  }
+  switch (reason) {
+    case "timeout":
+    case "rate_limit":
+    case "overloaded":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function resolveTransientRetryDelay(retryIndex: number): number {
+  return (
+    TRANSIENT_RETRY_BACKOFF_MS[retryIndex] ??
+    TRANSIENT_RETRY_BACKOFF_MS[TRANSIENT_RETRY_BACKOFF_MS.length - 1] ??
+    2_000
+  );
+}
+
+/** @internal – holder object so tests can override _sleep via the exported reference */
+export const _testHooks = {
+  sleep: (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)),
+};
 
 export type ModelFallbackRunOptions = {
   allowTransientCooldownProbe?: boolean;
@@ -412,6 +455,13 @@ function shouldProbePrimaryDuringCooldown(params: {
 }
 
 /** @internal – exposed for unit tests only */
+export const _transientRetryInternals = {
+  DEFAULT_TRANSIENT_RETRY_COUNT,
+  TRANSIENT_RETRY_BACKOFF_MS,
+  isTransientFailoverReason,
+} as const;
+
+/** @internal – exposed for unit tests only */
 export const _probeThrottleInternals = {
   lastProbeAttempt,
   MIN_PROBE_INTERVAL_MS,
@@ -521,6 +571,12 @@ export async function runWithModelFallback<T>(params: {
   agentDir?: string;
   /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
   fallbacksOverride?: string[];
+  /**
+   * Maximum number of retries on the same candidate for transient errors
+   * (timeout, rate-limit, overloaded) before falling over to the next
+   * candidate. Defaults to 2. Set to 0 to disable transient retries.
+   */
+  transientRetries?: number;
   run: ModelFallbackRunFn<T>;
   onError?: ModelFallbackErrorHandler;
 }): Promise<ModelFallbackRunResult<T>> {
@@ -655,101 +711,133 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
-    const attemptRun = await runFallbackAttempt({
-      run: params.run,
-      ...candidate,
-      attempts,
-      options: runOptions,
-    });
-    if ("success" in attemptRun) {
-      if (i > 0 || attempts.length > 0 || attemptedDuringCooldown) {
+    const maxTransientRetries = params.transientRetries ?? DEFAULT_TRANSIENT_RETRY_COUNT;
+    let candidateSucceeded = false;
+    for (let retryAttempt = 0; retryAttempt <= maxTransientRetries; retryAttempt += 1) {
+      const attemptRun = await runFallbackAttempt({
+        run: params.run,
+        ...candidate,
+        attempts,
+        options: runOptions,
+      });
+      if ("success" in attemptRun) {
+        if (i > 0 || attempts.length > 0 || attemptedDuringCooldown) {
+          logModelFallbackDecision({
+            decision: "candidate_succeeded",
+            runId: params.runId,
+            requestedProvider: params.provider,
+            requestedModel: params.model,
+            candidate,
+            attempt: i + 1,
+            total: candidates.length,
+            previousAttempts: attempts,
+            isPrimary,
+            requestedModelMatched: requestedModel,
+            fallbackConfigured: hasFallbackCandidates,
+          });
+        }
+        const notFoundAttempt =
+          i > 0 ? attempts.find((a) => a.reason === "model_not_found") : undefined;
+        if (notFoundAttempt) {
+          log.warn(
+            `Model "${sanitizeForLog(notFoundAttempt.provider)}/${sanitizeForLog(notFoundAttempt.model)}" not found. Fell back to "${sanitizeForLog(candidate.provider)}/${sanitizeForLog(candidate.model)}".`,
+          );
+        }
+        candidateSucceeded = true;
+        return attemptRun.success;
+      }
+      const err = attemptRun.error;
+      {
+        if (transientProbeProviderForAttempt) {
+          const probeFailureReason = describeFailoverError(err).reason;
+          const shouldPreserveTransientProbeSlot =
+            probeFailureReason === "model_not_found" ||
+            probeFailureReason === "format" ||
+            probeFailureReason === "auth" ||
+            probeFailureReason === "auth_permanent" ||
+            probeFailureReason === "session_expired";
+          if (!shouldPreserveTransientProbeSlot) {
+            cooldownProbeUsedProviders.add(transientProbeProviderForAttempt);
+          }
+        }
+        // Context overflow errors should be handled by the inner runner's
+        // compaction/retry logic, not by model fallback.  If one escapes as a
+        // throw, rethrow it immediately rather than trying a different model
+        // that may have a smaller context window and fail worse.
+        const errMessage = err instanceof Error ? err.message : String(err);
+        if (isLikelyContextOverflowError(errMessage)) {
+          throw err;
+        }
+        const normalized =
+          coerceToFailoverError(err, {
+            provider: candidate.provider,
+            model: candidate.model,
+          }) ?? err;
+
+        // Check if this is a transient error that should be retried on the same candidate.
+        // Only retry if we haven't exhausted our retry budget for this candidate.
+        const errorReason = describeFailoverError(normalized).reason ?? null;
+        if (
+          isTransientFailoverReason(errorReason) &&
+          retryAttempt < maxTransientRetries &&
+          hasFallbackCandidates
+        ) {
+          const delayMs = resolveTransientRetryDelay(retryAttempt);
+          log.info(
+            `Transient error (${errorReason}) on ${candidate.provider}/${candidate.model}, retrying in ${delayMs}ms (attempt ${retryAttempt + 1}/${maxTransientRetries})`,
+          );
+          await _testHooks.sleep(delayMs);
+          continue;
+        }
+
+        // Even unrecognized errors should not abort the fallback loop when
+        // there are remaining candidates.  Only abort/context-overflow errors
+        // (handled above) are truly non-retryable.
+        const isKnownFailover = isFailoverError(normalized);
+        if (!isKnownFailover && i === candidates.length - 1) {
+          throw err;
+        }
+
+        lastError = isKnownFailover ? normalized : err;
+        const described = describeFailoverError(normalized);
+        attempts.push({
+          provider: candidate.provider,
+          model: candidate.model,
+          error: described.message,
+          reason: described.reason ?? "unknown",
+          status: described.status,
+          code: described.code,
+        });
         logModelFallbackDecision({
-          decision: "candidate_succeeded",
+          decision: "candidate_failed",
           runId: params.runId,
           requestedProvider: params.provider,
           requestedModel: params.model,
           candidate,
           attempt: i + 1,
           total: candidates.length,
-          previousAttempts: attempts,
+          reason: described.reason,
+          status: described.status,
+          code: described.code,
+          error: described.message,
+          nextCandidate: candidates[i + 1],
           isPrimary,
           requestedModelMatched: requestedModel,
           fallbackConfigured: hasFallbackCandidates,
         });
-      }
-      const notFoundAttempt =
-        i > 0 ? attempts.find((a) => a.reason === "model_not_found") : undefined;
-      if (notFoundAttempt) {
-        log.warn(
-          `Model "${sanitizeForLog(notFoundAttempt.provider)}/${sanitizeForLog(notFoundAttempt.model)}" not found. Fell back to "${sanitizeForLog(candidate.provider)}/${sanitizeForLog(candidate.model)}".`,
-        );
-      }
-      return attemptRun.success;
-    }
-    const err = attemptRun.error;
-    {
-      if (transientProbeProviderForAttempt) {
-        const probeFailureReason = describeFailoverError(err).reason;
-        if (!shouldPreserveTransientCooldownProbeSlot(probeFailureReason)) {
-          cooldownProbeUsedProviders.add(transientProbeProviderForAttempt);
-        }
-      }
-      // Context overflow errors should be handled by the inner runner's
-      // compaction/retry logic, not by model fallback.  If one escapes as a
-      // throw, rethrow it immediately rather than trying a different model
-      // that may have a smaller context window and fail worse.
-      const errMessage = err instanceof Error ? err.message : String(err);
-      if (isLikelyContextOverflowError(errMessage)) {
-        throw err;
-      }
-      const normalized =
-        coerceToFailoverError(err, {
+        await params.onError?.({
           provider: candidate.provider,
           model: candidate.model,
-        }) ?? err;
-
-      // Even unrecognized errors should not abort the fallback loop when
-      // there are remaining candidates.  Only abort/context-overflow errors
-      // (handled above) are truly non-retryable.
-      const isKnownFailover = isFailoverError(normalized);
-      if (!isKnownFailover && i === candidates.length - 1) {
-        throw err;
+          error: isKnownFailover ? normalized : err,
+          attempt: i + 1,
+          total: candidates.length,
+        });
+        // Break out of retry loop — either permanent error or retries exhausted.
+        break;
       }
-
-      lastError = isKnownFailover ? normalized : err;
-      const described = describeFailoverError(normalized);
-      attempts.push({
-        provider: candidate.provider,
-        model: candidate.model,
-        error: described.message,
-        reason: described.reason ?? "unknown",
-        status: described.status,
-        code: described.code,
-      });
-      logModelFallbackDecision({
-        decision: "candidate_failed",
-        runId: params.runId,
-        requestedProvider: params.provider,
-        requestedModel: params.model,
-        candidate,
-        attempt: i + 1,
-        total: candidates.length,
-        reason: described.reason,
-        status: described.status,
-        code: described.code,
-        error: described.message,
-        nextCandidate: candidates[i + 1],
-        isPrimary,
-        requestedModelMatched: requestedModel,
-        fallbackConfigured: hasFallbackCandidates,
-      });
-      await params.onError?.({
-        provider: candidate.provider,
-        model: candidate.model,
-        error: isKnownFailover ? normalized : err,
-        attempt: i + 1,
-        total: candidates.length,
-      });
+    } // end transient retry loop
+    if (candidateSucceeded) {
+      break;
     }
   }
 

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -52,8 +52,8 @@ const TRANSIENT_RETRY_BACKOFF_MS = [1_000, 2_000];
  * Classify whether a failover reason represents a transient (retryable on
  * same model) error vs. a permanent error that should immediately failover.
  *
- * Transient: timeout, rate_limit, overloaded, unknown
- * Permanent: auth, auth_permanent, billing, format, model_not_found, session_expired
+ * Transient: timeout, rate_limit, overloaded
+ * Permanent: auth, auth_permanent, billing, format, model_not_found, session_expired, unknown
  */
 function isTransientFailoverReason(reason: FailoverReason | null | undefined): boolean {
   if (!reason) {
@@ -712,7 +712,6 @@ export async function runWithModelFallback<T>(params: {
     }
 
     const maxTransientRetries = params.transientRetries ?? DEFAULT_TRANSIENT_RETRY_COUNT;
-    let candidateSucceeded = false;
     for (let retryAttempt = 0; retryAttempt <= maxTransientRetries; retryAttempt += 1) {
       const attemptRun = await runFallbackAttempt({
         run: params.run,
@@ -743,7 +742,6 @@ export async function runWithModelFallback<T>(params: {
             `Model "${sanitizeForLog(notFoundAttempt.provider)}/${sanitizeForLog(notFoundAttempt.model)}" not found. Fell back to "${sanitizeForLog(candidate.provider)}/${sanitizeForLog(candidate.model)}".`,
           );
         }
-        candidateSucceeded = true;
         return attemptRun.success;
       }
       const err = attemptRun.error;
@@ -777,11 +775,7 @@ export async function runWithModelFallback<T>(params: {
         // Check if this is a transient error that should be retried on the same candidate.
         // Only retry if we haven't exhausted our retry budget for this candidate.
         const errorReason = describeFailoverError(normalized).reason ?? null;
-        if (
-          isTransientFailoverReason(errorReason) &&
-          retryAttempt < maxTransientRetries &&
-          hasFallbackCandidates
-        ) {
+        if (isTransientFailoverReason(errorReason) && retryAttempt < maxTransientRetries) {
           const delayMs = resolveTransientRetryDelay(retryAttempt);
           log.info(
             `Transient error (${errorReason}) on ${candidate.provider}/${candidate.model}, retrying in ${delayMs}ms (attempt ${retryAttempt + 1}/${maxTransientRetries})`,
@@ -836,9 +830,6 @@ export async function runWithModelFallback<T>(params: {
         break;
       }
     } // end transient retry loop
-    if (candidateSucceeded) {
-      break;
-    }
   }
 
   throwFallbackFailureSummary({

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -500,6 +500,55 @@ describe("createFollowupRunner messaging tool dedupe", () => {
     expect(onBlockReply).not.toHaveBeenCalled();
   });
 
+  it("does not dedupe text for cross-target messaging sends", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ text: "hello world!" }],
+        messagingToolSentTexts: ["hello world!"],
+        messagingToolSentTargets: [{ tool: "discord", provider: "discord", to: "channel:D1" }],
+      },
+      queued: {
+        ...baseQueuedRun("telegram"),
+        originatingChannel: "telegram",
+        originatingTo: "268300329",
+      } as FollowupRun,
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    // Reply is routed to originating channel, not suppressed by cross-target text dedup.
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "268300329",
+      }),
+    );
+  });
+
+  it("does not dedupe media for cross-target messaging sends", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ text: "photo", mediaUrl: "/tmp/img.png" }],
+        messagingToolSentMediaUrls: ["/tmp/img.png"],
+        messagingToolSentTargets: [{ tool: "discord", provider: "discord", to: "channel:D1" }],
+      },
+      queued: {
+        ...baseQueuedRun("telegram"),
+        originatingChannel: "telegram",
+        originatingTo: "268300329",
+      } as FollowupRun,
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          text: "photo",
+          mediaUrl: "/tmp/img.png",
+        }),
+      }),
+    );
+  });
+
   it("drops media URL from payload when messaging tool already sent it", async () => {
     const { onBlockReply } = await runMessagingCase({
       agentResult: {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -366,20 +366,13 @@ export function createFollowupRunner(params: {
         filterMessagingToolMediaDuplicates,
         shouldSuppressMessagingToolReplies,
       } = await loadReplyPayloadsRuntime();
-      const dedupedPayloads = filterMessagingToolDuplicates({
-        payloads: replyTaggedPayloads,
-        sentTexts: runResult.messagingToolSentTexts ?? [],
-      });
-      const mediaFilteredPayloads = filterMessagingToolMediaDuplicates({
-        payloads: dedupedPayloads,
-        sentMediaUrls: runResult.messagingToolSentMediaUrls ?? [],
-      });
+      const messagingToolSentTargets = runResult.messagingToolSentTargets ?? [];
       const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({
         messageProvider: resolveOriginMessageProvider({
           originatingChannel: queued.originatingChannel,
           provider: queued.run.messageProvider,
         }),
-        messagingToolSentTargets: runResult.messagingToolSentTargets,
+        messagingToolSentTargets,
         originatingTo: resolveOriginMessageTo({
           originatingTo: queued.originatingTo,
         }),
@@ -388,7 +381,29 @@ export function createFollowupRunner(params: {
           accountId: queued.run.agentAccountId,
         }),
       });
+      // Only dedupe against messaging tool sends for the same origin target.
+      // Cross-target sends (e.g. posting to another channel) must not
+      // suppress the current conversation's final reply.
+      // If target metadata is unavailable, keep legacy dedupe behavior.
+      const dedupeMessagingToolPayloads =
+        suppressMessagingToolReplies || messagingToolSentTargets.length === 0;
+      const dedupedPayloads = dedupeMessagingToolPayloads
+        ? filterMessagingToolDuplicates({
+            payloads: replyTaggedPayloads,
+            sentTexts: runResult.messagingToolSentTexts ?? [],
+          })
+        : replyTaggedPayloads;
+      const mediaFilteredPayloads = dedupeMessagingToolPayloads
+        ? filterMessagingToolMediaDuplicates({
+            payloads: dedupedPayloads,
+            sentMediaUrls: runResult.messagingToolSentMediaUrls ?? [],
+          })
+        : dedupedPayloads;
       let finalPayloads = suppressMessagingToolReplies ? [] : mediaFilteredPayloads;
+
+      if (finalPayloads.length === 0) {
+        return;
+      }
 
       if (autoCompactionCount > 0) {
         const count = await incrementRunCompactionCount({

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -34,6 +34,7 @@ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { throwIfAborted } from "./abort.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
+import { deliverySerializer } from "./delivery-serializer.js";
 import type { OutboundIdentity } from "./identity.js";
 import type { DeliveryMirror } from "./mirror.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
@@ -517,8 +518,14 @@ export async function deliverOutboundPayloads(
       }
     : params;
 
+  // Serialize deliveries to the same channel+account+recipient so concurrent
+  // sessions (e.g. main + sub-agent) don't interleave messages.
+  const serializerKey = `${channel}:${params.accountId ?? "default"}:${to}`;
+
   try {
-    const results = await deliverOutboundPayloadsCore(wrappedParams);
+    const results = await deliverySerializer.serialize(serializerKey, () =>
+      deliverOutboundPayloadsCore(wrappedParams),
+    );
     if (queueId) {
       if (hadPartialFailure) {
         await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(() => {});

--- a/src/infra/outbound/delivery-serializer.test.ts
+++ b/src/infra/outbound/delivery-serializer.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { DeliverySerializer } from "./delivery-serializer.js";
+
+describe("DeliverySerializer", () => {
+  it("serializes two sends to the same target in order", async () => {
+    const serializer = new DeliverySerializer();
+    const order: number[] = [];
+
+    const p1 = serializer.serialize("key", async () => {
+      await delay(50);
+      order.push(1);
+      return "a";
+    });
+    const p2 = serializer.serialize("key", async () => {
+      order.push(2);
+      return "b";
+    });
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(order).toEqual([1, 2]);
+    expect(r1).toBe("a");
+    expect(r2).toBe("b");
+  });
+
+  it("allows different targets to run concurrently", async () => {
+    const serializer = new DeliverySerializer();
+    const timeline: string[] = [];
+
+    const p1 = serializer.serialize("a", async () => {
+      timeline.push("a-start");
+      await delay(50);
+      timeline.push("a-end");
+    });
+    const p2 = serializer.serialize("b", async () => {
+      timeline.push("b-start");
+      await delay(50);
+      timeline.push("b-end");
+    });
+
+    await Promise.all([p1, p2]);
+    // Both should start before either ends (concurrent)
+    expect(timeline.indexOf("a-start")).toBeLessThan(timeline.indexOf("a-end"));
+    expect(timeline.indexOf("b-start")).toBeLessThan(timeline.indexOf("b-end"));
+    expect(timeline.indexOf("b-start")).toBeLessThan(timeline.indexOf("a-end"));
+  });
+
+  it("runs second task even if first fails", async () => {
+    const serializer = new DeliverySerializer();
+
+    const p1 = serializer.serialize("key", async () => {
+      throw new Error("boom");
+    });
+    const p2 = serializer.serialize("key", async () => "ok");
+
+    await expect(p1).rejects.toThrow("boom");
+    expect(await p2).toBe("ok");
+  });
+
+  it("cleans up keys when queue drains", async () => {
+    const serializer = new DeliverySerializer();
+
+    await serializer.serialize("key", async () => "done");
+    expect(serializer.size).toBe(0);
+  });
+
+  it("serializes 10 concurrent sends in order", async () => {
+    const serializer = new DeliverySerializer();
+    const order: number[] = [];
+
+    const promises = Array.from({ length: 10 }, (_, i) =>
+      serializer.serialize("key", async () => {
+        // Random tiny delay to stress ordering
+        await delay(Math.random() * 10);
+        order.push(i);
+        return i;
+      }),
+    );
+
+    const results = await Promise.all(promises);
+    expect(order).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(results).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(serializer.size).toBe(0);
+  });
+});
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/infra/outbound/delivery-serializer.test.ts
+++ b/src/infra/outbound/delivery-serializer.test.ts
@@ -86,3 +86,16 @@ describe("DeliverySerializer", () => {
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+it("handles synchronous throw from fn without hanging", async () => {
+  const serializer = new DeliverySerializer();
+
+  const p1 = serializer.serialize("key", () => {
+    throw new Error("sync boom");
+  });
+  const p2 = serializer.serialize("key", async () => "after-sync-throw");
+
+  await expect(p1).rejects.toThrow("sync boom");
+  expect(await p2).toBe("after-sync-throw");
+  expect(serializer.size).toBe(0);
+});

--- a/src/infra/outbound/delivery-serializer.ts
+++ b/src/infra/outbound/delivery-serializer.ts
@@ -22,26 +22,21 @@ export class DeliverySerializer {
 
     // Chain after previous delivery settles (success or failure).
     // The tail always resolves so one failure doesn't stall the queue.
-    const tail: Promise<void> = prev.then(
-      () =>
-        fn().then(
+    // Wrap fn() in Promise.resolve().then() so a synchronous throw is
+    // converted to a rejection — ensures resolve/reject are always called.
+    const runFn = () =>
+      Promise.resolve()
+        .then(() => fn())
+        .then(
           (v) => {
             resolve(v);
           },
           (e) => {
             reject(e);
           },
-        ),
-      () =>
-        fn().then(
-          (v) => {
-            resolve(v);
-          },
-          (e) => {
-            reject(e);
-          },
-        ),
-    );
+        );
+
+    const tail: Promise<void> = prev.then(runFn, runFn);
 
     this.queues.set(key, tail);
 

--- a/src/infra/outbound/delivery-serializer.ts
+++ b/src/infra/outbound/delivery-serializer.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-channel+recipient delivery mutex.
+ *
+ * Ensures concurrent deliveries to the same target (channel:accountId:recipient)
+ * are serialized in FIFO order, while different targets remain fully concurrent.
+ * In-memory only — this is for runtime ordering, not persistence.
+ */
+
+export class DeliverySerializer {
+  private queues = new Map<string, Promise<void>>();
+
+  /** Queue `fn` behind any pending delivery for the same key. */
+  async serialize<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.queues.get(key) ?? Promise.resolve();
+
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const resultPromise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    // Chain after previous delivery settles (success or failure).
+    // The tail always resolves so one failure doesn't stall the queue.
+    const tail: Promise<void> = prev.then(
+      () =>
+        fn().then(
+          (v) => {
+            resolve(v);
+          },
+          (e) => {
+            reject(e);
+          },
+        ),
+      () =>
+        fn().then(
+          (v) => {
+            resolve(v);
+          },
+          (e) => {
+            reject(e);
+          },
+        ),
+    );
+
+    this.queues.set(key, tail);
+
+    try {
+      return await resultPromise;
+    } finally {
+      // Auto-cleanup: if our tail is still the latest, the queue is drained.
+      if (this.queues.get(key) === tail) {
+        this.queues.delete(key);
+      }
+    }
+  }
+
+  /** Number of active keys (for testing / diagnostics). */
+  get size(): number {
+    return this.queues.size;
+  }
+}
+
+/** Singleton used by the outbound delivery path. */
+export const deliverySerializer = new DeliverySerializer();


### PR DESCRIPTION
## Summary

When an agent uses a messaging tool to send to a *different* channel (e.g. posts to Discord while the conversation originates on Telegram), the followup runner's text/media dedup incorrectly suppresses matching content from the conversation reply. The user on Telegram never sees the reply — it was silently dropped because the dedup filters matched the text/media already sent to Discord.

**Reproduction:** Configure an agent with a messaging tool that sends to Discord. Start a conversation on Telegram. If the agent sends "hello world" to Discord and also wants to reply "hello world" to the Telegram conversation, the Telegram reply is suppressed.

**Fix:** Guards `filterMessagingToolDuplicates` and `filterMessagingToolMediaDuplicates` behind a cross-target check — dedup only runs when the messaging tool sent to the *same* origin target, or when target metadata is unavailable (legacy fallback). This aligns `followup-runner.ts` with the same pattern already used in `agent-runner-payloads.ts` via `dedupeMessagingToolPayloads`.

Also moves `suppressMessagingToolReplies` computation earlier so the dedup flag can reference it.

Includes tests for both cross-target text and media non-suppression.

Rebased to 2026.3.13.
