### PR TITLE
fix: broadcast GatewayRestart system event to all active agent sessions

### DIFF
--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -1,8 +1,12 @@
+import { listAgentIds } from "../agents/agent-scope.js";
 import { resolveAnnounceTargetFromKey } from "../agents/tools/sessions-send-helpers.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { CliDeps } from "../cli/deps.js";
+import { loadConfig } from "../config/config.js";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import { parseSessionThreadInfo } from "../config/sessions/delivery-info.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { loadSessionStore } from "../config/sessions/store.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
@@ -12,6 +16,7 @@ import {
   summarizeRestartSentinel,
 } from "../infra/restart-sentinel.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
+import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { deliveryContextFromSession, mergeDeliveryContext } from "../utils/delivery-context.js";
 import { loadSessionEntry } from "./session-utils.js";
 
@@ -102,6 +107,75 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
     });
   } catch (err) {
     enqueueSystemEvent(`${summary}\n${String(err)}`, { sessionKey });
+  }
+
+  // Inject a system event into all recently active agent sessions so they
+  // can resume interrupted work.  The outbound delivery above notifies the
+  // *human* on the triggering session's channel; this notifies *agents*.
+  // Without it agents go silent after restarts until someone messages them,
+  // even though AGENTS.md tells them to read active-tasks.md and resume
+  // autonomously on GatewayRestart.
+  wakeRecentlyActiveSessions(message, sessionKey, payload.ts);
+}
+
+/**
+ * Inject a GatewayRestart system event into sessions that were likely
+ * mid-turn when the restart happened.  Uses a 60-second window before
+ * the sentinel timestamp: any session whose lastActiveMs falls within
+ * that window was probably processing a request when interrupted.
+ *
+ * The triggering session is always included regardless of timing.
+ */
+function wakeRecentlyActiveSessions(
+  message: string,
+  triggeringSessionKey: string,
+  restartTimestamp: number,
+) {
+  const ACTIVE_WINDOW_MS = 60 * 1000; // 60 seconds before restart
+  const cutoff = restartTimestamp - ACTIVE_WINDOW_MS;
+  const notified = new Set<string>();
+
+  // Always notify the triggering session
+  enqueueSystemEvent(message, { sessionKey: triggeringSessionKey });
+  notified.add(triggeringSessionKey);
+
+  try {
+    const cfg = loadConfig();
+    const agentIds = listAgentIds(cfg);
+    const storeCfg = cfg.session?.store;
+
+    for (const agentId of agentIds) {
+      const storePath = resolveStorePath(storeCfg, { agentId });
+      let store: Record<string, { lastActiveMs?: number }>;
+      try {
+        store = loadSessionStore(storePath) as Record<string, { lastActiveMs?: number }>;
+      } catch {
+        continue; // Store file missing or corrupt — skip this agent
+      }
+
+      for (const [key, entry] of Object.entries(store)) {
+        if (notified.has(key)) {
+          continue;
+        }
+        if (isCronRunSessionKey(key)) {
+          continue;
+        }
+        if (key === "global" || key === "unknown") {
+          continue;
+        }
+
+        // Wake sessions active within 60s before the restart — they were
+        // likely mid-turn when the process went down.
+        const lastActive = entry?.lastActiveMs ?? 0;
+        if (lastActive >= cutoff && lastActive <= restartTimestamp) {
+          enqueueSystemEvent(message, { sessionKey: key });
+          notified.add(key);
+        }
+      }
+    }
+  } catch {
+    // Config or store enumeration failed — at minimum the triggering
+    // session was already notified above, so this is best-effort.
   }
 }
 

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -33,6 +33,7 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
   if (!sessionKey) {
     const mainSessionKey = resolveMainSessionKeyFromConfig();
     enqueueSystemEvent(message, { sessionKey: mainSessionKey });
+    wakeRecentlyActiveSessions(message, mainSessionKey, payload.ts);
     return;
   }
 
@@ -60,6 +61,7 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
   const to = origin?.to;
   if (!channel || !to) {
     enqueueSystemEvent(message, { sessionKey });
+    wakeRecentlyActiveSessions(message, sessionKey, payload.ts);
     return;
   }
 
@@ -72,6 +74,7 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
   });
   if (!resolved.ok) {
     enqueueSystemEvent(message, { sessionKey });
+    wakeRecentlyActiveSessions(message, sessionKey, payload.ts);
     return;
   }
 

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -124,7 +124,7 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
 /**
  * Inject a GatewayRestart system event into sessions that were likely
  * mid-turn when the restart happened.  Uses a 60-second window before
- * the sentinel timestamp: any session whose lastActiveMs falls within
+ * the sentinel timestamp: any session whose lastActiveMs/updatedAt falls within
  * that window was probably processing a request when interrupted.
  *
  * The triggering session is always included regardless of timing.
@@ -149,9 +149,12 @@ function wakeRecentlyActiveSessions(
 
     for (const agentId of agentIds) {
       const storePath = resolveStorePath(storeCfg, { agentId });
-      let store: Record<string, { lastActiveMs?: number }>;
+      let store: Record<string, { lastActiveMs?: number; updatedAt?: number }>;
       try {
-        store = loadSessionStore(storePath) as Record<string, { lastActiveMs?: number }>;
+        store = loadSessionStore(storePath) as Record<
+          string,
+          { lastActiveMs?: number; updatedAt?: number }
+        >;
       } catch {
         continue; // Store file missing or corrupt — skip this agent
       }
@@ -169,7 +172,9 @@ function wakeRecentlyActiveSessions(
 
         // Wake sessions active within 60s before the restart — they were
         // likely mid-turn when the process went down.
-        const lastActive = entry?.lastActiveMs ?? 0;
+        // Session stores use `updatedAt` (not `lastActiveMs`) as their
+        // activity timestamp, so check both for forward-compatibility.
+        const lastActive = entry?.lastActiveMs ?? entry?.updatedAt ?? 0;
         if (lastActive >= cutoff && lastActive <= restartTimestamp) {
           enqueueSystemEvent(message, { sessionKey: key });
           notified.add(key);


### PR DESCRIPTION
## Problem

The restart sentinel delivers an outbound notification to the channel (notifying the human) but never injects a `GatewayRestart` system event into agent sessions. The `enqueueSystemEvent` call only exists as a fallback when outbound delivery fails.

This means agents go silent after restarts until someone messages them, even though the system prompt instructs them to read `active-tasks.md` and resume work autonomously on `GatewayRestart`.

## Fix

After the outbound channel delivery, enumerate all agent session stores and inject the `GatewayRestart` system event into:

1. **The triggering session** — always, regardless of timing
2. **Any session active within 60 seconds before the restart timestamp** — these were likely mid-turn when the process went down

Cron run sessions, `global`, and `unknown` pseudo-sessions are skipped. The entire enumeration is wrapped in try/catch so failures are best-effort (the triggering session is always notified first).

## Why 60 seconds?

- Too wide (e.g., 1 hour) would wake agents that finished their work and cause unnecessary token spend
- Too narrow would miss agents in the middle of multi-step tool call sequences  
- 60 seconds catches sessions that were actively processing when the restart hit
- A `turnStartedAt` field in the session store would be more precise but adds a disk write per turn start — overkill for a relatively rare event

## Changes

- `src/gateway/server-restart-sentinel.ts` — added `wakeRecentlyActiveSessions()` helper, new imports for session store enumeration