### PR TITLE
fix(feishu): suppress NO_REPLY silent token before API send

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { sendMediaFeishu } from "./media.js";
@@ -82,6 +83,11 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   sendText: async ({ cfg, to, text, accountId, replyToId, threadId, mediaLocalRoots }) => {
+    // Suppress NO_REPLY silent token — already delivered via another channel/plugin.
+    if (!text?.trim() || isSilentReplyText(text.trim(), SILENT_REPLY_TOKEN)) {
+      return { channel: "feishu", messageId: "suppressed", channelId: to };
+    }
+
     const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
     // Scheme A compatibility shim:
     // when upstream accidentally returns a local image path as plain text,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1,3 +1,4 @@
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk";
 import {
   createReplyPrefixContext,
   createTypingCallbacks,
@@ -251,6 +252,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const shouldDeliverText = hasText && !skipTextForDuplicateFinal;
 
         if (!shouldDeliverText && !hasMedia) {
+          return;
+        }
+
+        // Suppress NO_REPLY silent token — already delivered via another channel/plugin.
+        if (shouldDeliverText && !hasMedia && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
           return;
         }
 


### PR DESCRIPTION
## Summary

- Feishu channel was missing `SILENT_REPLY_TOKEN` filtering that other channels (e.g. MSTeams) already implement
- When an agent delivered a message via a plugin (e.g. the Feishu plugin itself) and replied with `NO_REPLY`, the token was sent as real text to the Feishu API, triggering a `⚠️ ✉️ Message failed` error
- Add `isSilentReplyText` checks in both the outbound adapter (`sendText`) and the reply dispatcher (`deliver`) to suppress the token before it reaches the Feishu API

## Changes

- `extensions/feishu/src/outbound.ts`: early-return with `suppressed` result when text is `NO_REPLY`
- `extensions/feishu/src/reply-dispatcher.ts`: skip delivery when text-only payload is `NO_REPLY`

## Test plan

- [ ] Send a message via Feishu plugin that triggers a `NO_REPLY` response — should no longer show `Message failed`
- [ ] Normal text messages still deliver correctly
- [ ] Messages with media + `NO_REPLY` text still deliver the media

🤖 Generated with [Claude Code](https://claude.com/claude-code)