### PR TITLE
feat(plugin-sdk): add session.readRecentMessages for channel plugins

### DIFF
--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -13,3 +13,4 @@ export * from "./sessions/session-file.js";
 export * from "./sessions/delivery-info.js";
 export * from "./sessions/disk-budget.js";
 export * from "./sessions/targets.js";
+export * from "./sessions/history.js";

--- a/src/config/sessions/history.test.ts
+++ b/src/config/sessions/history.test.ts
@@ -147,4 +147,111 @@ describe("readSessionRecentMessages", () => {
     });
     expect(result).toEqual([]);
   });
+
+  it("does not create directories when session file does not exist", async () => {
+    const sessionId = "ghost-session-no-file";
+    await saveSessionStore(storePath, {
+      "ghost-key": { sessionId, updatedAt: Date.now() },
+    });
+
+    // sessions directory that should NOT be created
+    const sessionsDir = path.join(tmpDir, "sessions");
+
+    const result = await readSessionRecentMessages({
+      storePath,
+      sessionKey: "ghost-key",
+    });
+
+    expect(result).toEqual([]);
+    // The sessions directory must not have been created as a side effect
+    await expect(fs.access(sessionsDir)).rejects.toThrow();
+  });
+
+  it("excludes toolResult messages from returned history", async () => {
+    const sessionId = "test-session-tool-result";
+    const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    await saveSessionStore(storePath, {
+      "tool-key": { sessionId, updatedAt: Date.now() },
+    });
+
+    const header = JSON.stringify({
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: sessionId,
+      timestamp: new Date().toISOString(),
+      cwd: tmpDir,
+    });
+
+    const lines: string[] = [header];
+    // user message
+    lines.push(
+      JSON.stringify({
+        type: "message",
+        id: "user001",
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "run my tool" }],
+          timestamp: Date.now(),
+        },
+      }),
+    );
+    // toolResult message — should be excluded
+    lines.push(
+      JSON.stringify({
+        type: "message",
+        id: "tool001",
+        parentId: "user001",
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "toolResult",
+          toolCallId: "call_abc",
+          toolName: "bash",
+          content: [{ type: "text", text: "tool output" }],
+          isError: false,
+          timestamp: Date.now(),
+        },
+      }),
+    );
+    // assistant message
+    lines.push(
+      JSON.stringify({
+        type: "message",
+        id: "asst001",
+        parentId: "tool001",
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "done" }],
+          api: "openai-responses",
+          provider: "openclaw",
+          model: "test",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "stop",
+          timestamp: Date.now(),
+        },
+      }),
+    );
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n", "utf-8");
+
+    const result = await readSessionRecentMessages({
+      storePath,
+      sessionKey: "tool-key",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ role: "user", content: "run my tool" });
+    expect(result[1]).toMatchObject({ role: "assistant", content: "done" });
+    // toolResult must not appear
+    expect(result.find((m) => m.role === ("toolResult" as string))).toBeUndefined();
+  });
 });

--- a/src/config/sessions/history.test.ts
+++ b/src/config/sessions/history.test.ts
@@ -154,17 +154,17 @@ describe("readSessionRecentMessages", () => {
       "ghost-key": { sessionId, updatedAt: Date.now() },
     });
 
-    // sessions directory that should NOT be created
-    const sessionsDir = path.join(tmpDir, "sessions");
+    // Snapshot tmpDir contents before the call
+    const beforeContents = await fs.readdir(tmpDir);
 
