### PR TITLE
fix(feishu): avoid post text truncation when line ends with colon

### DIFF
--- a/extensions/feishu/src/post.test.ts
+++ b/extensions/feishu/src/post.test.ts
@@ -102,4 +102,23 @@ describe("parsePostContent", () => {
       mentionedOpenIds: [],
     });
   });
+
+  it("escapes trailing colon in text runs", () => {
+    const content = JSON.stringify({
+      title: "",
+      content: [
+        [{ tag: "text", text: "This should keep trailing colon:" }],
+        [{ tag: "text", text: "URL: https://example.com:8080/path" }],
+      ],
+    });
+
+    const result = parsePostContent(content);
+
+    expect(result.textContent).toBe(
+      "This should keep trailing colon\\:\nURL: https://example.com:8080/path",
+    );
+    expect(result.imageKeys).toEqual([]);
+    expect(result.mediaKeys).toEqual([]);
+    expect(result.mentionedOpenIds).toEqual([]);
+  });
 });

--- a/extensions/feishu/src/post.ts
+++ b/extensions/feishu/src/post.ts
@@ -24,7 +24,9 @@ function toStringOrEmpty(value: unknown): string {
 }
 
 function escapeMarkdownText(text: string): string {
-  return text.replace(MARKDOWN_SPECIAL_CHARS, "\\$1");
+  const escaped = text.replace(MARKDOWN_SPECIAL_CHARS, "\\$1");
+  // Feishu post payloads can mis-handle trailing ":" in rendered text runs.
+  return escaped.replace(/:$/g, "\\:");
 }
 
 function toBoolean(value: unknown): boolean {


### PR DESCRIPTION
## Summary
- escape trailing `:` in Feishu post text runs to prevent end-of-line truncation in recipient rendering
- keep internal URL colons unchanged (no broad colon escaping)
- add regression coverage for trailing colon and URL colon behavior

## Testing
- `pnpm vitest run extensions/feishu/src/post.test.ts`

Closes #44776
