### PR TITLE
fix: make webui attachment maxBytes configurable (fixes #44757)

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -376,6 +376,14 @@ export type GatewayNodesConfig = {
   denyCommands?: string[];
 };
 
+export type GatewayWebuiConfig = {
+  /**
+   * Max bytes per attachment uploaded via webui agent.request.
+   * Default: 5_000_000 (5MB).
+   */
+  attachmentMaxBytes?: number;
+};
+
 export type GatewayToolsConfig = {
   /** Tools to deny via gateway HTTP /tools/invoke (extends defaults). */
   deny?: string[];
@@ -425,6 +433,8 @@ export type GatewayConfig = {
   allowRealIpFallback?: boolean;
   /** Tool access restrictions for HTTP /tools/invoke endpoint. */
   tools?: GatewayToolsConfig;
+  /** WebUI (Control UI) settings. */
+  webui?: GatewayWebuiConfig;
   /**
    * Channel health monitor interval in minutes.
    * Periodically checks channel health and restarts unhealthy channels.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -822,6 +822,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        webui: z
+          .object({
+            attachmentMaxBytes: z.number().int().positive().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -9,6 +9,7 @@ import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.j
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
+import { loadConfig } from "../../config/config.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
@@ -1133,11 +1134,13 @@ export const chatHandlers: GatewayRequestHandlers = {
       return;
     }
     let parsedMessage = inboundMessage;
+    const cfg = loadConfig();
+    const maxBytes = cfg.gateway?.webui?.attachmentMaxBytes ?? 5_000_000;
     let parsedImages: ChatImageContent[] = [];
     if (normalizedAttachments.length > 0) {
       try {
         const parsed = await parseMessageWithAttachments(inboundMessage, normalizedAttachments, {
-          maxBytes: 5_000_000,
+          maxBytes,
           log: context.logGateway,
         });
         parsedMessage = parsed.message;
@@ -1148,7 +1151,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       }
     }
     const rawSessionKey = p.sessionKey;
-    const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
+    const { entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
     const timeoutMs = resolveAgentTimeoutMs({
       cfg,
       overrideMs: p.timeoutMs,

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -359,11 +359,11 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(
         link?.attachments ?? undefined,
       );
+      const cfg = loadConfig();
+      const maxBytes = cfg.gateway?.webui?.attachmentMaxBytes ?? 5_000_000;
       let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
       if (normalizedAttachments.length > 0) {
         try {
-          const cfg = loadConfig();
-          const maxBytes = cfg.gateway?.webui?.attachmentMaxBytes ?? 5_000_000;
           const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
             maxBytes,
             log: ctx.logGateway,
@@ -392,7 +392,6 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
 
       const sessionKeyRaw = (link?.sessionKey ?? "").trim();
       const sessionKey = sessionKeyRaw.length > 0 ? sessionKeyRaw : `node-${nodeId}`;
-      const cfg = loadConfig();
       const { storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
       const now = Date.now();
       const sessionId = entry?.sessionId ?? randomUUID();

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -362,8 +362,10 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
       if (normalizedAttachments.length > 0) {
         try {
+          const cfg = loadConfig();
+          const maxBytes = cfg.gateway?.webui?.attachmentMaxBytes ?? 5_000_000;
           const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
-            maxBytes: 5_000_000,
+            maxBytes,
             log: ctx.logGateway,
           });
           message = parsed.message.trim();


### PR DESCRIPTION
## Summary

Fixes #44757

The webui \`agent.request\` handler previously hardcoded \`maxBytes: 5_000_000\` (5MB) when calling \`parseMessageWithAttachments\`. This prevented uploading images larger than 5MB through the webui, even though other channels have configurable limits.

## Changes

- Add \`GatewayWebuiConfig\` type with \`attachmentMaxBytes\` option to \`types.gateway.ts\`
- Add \`webui\` field to \`GatewayConfig\` type
- Update Zod schema for config validation
- Modify \`server-node-events.ts\` to read the config value with fallback to 5MB default

## Usage

Users can now configure in \`openclaw.json\`:

\`\`\`json
{
  "gateway": {
    "webui": {
      "attachmentMaxBytes": 20000000
    }
  }
}
\`\`\`

## Testing

- All existing tests pass
- Config schema validation passes
- TypeScript compilation passes