### PR TITLE
fix: align bundled provider extension names with folder convention

### DIFF
--- a/extensions/ollama/package.json
+++ b/extensions/ollama/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openclaw/ollama-provider",
+  "name": "@openclaw/ollama",
   "version": "2026.3.13",
   "private": true,
   "description": "OpenClaw Ollama provider plugin",

--- a/extensions/sglang/package.json
+++ b/extensions/sglang/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openclaw/sglang-provider",
+  "name": "@openclaw/sglang",
   "version": "2026.3.13",
   "private": true,
   "description": "OpenClaw SGLang provider plugin",

--- a/extensions/vllm/package.json
+++ b/extensions/vllm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openclaw/vllm-provider",
+  "name": "@openclaw/vllm",
   "version": "2026.3.13",
   "private": true,
   "description": "OpenClaw vLLM provider plugin",


### PR DESCRIPTION
## Summary

The bundled extensions `extensions/ollama/`, `extensions/sglang/`, and `extensions/vllm/` have package names (`@openclaw/ollama-provider`, etc.) that don't match their folder names. This causes `manifest-registry.ts` to emit a `plugin id mismatch` warning on every gateway bootstrap, since `deriveIdHint()` produces an `idHint` from the unscoped package name (e.g. `ollama-provider`) that differs from the folder-derived `manifest.id` (e.g. `ollama`).

Every other bundled extension follows the convention where the unscoped package name matches the folder name (e.g. `extensions/matrix/` → `@openclaw/matrix`). This aligns the three outliers:

- `@openclaw/ollama-provider` → `@openclaw/ollama`
- `@openclaw/sglang-provider` → `@openclaw/sglang`
- `@openclaw/vllm-provider` → `@openclaw/vllm`

All three packages are `"private": true` so no npm publish impact.

## Test plan

- [ ] Gateway bootstrap no longer emits `plugin id mismatch` warnings for ollama/sglang/vllm
- [ ] `pnpm build` passes