### PR TITLE
fix(daemon): add Nix Home Manager PATH support to service environment

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -27,6 +27,36 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/home/testuser/.asdf/shims");
     expect(result).toContain("/home/testuser/.local/share/pnpm");
     expect(result).toContain("/home/testuser/.bun/bin");
+    expect(result).toContain("/home/testuser/.nix-profile/bin");
+  });
+
+  it("includes Nix Home Manager profile directories on Linux", () => {
+    const result = getMinimalServicePathPartsFromEnv({
+      platform: "linux",
+      env: {
+        HOME: "/home/testuser",
+        NIX_PROFILES: "/nix/var/nix/profiles/default /home/testuser/.nix-profile",
+      },
+    });
+
+    // Should include default Nix profile
+    expect(result).toContain("/home/testuser/.nix-profile/bin");
+
+    // Should include all profiles from NIX_PROFILES env var
+    expect(result).toContain("/nix/var/nix/profiles/default/bin");
+  });
+
+  it("handles single Nix profile from NIX_PROFILES on Linux", () => {
+    const result = getMinimalServicePathPartsFromEnv({
+      platform: "linux",
+      env: {
+        HOME: "/home/testuser",
+        NIX_PROFILES: "/nix/var/nix/profiles/per-user/testuser/profile",
+      },
+    });
+
+    expect(result).toContain("/nix/var/nix/profiles/per-user/testuser/profile/bin");
+    expect(result).toContain("/home/testuser/.nix-profile/bin");
   });
 
   it("excludes user bin directories when HOME is undefined on Linux", () => {
@@ -117,10 +147,27 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/Users/testuser/Library/pnpm"); // pnpm default on macOS
     expect(result).toContain("/Users/testuser/.local/share/pnpm"); // pnpm XDG fallback
     expect(result).toContain("/Users/testuser/.bun/bin");
+    expect(result).toContain("/Users/testuser/.nix-profile/bin"); // Nix Home Manager
 
     // Should also include macOS system directories
     expect(result).toContain("/opt/homebrew/bin");
     expect(result).toContain("/usr/local/bin");
+  });
+
+  it("includes Nix Home Manager profile directories on macOS", () => {
+    const result = getMinimalServicePathPartsFromEnv({
+      platform: "darwin",
+      env: {
+        HOME: "/Users/testuser",
+        NIX_PROFILES: "/nix/var/nix/profiles/default /Users/testuser/.nix-profile",
+      },
+    });
+
+    // Should include default Nix profile
+    expect(result).toContain("/Users/testuser/.nix-profile/bin");
+
+    // Should include all profiles from NIX_PROFILES env var
+    expect(result).toContain("/nix/var/nix/profiles/default/bin");
   });
 
   it("includes env-configured version manager dirs on macOS", () => {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -98,6 +98,35 @@ function addCommonEnvConfiguredBinDirs(
   addNonEmptyDir(dirs, appendSubdir(env?.ASDF_DATA_DIR, "shims"));
 }
 
+/**
+ * Add Nix Home Manager bin directories.
+ * Works across all Unix platforms (macOS, Linux, BSD, etc.).
+ *
+ * Nix profiles can be in multiple locations:
+ * - ~/.nix-profile/bin (default single-user profile)
+ * - NIX_PROFILES env var (space-separated list of profile paths for multi-profile setups)
+ */
+function addNixProfileBinDirs(
+  dirs: string[],
+  home: string,
+  env: Record<string, string | undefined> | undefined,
+): void {
+  // Default single-user Nix profile
+  dirs.push(`${home}/.nix-profile/bin`);
+
+  // Multi-profile support: NIX_PROFILES is a space-separated list of profile paths
+  // Example: "/nix/var/nix/profiles/default /home/user/.nix-profile"
+  const nixProfiles = env?.NIX_PROFILES?.trim();
+  if (nixProfiles) {
+    const profiles = nixProfiles.split(/\s+/);
+    for (const profile of profiles) {
+      if (profile) {
+        addNonEmptyDir(dirs, `${profile}/bin`);
+      }
+    }
+  }
+}
+
 function resolveSystemPathDirs(platform: NodeJS.Platform): string[] {
   if (platform === "darwin") {
     return ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"];
@@ -140,6 +169,9 @@ export function resolveDarwinUserBinDirs(
   // Common user bin directories
   addCommonUserBinDirs(dirs, home);
 
+  // Nix Home Manager (cross-platform)
+  addNixProfileBinDirs(dirs, home, env);
+
   // Node version managers - macOS specific paths
   // nvm: no stable default path, depends on user's shell configuration
   // fnm: macOS default is ~/Library/Application Support/fnm, not ~/.fnm
@@ -173,6 +205,9 @@ export function resolveLinuxUserBinDirs(
 
   // Common user bin directories
   addCommonUserBinDirs(dirs, home);
+
+  // Nix Home Manager (cross-platform)
+  addNixProfileBinDirs(dirs, home, env);
 
   // Node version managers
   dirs.push(`${home}/.nvm/current/bin`); // nvm with current symlink


### PR DESCRIPTION
## Summary
- Add Nix Home Manager PATH support to LaunchAgent and systemd service environments
- Enables `openclaw gateway install` to capture Nix-installed binaries on both macOS and Linux
- Includes comprehensive test coverage for single and multi-profile Nix setups

## Root Cause
The `resolveDarwinUserBinDirs()` and `resolveLinuxUserBinDirs()` functions did not include Nix Home Manager paths (`~/.nix-profile/bin`, `NIX_PROFILES` env var). Users running OpenClaw under Nix Home Manager would find that commands available in their shell were missing when the gateway ran as a LaunchAgent/systemd service.

## Fix
Added `addNixProfileBinDirs()` helper that:
- Includes `~/.nix-profile/bin` by default (single-user Nix installations)
- Parses `NIX_PROFILES` env var (space-separated list) for multi-profile setups
- Works cross-platform (macOS, Linux, BSD - anywhere Nix Home Manager runs)

Called from both `resolveDarwinUserBinDirs()` and `resolveLinuxUserBinDirs()` to ensure consistent behavior.

## Testing
- Added tests for Linux Nix profile detection (single and multi-profile)
- Added tests for macOS Nix profile detection (single and multi-profile)
- Verified existing tests still pass
- Follows the same pattern as existing version manager integrations (nvm, fnm, volta)

## Implementation Notes
Per feedback in #44402, Nix Home Manager is **not macOS-specific** - it runs on any Unix system. The fix applies to both platforms via a shared helper function.

Closes #44402
