### PR TITLE
feat(media): add MiniMax coding_plan native image fallback (non-MCP)

### DIFF
--- a/src/media-understanding/runner.resolve-auto-image-model.test.ts
+++ b/src/media-understanding/runner.resolve-auto-image-model.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const resolveApiKeyForProviderMock = vi.fn(async () => "ok");
+const loadModelCatalogMock = vi.fn(async () => []);
+const findModelInCatalogMock = vi.fn(
+  (
+    catalog: Array<{ provider: string; id: string; input?: string[] }>,
+    provider: string,
+    modelId: string,
+  ) =>
+    catalog.find(
+      (entry) =>
+        entry.provider.toLowerCase() === provider.toLowerCase() &&
+        entry.id.toLowerCase() === modelId.toLowerCase(),
+    ),
+);
+const modelSupportsVisionMock = vi.fn(
+  (entry: { input?: string[] } | undefined) => entry?.input?.includes("image") ?? false,
+);
+
+vi.mock("../agents/model-auth.js", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+vi.mock("../agents/model-catalog.js", () => ({
+  findModelInCatalog: findModelInCatalogMock,
+  loadModelCatalog: loadModelCatalogMock,
+  modelSupportsVision: modelSupportsVisionMock,
+}));
+
+describe("resolveAutoImageModel", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("falls back to provider default image model when active model is text-only", async () => {
+    loadModelCatalogMock.mockResolvedValue([
+      { provider: "minimax-portal", id: "MiniMax-M2.5", input: ["text"] },
+      { provider: "minimax-portal", id: "MiniMax-VL-01", input: ["text", "image"] },
+    ]);
+
+    const { resolveAutoImageModel } = await import("./runner.js");
+    const resolved = await resolveAutoImageModel({
+      cfg: {} as never,
+      activeModel: { provider: "minimax-portal", model: "MiniMax-M2.5" },
+    });
+
+    expect(resolved).toEqual({ provider: "minimax-portal", model: "MiniMax-VL-01" });
+  });
+
+  it("keeps active model when catalog has no model metadata", async () => {
+    loadModelCatalogMock.mockResolvedValue([]);
+
+    const { resolveAutoImageModel } = await import("./runner.js");
+    const resolved = await resolveAutoImageModel({
+      cfg: {} as never,
+      activeModel: { provider: "minimax-portal", model: "unknown-model-id" },
+    });
+
+    expect(resolved).toEqual({ provider: "minimax-portal", model: "unknown-model-id" });
+  });
+});

