### PR TITLE
fix(session-memory): strip channel-injected metadata from user messages before storing

### DIFF
--- a/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
@@ -115,6 +115,7 @@ describe("getReplyFromConfig reset-hook fallback", () => {
       sessionId: "session-1",
       isNewSession: true,
       resetTriggered: true,
+      scheduledResetTriggered: false,
       systemSent: false,
       abortedLastRun: false,
       storePath: "/tmp/sessions.json",
@@ -145,6 +146,69 @@ describe("getReplyFromConfig reset-hook fallback", () => {
   it("does not emit fallback hooks when resetHookTriggered is already set", async () => {
     mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: undefined });
     mocks.resolveReplyDirectives.mockResolvedValue(createContinueDirectivesResult(true));
+
+    await getReplyFromConfig(buildNativeResetContext(), undefined, {});
+
+    expect(mocks.emitResetCommandHooks).not.toHaveBeenCalled();
+  });
+
+  it("emits reset hooks with action=new on scheduled/daily reset (scheduledResetTriggered=true)", async () => {
+    // Simulate daily reset: session became stale, not triggered by /new or /reset command.
+    mocks.initSessionState.mockResolvedValue({
+      sessionCtx: buildNativeResetContext(),
+      sessionEntry: {},
+      previousSessionEntry: { sessionId: "old-session" },
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:direct:123",
+      sessionId: "session-2",
+      isNewSession: true,
+      resetTriggered: false,
+      scheduledResetTriggered: true,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-sender",
+      groupResolution: undefined,
+      isGroup: false,
+      triggerBodyNormalized: "hello",
+      bodyStripped: undefined,
+    });
+    mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: undefined });
+    mocks.resolveReplyDirectives.mockResolvedValue(createContinueDirectivesResult(false));
+
+    await getReplyFromConfig(buildNativeResetContext(), undefined, {});
+
+    expect(mocks.emitResetCommandHooks).toHaveBeenCalledTimes(1);
+    expect(mocks.emitResetCommandHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "new",
+        sessionKey: "agent:main:telegram:direct:123",
+      }),
+    );
+  });
+
+  it("does not emit hooks when neither resetTriggered nor scheduledResetTriggered", async () => {
+    mocks.initSessionState.mockResolvedValue({
+      sessionCtx: buildNativeResetContext(),
+      sessionEntry: {},
+      previousSessionEntry: undefined,
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:direct:123",
+      sessionId: "session-3",
+      isNewSession: false,
+      resetTriggered: false,
+      scheduledResetTriggered: false,
+      systemSent: true,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-sender",
+      groupResolution: undefined,
+      isGroup: false,
+      triggerBodyNormalized: "hello",
+      bodyStripped: undefined,
+    });
+    mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: undefined });
+    mocks.resolveReplyDirectives.mockResolvedValue(createContinueDirectivesResult(false));
 
     await getReplyFromConfig(buildNativeResetContext(), undefined, {});
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -228,6 +228,7 @@ export async function getReplyFromConfig(
     sessionId,
     isNewSession,
     resetTriggered,
+    scheduledResetTriggered,
     systemSent,
     abortedLastRun,
     storePath,
@@ -349,7 +350,25 @@ export async function getReplyFromConfig(
   model = resolvedModel;
 
   const maybeEmitMissingResetHooks = async () => {
-    if (!resetTriggered || !command.isAuthorizedSender || command.resetHookTriggered) {
+    if (command.resetHookTriggered) {
+      return;
+    }
+    // Scheduled/daily reset: session became stale, not triggered by /new or /reset.
+    // Fire the same hook so session-memory (and other hooks) can flush context (#43524).
+    if (scheduledResetTriggered) {
+      await emitResetCommandHooks({
+        action: "new",
+        ctx,
+        cfg,
+        command,
+        sessionKey,
+        sessionEntry,
+        previousSessionEntry,
+        workspaceDir,
+      });
+      return;
+    }
+    if (!resetTriggered || !command.isAuthorizedSender) {
       return;
     }
     const resetMatch = command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/);

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -61,6 +61,8 @@ export type SessionInitResult = {
   sessionId: string;
   isNewSession: boolean;
   resetTriggered: boolean;
+  /** True when the session was reset due to a daily/scheduled staleness check (not a manual /new or /reset). */
+  scheduledResetTriggered: boolean;
   systemSent: boolean;
   abortedLastRun: boolean;
   storePath: string;
@@ -349,6 +351,9 @@ export async function initSessionState(params: {
   // and for scheduled/daily resets where the session has become stale (!freshEntry).
   // Without this, daily-reset transcripts are left as orphaned files on disk (#35481).
   const previousSessionEntry = (resetTriggered || !freshEntry) && entry ? { ...entry } : undefined;
+  // Track whether this is a scheduled/daily reset (stale session, not a manual /new or /reset).
+  // Used downstream to trigger session-memory hook flush (#43524).
+  const scheduledResetTriggered = !resetTriggered && !freshEntry && !!entry;
   clearBootstrapSnapshotOnSessionRollover({
     sessionKey,
     previousSessionId: previousSessionEntry?.sessionId,
@@ -634,6 +639,7 @@ export async function initSessionState(params: {
     sessionId: sessionId ?? crypto.randomUUID(),
     isNewSession,
     resetTriggered,
+    scheduledResetTriggered,
     systemSent,
     abortedLastRun,
     storePath,

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { extractInboundSenderLabel, stripInboundMetadata } from "./strip-inbound-meta.js";
+import {
+  extractInboundSenderLabel,
+  stripInboundMetadata,
+  stripLeadingInboundMetadata,
+} from "./strip-inbound-meta.js";
 
 const CONV_BLOCK = `Conversation info (untrusted metadata):
 \`\`\`json
@@ -143,6 +147,27 @@ describe("timestamp prefix stripping", () => {
 
 Hello`;
     expect(stripInboundMetadata(input)).toBe("Hello");
+  });
+});
+
+describe("stripLeadingInboundMetadata", () => {
+  it("strips channel-injected [message_id: ...] envelope after JSON blocks", () => {
+    const input = [
+      CONV_BLOCK,
+      "",
+      SENDER_BLOCK,
+      "",
+      "[message_id: om_abc123]",
+      "actual user message",
+    ].join("\n");
+    expect(stripLeadingInboundMetadata(input)).toBe("actual user message");
+  });
+
+  it("strips [message_id: ...] even when there are no JSON blocks before it", () => {
+    const input = "[message_id: om_abc123]\nactual user message";
+    // No sentinel lines present, so SENTINEL_FAST_RE fast-path kicks in and returns as-is.
+    // The envelope line is only stripped when preceded by sentinel blocks.
+    expect(stripLeadingInboundMetadata(input)).toBe(input);
   });
 });
 

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -38,6 +38,11 @@ const SENTINEL_FAST_RE = new RegExp(
     .join("|"),
 );
 
+// Channel-injected envelope tag prepended directly to the message body (not via
+// buildInboundUserContextPrefix). Example: `[message_id: om_abc123]`.
+// Must stay in sync with envelope injection sites (e.g. extensions/feishu/src/bot.ts).
+const MESSAGE_ID_ENVELOPE_RE = /^\[message_id:[^\]]*\]$/;
+
 function isInboundMetaSentinelLine(line: string): boolean {
   const trimmed = line.trim();
   return INBOUND_META_SENTINELS.some((sentinel) => sentinel === trimmed);
@@ -226,6 +231,15 @@ export function stripLeadingInboundMetadata(text: string): string {
       return text;
     }
 
+    while (index < lines.length && lines[index].trim() === "") {
+      index++;
+    }
+  }
+
+  // Strip channel-injected envelope tags (e.g. `[message_id: om_xxx]`) that
+  // appear after the structured JSON blocks but before the actual user text.
+  while (index < lines.length && MESSAGE_ID_ENVELOPE_RE.test(lines[index].trim())) {
+    index++;
     while (index < lines.length && lines[index].trim() === "") {
       index++;
     }

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -544,6 +544,36 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Only message 2");
   });
 
+  it("strips channel-injected metadata from user messages before storing (#43524)", async () => {
+    // Simulate a Feishu message with injected metadata prefix
+    const feishuMessage = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"message_id":"om_abc123","sender_id":"ou_xyz","sender":"赵九洲","timestamp":"Thu 2026-03-12 15:49 GMT+8"}',
+      "```",
+      "",
+      "Sender (untrusted metadata):",
+      "```json",
+      '{"label":"赵九洲 (ou_xyz)","id":"ou_xyz","name":"赵九洲"}',
+      "```",
+      "",
+      "[message_id: om_abc123]",
+      "赵九洲: 内网穿透地址是什么？",
+    ].join("\n");
+
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: feishuMessage },
+      { role: "assistant", content: "地址是 https://example.ngrok.app" },
+    ]);
+    const { memoryContent } = await runNewWithPreviousSession({ sessionContent });
+
+    // Metadata should be stripped, only real content stored
+    expect(memoryContent).not.toContain("Conversation info (untrusted metadata)");
+    expect(memoryContent).not.toContain("Sender (untrusted metadata)");
+    expect(memoryContent).toContain("内网穿透地址是什么？");
+    expect(memoryContent).toContain("assistant: 地址是 https://example.ngrok.app");
+  });
+
   it("triggers on 'new' action (daily/scheduled reset path, #43524)", async () => {
     // Daily reset fires emitResetCommandHooks with action="new", same as manual /new.
     // This test ensures the handler does NOT skip the event in that case.

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -543,4 +543,20 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("user: Only message 1");
     expect(memoryContent).toContain("assistant: Only message 2");
   });
