### PR TITLE
fix(agents): preserve thinking/redacted_thinking blocks in session history

### DIFF
--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -4,7 +4,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { WorkspaceBootstrapFile } from "../workspace.js";
-import { isImmutableThinkingBlock } from "./thinking-guard.js";
+
 import type { EmbeddedContextFile } from "./types.js";
 
 type ContentBlockWithSignature = {
@@ -64,9 +64,6 @@ export function stripThoughtSignatures<T>(
   };
   return content.map((block) => {
     if (!block || typeof block !== "object") {
-      return block;
-    }
-    if (isImmutableThinkingBlock(block)) {
       return block;
     }
     const rec = block as ContentBlockWithSignature;

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -4,7 +4,6 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { WorkspaceBootstrapFile } from "../workspace.js";
-
 import type { EmbeddedContextFile } from "./types.js";
 
 type ContentBlockWithSignature = {

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -4,6 +4,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { WorkspaceBootstrapFile } from "../workspace.js";
+import { isImmutableThinkingBlock } from "./thinking-guard.js";
 import type { EmbeddedContextFile } from "./types.js";
 
 type ContentBlockWithSignature = {
@@ -63,6 +64,9 @@ export function stripThoughtSignatures<T>(
   };
   return content.map((block) => {
     if (!block || typeof block !== "object") {
+      return block;
+    }
+    if (isImmutableThinkingBlock(block)) {
       return block;
     }
     const rec = block as ContentBlockWithSignature;

--- a/src/agents/pi-embedded-helpers/thinking-guard.test.ts
+++ b/src/agents/pi-embedded-helpers/thinking-guard.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isImmutableThinkingBlock } from "./thinking-guard.js";
+
+describe("isImmutableThinkingBlock", () => {
+  it("returns true for thinking blocks", () => {
+    expect(isImmutableThinkingBlock({ type: "thinking", thinking: "some thought" })).toBe(true);
+  });
+
+  it("returns true for redacted_thinking blocks", () => {
+    expect(isImmutableThinkingBlock({ type: "redacted_thinking", data: "encrypted-payload" })).toBe(
+      true,
+    );
+  });
+
+  it("returns false for text blocks", () => {
+    expect(isImmutableThinkingBlock({ type: "text", text: "hello" })).toBe(false);
+  });
+
+  it("returns false for image blocks", () => {
+    expect(isImmutableThinkingBlock({ type: "image", data: "base64" })).toBe(false);
+  });
+
+  it("returns false for null/undefined/primitives", () => {
+    expect(isImmutableThinkingBlock(null)).toBe(false);
+    expect(isImmutableThinkingBlock(undefined)).toBe(false);
+    expect(isImmutableThinkingBlock("string")).toBe(false);
+    expect(isImmutableThinkingBlock(42)).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-helpers/thinking-guard.ts
+++ b/src/agents/pi-embedded-helpers/thinking-guard.ts
@@ -1,0 +1,20 @@
+/**
+ * Guard for immutable thinking/redacted_thinking content blocks.
+ *
+ * The Anthropic API requires that thinking and redacted_thinking blocks
+ * in assistant messages are returned byte-for-byte identical. Spreading,
+ * deleting fields, or any other mutation causes the API to reject the
+ * request with:
+ *   "thinking or redacted_thinking blocks in the latest assistant message
+ *    cannot be modified"
+ *
+ * Every function that maps/transforms content blocks must call this guard
+ * and short-circuit (return the block as-is) when it returns true.
+ */
+export function isImmutableThinkingBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return type === "thinking" || type === "redacted_thinking";
+}

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { isImmutableThinkingBlock } from "../../pi-embedded-helpers/thinking-guard.js";
 
 export const PRUNED_HISTORY_IMAGE_MARKER = "[image data removed - already processed by model]";
 
@@ -31,6 +32,9 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
     for (let j = 0; j < message.content.length; j++) {
       const block = message.content[j];
       if (!block || typeof block !== "object") {
+        continue;
+      }
+      if (isImmutableThinkingBlock(block)) {
         continue;
       }
       if ((block as { type?: string }).type !== "image") {

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -58,4 +58,21 @@ describe("dropThinkingBlocks", () => {
     const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
     expect(assistant.content).toEqual([{ type: "text", text: "" }]);
   });
+
+  it("drops redacted_thinking blocks alongside thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "visible thought" },
+          { type: "redacted_thinking", data: "encrypted-payload" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = dropThinkingBlocks(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "answer" }]);
+  });
 });

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -13,7 +13,7 @@ export function isAssistantMessageWithContent(message: AgentMessage): message is
 }
 
 /**
- * Strip all `type: "thinking"` content blocks from assistant messages.
+ * Strip all `type: "thinking"` and `type: "redacted_thinking"` content blocks from assistant messages.
  *
  * If an assistant message becomes empty after stripping, it is replaced with
  * a synthetic `{ type: "text", text: "" }` block to preserve turn structure

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -33,7 +33,9 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
     const nextContent: AssistantContentBlock[] = [];
     let changed = false;
     for (const block of msg.content) {
-      if (block && typeof block === "object" && (block as { type?: unknown }).type === "thinking") {
+      const blockType =
+        block && typeof block === "object" ? (block as { type?: unknown }).type : undefined;
+      if (blockType === "thinking" || blockType === "redacted_thinking") {
         touched = true;
         changed = true;
         continue;

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -3,6 +3,7 @@ import { normalizeTargetForProvider } from "../infra/outbound/target-normalizati
 import { splitMediaFromOutput } from "../media/parse.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { collectTextContentBlocks } from "./content-blocks.js";
+import { isImmutableThinkingBlock } from "./pi-embedded-helpers/thinking-guard.js";
 import { type MessagingToolSend } from "./pi-embedded-messaging.js";
 import { normalizeToolName } from "./tool-policy.js";
 
@@ -94,6 +95,9 @@ export function sanitizeToolResult(result: unknown): unknown {
   }
   const sanitized = content.map((item) => {
     if (!item || typeof item !== "object") {
+      return item;
+    }
+    if (isImmutableThinkingBlock(item)) {
       return item;
     }
     const entry = item as Record<string, unknown>;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -44,8 +44,8 @@ import { checkBrowserOrigin } from "../../origin-check.js";
 import { GATEWAY_CLIENT_IDS } from "../../protocol/client-info.js";
 import {
   ConnectErrorDetailCodes,
-  resolveDeviceAuthConnectErrorDetailCode,
   resolveAuthConnectErrorDetailCode,
+  resolveDeviceAuthConnectErrorDetailCode,
 } from "../../protocol/connect-error-details.js";
 import {
   type ConnectParams,


### PR DESCRIPTION
## Summary

- The Anthropic API requires `thinking` and `redacted_thinking` blocks in assistant messages to be returned byte-for-byte identical when replayed in conversation history
- Multiple sanitization functions in the session history pipeline were mutating these blocks via object spread and field deletion, causing API rejections on multi-turn conversations with extended thinking enabled
- Adds a shared `isImmutableThinkingBlock()` guard and applies it across **all four mutation sites**, not just `stripThoughtSignatures`

## Root Cause

Four functions in the sanitization pipeline modify content blocks before sending them back to the Anthropic API:

| Function | File | Mutation |
|----------|------|----------|
| `stripThoughtSignatures` | `pi-embedded-helpers/bootstrap.ts` | Spread-copies blocks and deletes `thought_signature` fields |
| `sanitizeToolResult` | `pi-embedded-subscribe.tools.ts` | Spread-copies blocks and deletes `.data` field (breaks `redacted_thinking` encrypted payload) |
| `pruneProcessedHistoryImages` | `pi-embedded-runner/run/history-image-prune.ts` | Replaces content blocks in-place |
| `dropThinkingBlocks` | `pi-embedded-runner/thinking.ts` | Only checked `type === "thinking"`, missed `redacted_thinking` |

## Fix

- New shared guard: `isImmutableThinkingBlock(block)` returns `true` for `thinking` and `redacted_thinking` types
- Each mutation site now short-circuits and returns thinking blocks as-is
- `dropThinkingBlocks` now also handles `redacted_thinking` blocks

## Reproduction

1. Enable extended thinking on Anthropic provider
2. Have a multi-turn conversation (e.g. Discord thread or Telegram)
3. On subsequent turns, session history replay triggers `sanitizeSessionHistory` pipeline
4. API rejects with: `"thinking or redacted_thinking blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response."`

## Test plan

- [x] New tests for `isImmutableThinkingBlock` guard (5 cases)
- [x] New test for `dropThinkingBlocks` with `redacted_thinking` blocks
- [x] All existing thinking tests pass
- [x] Build passes
- [ ] Verify multi-turn extended thinking conversations no longer produce the error

Fixes #29618
Supersedes #29620

🤖 Generated with [Claude Code](https://claude.com/claude-code)