### PR TITLE
fix(deps): patch gaxios to prefer globalThis.fetch over node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -464,6 +464,9 @@
           "strip-ansi": "^7.2.0"
         }
       }
+    },
+    "patchedDependencies": {
+      "gaxios@7.1.3": "patches/gaxios@7.1.3.patch"
     }
   }
 }

--- a/patches/gaxios@7.1.3.patch
+++ b/patches/gaxios@7.1.3.patch
@@ -1,0 +1,46 @@
+diff --git a/build/cjs/src/gaxios.js b/build/cjs/src/gaxios.js
+index 84ddd4a40cfff0e2869e14f2c1029f21ffc4e602..da8466619fcf1e9c9d81005d6de5e47abc92b3c4 100644
+--- a/build/cjs/src/gaxios.js
++++ b/build/cjs/src/gaxios.js
+@@ -525,9 +525,15 @@ class Gaxios {
+     }
+     static async #getFetch() {
+         const hasWindow = typeof window !== 'undefined' && !!window;
+-        this.#fetch ||= hasWindow
+-            ? window.fetch
+-            : (await import('node-fetch')).default;
++        if (!this.#fetch) {
++            if (hasWindow) {
++                this.#fetch = window.fetch;
++            } else if (typeof globalThis !== 'undefined' && typeof globalThis.fetch === 'function') {
++                this.#fetch = globalThis.fetch;
++            } else {
++                this.#fetch = (await import('node-fetch')).default;
++            }
++        }
+         return this.#fetch;
+     }
+     /**
+diff --git a/build/esm/src/gaxios.js b/build/esm/src/gaxios.js
+index 4c0708e8366a2c3ddcfbf13d5fa8018985aee339..158b89e2504bc9b8ef60d2dedfbcdffa2f532bbf 100644
+--- a/build/esm/src/gaxios.js
++++ b/build/esm/src/gaxios.js
+@@ -519,9 +519,15 @@ export class Gaxios {
+     }
+     static async #getFetch() {
+         const hasWindow = typeof window !== 'undefined' && !!window;
+-        this.#fetch ||= hasWindow
+-            ? window.fetch
+-            : (await import('node-fetch')).default;
++        if (!this.#fetch) {
++            if (hasWindow) {
++                this.#fetch = window.fetch;
++            } else if (typeof globalThis !== 'undefined' && typeof globalThis.fetch === 'function') {
++                this.#fetch = globalThis.fetch;
++            } else {
++                this.#fetch = (await import('node-fetch')).default;
++            }
++        }
+         return this.#fetch;
+     }
+     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
+patchedDependencies:
+  gaxios@7.1.3:
+    hash: 99a8750bfe41ed342e8eb0573c489cd263eac600436482791080020bb0d241e8
+    path: patches/gaxios@7.1.3.patch
+
 importers:
 
   .:
@@ -12412,7 +12417,7 @@ snapshots:
       wide-align: 1.1.5
     optional: true
 
-  gaxios@7.1.3:
+  gaxios@7.1.3(patch_hash=99a8750bfe41ed342e8eb0573c489cd263eac600436482791080020bb0d241e8):
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
@@ -12423,7 +12428,7 @@ snapshots:
 
   gcp-metadata@8.1.2:
     dependencies:
-      gaxios: 7.1.3
+      gaxios: 7.1.3(patch_hash=99a8750bfe41ed342e8eb0573c489cd263eac600436482791080020bb0d241e8)
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -12508,7 +12513,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.3
+      gaxios: 7.1.3(patch_hash=99a8750bfe41ed342e8eb0573c489cd263eac600436482791080020bb0d241e8)
       gcp-metadata: 8.1.2
       google-logging-utils: 1.1.3
       jws: 4.0.1


### PR DESCRIPTION
## Summary

- Patches `gaxios@7.1.3` to prefer `globalThis.fetch` (built-in on Node 22+) over dynamically importing `node-fetch`
- Fixes `Cannot convert undefined or null to object` crash when using Google Vertex AI providers under pnpm strict isolation

## Root Cause

`gaxios@7.1.3`'s `#getFetch()` falls back to `await import('node-fetch')` in non-browser environments. Under pnpm's strict `node_modules` layout, `node-fetch` cannot be resolved from gaxios's context, causing a runtime crash. Since OpenClaw requires Node 22+ which ships with a stable built-in `globalThis.fetch`, the `node-fetch` import is unnecessary.

## Changes

- `patches/gaxios@7.1.3.patch`: modifies `#getFetch()` in both ESM and CJS builds to check `globalThis.fetch` before falling back to `node-fetch`
- `package.json`: registers the patch in `pnpm.patchedDependencies`

## Test plan

- [ ] `pnpm install` applies patch without errors
- [ ] `pnpm build` succeeds
- [ ] Google Vertex AI agent runs work without `NODE_OPTIONS` workaround
- [ ] No regression on non-Google providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)