### PR TITLE
Feishu: return [Image] placeholder for image messages to fix MediaPath mismatch (#44792)

### DIFF
--- a/extensions/feishu/src/bot.stripBotMention.test.ts
+++ b/extensions/feishu/src/bot.stripBotMention.test.ts
@@ -132,3 +132,22 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
     expect(ctx.content).toBe('<at user_id="ou_x">&lt;script&gt;</at> test');
   });
 });
+
+describe("parseFeishuMessageEvent – image message content (#44792)", () => {
+  it("returns [Image] placeholder for image messages so agent uses MediaPath", () => {
+    const event = {
+      sender: { sender_id: { open_id: "ou_user" } },
+      message: {
+        message_id: "msg_img",
+        chat_id: "oc_dm",
+        chat_type: "p2p",
+        message_type: "image",
+        content: JSON.stringify({
+          image_key: "img_v3_02vo_53bcb69b-2d18-4be7-b6ba-8e8a09fe2e5g",
+        }),
+      },
+    };
+    const ctx = parseFeishuMessageEvent(event as any);
+    expect(ctx.content).toBe("[Image]");
+  });
+});

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -312,6 +312,11 @@ function parseMessageContent(content: string, messageType: string): string {
     const { textContent } = parsePostContent(content);
     return textContent;
   }
+  if (messageType === "image") {
+    // Return placeholder so the agent uses MediaPath (actual saved path) instead of
+    // constructing a path from image_key, which would be wrong (#44792).
+    return "[Image]";
+  }
 
   try {
     const parsed = JSON.parse(content);


### PR DESCRIPTION
## Summary

飞书 channel 下载图片后保存的文件名与传递给 Agent 的文件路径不一致，导致 Agent 无法读取图片。

## Root cause

对于 `image` 类型消息，`parseMessageContent` 未单独处理，直接返回原始 JSON（如 `{"image_key":"img_v3_02vo_..."}`）。Agent 可能据此用 `image_key` 后缀构造路径，而实际文件由 `saveMediaBuffer` 用随机 UUID 保存，导致路径不一致。

## Fix

在 `parseMessageContent` 中为 `image` 类型增加分支，返回占位符 `"[Image]"` 而非原始 JSON，让 Agent 使用上下文中的 `MediaPath`（即实际保存路径）。

## Files changed

- `extensions/feishu/src/bot.ts` — 增加 image case
- `extensions/feishu/src/bot.stripBotMention.test.ts` — 新增测试

## Reference

- Closes #44792
- Issue: https://github.com/openclaw/openclaw/issues/44792
