### PR TITLE
Cron: isolate cron run session lanes

### DIFF
--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -327,7 +327,7 @@ describe("runCronIsolatedAgentTurn", () => {
         workspaceDir?: string;
         sessionFile?: string;
       };
-      expect(call?.sessionKey).toBe("agent:ops:cron:job-ops");
+      expect(call?.sessionKey).toMatch(/^agent:ops:cron:job-ops:run:/);
       expect(call?.workspaceDir).toBe(opsWorkspace);
       expect(call?.sessionFile).toContain(path.join("agents", "ops"));
     });

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -98,6 +98,7 @@ function makeBaseParams(overrides: { synthesizedText?: string; deliveryRequested
     } as never,
     agentId: "main",
     agentSessionKey: "agent:main",
+    executionSessionKey: "agent:main:cron:test-job:run:run-123",
     runSessionId: "run-123",
     runStartedAt: Date.now(),
     runEndedAt: Date.now(),
@@ -163,6 +164,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
     // No announce should have been attempted (subagents still running)
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(countActiveDescendantRuns).toHaveBeenCalledWith("agent:main:cron:test-job:run:run-123");
   });
 
   it("early return (stale interim suppression) sets deliveryAttempted=true so timer skips enqueueSystemEvent", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -76,6 +76,7 @@ type DispatchCronDeliveryParams = {
   job: CronJob;
   agentId: string;
   agentSessionKey: string;
+  executionSessionKey: string;
   runSessionId: string;
   runStartedAt: number;
   runEndedAt: number;
@@ -315,7 +316,7 @@ export async function dispatchCronDelivery(
       return null;
     }
     const initialSynthesizedText = synthesizedText.trim();
-    let activeSubagentRuns = countActiveDescendantRuns(params.agentSessionKey);
+    let activeSubagentRuns = countActiveDescendantRuns(params.executionSessionKey);
     const expectedSubagentFollowup = expectsSubagentFollowup(initialSynthesizedText);
     // Also check for already-completed descendants. If the subagent finished
     // before delivery-dispatch runs, activeSubagentRuns is 0 and
@@ -325,22 +326,22 @@ export async function dispatchCronDelivery(
     const completedDescendantReply =
       activeSubagentRuns === 0 && isLikelyInterimCronMessage(initialSynthesizedText)
         ? await readDescendantSubagentFallbackReply({
-            sessionKey: params.agentSessionKey,
+            sessionKey: params.executionSessionKey,
             runStartedAt: params.runStartedAt,
           })
         : undefined;
     const hadDescendants = activeSubagentRuns > 0 || Boolean(completedDescendantReply);
     if (activeSubagentRuns > 0 || expectedSubagentFollowup) {
       let finalReply = await waitForDescendantSubagentSummary({
-        sessionKey: params.agentSessionKey,
+        sessionKey: params.executionSessionKey,
         initialReply: initialSynthesizedText,
         timeoutMs: params.timeoutMs,
         observedActiveDescendants: activeSubagentRuns > 0 || expectedSubagentFollowup,
       });
-      activeSubagentRuns = countActiveDescendantRuns(params.agentSessionKey);
+      activeSubagentRuns = countActiveDescendantRuns(params.executionSessionKey);
       if (!finalReply && activeSubagentRuns === 0) {
         finalReply = await readDescendantSubagentFallbackReply({
-          sessionKey: params.agentSessionKey,
+          sessionKey: params.executionSessionKey,
           runStartedAt: params.runStartedAt,
         });
       }

--- a/src/cron/isolated-agent/run.execution-session-key.test.ts
+++ b/src/cron/isolated-agent/run.execution-session-key.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   clearFastTestEnv,
+  isCliProviderMock,
   loadRunCronIsolatedAgentTurn,
   makeCronSession,
   resetRunCronIsolatedAgentTurnHarness,
   resolveCronSessionMock,
   restoreFastTestEnv,
+  runCliAgentMock,
   runEmbeddedPiAgentMock,
   runWithModelFallbackMock,
 } from "./run.test-harness.js";
@@ -62,5 +64,21 @@ describe("runCronIsolatedAgentTurn execution session key", () => {
     expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.sessionKey).toBe(
       "agent:default:cron:execution-session-key:run:run-123",
     );
+  });
+
+  it("uses the per-run session key when executing the CLI agent", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    runCliAgentMock.mockResolvedValue({
+      payloads: [{ text: "cli result" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.sessionKey).toBe(
+      "agent:default:cron:execution-session-key:run:run-123",
+    );
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cron/isolated-agent/run.execution-session-key.test.ts
+++ b/src/cron/isolated-agent/run.execution-session-key.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearFastTestEnv,
+  loadRunCronIsolatedAgentTurn,
+  makeCronSession,
+  resetRunCronIsolatedAgentTurnHarness,
+  resolveCronSessionMock,
+  restoreFastTestEnv,
+  runEmbeddedPiAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function makeParams() {
+  return {
+    cfg: {},
+    deps: {} as never,
+    job: {
+      id: "execution-session-key",
+      name: "Execution Session Key",
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "summarize latest items" },
+      delivery: { mode: "none" },
+    } as never,
+    message: "summarize latest items",
+    sessionKey: "cron:execution-session-key",
+  };
+}
+
+describe("runCronIsolatedAgentTurn execution session key", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({
+        sessionEntry: {
+          sessionId: "run-123",
+          updatedAt: 0,
+          systemSent: false,
+          skillsSnapshot: undefined,
+        },
+      }),
+    );
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
+      const result = await run(provider, model);
+      return { result, provider, model, attempts: [] };
+    });
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("uses the per-run session key when executing the isolated agent", async () => {
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.sessionKey).toBe(
+      "agent:default:cron:execution-session-key:run:run-123",
+    );
+  });
+});

