### PR TITLE
Fix exec approval follow-ups for internal sessions

### DIFF
--- a/.github/pr-assets/exec-approval-followup-route.svg
+++ b/.github/pr-assets/exec-approval-followup-route.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="860" viewBox="0 0 1200 860" fill="none">
+  <defs>
+    <style>
+      .title { font: 700 28px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+      .subtitle { font: 600 18px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+      .label { font: 600 16px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+      .body { font: 500 15px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #334155; }
+      .mono { font: 600 14px ui-monospace, "SFMono-Regular", Consolas, monospace; fill: #0f172a; }
+      .small { font: 500 13px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+      .lane { stroke: #cbd5e1; stroke-width: 2; stroke-dasharray: 6 8; }
+      .arrow-red { stroke: #dc2626; stroke-width: 3; fill: none; marker-end: url(#arrow-red); }
+      .arrow-green { stroke: #15803d; stroke-width: 3; fill: none; marker-end: url(#arrow-green); }
+      .arrow-gray { stroke: #64748b; stroke-width: 2.5; fill: none; marker-end: url(#arrow-gray); }
+    </style>
+    <marker id="arrow-red" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#dc2626"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#15803d"/>
+    </marker>
+    <marker id="arrow-gray" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="860" fill="#f8fafc"/>
+  <rect x="24" y="24" width="1152" height="812" rx="24" fill="#ffffff" stroke="#e2e8f0"/>
+
+  <text x="56" y="74" class="title">Exec approval follow-up route</text>
+  <text x="56" y="106" class="body">Why the old flow dropped approved exec results, and why the new flow keeps Web UI / TUI follow-ups inside the originating session.</text>
+
+  <rect x="56" y="136" width="1088" height="300" rx="20" fill="#fff1f2" stroke="#fecdd3"/>
+  <text x="84" y="176" class="subtitle">Before</text>
+  <text x="84" y="202" class="body">The approval itself succeeds, but the follow-up always re-enters outbound delivery with no concrete channel target.</text>
+
+  <rect x="92" y="236" width="180" height="74" rx="16" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="120" y="268" class="label">Web UI / TUI</text>
+  <text x="120" y="292" class="small">approved exec turn</text>
+
+  <rect x="332" y="236" width="228" height="74" rx="16" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="360" y="268" class="label">Gateway approval wait</text>
+  <text x="360" y="292" class="mono">exec.approval.waitDecision ✓</text>
+
+  <rect x="620" y="236" width="212" height="74" rx="16" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="648" y="268" class="label">Follow-up agent call</text>
+  <text x="648" y="292" class="mono">deliver: true</text>
+
+  <rect x="892" y="236" width="212" height="74" rx="16" fill="#ffffff" stroke="#fca5a5"/>
+  <text x="920" y="268" class="label">Channel selection</text>
+  <text x="920" y="292" class="mono">Channel is required</text>
+
+  <path d="M272 273H332" class="arrow-gray"/>
+  <path d="M560 273H620" class="arrow-gray"/>
+  <path d="M832 273H892" class="arrow-red"/>
+
+  <text x="649" y="340" class="small">follow-up params</text>
+  <text x="649" y="362" class="mono">sessionKey=agent:main:main</text>
+  <text x="649" y="384" class="mono">channel=undefined</text>
+  <text x="649" y="406" class="mono">to=undefined</text>
+
+  <rect x="92" y="332" width="1012" height="72" rx="16" fill="#ffffff" stroke="#fecaca"/>
+  <text x="120" y="362" class="body">Result: the user approved the exec, but the completion message never made it back to the active session because outbound routing was invoked without a deliverable channel + recipient.</text>
+  <text x="120" y="388" class="mono">approval resolves → follow-up agent request → outbound channel selection error</text>
+
+  <rect x="56" y="468" width="1088" height="320" rx="20" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="84" y="508" class="subtitle">After</text>
+  <text x="84" y="534" class="body">The follow-up only re-enters outbound delivery when the originating turn still has a deliverable channel and an explicit recipient target.</text>
+
+  <rect x="92" y="570" width="180" height="74" rx="16" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="120" y="602" class="label">Web UI / TUI</text>
+  <text x="120" y="626" class="small">approved exec turn</text>
+
+  <rect x="332" y="570" width="228" height="74" rx="16" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="360" y="602" class="label">Gateway approval wait</text>
+  <text x="360" y="626" class="mono">exec.approval.waitDecision ✓</text>
+
+  <rect x="620" y="570" width="212" height="74" rx="16" fill="#ffffff" stroke="#86efac"/>
+  <text x="648" y="602" class="label">Follow-up agent call</text>
+  <text x="648" y="626" class="mono">deliver: false</text>
+
+  <rect x="892" y="570" width="212" height="74" rx="16" fill="#ffffff" stroke="#86efac"/>
+  <text x="920" y="602" class="label">Current session</text>
+  <text x="920" y="626" class="mono">append result in-place</text>
+
+  <path d="M272 607H332" class="arrow-gray"/>
+  <path d="M560 607H620" class="arrow-gray"/>
+  <path d="M832 607H892" class="arrow-green"/>
+
+  <text x="649" y="674" class="small">route guard</text>
+  <text x="649" y="696" class="mono">webchat → channel=webchat, deliver=false</text>
+  <text x="649" y="718" class="mono">tui → channel=undefined, deliver=false</text>
+  <text x="649" y="740" class="mono">telegram/slack/etc + explicit target → deliver=true</text>
+
+  <rect x="92" y="666" width="472" height="88" rx="16" fill="#ffffff" stroke="#bbf7d0"/>
+  <text x="120" y="696" class="body">Internal clients stay internal:</text>
+  <text x="120" y="722" class="mono">actual output: followup-fix-check</text>
+  <text x="120" y="744" class="mono">approval-followup-ok</text>
+
+  <rect x="84" y="806" width="1032" height="1" fill="#dbeafe"/>
+</svg>

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("./tools/gateway.js", () => ({
+  callGatewayTool: vi.fn(),
+}));
+
+let callGatewayTool: typeof import("./tools/gateway.js").callGatewayTool;
+let sendExecApprovalFollowup: typeof import("./bash-tools.exec-approval-followup.js").sendExecApprovalFollowup;
+
+beforeAll(async () => {
+  ({ callGatewayTool } = await import("./tools/gateway.js"));
+  ({ sendExecApprovalFollowup } = await import("./bash-tools.exec-approval-followup.js"));
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("sendExecApprovalFollowup", () => {
+  it("keeps Web UI follow-ups in-session when no explicit target exists", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ status: "ok" });
+
+    const sent = await sendExecApprovalFollowup({
+      approvalId: "approval-webchat",
+      sessionKey: "agent:main:main",
+      turnSourceChannel: "webchat",
+      resultText: "Exec finished",
+    });
+
+    expect(sent).toBe(true);
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      { timeoutMs: 60_000 },
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        channel: "webchat",
+        deliver: false,
+        to: undefined,
+        idempotencyKey: "exec-approval-followup:approval-webchat",
+      }),
+      { expectFinal: true },
+    );
+  });
+
+  it("falls back to in-session follow-ups when the turn source is tui", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ status: "ok" });
+
+    const sent = await sendExecApprovalFollowup({
+      approvalId: "approval-tui",
+      sessionKey: "agent:main:main",
+      turnSourceChannel: "tui",
+      resultText: "Exec finished",
+    });
+
+    expect(sent).toBe(true);
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      { timeoutMs: 60_000 },
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        channel: undefined,
+        deliver: false,
+        to: undefined,
+        idempotencyKey: "exec-approval-followup:approval-tui",
+      }),
+      { expectFinal: true },
+    );
+  });
+
+  it("keeps the follow-up in-session when an external channel has no target", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ status: "ok" });
+
+    const sent = await sendExecApprovalFollowup({
+      approvalId: "approval-telegram-missing-target",
+      sessionKey: "agent:main:main",
+      turnSourceChannel: "telegram",
+      resultText: "Exec finished",
+    });
+
+    expect(sent).toBe(true);
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      { timeoutMs: 60_000 },
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        channel: "telegram",
+        deliver: false,
+        to: undefined,
+        accountId: undefined,
+        threadId: undefined,
+        idempotencyKey: "exec-approval-followup:approval-telegram-missing-target",
+      }),
+      { expectFinal: true },
+    );
+  });
+
+  it("preserves explicit external delivery targets when available", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ status: "ok" });
+
+    const sent = await sendExecApprovalFollowup({
+      approvalId: "approval-whatsapp",
+      sessionKey: "agent:main:main",
+      turnSourceChannel: "whatsapp",
+      turnSourceTo: "+15551234567",
+      turnSourceAccountId: "primary",
+      turnSourceThreadId: "thread-1",
+      resultText: "Exec finished",
+    });
+
+    expect(sent).toBe(true);
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      { timeoutMs: 60_000 },
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        channel: "whatsapp",
+        deliver: true,
+        to: "+15551234567",
+        accountId: "primary",
+        threadId: "thread-1",
+        idempotencyKey: "exec-approval-followup:approval-whatsapp",
+      }),
+      { expectFinal: true },
+    );
+  });
+});

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -1,3 +1,8 @@
+import {
+  type GatewayMessageChannel,
+  isDeliverableMessageChannel,
+  resolveGatewayMessageChannel,
+} from "../utils/message-channel.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 type ExecApprovalFollowupParams = {
@@ -8,6 +13,14 @@ type ExecApprovalFollowupParams = {
   turnSourceAccountId?: string;
   turnSourceThreadId?: string | number;
   resultText: string;
+};
+
+type ExecApprovalFollowupRoute = {
+  channel?: GatewayMessageChannel;
+  deliver: boolean;
+  to?: string;
+  accountId?: string;
+  threadId?: string;
 };
 
 export function buildExecApprovalFollowupPrompt(resultText: string): string {
@@ -24,6 +37,38 @@ export function buildExecApprovalFollowupPrompt(resultText: string): string {
   ].join("\n");
 }
 