-    const result = await readSessionRecentMessages({
+    await readSessionRecentMessages({
       storePath,
       sessionKey: "ghost-key",
     });
 
-    expect(result).toEqual([]);
-    // The sessions directory must not have been created as a side effect
-    await expect(fs.access(sessionsDir)).rejects.toThrow();
+    // Snapshot after the call — no new entries should appear
+    const afterContents = await fs.readdir(tmpDir);
+    expect(afterContents).toEqual(beforeContents);
   });
 
   it("excludes toolResult messages from returned history", async () => {

--- a/src/config/sessions/history.test.ts
+++ b/src/config/sessions/history.test.ts
@@ -1,0 +1,150 @@
+// src/config/sessions/history.test.ts
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readSessionRecentMessages } from "./history.js";
+import { saveSessionStore } from "./store.js";
+
+describe("readSessionRecentMessages", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-history-test-"));
+    storePath = path.join(tmpDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when session key not found", async () => {
+    await saveSessionStore(storePath, {});
+    const result = await readSessionRecentMessages({
+      storePath,
+      sessionKey: "nonexistent",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when session file does not exist", async () => {
+    await saveSessionStore(storePath, {
+      "test-key": { sessionId: "missing-session-id", updatedAt: Date.now() },
+    });
+    const result = await readSessionRecentMessages({
+      storePath,
+      sessionKey: "test-key",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("reads messages from session transcript", async () => {
+    const sessionId = "test-session-abc123";
+    const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    await saveSessionStore(storePath, {
+      "test-key": { sessionId, updatedAt: Date.now() },
+    });
+
+    const header = JSON.stringify({
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: sessionId,
+      timestamp: new Date().toISOString(),
+      cwd: tmpDir,
+    });
+    await fs.writeFile(sessionFile, `${header}\n`, "utf-8");
+
+    const manager = SessionManager.open(sessionFile);
+    manager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "hello world" }],
+      timestamp: Date.now(),
+    });
+    manager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "hi there" }],
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "test",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+
+    const result = await readSessionRecentMessages({
+      storePath,
+      sessionKey: "test-key",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ role: "user", content: "hello world" });
+    expect(result[1]).toMatchObject({ role: "assistant", content: "hi there" });
+  });
+
+  it("respects limit parameter", async () => {
+    const sessionId = "test-session-limit";
+    const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    await saveSessionStore(storePath, {
+      "limit-key": { sessionId, updatedAt: Date.now() },
+    });
+
+    const header = JSON.stringify({
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: sessionId,
+      timestamp: new Date().toISOString(),
+      cwd: tmpDir,
+    });
+    // Write header + 5 user messages + 1 assistant message directly to trigger
+    // SessionManager's persist logic (which only flushes once an assistant
+    // message exists). Writing the JSONL manually avoids that constraint.
+    const lines: string[] = [header];
+    let prevId: string | null = null;
+    for (let i = 0; i < 5; i++) {
+      const id = `user${i}00000`;
+      lines.push(
+        JSON.stringify({
+          type: "message",
+          id,
+          parentId: prevId,
+          timestamp: new Date().toISOString(),
+          message: {
+            role: "user",
+            content: [{ type: "text", text: `message ${i}` }],
+            timestamp: Date.now(),
+          },
+        }),
+      );
+      prevId = id;
+    }
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n", "utf-8");
+
+    const result = await readSessionRecentMessages({
+      storePath,
+      sessionKey: "limit-key",
+      limit: 3,
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result[2]).toMatchObject({ content: "message 4" });
+  });
+
+  it("returns empty array on any error (graceful degradation)", async () => {
+    const result = await readSessionRecentMessages({
+      storePath: path.join(tmpDir, "nonexistent", "sessions.json"),
+      sessionKey: "any-key",
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/src/config/sessions/history.ts
+++ b/src/config/sessions/history.ts
@@ -10,6 +10,26 @@ export type SessionHistoryMessage = {
   content: string;
 };
 
+const SKIP_BLOCK_TYPES = new Set([
+  // snake_case variants
+  "tool_use",
+  "tool_result",
+  "tool_call",
+  // camelCase variants
+  "toolCall",
+  "toolUse",
+  "toolResult",
+  "functionCall",
+  // internal aliases
+  "toolcall",
+  // reasoning blocks (not user-visible)
+  "thinking",
+]);
+
+function isToolOrReasoningBlock(type?: string): boolean {
+  return !!type && SKIP_BLOCK_TYPES.has(type);
+}
+
 function extractTextContent(content: unknown): string {
   if (typeof content === "string") {
     return content;
@@ -21,14 +41,8 @@ function extractTextContent(content: unknown): string {
         parts.push(c.text);
       } else if (c.type === "image") {
         parts.push("[image]");
-      } else if (
-        c.type === "tool_use" ||
-        c.type === "tool_result" ||
-        c.type === "toolCall" ||
-        c.type === "toolUse" ||
-        c.type === "toolResult"
-      ) {
-        // skip tool blocks (both snake_case and camelCase variants)
+      } else if (isToolOrReasoningBlock(c.type)) {
+        // skip tool and reasoning blocks
       } else if (c.type) {
         parts.push(`[${c.type}]`);
       }

--- a/src/config/sessions/history.ts
+++ b/src/config/sessions/history.ts
@@ -14,7 +14,7 @@ function extractTextContent(content: unknown): string {
     return content;
   }
   if (Array.isArray(content)) {
-    return content.map((c: { text?: string }) => c.text ?? "").join("");
+    return content.map((c: { text?: string }) => c.text ?? "").join(" ");
   }
   return "";
 }

--- a/src/config/sessions/history.ts
+++ b/src/config/sessions/history.ts
@@ -1,21 +1,12 @@
 // src/config/sessions/history.ts
-import { SessionManager } from "@mariozechner/pi-coding-agent";
+import fs from "node:fs";
+import { SessionManager, type SessionEntry } from "@mariozechner/pi-coding-agent";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "./paths.js";
 import { loadSessionStore, resolveSessionStoreEntry } from "./store.js";
 
 export type SessionHistoryMessage = {
-  role: string;
+  role: "user" | "assistant";
   content: string;
-  senderName?: string;
-};
-
-type MessageEntry = {
-  type?: string;
-  message?: {
-    role?: string;
-    content?: unknown;
-    senderName?: string;
-  };
 };
 
 function extractTextContent(content: unknown): string {
@@ -55,12 +46,19 @@ export async function readSessionRecentMessages(params: {
     const opts = resolveSessionFilePathOptions({ agentId, storePath });
     const sessionFile = resolveSessionFilePath(entry.sessionId, entry, opts);
 
+    if (!fs.existsSync(sessionFile)) {
+      return [];
+    }
+
     const sessionManager = SessionManager.open(sessionFile);
-    const entries = sessionManager.getEntries() as MessageEntry[];
+    const entries: SessionEntry[] = sessionManager.getEntries();
 
     const messages: SessionHistoryMessage[] = [];
     for (const e of entries) {
-      if (e.type !== "message" || !e.message?.role) {
+      if (e.type !== "message" || !("message" in e) || !e.message?.role) {
+        continue;
+      }
+      if (e.message.role !== "user" && e.message.role !== "assistant") {
         continue;
       }
       const content = extractTextContent(e.message.content);
@@ -70,7 +68,6 @@ export async function readSessionRecentMessages(params: {
       messages.push({
         role: e.message.role,
         content,
-        senderName: e.message.senderName,
       });
     }
 

--- a/src/config/sessions/history.ts
+++ b/src/config/sessions/history.ts
@@ -1,0 +1,81 @@
+// src/config/sessions/history.ts
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { resolveSessionFilePath, resolveSessionFilePathOptions } from "./paths.js";
+import { loadSessionStore, resolveSessionStoreEntry } from "./store.js";
+
+export type SessionHistoryMessage = {
+  role: string;
+  content: string;
+  senderName?: string;
+};
+
+type MessageEntry = {
+  type?: string;
+  message?: {
+    role?: string;
+    content?: unknown;
+    senderName?: string;
+  };
+};
+
+function extractTextContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content.map((c: { text?: string }) => c.text ?? "").join("");
+  }
+  return "";
+}
+
+/**
+ * Read recent messages from a session transcript.
+ *
+ * Returns the last `limit` user/assistant messages from the session identified
+ * by `sessionKey` in the given store. Returns an empty array on any error
+ * (missing session, missing file, parse error) — callers should treat an empty
+ * result as "no history available" rather than an error.
+ */
+export async function readSessionRecentMessages(params: {
+  storePath: string;
+  sessionKey: string;
+  /** Agent ID used to resolve the sessions directory (default: main agent). */
+  agentId?: string;
+  /** Maximum number of messages to return, counting from the end (default: 10). */
+  limit?: number;
+}): Promise<SessionHistoryMessage[]> {
+  const { storePath, sessionKey, agentId, limit = 10 } = params;
+  try {
+    const store = loadSessionStore(storePath);
+    const { existing: entry } = resolveSessionStoreEntry({ store, sessionKey });
+    if (!entry?.sessionId) {
+      return [];
+    }
+
+    const opts = resolveSessionFilePathOptions({ agentId, storePath });
+    const sessionFile = resolveSessionFilePath(entry.sessionId, entry, opts);
+
+    const sessionManager = SessionManager.open(sessionFile);
+    const entries = sessionManager.getEntries() as MessageEntry[];
+
+    const messages: SessionHistoryMessage[] = [];
+    for (const e of entries) {
+      if (e.type !== "message" || !e.message?.role) {
+        continue;
+      }
+      const content = extractTextContent(e.message.content);
+      if (!content.trim()) {
+        continue;
+      }
+      messages.push({
+        role: e.message.role,
+        content,
+        senderName: e.message.senderName,
+      });
+    }
+
+    return messages.slice(-limit);
+  } catch {
+    return [];
+  }
+}

--- a/src/config/sessions/history.ts
+++ b/src/config/sessions/history.ts
@@ -21,8 +21,14 @@ function extractTextContent(content: unknown): string {
         parts.push(c.text);
       } else if (c.type === "image") {
         parts.push("[image]");
-      } else if (c.type === "tool_use" || c.type === "tool_result") {
-        // skip tool blocks
+      } else if (
+        c.type === "tool_use" ||
+        c.type === "tool_result" ||
+        c.type === "toolCall" ||
+        c.type === "toolUse" ||
+        c.type === "toolResult"
+      ) {
+        // skip tool blocks (both snake_case and camelCase variants)
       } else if (c.type) {
         parts.push(`[${c.type}]`);
       }
@@ -44,6 +50,10 @@ function extractTextContent(content: unknown): string {
  * auto-compaction, this may include turns from inactive branches. For most
  * channel-plugin use cases (recent context injection) this is acceptable;
  * consumers needing branch-accurate history should use the gateway API instead.
+ *
+ * Limitation: older topic/thread sessions without a persisted `sessionFile`
+ * entry may not be found, as this helper does not perform the topic-specific
+ * path fallback that `resolveAndPersistSessionFile` provides.
  */
 export async function readSessionRecentMessages(params: {
   /**

--- a/src/config/sessions/history.ts
+++ b/src/config/sessions/history.ts
@@ -1,5 +1,5 @@
 // src/config/sessions/history.ts
-import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import { SessionManager, type SessionEntry } from "@mariozechner/pi-coding-agent";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "./paths.js";
 import { loadSessionStore, resolveSessionStoreEntry } from "./store.js";
@@ -36,6 +36,7 @@ export async function readSessionRecentMessages(params: {
   limit?: number;
 }): Promise<SessionHistoryMessage[]> {
   const { storePath, sessionKey, agentId, limit = 10 } = params;
+  const effectiveLimit = limit > 0 ? limit : 10;
   try {
     const store = loadSessionStore(storePath);
     const { existing: entry } = resolveSessionStoreEntry({ store, sessionKey });
@@ -46,7 +47,9 @@ export async function readSessionRecentMessages(params: {
     const opts = resolveSessionFilePathOptions({ agentId, storePath });
     const sessionFile = resolveSessionFilePath(entry.sessionId, entry, opts);
 
-    if (!fs.existsSync(sessionFile)) {
+    try {
+      await fsPromises.stat(sessionFile);
+    } catch {
       return [];
     }
 
@@ -71,7 +74,7 @@ export async function readSessionRecentMessages(params: {
       });
     }
 
-    return messages.slice(-limit);
+    return messages.slice(-effectiveLimit);
   } catch {
     return [];
   }

--- a/src/config/sessions/history.ts
+++ b/src/config/sessions/history.ts
@@ -15,7 +15,19 @@ function extractTextContent(content: unknown): string {
     return content;
   }
   if (Array.isArray(content)) {
-    return content.map((c: { text?: string }) => c.text ?? "").join(" ");
+    const parts: string[] = [];
+    for (const c of content as Array<{ type?: string; text?: string }>) {
+      if (c.text) {
+        parts.push(c.text);
+      } else if (c.type === "image") {
+        parts.push("[image]");
+      } else if (c.type === "tool_use" || c.type === "tool_result") {
+        // skip tool blocks
+      } else if (c.type) {
+        parts.push(`[${c.type}]`);
+      }
+    }
+    return parts.join(" ");
   }
   return "";
 }
@@ -34,9 +46,14 @@ function extractTextContent(content: unknown): string {
  * consumers needing branch-accurate history should use the gateway API instead.
  */
 export async function readSessionRecentMessages(params: {
+  /**
+   * Path to the sessions store (sessions.json). For non-main agents, callers
+   * must pass the agent-specific store path (e.g., via
+   * `rt.channel.session.resolveStorePath(cfg.session?.store, { agentId })`).
+   */
   storePath: string;
   sessionKey: string;
-  /** Agent ID used to resolve the sessions directory (default: main agent). */
+  /** Agent ID used as a hint for session file path resolution. */
   agentId?: string;
   /** Maximum number of messages to return, counting from the end (default: 10). */
   limit?: number;

--- a/src/config/sessions/history.ts
+++ b/src/config/sessions/history.ts
@@ -1,6 +1,7 @@
 // src/config/sessions/history.ts
 import fsPromises from "node:fs/promises";
 import { SessionManager, type SessionEntry } from "@mariozechner/pi-coding-agent";
+import { hasInterSessionUserProvenance } from "../../sessions/input-provenance.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "./paths.js";
 import { loadSessionStore, resolveSessionStoreEntry } from "./store.js";
 
@@ -26,6 +27,11 @@ function extractTextContent(content: unknown): string {
  * by `sessionKey` in the given store. Returns an empty array on any error
  * (missing session, missing file, parse error) — callers should treat an empty
  * result as "no history available" rather than an error.
+ *
+ * Note: reads entries in append order. In sessions with `/tree` branches or
+ * auto-compaction, this may include turns from inactive branches. For most
+ * channel-plugin use cases (recent context injection) this is acceptable;
+ * consumers needing branch-accurate history should use the gateway API instead.
  */
 export async function readSessionRecentMessages(params: {
   storePath: string;
@@ -62,6 +68,11 @@ export async function readSessionRecentMessages(params: {
         continue;
       }
       if (e.message.role !== "user" && e.message.role !== "assistant") {
+        continue;
+      }
+      // Skip synthetic inter-session messages (e.g., sessions_send, subagent
+      // announcements) to avoid leaking internal agent traffic into plugin context.
+      if (hasInterSessionUserProvenance(e.message)) {
         continue;
       }
       const content = extractTextContent(e.message.content);

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -60,6 +60,7 @@ export type { OpenClawConfig as ClawdbotConfig } from "../config/config.js";
 export * from "./image-generation.js";
 export type { SecretInput, SecretRef } from "../config/types.secrets.js";
 export type { RuntimeEnv } from "../runtime.js";
+export type { SessionHistoryMessage } from "../config/sessions/history.js";
 export type { HookEntry } from "../hooks/types.js";
 export type { ReplyPayload } from "../auto-reply/types.js";
 export type { WizardPrompter } from "../wizard/prompts.js";

--- a/src/plugins/runtime/runtime-channel.ts
+++ b/src/plugins/runtime/runtime-channel.ts
@@ -42,6 +42,7 @@ import {
 } from "../../config/group-policy.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import {
+  readSessionRecentMessages,
   readSessionUpdatedAt,
   recordSessionMetaFromInbound,
   resolveStorePath,
@@ -163,6 +164,7 @@ export function createRuntimeChannel(): PluginRuntime["channel"] {
       recordSessionMetaFromInbound,
       recordInboundSession,
       updateLastRoute,
+      readRecentMessages: readSessionRecentMessages,
     },
     mentions: {
       buildMentionRegexes,

--- a/src/plugins/runtime/types-channel.ts
+++ b/src/plugins/runtime/types-channel.ts
@@ -69,6 +69,7 @@ export type PluginRuntimeChannel = {
     recordSessionMetaFromInbound: typeof import("../../config/sessions.js").recordSessionMetaFromInbound;
     recordInboundSession: typeof import("../../channels/session.js").recordInboundSession;
     updateLastRoute: typeof import("../../config/sessions.js").updateLastRoute;
+    readRecentMessages: typeof import("../../config/sessions.js").readSessionRecentMessages;
   };
   mentions: {
     buildMentionRegexes: typeof import("../../auto-reply/reply/mentions.js").buildMentionRegexes;

--- a/test/helpers/extensions/plugin-runtime-mock.ts
+++ b/test/helpers/extensions/plugin-runtime-mock.ts
@@ -241,8 +241,11 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
           vi.fn() as unknown as PluginRuntime["channel"]["session"]["recordInboundSession"],
         updateLastRoute:
           vi.fn() as unknown as PluginRuntime["channel"]["session"]["updateLastRoute"],
-        readRecentMessages:
-          vi.fn() as unknown as PluginRuntime["channel"]["session"]["readRecentMessages"],
+        readRecentMessages: vi
+          .fn()
+          .mockResolvedValue(
+            [],
+          ) as unknown as PluginRuntime["channel"]["session"]["readRecentMessages"],
       },
       mentions: {
         buildMentionRegexes: vi.fn(() => [

--- a/test/helpers/extensions/plugin-runtime-mock.ts
+++ b/test/helpers/extensions/plugin-runtime-mock.ts
@@ -241,6 +241,8 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
           vi.fn() as unknown as PluginRuntime["channel"]["session"]["recordInboundSession"],
         updateLastRoute:
           vi.fn() as unknown as PluginRuntime["channel"]["session"]["updateLastRoute"],
+        readRecentMessages:
+          vi.fn() as unknown as PluginRuntime["channel"]["session"]["readRecentMessages"],
       },
       mentions: {
         buildMentionRegexes: vi.fn(() => [


### PR DESCRIPTION
## Summary

- **Problem:** Channel plugins that implement multi-agent @mention routing (e.g. DingTalk) need recent group conversation history to inject as context for sub-agents. Currently they read OpenClaw's internal JSONL session files directly, coupling to an internal implementation detail.
- **Why it matters:** Direct JSONL reads will silently break if OpenClaw changes session storage format, with no type safety or API contract.
- **What changed:** Added `readSessionRecentMessages()` to `src/config/sessions/history.ts`, exported `SessionHistoryMessage` from plugin-sdk, and wired `rt.channel.session.readRecentMessages()` into `PluginRuntimeChannel`.
- **What did NOT change:** No existing session read/write paths were modified. This is additive only.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: DingTalk channel plugin @agent routing feature (external fork)

## User-visible / Behavior Changes

None — this is a new internal API for channel plugin authors. No end-user behavior changes.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **Yes** — the new API reads session transcript files. However, `resolveSessionFilePath` already enforces that paths stay within the agent's sessions directory (path traversal protected). The function is read-only with no write side effects.

## Repro + Verification

### Environment

- OS: macOS 24.6.0
- Runtime/container: Node.js (local)
- Model/provider: N/A (storage layer only)
- Integration/channel: DingTalk (consumer of this API)
- Relevant config: `agents.list` with multiple agent IDs

### Steps

1. Call `rt.channel.session.readRecentMessages({ storePath, sessionKey, limit: 5 })` from a channel plugin
2. Returns last 5 `{ role, content }` messages from the session transcript

### Expected

- Array of `SessionHistoryMessage` objects with `role: "user" | "assistant"` and `content: string`
- Returns `[]` when session not found, file missing, or any error

### Actual

- Works as expected per unit tests

## Evidence

- [x] 7 unit tests pass: missing key, missing file, read messages, limit, no directory side-effect, toolResult excluded, graceful degradation
- Test file: `src/config/sessions/history.test.ts`

## Human Verification (required)

- Verified scenarios: all 7 unit test cases cover the main paths
- Edge cases checked: `limit=0` (uses default 10), missing session file (no directory created as side effect), `toolResult` messages excluded
- What I did **not** verify: behavior under concurrent reads from multiple processes; very large session files (event loop blocking risk mitigated by using `fsPromises.stat` for the file existence check, but `SessionManager.open().getEntries()` remains synchronous)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

> **Greptile review** (3 findings — all addressed in commit `46bf3c05f`):
> - `slice(-0)` bug → fixed with `effectiveLimit = limit > 0 ? limit : 10`
> - `async` function with no `await` → replaced `fs.existsSync` with `await fsPromises.stat()`
> - "no directory creation" test checked wrong path → fixed with before/after `readdir` snapshot

## Compatibility / Migration

- Backward compatible? **Yes** — additive only
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)

- How to disable/revert: revert commits on `feat/plugin-sdk-session-history` branch; channel plugins fall back to direct JSONL reads (their previous behavior)
- Files/config to restore: `src/config/sessions/history.ts`, `src/config/sessions.ts`, `src/plugins/runtime/types-channel.ts`, `src/plugins/runtime/runtime-channel.ts`, `src/plugin-sdk/index.ts`
- Known bad symptoms: `rt.channel.session.readRecentMessages` would be undefined — channel plugins calling it would throw at runtime

## Risks and Mitigations

- Risk: `SessionManager.open().getEntries()` is synchronous and could block the event loop for large session files
  - Mitigation: Session transcripts are bounded by compaction (they don't grow unboundedly). The function is only called on inbound group messages to inject history context, not in hot paths. Acceptable for now; can be made fully async if `SessionManager` gains async read support.

---

> 🤖 **AI-assisted PR** — implemented with Claude Code (claude-sonnet-4-6)
> - Degree of testing: fully tested (7 unit tests, 510 tests total pass in the repo)
> - The author ([@wjueyao](https://github.com/wjueyao)) has reviewed and understands all changes