### PR TITLE
fix(telegram): polling stall recovery fails when grammY retries mask the stall

### DIFF
--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -52,6 +52,7 @@ type TelegramPollingSessionOpts = {
 
 export class TelegramPollingSession {
   #restartAttempts = 0;
+  #consecutiveStallRestarts = 0;
   #webhookCleared = false;
   #forceRestarted = false;
   #activeRunner: ReturnType<typeof run> | undefined;
@@ -183,13 +184,12 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
-    let consecutiveStallRestarts = 0;
     bot.api.config.use(async (prev, method, payload, signal) => {
       const result = await prev(method, payload, signal);
       if (method === "getUpdates") {
         lastGetUpdatesAt = Date.now();
         this.#restartAttempts = 0;
-        consecutiveStallRestarts = 0;
+        this.#consecutiveStallRestarts = 0;
       }
       return result;
     });
@@ -232,16 +232,16 @@ export class TelegramPollingSession {
       }
       const elapsed = Date.now() - lastGetUpdatesAt;
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
-        consecutiveStallRestarts += 1;
+        this.#consecutiveStallRestarts += 1;
         stalledRestart = true;
-        if (consecutiveStallRestarts >= MAX_CONSECUTIVE_POLL_RESTARTS) {
+        if (this.#consecutiveStallRestarts >= MAX_CONSECUTIVE_POLL_RESTARTS) {
           this.opts.log(
-            `[telegram] Polling recovery exhausted after ${consecutiveStallRestarts} consecutive stall restarts without successful getUpdates; escalating to process exit.`,
+            `[telegram] Polling recovery exhausted after ${this.#consecutiveStallRestarts} consecutive stall restarts without successful getUpdates; escalating to process exit.`,
           );
           process.exit(1);
         }
         this.opts.log(
-          `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart (attempt ${consecutiveStallRestarts}/${MAX_CONSECUTIVE_POLL_RESTARTS}).`,
+          `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart (attempt ${this.#consecutiveStallRestarts}/${MAX_CONSECUTIVE_POLL_RESTARTS}).`,
         );
         void stopRunner();
         void stopBot();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -16,6 +16,7 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
+const MAX_CONSECUTIVE_POLL_RESTARTS = 5;
 
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -182,11 +183,15 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
-    bot.api.config.use((prev, method, payload, signal) => {
+    let consecutiveStallRestarts = 0;
+    bot.api.config.use(async (prev, method, payload, signal) => {
+      const result = await prev(method, payload, signal);
       if (method === "getUpdates") {
         lastGetUpdatesAt = Date.now();
+        this.#restartAttempts = 0;
+        consecutiveStallRestarts = 0;
       }
-      return prev(method, payload, signal);
+      return result;
     });
 
     const runner = run(bot, this.opts.runnerOptions);
@@ -227,9 +232,16 @@ export class TelegramPollingSession {
       }
       const elapsed = Date.now() - lastGetUpdatesAt;
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
+        consecutiveStallRestarts += 1;
         stalledRestart = true;
+        if (consecutiveStallRestarts >= MAX_CONSECUTIVE_POLL_RESTARTS) {
+          this.opts.log(
+            `[telegram] Polling recovery exhausted after ${consecutiveStallRestarts} consecutive stall restarts without successful getUpdates; escalating to process exit.`,
+          );
+          process.exit(1);
+        }
         this.opts.log(
-          `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
+          `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart (attempt ${consecutiveStallRestarts}/${MAX_CONSECUTIVE_POLL_RESTARTS}).`,
         );
         void stopRunner();
         void stopBot();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -234,7 +234,7 @@ export class TelegramPollingSession {
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
         this.#consecutiveStallRestarts += 1;
         stalledRestart = true;
-        if (this.#consecutiveStallRestarts >= MAX_CONSECUTIVE_POLL_RESTARTS) {
+        if (this.#consecutiveStallRestarts > MAX_CONSECUTIVE_POLL_RESTARTS) {
           this.opts.log(
             `[telegram] Polling recovery exhausted after ${this.#consecutiveStallRestarts} consecutive stall restarts without successful getUpdates; escalating to process exit.`,
           );


### PR DESCRIPTION
## Summary

Fixes #44595

The polling stall watchdog in `TelegramPollingSession` tracks `getUpdates` call **initiation**, not **successful completion**. When the watchdog triggers a restart but network recovery fails, grammY's internal retry mechanism continues making failed `getUpdates` calls at intervals shorter than the 90s stall threshold. Each failed attempt updates `lastGetUpdatesAt` through the API middleware, fooling the watchdog into thinking polling is healthy when it's actually broken.

This caused a **50-minute outage** where the gateway process was alive (`/health` returning `{"ok":true}`) but Telegram was completely deaf — no messages received on any account.

## Root Cause

```typescript
// BEFORE: timestamps on initiation — broken retries mask the stall
bot.api.config.use((prev, method, payload, signal) => {
  if (method === "getUpdates") lastGetUpdatesAt = Date.now();
  return prev(method, payload, signal);
});
```

**Timeline of the failure:**
1. Polling stall detected (92–103s silence) → watchdog fired correctly, restart triggered ✅
2. Second stall (90s) → watchdog fired again, restart #2 triggered ✅
3. After restart #2: grammY's retry interval < 90s → each failed `getUpdates` call updates timestamp → **watchdog never fires again** ❌
4. Gateway sat deaf for 50 minutes until manual restart

## Fix (3 changes, 1 file)

### 1. Track success, not initiation
Make the API transformer `async`, `await prev()` before updating `lastGetUpdatesAt`. Failed calls no longer reset the watchdog clock.

### 2. Reset `#restartAttempts` on success
Prevents permanent backoff growth after genuine recovery — the counter resets when `getUpdates` actually succeeds.

### 3. Escalate after 5 consecutive stall restarts
New `MAX_CONSECUTIVE_POLL_RESTARTS = 5` constant. After exhausting retries without a single successful `getUpdates`, calls `process.exit(1)` to let the process manager (systemd/launchd/pm2) do a clean restart.

## Testing

This was discovered and diagnosed from production logs on OpenClaw 2026.3.8. The fix addresses the specific code path in `src/telegram/polling-session.ts` that the existing `monitor.test.ts` stall detection tests don't cover (they test detection, not recovery failure under grammY retries).