### PR TITLE
fix(tts): add channel adaptation layer for voice-bubble format conversion

### DIFF
--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -572,6 +572,11 @@ export async function sendVoiceMessageDiscord(
     throw err;
   } finally {
     await unlinkIfExists(oggCleanup ? oggPath : null);
+    if (oggCleanup && oggPath) {
+      // ensureVoiceFormat writes into a dedicated voice-fmt-* subdirectory;
+      // remove it too so no empty temp directories accumulate.
+      await fs.rm(path.dirname(oggPath), { recursive: true, force: true }).catch(() => {});
+    }
     await unlinkIfExists(localInputPath);
   }
 }

--- a/src/discord/voice-message.ts
+++ b/src/discord/voice-message.ts
@@ -16,14 +16,14 @@ import path from "node:path";
 import { RateLimitError, type RequestClient } from "@buape/carbon";
 import type { RetryRunner } from "../infra/retry-policy.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
-import { parseFfprobeCodecAndSampleRate, runFfmpeg, runFfprobe } from "../media/ffmpeg-exec.js";
+import { ensureVoiceFormat } from "../media/ensure-voice-format.js";
+import { runFfmpeg, runFfprobe } from "../media/ffmpeg-exec.js";
 import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS } from "../media/ffmpeg-limits.js";
 import { unlinkIfExists } from "../media/temp-files.js";
 
 const DISCORD_VOICE_MESSAGE_FLAG = 1 << 13;
 const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
 const WAVEFORM_SAMPLES = 256;
