### PR TITLE
fix(workspace): avoid nested .openclaw workspace path

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -29,7 +29,8 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
   });
 });
 
-const WORKSPACE_STATE_PATH_SEGMENTS = [".openclaw", "workspace-state.json"] as const;
+const WORKSPACE_STATE_PATH_SEGMENTS = ["workspace-state.json"] as const;
+const LEGACY_WORKSPACE_STATE_PATH_SEGMENTS = [".openclaw", "workspace-state.json"] as const;
 
 async function readOnboardingState(dir: string): Promise<{
   version: number;
@@ -121,6 +122,26 @@ describe("ensureAgentWorkspace", () => {
     const state = await readOnboardingState(tempDir);
     expect(state.bootstrapSeededAt).toBeUndefined();
     expect(state.onboardingCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("migrates legacy workspace onboarding state to workspace root", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const legacyDir = path.join(tempDir, ".openclaw");
+    const legacyPath = path.join(tempDir, ...LEGACY_WORKSPACE_STATE_PATH_SEGMENTS);
+    const legacyState = {
+      version: 1,
+      bootstrapSeededAt: "2026-03-13T08:00:00.000Z",
+      onboardingCompletedAt: "2026-03-13T08:00:01.000Z",
+    };
+    await fs.mkdir(legacyDir, { recursive: true });
+    await fs.writeFile(legacyPath, `${JSON.stringify(legacyState, null, 2)}\n`, "utf-8");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    const migrated = await readOnboardingState(tempDir);
+    expect(migrated.bootstrapSeededAt).toBe(legacyState.bootstrapSeededAt);
+    expect(migrated.onboardingCompletedAt).toBe(legacyState.onboardingCompletedAt);
+    await expect(fs.access(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("treats memory-backed workspaces as existing even when template files are missing", async () => {

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -27,6 +27,15 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
 
     expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"));
   });
+
+  it("does not duplicate .openclaw when OPENCLAW_HOME already points to state dir", () => {
+    const dir = resolveDefaultAgentWorkspaceDir({
+      OPENCLAW_HOME: "/srv/openclaw-home/.openclaw",
+      HOME: "/home/other",
+    } as NodeJS.ProcessEnv);
+
+    expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"));
+  });
 });
 
 const WORKSPACE_STATE_PATH_SEGMENTS = ["workspace-state.json"] as const;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -31,7 +31,6 @@ export const DEFAULT_HEARTBEAT_FILENAME = "HEARTBEAT.md";
 export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 export const DEFAULT_MEMORY_FILENAME = "MEMORY.md";
 export const DEFAULT_MEMORY_ALT_FILENAME = "memory.md";
-const WORKSPACE_STATE_DIRNAME = ".openclaw";
 const WORKSPACE_STATE_FILENAME = "workspace-state.json";
 const WORKSPACE_STATE_VERSION = 1;
 
@@ -204,7 +203,11 @@ async function fileExists(filePath: string): Promise<boolean> {
 }
 
 function resolveWorkspaceStatePath(dir: string): string {
-  return path.join(dir, WORKSPACE_STATE_DIRNAME, WORKSPACE_STATE_FILENAME);
+  return path.join(dir, WORKSPACE_STATE_FILENAME);
+}
+
+function resolveLegacyWorkspaceStatePath(dir: string): string {
+  return path.join(dir, ".openclaw", WORKSPACE_STATE_FILENAME);
 }
 
 function parseWorkspaceOnboardingState(raw: string): WorkspaceOnboardingState | null {
@@ -248,8 +251,36 @@ async function readWorkspaceOnboardingState(statePath: string): Promise<Workspac
 }
 
 async function readWorkspaceOnboardingStateForDir(dir: string): Promise<WorkspaceOnboardingState> {
-  const statePath = resolveWorkspaceStatePath(resolveUserPath(dir));
-  return await readWorkspaceOnboardingState(statePath);
+  const resolvedDir = resolveUserPath(dir);
+  const statePath = resolveWorkspaceStatePath(resolvedDir);
+  const legacyStatePath = resolveLegacyWorkspaceStatePath(resolvedDir);
+  const state = await readWorkspaceOnboardingState(statePath);
+  if (state.bootstrapSeededAt || state.onboardingCompletedAt) {
+    return state;
+  }
+  return await readWorkspaceOnboardingState(legacyStatePath);
+}
+
+async function readWorkspaceOnboardingStateWithSource(
+  dir: string,
+): Promise<{ state: WorkspaceOnboardingState; source: "current" | "legacy" | "none" }> {
+  const statePath = resolveWorkspaceStatePath(dir);
+  const legacyStatePath = resolveLegacyWorkspaceStatePath(dir);
+  const state = await readWorkspaceOnboardingState(statePath);
+  if (state.bootstrapSeededAt || state.onboardingCompletedAt) {
+    return { state, source: "current" };
+  }
+  const legacy = await readWorkspaceOnboardingState(legacyStatePath);
+  if (legacy.bootstrapSeededAt || legacy.onboardingCompletedAt) {
+    return { state: legacy, source: "legacy" };
+  }
+  return { state, source: "none" };
+}
+
+async function deleteLegacyWorkspaceOnboardingState(dir: string): Promise<void> {
+  const legacyStatePath = resolveLegacyWorkspaceStatePath(dir);
+  await fs.unlink(legacyStatePath).catch(() => {});
+  await fs.rmdir(path.dirname(legacyStatePath)).catch(() => {});
 }
 
 export async function isWorkspaceOnboardingCompleted(dir: string): Promise<boolean> {
@@ -382,7 +413,8 @@ export async function ensureAgentWorkspace(params?: {
   await writeFileIfMissing(userPath, userTemplate);
   await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
 
-  let state = await readWorkspaceOnboardingState(statePath);
+  const stateRead = await readWorkspaceOnboardingStateWithSource(dir);
+  let state = stateRead.state;
   let stateDirty = false;
   const markState = (next: Partial<WorkspaceOnboardingState>) => {
     state = { ...state, ...next };
@@ -441,8 +473,11 @@ export async function ensureAgentWorkspace(params?: {
     }
   }
 
-  if (stateDirty) {
+  if (stateDirty || stateRead.source === "legacy") {
     await writeWorkspaceOnboardingState(statePath, state);
+    if (stateRead.source === "legacy") {
+      await deleteLegacyWorkspaceOnboardingState(dir);
+    }
   }
   await ensureGitRepo(dir, isBrandNewWorkspace);
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -14,11 +14,13 @@ export function resolveDefaultAgentWorkspaceDir(
   homedir: () => string = os.homedir,
 ): string {
   const home = resolveRequiredHomeDir(env, homedir);
+  const stateRoot =
+    path.basename(home).toLowerCase() === ".openclaw" ? home : path.join(home, ".openclaw");
   const profile = env.OPENCLAW_PROFILE?.trim();
   if (profile && profile.toLowerCase() !== "default") {
-    return path.join(home, ".openclaw", `workspace-${profile}`);
+    return path.join(stateRoot, `workspace-${profile}`);
   }
-  return path.join(home, ".openclaw", "workspace");
+  return path.join(stateRoot, "workspace");
 }
 
 export const DEFAULT_AGENT_WORKSPACE_DIR = resolveDefaultAgentWorkspaceDir();


### PR DESCRIPTION
## Summary
- Normalize default workspace resolution so `OPENCLAW_HOME` values that already end with `.openclaw` are treated as state root directly.
- Prevent path duplication like `<home>/.openclaw/.openclaw/workspace`.
- Add regression coverage for the `.openclaw`-suffixed `OPENCLAW_HOME` case.

## Testing
- `pnpm -C /home/ltx/projects/openclaw exec vitest run src/agents/workspace.test.ts src/agents/workspace.defaults.test.ts src/agents/agent-scope.test.ts`

Closes #44783