### PR TITLE
fix(discord): add content-based fallback for mention detection

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -406,19 +406,19 @@ export async function preflightDiscordMessage(
   const mentionRegexes = buildMentionRegexes(params.cfg, effectiveRoute.agentId);
   const explicitlyMentioned = Boolean(
     botId &&
-      (message.mentionedUsers?.some((user: User) => user.id === botId) ||
-        message.content?.includes(`<@${botId}>`) ||
-        message.content?.includes(`<@!${botId}>`)),
+    (message.mentionedUsers?.some((user: User) => user.id === botId) ||
+      message.content?.includes(`<@${botId}>`) ||
+      message.content?.includes(`<@!${botId}>`)),
   );
   const hasAnyMention = Boolean(
     !isDirectMessage &&
-      ((message.mentionedUsers?.length ?? 0) > 0 ||
-        (message.mentionedRoles?.length ?? 0) > 0 ||
-        (message.mentionedEveryone && (!author.bot || sender.isPluralKit))),
+    ((message.mentionedUsers?.length ?? 0) > 0 ||
+      (message.mentionedRoles?.length ?? 0) > 0 ||
+      (message.mentionedEveryone && (!author.bot || sender.isPluralKit))),
   );
   const hasUserOrRoleMention = Boolean(
     !isDirectMessage &&
-      ((message.mentionedUsers?.length ?? 0) > 0 || (message.mentionedRoles?.length ?? 0) > 0),
+    ((message.mentionedUsers?.length ?? 0) > 0 || (message.mentionedRoles?.length ?? 0) > 0),
   );
 
   if (
@@ -613,9 +613,9 @@ export async function preflightDiscordMessage(
     });
   const implicitMention = Boolean(
     !isDirectMessage &&
-      botId &&
-      message.referencedMessage?.author?.id &&
-      message.referencedMessage.author.id === botId,
+    botId &&
+    message.referencedMessage?.author?.id &&
+    message.referencedMessage.author.id === botId,
   );
   if (shouldLogVerbose()) {
     logVerbose(

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -412,13 +412,13 @@ export async function preflightDiscordMessage(
   );
   const hasAnyMention = Boolean(
     !isDirectMessage &&
-    ((message.mentionedUsers?.length ?? 0) > 0 ||
-      (message.mentionedRoles?.length ?? 0) > 0 ||
-      (message.mentionedEveryone && (!author.bot || sender.isPluralKit))),
+      ((message.mentionedUsers?.length ?? 0) > 0 ||
+        (message.mentionedRoles?.length ?? 0) > 0 ||
+        (message.mentionedEveryone && (!author.bot || sender.isPluralKit))),
   );
   const hasUserOrRoleMention = Boolean(
     !isDirectMessage &&
-    ((message.mentionedUsers?.length ?? 0) > 0 || (message.mentionedRoles?.length ?? 0) > 0),
+      ((message.mentionedUsers?.length ?? 0) > 0 || (message.mentionedRoles?.length ?? 0) > 0),
   );
 
   if (
@@ -613,9 +613,9 @@ export async function preflightDiscordMessage(
     });
   const implicitMention = Boolean(
     !isDirectMessage &&
-    botId &&
-    message.referencedMessage?.author?.id &&
-    message.referencedMessage.author.id === botId,
+      botId &&
+      message.referencedMessage?.author?.id &&
+      message.referencedMessage.author.id === botId,
   );
   if (shouldLogVerbose()) {
     logVerbose(

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -405,11 +405,10 @@ export async function preflightDiscordMessage(
   }
   const mentionRegexes = buildMentionRegexes(params.cfg, effectiveRoute.agentId);
   const explicitlyMentioned = Boolean(
-    botId && (
-      message.mentionedUsers?.some((user: User) => user.id === botId) ||
-      message.content?.includes(`<@${botId}>`) ||
-      message.content?.includes(`<@!${botId}>`)
-    ),
+    botId &&
+      (message.mentionedUsers?.some((user: User) => user.id === botId) ||
+        message.content?.includes(`<@${botId}>`) ||
+        message.content?.includes(`<@!${botId}>`)),
   );
   const hasAnyMention = Boolean(
     !isDirectMessage &&

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -405,7 +405,11 @@ export async function preflightDiscordMessage(
   }
   const mentionRegexes = buildMentionRegexes(params.cfg, effectiveRoute.agentId);
   const explicitlyMentioned = Boolean(
-    botId && message.mentionedUsers?.some((user: User) => user.id === botId),
+    botId && (
+      message.mentionedUsers?.some((user: User) => user.id === botId) ||
+      message.content?.includes(`<@${botId}>`) ||
+      message.content?.includes(`<@!${botId}>`)
+    ),
   );
   const hasAnyMention = Boolean(
     !isDirectMessage &&

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { AgentIdentityResult } from "../types.ts";
 import {
   agentLogoUrl,
   resolveConfiguredCronModelSuggestions,
@@ -116,12 +117,14 @@ describe("resolveAgentAvatarUrl", () => {
   it("prefers a runtime avatar URL over non-URL identity avatars", () => {
     expect(
       resolveAgentAvatarUrl(
-        { identity: { avatar: "A", avatarUrl: "/avatar/main" } },
+        { identity: { avatar: "A", avatarUrl: "/avatar/main" } } as unknown as {
+          identity: { avatar: string; avatarUrl: string };
+        },
         {
           agentId: "main",
           avatar: "A",
           name: "Main",
-        },
+        } as unknown as AgentIdentityResult,
       ),
     ).toBe("/avatar/main");
   });


### PR DESCRIPTION
### Summary
Added a content-based fallback to detect mentions via `message.content` when `mentionedUsers` doesn't contain the bot. This ensures mentions are not missed in certain scenarios (e.g. threads).

Resolves #44524

### Problem statement
Discord's mention detection relies solely on the `message.mentionedUsers` array. In certain scenarios, Discord may not consistently populate this array even when the message content clearly contains `@Bot` mentions. This causes `explicitlyMentioned` to evaluate to `false`, and the message is dropped.

### Proposed solution
Add content-based fallback checking `message.content?.includes(<@${botId}>)` and `message.content?.includes(<@!${botId}>)` to robustly detect standard and legacy mention formats when `mentionedUsers` fails us.

### Acceptance criteria
Discord mentions in threads or channel main areas without correct `mentionedUsers` population are now properly detected by checking message content.