### PR TITLE
fix(systemd): detect service scope across lifecycle operations

### DIFF
--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -19,7 +19,10 @@ export type GatewayServiceControlArgs = {
   env?: GatewayServiceEnv;
 };
 
-export type GatewayServiceRestartResult = { outcome: "completed" } | { outcome: "scheduled" };
+export type GatewayServiceRestartResult =
+  | { outcome: "completed" }
+  | { outcome: "completed"; scope?: "user" | "system"; detail?: string; tried?: string[] }
+  | { outcome: "scheduled" };
 
 export type GatewayServiceEnvArgs = {
   env?: GatewayServiceEnv;

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -20,8 +20,7 @@ export type GatewayServiceControlArgs = {
 };
 
 export type GatewayServiceRestartResult =
-  | { outcome: "completed" }
-  | { outcome: "completed"; scope?: "user" | "system"; detail?: string; tried?: string[] }
+  | { outcome: "completed"; scope?: "user" | "system" }
   | { outcome: "scheduled" };
 
 export type GatewayServiceEnvArgs = {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -179,16 +179,61 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
-  it("returns false without calling systemctl when the managed unit file is missing", async () => {
+  it("detects system-scoped units when the managed user unit file is missing", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     const err = new Error("missing unit") as NodeJS.ErrnoException;
     err.code = "ENOENT";
     vi.spyOn(fs, "access").mockRejectedValueOnce(err);
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-enabled", GATEWAY_SERVICE]);
+        cb(
+          createExecFileError("disabled", {
+            stderr: "disabled",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-active", GATEWAY_SERVICE]);
+        cb(null, "active\n", "");
+      });
 
     const result = await isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } });
 
+    expect(result).toBe(true);
+  });
+
+  it("returns false when user unit file is missing and system unit is also missing", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    const err = new Error("missing unit") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    vi.spyOn(fs, "access").mockRejectedValueOnce(err);
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-enabled", GATEWAY_SERVICE]);
+        cb(
+          createExecFileError("not found", {
+            stderr: "Unit openclaw-gateway.service could not be found.",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-active", GATEWAY_SERVICE]);
+        cb(
+          createExecFileError("not found", {
+            stderr: "Unit openclaw-gateway.service could not be found.",
+          }),
+          "",
+          "",
+        );
+      });
+
+    const result = await isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } });
     expect(result).toBe(false);
-    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   it("calls systemctl is-enabled when systemctl is present", async () => {
@@ -635,6 +680,34 @@ describe("systemd system-scope fallback", () => {
     expect(write).toHaveBeenCalledTimes(1);
   });
 
+  it("surfaces system-scope restart failure after user-unit-missing fallback", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: Function) =>
+        cb(null, "", ""),
+      )
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        expect(args).toEqual(["--user", "restart", "openclaw-gateway.service"]);
+        cb(
+          createExecFileError("Unit not found", {
+            stderr: "Unit openclaw-gateway.service not found.",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        expect(args).toEqual(["restart", "openclaw-gateway.service"]);
+        cb(createExecFileError("permission denied", { stderr: "permission denied" }), "", "");
+      });
+
+    await expect(
+      restartSystemdService({
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        env: {},
+      }),
+    ).rejects.toThrow("systemctl restart failed: permission denied");
+  });
+
   it("reads runtime from system scope when user unit is not found", async () => {
     const { readSystemdServiceRuntime } = await import("./systemd.js");
     // assertSystemdAvailable: user status ok
@@ -666,6 +739,36 @@ describe("systemd system-scope fallback", () => {
       status: "running",
       pid: 123,
       detail: "system scope",
+    });
+  });
+
+  it("surfaces system-scope runtime probe errors instead of reporting missing service", async () => {
+    const { readSystemdServiceRuntime } = await import("./systemd.js");
+    execFileMock
+      .mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: Function) =>
+        cb(null, "", ""),
+      )
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        expect(args[0]).toBe("--user");
+        expect(args[1]).toBe("show");
+        cb(
+          createExecFileError("Unit not found", {
+            stderr: "Unit openclaw-gateway.service not found.",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        expect(args[0]).toBe("show");
+        expect(args[1]).toBe("openclaw-gateway.service");
+        cb(createExecFileError("permission denied", { stderr: "permission denied" }), "", "");
+      });
+
+    const runtime = await readSystemdServiceRuntime({ HOME: "/tmp/openclaw-test-home" });
+    expect(runtime).toEqual({
+      status: "unknown",
+      detail: "permission denied",
     });
   });
 });
@@ -742,24 +845,79 @@ describe("systemd service control", () => {
     ).rejects.toThrow("systemctl stop failed: permission denied");
   });
 
-  it("throws the user-bus error before stop when systemd is unavailable", async () => {
+  it("throws when both user and system status checks are unavailable", async () => {
     vi.spyOn(os, "userInfo").mockImplementationOnce(() => {
       throw new Error("no user info");
     });
-    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
-      cb(
-        createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
-        "",
-        "",
-      );
-    });
+    execFileMock
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
+        cb(
+          createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["status"]);
+        cb(
+          createExecFileError("System has not been booted with systemd", {
+            stderr: "System has not been booted with systemd",
+          }),
+          "",
+          "",
+        );
+      });
 
     await expect(
       stopSystemdService({
         stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
         env: { USER: "", LOGNAME: "" },
       }),
-    ).rejects.toThrow("systemctl --user unavailable: Failed to connect to bus");
+    ).rejects.toThrow("systemctl unavailable: System has not been booted with systemd");
+  });
+
+  it("accepts degraded system status when user scope is unavailable", async () => {
+    vi.spyOn(os, "userInfo").mockImplementationOnce(() => {
+      throw new Error("no user info");
+    });
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "status"]);
+        cb(
+          createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["status"]);
+        cb(
+          createExecFileError("degraded", {
+            stderr: "State: degraded",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "stop", GATEWAY_SERVICE]);
+        cb(
+          createExecFileError("Unit not found", {
+            stderr: "Unit openclaw-gateway.service not found.",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["stop", GATEWAY_SERVICE]);
+        cb(null, "", "");
+      });
+
+    await stopSystemdService({
+      stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+      env: { USER: "", LOGNAME: "" },
+    });
   });
 
   it("targets the sudo caller's user scope when SUDO_USER is set", async () => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -601,6 +601,85 @@ describe("readSystemdServiceExecStart", () => {
   });
 });
 
