### PR TITLE
feat(agent): add configurable streamIdleTimeoutMs for LLM SSE connections

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1375,7 +1375,9 @@ export async function runEmbeddedAttempt(
   // Proxy bootstrap must happen before timeout tuning so the timeouts wrap the
   // active EnvHttpProxyAgent instead of being replaced by a bare proxy dispatcher.
   ensureGlobalUndiciEnvProxyDispatcher();
-  ensureGlobalUndiciStreamTimeouts();
+  ensureGlobalUndiciStreamTimeouts({
+    timeoutMs: params.config?.agents?.defaults?.streamIdleTimeoutMs,
+  });
 
   log.debug(
     `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -207,6 +207,14 @@ export type AgentDefaultsConfig = {
   /** Human-like delay between block replies. */
   humanDelay?: HumanDelayConfig;
   timeoutSeconds?: number;
+  /**
+   * Timeout in milliseconds between streamed SSE body chunks from the LLM provider.
+   * The timer resets on every received chunk; if no data arrives within this window
+   * the HTTP connection is aborted. Only affects the body-chunk idle timeout
+   * (undici bodyTimeout); the initial response-headers timeout is not changed.
+   * Default: 1 800 000 (30 minutes).
+   */
+  streamIdleTimeoutMs?: number;
   /** Max inbound media size in MB for agent-visible attachments (text note or future image attach). */
   mediaMaxMb?: number;
   /**

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -155,6 +155,17 @@ export const AgentDefaultsSchema = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     humanDelay: HumanDelaySchema.optional(),
     timeoutSeconds: z.number().int().positive().optional(),
+    streamIdleTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        "Timeout in milliseconds between streamed SSE body chunks from the LLM provider. " +
+          "The timer resets on every received chunk; if no data arrives within this window " +
+          "the HTTP connection is aborted. Only affects the body-chunk idle timeout; " +
+          "the initial response-headers timeout is not changed. Default: 1800000 (30 minutes).",
+      ),
     mediaMaxMb: z.number().positive().optional(),
     imageMaxDimensionPx: z.number().int().positive().optional(),
     typingIntervalSeconds: z.number().int().positive().optional(),

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -128,6 +128,27 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
 
+  it("applies custom bodyTimeout via timeoutMs while keeping headersTimeout at default", () => {
+    getDefaultAutoSelectFamily.mockReturnValue(true);
+
+    ensureGlobalUndiciStreamTimeouts({ timeoutMs: 120_000 });
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(Agent);
+    expect(next.options?.bodyTimeout).toBe(120_000);
+    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+  });
+
+  it("is idempotent when called twice with the same custom timeoutMs", () => {
+    getDefaultAutoSelectFamily.mockReturnValue(true);
+
+    ensureGlobalUndiciStreamTimeouts({ timeoutMs: 120_000 });
+    ensureGlobalUndiciStreamTimeouts({ timeoutMs: 120_000 });
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
   it("re-applies when autoSelectFamily decision changes", () => {
     getDefaultAutoSelectFamily.mockReturnValue(true);
     ensureGlobalUndiciStreamTimeouts();

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -100,19 +100,33 @@ export function ensureGlobalUndiciEnvProxyDispatcher(): void {
   }
 }
 
-export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }): void {
-  const timeoutMsRaw = opts?.timeoutMs ?? DEFAULT_UNDICI_STREAM_TIMEOUT_MS;
-  const timeoutMs = Math.max(1, Math.floor(timeoutMsRaw));
-  if (!Number.isFinite(timeoutMsRaw)) {
+export function ensureGlobalUndiciStreamTimeouts(opts?: {
+  timeoutMs?: number;
+  headersTimeoutMs?: number;
+}): void {
+  const bodyTimeoutMsRaw = opts?.timeoutMs ?? DEFAULT_UNDICI_STREAM_TIMEOUT_MS;
+  const bodyTimeoutMs = Math.max(1, Math.floor(bodyTimeoutMsRaw));
+  if (!Number.isFinite(bodyTimeoutMsRaw)) {
     return;
   }
+  // headersTimeout defaults to the overall default independently so that a
+  // short bodyTimeout (e.g. 5 s to detect stalled SSE streams) does not also
+  // shorten the time allowed to receive initial response headers.
+  const headersTimeoutMsRaw = opts?.headersTimeoutMs ?? DEFAULT_UNDICI_STREAM_TIMEOUT_MS;
+  const headersTimeoutMs = Math.max(1, Math.floor(headersTimeoutMsRaw));
+  if (!Number.isFinite(headersTimeoutMsRaw)) {
+    return;
+  }
+
   const kind = resolveCurrentDispatcherKind();
   if (kind === null) {
     return;
   }
 
   const autoSelectFamily = resolveAutoSelectFamily();
-  const nextKey = resolveDispatcherKey({ kind, timeoutMs, autoSelectFamily });
+  const nextKey =
+    resolveDispatcherKey({ kind, timeoutMs: bodyTimeoutMs, autoSelectFamily }) +
+    `:h${headersTimeoutMs}`;
   if (lastAppliedTimeoutKey === nextKey) {
     return;
   }
@@ -121,16 +135,16 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
   try {
     if (kind === "env-proxy") {
       const proxyOptions = {
-        bodyTimeout: timeoutMs,
-        headersTimeout: timeoutMs,
+        bodyTimeout: bodyTimeoutMs,
+        headersTimeout: headersTimeoutMs,
         ...(connect ? { connect } : {}),
       } as ConstructorParameters<typeof EnvHttpProxyAgent>[0];
       setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
     } else {
       setGlobalDispatcher(
         new Agent({
-          bodyTimeout: timeoutMs,
-          headersTimeout: timeoutMs,
+          bodyTimeout: bodyTimeoutMs,
+          headersTimeout: headersTimeoutMs,
           ...(connect ? { connect } : {}),
         }),
       );


### PR DESCRIPTION
## Summary

- Add `agents.defaults.streamIdleTimeoutMs` config option to allow users to override the undici global dispatcher `bodyTimeout`/`headersTimeout` for LLM SSE streaming connections.
- The undici `bodyTimeout` resets on every received data chunk, so this effectively acts as a "no data for N ms" circuit breaker for stalled SSE streams.
- When not configured, the existing 30-minute default is preserved (no behavior change).

### Problem

When an LLM provider returns HTTP 200 headers and then stalls the SSE stream (no further chunks), the OpenAI SDK clears its own request timeout upon receiving headers. The only remaining protection is the undici `bodyTimeout` (30 minutes) and the agent-level `setTimeout` (10 minutes via `agents.defaults.timeoutSeconds`). Users with unreliable LLM proxies can experience 10+ minute hangs that block the main command queue lane.

### Solution

Expose the undici stream idle timeout as a user-configurable option so users can set a shorter value (e.g. 120000ms / 2 minutes) without code changes:

```json
{
  "agents": {
    "defaults": {
      "streamIdleTimeoutMs": 120000
    }
  }
}
```

## Test plan

- [x] `pnpm test src/infra/net/undici-global-dispatcher.test.ts` passes
- [x] `pnpm build` succeeds
- [ ] Manual: set `streamIdleTimeoutMs: 120000` in config, verify stalled LLM connections abort after ~2 minutes instead of 10+