### PR TITLE
feat(msteams): extract structured quote/reply context from HTML attachments

### DIFF
--- a/extensions/msteams/src/inbound.test.ts
+++ b/extensions/msteams/src/inbound.test.ts
@@ -111,7 +111,7 @@ describe("extractMSTeamsQuoteInfo", () => {
     expect(result!.cleanBody).toBe("不是我改的");
   });
 
-  it("extracts quote from simple blockquote without schema attrs", () => {
+  it("ignores generic blockquote without schema.skype.com/Reply attrs", () => {
     const html = [
       "<blockquote>",
       "  <strong>Robin Liu</strong>",
@@ -125,9 +125,8 @@ describe("extractMSTeamsQuoteInfo", () => {
       attachments: [{ contentType: "text/html", content: html }],
     });
 
-    expect(result).toBeDefined();
-    expect(result!.quotedSender).toBe("Robin Liu");
-    expect(result!.cleanBody).toBe("my reply here");
+    // Generic blockquotes should not be treated as reply metadata
+    expect(result).toBeUndefined();
   });
 
   it("handles content as object with text property", () => {
@@ -185,5 +184,23 @@ describe("extractMSTeamsQuoteInfo", () => {
     expect(result!.quotedSender).toBe("Xiang Chen");
     expect(result!.quotedBody).toBe("谢谢");
     expect(result!.cleanBody).toBe("不客气");
+  });
+
+  it("decodes numeric HTML entities in quoted content", () => {
+    const html =
+      '<blockquote itemscope itemtype="http://schema.skype.com/Reply" itemid="1">' +
+      "<strong>Alice</strong>" +
+      '<p itemprop="copy">Hello &#x2019;world&#x2019; &#8212; test</p>' +
+      "</blockquote>" +
+      "<p>reply here</p>";
+
+    const result = extractMSTeamsQuoteInfo({
+      text: "Alicereply here",
+      attachments: [{ contentType: "text/html", content: html }],
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.quotedBody).toBe("Hello \u2019world\u2019 \u2014 test");
+    expect(result!.cleanBody).toBe("reply here");
   });
 });

--- a/extensions/msteams/src/inbound.test.ts
+++ b/extensions/msteams/src/inbound.test.ts
@@ -64,3 +64,126 @@ describe("msteams inbound", () => {
     });
   });
 });