+describe("systemd system-scope detection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    execFileMock.mockReset();
+  });
+
+  it("treats an active system unit as enabled even when the user unit file is missing", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    const err = new Error("missing unit") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    vi.spyOn(fs, "access").mockRejectedValueOnce(err);
+
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+        cb(createExecFileError("disabled", { stderr: "disabled" }), "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-enabled", "openclaw-gateway.service"]);
+        cb(null, "enabled", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "is-active", "openclaw-gateway.service"]);
+        cb(createExecFileError("inactive", { stderr: "inactive" }), "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-active", "openclaw-gateway.service"]);
+        cb(null, "active", "");
+      });
+
+    await expect(isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } })).resolves.toBe(true);
+  });
+
+  it("reads runtime from the detected system scope when the user scope is not active", async () => {
+    const { readSystemdServiceRuntime } = await import("./systemd.js");
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "status"]);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["status"]);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+        cb(createExecFileError("disabled", { stderr: "disabled" }), "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-enabled", "openclaw-gateway.service"]);
+        cb(null, "enabled", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "is-active", "openclaw-gateway.service"]);
+        cb(createExecFileError("inactive", { stderr: "inactive" }), "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-active", "openclaw-gateway.service"]);
+        cb(null, "active", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual([
+          "show",
+          "--no-page",
+          "--property",
+          "ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode",
+          "openclaw-gateway.service",
+        ]);
+        cb(null, ["ActiveState=active", "SubState=running", "MainPID=123"].join("\n"), "");
+      });
+
+    await expect(readSystemdServiceRuntime({ HOME: "/tmp/openclaw-test-home" })).resolves.toMatchObject({
+      status: "running",
+      pid: 123,
+      detail: "system (enabled+active)",
+    });
+  });
+});
+
 describe("systemd service control", () => {
   const assertMachineRestartArgs = (args: string[]) => {
     assertMachineUserSystemctlArgs(args, "debian", "restart", GATEWAY_SERVICE);

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -179,25 +179,16 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
-  it("returns false when the managed unit file is missing and system scope has no unit", async () => {
+  it("returns false without calling systemctl when the managed unit file is missing", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     const err = new Error("missing unit") as NodeJS.ErrnoException;
     err.code = "ENOENT";
     vi.spyOn(fs, "access").mockRejectedValueOnce(err);
 
-    // probeSystemScope: system is-enabled → disabled, system is-active → inactive
-    execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["is-enabled", "openclaw-gateway.service"]);
-        cb(createExecFileError("disabled", { stderr: "disabled" }), "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["is-active", "openclaw-gateway.service"]);
-        cb(createExecFileError("inactive", { stderr: "inactive" }), "", "");
-      });
-
     const result = await isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } });
+
     expect(result).toBe(false);
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   it("calls systemctl is-enabled when systemctl is present", async () => {
@@ -317,7 +308,7 @@ describe("isSystemdServiceEnabled", () => {
     ).rejects.toThrow("systemctl is-enabled unavailable: permission denied");
   });
 
-  it("returns false when systemctl is-enabled exits with code 4 (not-found) in both scopes", async () => {
+  it("returns false when systemctl is-enabled exits with code 4 (not-found)", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     vi.spyOn(fs, "access").mockResolvedValue(undefined);
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
@@ -616,50 +607,7 @@ describe("systemd system-scope fallback", () => {
     execFileMock.mockReset();
   });
 
-  it("treats an active system unit as enabled when the user unit file is missing", async () => {
-    const { isSystemdServiceEnabled } = await import("./systemd.js");
-    const err = new Error("missing unit") as NodeJS.ErrnoException;
-    err.code = "ENOENT";
-    vi.spyOn(fs, "access").mockRejectedValueOnce(err);
-
-    // probeSystemScope: is-enabled (system), is-active (system)
-    execFileMock
-      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
-        expect(args).toEqual(["is-enabled", "openclaw-gateway.service"]);
-        cb(createExecFileError("disabled", { stderr: "disabled" }), "", "");
-      })
-      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
-        expect(args).toEqual(["is-active", "openclaw-gateway.service"]);
-        cb(null, "active", "");
-      });
-
-    await expect(
-      isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } }),
-    ).resolves.toBe(true);
-  });
-
-  it("returns false when both user unit file and system scope are missing", async () => {
-    const { isSystemdServiceEnabled } = await import("./systemd.js");
-    const err = new Error("missing unit") as NodeJS.ErrnoException;
-    err.code = "ENOENT";
-    vi.spyOn(fs, "access").mockRejectedValueOnce(err);
-
-    execFileMock
-      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
-        expect(args).toEqual(["is-enabled", "openclaw-gateway.service"]);
-        cb(createExecFileError("disabled", { stderr: "disabled" }), "", "");
-      })
-      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
-        expect(args).toEqual(["is-active", "openclaw-gateway.service"]);
-        cb(createExecFileError("inactive", { stderr: "inactive" }), "", "");
-      });
-
-    await expect(
-      isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } }),
-    ).resolves.toBe(false);
-  });
-
-  it("falls back to system scope for restart when user-scope restart fails", async () => {
+  it("falls back to system scope for restart when user unit is not found", async () => {
     // assertSystemdAvailable: user status ok
     // runSystemdServiceAction: user restart fails, system restart succeeds
     execFileMock
@@ -687,7 +635,7 @@ describe("systemd system-scope fallback", () => {
     expect(write).toHaveBeenCalledTimes(1);
   });
 
-  it("reads runtime from system scope when user-scope show fails", async () => {
+  it("reads runtime from system scope when user unit is not found", async () => {
     const { readSystemdServiceRuntime } = await import("./systemd.js");
     // assertSystemdAvailable: user status ok
     execFileMock

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -784,12 +784,6 @@ describe("systemd service control", () => {
         const err = new Error("stop failed") as Error & { code?: number };
         err.code = 1;
         cb(err, "", "permission denied");
-      })
-      // system-scope fallback also fails
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
-        const err = new Error("stop failed") as Error & { code?: number };
-        err.code = 1;
-        cb(err, "", "permission denied");
       });
 
     await expect(

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -179,16 +179,25 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
-  it("returns false without calling systemctl when the managed unit file is missing", async () => {
+  it("returns false when the managed unit file is missing and system scope has no unit", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     const err = new Error("missing unit") as NodeJS.ErrnoException;
     err.code = "ENOENT";
     vi.spyOn(fs, "access").mockRejectedValueOnce(err);
 
-    const result = await isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } });
+    // probeSystemScope: system is-enabled → disabled, system is-active → inactive
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-enabled", "openclaw-gateway.service"]);
+        cb(createExecFileError("disabled", { stderr: "disabled" }), "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-active", "openclaw-gateway.service"]);
+        cb(createExecFileError("inactive", { stderr: "inactive" }), "", "");
+      });
 
+    const result = await isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } });
     expect(result).toBe(false);
-    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   it("calls systemctl is-enabled when systemctl is present", async () => {
@@ -308,7 +317,7 @@ describe("isSystemdServiceEnabled", () => {
     ).rejects.toThrow("systemctl is-enabled unavailable: permission denied");
   });
 
-  it("returns false when systemctl is-enabled exits with code 4 (not-found)", async () => {
+  it("returns false when systemctl is-enabled exits with code 4 (not-found) in both scopes", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     vi.spyOn(fs, "access").mockResolvedValue(undefined);
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
@@ -601,81 +610,114 @@ describe("readSystemdServiceExecStart", () => {
   });
 });
 
-describe("systemd system-scope detection", () => {
+describe("systemd system-scope fallback", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     execFileMock.mockReset();
   });
 
-  it("treats an active system unit as enabled even when the user unit file is missing", async () => {
+  it("treats an active system unit as enabled when the user unit file is missing", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    const err = new Error("missing unit") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    vi.spyOn(fs, "access").mockRejectedValueOnce(err);
+
+    // probeSystemScope: is-enabled (system), is-active (system)
+    execFileMock
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        expect(args).toEqual(["is-enabled", "openclaw-gateway.service"]);
+        cb(createExecFileError("disabled", { stderr: "disabled" }), "", "");
+      })
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        expect(args).toEqual(["is-active", "openclaw-gateway.service"]);
+        cb(null, "active", "");
+      });
+
+    await expect(
+      isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } }),
+    ).resolves.toBe(true);
+  });
+
+  it("returns false when both user unit file and system scope are missing", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     const err = new Error("missing unit") as NodeJS.ErrnoException;
     err.code = "ENOENT";
     vi.spyOn(fs, "access").mockRejectedValueOnce(err);
 
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        expect(args).toEqual(["is-enabled", "openclaw-gateway.service"]);
         cb(createExecFileError("disabled", { stderr: "disabled" }), "", "");
       })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["is-enabled", "openclaw-gateway.service"]);
-        cb(null, "enabled", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "is-active", "openclaw-gateway.service"]);
-        cb(createExecFileError("inactive", { stderr: "inactive" }), "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
         expect(args).toEqual(["is-active", "openclaw-gateway.service"]);
-        cb(null, "active", "");
+        cb(createExecFileError("inactive", { stderr: "inactive" }), "", "");
       });
 
-    await expect(isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } })).resolves.toBe(true);
+    await expect(
+      isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } }),
+    ).resolves.toBe(false);
   });
 
-  it("reads runtime from the detected system scope when the user scope is not active", async () => {
-    const { readSystemdServiceRuntime } = await import("./systemd.js");
+  it("falls back to system scope for restart when user-scope restart fails", async () => {
+    // assertSystemdAvailable: user status ok
+    // runSystemdServiceAction: user restart fails, system restart succeeds
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "status"]);
+      .mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: Function) =>
+        cb(null, "", ""),
+      )
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        expect(args).toEqual(["--user", "restart", "openclaw-gateway.service"]);
+        cb(
+          createExecFileError("Unit not found", {
+            stderr: "Unit openclaw-gateway.service not found.",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        expect(args).toEqual(["restart", "openclaw-gateway.service"]);
         cb(null, "", "");
+      });
+
+    const { write, stdout } = createWritableStreamMock();
+    const result = await restartSystemdService({ stdout, env: {} });
+    expect(result).toEqual({ outcome: "completed", scope: "system" });
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads runtime from system scope when user-scope show fails", async () => {
+    const { readSystemdServiceRuntime } = await import("./systemd.js");
+    // assertSystemdAvailable: user status ok
+    execFileMock
+      .mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: Function) =>
+        cb(null, "", ""),
+      )
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        // user-scope show fails
+        expect(args[0]).toBe("--user");
+        expect(args[1]).toBe("show");
+        cb(
+          createExecFileError("Unit not found", {
+            stderr: "Unit openclaw-gateway.service not found.",
+          }),
+          "",
+          "",
+        );
       })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["status"]);
-        cb(null, "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
-        cb(createExecFileError("disabled", { stderr: "disabled" }), "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["is-enabled", "openclaw-gateway.service"]);
-        cb(null, "enabled", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "is-active", "openclaw-gateway.service"]);
-        cb(createExecFileError("inactive", { stderr: "inactive" }), "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["is-active", "openclaw-gateway.service"]);
-        cb(null, "active", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual([
-          "show",
-          "--no-page",
-          "--property",
-          "ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode",
-          "openclaw-gateway.service",
-        ]);
+      .mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        // system-scope show succeeds
+        expect(args[0]).toBe("show");
+        expect(args[1]).toBe("openclaw-gateway.service");
         cb(null, ["ActiveState=active", "SubState=running", "MainPID=123"].join("\n"), "");
       });
 
-    await expect(readSystemdServiceRuntime({ HOME: "/tmp/openclaw-test-home" })).resolves.toMatchObject({
+    const runtime = await readSystemdServiceRuntime({ HOME: "/tmp/openclaw-test-home" });
+    expect(runtime).toMatchObject({
       status: "running",
       pid: 123,
-      detail: "system (enabled+active)",
+      detail: "system scope",
     });
   });
 });
