### PR TITLE
feat(discord): add connectStagger config to prevent rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Discord/connection stagger: add `channels.discord.connectStagger` config option (milliseconds) to control the delay between sequential Discord bot connections at gateway startup, preventing API rate limits when deploying 5+ bot accounts simultaneously. Default: 0 (concurrent, preserves existing behavior). (#44400)
 - Agents/subagents: add `sessions_yield` so orchestrators can end the current turn immediately, skip queued tool work, and carry a hidden follow-up payload into the next session turn. (#36537) thanks @jriff
 - Docs/Kubernetes: Add a starter K8s install path with raw manifests, Kind setup, and deployment docs. Thanks @sallyom @dzianisv @egkristi
 - Control UI/dashboard-v2: refresh the gateway dashboard with modular overview, chat, config, agent, and session views, plus a command palette, mobile bottom tabs, and richer chat tools like slash commands, search, export, and pinned messages. (#41503) Thanks @BunsDev.

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -363,4 +363,10 @@ export type DiscordConfig = {
   accounts?: Record<string, DiscordAccountConfig>;
   /** Optional default account id when multiple accounts are configured. */
   defaultAccount?: string;
+  /**
+   * Delay (in milliseconds) between sequential Discord bot connections at gateway startup.
+   * Default: 0 (all bots connect simultaneously).
+   * Recommended: 2000 for deployments with 5+ bot accounts to avoid Discord API rate limits.
+   */
+  connectStagger?: number;
 } & DiscordAccountConfig;

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -180,4 +180,83 @@ describe("server-channels auto restart", () => {
     await manager.startChannels();
     expect(startAccount).toHaveBeenCalledTimes(1);
   });
+
+  it("staggers Discord account connections when connectStagger is configured", async () => {
+    const startTimes: number[] = [];
+    const startAccount = vi.fn(async () => {
+      startTimes.push(Date.now());
+    });
+
+    const testPlugin = createTestPlugin({ startAccount });
+    // Override listAccountIds to return multiple accounts
+    testPlugin.config.listAccountIds = () => ["bot1", "bot2", "bot3"];
+
+    installTestRegistry(testPlugin);
+
+    // Configure connectStagger
+    const manager = createManager({
+      loadConfig: () => ({
+        channels: {
+          discord: {
+            connectStagger: 2000,
+          },
+        },
+      }),
+    });
+
+    const startTime = Date.now();
+    await manager.startChannels();
+
+    expect(startAccount).toHaveBeenCalledTimes(3);
+    expect(startTimes).toHaveLength(3);
+
+    // Verify connections were staggered
+    const firstDelay = startTimes[1]! - startTimes[0]!;
+    const secondDelay = startTimes[2]! - startTimes[1]!;
+
+    // Allow some tolerance for timing
+    expect(firstDelay).toBeGreaterThanOrEqual(1900);
+    expect(firstDelay).toBeLessThan(2200);
+    expect(secondDelay).toBeGreaterThanOrEqual(1900);
+    expect(secondDelay).toBeLessThan(2200);
+
+    // Total time should be at least 4000ms (2 staggers * 2000ms)
+    const totalTime = Date.now() - startTime;
+    expect(totalTime).toBeGreaterThanOrEqual(3800);
+  });
+
+  it("connects concurrently when connectStagger is 0 or not configured", async () => {
+    const startTimes: number[] = [];
+    const startAccount = vi.fn(async () => {
+      startTimes.push(Date.now());
+      // Add a small delay to ensure we can measure concurrency
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    const testPlugin = createTestPlugin({ startAccount });
+    testPlugin.config.listAccountIds = () => ["bot1", "bot2", "bot3"];
+
+    installTestRegistry(testPlugin);
+
+    const manager = createManager({
+      loadConfig: () => ({
+        channels: {
+          discord: {},
+        },
+      }),
+    });
+
+    const startTime = Date.now();
+    await manager.startChannels();
+
+    expect(startAccount).toHaveBeenCalledTimes(3);
+
+    // All connections should start nearly simultaneously
+    const maxSpread = Math.max(...startTimes) - Math.min(...startTimes);
+    expect(maxSpread).toBeLessThan(100); // Allow for some timing variance
+
+    // Total time should be close to 100ms (the artificial delay), not 300ms
+    const totalTime = Date.now() - startTime;
+    expect(totalTime).toBeLessThan(200);
+  });
 });

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -165,83 +165,86 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       return;
     }
 
-    await Promise.all(
-      accountIds.map(async (id) => {
-        if (store.tasks.has(id)) {
-          return;
-        }
-        const account = plugin.config.resolveAccount(cfg, id);
-        const enabled = plugin.config.isEnabled
-          ? plugin.config.isEnabled(account, cfg)
-          : isAccountEnabled(account);
-        if (!enabled) {
-          setRuntime(channelId, id, {
-            accountId: id,
-            enabled: false,
-            configured: true,
-            running: false,
-            restartPending: false,
-            lastError: plugin.config.disabledReason?.(account, cfg) ?? "disabled",
-          });
-          return;
-        }
+    const startAccountTask = async (id: string, delayMs = 0) => {
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
 
-        let configured = true;
-        if (plugin.config.isConfigured) {
-          configured = await plugin.config.isConfigured(account, cfg);
-        }
-        if (!configured) {
-          setRuntime(channelId, id, {
-            accountId: id,
-            enabled: true,
-            configured: false,
-            running: false,
-            restartPending: false,
-            lastError: plugin.config.unconfiguredReason?.(account, cfg) ?? "not configured",
-          });
-          return;
-        }
+      if (store.tasks.has(id)) {
+        return;
+      }
+      const account = plugin.config.resolveAccount(cfg, id);
+      const enabled = plugin.config.isEnabled
+        ? plugin.config.isEnabled(account, cfg)
+        : isAccountEnabled(account);
+      if (!enabled) {
+        setRuntime(channelId, id, {
+          accountId: id,
+          enabled: false,
+          configured: true,
+          running: false,
+          restartPending: false,
+          lastError: plugin.config.disabledReason?.(account, cfg) ?? "disabled",
+        });
+        return;
+      }
 
-        const rKey = restartKey(channelId, id);
-        if (!preserveManualStop) {
-          manuallyStopped.delete(rKey);
-        }
-
-        const abort = new AbortController();
-        store.aborts.set(id, abort);
-        if (!preserveRestartAttempts) {
-          restartAttempts.delete(rKey);
-        }
+      let configured = true;
+      if (plugin.config.isConfigured) {
+        configured = await plugin.config.isConfigured(account, cfg);
+      }
+      if (!configured) {
         setRuntime(channelId, id, {
           accountId: id,
           enabled: true,
-          configured: true,
-          running: true,
+          configured: false,
+          running: false,
           restartPending: false,
-          lastStartAt: Date.now(),
-          lastError: null,
-          reconnectAttempts: preserveRestartAttempts ? (restartAttempts.get(rKey) ?? 0) : 0,
+          lastError: plugin.config.unconfiguredReason?.(account, cfg) ?? "not configured",
         });
+        return;
+      }
 
-        const log = channelLogs[channelId];
-        const task = startAccount({
-          cfg,
-          accountId: id,
-          account,
-          runtime: channelRuntimeEnvs[channelId],
-          abortSignal: abort.signal,
-          log,
-          getStatus: () => getRuntime(channelId, id),
-          setStatus: (next) => setRuntime(channelId, id, next),
-          ...(channelRuntime ? { channelRuntime } : {}),
-        });
-        const trackedPromise = Promise.resolve(task)
-          .catch((err) => {
-            const message = formatErrorMessage(err);
-            setRuntime(channelId, id, { accountId: id, lastError: message });
-            log.error?.(`[${id}] channel exited: ${message}`);
-          })
-          .finally(() => {
+      const rKey = restartKey(channelId, id);
+      if (!preserveManualStop) {
+        manuallyStopped.delete(rKey);
+      }
+
+      const abort = new AbortController();
+      store.aborts.set(id, abort);
+      if (!preserveRestartAttempts) {
+        restartAttempts.delete(rKey);
+      }
+      setRuntime(channelId, id, {
+        accountId: id,
+        enabled: true,
+        configured: true,
+        running: true,
+        restartPending: false,
+        lastStartAt: Date.now(),
+        lastError: null,
+        reconnectAttempts: preserveRestartAttempts ? (restartAttempts.get(rKey) ?? 0) : 0,
+      });
+
+      const log = channelLogs[channelId];
+      const task = startAccount({
+        cfg,
+        accountId: id,
+        account,
+        runtime: channelRuntimeEnvs[channelId],
+        abortSignal: abort.signal,
+        log,
+        getStatus: () => getRuntime(channelId, id),
+        setStatus: (next) => setRuntime(channelId, id, next),
+        ...(channelRuntime ? { channelRuntime } : {}),
+      });
+      const trackedPromise = Promise.resolve(task)
+        .catch((err) => {
+          const message = formatErrorMessage(err);
+          setRuntime(channelId, id, { accountId: id, lastError: message });
+          log.error?.(`[${id}] channel exited: ${message}`);
+        })
+        .finally(() => {
             setRuntime(channelId, id, {
               accountId: id,
               running: false,
@@ -299,9 +302,25 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               store.aborts.delete(id);
             }
           });
-        store.tasks.set(id, trackedPromise);
-      }),
-    );
+      store.tasks.set(id, trackedPromise);
+    };
+
+    // Check if we should stagger Discord connections
+    const staggerMs =
+      channelId === "discord" && typeof cfg.channels?.discord?.connectStagger === "number"
+        ? cfg.channels.discord.connectStagger
+        : 0;
+
+    if (staggerMs > 0 && accountIds.length > 1) {
+      // Sequential startup with delays
+      for (let i = 0; i < accountIds.length; i++) {
+        const delayMs = i === 0 ? 0 : staggerMs;
+        await startAccountTask(accountIds[i]!, delayMs);
+      }
+    } else {
+      // Concurrent startup (original behavior)
+      await Promise.all(accountIds.map((id) => startAccountTask(id, 0)));
+    }
   };
 
   const startChannel = async (channelId: ChannelId, accountId?: string) => {


### PR DESCRIPTION
## Problem

When the gateway starts with multiple Discord bot accounts (e.g., 9 agents), all bots connect simultaneously via `Promise.all()`. This overwhelms Discord's API with concurrent connections, triggering 503 'upstream overflow' errors. Failed bots then enter a 5-second auto-restart loop, creating cascading failures.

## Solution

Add a `channels.discord.connectStagger` config option (integer, milliseconds) that controls the delay between sequential Discord account connections at gateway startup.

```json
{
  "channels": {
    "discord": {
      "connectStagger": 2000
    }
  }
}
```

- **Default:** 0 (preserves existing concurrent behavior)
- **Recommended:** 2000 for deployments with 5+ bot accounts

## Changes

- Add `connectStagger` config option to `DiscordConfig` type
- Modify `startChannelInternal` in `server-channels.ts` to handle sequential vs concurrent startup based on config
- Add comprehensive tests for both staggered and concurrent connection behavior
- Update CHANGELOG

## Testing

Added two new tests:
1. Verifies connections are staggered when `connectStagger` is configured
2. Verifies connections remain concurrent when `connectStagger` is 0 or not configured

## Impact

Without this fix, multi-bot deployments with 5+ accounts are prone to cascading gateway crashes on startup. This change provides a clean configuration-based solution that preserves backward compatibility.

Fixes #44400