--- a/src/media-understanding/runner.resolve-auto-image-model.test.ts
+++ b/src/media-understanding/runner.resolve-auto-image-model.test.ts
@@ -32,8 +32,13 @@ describe("resolveAutoImageModel", () => {
 
   it("falls back to provider default image model when active model is text-only", async () => {
     loadModelCatalogMock.mockResolvedValue([
-      { provider: "minimax-portal", id: "MiniMax-M2.5", input: ["text"] },
-      { provider: "minimax-portal", id: "MiniMax-VL-01", input: ["text", "image"] },
+      { provider: "minimax-portal", id: "MiniMax-M2.5", name: "MiniMax-M2.5", input: ["text"] },
+      {
+        provider: "minimax-portal",
+        id: "MiniMax-VL-01",
+        name: "MiniMax-VL-01",
+        input: ["text", "image"],
+      },
     ]);
 
     const { resolveAutoImageModel } = await import("./runner.js");
@@ -47,7 +52,12 @@ describe("resolveAutoImageModel", () => {
 
   it("keeps active model when catalog confirms it supports vision", async () => {
     loadModelCatalogMock.mockResolvedValue([
-      { provider: "minimax-portal", id: "MiniMax-VL-01", input: ["text", "image"] },
+      {
+        provider: "minimax-portal",
+        id: "MiniMax-VL-01",
+        name: "MiniMax-VL-01",
+        input: ["text", "image"],
+      },
     ]);
 
     const { resolveAutoImageModel } = await import("./runner.js");
@@ -72,7 +82,9 @@ describe("resolveAutoImageModel", () => {
   });
 
   it("keeps active model when catalog entry exists but input capability metadata is missing", async () => {
-    loadModelCatalogMock.mockResolvedValue([{ provider: "minimax-portal", id: "MiniMax-M2.5" }]);
+    loadModelCatalogMock.mockResolvedValue([
+      { provider: "minimax-portal", id: "MiniMax-M2.5", name: "MiniMax-M2.5" },
+    ]);
 
     const { resolveAutoImageModel } = await import("./runner.js");
     const resolved = await resolveAutoImageModel({

--- a/src/media-understanding/runner.resolve-auto-image-model.test.ts
+++ b/src/media-understanding/runner.resolve-auto-image-model.test.ts
@@ -30,7 +30,7 @@ vi.mock("../agents/model-catalog.js", () => ({
 
 describe("resolveAutoImageModel", () => {
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it("falls back to provider default image model when active model is text-only", async () => {

--- a/src/media-understanding/runner.resolve-auto-image-model.test.ts
+++ b/src/media-understanding/runner.resolve-auto-image-model.test.ts
@@ -1,13 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { type ModelCatalogEntry } from "../agents/model-catalog.js";
 
 const resolveApiKeyForProviderMock = vi.fn(async () => "ok");
-const loadModelCatalogMock = vi.fn(async () => []);
+const loadModelCatalogMock = vi.fn<() => Promise<ModelCatalogEntry[]>>(async () => []);
 const findModelInCatalogMock = vi.fn(
-  (
-    catalog: Array<{ provider: string; id: string; input?: string[] }>,
-    provider: string,
-    modelId: string,
-  ) =>
+  (catalog: ModelCatalogEntry[], provider: string, modelId: string) =>
     catalog.find(
       (entry) =>
         entry.provider.toLowerCase() === provider.toLowerCase() &&

--- a/src/media-understanding/runner.resolve-auto-image-model.test.ts
+++ b/src/media-understanding/runner.resolve-auto-image-model.test.ts
@@ -59,4 +59,16 @@ describe("resolveAutoImageModel", () => {
 
     expect(resolved).toEqual({ provider: "minimax-portal", model: "unknown-model-id" });
   });
+
+  it("keeps active model when catalog entry exists but input capability metadata is missing", async () => {
+    loadModelCatalogMock.mockResolvedValue([{ provider: "minimax-portal", id: "MiniMax-M2.5" }]);
+
+    const { resolveAutoImageModel } = await import("./runner.js");
+    const resolved = await resolveAutoImageModel({
+      cfg: {} as never,
+      activeModel: { provider: "minimax-portal", model: "MiniMax-M2.5" },
+    });
+
+    expect(resolved).toEqual({ provider: "minimax-portal", model: "MiniMax-M2.5" });
+  });
 });

--- a/src/media-understanding/runner.resolve-auto-image-model.test.ts
+++ b/src/media-understanding/runner.resolve-auto-image-model.test.ts
@@ -94,4 +94,18 @@ describe("resolveAutoImageModel", () => {
 
     expect(resolved).toEqual({ provider: "minimax-portal", model: "MiniMax-M2.5" });
   });
+
+  it("keeps requested model when a text-only provider has no default image fallback", async () => {
+    loadModelCatalogMock.mockResolvedValue([
+      { provider: "moonshot", id: "kimi-k2", name: "Kimi K2", input: ["text"] },
+    ]);
+
+    const { resolveAutoImageModel } = await import("./runner.js");
+    const resolved = await resolveAutoImageModel({
+      cfg: {} as never,
+      activeModel: { provider: "moonshot", model: "kimi-k2" },
+    });
+
+    expect(resolved).toEqual({ provider: "moonshot", model: "kimi-k2" });
+  });
 });

--- a/src/media-understanding/runner.resolve-auto-image-model.test.ts
+++ b/src/media-understanding/runner.resolve-auto-image-model.test.ts
@@ -48,6 +48,20 @@ describe("resolveAutoImageModel", () => {
     expect(resolved).toEqual({ provider: "minimax-portal", model: "MiniMax-VL-01" });
   });
 
+  it("keeps active model when catalog confirms it supports vision", async () => {
+    loadModelCatalogMock.mockResolvedValue([
+      { provider: "minimax-portal", id: "MiniMax-VL-01", input: ["text", "image"] },
+    ]);
+
+    const { resolveAutoImageModel } = await import("./runner.js");
+    const resolved = await resolveAutoImageModel({
+      cfg: {} as never,
+      activeModel: { provider: "minimax-portal", model: "MiniMax-VL-01" },
+    });
+
+    expect(resolved).toEqual({ provider: "minimax-portal", model: "MiniMax-VL-01" });
+  });
+
   it("keeps active model when catalog has no model metadata", async () => {
     loadModelCatalogMock.mockResolvedValue([]);
 

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -370,10 +370,31 @@ async function resolveKeyEntry(params: {
     }
   };
 
+  const resolvePreferredImageModel = async (
+    providerId: string,
+    requestedModel?: string,
+  ): Promise<string | undefined> => {
+    const requested = requestedModel?.trim();
+    if (!requested) {
+      return DEFAULT_IMAGE_MODELS[providerId];
+    }
+
+    const catalog = await loadModelCatalog({ config: cfg });
+    const entry = findModelInCatalog(catalog, providerId, requested);
+    if (entry && !modelSupportsVision(entry)) {
+      return DEFAULT_IMAGE_MODELS[providerId];
+    }
+    return requested;
+  };
+
   if (capability === "image") {
     const activeProvider = params.activeModel?.provider?.trim();
     if (activeProvider) {
-      const activeEntry = await checkProvider(activeProvider, params.activeModel?.model);
+      const activeModel = await resolvePreferredImageModel(
+        activeProvider,
+        params.activeModel?.model,
+      );
+      const activeEntry = await checkProvider(activeProvider, activeModel);
       if (activeEntry) {
         return activeEntry;
       }
@@ -553,6 +574,21 @@ async function resolveActiveModelEntry(params: {
   if (params.capability === "video" && !provider.describeVideo) {
     return null;
   }
+  let resolvedModel = params.activeModel?.model;
+  if (params.capability === "image") {
+    const requestedModel = params.activeModel?.model?.trim();
+    if (!requestedModel) {
+      resolvedModel = DEFAULT_IMAGE_MODELS[providerId];
+    } else {
+      const catalog = await loadModelCatalog({ config: params.cfg });
+      const entry = findModelInCatalog(catalog, providerId, requestedModel);
+      if (entry && !modelSupportsVision(entry)) {
+        resolvedModel = DEFAULT_IMAGE_MODELS[providerId];
+      } else {
+        resolvedModel = requestedModel;
+      }
+    }
+  }
   try {
     await resolveApiKeyForProvider({
       provider: providerId,
@@ -565,7 +601,7 @@ async function resolveActiveModelEntry(params: {
   return {
     type: "provider",
     provider: providerId,
-    model: params.activeModel?.model,
+    model: resolvedModel,
   };
 }
 

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -337,12 +337,31 @@ async function resolveGeminiCliEntry(
   };
 }
 
+async function resolveImageModelForCapability(params: {
+  cfg: OpenClawConfig;
+  providerId: string;
+  requestedModel?: string;
+  catalog?: Awaited<ReturnType<typeof loadModelCatalog>>;
+}): Promise<string | undefined> {
+  const requested = params.requestedModel?.trim();
+  if (!requested) {
+    return DEFAULT_IMAGE_MODELS[params.providerId];
+  }
+  const catalog = params.catalog ?? (await loadModelCatalog({ config: params.cfg }));
+  const entry = findModelInCatalog(catalog, params.providerId, requested);
+  if (entry && !modelSupportsVision(entry)) {
+    return DEFAULT_IMAGE_MODELS[params.providerId];
+  }
+  return requested;
+}
+
 async function resolveKeyEntry(params: {
   cfg: OpenClawConfig;
   agentDir?: string;
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
+  modelCatalog?: Awaited<ReturnType<typeof loadModelCatalog>>;
 }): Promise<MediaUnderstandingModelConfig | null> {
   const { cfg, agentDir, providerRegistry, capability } = params;
   const checkProvider = async (
@@ -370,30 +389,15 @@ async function resolveKeyEntry(params: {
     }
   };
 
-  const resolvePreferredImageModel = async (
-    providerId: string,
-    requestedModel?: string,
-  ): Promise<string | undefined> => {
-    const requested = requestedModel?.trim();
-    if (!requested) {
-      return DEFAULT_IMAGE_MODELS[providerId];
-    }
-
-    const catalog = await loadModelCatalog({ config: cfg });
-    const entry = findModelInCatalog(catalog, providerId, requested);
-    if (entry && !modelSupportsVision(entry)) {
-      return DEFAULT_IMAGE_MODELS[providerId];
-    }
-    return requested;
-  };
-
   if (capability === "image") {
     const activeProvider = params.activeModel?.provider?.trim();
     if (activeProvider) {
-      const activeModel = await resolvePreferredImageModel(
-        activeProvider,
-        params.activeModel?.model,
-      );
+      const activeModel = await resolveImageModelForCapability({
+        cfg,
+        providerId: activeProvider,
+        requestedModel: params.activeModel?.model,
+        catalog: params.modelCatalog,
+      });
       const activeEntry = await checkProvider(activeProvider, activeModel);
       if (activeEntry) {
         return activeEntry;
@@ -478,7 +482,12 @@ async function resolveAutoEntries(params: {
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
 }): Promise<MediaUnderstandingModelConfig[]> {
-  const activeEntry = await resolveActiveModelEntry(params);
+  const sharedImageCatalog =
+    params.capability === "image" ? await loadModelCatalog({ config: params.cfg }) : undefined;
+  const activeEntry = await resolveActiveModelEntry({
+    ...params,
+    modelCatalog: sharedImageCatalog,
+  });
   if (activeEntry) {
     return [activeEntry];
   }
@@ -498,7 +507,10 @@ async function resolveAutoEntries(params: {
   if (gemini) {
     return [gemini];
   }
-  const keys = await resolveKeyEntry(params);
+  const keys = await resolveKeyEntry({
+    ...params,
+    modelCatalog: sharedImageCatalog,
+  });
   if (keys) {
     return [keys];
   }
@@ -511,6 +523,7 @@ export async function resolveAutoImageModel(params: {
   activeModel?: ActiveMediaModel;
 }): Promise<ActiveMediaModel | null> {
   const providerRegistry = buildProviderRegistry();
+  const imageCatalog = await loadModelCatalog({ config: params.cfg });
   const toActive = (entry: MediaUnderstandingModelConfig | null): ActiveMediaModel | null => {
     if (!entry || entry.type === "cli") {
       return null;
@@ -531,6 +544,7 @@ export async function resolveAutoImageModel(params: {
     providerRegistry,
     capability: "image",
     activeModel: params.activeModel,
+    modelCatalog: imageCatalog,
   });
   const resolvedActive = toActive(activeEntry);
   if (resolvedActive) {
@@ -542,6 +556,7 @@ export async function resolveAutoImageModel(params: {
     providerRegistry,
     capability: "image",
     activeModel: params.activeModel,
+    modelCatalog: imageCatalog,
   });
   return toActive(keyEntry);
 }
@@ -552,6 +567,7 @@ async function resolveActiveModelEntry(params: {
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
+  modelCatalog?: Awaited<ReturnType<typeof loadModelCatalog>>;
 }): Promise<MediaUnderstandingModelConfig | null> {
   const activeProviderRaw = params.activeModel?.provider?.trim();
   if (!activeProviderRaw) {
@@ -576,18 +592,12 @@ async function resolveActiveModelEntry(params: {
   }
   let resolvedModel = params.activeModel?.model;
   if (params.capability === "image") {
-    const requestedModel = params.activeModel?.model?.trim();
-    if (!requestedModel) {
-      resolvedModel = DEFAULT_IMAGE_MODELS[providerId];
-    } else {
-      const catalog = await loadModelCatalog({ config: params.cfg });
-      const entry = findModelInCatalog(catalog, providerId, requestedModel);
-      if (entry && !modelSupportsVision(entry)) {
-        resolvedModel = DEFAULT_IMAGE_MODELS[providerId];
-      } else {
-        resolvedModel = requestedModel;
-      }
-    }
+    resolvedModel = await resolveImageModelForCapability({
+      cfg: params.cfg,
+      providerId,
+      requestedModel: params.activeModel?.model,
+      catalog: params.modelCatalog,
+    });
   }
   try {
     await resolveApiKeyForProvider({

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -393,9 +393,10 @@ async function resolveKeyEntry(params: {
   if (capability === "image") {
     const activeProvider = params.activeModel?.provider?.trim();
     if (activeProvider) {
+      const normalizedActiveProvider = normalizeMediaProviderId(activeProvider);
       const activeModel = await resolveImageModelForCapability({
         cfg,
-        providerId: activeProvider,
+        providerId: normalizedActiveProvider,
         requestedModel: params.activeModel?.model,
         catalog: params.modelCatalog,
       });

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -351,7 +351,7 @@ async function resolveImageModelForCapability(params: {
   const entry = findModelInCatalog(catalog, params.providerId, requested);
   const hasDeclaredInputMetadata = Array.isArray((entry as { input?: unknown } | undefined)?.input);
   if (entry && hasDeclaredInputMetadata && !modelSupportsVision(entry)) {
-    return DEFAULT_IMAGE_MODELS[params.providerId];
+    return DEFAULT_IMAGE_MODELS[params.providerId] ?? requested;
   }
   return requested;
 }

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -349,7 +349,8 @@ async function resolveImageModelForCapability(params: {
   }
   const catalog = params.catalog ?? (await loadModelCatalog({ config: params.cfg }));
   const entry = findModelInCatalog(catalog, params.providerId, requested);
-  if (entry && !modelSupportsVision(entry)) {
+  const hasDeclaredInputMetadata = Array.isArray((entry as { input?: unknown } | undefined)?.input);
+  if (entry && hasDeclaredInputMetadata && !modelSupportsVision(entry)) {
     return DEFAULT_IMAGE_MODELS[params.providerId];
   }
   return requested;


### PR DESCRIPTION
## Why
- Some deployments can process images only via MCP-specific tooling, which creates an avoidable dependency.
- We want native OpenClaw media-understanding fallback to keep working when primary model/image capability is unavailable.
- MiniMax coding_plan already has OAuth-based capability in real deployments, so adding it as a native fallback improves reliability and lowers setup friction.

## What
- Add MiniMax `coding_plan` path as a native image fallback provider in media-understanding resolution (non-MCP path).
- Keep existing primary-model behavior: prefer current model/provider when image capability is available.
- Use fallback only when needed, without changing existing provider contracts.
- Preserve active image model when catalog capability metadata is unknown (fallback only on explicit non-vision metadata).
- Include tests covering auto image-model resolution and fallback selection behavior.

## Compatibility
- Backward compatible for existing configs.
- No config schema migration required.
- Existing MCP-based image workflows continue to work; this only adds a native fallback path.

## Notes
- This PR focuses on media-understanding provider/model resolution behavior.
- It does not replace MCP tools; it reduces hard dependency on them for image understanding.