-const DISCORD_OPUS_SAMPLE_RATE_HZ = 48_000;
 
 export type VoiceMessageMetadata = {
   durationSecs: number;
@@ -148,65 +148,7 @@ function generatePlaceholderWaveform(): string {
  * Returns path to the OGG file (may be same as input if already OGG/Opus)
  */
 export async function ensureOggOpus(filePath: string): Promise<{ path: string; cleanup: boolean }> {
-  const trimmed = filePath.trim();
-  // Defense-in-depth: callers should never hand ffmpeg/ffprobe a URL/protocol path.
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
-    throw new Error(
-      `Voice message conversion requires a local file path; received a URL/protocol source: ${trimmed}`,
-    );
-  }
-
-  const ext = path.extname(filePath).toLowerCase();
-
-  // Check if already OGG
-  if (ext === ".ogg") {
-    // Fast-path only when the file is Opus at Discord's expected 48kHz.
-    try {
-      const stdout = await runFfprobe([
-        "-v",
-        "error",
-        "-select_streams",
-        "a:0",
-        "-show_entries",
-        "stream=codec_name,sample_rate",
-        "-of",
-        "csv=p=0",
-        filePath,
-      ]);
-      const { codec, sampleRateHz } = parseFfprobeCodecAndSampleRate(stdout);
-      if (codec === "opus" && sampleRateHz === DISCORD_OPUS_SAMPLE_RATE_HZ) {
-        return { path: filePath, cleanup: false };
-      }
-    } catch {
-      // If probe fails, convert anyway
-    }
-  }
-
-  // Convert to OGG/Opus
-  // Always resample to 48kHz to ensure Discord voice messages play at correct speed
-  // (Discord expects 48kHz; lower sample rates like 24kHz from some TTS providers cause 0.5x playback)
-  const tempDir = resolvePreferredOpenClawTmpDir();
-  const outputPath = path.join(tempDir, `voice-${crypto.randomUUID()}.ogg`);
-
-  await runFfmpeg([
-    "-y",
-    "-i",
-    filePath,
-    "-vn",
-    "-sn",
-    "-dn",
-    "-t",
-    String(MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS),
-    "-ar",
-    String(DISCORD_OPUS_SAMPLE_RATE_HZ),
-    "-c:a",
-    "libopus",
-    "-b:a",
-    "64k",
-    outputPath,
-  ]);
-
-  return { path: outputPath, cleanup: true };
+  return ensureVoiceFormat(filePath);
 }
 
 /**

--- a/src/media/ensure-voice-format.ts
+++ b/src/media/ensure-voice-format.ts
@@ -1,0 +1,80 @@
+import crypto from "node:crypto";
+import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { parseFfprobeCodecAndSampleRate, runFfmpeg, runFfprobe } from "./ffmpeg-exec.js";
+import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS } from "./ffmpeg-limits.js";
+
+/** Sample rate Discord (and most voice-bubble channels) expect for Opus audio */
+export const VOICE_OPUS_SAMPLE_RATE_HZ = 48_000;
+
+/**
+ * Convert an audio file to OGG/Opus format suitable for voice-bubble delivery.
+ *
+ * Returns the original path unchanged (cleanup = false) when the file is already
+ * OGG/Opus at the expected sample rate.  Otherwise transcodes to a new temp file
+ * (cleanup = true) which the caller is responsible for deleting.
+ *
+ * Callers must only pass local file paths — not URLs or protocol strings.
+ */
+export async function ensureVoiceFormat(
+  filePath: string,
+): Promise<{ path: string; cleanup: boolean }> {
+  const trimmed = filePath.trim();
+  // Defense-in-depth: reject URL/protocol strings before handing to ffmpeg.
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    throw new Error(
+      `ensureVoiceFormat requires a local file path; received a URL/protocol source: ${trimmed}`,
+    );
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+
+  // Fast-path: already OGG — check codec and sample rate.
+  if (ext === ".ogg") {
+    try {
+      const stdout = await runFfprobe([
+        "-v",
+        "error",
+        "-select_streams",
+        "a:0",
+        "-show_entries",
+        "stream=codec_name,sample_rate",
+        "-of",
+        "csv=p=0",
+        filePath,
+      ]);
+      const { codec, sampleRateHz } = parseFfprobeCodecAndSampleRate(stdout);
+      if (codec === "opus" && sampleRateHz === VOICE_OPUS_SAMPLE_RATE_HZ) {
+        return { path: filePath, cleanup: false };
+      }
+    } catch {
+      // If probe fails, convert anyway.
+    }
+  }
+
+  // Transcode to OGG/Opus at the expected sample rate.
+  // Always resample to 48 kHz — lower rates (e.g. 24 kHz from some TTS providers)
+  // cause 0.5× playback speed on channels that hard-code 48 kHz decoding.
+  const tempDir = resolvePreferredOpenClawTmpDir();
+  const outputPath = path.join(tempDir, `voice-${crypto.randomUUID()}.ogg`);
+
+  await runFfmpeg([
+    "-y",
+    "-i",
+    filePath,
+    "-vn",
+    "-sn",
+    "-dn",
+    "-t",
+    String(MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS),
+    "-ar",
+    String(VOICE_OPUS_SAMPLE_RATE_HZ),
+    "-c:a",
+    "libopus",
+    "-b:a",
+    "64k",
+    outputPath,
+  ]);
+
+  return { path: outputPath, cleanup: true };
+}

--- a/src/media/ensure-voice-format.ts
+++ b/src/media/ensure-voice-format.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { mkdirSync, mkdtempSync } from "node:fs";
 import path from "node:path";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { parseFfprobeCodecAndSampleRate, runFfmpeg, runFfprobe } from "./ffmpeg-exec.js";
@@ -55,7 +56,10 @@ export async function ensureVoiceFormat(
   // Transcode to OGG/Opus at the expected sample rate.
   // Always resample to 48 kHz — lower rates (e.g. 24 kHz from some TTS providers)
   // cause 0.5× playback speed on channels that hard-code 48 kHz decoding.
-  const tempDir = resolvePreferredOpenClawTmpDir();
+  // Write into a temp subdirectory so callers can use scheduleCleanup(dir).
+  const tempRoot = resolvePreferredOpenClawTmpDir();
+  mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+  const tempDir = mkdtempSync(path.join(tempRoot, "voice-fmt-"));
   const outputPath = path.join(tempDir, `voice-${crypto.randomUUID()}.ogg`);
 
   await runFfmpeg([

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -26,6 +26,7 @@ import { logVerbose } from "../globals.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { stripMarkdown } from "../line/markdown-to-line.js";
 import { isVoiceCompatibleAudio } from "../media/audio.js";
+import { ensureVoiceFormat } from "../media/ensure-voice-format.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
   DEFAULT_OPENAI_BASE_URL,
@@ -941,11 +942,29 @@ export async function maybeApplyTtsToPayload(params: {
     };
 
     const channelId = resolveChannelId(params.channel);
-    const shouldVoice =
-      channelId !== null && VOICE_BUBBLE_CHANNELS.has(channelId) && result.voiceCompatible === true;
+    const needsVoiceBubble = channelId !== null && VOICE_BUBBLE_CHANNELS.has(channelId);
+
+    let audioPath = result.audioPath;
+    let voiceCompatible = result.voiceCompatible === true;
+
+    // If the channel expects a voice bubble but the provider produced a non-opus
+    // format (e.g. MiniMax/Edge → mp3), transcode to OGG/Opus in the channel
+    // adaptation layer so the upstream TTS providers stay format-agnostic.
+    if (needsVoiceBubble && !voiceCompatible) {
+      try {
+        const converted = await ensureVoiceFormat(audioPath);
+        audioPath = converted.path;
+        voiceCompatible = true;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        logVerbose(`TTS: voice format conversion failed, sending as regular audio: ${errMsg}`);
+      }
+    }
+
+    const shouldVoice = needsVoiceBubble && voiceCompatible;
     const finalPayload = {
       ...nextPayload,
-      mediaUrl: result.audioPath,
+      mediaUrl: audioPath,
       audioAsVoice: shouldVoice || params.payload.audioAsVoice,
     };
     return finalPayload;

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -953,6 +953,10 @@ export async function maybeApplyTtsToPayload(params: {
     if (needsVoiceBubble && !voiceCompatible) {
       try {
         const converted = await ensureVoiceFormat(audioPath);
+        if (converted.cleanup) {
+          // Schedule cleanup of the transcoded temp dir (same pattern as TTS providers).
+          scheduleCleanup(path.dirname(converted.path));
+        }
         audioPath = converted.path;
         voiceCompatible = true;
       } catch (err) {


### PR DESCRIPTION
## Problem

Channels that require voice bubbles (Telegram, Feishu, WhatsApp) only work when the TTS provider produces OGG/Opus audio. Providers that output MP3 (Edge TTS, and any future provider) silently fall back to regular audio instead of a voice bubble, because `voiceCompatible` is `false`.

Discord already handles this with `ensureOggOpus()` in its own channel code, but that logic was not shared with the TTS orchestration layer.

## Solution

- Extract `ensureVoiceFormat()` into `src/media/ensure-voice-format.ts` as a shared utility (same logic as Discord's `ensureOggOpus()`)
- Refactor `ensureOggOpus()` to delegate to the shared utility (no behaviour change for Discord)
- In `maybeApplyTtsToPayload()`, after TTS completes: if the channel needs a voice bubble but the provider returned non-Opus audio, transcode to OGG/Opus via ffmpeg in the channel adaptation layer
- If transcoding fails, fall back gracefully to regular audio (no crash)

TTS providers remain format-agnostic — format conversion is the responsibility of the channel layer, not the provider layer.

## Test plan

- [ ] Existing Discord voice-message tests pass unchanged
- [ ] Existing TTS tests pass unchanged
- [ ] Edge TTS on Telegram/Feishu/WhatsApp now produces voice bubbles