### PR TITLE
fix: avoid false-positive cron payload kind normalization

### DIFF
--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -75,4 +75,60 @@ describe("normalizeStoredCronJobs", () => {
       channel: "slack",
     });
   });
+
+  it("does not report legacyPayloadKind when payload.kind is already canonical", () => {
+    const jobs = [
+      {
+        id: "canonical-kind",
+        name: "canonical-kind",
+        enabled: true,
+        wakeMode: "now",
+        sessionTarget: "isolated",
+        state: {},
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: {
+          kind: "agentTurn",
+          message: "ping",
+        },
+        delivery: { mode: "announce" },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(false);
+    expect(result.issues.legacyPayloadKind).toBeUndefined();
+    expect(jobs[0]?.payload).toMatchObject({
+      kind: "agentTurn",
+      message: "ping",
+    });
+  });
+
+  it("normalizes payload.kind casing and reports legacyPayloadKind when needed", () => {
+    const jobs = [
+      {
+        id: "legacy-kind",
+        name: "legacy-kind",
+        enabled: true,
+        wakeMode: "now",
+        sessionTarget: "isolated",
+        state: {},
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: {
+          kind: "agentturn",
+          message: "ping",
+        },
+        delivery: { mode: "announce" },
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.legacyPayloadKind).toBe(1);
+    expect(jobs[0]?.payload).toMatchObject({
+      kind: "agentTurn",
+      message: "ping",
+    });
+  });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -28,14 +28,22 @@ function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
-  const raw = typeof payload.kind === "string" ? payload.kind.trim().toLowerCase() : "";
-  if (raw === "agentturn") {
-    payload.kind = "agentTurn";
-    return true;
+  const raw = typeof payload.kind === "string" ? payload.kind.trim() : "";
+  const lower = raw.toLowerCase();
+
+  if (lower === "agentturn") {
+    if (raw !== "agentTurn") {
+      payload.kind = "agentTurn";
+      return true;
+    }
+    return false;
   }
-  if (raw === "systemevent") {
-    payload.kind = "systemEvent";
-    return true;
+  if (lower === "systemevent") {
+    if (raw !== "systemEvent") {
+      payload.kind = "systemEvent";
+      return true;
+    }
+    return false;
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- avoid reporting cron payload kind normalization when  is already canonical
- keep normalizing legacy casing like  / 
- add regression coverage for both the already-canonical and legacy-casing paths

## Testing
- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/Users/jordanweitz/code/openclaw[39m

 [32m✓[39m src/cron/store-migration.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 2[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m4 passed[39m[22m[90m (4)[39m
[2m   Start at [22m 16:05:09
[2m   Duration [22m 209ms[2m (transform 116ms, setup 123ms, import 25ms, tests 2ms, environment 0ms)[22m

Closes #44186