### PR TITLE
fix: avoid TDZ on Anthropic model aliases in context pruning defaults

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -31,13 +31,6 @@ export type ModelAliasIndex = {
   byKey: Map<string, string[]>;
 };
 
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
-};
-
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();
 }
@@ -151,7 +144,13 @@ function normalizeAnthropicModelId(model: string): string {
     return trimmed;
   }
   const lower = trimmed.toLowerCase();
-  return ANTHROPIC_MODEL_ALIASES[lower] ?? trimmed;
+  const aliases: Record<string, string> = {
+    "opus-4.6": "claude-opus-4-6",
+    "opus-4.5": "claude-opus-4-5",
+    "sonnet-4.6": "claude-sonnet-4-6",
+    "sonnet-4.5": "claude-sonnet-4-5",
+  };
+  return aliases[lower] ?? trimmed;
 }
 
 function normalizeProviderModelId(provider: string, model: string): string {


### PR DESCRIPTION
## Description

### Summary

Fix a runtime `ReferenceError` when loading config in builds where the Anthropic model alias map is initialized after functions that reference it. In those bundles, `normalizeAnthropicModelId` can be executed before the alias table is initialized, causing the non-fatal but noisy error reported in #44854 when applying context pruning defaults.

### Background

After upgrading to `2026.3.12`, every `openclaw` CLI invocation can log a non-fatal error such as:

```text
Failed to read config at ~/.openclaw/openclaw.json ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization
    at normalizeAnthropicModelId (...)
    at normalizeProviderModelId (...)
    at normalizeModelRef (...)
    at parseModelRef (...)
    at applyContextPruningDefaults (...)
    at Object.loadConfig (...)
```

The config still loads and the gateway runs, but this error appears on each CLI/gateway operation and is confusing for users. The stack matches the code path where `applyContextPruningDefaults` parses model refs and normalizes Anthropic IDs while applying defaults.

### Changes

- **Model selection** (`src/agents/model-selection.ts`)
  - Remove the top-level module constant:

    ```ts
    const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
      "opus-4.6": "claude-opus-4-6",
      "opus-4.5": "claude-opus-4-5",
      "sonnet-4.6": "claude-sonnet-4-6",
      "sonnet-4.5": "claude-sonnet-4-5",
    };
    ```

  - Refactor `normalizeAnthropicModelId` to use a function-local alias map instead of referencing a module-level `const`, eliminating any Temporal Dead Zone (TDZ) access risk when bundlers reorder module initialization:

    ```ts
    function normalizeAnthropicModelId(model: string): string {
      const trimmed = model.trim();
      if (!trimmed) {
        return trimmed;
      }
      const lower = trimmed.toLowerCase();
      const aliases: Record<string, string> = {
        "opus-4.6": "claude-opus-4-6",
        "opus-4.5": "claude-opus-4-5",
        "sonnet-4.6": "claude-sonnet-4-6",
        "sonnet-4.5": "claude-sonnet-4-5",
      };
      return aliases[lower] ?? trimmed;
    }
    ```

  - Preserve existing behavior for:
    - Bare Anthropic aliases like `"opus-4.6"` / `"sonnet-4.6"`;
    - Vercel Anthropic shorthands (e.g. `vercel-ai-gateway/opus-4.6`);
    - Downstream consumers (`normalizeModelRef`, `parseModelRef`) that rely on canonical `claude-*` IDs.

### Rationale

- The `ReferenceError` in #44854 is a classic TDZ problem: `normalizeAnthropicModelId` is executed in a bundle before the module-level `ANTHROPIC_MODEL_ALIASES` constant has been initialized.
- Moving the alias map into a function-local constant ensures the map is created within the same execution frame as the function call, independent of module initialization order.
- The alias table is small, so the per-call allocation cost is negligible compared to removing a recurring runtime error in config loading and context pruning defaults.

### Testing

- **Unit tests**

  - Attempted to run:

    ```bash
    pnpm test -- src/agents/model-selection.test.ts --run
    ```

  - On this environment, the test suite fails to start due to a missing external dev dependency:

    ```text
    Error: Cannot find package '@mariozechner/pi-ai/oauth' imported from src/agents/auth-profiles/oauth.ts
    ```

  - This pre-existing dependency issue is unrelated to the change in `model-selection.ts`. The refactor keeps the observable behavior of model alias resolution and `parseModelRef` unchanged.

- **Behavioral consistency**

  - Existing tests for `parseModelRef` already cover Anthropic alias normalization (e.g. `"opus-4.6"` / `"sonnet-4.6"`, Vercel shorthands). The new implementation preserves these mappings; only the storage location of the alias table changed.

### Impact

- Removes the non-fatal but noisy `ReferenceError` seen when loading config and applying context pruning defaults for Anthropic profiles.
- Ensures context pruning defaults can be applied without TDZ issues in bundled builds.
- No changes to public configuration surface, schemas, or documented behavior.
- No version bump or release flow changes.

### Related

- #44854