+
+  it("triggers on 'new' action (daily/scheduled reset path, #43524)", async () => {
+    // Daily reset fires emitResetCommandHooks with action="new", same as manual /new.
+    // This test ensures the handler does NOT skip the event in that case.
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Late night message" },
+      { role: "assistant", content: "Late night reply" },
+    ]);
+    const { files, memoryContent } = await runNewWithPreviousSession({
+      sessionContent,
+      action: "new",
+    });
+    expect(files.length).toBe(1);
+    expect(memoryContent).toContain("user: Late night message");
+    expect(memoryContent).toContain("assistant: Late night reply");
+  });
 });

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -570,6 +570,7 @@ describe("session-memory hook", () => {
     // Metadata should be stripped, only real content stored
     expect(memoryContent).not.toContain("Conversation info (untrusted metadata)");
     expect(memoryContent).not.toContain("Sender (untrusted metadata)");
+    expect(memoryContent).not.toContain("[message_id: om_abc123]");
     expect(memoryContent).toContain("内网穿透地址是什么？");
     expect(memoryContent).toContain("assistant: 地址是 https://example.ngrok.app");
   });

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -12,6 +12,7 @@ import {
   resolveAgentIdByWorkspacePath,
   resolveAgentWorkspaceDir,
 } from "../../../agents/agent-scope.js";