--- a/src/cron/isolated-agent/run.interim-retry.test.ts
+++ b/src/cron/isolated-agent/run.interim-retry.test.ts
@@ -95,5 +95,11 @@ describe("runCronIsolatedAgentTurn — interim ack retry", () => {
 
     mockFallbackPassthrough();
     await runTurnAndExpectOk(1, 1);
+    expect(listDescendantRunsForRequesterMock).toHaveBeenCalledWith(
+      "agent:default:cron:test:run:test-session-id",
+    );
+    expect(countActiveDescendantRunsMock).toHaveBeenCalledWith(
+      "agent:default:cron:test:run:test-session-id",
+    );
   });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -666,7 +666,7 @@ export async function runCronIsolatedAgentTurn(params: {
         (interimDeliveryPayload?.mediaUrls?.length ?? 0) > 0 ||
         Object.keys(interimDeliveryPayload?.channelData ?? {}).length > 0;
       const interimText = pickLastNonEmptyTextFromPayloads(interimPayloads)?.trim() ?? "";
-      const hasDescendantsSinceRunStart = listDescendantRunsForRequester(agentSessionKey).some(
+      const hasDescendantsSinceRunStart = listDescendantRunsForRequester(runSessionKey).some(
         (entry) => {
           const descendantStartedAt =
             typeof entry.startedAt === "number" ? entry.startedAt : entry.createdAt;
@@ -678,7 +678,7 @@ export async function runCronIsolatedAgentTurn(params: {
         !interimRunResult.didSendViaMessagingTool &&
         !interimPayloadHasStructuredContent &&
         !interimPayloads.some((payload) => payload?.isError === true) &&
-        countActiveDescendantRuns(agentSessionKey) === 0 &&
+        countActiveDescendantRuns(runSessionKey) === 0 &&
         !hasDescendantsSinceRunStart &&
         isLikelyInterimCronMessage(interimText);
 
@@ -848,6 +848,7 @@ export async function runCronIsolatedAgentTurn(params: {
     timeoutMs,
     resolvedDelivery,
     deliveryRequested,
+    executionSessionKey: runSessionKey,
     skipHeartbeatDelivery,
     skipMessagingToolDelivery,
     deliveryBestEffort,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -575,7 +575,10 @@ export async function runCronIsolatedAgentTurn(params: {
               : getCliSessionId(cronSession.sessionEntry, providerOverride);
             const result = await runCliAgent({
               sessionId: cronSession.sessionEntry.sessionId,
-              sessionKey: agentSessionKey,
+              // Use the per-run session key for execution so each isolated cron
+              // run gets its own session lane instead of queueing behind stale
+              // work on the stable job-scoped key.
+              sessionKey: runSessionKey,
               agentId,
               sessionFile,
               workspaceDir,
@@ -597,7 +600,10 @@ export async function runCronIsolatedAgentTurn(params: {
           }
           const result = await runEmbeddedPiAgent({
             sessionId: cronSession.sessionEntry.sessionId,
-            sessionKey: agentSessionKey,
+            // Use the per-run session key for execution so each isolated cron
+            // run gets its own session lane instead of queueing behind stale
+            // work on the stable job-scoped key.
+            sessionKey: runSessionKey,
             agentId,
             trigger: "cron",
             // Cron jobs are trusted local automation, so isolated runs should


### PR DESCRIPTION
## Summary

- Problem: isolated cron `agentTurn` runs generated a per-run session key for persistence, but still executed on the stable job-scoped session key.
- Why it matters: repeated runs of the same cron job could queue behind stale work on `session:agent:main:cron:<job-id>`, matching the timeout/stuck symptoms in #44541.
- What changed: isolated cron execution now passes the per-run `...:run:<sessionId>` session key into the CLI/embedded agent runner, and adds a regression test that asserts the execution key is per-run.
- What did NOT change (scope boundary): this PR does not change model/provider selection, cron timeout policy, or delivery behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44541
- Related #29774

## User-visible / Behavior Changes

- Isolated cron runs now execute on a unique per-run session lane instead of reusing the stable job-scoped cron lane.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local test harness
- Model/provider: mocked
- Integration/channel (if any): N/A
- Relevant config (redacted): isolated cron `agentTurn`

### Steps

1. Create an isolated cron job with `payload.kind = "agentTurn"`.
2. Execute the job runner twice for the same job.
3. Inspect the session key passed into the isolated runner.

### Expected

- Each execution uses its own `...:run:<sessionId>` session key/lane.

### Actual

- Before this change the runner still used the stable job-scoped session key.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran targeted Vitest coverage for isolated cron execution session-key behavior and nearby cron isolated-agent behavior.
- Edge cases checked: existing message-tool policy and owner-auth isolated cron tests still pass.
- What you did **not** verify: live provider-backed cron execution on a machine with model credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit 1b9e43ce4.
- Files/config to restore: `src/cron/isolated-agent/run.ts`
- Known bad symptoms reviewers should watch for: isolated cron runs unexpectedly sharing the same stable session lane again.

## Risks and Mitigations

- Risk: per-run session-key execution could diverge from persisted cron session bookkeeping.
  - Mitigation: the stable cron key is still persisted alongside the per-run key; the change only affects execution-time lane selection.