@@ -738,6 +780,12 @@ describe("systemd service control", () => {
   it("surfaces stop failures with systemctl detail", async () => {
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
+        const err = new Error("stop failed") as Error & { code?: number };
+        err.code = 1;
+        cb(err, "", "permission denied");
+      })
+      // system-scope fallback also fails
       .mockImplementationOnce((_cmd, _args, _opts, cb) => {
         const err = new Error("stop failed") as Error & { code?: number };
         err.code = 1;

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -236,6 +236,37 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when system scope has no running systemd manager", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    const err = new Error("missing unit") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    vi.spyOn(fs, "access").mockRejectedValueOnce(err);
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-enabled", GATEWAY_SERVICE]);
+        cb(
+          createExecFileError("disabled", {
+            stderr: "disabled",
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["is-active", GATEWAY_SERVICE]);
+        cb(
+          createExecFileError("not booted", {
+            stderr: "System has not been booted with systemd as init system",
+          }),
+          "",
+          "",
+        );
+      });
+
+    const result = await isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } });
+    expect(result).toBe(false);
+  });
+
   it("calls systemctl is-enabled when systemctl is present", async () => {
     execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
       assertUserSystemctlArgs(args, "is-enabled", GATEWAY_SERVICE);

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -426,22 +426,6 @@ async function execSystemctlSystem(
   return await execSystemctl(args);
 }
 
-// Probe whether a unit is enabled/active in system scope.
-// Returns null when systemctl itself is unavailable.
-async function probeSystemScope(
-  unitName: string,
-): Promise<{ enabled: boolean; active: boolean } | null> {
-  const enabledRes = await execSystemctlSystem(["is-enabled", unitName]);
-  if (isSystemctlMissing(readSystemctlDetail(enabledRes))) {
-    return null;
-  }
-  const activeRes = await execSystemctlSystem(["is-active", unitName]);
-  return {
-    enabled: enabledRes.code === 0,
-    active: activeRes.code === 0,
-  };
-}
-
 export async function isSystemdUserServiceAvailable(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
 ): Promise<boolean> {
@@ -638,11 +622,9 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     await fs.access(resolveSystemdUnitPath(env));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      // User unit file missing — check system scope.
-      const serviceName = resolveSystemdServiceName(env);
-      const unitName = `${serviceName}.service`;
-      const system = await probeSystemScope(unitName);
-      return system !== null && (system.enabled || system.active);
+      // User unit file missing — keep returning false to avoid routing
+      // callers (e.g. uninstall) into paths that only handle user scope.
+      return false;
     }
     throw error;
   }
@@ -655,11 +637,6 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   }
   const detail = readSystemctlDetail(res);
   if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