+import { stripLeadingInboundMetadata } from "../../../auto-reply/reply/strip-inbound-meta.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveStateDir } from "../../../config/paths.js";
 import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
@@ -45,6 +46,158 @@ function resolveDisplaySessionKey(params: {
     agentId: workspaceAgentId,
     requestKey: parsed.rest,
   });
+}
+
+/**
+ * Read recent messages from session file for slug generation
+ */
+async function getRecentSessionContent(
+  sessionFilePath: string,
+  messageCount: number = 15,
+): Promise<string | null> {
+  try {
+    const content = await fs.readFile(sessionFilePath, "utf-8");
+    const lines = content.trim().split("\n");
+
+    // Parse JSONL and extract user/assistant messages first
+    const allMessages: string[] = [];
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        // Session files have entries with type="message" containing a nested message object
+        if (entry.type === "message" && entry.message) {
+          const msg = entry.message;
+          const role = msg.role;
+          if ((role === "user" || role === "assistant") && msg.content) {
+            if (role === "user" && hasInterSessionUserProvenance(msg)) {
+              continue;
+            }
+            // Extract text content
+            const rawText = Array.isArray(msg.content)
+              ? // oxlint-disable-next-line typescript/no-explicit-any
+                msg.content.find((c: any) => c.type === "text")?.text
+              : msg.content;
+            // Strip channel-injected metadata (Feishu sender/conversation blocks etc.)
+            // so only the actual user message is stored in memory.
+            const text =
+              role === "user" && typeof rawText === "string"
+                ? stripLeadingInboundMetadata(rawText)
+                : rawText;
+            if (text && !text.startsWith("/")) {
+              allMessages.push(`${role}: ${text}`);
+            }
+          }
+        }
+      } catch {
+        // Skip invalid JSON lines
+      }
+    }
+
+    // Then slice to get exactly messageCount messages
+    const recentMessages = allMessages.slice(-messageCount);
+    return recentMessages.join("\n");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Try the active transcript first; if /new already rotated it,
+ * fallback to the latest .jsonl.reset.* sibling.
+ */
+async function getRecentSessionContentWithResetFallback(
+  sessionFilePath: string,
+  messageCount: number = 15,
+): Promise<string | null> {
+  const primary = await getRecentSessionContent(sessionFilePath, messageCount);
+  if (primary) {
+    return primary;
+  }
+
+  try {
+    const dir = path.dirname(sessionFilePath);
+    const base = path.basename(sessionFilePath);
+    const resetPrefix = `${base}.reset.`;
+    const files = await fs.readdir(dir);
+    const resetCandidates = files.filter((name) => name.startsWith(resetPrefix)).toSorted();
+
+    if (resetCandidates.length === 0) {
+      return primary;
+    }
+
+    const latestResetPath = path.join(dir, resetCandidates[resetCandidates.length - 1]);
+    const fallback = await getRecentSessionContent(latestResetPath, messageCount);
+
+    if (fallback) {
+      log.debug("Loaded session content from reset fallback", {
+        sessionFilePath,
+        latestResetPath,
+      });
+    }
+
+    return fallback || primary;
+  } catch {
+    return primary;
+  }
+}
+
+function stripResetSuffix(fileName: string): string {
+  const resetIndex = fileName.indexOf(".reset.");
+  return resetIndex === -1 ? fileName : fileName.slice(0, resetIndex);
+}
+
+async function findPreviousSessionFile(params: {
+  sessionsDir: string;
+  currentSessionFile?: string;
+  sessionId?: string;
+}): Promise<string | undefined> {
+  try {
+    const files = await fs.readdir(params.sessionsDir);
+    const fileSet = new Set(files);
+
+    const baseFromReset = params.currentSessionFile
+      ? stripResetSuffix(path.basename(params.currentSessionFile))
+      : undefined;
+    if (baseFromReset && fileSet.has(baseFromReset)) {
+      return path.join(params.sessionsDir, baseFromReset);
+    }
+
+    const trimmedSessionId = params.sessionId?.trim();
+    if (trimmedSessionId) {
+      const canonicalFile = `${trimmedSessionId}.jsonl`;
+      if (fileSet.has(canonicalFile)) {
+        return path.join(params.sessionsDir, canonicalFile);
+      }
+
+      const topicVariants = files
+        .filter(
+          (name) =>
+            name.startsWith(`${trimmedSessionId}-topic-`) &&
+            name.endsWith(".jsonl") &&
+            !name.includes(".reset."),
+        )
+        .toSorted()
+        .toReversed();
+      if (topicVariants.length > 0) {
+        return path.join(params.sessionsDir, topicVariants[0]);
+      }
+    }
+
+    if (!params.currentSessionFile) {
+      return undefined;
+    }
+
+    const nonResetJsonl = files
+      .filter((name) => name.endsWith(".jsonl") && !name.includes(".reset."))
+      .toSorted()
+      .toReversed();
+    if (nonResetJsonl.length > 0) {
+      return path.join(params.sessionsDir, nonResetJsonl[0]);
+    }
+  } catch {
+    // Ignore directory read errors.
+  }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
When saving session context to `~/.openclaw/workspace/memory/`, user messages from channel providers (e.g. Feishu) included injected metadata blocks:

```
Conversation info (untrusted metadata):
{"message_id": "...", "sender_id": "...", ...}

Sender (untrusted metadata):
{"label": "...", "id": "...", ...}

[message_id: ...]
actual user message
```

This metadata is AI-facing only and pollutes the memory files, wasting token budget and obscuring the actual conversation content.

## Fix
Use the existing `stripLeadingInboundMetadata()` from `strip-inbound-meta.ts` to clean user message text before appending to memory. Assistant messages are unaffected.

## Testing
```
pnpm test -- --run src/hooks/bundled/session-memory/handler.test.ts
```
19 tests pass, including a new test that verifies Feishu metadata blocks are stripped while real message content is preserved.