+
+import { extractMSTeamsQuoteInfo, type MSTeamsQuoteInfo } from "./inbound.js";
+
+describe("extractMSTeamsQuoteInfo", () => {
+  it("returns undefined when there are no attachments", () => {
+    expect(extractMSTeamsQuoteInfo({ text: "hello" })).toBeUndefined();
+  });
+
+  it("returns undefined when attachments have no text/html type", () => {
+    expect(
+      extractMSTeamsQuoteInfo({
+        text: "hello",
+        attachments: [{ contentType: "image/png" }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when html attachment has no blockquote", () => {
+    expect(
+      extractMSTeamsQuoteInfo({
+        text: "hello",
+        attachments: [{ contentType: "text/html", content: "<p>just text</p>" }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("extracts quote from Teams schema.skype.com/Reply blockquote", () => {
+    const html = [
+      '<blockquote itemscope itemtype="http://schema.skype.com/Reply" itemid="1234">',
+      '  <strong itemprop="mri" itemid="user:abc">Jianmei Yu</strong>',
+      '  <span itemprop="time" itemid="2026-03-13T05:57:00Z"></span>',
+      '  <p itemprop="copy">是你偷偷改格式了吗？</p>',
+      "</blockquote>",
+      "<p>不是我改的</p>",
+    ].join("\n");
+
+    const result = extractMSTeamsQuoteInfo({
+      text: "Jianmei Yu是你偷偷改格式了吗？不是我改的",
+      attachments: [{ contentType: "text/html", content: html }],
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.quotedSender).toBe("Jianmei Yu");
+    expect(result!.quotedBody).toBe("是你偷偷改格式了吗？");
+    expect(result!.cleanBody).toBe("不是我改的");
+  });
+
+  it("extracts quote from simple blockquote without schema attrs", () => {
+    const html = [
+      "<blockquote>",
+      "  <strong>Robin Liu</strong>",
+      "  <p>original message</p>",
+      "</blockquote>",
+      "<p>my reply here</p>",
+    ].join("\n");
+
+    const result = extractMSTeamsQuoteInfo({
+      text: "Robin Liuoriginal messagemy reply here",
+      attachments: [{ contentType: "text/html", content: html }],
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.quotedSender).toBe("Robin Liu");
+    expect(result!.cleanBody).toBe("my reply here");
+  });
+
+  it("handles content as object with text property", () => {
+    const html =
+      '<blockquote itemscope itemtype="http://schema.skype.com/Reply" itemid="msg1">' +
+      "<strong>Alice</strong>" +
+      '<p itemprop="copy">hello world</p>' +
+      "</blockquote>" +
+      "<p>hi Alice</p>";
+
+    const result = extractMSTeamsQuoteInfo({
+      text: "Alicehello worldhi Alice",
+      attachments: [{ contentType: "text/html", content: { text: html } }],
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.quotedSender).toBe("Alice");
+    expect(result!.quotedBody).toBe("hello world");
+    expect(result!.cleanBody).toBe("hi Alice");
+  });
+
+  it("falls back to text param when afterBlockquote is empty", () => {
+    const html =
+      '<blockquote itemscope itemtype="http://schema.skype.com/Reply" itemid="x">' +
+      "<strong>Bob</strong>" +
+      '<p itemprop="copy">some quote</p>' +
+      "</blockquote>";
+
+    const result = extractMSTeamsQuoteInfo({
+      text: "Bobsome quotemy actual message",
+      attachments: [{ contentType: "text/html", content: html }],
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.quotedSender).toBe("Bob");
+    expect(result!.quotedBody).toBe("some quote");
+    // When no content after blockquote, falls back to full text
+    expect(result!.cleanBody).toBe("Bobsome quotemy actual message");
+  });
+
+  it("handles mentions inside blockquote sender", () => {
+    const html =
+      '<blockquote itemscope itemtype="http://schema.skype.com/Reply" itemid="1">' +
+      '<strong itemprop="mri">Xiang <span>Chen</span></strong>' +
+      '<p itemprop="copy">谢谢</p>' +
+      "</blockquote>" +
+      "不客气";
+
+    const result = extractMSTeamsQuoteInfo({
+      text: "Xiang Chen谢谢不客气",
+      attachments: [{ contentType: "text/html", content: html }],
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.quotedSender).toBe("Xiang Chen");
+    expect(result!.quotedBody).toBe("谢谢");
+    expect(result!.cleanBody).toBe("不客气");
+  });
+});

--- a/extensions/msteams/src/inbound.ts
+++ b/extensions/msteams/src/inbound.ts
@@ -107,7 +107,7 @@ export function extractMSTeamsQuoteInfo(params: {
   text: string;
   /** Raw attachments from the activity. */
   attachments?: ReadonlyArray<{
-    contentType?: string;
+    contentType?: string | null;
     content?: unknown;
   }>;
 }): MSTeamsQuoteInfo | undefined {
@@ -129,7 +129,7 @@ export function extractMSTeamsQuoteInfo(params: {
 function extractQuoteFromHtmlAttachments(
   fallbackText: string,
   attachments: ReadonlyArray<{
-    contentType?: string;
+    contentType?: string | null;
     content?: unknown;
   }>,
 ): MSTeamsQuoteInfo | undefined {

--- a/extensions/msteams/src/inbound.ts
+++ b/extensions/msteams/src/inbound.ts
@@ -65,19 +65,24 @@ export interface MSTeamsQuoteInfo {
  * Strip HTML tags, decode common entities, collapse whitespace and trim.
  */
 function htmlToPlainText(html: string): string {
-  return html
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<\/p>/gi, "\n")
-    .replace(/<[^>]*>/g, "")
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, "&")
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">")
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/[ \t]+/g, " ")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+  return (
+    html
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/p>/gi, "\n")
+      .replace(/<[^>]*>/g, "")
+      .replace(/&nbsp;/gi, " ")
+      .replace(/&amp;/gi, "&")
+      .replace(/&lt;/gi, "<")
+      .replace(/&gt;/gi, ">")
+      .replace(/&quot;/gi, '"')
+      .replace(/&#39;/gi, "'")
+      // Decode numeric character references (decimal and hex) that Teams may produce.
+      .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+      .replace(/&#([0-9]+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+      .replace(/[ \t]+/g, " ")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  );
 }
 
 /**
@@ -144,17 +149,17 @@ function extractQuoteFromHtmlAttachments(
     }
 
     // Match <blockquote> that Teams uses for quoted replies (with Skype Reply schema).
+    // Note: non-greedy match stops at the first </blockquote>, so nested
+    // blockquotes are not supported. Teams does not currently produce them
+    // for quote/reply scenarios.
     const blockquoteRe =
       /<blockquote[^>]*itemtype=["']http:\/\/schema\.skype\.com\/Reply["'][^>]*>([\s\S]*?)<\/blockquote>/i;
     const bqMatch = blockquoteRe.exec(html);
     if (!bqMatch) {
-      // Try a more lenient blockquote match (some Teams clients omit schema attrs).
-      const simpleBqRe = /<blockquote[^>]*>([\s\S]*?)<\/blockquote>/i;
-      const simpleBqMatch = simpleBqRe.exec(html);
-      if (!simpleBqMatch) {
-        continue;
-      }
-      return parseBlockquoteContent(simpleBqMatch, html, fallbackText);
+      // Only match blockquotes with the Skype Reply schema attribute.
+      // Generic blockquotes (e.g. user-authored quote formatting) are not
+      // treated as reply metadata to avoid misinterpreting normal messages.
+      continue;
     }
     return parseBlockquoteContent(bqMatch, html, fallbackText);
   }

--- a/extensions/msteams/src/inbound.ts
+++ b/extensions/msteams/src/inbound.ts
@@ -46,3 +46,160 @@ export function wasMSTeamsBotMentioned(activity: MentionableActivity): boolean {
   const entities = activity.entities ?? [];
   return entities.some((e) => e.type === "mention" && e.mentioned?.id === botId);
 }
+
+// ── Quote / reply-to extraction ──────────────────────────────────────────────
+
+/**
+ * Structured info extracted from a Teams quoted/reply message.
+ */
+export interface MSTeamsQuoteInfo {
+  /** Display name of the person whose message was quoted. */
+  quotedSender?: string;
+  /** Plain-text body of the quoted message. */
+  quotedBody?: string;
+  /** The message text with the quoted prefix stripped (the sender's own words). */
+  cleanBody: string;
+}
+
+/**
+ * Strip HTML tags, decode common entities, collapse whitespace and trim.
+ */
+function htmlToPlainText(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Try to extract structured quote context from the Teams activity body.
+ *
+ * Teams wraps quoted / replied-to content in the `activity.text` field itself
+ * (plain-text) and sometimes in a `text/html` attachment.  The HTML form looks
+ * roughly like:
+ *
+ * ```html
+ * <blockquote itemscope itemtype="http://schema.skype.com/Reply" itemid="…">
+ *   <strong itemprop="mri" itemid="…">Sender Name</strong>
+ *   <span itemprop="time" itemid="…"></span>
+ *   <p itemprop="copy">quoted text</p>
+ * </blockquote>
+ * actual message body
+ * ```
+ *
+ * The plain-text `activity.text` squashes everything together:
+ *   "Sender NameActual message body"
+ *
+ * This function tries the HTML attachment path to give the agent structured
+ * context about which part is the quote and who originally wrote it.
+ */
+export function extractMSTeamsQuoteInfo(params: {
+  /** Plain text body after mention-tag stripping. */
+  text: string;
+  /** Raw attachments from the activity. */
+  attachments?: ReadonlyArray<{
+    contentType?: string;
+    content?: unknown;
+  }>;
+}): MSTeamsQuoteInfo | undefined {
+  const { text, attachments } = params;
+
+  // Try HTML attachment path (most reliable).
+  if (attachments) {
+    const result = extractQuoteFromHtmlAttachments(text, attachments);
+    if (result) {
+      return result;
+    }
+  }
+
+  // No structured quote detected.
+  return undefined;
+}
+
+/** Extract quote info from text/html attachments. */
+function extractQuoteFromHtmlAttachments(
+  fallbackText: string,
+  attachments: ReadonlyArray<{
+    contentType?: string;
+    content?: unknown;
+  }>,
+): MSTeamsQuoteInfo | undefined {
+  for (const att of attachments) {
+    const ct = typeof att.contentType === "string" ? att.contentType.toLowerCase() : "";
+    if (!ct.startsWith("text/html")) {
+      continue;
+    }
+    const html = resolveHtmlContent(att.content);
+    if (!html) {
+      continue;
+    }
+
+    // Match <blockquote> that Teams uses for quoted replies (with Skype Reply schema).
+    const blockquoteRe =
+      /<blockquote[^>]*itemtype=["']http:\/\/schema\.skype\.com\/Reply["'][^>]*>([\s\S]*?)<\/blockquote>/i;
+    const bqMatch = blockquoteRe.exec(html);
+    if (!bqMatch) {
+      // Try a more lenient blockquote match (some Teams clients omit schema attrs).
+      const simpleBqRe = /<blockquote[^>]*>([\s\S]*?)<\/blockquote>/i;
+      const simpleBqMatch = simpleBqRe.exec(html);
+      if (!simpleBqMatch) {
+        continue;
+      }
+      return parseBlockquoteContent(simpleBqMatch, html, fallbackText);
+    }
+    return parseBlockquoteContent(bqMatch, html, fallbackText);
+  }
+  return undefined;
+}
+
+function parseBlockquoteContent(
+  bqMatch: RegExpExecArray,
+  html: string,
+  fallbackText: string,
+): MSTeamsQuoteInfo {
+  const quoteHtml = bqMatch[1] ?? "";
+
+  // Extract sender name from <strong> tag.
+  const senderRe = /<strong[^>]*>([\s\S]*?)<\/strong>/i;
+  const senderMatch = senderRe.exec(quoteHtml);
+  const quotedSender = senderMatch ? htmlToPlainText(senderMatch[1] ?? "") : undefined;
+
+  // Extract quoted body: prefer itemprop="copy", fall back to remaining text.
+  const copyRe = /<p[^>]*itemprop=["']copy["'][^>]*>([\s\S]*?)<\/p>/i;
+  const copyMatch = copyRe.exec(quoteHtml);
+  const quotedBody = copyMatch
+    ? htmlToPlainText(copyMatch[1] ?? "")
+    : htmlToPlainText(quoteHtml.replace(senderRe, ""));
+
+  // The actual message is everything after the blockquote.
+  const afterBlockquote = html.slice(bqMatch.index + bqMatch[0].length);
+  const cleanBody = htmlToPlainText(afterBlockquote) || fallbackText;
+
+  return {
+    quotedSender: quotedSender || undefined,
+    quotedBody: quotedBody || undefined,
+    cleanBody,
+  };
+}
+
+function resolveHtmlContent(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (content && typeof content === "object" && !Array.isArray(content)) {
+    const rec = content as Record<string, unknown>;
+    if (typeof rec.text === "string") return rec.text;
+    if (typeof rec.body === "string") return rec.body;
+    if (typeof rec.content === "string") return rec.content;
+  }
+  return undefined;
+}

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -511,10 +511,15 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
 
     // When a quote is detected, build a structured reply annotation
     // similar to how Telegram formats [Replying to ...] blocks.
-    const agentBody = quoteInfo
-      ? quoteInfo.cleanBody +
-        `\n\n[Replying to ${quoteInfo.quotedSender ?? "unknown"}]\n${quoteInfo.quotedBody ?? "(no text)"}\n[/Replying]`
-      : rawBody;
+    // If cleanBody fell back to the raw text (no content after blockquote in HTML),
+    // skip the annotation to avoid duplicating quoted content.
+    // Also preserve the original rawBody for attachment-only replies so the
+    // attachment placeholder is not lost.
+    const agentBody =
+      quoteInfo && quoteInfo.cleanBody !== text
+        ? quoteInfo.cleanBody +
+          `\n\n[Replying to ${quoteInfo.quotedSender ?? "unknown"}]\n${quoteInfo.quotedBody ?? "(no text)"}\n[/Replying]`
+        : rawBody;
 
     const ctxPayload = core.channel.reply.finalizeInboundContext({
       Body: combinedBody,

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -32,6 +32,7 @@ import {
   extractMSTeamsConversationMessageId,
   normalizeMSTeamsConversationId,
   parseMSTeamsActivityTimestamp,
+  extractMSTeamsQuoteInfo,
   stripMSTeamsMentionTags,
   wasMSTeamsBotMentioned,
 } from "../inbound.js";
@@ -103,6 +104,9 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     const attachments = params.attachments;
     const attachmentPlaceholder = buildMSTeamsAttachmentPlaceholder(attachments);
     const rawBody = text || attachmentPlaceholder;
+
+    // Extract structured quote/reply context from HTML attachments.
+    const quoteInfo = extractMSTeamsQuoteInfo({ text, attachments });
     const from = activity.from;
     const conversation = activity.conversation;
 
@@ -505,9 +509,16 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         : undefined;
     const commandBody = text.trim();
 
+    // When a quote is detected, build a structured reply annotation
+    // similar to how Telegram formats [Replying to ...] blocks.
+    const agentBody = quoteInfo
+      ? quoteInfo.cleanBody +
+        `\n\n[Replying to ${quoteInfo.quotedSender ?? "unknown"}]\n${quoteInfo.quotedBody ?? "(no text)"}\n[/Replying]`
+      : rawBody;
+
     const ctxPayload = core.channel.reply.finalizeInboundContext({
       Body: combinedBody,
-      BodyForAgent: rawBody,
+      BodyForAgent: agentBody,
       InboundHistory: inboundHistory,
       RawBody: rawBody,
       CommandBody: commandBody,
@@ -524,6 +535,8 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       Provider: "msteams" as const,
       Surface: "msteams" as const,
       MessageSid: activity.id,
+      ReplyToSender: quoteInfo?.quotedSender,
+      ReplyToBody: quoteInfo?.quotedBody,
       Timestamp: timestamp?.getTime() ?? Date.now(),
       WasMentioned: isDirectMessage || params.wasMentioned || params.implicitMention,
       CommandAuthorized: commandAuthorized,


### PR DESCRIPTION
## Problem

When a Teams user quotes/replies to a message, the quoted sender name and body are merged into `activity.text` as a flat string. The agent receives something like:

```
Jianmei YuRobin's Claw 是你偷偷改格式了吗？
```

...with no way to distinguish the quoted content from the actual message, or identify who originally wrote the quoted part.

## Solution

- **`inbound.ts`**: Add `extractMSTeamsQuoteInfo()` to parse Teams `<blockquote>` HTML from `text/html` attachments. Supports both the `schema.skype.com/Reply` format and simpler blockquote variants.
- **`message-handler.ts`**: 
  - Call quote extraction on inbound messages
  - Populate `ReplyToSender` and `ReplyToBody` in the inbound context (consistent with Telegram and WhatsApp implementations)
  - Format the agent body with a `[Replying to ...]` annotation block

### After this change, the agent sees:

```
actual message text

[Replying to Jianmei Yu]
是你偷偷改格式了吗？
[/Replying]
```

## Changes

| File | Change |
|------|--------|
| `extensions/msteams/src/inbound.ts` | +`extractMSTeamsQuoteInfo()`, `MSTeamsQuoteInfo` type, HTML parsing helpers |
| `extensions/msteams/src/inbound.test.ts` | +6 test cases covering various blockquote formats |
| `extensions/msteams/src/monitor-handler/message-handler.ts` | Wire up quote extraction, populate `ReplyToSender`/`ReplyToBody`, format `[Replying to ...]` block |

## Testing

- All 233 existing msteams tests pass ✅
- 6 new tests added for quote extraction ✅
- 1 pre-existing failure in `probe.test.ts` (unrelated to this change)
