### PR TITLE
fix(feishu): prevent duplicate plugin id by respecting channels.* config for extension-based channels

### DIFF
--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -383,6 +383,20 @@ function isPluginExplicitlyDisabled(cfg: OpenClawConfig, pluginId: string): bool
       return true;
     }
   }
+  // Also check channels.* for extension-based channels (e.g. feishu)
+  // that are not in the built-in registry but configured under channels.*
+  if (!builtInChannelId) {
+    const channels = cfg.channels as Record<string, unknown> | undefined;
+    const channelConfig = channels?.[pluginId];
+    if (
+      channelConfig &&
+      typeof channelConfig === "object" &&
+      !Array.isArray(channelConfig) &&
+      (channelConfig as { enabled?: unknown }).enabled === false
+    ) {
+      return true;
+    }
+  }
   const entry = cfg.plugins?.entries?.[pluginId];
   return entry?.enabled === false;
 }

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -445,6 +445,28 @@ function registerPluginEntry(cfg: OpenClawConfig, pluginId: string): OpenClawCon
       },
     };
   }
+  // Extension-based channels (e.g. feishu) are not in the built-in registry
+  // but may still be configured under channels.*. When that is the case,
+  // enable the channel there instead of creating a plugins.entries record
+  // which would cause a duplicate plugin id conflict with the bundled extension.
+  const channelsRaw = cfg.channels as Record<string, unknown> | undefined;
+  const existingChannelCfg = channelsRaw?.[pluginId];
+  if (
+    existingChannelCfg &&
+    typeof existingChannelCfg === "object" &&
+    !Array.isArray(existingChannelCfg)
+  ) {
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        [pluginId]: {
+          ...(existingChannelCfg as Record<string, unknown>),
+          enabled: true,
+        },
+      },
+    };
+  }
   const entries = {
     ...cfg.plugins?.entries,
     [pluginId]: {
@@ -521,7 +543,24 @@ export function applyPluginAutoEnable(params: {
             }
             return (channelConfig as { enabled?: unknown }).enabled === true;
           })()
-        : next.plugins?.entries?.[entry.pluginId]?.enabled === true;
+        : (() => {
+            // Check plugins.entries first
+            if (next.plugins?.entries?.[entry.pluginId]?.enabled === true) {
+              return true;
+            }
+            // Also check channels.* for extension-based channels (e.g. feishu)
+            // that are not in the built-in registry but configured under channels.*
+            const channels = next.channels as Record<string, unknown> | undefined;
+            const channelConfig = channels?.[entry.pluginId];
+            if (
+              channelConfig &&
+              typeof channelConfig === "object" &&
+              !Array.isArray(channelConfig)
+            ) {
+              return (channelConfig as { enabled?: unknown }).enabled === true;
+            }
+            return false;
+          })();
     if (alreadyEnabled && !allowMissing) {
       continue;
     }


### PR DESCRIPTION
## Summary

Resolves the long-standing Feishu duplicate plugin ID issue that has affected all Feishu users since v2026.2.3. After upgrading OpenClaw, the Feishu channel becomes completely non-functional — no messages received, no pairing codes returned, and the persistent WebSocket connection is never established.

## Root Cause

Feishu is a bundled extension, not a built-in channel registered in `src/channels/registry.ts`. This means `normalizeChatChannelId("feishu")` returns `null`. As a result:

1. **`registerPluginEntry()`** always fell through to the `plugins.entries` branch, creating `plugins.entries.feishu = { enabled: true }` even when `channels.feishu` was already properly configured.
2. The gateway then loaded the Feishu plugin from two different paths (bundled extension + plugins.entries), and since the paths differ, the `samePath` deduplication in `manifest-registry.ts` did not catch it.
3. This triggered the `"duplicate plugin id detected"` warning and in many cases prevented the Feishu long connection from being established at all.

## Changes

**`src/config/plugin-auto-enable.ts`:**

- **`registerPluginEntry()`**: Added a `channels.*` fallback check before the `plugins.entries` branch. When an extension-based channel (e.g. feishu) is already configured under `channels.*`, the function now enables it there instead of creating a conflicting `plugins.entries` record.
- **`alreadyEnabled` check**: Extended to also inspect `channels.*` for non-built-in plugins, so the auto-enable loop correctly detects that feishu is already enabled and skips redundant registration.

## Testing

- Verified `openclaw doctor` no longer shows "duplicate plugin id detected" warning
- Verified no `plugins.entries.feishu` is auto-created when `channels.feishu` exists
- `pnpm build` passes with zero errors
- Linting passes with zero warnings

## Related Issues

Fixes #40854, #37548, #34394, #30321, #29632, #20932, #15139, #10484, #10287