### PR TITLE
fix(windows): delegate npm global update to detached helper to avoid EBUSY

### DIFF
--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -92,6 +92,37 @@ export const updateHandlers: GatewayRequestHandlers = {
       sentinelPath = null;
     }
 
+    // When the update was delegated to a detached helper (Windows EBUSY workaround),
+    // the Gateway must fully exit so the helper can replace locked files.
+    // The detached helper will restart the Gateway via Scheduled Task after install.
+    // Use a hard process.exit() after a brief delay to let the response flush.
+    if (result.detachedResultPath) {
+      context?.logGateway?.info(
+        `update.run delegated to detached helper ${formatControlPlaneActor(actor)} resultPath=${result.detachedResultPath}`,
+      );
+
+      respond(
+        true,
+        {
+          ok: true,
+          result,
+          restart: { ok: true, method: "detached-win32", delayMs: restartDelayMs },
+          sentinel: { path: sentinelPath, payload },
+        },
+        undefined,
+      );
+
+      // Give the response time to flush, then exit so the detached helper can proceed.
+      setTimeout(
+        () => {
+          context?.logGateway?.info("Exiting for detached Windows update...");
+          process.exit(0);
+        },
+        Math.max(restartDelayMs, 2000),
+      );
+      return;
+    }
+
     // Only restart the gateway when the update actually succeeded.
     // Restarting after a failed update leaves the process in a broken state
     // (corrupted node_modules, partial builds) and causes a crash loop.

