### PR TITLE
fix: enable Discord voice-bubble output

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -188,7 +188,7 @@ describe("tts", () => {
   });
 
   describe("resolveOutputFormat", () => {
-    it("selects opus for voice-bubble channels (telegram/feishu/whatsapp) and mp3 for others", () => {
+    it("selects opus for voice-bubble channels (telegram/discord/feishu/whatsapp) and mp3 for others", () => {
       const cases = [
         {
           channel: "telegram",
@@ -220,10 +220,10 @@ describe("tts", () => {
         {
           channel: "discord",
           expected: {
-            openai: "mp3",
-            elevenlabs: "mp3_44100_128",
-            extension: ".mp3",
-            voiceCompatible: false,
+            openai: "opus",
+            elevenlabs: "opus_48000_64",
+            extension: ".opus",
+            voiceCompatible: true,
           },
         },
       ] as const;

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -501,7 +501,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 /** Channels that require opus audio and support voice-bubble playback */
-const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp"]);
+const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "discord", "feishu", "whatsapp"]);
 
 function resolveOutputFormat(channelId?: string | null) {
   if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId)) {


### PR DESCRIPTION
## Summary

- Problem: Discord TTS output fell back to file-style audio instead of inline voice-bubble playback.
- Why it matters: Discord supports native voice messages in text channels, so the previous behavior was inconsistent with user expectations and worse than the existing voice-bubble behavior on other supported channels.
- What changed: Added `discord` to the TTS voice-bubble channel set and updated the regression test to expect opus voice-bubble output.
- What did NOT change (scope boundary): No Discord channel adapter changes, no config surface changes, and no non-TTS media delivery changes.


## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44633
- Related #

## User-visible / Behavior Changes

- Discord TTS output now resolves to opus voice-bubble output instead of mp3/file-style output.


## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Macos
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Confirmed the updated Discord expectation failed before the code change.
  - Confirmed `pnpm test src/tts/tts.test.ts` passed after adding `discord` to `VOICE_BUBBLE_CHANNELS`.
- Edge cases checked:
  - Existing voice-bubble channels in the same regression test still resolve to opus output.
- What you did **not** verify:
  - End-to-end Discord playback UX.
## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
