### PR TITLE
fix(windows): suppress visible console windows during restart and process cleanup

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -287,6 +287,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("/bin/sh", [scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -302,6 +303,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", scriptPath], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
       expect(mockChild.unref).toHaveBeenCalled();
     });
@@ -317,6 +319,7 @@ describe("restart-helper", () => {
       expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", `"${scriptPath}"`], {
         detached: true,
         stdio: "ignore",
+        windowsHide: true,
       });
     });
   });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -169,6 +169,7 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
+    windowsHide: true,
   });
   child.unref();
 }

--- a/src/process/kill-tree.ts
+++ b/src/process/kill-tree.ts
@@ -83,6 +83,7 @@ function runTaskkill(args: string[]): void {
     spawn("taskkill", args, {
       stdio: "ignore",
       detached: true,
+      windowsHide: true,
     });
   } catch {
     // Ignore taskkill spawn failures


### PR DESCRIPTION
## Summary

Fixes #44693

On Windows, detached spawn calls for the restart script and `taskkill` process cleanup were missing `windowsHide: true`, causing visible command prompt windows to flash on screen during gateway restart operations.

### Changes

- **`src/cli/update-cli/restart-helper.ts`**: Added `windowsHide: true` to the `spawn()` options in `runRestartScript()`. This matches the existing pattern in `src/infra/windows-task-restart.ts` which already had this option.
- **`src/process/kill-tree.ts`**: Added `windowsHide: true` to the `taskkill` `spawn()` call in `runTaskkill()` to prevent console windows from flashing when terminating process trees.
- **`src/cli/update-cli/restart-helper.test.ts`**: Updated test expectations to include the new `windowsHide: true` option.