--- a/src/infra/update-detached-win32.test.ts
+++ b/src/infra/update-detached-win32.test.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const resolvePreferredOpenClawTmpDirMock = vi.hoisted(() => vi.fn(() => os.tmpdir()));
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+vi.mock("./tmp-openclaw-dir.js", () => ({
+  resolvePreferredOpenClawTmpDir: () => resolvePreferredOpenClawTmpDirMock(),
+}));
+
+import { readDetachedUpdateResult, spawnDetachedUpdate } from "./update-detached-win32.js";
+
+const createdFiles = new Set<string>();
+
+function decodeCmdPathArg(value: string): string {
+  const trimmed = value.trim();
+  const withoutQuotes =
+    trimmed.startsWith('"') && trimmed.endsWith('"') ? trimmed.slice(1, -1) : trimmed;
+  return withoutQuotes.replace(/\^!/g, "!").replace(/%%/g, "%");
+}
+
+afterEach(() => {
+  spawnMock.mockReset();
+  resolvePreferredOpenClawTmpDirMock.mockReset();
+  resolvePreferredOpenClawTmpDirMock.mockReturnValue(os.tmpdir());
+  for (const filePath of createdFiles) {
+    try {
+      fs.unlinkSync(filePath);
+    } catch {
+      // best-effort
+    }
+  }
+  createdFiles.clear();
+});
+
+describe("spawnDetachedUpdate", () => {
+  it("writes a batch script and spawns a detached process", () => {
+    const unref = vi.fn();
+    let seenScriptPath = "";
+    spawnMock.mockImplementation((_file: string, args: string[]) => {
+      seenScriptPath = decodeCmdPathArg(args[3]);
+      createdFiles.add(seenScriptPath);
+      return { unref };
+    });
+
+    const result = spawnDetachedUpdate({
+      installArgv: ["npm", "i", "-g", "openclaw@latest"],
+      env: { OPENCLAW_WINDOWS_TASK_NAME: "TestTask" } as unknown as NodeJS.ProcessEnv,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.scriptPath).toMatch(/openclaw-detached-update-.*\.cmd$/);
+    expect(result.resultPath).toMatch(/openclaw-detached-update-.*\.json$/);
+
+    // Verify spawn was called correctly
+    expect(spawnMock).toHaveBeenCalledOnce();
+    const [file, args, opts] = spawnMock.mock.calls[0];
+    expect(file).toBe("cmd.exe");
+    expect(args[0]).toBe("/d");
+    expect(args[1]).toBe("/s");
+    expect(args[2]).toBe("/c");
+    expect(opts.detached).toBe(true);
+    expect(opts.stdio).toBe("ignore");
+    expect(opts.windowsHide).toBe(true);
+
+    // Verify the script content
+    const scriptContent = fs.readFileSync(seenScriptPath, "utf8");
+    expect(scriptContent).toContain("npm i -g openclaw@latest");
+    expect(scriptContent).toContain(`PID eq ${process.pid}`);
+    expect(scriptContent).toContain("TestTask");
+    expect(scriptContent).toContain("schtasks /Run");
+  });
+
+  it("returns ok:false when spawn throws", () => {
+    spawnMock.mockImplementation(() => {
+      throw new Error("spawn failed");
+    });
+
+    const result = spawnDetachedUpdate({
+      installArgv: ["npm", "i", "-g", "openclaw@latest"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toBe("spawn failed");
+  });
+
+  it("uses default task name when env override is not set", () => {
+    const unref = vi.fn();
+    let seenScriptPath = "";
+    spawnMock.mockImplementation((_file: string, args: string[]) => {
+      seenScriptPath = decodeCmdPathArg(args[3]);
+      createdFiles.add(seenScriptPath);
+      return { unref };
+    });
+
+    const result = spawnDetachedUpdate({
+      installArgv: ["npm", "i", "-g", "openclaw@latest"],
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(result.ok).toBe(true);
+    const scriptContent = fs.readFileSync(seenScriptPath, "utf8");
+    expect(scriptContent).toContain("OpenClaw Gateway");
+  });
+});
+
+describe("readDetachedUpdateResult", () => {
+  it("returns parsed JSON when file exists", () => {
+    const tmpPath = path.join(os.tmpdir(), `test-detached-result-${Date.now()}.json`);
+    createdFiles.add(tmpPath);
+    fs.writeFileSync(tmpPath, JSON.stringify({ ok: true, reason: "install-succeeded" }));
+
+    const result = readDetachedUpdateResult(tmpPath);
+    expect(result).toEqual({ ok: true, reason: "install-succeeded" });
+  });
+
+  it("returns null when file does not exist", () => {
+    const result = readDetachedUpdateResult("/nonexistent/path.json");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when file contains invalid JSON", () => {
+    const tmpPath = path.join(os.tmpdir(), `test-detached-result-bad-${Date.now()}.json`);
+    createdFiles.add(tmpPath);
+    fs.writeFileSync(tmpPath, "not json");
+
+    const result = readDetachedUpdateResult(tmpPath);
+    expect(result).toBeNull();
+  });
+});

--- a/src/infra/update-detached-win32.ts
+++ b/src/infra/update-detached-win32.ts
@@ -1,0 +1,188 @@
+/**
+ * Windows detached update helper.
+ *
+ * On Windows, `npm i -g openclaw@latest` fails with EBUSY when the Gateway
+ * process is still running because Node.js keeps loaded `.js` files locked.
+ *
+ * This module spawns a detached `.cmd` script that:
+ *   1. Waits for the current Gateway process (by PID) to exit
+ *   2. Runs the npm global install command
+ *   3. Re-launches the Gateway via its Scheduled Task
+ *   4. Writes a JSON result file so the next Gateway boot can report the outcome
+ *
+ * The caller (update-runner) should schedule a graceful shutdown *after*
+ * spawning this helper so the helper can proceed once the lock is released.
+ */
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { quoteCmdScriptArg } from "../daemon/cmd-argv.js";
+import { resolveGatewayWindowsTaskName } from "../daemon/constants.js";
+import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
+
+/** Maximum seconds the helper will wait for the Gateway PID to disappear. */
+const PID_WAIT_TIMEOUT_SEC = 60;
+/** Seconds between PID-alive polls. */
+const PID_POLL_INTERVAL_SEC = 2;
+/** Retry limit for schtasks /Run after install completes. */
+const TASK_RESTART_RETRY_LIMIT = 12;
+const TASK_RESTART_RETRY_DELAY_SEC = 1;
+
+export type DetachedUpdateResult = {
+  ok: boolean;
+  scriptPath: string;
+  resultPath: string;
+  detail?: string;
+};
+
+function resolveWindowsTaskName(env: NodeJS.ProcessEnv): string {
+  const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
+  if (override) {
+    return override;
+  }
+  return resolveGatewayWindowsTaskName(env.OPENCLAW_PROFILE);
+}
+
+/**
+ * Build a `.cmd` batch script that:
+ *   - Polls until `gatewayPid` is no longer alive (or timeout)
+ *   - Executes `installArgv` (e.g. `npm i -g openclaw@latest ...`)
+ *   - Restarts the Gateway via Scheduled Task
+ *   - Writes a small JSON result to `resultPath`
+ */
+function buildDetachedUpdateScript(params: {
+  gatewayPid: number;
+  installCommand: string;
+  taskName: string;
+  resultPath: string;
+}): string {
+  const { gatewayPid, installCommand, taskName, resultPath } = params;
+  const quotedTaskName = quoteCmdScriptArg(taskName);
+  // Use forward-slash-safe result path and escape for cmd
+  const quotedResultPath = quoteCmdScriptArg(resultPath);
+
+  return [
+    "@echo off",
+    "setlocal enabledelayedexpansion",
+    "",
+    "REM === Phase 1: Wait for Gateway process to exit ===",
+    "set /a waited=0",
+    `:wait_pid`,
+    `tasklist /FI "PID eq ${gatewayPid}" 2>nul | findstr /I "${gatewayPid}" >nul 2>&1`,
+    `if errorlevel 1 goto pid_gone`,
+    `timeout /t ${PID_POLL_INTERVAL_SEC} /nobreak >nul`,
+    `set /a waited+=1`,
+    `set /a maxPolls=${Math.ceil(PID_WAIT_TIMEOUT_SEC / PID_POLL_INTERVAL_SEC)}`,
+    `if !waited! GEQ !maxPolls! (`,
+    `  echo {"ok":false,"reason":"pid-wait-timeout"} > ${quotedResultPath}`,
+    `  goto cleanup`,
+    `)`,
+    `goto wait_pid`,
+    "",
+    `:pid_gone`,
+    "REM Brief pause to let file handles release",
+    "timeout /t 2 /nobreak >nul",
+    "",
+    "REM === Phase 2: Run npm global install ===",
+    `${installCommand}`,
+    `set INSTALL_EXIT=!errorlevel!`,
+    "",
+    `if !INSTALL_EXIT! NEQ 0 (`,
+    `  echo {"ok":false,"reason":"install-failed","exitCode":!INSTALL_EXIT!} > ${quotedResultPath}`,
+    `  goto restart_gateway`,
+    `)`,
+    "",
+    `echo {"ok":true,"reason":"install-succeeded"} > ${quotedResultPath}`,
+    "",
+    `:restart_gateway`,
+    "REM === Phase 3: Restart Gateway via Scheduled Task ===",
+    "set /a attempts=0",
+    ":retry_restart",
+    `timeout /t ${TASK_RESTART_RETRY_DELAY_SEC} /nobreak >nul`,
+    "set /a attempts+=1",
+    `schtasks /Run /TN ${quotedTaskName} >nul 2>&1`,
+    "if not errorlevel 1 goto cleanup",
+    `if !attempts! GEQ ${TASK_RESTART_RETRY_LIMIT} goto cleanup`,
+    "goto retry_restart",
+    "",
+    ":cleanup",
+    'del "%~f0" >nul 2>&1',
+  ].join("\r\n");
+}
+
+/**
+ * Spawn a detached batch script that will perform the npm global update
+ * after the current Gateway process exits.
+ *
+ * @returns Result with paths to the script and the JSON result file.
+ *          The caller should initiate a graceful Gateway shutdown after this call.
+ */
+export function spawnDetachedUpdate(params: {
+  installArgv: string[];
+  env?: NodeJS.ProcessEnv;
+}): DetachedUpdateResult {
+  const env = params.env ?? process.env;
+  const tmpDir = resolvePreferredOpenClawTmpDir();
+  const id = randomUUID();
+  const scriptPath = path.join(tmpDir, `openclaw-detached-update-${id}.cmd`);
+  const resultPath = path.join(tmpDir, `openclaw-detached-update-${id}.json`);
+  const taskName = resolveWindowsTaskName(env);
+
+  // Build the install command line with proper quoting
+  const installCommand = params.installArgv
+    .map((arg) => (arg.includes(" ") ? `"${arg}"` : arg))
+    .join(" ");
+
+  const script = buildDetachedUpdateScript({
+    gatewayPid: process.pid,
+    installCommand,
+    taskName,
+    resultPath,
+  });
+
+  try {
+    fs.writeFileSync(scriptPath, `${script}\r\n`, "utf8");
+    const child = spawn("cmd.exe", ["/d", "/s", "/c", quoteCmdScriptArg(scriptPath)], {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    child.unref();
+    return {
+      ok: true,
+      scriptPath,
+      resultPath,
+    };
+  } catch (err) {
+    // Clean up on failure
+    try {
+      fs.unlinkSync(scriptPath);
+    } catch {
+      // best-effort
+    }
+    return {
+      ok: false,
+      scriptPath,
+      resultPath,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Read the result JSON left by a previous detached update.
+ * Returns null if the file doesn't exist or is unreadable.
+ */
+export function readDetachedUpdateResult(
+  resultPath: string,
+): { ok: boolean; reason?: string; exitCode?: number } | null {
+  try {
+    const raw = fs.readFileSync(resultPath, "utf8").trim();
+    const parsed = JSON.parse(raw);
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -20,6 +20,7 @@ import {
   type UpdateChannel,
 } from "./update-channels.js";
 import { compareSemverStrings } from "./update-check.js";
+import { spawnDetachedUpdate } from "./update-detached-win32.js";
 import {
   cleanupGlobalRenameDirs,
   createGlobalInstallEnv,
@@ -48,6 +49,13 @@ export type UpdateRunResult = {
   after?: { sha?: string | null; version?: string | null };
   steps: UpdateStepResult[];
   durationMs: number;
+  /**
+   * When set, the update has been delegated to a detached helper process.
+   * The Gateway should shut down so the helper can replace locked files,
+   * then the helper will restart the Gateway via Scheduled Task.
+   * The result of the detached install is written to this path.
+   */
+  detachedResultPath?: string;
 };
 
 type CommandRunner = (
@@ -880,6 +888,59 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       tag,
       env: globalInstallEnv,
     });
+
+    // On Windows, npm cannot replace files that are locked by the running
+    // Gateway process (EBUSY).  Delegate the install to a detached helper
+    // that waits for the Gateway to exit, performs `npm i -g`, then relaunches
+    // the Gateway via its Scheduled Task.
+    if (process.platform === "win32") {
+      const installArgv = globalInstallArgs(globalManager, spec);
+      const detached = spawnDetachedUpdate({
+        installArgv,
+        env: globalInstallEnv as NodeJS.ProcessEnv | undefined,
+      });
+      if (!detached.ok) {
+        steps.push({
+          name: "detached update spawn",
+          command: installArgv.join(" "),
+          cwd: pkgRoot,
+          durationMs: 0,
+          exitCode: 1,
+          stderrTail: detached.detail ?? "failed to spawn detached update helper",
+        });
+        return {
+          status: "error",
+          mode: globalManager,
+          root: pkgRoot,
+          reason: "detached-update-spawn-failed",
+          before: { version: beforeVersion },
+          steps,
+          durationMs: Date.now() - startedAt,
+        };
+      }
+
+      steps.push({
+        name: "detached update (win32)",
+        command: installArgv.join(" "),
+        cwd: pkgRoot,
+        durationMs: 0,
+        exitCode: 0,
+        stdoutTail: `Delegated to detached helper. Result will be written to ${detached.resultPath}`,
+      });
+
+      // Return status "ok" so the caller schedules a graceful shutdown.
+      // The detached script handles the actual install + restart.
+      return {
+        status: "ok",
+        mode: globalManager,
+        root: pkgRoot,
+        before: { version: beforeVersion },
+        steps,
+        durationMs: Date.now() - startedAt,
+        detachedResultPath: detached.resultPath,
+      };
+    }
+
     const updateStep = await runStep({
       runCommand,
       name: "global update",


### PR DESCRIPTION
## Problem

On Windows, the Dashboard "Update now" button (`update.run`) always fails with `EBUSY` because:

1. The Gateway process is running and Node.js keeps loaded `.js` files locked
2. `npm i -g openclaw@latest` needs to rename/delete those locked files
3. npm fails with `EPERM`/`EBUSY` → update never succeeds

This breaks the user expectation that clicking "Update now" should work. The current workaround requires manually stopping the Gateway, running npm, and restarting — which defeats the purpose of having an update button.

## Solution

Introduce a **detached update flow** for Windows that mirrors the existing `windows-task-restart.ts` pattern:

1. `update-runner.ts` detects Windows + global npm install scenario
2. Spawns a detached `.cmd` helper script (`update-detached-win32.ts`)
3. Returns `status: "ok"` with `detachedResultPath` to signal delegation
4. The `update.ts` handler sees `detachedResultPath` → sends response → exits the Gateway process (`process.exit(0)`)
5. The detached helper:
   - Waits for the Gateway PID to disappear (file locks released)
   - Runs `npm i -g openclaw@latest`
   - Relaunches the Gateway via Scheduled Task (`schtasks /Run`)
   - Writes a JSON result file for diagnostics

This is the same approach used by many desktop apps (VS Code, Chrome, etc.): exit the main process, let an updater replace files, then restart.

## Changes

| File | Change |
|------|--------|
| `src/infra/update-detached-win32.ts` | **New** — Detached update helper (spawn script, read results) |
| `src/infra/update-runner.ts` | Windows branch in global update path; new `detachedResultPath` field on `UpdateRunResult` |
| `src/gateway/server-methods/update.ts` | Handle `detachedResultPath`: respond, then `process.exit(0)` to release file locks |
| `src/infra/update-detached-win32.test.ts` | **New** — Tests for spawn and result reading |

## Non-Windows platforms

No changes. Linux/macOS continue to use the existing in-process `npm i -g` + SIGUSR1 restart flow, which works fine because those platforms don't lock loaded JS files.

## Testing

- Unit tests for the detached helper module
- Tested manually on Windows 10 with npm global install