### PR TITLE
fix(secrets): prevent plugin logs from corrupting interactive configure UI

### DIFF
--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -8,6 +8,8 @@ const resolveSecretsAuditExitCode = vi.fn();
 const runSecretsConfigureInteractive = vi.fn();
 const runSecretsApply = vi.fn();
 const confirm = vi.fn();
+const setConsoleSubsystemFilter = vi.fn();
+const getConsoleSubsystemFilter = vi.fn();
 
 const { defaultRuntime, runtimeLogs, runtimeErrors, resetRuntimeCapture } =
   createCliRuntimeCapture();
@@ -40,6 +42,11 @@ vi.mock("@clack/prompts", () => ({
   confirm: (options: unknown) => confirm(options),
 }));
 
+vi.mock("../logging/console.js", () => ({
+  setConsoleSubsystemFilter: (filters?: string[] | null) => setConsoleSubsystemFilter(filters),
+  getConsoleSubsystemFilter: () => getConsoleSubsystemFilter(),
+}));
+
 const { registerSecretsCli } = await import("./secrets-cli.js");
 
 describe("secrets CLI", () => {
@@ -58,6 +65,9 @@ describe("secrets CLI", () => {
     runSecretsConfigureInteractive.mockReset();
     runSecretsApply.mockReset();
     confirm.mockReset();
+    setConsoleSubsystemFilter.mockReset();
+    getConsoleSubsystemFilter.mockReset();
+    getConsoleSubsystemFilter.mockReturnValue(null);
   });
 
   it("calls secrets.reload and prints human output", async () => {
@@ -140,6 +150,8 @@ describe("secrets CLI", () => {
 
     await createProgram().parseAsync(["secrets", "configure"], { from: "user" });
     expect(runSecretsConfigureInteractive).toHaveBeenCalled();
+    expect(setConsoleSubsystemFilter).toHaveBeenNthCalledWith(1, ["secrets", "cli"]);
+    expect(setConsoleSubsystemFilter).toHaveBeenNthCalledWith(2, null);
     expect(runSecretsApply).toHaveBeenCalledWith(
       expect.objectContaining({
         write: true,

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { confirm } from "@clack/prompts";
 import type { Command } from "commander";
 import { danger } from "../globals.js";
+import { getConsoleSubsystemFilter, setConsoleSubsystemFilter } from "../logging/console.js";
 import { defaultRuntime } from "../runtime.js";
 import { runSecretsApply } from "../secrets/apply.js";
 import { resolveSecretsAuditExitCode, runSecretsAudit } from "../secrets/audit.js";
@@ -132,11 +133,20 @@ export function registerSecretsCli(program: Command) {
     .option("--json", "Output JSON", false)
     .action(async (opts: SecretsConfigureOptions) => {
       try {
-        const configured = await runSecretsConfigureInteractive({
-          providersOnly: Boolean(opts.providersOnly),
-          skipProviderSetup: Boolean(opts.skipProviderSetup),
-          agentId: typeof opts.agent === "string" ? opts.agent : undefined,
-        });
+        const previousSubsystemFilter = getConsoleSubsystemFilter();
+        // Keep interactive prompts readable by suppressing noisy plugin subsystem logs.
+        setConsoleSubsystemFilter(["secrets", "cli"]);
+        const configured = await (async () => {
+          try {
+            return await runSecretsConfigureInteractive({
+              providersOnly: Boolean(opts.providersOnly),
+              skipProviderSetup: Boolean(opts.skipProviderSetup),
+              agentId: typeof opts.agent === "string" ? opts.agent : undefined,
+            });
+          } finally {
+            setConsoleSubsystemFilter(previousSubsystemFilter);
+          }
+        })();
         if (opts.planOut) {
           fs.writeFileSync(opts.planOut, `${JSON.stringify(configured.plan, null, 2)}\n`, "utf8");
         }

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -125,6 +125,11 @@ export function setConsoleSubsystemFilter(filters?: string[] | null): void {
   loggingState.consoleSubsystemFilter = normalized.length > 0 ? normalized : null;
 }
 
+export function getConsoleSubsystemFilter(): string[] | null {
+  const current = loggingState.consoleSubsystemFilter;
+  return current ? [...current] : null;
+}
+
 export function setConsoleTimestampPrefix(enabled: boolean): void {
   loggingState.consoleTimestampPrefix = enabled;
 }


### PR DESCRIPTION
## Summary
- Add `getConsoleSubsystemFilter()` so CLI commands can temporarily preserve/restore console subsystem filters.
- During `openclaw secrets configure`, temporarily narrow console subsystem output to `secrets`/`cli` while prompts are active.
- Restore the previous filter after interactive configure completes (even on error/cancel).
- Add CLI test coverage for filter setup/restore behavior.

## Testing
- `pnpm -C /home/ltx/projects/openclaw exec vitest run src/cli/secrets-cli.test.ts`

Closes #44727
