### PR TITLE
Gateway: add safe restart script to avoid suicide paradox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,16 @@
 - Release guardrails: do not change version numbers without operator’s explicit consent; always ask permission before running any npm publish/release step.
 - Beta release guardrail: when using a beta Git tag (for example `vYYYY.M.D-beta.N`), publish npm with a matching beta version suffix (for example `YYYY.M.D-beta.N`) rather than a plain version on `--tag beta`; otherwise the plain version name gets consumed/blocked.
 
+### Gateway restart guidance for agents
+
+- When the agent is running **inside the Gateway process**, do **not** use `pkill -f openclaw-gateway` (or equivalent kill commands) directly to restart the Gateway. Shell pipelines like `pkill -f openclaw-gateway && sleep 2 && openclaw gateway ...` are unsafe in this context because they kill the Gateway (and the agent session) before the restart command can run.
+- Prefer the **Gateway restart tool** when available:
+  - Use the existing gateway tool `restart` action (see `src/agents/tools/gateway-tool.ts`) and ensure `commands.restart=true` in config.
+- When you must restart via shell (for example in some Docker or self-hosted setups), only call the **safe restart script**:
+  - Use `sh scripts/restart-gateway.sh` (or the equivalent path inside the container) instead of constructing your own `pkill` pipeline.
+  - The script is responsible for safely killing and restarting the Gateway from a detached child process so the restart can complete even if the current session is terminated.
+  - Do not invent new `pkill`-based restart chains; if restart behavior needs to change, update the script or gateway tool, not ad-hoc commands.
+
 ## NPM + 1Password (publish/verify)
 
 - Use the 1password skill; all `op` commands must run inside a fresh tmux session.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1693,6 +1693,7 @@ A full restart is required for `gateway`, `discovery`, and `canvasHost` changes.
 ### Is there an API RPC way to apply config
 
 Yes. `config.apply` validates + writes the full config and restarts the Gateway as part of the operation.
+When you need to restart the Gateway from a shell on the same host (for example after changing config or environment), prefer using the safe helper script `scripts/restart-gateway.sh` instead of hand-written `pkill` pipelines so the restart can complete even if the original shell session is terminated.
 
 ### configapply wiped my config How do I recover and avoid this
 

--- a/scripts/restart-gateway.sh
+++ b/scripts/restart-gateway.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+LOG_PATH="${OPENCLAW_GATEWAY_RESTART_LOG:-/tmp/openclaw-gateway-restart.log}"
+
+mkdir -p "$(dirname "${LOG_PATH}")"
+
+nohup sh -c '
+  LOG_PATH="'"${LOG_PATH}"'"
+  {
+    printf "%s\n" "==> openclaw gateway restart requested at $(date -Is)"
+    pkill -f openclaw-gateway || true
+    sleep 2
+    openclaw gateway run --bind loopback --port 18789 --force
+  } >>"${LOG_PATH}" 2>&1
+' >/dev/null 2>&1 &
+
+printf "%s\n" "Gateway restart scheduled; see ${LOG_PATH} for details."
+

--- a/scripts/restart-gateway.sh
+++ b/scripts/restart-gateway.sh
@@ -3,16 +3,17 @@
 set -euo pipefail
 
 LOG_PATH="${OPENCLAW_GATEWAY_RESTART_LOG:-/tmp/openclaw-gateway-restart.log}"
+GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-loopback}"
 
 mkdir -p "$(dirname "${LOG_PATH}")"
 
-nohup sh -c '
-  LOG_PATH="'"${LOG_PATH}"'"
+nohup env LOG_PATH="${LOG_PATH}" sh -c '
   {
-    printf "%s\n" "==> openclaw gateway restart requested at $(date -Is)"
+    printf "%s\n" "==> openclaw gateway restart requested at $(date -u +\"%Y-%m-%dT%H:%M:%SZ\")"
     pkill -f openclaw-gateway || true
     sleep 2
-    openclaw gateway run --bind loopback --port 18789 --force
+    openclaw gateway run --bind "${GATEWAY_BIND}" --port "${GATEWAY_PORT}" --force
   } >>"${LOG_PATH}" 2>&1
 ' >/dev/null 2>&1 &
 


### PR DESCRIPTION
  ## Summary
  - Add `scripts/restart-gateway.sh` to safely restart the gateway from a detached child process (nohup + background), avoiding self-termination when the agent runs inside the gateway.
  - Update `AGENTS.md` to forbid direct `pkill -f openclaw-gateway` pipelines inside the gateway process and recommend using the gateway restart tool or `scripts/restart-gateway.sh` instead.
  - Mention the safe restart script in `docs/help/faq.md` for shell-based restarts on the same host.

  ## Fixes
  Fixes #44000

  ## Details
  - The script runs `pkill -f openclaw-gateway || true`, sleeps briefly, then runs `openclaw gateway run --bind loopback --port 18789 --force` inside a `nohup sh -c '...' &` child process.
  - This ensures the restart sequence can complete even if the original shell or agent session is terminated by the kill.
  - Agent guidance explains the "Suicide Paradox" scenario and directs models to use the gateway tool `restart` action when `commands.restart=true`, or the script when a shell restart is required.

  ## Test plan
  - Run `bash scripts/restart-gateway.sh` on a host with OpenClaw installed.
    - Verify the command returns quickly with: `Gateway restart scheduled; see /tmp/openclaw-gateway-restart.log for details.`
    - Verify `/tmp/openclaw-gateway-restart.log` contains a `openclaw gateway restart requested` entry with a timestamp.
  - In an environment with a running gateway process, use `ps`/`ss`/`openclaw gateway status` (or equivalent) to confirm the old gateway is stopped and a new instance starts after running the script.