### PR TITLE
fix: always release embedded session lock when cleanup throws

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts
@@ -28,6 +28,8 @@ const hoisted = vi.hoisted(() => {
   const resolveSandboxContextMock = vi.fn();
   const subscribeEmbeddedPiSessionMock = vi.fn();
   const acquireSessionWriteLockMock = vi.fn();
+  const flushPendingToolResultsAfterIdleMock = vi.fn(async () => {});
+  const releaseWsSessionMock = vi.fn();
   const sessionManager = {
     getLeafEntry: vi.fn(() => null),
     branch: vi.fn(),
@@ -42,6 +44,8 @@ const hoisted = vi.hoisted(() => {
     resolveSandboxContextMock,
     subscribeEmbeddedPiSessionMock,
     acquireSessionWriteLockMock,
+    flushPendingToolResultsAfterIdleMock,
+    releaseWsSessionMock,
     sessionManager,
   };
 });
@@ -155,7 +159,8 @@ vi.mock("../tool-result-context-guard.js", () => ({
 }));
 
 vi.mock("../wait-for-idle-before-flush.js", () => ({
-  flushPendingToolResultsAfterIdle: async () => {},
+  flushPendingToolResultsAfterIdle: (...args: unknown[]) =>
+    hoisted.flushPendingToolResultsAfterIdleMock(...args),
 }));
 
 vi.mock("../runs.js", () => ({
@@ -192,7 +197,7 @@ vi.mock("../extra-params.js", () => ({
 
 vi.mock("../../openai-ws-stream.js", () => ({
   createOpenAIWebSocketStreamFn: vi.fn(),
-  releaseWsSession: () => {},
+  releaseWsSession: (...args: unknown[]) => hoisted.releaseWsSessionMock(...args),
 }));
 
 vi.mock("../../anthropic-payload-log.js", () => ({
@@ -281,6 +286,8 @@ describe("runEmbeddedAttempt sessions_spawn workspace inheritance", () => {
     hoisted.acquireSessionWriteLockMock.mockReset().mockResolvedValue({
       release: async () => {},
     });
+    hoisted.flushPendingToolResultsAfterIdleMock.mockReset().mockResolvedValue(undefined);
+    hoisted.releaseWsSessionMock.mockReset();
     hoisted.sessionManager.getLeafEntry.mockReset().mockReturnValue(null);
     hoisted.sessionManager.branch.mockReset();
     hoisted.sessionManager.resetLeaf.mockReset();
@@ -504,6 +511,69 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
         timestamp: expect.any(Number),
       }),
     );
+  });
+
+  it("releases session lock even when flushPendingToolResultsAfterIdle throws", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cleanup-workspace-"));
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cleanup-agent-"));
+    const sessionFile = path.join(workspaceDir, "session.jsonl");
+    tempPaths.push(workspaceDir, agentDir);
+    await fs.writeFile(sessionFile, "", "utf8");
+
+    const releaseLock = vi.fn(async () => {});
+    hoisted.acquireSessionWriteLockMock.mockResolvedValue({
+      release: releaseLock,
+    });
+    hoisted.flushPendingToolResultsAfterIdleMock.mockRejectedValue(
+      new Error("flush cleanup failure"),
+    );
+    hoisted.createAgentSessionMock.mockImplementation(async () => {
+      const session: MutableSession = {
+        sessionId: "embedded-session",
+        messages: [],
+        isCompacting: false,
+        isStreaming: false,
+        agent: {
+          replaceMessages: (messages: unknown[]) => {
+            session.messages = [...messages];
+          },
+        },
+        prompt: async () => {
+          session.messages = [
+            ...session.messages,
+            { role: "assistant", content: "done", timestamp: 2 },
+          ];
+        },
+        abort: async () => {},
+        dispose: () => {},
+        steer: async () => {},
+      };
+
+      return { session };
+    });
+
+    const result = await runEmbeddedAttempt({
+      sessionId: "embedded-session",
+      sessionKey: "agent:main:test-cleanup-lock-release",
+      sessionFile,
+      workspaceDir,
+      agentDir,
+      config: {},
+      prompt: "hello",
+      timeoutMs: 10_000,
+      runId: "run-cleanup-lock-release",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-20250514",
+      model: cacheTtlEligibleModel,
+      authStorage: {} as AuthStorage,
+      modelRegistry: {} as ModelRegistry,
+      thinkLevel: "off",
+      senderIsOwner: true,
+      disableMessageTool: true,
+    });
+
+    expect(result.promptError).toBeNull();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2796,14 +2796,40 @@ export async function runEmbeddedAttempt(
       // synthetic "missing tool result" errors and causing silent agent failures.
       // See: https://github.com/openclaw/openclaw/issues/8643
       removeToolResultContextGuard?.();
-      await flushPendingToolResultsAfterIdle({
-        agent: session?.agent,
-        sessionManager,
-        clearPendingOnTimeout: true,
+      try {
+        await flushPendingToolResultsAfterIdle({
+          agent: session?.agent,
+          sessionManager,
+          clearPendingOnTimeout: true,
+        });
+      } catch (err) {
+        log.warn("flushPendingToolResultsAfterIdle failed during attempt cleanup", {
+          errorMessage: err instanceof Error ? err.message : String(err),
+          errorStack: err instanceof Error ? err.stack : undefined,
+        });
+      }
+      try {
+        session?.dispose();
+      } catch (err) {
+        log.warn("session.dispose failed during attempt cleanup", {
+          errorMessage: err instanceof Error ? err.message : String(err),
+          errorStack: err instanceof Error ? err.stack : undefined,
+        });
+      }
+      try {
+        releaseWsSession(params.sessionId);
+      } catch (err) {
+        log.warn("releaseWsSession failed during attempt cleanup", {
+          errorMessage: err instanceof Error ? err.message : String(err),
+          errorStack: err instanceof Error ? err.stack : undefined,
+        });
+      }
+      await sessionLock.release().catch((err) => {
+        log.warn("session lock release failed during attempt cleanup", {
+          errorMessage: err instanceof Error ? err.message : String(err),
+          errorStack: err instanceof Error ? err.stack : undefined,
+        });
       });
-      session?.dispose();
-      releaseWsSession(params.sessionId);
-      await sessionLock.release();
     }
   } finally {
     restoreSkillEnv?.();


### PR DESCRIPTION
## Summary
- isolate attempt cleanup steps (`flushPendingToolResultsAfterIdle`, `session.dispose`, and `releaseWsSession`) so failures do not short-circuit lock release
- make session lock release best-effort in cleanup with warning logs on failure
- add a regression test proving `sessionLock.release()` is still called when flush throws

## Testing
- `pnpm vitest run src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test.ts`

Closes #44795
