### PR TITLE
fix(cron): harden telegram direct-thread delivery inference

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -343,6 +343,19 @@ describe("cron tool", () => {
     });
   });
 
+  it("converts telegram direct thread session keys into topic-qualified delivery targets", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-telegram-direct-thread",
+        agentSessionKey: "agent:velizar:telegram:direct:834275911:thread:834275911:197918",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "834275911:topic:197918",
+    });
+  });
+
   it("infers delivery when delivery is null", async () => {
     expect(
       await executeAddAndReadDelivery({

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -154,11 +154,26 @@ function stripThreadSuffixFromSessionKey(sessionKey: string): string {
   return parent ? parent : sessionKey;
 }
 
+function extractTelegramDirectThreadTarget(sessionKey: string): string | null {
+  const normalized = sessionKey.trim().toLowerCase();
+  const match = /^agent:[^:]+:telegram:direct:([^:]+):thread:[^:]+:(\d+)$/.exec(normalized);
+  if (!match) {
+    return null;
+  }
+  const chatId = match[1]?.trim();
+  const threadId = match[2]?.trim();
+  if (!chatId || !threadId) {
+    return null;
+  }
+  return `${chatId}:topic:${threadId}`;
+}
+
 function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | null {
   const rawSessionKey = agentSessionKey?.trim();
   if (!rawSessionKey) {
     return null;
   }
+  const telegramThreadTarget = extractTelegramDirectThreadTarget(rawSessionKey);
   const parsed = parseAgentSessionKey(stripThreadSuffixFromSessionKey(rawSessionKey));
   if (!parsed || !parsed.rest) {
     return null;
@@ -200,7 +215,8 @@ function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | n
     channel = parts[0]?.trim().toLowerCase() as CronMessageChannel;
   }
 
-  const delivery: CronDelivery = { mode: "announce", to: peerId };
+  const resolvedPeerId = channel === "telegram" && telegramThreadTarget ? telegramThreadTarget : peerId;
+  const delivery: CronDelivery = { mode: "announce", to: resolvedPeerId };
   if (channel) {
     delivery.channel = channel;
   }

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -155,17 +155,22 @@ function stripThreadSuffixFromSessionKey(sessionKey: string): string {
 }
 
 function extractTelegramDirectThreadTarget(sessionKey: string): string | null {
-  const normalized = sessionKey.trim().toLowerCase();
-  const match = /^agent:[^:]+:telegram:direct:([^:]+):thread:[^:]+:(\d+)$/.exec(normalized);
+  const trimmed = sessionKey.trim();
+  const match = /^agent:[^:]+:telegram:(?:[^:]+:)?direct:([^:]+):thread:([^:]+):(\d+)$/i.exec(
+    trimmed,
+  );
   if (!match) {
     return null;
   }
-  const chatId = match[1]?.trim();
-  const threadId = match[2]?.trim();
-  if (!chatId || !threadId) {
+  // NOTE: Keep the original casing for chat identifiers.
+  const directPeerId = match[1]?.trim();
+  const threadChatId = match[2]?.trim();
+  const threadId = match[3]?.trim();
+  if (!directPeerId || !threadChatId || !threadId) {
     return null;
   }
-  return `${chatId}:topic:${threadId}`;
+  // Prefer the chatId from the thread suffix (Telegram DM flows can have senderId != chat.id).
+  return `${threadChatId}:topic:${threadId}`;
 }
 
 function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | null {
@@ -215,7 +220,8 @@ function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | n
     channel = parts[0]?.trim().toLowerCase() as CronMessageChannel;
   }
 
-  const resolvedPeerId = channel === "telegram" && telegramThreadTarget ? telegramThreadTarget : peerId;
+  const resolvedPeerId =
+    channel === "telegram" && telegramThreadTarget ? telegramThreadTarget : peerId;
   const delivery: CronDelivery = { mode: "announce", to: resolvedPeerId };
   if (channel) {
     delivery.channel = channel;


### PR DESCRIPTION
Follow-up fix based on review feedback on #44351.

What changed:
- Avoid lowercasing captured Telegram chat identifiers (preserve casing).
- Support optional Telegram accountId segment in session keys.
- Prefer the thread-suffix chatId (`...:thread:<chatId>:<threadId>`) when deriving `<chatId>:topic:<threadId>`.

Testing:
- `pnpm test src/agents/tools/cron-tool.test.ts`