### PR TITLE
docs: clarify Chrome extension attaches to the active tab

### DIFF
--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -96,6 +96,14 @@ Configure the extension to use the derived relay port in the extension Options p
   - Badge shows `ON` when attached.
 - Click again to detach.
 
+**Common gotcha:** the extension attaches to the **currently active tab**.
+If you click it while focused on your OpenClaw Control UI (or any other page), you will attach that tab instead of the one you intended.
+
+To verify what’s attached:
+
+- CLI: `openclaw browser --browser-profile chrome tabs`
+- Tool: `browser` with `profile="chrome"` → `tabs`
+
 ## Which tab does it control?
 
 - It does **not** automatically control “whatever tab you’re looking at”.


### PR DESCRIPTION
Adds a short troubleshooting note to docs/tools/chrome-extension.md: the Browser Relay attaches to the currently active tab, so it’s easy to accidentally attach the wrong tab (e.g., the OpenClaw Control UI). Includes a quick verification command.