-    // User scope says not enabled — check system scope.
-    const system = await probeSystemScope(unitName);
-    if (system !== null && (system.enabled || system.active)) {
-      return true;
-    }
     return false;
   }
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
@@ -703,13 +680,15 @@ export async function readSystemdServiceRuntime(
   if (res.code === 0) {
     return buildRuntimeFromShow(res.stdout);
   }
-  // User-scope show failed — try system scope.
-  const systemRes = await execSystemctlSystem(showArgs);
-  if (systemRes.code === 0) {
-    return { ...buildRuntimeFromShow(systemRes.stdout), detail: "system scope" };
-  }
   const detail = (res.stderr || res.stdout).trim();
   const missing = detail.toLowerCase().includes("not found");
+  // Only fall back to system scope when user unit is missing.
+  if (missing) {
+    const systemRes = await execSystemctlSystem(showArgs);
+    if (systemRes.code === 0) {
+      return { ...buildRuntimeFromShow(systemRes.stdout), detail: "system scope" };
+    }
+  }
   return {
     status: missing ? "stopped" : "unknown",
     detail: detail || undefined,

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -323,6 +323,25 @@ function isSystemdUserScopeUnavailable(detail: string): boolean {
   );
 }
 
+function isSystemdUnavailable(detail: string): boolean {
+  if (!detail) {
+    return false;
+  }
+  const normalized = detail.toLowerCase();
+  return (
+    isSystemctlMissing(normalized) ||
+    normalized.includes("not been booted") ||
+    normalized.includes("not supported")
+  );
+}
+
+function isDegradedSystemdStatus(detail: string): boolean {
+  if (!detail) {
+    return false;
+  }
+  return detail.toLowerCase().includes("degraded");
+}
+
 function isSystemdUnitMissing(detail: string): boolean {
   const normalized = detail.toLowerCase();
   return (
@@ -456,25 +475,25 @@ async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as Ga
     return;
   }
   const detail = readSystemctlDetail(res);
-  if (isSystemctlMissing(detail)) {
-    // User-scope systemctl missing — check if system-scope works.
-    const systemRes = await execSystemctlSystem(["status"]);
-    const systemDetail = readSystemctlDetail(systemRes);
-    if (systemRes.code === 0) {
-      return;
-    }
-    // System scope also unusable — report appropriately.
-    if (isSystemctlMissing(systemDetail)) {
-      throw new Error("systemctl not available; systemd services are required on Linux.");
-    }
-    // systemctl exists but systemd itself is not running (e.g. "System has not been booted with systemd").
-    throw new Error(`systemctl unavailable: ${systemDetail || "unknown error"}`.trim());
-  }
   if (!detail) {
     throw new Error("systemctl --user unavailable: unknown error");
   }
   if (!isSystemdUserScopeUnavailable(detail)) {
     return;
+  }
+
+  // User scope is unavailable; probe system scope before failing. This keeps
+  // system-scope installs operable in non-login/root sessions.
+  const systemRes = await execSystemctlSystem(["status"]);
+  const systemDetail = readSystemctlDetail(systemRes);
+  if (systemRes.code === 0 || isDegradedSystemdStatus(systemDetail)) {
+    return;
+  }
+  if (isSystemctlMissing(systemDetail)) {
+    throw new Error("systemctl not available; systemd services are required on Linux.");
+  }
+  if (isSystemdUnavailable(systemDetail)) {
+    throw new Error(`systemctl unavailable: ${systemDetail || "unknown error"}`.trim());
   }
   throw new Error(`systemctl --user unavailable: ${detail || "unknown error"}`.trim());
 }
@@ -594,8 +613,10 @@ async function runSystemdServiceAction(params: {
       params.stdout.write(`${formatLine(params.label, unitName)}\n`);
       return { scope: "system" };
     }
+    const systemDetail = readSystemctlDetail(systemRes);
+    throw new Error(`systemctl ${params.action} failed: ${systemDetail || "unknown error"}`.trim());
   }
-  throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
+  throw new Error(`systemctl ${params.action} failed: ${userDetail || "unknown error"}`.trim());
 }
 
 export async function stopSystemdService({
@@ -625,19 +646,49 @@ export async function restartSystemdService({
 
 export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Promise<boolean> {
   const env = args.env ?? process.env;
+  const serviceName = resolveSystemdServiceName(env);
+  const unitName = `${serviceName}.service`;
   try {
     await fs.access(resolveSystemdUnitPath(env));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      // User unit file missing — keep returning false to avoid routing
-      // callers (e.g. uninstall) into paths that only handle user scope.
-      return false;
+      // User unit file missing; detect system-scope installs so lifecycle
+      // commands can operate on gateways installed under /etc/systemd/system.
+      const systemEnabled = await execSystemctlSystem(["is-enabled", unitName]);
+      if (systemEnabled.code === 0) {
+        return true;
+      }
+      const systemEnabledDetail = readSystemctlDetail(systemEnabled);
+      if (
+        !isSystemctlMissing(systemEnabledDetail) &&
+        !isSystemdUnitNotEnabled(systemEnabledDetail)
+      ) {
+        throw new Error(
+          `systemctl is-enabled unavailable: ${systemEnabledDetail || "unknown error"}`.trim(),
+          { cause: error },
+        );
+      }
+
+      const systemActive = await execSystemctlSystem(["is-active", unitName]);
+      if (systemActive.code === 0) {
+        return true;
+      }
+      const systemActiveDetail = readSystemctlDetail(systemActive);
+      if (isSystemctlMissing(systemActiveDetail) || isSystemdUnitMissing(systemActiveDetail)) {
+        return false;
+      }
+      const activeState = systemActive.stdout.trim().toLowerCase();
+      if (activeState && activeState !== "active") {
+        return false;
+      }
+      throw new Error(
+        `systemctl is-active unavailable: ${systemActiveDetail || "unknown error"}`.trim(),
+        { cause: error },
+      );
     }
     throw error;
   }
 
-  const serviceName = resolveSystemdServiceName(env);
-  const unitName = `${serviceName}.service`;
   const res = await execSystemctlUser(env, ["is-enabled", unitName]);
   if (res.code === 0) {
     return true;
@@ -695,6 +746,19 @@ export async function readSystemdServiceRuntime(
     if (systemRes.code === 0) {
       return { ...buildRuntimeFromShow(systemRes.stdout), detail: "system scope" };
     }
+    const systemDetail = readSystemctlDetail(systemRes);
+    const systemMissing = isSystemdUnitMissing(systemDetail);
+    if (!systemMissing) {
+      return {
+        status: "unknown",
+        detail: systemDetail || undefined,
+      };
+    }
+    return {
+      status: "stopped",
+      detail: systemDetail || detail || undefined,
+      missingUnit: true,
+    };
   }
   return {
     status: missing ? "stopped" : "unknown",

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -57,6 +57,25 @@ export function resolveSystemdUserUnitPath(env: GatewayServiceEnv): string {
 export { enableSystemdUserLinger, readSystemdUserLingerStatus };
 export type { SystemdUserLingerStatus };
 
+export type SystemdServiceScope = "user" | "system";
+
+type SystemctlResult = { stdout: string; stderr: string; code: number };
+
+type ScopedSystemctlResult = {
+  scope: SystemdServiceScope;
+  args: string[];
+  result: SystemctlResult;
+};
+
+type SystemdScopeDetection = {
+  preferredScope: SystemdServiceScope | null;
+  detail?: string;
+  userEnabled: boolean;
+  systemEnabled: boolean;
+  userActive: boolean;
+  systemActive: boolean;
+};
+
 // Unit file parsing/rendering: see systemd-unit.ts
 
 export async function readSystemdServiceExecStart(
@@ -130,7 +149,6 @@ function buildEnvironmentValueSources(
 }
 
 function expandSystemdSpecifier(input: string, env: GatewayServiceEnv): string {
-  // Support the common unit-specifier used in user services.
   return input.replaceAll("%h", toPosixPath(resolveHomeDir(env)));
 }
 
@@ -202,9 +220,6 @@ async function resolveSystemdEnvironmentFiles(params: {
         const fromFile = await readSystemdEnvironmentFile(pathname);
         Object.assign(resolved, fromFile);
       } catch {
-        // Keep service auditing resilient even when env files are unavailable
-        // in the current runtime context. Both optional and non-optional
-        // EnvironmentFile entries are skipped gracefully for diagnostics.
         continue;
       }
     }
@@ -252,23 +267,17 @@ export function parseSystemdShow(output: string): SystemdServiceInfo {
   return info;
 }
 
-async function execSystemctl(
-  args: string[],
-): Promise<{ stdout: string; stderr: string; code: number }> {
+async function execSystemctl(args: string[]): Promise<SystemctlResult> {
   return await execFileUtf8("systemctl", args);
 }
 
-function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
-  // Concatenate both streams so pattern matchers (isSystemdUnitNotEnabled,
-  // isSystemctlMissing) can see the unit status from stdout even when
-  // execFileUtf8 populates stderr with the Node error message fallback.
-  return `${result.stderr} ${result.stdout}`.trim();
+function readSystemctlDetail(result: SystemctlResult): string {
+  const stdout = result.stdout?.trim();
+  const stderr = result.stderr?.trim();
+  return [stderr, stdout].filter(Boolean).join(" ").trim();
 }
 
 function isSystemctlMissing(detail: string): boolean {
-  if (!detail) {
-    return false;
-  }
   const normalized = detail.toLowerCase();
   return (
     normalized.includes("not found") ||
@@ -278,54 +287,27 @@ function isSystemctlMissing(detail: string): boolean {
   );
 }
 
-function isSystemdUnitNotEnabled(detail: string): boolean {
-  if (!detail) {
-    return false;
-  }
-  const normalized = detail.toLowerCase();
-  return (
-    normalized.includes("disabled") ||
-    normalized.includes("static") ||
-    normalized.includes("indirect") ||
-    normalized.includes("masked") ||
-    normalized.includes("not-found") ||
-    normalized.includes("could not be found") ||
-    normalized.includes("failed to get unit file state")
-  );
-}
-
-function isSystemctlBusUnavailable(detail: string): boolean {
-  if (!detail) {
-    return false;
-  }
+function isSystemdUserScopeUnavailable(detail: string): boolean {
   const normalized = detail.toLowerCase();
   return (
     normalized.includes("failed to connect to bus") ||
     normalized.includes("failed to connect to user scope bus") ||
     normalized.includes("dbus_session_bus_address") ||
-    normalized.includes("xdg_runtime_dir") ||
-    normalized.includes("no medium found")
+    normalized.includes("xdg_runtime_dir")
   );
 }
 
-function isSystemdUserScopeUnavailable(detail: string): boolean {
-  if (!detail) {
-    return false;
-  }
+function isSystemctlBusUnavailable(detail: string): boolean {
+  return isSystemdUserScopeUnavailable(detail);
+}
+
+function isSystemdUnitNotEnabled(detail: string): boolean {
   const normalized = detail.toLowerCase();
-  return (
-    isSystemctlMissing(normalized) ||
-    isSystemctlBusUnavailable(normalized) ||
-    normalized.includes("not been booted") ||
-    normalized.includes("not supported")
-  );
+  return normalized.includes("disabled") || normalized.includes("static") || normalized.includes("indirect");
 }
 
 function isGenericSystemctlIsEnabledFailure(detail: string): boolean {
-  if (!detail) {
-    return false;
-  }
-  const normalized = detail.toLowerCase().trim();
+  const normalized = detail.toLowerCase();
   return (
     normalized.startsWith("command failed: systemctl") &&
     normalized.includes(" is-enabled ") &&
@@ -388,11 +370,10 @@ function shouldFallbackToMachineUserScope(detail: string): boolean {
 async function execSystemctlUser(
   env: GatewayServiceEnv,
   args: string[],
-): Promise<{ stdout: string; stderr: string; code: number }> {
+): Promise<SystemctlResult> {
   const machineUser = resolveSystemctlMachineScopeUser(env);
   const sudoUser = env.SUDO_USER?.trim();
 
-  // Under sudo, prefer the invoking non-root user's scope directly.
   if (sudoUser && sudoUser !== "root" && machineUser) {
     const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
     if (machineScopeArgs.length > 0) {
@@ -417,6 +398,94 @@ async function execSystemctlUser(
   return await execSystemctl([...machineScopeArgs, ...args]);
 }
 
+async function execSystemctlForScope(
+  env: GatewayServiceEnv,
+  scope: SystemdServiceScope,
+  args: string[],
+): Promise<SystemctlResult> {
+  if (scope === "user") {
+    return await execSystemctlUser(env, args);
+  }
+  return await execSystemctl(args);
+}
+
+async function probeSystemdScopeDetection(
+  env: GatewayServiceEnv,
+  unitName: string,
+): Promise<SystemdScopeDetection> {
+  const [userEnabledRes, systemEnabledRes, userActiveRes, systemActiveRes] = await Promise.all([
+    execSystemctlForScope(env, "user", ["is-enabled", unitName]),
+    execSystemctlForScope(env, "system", ["is-enabled", unitName]),
+    execSystemctlForScope(env, "user", ["is-active", unitName]),
+    execSystemctlForScope(env, "system", ["is-active", unitName]),
+  ]);
+
+  const userEnabled = userEnabledRes.code === 0;
+  const systemEnabled = systemEnabledRes.code === 0;
+  const userActive = userActiveRes.code === 0;
+  const systemActive = systemActiveRes.code === 0;
+
+  let preferredScope: SystemdServiceScope | null = null;
+  let detail: string | undefined;
+  if (userEnabled && userActive) {
+    preferredScope = "user";
+    detail = "user (enabled+active)";
+  } else if (systemEnabled && systemActive) {
+    preferredScope = "system";
+    detail = "system (enabled+active)";
+  } else if (userEnabled) {
+    preferredScope = "user";
+    detail = "user (enabled)";
+  } else if (systemEnabled) {
+    preferredScope = "system";
+    detail = "system (enabled)";
+  } else if (userActive) {
+    preferredScope = "user";
+    detail = "user (active)";
+  } else if (systemActive) {
+    preferredScope = "system";
+    detail = "system (active)";
+  }
+
+  return { preferredScope, detail, userEnabled, systemEnabled, userActive, systemActive };
+}
+
+function scopeOrder(preferred: SystemdServiceScope | null): SystemdServiceScope[] {
+  if (preferred === "user") {
+    return ["user", "system"];
+  }
+  if (preferred === "system") {
+    return ["system", "user"];
+  }
+  return ["user", "system"];
+}
+
+async function trySystemctlAcrossScopes(
+  env: GatewayServiceEnv,
+  unitName: string,
+  args: string[],
+  preferred: SystemdServiceScope | null,
+): Promise<ScopedSystemctlResult[]> {
+  const out: ScopedSystemctlResult[] = [];
+  for (const scope of scopeOrder(preferred)) {
+    out.push({
+      scope,
+      args,
+      result: await execSystemctlForScope(env, scope, [...args, unitName]),
+    });
+  }
+  return out;
+}
+
+function formatScopeLabel(scope: SystemdServiceScope): string {
+  return scope === "user" ? "user" : "system";
+}
+
+function formatScopedCommand(scope: SystemdServiceScope, args: string[], unitName: string): string {
+  const prefix = scope === "user" ? "systemctl --user" : "systemctl";
+  return `${prefix} ${[...args, unitName].join(" ")}`;
+}
+
 export async function isSystemdUserServiceAvailable(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
 ): Promise<boolean> {
@@ -432,21 +501,27 @@ export async function isSystemdUserServiceAvailable(
 }
 
 async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as GatewayServiceEnv) {
-  const res = await execSystemctlUser(env, ["status"]);
-  if (res.code === 0) {
+  const [userRes, systemRes] = await Promise.all([
+    execSystemctlUser(env, ["status"]),
+    execSystemctl(["status"]),
+  ]);
+  if (userRes.code === 0 || systemRes.code === 0) {
     return;
   }
-  const detail = readSystemctlDetail(res);
-  if (isSystemctlMissing(detail)) {
-    throw new Error("systemctl not available; systemd user services are required on Linux.");
+  const userDetail = readSystemctlDetail(userRes);
+  const systemDetail = readSystemctlDetail(systemRes);
+  if (isSystemctlMissing(userDetail) && isSystemctlMissing(systemDetail)) {
+    throw new Error("systemctl not available; systemd services are required on Linux.");
   }
-  if (!detail) {
-    throw new Error("systemctl --user unavailable: unknown error");
+  if (!userDetail && !systemDetail) {
+    throw new Error("systemctl unavailable: unknown error");
   }
-  if (!isSystemdUserScopeUnavailable(detail)) {
+  if (!isSystemdUserScopeUnavailable(userDetail)) {
     return;
   }
-  throw new Error(`systemctl --user unavailable: ${detail || "unknown error"}`.trim());
+  if (!systemDetail || isSystemctlMissing(systemDetail)) {
+    throw new Error(`systemctl --user unavailable: ${userDetail || "unknown error"}`.trim());
+  }
 }
 
 export async function installSystemdService({
@@ -462,7 +537,6 @@ export async function installSystemdService({
   const unitPath = resolveSystemdUnitPath(env);
   await fs.mkdir(path.dirname(unitPath), { recursive: true });
 
-  // Preserve user customizations: back up existing unit file before overwriting.
   let backedUp = false;
   try {
     await fs.access(unitPath);
@@ -470,7 +544,7 @@ export async function installSystemdService({
     await fs.copyFile(unitPath, backupPath);
     backedUp = true;
   } catch {
-    // File does not exist yet — nothing to back up.
+    // ignore
   }
 
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
@@ -499,32 +573,18 @@ export async function installSystemdService({
     throw new Error(`systemctl restart failed: ${restart.stderr || restart.stdout}`.trim());
   }
 
-  // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
   writeFormattedLines(
     stdout,
     [
-      {
-        label: "Installed systemd service",
-        value: unitPath,
-      },
-      ...(backedUp
-        ? [
-            {
-              label: "Previous unit backed up to",
-              value: `${unitPath}.bak`,
-            },
-          ]
-        : []),
+      { label: "Installed systemd service", value: unitPath },
+      ...(backedUp ? [{ label: "Previous unit backed up to", value: `${unitPath}.bak` }] : []),
     ],
     { leadingBlankLine: true },
   );
   return { unitPath };
 }
 
-export async function uninstallSystemdService({
-  env,
-  stdout,
-}: GatewayServiceManageArgs): Promise<void> {
+export async function uninstallSystemdService({ env, stdout }: GatewayServiceManageArgs): Promise<void> {
   await assertSystemdAvailable(env);
   const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
   const unitName = `${serviceName}.service`;
@@ -544,41 +604,43 @@ async function runSystemdServiceAction(params: {
   env?: GatewayServiceEnv;
   action: "stop" | "restart";
   label: string;
-}) {
+}): Promise<GatewayServiceRestartResult> {
   const env = params.env ?? process.env;
   await assertSystemdAvailable(env);
   const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
-  const res = await execSystemctlUser(env, [params.action, unitName]);
-  if (res.code !== 0) {
-    throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
+  const detection = await probeSystemdScopeDetection(env, unitName);
+  const tried = await trySystemctlAcrossScopes(env, unitName, [params.action], detection.preferredScope);
+  const success = tried.find((entry) => entry.result.code === 0);
+  if (!success) {
+    const detail = tried
+      .map((entry) => `${formatScopeLabel(entry.scope)}: ${readSystemctlDetail(entry.result) || `exit ${entry.result.code}`}`)
+      .join("; ");
+    throw new Error(`systemctl ${params.action} failed: ${detail}`.trim());
   }
   params.stdout.write(`${formatLine(params.label, unitName)}\n`);
+  return {
+    outcome: "completed",
+    detail: detection.detail || formatScopeLabel(success.scope),
+    scope: success.scope,
+    tried: tried.map((entry) => formatScopedCommand(entry.scope, [params.action], unitName)),
+  } as GatewayServiceRestartResult;
 }
 
-export async function stopSystemdService({
-  stdout,
-  env,
-}: GatewayServiceControlArgs): Promise<void> {
-  await runSystemdServiceAction({
-    stdout,
-    env,
-    action: "stop",
-    label: "Stopped systemd service",
-  });
+export async function stopSystemdService({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
+  await runSystemdServiceAction({ stdout, env, action: "stop", label: "Stopped systemd service" });
 }
 
 export async function restartSystemdService({
   stdout,
   env,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
-  await runSystemdServiceAction({
+  return await runSystemdServiceAction({
     stdout,
     env,
     action: "restart",
     label: "Restarted systemd service",
   });
-  return { outcome: "completed" };
 }
 
 export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Promise<boolean> {
@@ -587,22 +649,32 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     await fs.access(resolveSystemdUnitPath(env));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
+      const serviceName = resolveSystemdServiceName(env);
+      const unitName = `${serviceName}.service`;
+      const detection = await probeSystemdScopeDetection(env, unitName);
+      return detection.systemEnabled || detection.systemActive;
     }
     throw error;
   }
 
   const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
-  const res = await execSystemctlUser(env, ["is-enabled", unitName]);
-  if (res.code === 0) {
+  const detection = await probeSystemdScopeDetection(env, unitName);
+  if (detection.userEnabled || detection.userActive || detection.systemEnabled || detection.systemActive) {
     return true;
   }
-  const detail = readSystemctlDetail(res);
-  if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
-    return false;
+
+  const tried = await trySystemctlAcrossScopes(env, unitName, ["is-enabled"], detection.preferredScope);
+  for (const entry of tried) {
+    if (entry.result.code === 0) {
+      return true;
+    }
+    const detail = readSystemctlDetail(entry.result);
+    if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
+      continue;
+    }
   }
-  throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
+  return false;
 }
 
 export async function readSystemdServiceRuntime(
@@ -618,15 +690,16 @@ export async function readSystemdServiceRuntime(
   }
   const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
-  const res = await execSystemctlUser(env, [
-    "show",
+  const detection = await probeSystemdScopeDetection(env, unitName);
+  const tried = await trySystemctlAcrossScopes(
+    env,
     unitName,
-    "--no-page",
-    "--property",
-    "ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode",
-  ]);
-  if (res.code !== 0) {
-    const detail = (res.stderr || res.stdout).trim();
+    ["show", "--no-page", "--property", "ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode"],
+    detection.preferredScope,
+  );
+  const success = tried.find((entry) => entry.result.code === 0);
+  if (!success) {
+    const detail = tried.map((entry) => readSystemctlDetail(entry.result)).filter(Boolean).join("; ");
     const missing = detail.toLowerCase().includes("not found");
     return {
       status: missing ? "stopped" : "unknown",
@@ -634,7 +707,7 @@ export async function readSystemdServiceRuntime(
       missingUnit: missing,
     };
   }
-  const parsed = parseSystemdShow(res.stdout || "");
+  const parsed = parseSystemdShow(success.result.stdout || "");
   const activeState = parsed.activeState?.toLowerCase();
   const status = activeState === "active" ? "running" : activeState ? "stopped" : "unknown";
   return {
@@ -644,8 +717,10 @@ export async function readSystemdServiceRuntime(
     pid: parsed.mainPid,
     lastExitStatus: parsed.execMainStatus,
     lastExitReason: parsed.execMainCode,
+    detail: detection.detail || formatScopeLabel(success.scope),
   };
 }
+
 export type LegacySystemdUnit = {
   name: string;
   unitPath: string;
@@ -654,11 +729,14 @@ export type LegacySystemdUnit = {
 };
 
 async function isSystemctlAvailable(env: GatewayServiceEnv): Promise<boolean> {
-  const res = await execSystemctlUser(env, ["status"]);
-  if (res.code === 0) {
+  const [userRes, systemRes] = await Promise.all([
+    execSystemctlUser(env, ["status"]),
+    execSystemctl(["status"]),
+  ]);
+  if (userRes.code === 0 || systemRes.code === 0) {
     return true;
   }
-  return !isSystemctlMissing(readSystemctlDetail(res));
+  return !(isSystemctlMissing(readSystemctlDetail(userRes)) && isSystemctlMissing(readSystemctlDetail(systemRes)));
 }
 
 export async function findLegacySystemdUnits(env: GatewayServiceEnv): Promise<LegacySystemdUnit[]> {
@@ -675,8 +753,9 @@ export async function findLegacySystemdUnits(env: GatewayServiceEnv): Promise<Le
     }
     let enabled = false;
     if (systemctlAvailable) {
-      const res = await execSystemctlUser(env, ["is-enabled", `${name}.service`]);
-      enabled = res.code === 0;
+      const unitName = `${name}.service`;
+      const detection = await probeSystemdScopeDetection(env, unitName);
+      enabled = detection.userEnabled || detection.systemEnabled;
     }
     if (exists || enabled) {
       results.push({ name, unitPath, enabled, exists });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -465,10 +465,16 @@ async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as Ga
   if (isSystemctlMissing(detail)) {
     // User-scope systemctl missing — check if system-scope works.
     const systemRes = await execSystemctlSystem(["status"]);
-    if (systemRes.code === 0 || !isSystemctlMissing(readSystemctlDetail(systemRes))) {
+    const systemDetail = readSystemctlDetail(systemRes);
+    if (systemRes.code === 0) {
       return;
     }
-    throw new Error("systemctl not available; systemd services are required on Linux.");
+    // System scope also unusable — report appropriately.
+    if (isSystemctlMissing(systemDetail)) {
+      throw new Error("systemctl not available; systemd services are required on Linux.");
+    }
+    // systemctl exists but systemd itself is not running (e.g. "System has not been booted with systemd").
+    throw new Error(`systemctl unavailable: ${systemDetail || "unknown error"}`.trim());
   }
   if (!detail) {
     throw new Error("systemctl --user unavailable: unknown error");
@@ -584,11 +590,19 @@ async function runSystemdServiceAction(params: {
     params.stdout.write(`${formatLine(params.label, unitName)}\n`);
     return { scope: "user" };
   }
-  // User-scope failed — try system scope before giving up.
-  const systemRes = await execSystemctlSystem([params.action, unitName]);
-  if (systemRes.code === 0) {
-    params.stdout.write(`${formatLine(params.label, unitName)}\n`);
-    return { scope: "system" };
+  // Only fall back to system scope when the user unit is missing/not-loaded.
+  // Operational errors (permission denied, bus failures) should surface immediately.
+  const userDetail = readSystemctlDetail(res);
+  const isUnitMissing =
+    userDetail.toLowerCase().includes("not found") ||
+    userDetail.toLowerCase().includes("not loaded") ||
+    userDetail.toLowerCase().includes("no such unit");
+  if (isUnitMissing) {
+    const systemRes = await execSystemctlSystem([params.action, unitName]);
+    if (systemRes.code === 0) {
+      params.stdout.write(`${formatLine(params.label, unitName)}\n`);
+      return { scope: "system" };
+    }
   }
   throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
 }

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -331,6 +331,7 @@ function isSystemdUnavailable(detail: string): boolean {
   return (
     isSystemctlMissing(normalized) ||
     normalized.includes("not been booted") ||
+    normalized.includes("not booted") ||
     normalized.includes("not supported")
   );
 }
@@ -675,6 +676,9 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
       }
       const systemActiveDetail = readSystemctlDetail(systemActive);
       if (isSystemctlMissing(systemActiveDetail) || isSystemdUnitMissing(systemActiveDetail)) {
+        return false;
+      }
+      if (isSystemdUnavailable(systemActiveDetail)) {
         return false;
       }
       const activeState = systemActive.stdout.trim().toLowerCase();

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -59,23 +59,6 @@ export type { SystemdUserLingerStatus };
 
 export type SystemdServiceScope = "user" | "system";
 
-type SystemctlResult = { stdout: string; stderr: string; code: number };
-
-type ScopedSystemctlResult = {
-  scope: SystemdServiceScope;
-  args: string[];
-  result: SystemctlResult;
-};
-
-type SystemdScopeDetection = {
-  preferredScope: SystemdServiceScope | null;
-  detail?: string;
-  userEnabled: boolean;
-  systemEnabled: boolean;
-  userActive: boolean;
-  systemActive: boolean;
-};
-
 // Unit file parsing/rendering: see systemd-unit.ts
 
 export async function readSystemdServiceExecStart(
@@ -149,6 +132,7 @@ function buildEnvironmentValueSources(
 }
 
 function expandSystemdSpecifier(input: string, env: GatewayServiceEnv): string {
+  // Support the common unit-specifier used in user services.
   return input.replaceAll("%h", toPosixPath(resolveHomeDir(env)));
 }
 
@@ -220,6 +204,9 @@ async function resolveSystemdEnvironmentFiles(params: {
         const fromFile = await readSystemdEnvironmentFile(pathname);
         Object.assign(resolved, fromFile);
       } catch {
+        // Keep service auditing resilient even when env files are unavailable
+        // in the current runtime context. Both optional and non-optional
+        // EnvironmentFile entries are skipped gracefully for diagnostics.
         continue;
       }
     }
@@ -267,17 +254,23 @@ export function parseSystemdShow(output: string): SystemdServiceInfo {
   return info;
 }
 
-async function execSystemctl(args: string[]): Promise<SystemctlResult> {
+async function execSystemctl(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
   return await execFileUtf8("systemctl", args);
 }
 
-function readSystemctlDetail(result: SystemctlResult): string {
-  const stdout = result.stdout?.trim();
-  const stderr = result.stderr?.trim();
-  return [stderr, stdout].filter(Boolean).join(" ").trim();
+function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
+  // Concatenate both streams so pattern matchers (isSystemdUnitNotEnabled,
+  // isSystemctlMissing) can see the unit status from stdout even when
+  // execFileUtf8 populates stderr with the Node error message fallback.
+  return `${result.stderr} ${result.stdout}`.trim();
 }
 
 function isSystemctlMissing(detail: string): boolean {
+  if (!detail) {
+    return false;
+  }
   const normalized = detail.toLowerCase();
   return (
     normalized.includes("not found") ||
@@ -287,27 +280,54 @@ function isSystemctlMissing(detail: string): boolean {
   );
 }
 
-function isSystemdUserScopeUnavailable(detail: string): boolean {
+function isSystemdUnitNotEnabled(detail: string): boolean {
+  if (!detail) {
+    return false;
+  }
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes("disabled") ||
+    normalized.includes("static") ||
+    normalized.includes("indirect") ||
+    normalized.includes("masked") ||
+    normalized.includes("not-found") ||
+    normalized.includes("could not be found") ||
+    normalized.includes("failed to get unit file state")
+  );
+}
+
+function isSystemctlBusUnavailable(detail: string): boolean {
+  if (!detail) {
+    return false;
+  }
   const normalized = detail.toLowerCase();
   return (
     normalized.includes("failed to connect to bus") ||
     normalized.includes("failed to connect to user scope bus") ||
     normalized.includes("dbus_session_bus_address") ||
-    normalized.includes("xdg_runtime_dir")
+    normalized.includes("xdg_runtime_dir") ||
+    normalized.includes("no medium found")
   );
 }
 
-function isSystemctlBusUnavailable(detail: string): boolean {
-  return isSystemdUserScopeUnavailable(detail);
-}
-
-function isSystemdUnitNotEnabled(detail: string): boolean {
+function isSystemdUserScopeUnavailable(detail: string): boolean {
+  if (!detail) {
+    return false;
+  }
   const normalized = detail.toLowerCase();
-  return normalized.includes("disabled") || normalized.includes("static") || normalized.includes("indirect");
+  return (
+    isSystemctlMissing(normalized) ||
+    isSystemctlBusUnavailable(normalized) ||
+    normalized.includes("not been booted") ||
+    normalized.includes("not supported")
+  );
 }
 
 function isGenericSystemctlIsEnabledFailure(detail: string): boolean {
-  const normalized = detail.toLowerCase();
+  if (!detail) {
+    return false;
+  }
+  const normalized = detail.toLowerCase().trim();
   return (
     normalized.startsWith("command failed: systemctl") &&
     normalized.includes(" is-enabled ") &&
@@ -370,10 +390,11 @@ function shouldFallbackToMachineUserScope(detail: string): boolean {
 async function execSystemctlUser(
   env: GatewayServiceEnv,
   args: string[],
-): Promise<SystemctlResult> {
+): Promise<{ stdout: string; stderr: string; code: number }> {
   const machineUser = resolveSystemctlMachineScopeUser(env);
   const sudoUser = env.SUDO_USER?.trim();
 
+  // Under sudo, prefer the invoking non-root user's scope directly.
   if (sudoUser && sudoUser !== "root" && machineUser) {
     const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
     if (machineScopeArgs.length > 0) {
@@ -398,92 +419,27 @@ async function execSystemctlUser(
   return await execSystemctl([...machineScopeArgs, ...args]);
 }
 
-async function execSystemctlForScope(
-  env: GatewayServiceEnv,
-  scope: SystemdServiceScope,
+// Execute systemctl without --user for system-scope units.
+async function execSystemctlSystem(
   args: string[],
-): Promise<SystemctlResult> {
-  if (scope === "user") {
-    return await execSystemctlUser(env, args);
-  }
+): Promise<{ stdout: string; stderr: string; code: number }> {
   return await execSystemctl(args);
 }
 
-async function probeSystemdScopeDetection(
-  env: GatewayServiceEnv,
+// Probe whether a unit is enabled/active in system scope.
+// Returns null when systemctl itself is unavailable.
+async function probeSystemScope(
   unitName: string,
-): Promise<SystemdScopeDetection> {
-  const [userEnabledRes, systemEnabledRes, userActiveRes, systemActiveRes] = await Promise.all([
-    execSystemctlForScope(env, "user", ["is-enabled", unitName]),
-    execSystemctlForScope(env, "system", ["is-enabled", unitName]),
-    execSystemctlForScope(env, "user", ["is-active", unitName]),
-    execSystemctlForScope(env, "system", ["is-active", unitName]),
-  ]);
-
-  const userEnabled = userEnabledRes.code === 0;
-  const systemEnabled = systemEnabledRes.code === 0;
-  const userActive = userActiveRes.code === 0;
-  const systemActive = systemActiveRes.code === 0;
-
-  let preferredScope: SystemdServiceScope | null = null;
-  let detail: string | undefined;
-  if (userEnabled && userActive) {
-    preferredScope = "user";
-    detail = "user (enabled+active)";
-  } else if (systemEnabled && systemActive) {
-    preferredScope = "system";
-    detail = "system (enabled+active)";
-  } else if (userEnabled) {
-    preferredScope = "user";
-    detail = "user (enabled)";
-  } else if (systemEnabled) {
-    preferredScope = "system";
-    detail = "system (enabled)";
-  } else if (userActive) {
-    preferredScope = "user";
-    detail = "user (active)";
-  } else if (systemActive) {
-    preferredScope = "system";
-    detail = "system (active)";
+): Promise<{ enabled: boolean; active: boolean } | null> {
+  const enabledRes = await execSystemctlSystem(["is-enabled", unitName]);
+  if (isSystemctlMissing(readSystemctlDetail(enabledRes))) {
+    return null;
   }
-
-  return { preferredScope, detail, userEnabled, systemEnabled, userActive, systemActive };
-}
-
-function scopeOrder(preferred: SystemdServiceScope | null): SystemdServiceScope[] {
-  if (preferred === "user") {
-    return ["user", "system"];
-  }
-  if (preferred === "system") {
-    return ["system", "user"];
-  }
-  return ["user", "system"];
-}
-
-async function trySystemctlAcrossScopes(
-  env: GatewayServiceEnv,
-  unitName: string,
-  args: string[],
-  preferred: SystemdServiceScope | null,
-): Promise<ScopedSystemctlResult[]> {
-  const out: ScopedSystemctlResult[] = [];
-  for (const scope of scopeOrder(preferred)) {
-    out.push({
-      scope,
-      args,
-      result: await execSystemctlForScope(env, scope, [...args, unitName]),
-    });
-  }
-  return out;
-}
-
-function formatScopeLabel(scope: SystemdServiceScope): string {
-  return scope === "user" ? "user" : "system";
-}
-
-function formatScopedCommand(scope: SystemdServiceScope, args: string[], unitName: string): string {
-  const prefix = scope === "user" ? "systemctl --user" : "systemctl";
-  return `${prefix} ${[...args, unitName].join(" ")}`;
+  const activeRes = await execSystemctlSystem(["is-active", unitName]);
+  return {
+    enabled: enabledRes.code === 0,
+    active: activeRes.code === 0,
+  };
 }
 
 export async function isSystemdUserServiceAvailable(
@@ -501,27 +457,26 @@ export async function isSystemdUserServiceAvailable(
 }
 
 async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as GatewayServiceEnv) {
-  const [userRes, systemRes] = await Promise.all([
-    execSystemctlUser(env, ["status"]),
-    execSystemctl(["status"]),
-  ]);
-  if (userRes.code === 0 || systemRes.code === 0) {
+  const res = await execSystemctlUser(env, ["status"]);
+  if (res.code === 0) {
     return;
   }
-  const userDetail = readSystemctlDetail(userRes);
-  const systemDetail = readSystemctlDetail(systemRes);
-  if (isSystemctlMissing(userDetail) && isSystemctlMissing(systemDetail)) {
+  const detail = readSystemctlDetail(res);
+  if (isSystemctlMissing(detail)) {
+    // User-scope systemctl missing — check if system-scope works.
+    const systemRes = await execSystemctlSystem(["status"]);
+    if (systemRes.code === 0 || !isSystemctlMissing(readSystemctlDetail(systemRes))) {
+      return;
+    }
     throw new Error("systemctl not available; systemd services are required on Linux.");
   }
-  if (!userDetail && !systemDetail) {
-    throw new Error("systemctl unavailable: unknown error");
+  if (!detail) {
+    throw new Error("systemctl --user unavailable: unknown error");
   }
-  if (!isSystemdUserScopeUnavailable(userDetail)) {
+  if (!isSystemdUserScopeUnavailable(detail)) {
     return;
   }
-  if (!systemDetail || isSystemctlMissing(systemDetail)) {
-    throw new Error(`systemctl --user unavailable: ${userDetail || "unknown error"}`.trim());
-  }
+  throw new Error(`systemctl --user unavailable: ${detail || "unknown error"}`.trim());
 }
 
 export async function installSystemdService({
@@ -537,6 +492,7 @@ export async function installSystemdService({
   const unitPath = resolveSystemdUnitPath(env);
   await fs.mkdir(path.dirname(unitPath), { recursive: true });
 
+  // Preserve user customizations: back up existing unit file before overwriting.
   let backedUp = false;
   try {
     await fs.access(unitPath);
@@ -544,7 +500,7 @@ export async function installSystemdService({
     await fs.copyFile(unitPath, backupPath);
     backedUp = true;
   } catch {
-    // ignore
+    // File does not exist yet — nothing to back up.
   }
 
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
@@ -573,18 +529,32 @@ export async function installSystemdService({
     throw new Error(`systemctl restart failed: ${restart.stderr || restart.stdout}`.trim());
   }
 
+  // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
   writeFormattedLines(
     stdout,
     [
-      { label: "Installed systemd service", value: unitPath },
-      ...(backedUp ? [{ label: "Previous unit backed up to", value: `${unitPath}.bak` }] : []),
+      {
+        label: "Installed systemd service",
+        value: unitPath,
+      },
+      ...(backedUp
+        ? [
+            {
+              label: "Previous unit backed up to",
+              value: `${unitPath}.bak`,
+            },
+          ]
+        : []),
     ],
     { leadingBlankLine: true },
   );
   return { unitPath };
 }
 
-export async function uninstallSystemdService({ env, stdout }: GatewayServiceManageArgs): Promise<void> {
+export async function uninstallSystemdService({
+  env,
+  stdout,
+}: GatewayServiceManageArgs): Promise<void> {
   await assertSystemdAvailable(env);
   const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
   const unitName = `${serviceName}.service`;
@@ -604,43 +574,48 @@ async function runSystemdServiceAction(params: {
   env?: GatewayServiceEnv;
   action: "stop" | "restart";
   label: string;
-}): Promise<GatewayServiceRestartResult> {
+}): Promise<{ scope: SystemdServiceScope }> {
   const env = params.env ?? process.env;
   await assertSystemdAvailable(env);
   const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
-  const detection = await probeSystemdScopeDetection(env, unitName);
-  const tried = await trySystemctlAcrossScopes(env, unitName, [params.action], detection.preferredScope);
-  const success = tried.find((entry) => entry.result.code === 0);
-  if (!success) {
-    const detail = tried
-      .map((entry) => `${formatScopeLabel(entry.scope)}: ${readSystemctlDetail(entry.result) || `exit ${entry.result.code}`}`)
-      .join("; ");
-    throw new Error(`systemctl ${params.action} failed: ${detail}`.trim());
+  const res = await execSystemctlUser(env, [params.action, unitName]);
+  if (res.code === 0) {
+    params.stdout.write(`${formatLine(params.label, unitName)}\n`);
+    return { scope: "user" };
   }
-  params.stdout.write(`${formatLine(params.label, unitName)}\n`);
-  return {
-    outcome: "completed",
-    detail: detection.detail || formatScopeLabel(success.scope),
-    scope: success.scope,
-    tried: tried.map((entry) => formatScopedCommand(entry.scope, [params.action], unitName)),
-  } as GatewayServiceRestartResult;
+  // User-scope failed — try system scope before giving up.
+  const systemRes = await execSystemctlSystem([params.action, unitName]);
+  if (systemRes.code === 0) {
+    params.stdout.write(`${formatLine(params.label, unitName)}\n`);
+    return { scope: "system" };
+  }
+  throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
 }
 
-export async function stopSystemdService({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
-  await runSystemdServiceAction({ stdout, env, action: "stop", label: "Stopped systemd service" });
+export async function stopSystemdService({
+  stdout,
+  env,
+}: GatewayServiceControlArgs): Promise<void> {
+  await runSystemdServiceAction({
+    stdout,
+    env,
+    action: "stop",
+    label: "Stopped systemd service",
+  });
 }
 
 export async function restartSystemdService({
   stdout,
   env,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
-  return await runSystemdServiceAction({
+  const { scope } = await runSystemdServiceAction({
     stdout,
     env,
     action: "restart",
     label: "Restarted systemd service",
   });
+  return { outcome: "completed", scope };
 }
 
 export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Promise<boolean> {
@@ -649,32 +624,45 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     await fs.access(resolveSystemdUnitPath(env));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      // User unit file missing — check system scope.
       const serviceName = resolveSystemdServiceName(env);
       const unitName = `${serviceName}.service`;
-      const detection = await probeSystemdScopeDetection(env, unitName);
-      return detection.systemEnabled || detection.systemActive;
+      const system = await probeSystemScope(unitName);
+      return system !== null && (system.enabled || system.active);
     }
     throw error;
   }
 
   const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
-  const detection = await probeSystemdScopeDetection(env, unitName);
-  if (detection.userEnabled || detection.userActive || detection.systemEnabled || detection.systemActive) {
+  const res = await execSystemctlUser(env, ["is-enabled", unitName]);
+  if (res.code === 0) {
     return true;
   }
-
-  const tried = await trySystemctlAcrossScopes(env, unitName, ["is-enabled"], detection.preferredScope);
-  for (const entry of tried) {
-    if (entry.result.code === 0) {
+  const detail = readSystemctlDetail(res);
+  if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
+    // User scope says not enabled — check system scope.
+    const system = await probeSystemScope(unitName);
+    if (system !== null && (system.enabled || system.active)) {
       return true;
     }
-    const detail = readSystemctlDetail(entry.result);
-    if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
-      continue;
-    }
+    return false;
   }
-  return false;
+  throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
+}
+
+function buildRuntimeFromShow(stdout: string): GatewayServiceRuntime {
+  const parsed = parseSystemdShow(stdout || "");
+  const activeState = parsed.activeState?.toLowerCase();
+  const status = activeState === "active" ? "running" : activeState ? "stopped" : "unknown";
+  return {
+    status,
+    state: parsed.activeState,
+    subState: parsed.subState,
+    pid: parsed.mainPid,
+    lastExitStatus: parsed.execMainStatus,
+    lastExitReason: parsed.execMainCode,
+  };
 }
 
 export async function readSystemdServiceRuntime(
@@ -690,37 +678,30 @@ export async function readSystemdServiceRuntime(
   }
   const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
-  const detection = await probeSystemdScopeDetection(env, unitName);
-  const tried = await trySystemctlAcrossScopes(
-    env,
+  const showArgs = [
+    "show",
     unitName,
-    ["show", "--no-page", "--property", "ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode"],
-    detection.preferredScope,
-  );
-  const success = tried.find((entry) => entry.result.code === 0);
-  if (!success) {
-    const detail = tried.map((entry) => readSystemctlDetail(entry.result)).filter(Boolean).join("; ");
-    const missing = detail.toLowerCase().includes("not found");
-    return {
-      status: missing ? "stopped" : "unknown",
-      detail: detail || undefined,
-      missingUnit: missing,
-    };
+    "--no-page",
+    "--property",
+    "ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode",
+  ];
+  const res = await execSystemctlUser(env, showArgs);
+  if (res.code === 0) {
+    return buildRuntimeFromShow(res.stdout);
   }
-  const parsed = parseSystemdShow(success.result.stdout || "");
-  const activeState = parsed.activeState?.toLowerCase();
-  const status = activeState === "active" ? "running" : activeState ? "stopped" : "unknown";
+  // User-scope show failed — try system scope.
+  const systemRes = await execSystemctlSystem(showArgs);
+  if (systemRes.code === 0) {
+    return { ...buildRuntimeFromShow(systemRes.stdout), detail: "system scope" };
+  }
+  const detail = (res.stderr || res.stdout).trim();
+  const missing = detail.toLowerCase().includes("not found");
   return {
-    status,
-    state: parsed.activeState,
-    subState: parsed.subState,
-    pid: parsed.mainPid,
-    lastExitStatus: parsed.execMainStatus,
-    lastExitReason: parsed.execMainCode,
-    detail: detection.detail || formatScopeLabel(success.scope),
+    status: missing ? "stopped" : "unknown",
+    detail: detail || undefined,
+    missingUnit: missing,
   };
 }
-
 export type LegacySystemdUnit = {
   name: string;
   unitPath: string;
@@ -729,14 +710,11 @@ export type LegacySystemdUnit = {
 };
 
 async function isSystemctlAvailable(env: GatewayServiceEnv): Promise<boolean> {
-  const [userRes, systemRes] = await Promise.all([
-    execSystemctlUser(env, ["status"]),
-    execSystemctl(["status"]),
-  ]);
-  if (userRes.code === 0 || systemRes.code === 0) {
+  const res = await execSystemctlUser(env, ["status"]);
+  if (res.code === 0) {
     return true;
   }
-  return !(isSystemctlMissing(readSystemctlDetail(userRes)) && isSystemctlMissing(readSystemctlDetail(systemRes)));
+  return !isSystemctlMissing(readSystemctlDetail(res));
 }
 
 export async function findLegacySystemdUnits(env: GatewayServiceEnv): Promise<LegacySystemdUnit[]> {
@@ -753,9 +731,8 @@ export async function findLegacySystemdUnits(env: GatewayServiceEnv): Promise<Le
     }
     let enabled = false;
     if (systemctlAvailable) {
-      const unitName = `${name}.service`;
-      const detection = await probeSystemdScopeDetection(env, unitName);
-      enabled = detection.userEnabled || detection.systemEnabled;
+      const res = await execSystemctlUser(env, ["is-enabled", `${name}.service`]);
+      enabled = res.code === 0;
     }
     if (exists || enabled) {
       results.push({ name, unitPath, enabled, exists });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -323,6 +323,16 @@ function isSystemdUserScopeUnavailable(detail: string): boolean {
   );
 }
 
+function isSystemdUnitMissing(detail: string): boolean {
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes("not found") ||
+    normalized.includes("not loaded") ||
+    normalized.includes("no such unit") ||
+    normalized.includes("could not be found")
+  );
+}
+
 function isGenericSystemctlIsEnabledFailure(detail: string): boolean {
   if (!detail) {
     return false;
@@ -577,10 +587,7 @@ async function runSystemdServiceAction(params: {
   // Only fall back to system scope when the user unit is missing/not-loaded.
   // Operational errors (permission denied, bus failures) should surface immediately.
   const userDetail = readSystemctlDetail(res);
-  const isUnitMissing =
-    userDetail.toLowerCase().includes("not found") ||
-    userDetail.toLowerCase().includes("not loaded") ||
-    userDetail.toLowerCase().includes("no such unit");
+  const isUnitMissing = isSystemdUnitMissing(userDetail);
   if (isUnitMissing) {
     const systemRes = await execSystemctlSystem([params.action, unitName]);
     if (systemRes.code === 0) {
@@ -681,7 +688,7 @@ export async function readSystemdServiceRuntime(
     return buildRuntimeFromShow(res.stdout);
   }
   const detail = (res.stderr || res.stdout).trim();
-  const missing = detail.toLowerCase().includes("not found");
+  const missing = isSystemdUnitMissing(detail);
   // Only fall back to system scope when user unit is missing.
   if (missing) {
     const systemRes = await execSystemctlSystem(showArgs);


### PR DESCRIPTION
## Summary

- Problem: Linux gateway lifecycle operations (restart, stop, status, enabled-check) only target user-scope systemd units (`systemctl --user`), failing silently when the service is installed at system level (`/etc/systemd/system/`).
- Why it matters: Users who install OpenClaw as a system-level service get broken restart/stop/status behavior with no actionable error message.
- What changed: `assertSystemdAvailable`, `runSystemdServiceAction` (restart/stop), and `readSystemdServiceRuntime` now fall back to system scope when the user-scope unit is missing (not found). `restartSystemdService` returns the detected scope.
- What did NOT change (scope boundary): `isSystemdServiceEnabled` ENOENT path still returns `false` (avoids routing uninstall into user-scope-only paths). All error classification functions (`isSystemctlMissing`, `isSystemdUnitNotEnabled`, `isSystemctlBusUnavailable`, `isSystemdUserScopeUnavailable`, etc.) are unchanged. Install/uninstall remain user-scope only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44575
- Related #44628

## User-visible / Behavior Changes

- `gateway restart` and `gateway stop` now succeed when the service is installed at system scope (previously failed with "systemctl restart/stop failed").
- `gateway status` now reports correct runtime state for system-scope services (previously showed "unknown" or "stopped").
- `restartSystemdService` return value now includes `scope: "user" | "system"` indicating which scope was used.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — only adds `systemctl` calls without `--user` flag, same binary already in use.
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (any distro with systemd)
- Runtime/container: Node 22+
- Model/provider: N/A (gateway infra)
- Integration/channel (if any): N/A
- Relevant config: system-level systemd unit at `/etc/systemd/system/openclaw-gateway.service`

### Steps

1. Install OpenClaw gateway as a system-level service (not user-level)
2. Run `openclaw gateway restart`
3. Observe error: "systemctl restart failed: Unit openclaw-gateway.service not found."

### Expected

- Gateway restarts successfully using the system-scope unit.

### Actual

- Fails because only `systemctl --user restart` is attempted.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All 45 tests pass, including 2 new system-scope fallback tests covering restart and runtime detection.

## Human Verification (required)

- Verified scenarios: All existing systemd tests pass unchanged (user-scope behavior preserved). New tests verify system-scope fallback for restart and runtime.
- Edge cases checked: Permission denied does NOT trigger system fallback (surfaces immediately). Bus unavailability does NOT trigger system fallback. Only "not found"/"not loaded"/"no such unit" triggers fallback.
- What you did **not** verify: Live system-scope deployment (no access to system-level systemd environment). Verified via unit tests with mocked `execFile`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — user-scope behavior unchanged; system scope is additive fallback only.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR; user-scope-only behavior is the default.
- Files/config to restore: `src/daemon/systemd.ts`, `src/daemon/service-types.ts`
- Known bad symptoms reviewers should watch for: Unexpected system-scope restarts when both user and system units exist (mitigated: system scope only tried when user scope returns "not found").

## Risks and Mitigations

- Risk: System-scope restart/stop operates on a different unit than intended when both scopes have a unit.
  - Mitigation: System scope is only tried when user scope explicitly reports "not found" / "not loaded" / "no such unit". If user scope fails for other reasons (permission, bus), the error surfaces immediately.
