### PR TITLE
fix(sessions_send): keep parent deliveryContext when sub-agent sends

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -633,7 +633,6 @@ describe("sessions tools", () => {
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: "nested",
-        channel: "webchat",
         inputProvenance: { kind: "inter_session" },
       });
     }
@@ -813,10 +812,20 @@ describe("sessions tools", () => {
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: "nested",
-        channel: "webchat",
         inputProvenance: { kind: "inter_session" },
       });
     }
+
+    const requesterReplyStep = agentCalls.find((call) => {
+      const params = call.params as { sessionKey?: string; extraSystemPrompt?: string } | undefined;
+      return (
+        params?.sessionKey === requesterKey &&
+        params?.extraSystemPrompt?.includes("Agent-to-agent reply step")
+      );
+    });
+    expect((requesterReplyStep?.params as { channel?: string } | undefined)?.channel).toBe(
+      "discord",
+    );
 
     const replySteps = calls.filter(
       (call) =>
@@ -832,6 +841,119 @@ describe("sessions tools", () => {
       channel: "discord",
       message: "announce now",
     });
+  });
+
+  it("sessions_send keeps requester channel context during ping-pong when requesterChannel is omitted", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    let agentCallCount = 0;
+    let lastWaitedRunId: string | undefined;
+    const replyByRunId = new Map<string, string>();
+    const requesterKey = "agent:main:main";
+    const targetKey = "agent:main:worker";
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        agentCallCount += 1;
+        const runId = `run-${agentCallCount}`;
+        const params = request.params as
+          | {
+              message?: string;
+              sessionKey?: string;
+              extraSystemPrompt?: string;
+            }
+          | undefined;
+        let reply = "initial";
+        if (params?.extraSystemPrompt?.includes("Agent-to-agent reply step")) {
+          reply = params.sessionKey === requesterKey ? "pong-1" : "pong-2";
+        }
+        if (params?.extraSystemPrompt?.includes("Agent-to-agent announce step")) {
+          reply = "ANNOUNCE_SKIP";
+        }
+        replyByRunId.set(runId, reply);
+        return { runId, status: "accepted", acceptedAt: 2000 + agentCallCount };
+      }
+      if (request.method === "agent.wait") {
+        const params = request.params as { runId?: string } | undefined;
+        lastWaitedRunId = params?.runId;
+        return { runId: params?.runId ?? "run-1", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: requesterKey,
+              deliveryContext: { channel: "telegram", to: "12345" },
+              lastChannel: "telegram",
+              lastTo: "12345",
+            },
+            {
+              key: targetKey,
+              deliveryContext: { channel: "telegram", to: "67890" },
+              lastChannel: "telegram",
+              lastTo: "67890",
+            },
+          ],
+        };
+      }
+      if (request.method === "send") {
+        return { messageId: "m-announce" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const waited = await tool.execute("call8", {
+      sessionKey: targetKey,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+    expect(waited.details).toMatchObject({
+      status: "ok",
+      reply: "initial",
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(calls.filter((call) => call.method === "agent")).toHaveLength(4);
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+
+    const requesterReplyStep = calls.find((call) => {
+      if (call.method !== "agent") {
+        return false;
+      }
+      const params = call.params as { sessionKey?: string; extraSystemPrompt?: string } | undefined;
+      return (
+        params?.sessionKey === requesterKey &&
+        params?.extraSystemPrompt?.includes("Agent-to-agent reply step")
+      );
+    });
+    expect(requesterReplyStep).toBeDefined();
+    expect((requesterReplyStep?.params as { channel?: string } | undefined)?.channel).toBe(
+      "telegram",
+    );
   });
 
   it("subagents lists active and recent runs", async () => {

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -54,21 +54,21 @@ export async function runSessionsSendA2AFlow(params: {
       return;
     }
 
-    const announceTarget = await resolveAnnounceTarget({
-      sessionKey: params.targetSessionKey,
-      displayKey: params.displayKey,
-    });
-    const targetChannelRaw = announceTarget?.channel;
-    const targetChannel =
-      targetChannelRaw && isGatewayMessageChannel(targetChannelRaw) ? targetChannelRaw : undefined;
-
-    const requesterAnnounceTarget =
+    const [announceTarget, requesterAnnounceTarget] = await Promise.all([
+      resolveAnnounceTarget({
+        sessionKey: params.targetSessionKey,
+        displayKey: params.displayKey,
+      }),
       params.requesterSessionKey && !params.requesterChannel
-        ? await resolveAnnounceTarget({
+        ? resolveAnnounceTarget({
             sessionKey: params.requesterSessionKey,
             displayKey: params.requesterSessionKey,
           })
-        : null;
+        : Promise.resolve(null),
+    ]);
+    const targetChannelRaw = announceTarget?.channel;
+    const targetChannel =
+      targetChannelRaw && isGatewayMessageChannel(targetChannelRaw) ? targetChannelRaw : undefined;
     const requesterChannelRaw = params.requesterChannel ?? requesterAnnounceTarget?.channel;
     const requesterChannel =
       requesterChannelRaw && isGatewayMessageChannel(requesterChannelRaw)

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -2,7 +2,10 @@ import crypto from "node:crypto";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import {
+  isGatewayMessageChannel,
+  type GatewayMessageChannel,
+} from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import { readLatestAssistantReply, runAgentStep } from "./agent-step.js";
 import { resolveAnnounceTarget } from "./sessions-announce-target.js";
@@ -55,7 +58,24 @@ export async function runSessionsSendA2AFlow(params: {
       sessionKey: params.targetSessionKey,
       displayKey: params.displayKey,
     });
-    const targetChannel = announceTarget?.channel ?? "unknown";
+    const targetChannelRaw = announceTarget?.channel;
+    const targetChannel =
+      targetChannelRaw && isGatewayMessageChannel(targetChannelRaw) ? targetChannelRaw : undefined;
+
+    const requesterAnnounceTarget =
+      params.requesterSessionKey && !params.requesterChannel
+        ? await resolveAnnounceTarget({
+            sessionKey: params.requesterSessionKey,
+            displayKey: params.requesterSessionKey,
+          })
+        : null;
+    const requesterChannelRaw = params.requesterChannel ?? requesterAnnounceTarget?.channel;
+    const requesterChannel =
+      requesterChannelRaw && isGatewayMessageChannel(requesterChannelRaw)
+        ? requesterChannelRaw
+        : undefined;
+
+    const targetChannelForContext = targetChannel ?? "unknown";
 
     if (
       params.maxPingPongTurns > 0 &&
@@ -70,22 +90,26 @@ export async function runSessionsSendA2AFlow(params: {
           currentSessionKey === params.requesterSessionKey ? "requester" : "target";
         const replyPrompt = buildAgentToAgentReplyContext({
           requesterSessionKey: params.requesterSessionKey,
-          requesterChannel: params.requesterChannel,
+          requesterChannel,
           targetSessionKey: params.displayKey,
-          targetChannel,
+          targetChannel: targetChannelForContext,
           currentRole,
           turn,
           maxTurns: params.maxPingPongTurns,
         });
+        const currentChannel =
+          currentSessionKey === params.requesterSessionKey ? requesterChannel : targetChannel;
+        const sourceChannel =
+          nextSessionKey === params.requesterSessionKey ? requesterChannel : targetChannel;
         const replyText = await runAgentStep({
           sessionKey: currentSessionKey,
           message: incomingMessage,
           extraSystemPrompt: replyPrompt,
           timeoutMs: params.announceTimeoutMs,
+          channel: currentChannel,
           lane: AGENT_LANE_NESTED,
           sourceSessionKey: nextSessionKey,
-          sourceChannel:
-            nextSessionKey === params.requesterSessionKey ? params.requesterChannel : targetChannel,
+          sourceChannel,
           sourceTool: "sessions_send",
         });
         if (!replyText || isReplySkip(replyText)) {
@@ -101,9 +125,9 @@ export async function runSessionsSendA2AFlow(params: {
 
     const announcePrompt = buildAgentToAgentAnnounceContext({
       requesterSessionKey: params.requesterSessionKey,
-      requesterChannel: params.requesterChannel,
+      requesterChannel,
       targetSessionKey: params.displayKey,
-      targetChannel,
+      targetChannel: targetChannelForContext,
       originalMessage: params.message,
       roundOneReply: primaryReply,
       latestReply,
@@ -113,9 +137,10 @@ export async function runSessionsSendA2AFlow(params: {
       message: "Agent-to-agent announce step.",
       extraSystemPrompt: announcePrompt,
       timeoutMs: params.announceTimeoutMs,
+      channel: targetChannel,
       lane: AGENT_LANE_NESTED,
       sourceSessionKey: params.requesterSessionKey,
-      sourceChannel: params.requesterChannel,
+      sourceChannel: requesterChannel,
       sourceTool: "sessions_send",
     });
     if (announceTarget && announceReply && announceReply.trim() && !isAnnounceSkip(announceReply)) {


### PR DESCRIPTION
## Summary
Fix sessions_send A2A flow to preserve requester session channel context (e.g. Telegram) instead of defaulting to webchat during sub-agent ping-pong.

## Root cause
runAgentStep calls in sessions_send A2A path did not pass explicit channel when requesterChannel was omitted, so internal fallback could record webchat as last route on parent session.

## Changes
- Resolve requester channel from requester session delivery context when omitted.
- Pass validated explicit channel into A2A runAgentStep calls.
- Keep existing behavior for announce/prompt/context.

## Tests
- Added regression test for omitted requesterChannel case to ensure requester-side ping-pong uses telegram channel.

Closes #44153