+function resolveExecApprovalFollowupRoute(
+  params: Pick<
+    ExecApprovalFollowupParams,
+    "turnSourceChannel" | "turnSourceTo" | "turnSourceAccountId" | "turnSourceThreadId"
+  >,
+): ExecApprovalFollowupRoute {
+  const channel = resolveGatewayMessageChannel(params.turnSourceChannel);
+  const to = params.turnSourceTo?.trim() || undefined;
+  const threadId =
+    params.turnSourceThreadId != null && params.turnSourceThreadId !== ""
+      ? String(params.turnSourceThreadId)
+      : undefined;
+
+  // Approval follow-ups already have a live agent session to write back to.
+  // Only re-enter outbound delivery when we still have a deliverable chat
+  // channel and a concrete recipient target from the originating turn.
+  if (!channel || !isDeliverableMessageChannel(channel) || !to) {
+    return {
+      channel,
+      deliver: false,
+    };
+  }
+
+  return {
+    channel,
+    deliver: true,
+    to,
+    accountId: params.turnSourceAccountId?.trim() || undefined,
+    threadId,
+  };
+}
+
 export async function sendExecApprovalFollowup(
   params: ExecApprovalFollowupParams,
 ): Promise<boolean> {
@@ -33,12 +78,7 @@ export async function sendExecApprovalFollowup(
     return false;
   }
 
-  const channel = params.turnSourceChannel?.trim();
-  const to = params.turnSourceTo?.trim();
-  const threadId =
-    params.turnSourceThreadId != null && params.turnSourceThreadId !== ""
-      ? String(params.turnSourceThreadId)
-      : undefined;
+  const route = resolveExecApprovalFollowupRoute(params);
 
   await callGatewayTool(
     "agent",
@@ -46,12 +86,12 @@ export async function sendExecApprovalFollowup(
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: true,
+      deliver: route.deliver,
       bestEffortDeliver: true,
-      channel: channel && to ? channel : undefined,
-      to: channel && to ? to : undefined,
-      accountId: channel && to ? params.turnSourceAccountId?.trim() || undefined : undefined,
-      threadId: channel && to ? threadId : undefined,
+      channel: route.channel,
+      to: route.to,
+      accountId: route.accountId,
+      threadId: route.threadId,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
     },
     { expectFinal: true },

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -327,7 +327,7 @@ describe("exec approvals", () => {
     expect(calls).toContain("exec.approval.waitDecision");
   });
 
-  it("starts a direct agent follow-up after approved gateway exec completes", async () => {
+  it("keeps exec approval follow-up internal for webchat sessions without an explicit target", async () => {
     const agentCalls: Array<Record<string, unknown>> = [];
 
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
@@ -349,10 +349,11 @@ describe("exec approvals", () => {
       ask: "always",
       approvalRunningNoticeMs: 0,
       sessionKey: "agent:main:main",
+      messageProvider: "webchat",
       elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
     });
 
-    const result = await tool.execute("call-gw-followup", {
+    const result = await tool.execute("call-gw-followup-webchat", {
       command: "echo ok",
       workdir: process.cwd(),
       gatewayUrl: undefined,
@@ -364,7 +365,9 @@ describe("exec approvals", () => {
     expect(agentCalls[0]).toEqual(
       expect.objectContaining({
         sessionKey: "agent:main:main",
-        deliver: true,
+        channel: "webchat",
+        deliver: false,
+        to: undefined,
         idempotencyKey: expect.stringContaining("exec-approval-followup:"),
       }),
     );


### PR DESCRIPTION
## Summary

This fixes a separate post-approval regression in the exec approval flow for internal sessions (`webchat`, `tui`).

Approvals were already succeeding, but the completion follow-up could still disappear because the follow-up `agent` call always forced outbound delivery.

![Exec approval follow-up route](https://raw.githubusercontent.com/microTT/openclaw/fix/webchat-exec-approval-followup/.github/pr-assets/exec-approval-followup-route.svg)

## Root Cause

Before this change, `sendExecApprovalFollowup()` always sent `deliver: true`.

That is wrong for internal sessions:

- `webchat` has no outbound recipient target
- `tui` is not a deliverable message channel

So the approved exec completion was pushed back through outbound channel selection instead of being written to the already-active session.

On a gateway with no configured outbound channels, the follow-up could fail with:

```text
Channel is required (no configured channels detected).
```

## What Changed

- Introduced `resolveExecApprovalFollowupRoute()` to derive the correct follow-up route from the originating turn
- Only set `deliver: true` when we still have both:
  - a deliverable message channel
  - an explicit recipient target (`to`)
- Keep internal follow-ups in-session for `webchat`
- Keep gateway-local follow-ups in-session for `tui`
- Preserve external delivery when the original turn came from a deliverable channel with an explicit target
- Added focused route tests plus an exec-approval integration regression test

## Why This Is Safe

- External delivery behavior is unchanged when the original turn still has a valid `channel + to` pair
- Internal sessions now prefer the existing session path instead of falling into outbound channel selection
- Missing-target external turns degrade to in-session follow-ups instead of hard-failing after approval

## Repro Before

1. Start a `webchat` or `tui` session with gateway exec approvals enabled
2. Run a harmless command such as `printf 'followup-fix-check\n'`
3. Approve the exec request
4. Observe:
   - `exec.approval.waitDecision` resolves successfully
   - no completion message is appended to the session
   - the follow-up `agent` request can fail with `Channel is required (no configured channels detected)`

## Repro After

Using the same scenario:

1. Run `printf 'followup-fix-check\n'`
2. Approve the request
3. The completion is appended to the same session:

```text
actual output:
followup-fix-check

approval-followup-ok
```

## Scope

This PR does **not** attempt to fix stale / expired approval IDs in the Control UI button flow.

It fixes the separate post-approval routing bug that occurs **after** approval has already succeeded.

## Tests

- `pnpm check`
- `pnpm exec vitest run src/agents/bash-tools.exec-approval-followup.test.ts`
- `pnpm exec vitest run src/agents/bash-tools.exec.approval-id.test.ts -t "keeps exec approval follow-up internal for webchat sessions without an explicit target"`
- `pnpm exec vitest run src/gateway/server.agent.gateway-server-agent-b.test.ts -t "agent uses webchat for internal runs when last provider is webchat"`

## Manual Verification

- Built the branch and ran an isolated gateway on a separate port
- Triggered a real `webchat` exec approval for `printf 'followup-fix-check\n'`
- Approved the request in the Control UI
- Verified both:
  - `exec.approval.waitDecision` completed successfully
  - the session received the final follow-up text:

```text
actual output:
followup-fix-check

approval-followup-ok
```
