### PR TITLE
fix(agents): compact Kimi tool schemas for openai-completions

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -454,6 +454,42 @@ describe("createOpenClawCodingTools", () => {
       expect(violations).toEqual([]);
     }
   });
+  it("compacts tool schemas for Kimi-compatible OpenAI models", () => {
+    const openAiTools = createOpenClawCodingTools({
+      modelProvider: "openai",
+      modelId: "gpt-5",
+      senderIsOwner: true,
+    });
+    const kimiTools = createOpenClawCodingTools({
+      modelProvider: "nvidia-nim",
+      modelId: "moonshotai/kimi-k2.5",
+      senderIsOwner: true,
+    });
+
+    const totalSchemaSize = (tools: Array<{ parameters: unknown }>) =>
+      tools.reduce((sum, tool) => sum + JSON.stringify(tool.parameters ?? {}).length, 0);
+
+    expect(totalSchemaSize(kimiTools)).toBeLessThan(totalSchemaSize(openAiTools));
+
+    const openAiSessionsSpawn = openAiTools.find((tool) => tool.name === "sessions_spawn");
+    const kimiSessionsSpawn = kimiTools.find((tool) => tool.name === "sessions_spawn");
+    expect(openAiSessionsSpawn).toBeDefined();
+    expect(kimiSessionsSpawn).toBeDefined();
+
+    const openAiParameters = openAiSessionsSpawn?.parameters as {
+      properties?: Record<string, unknown>;
+    };
+    const kimiParameters = kimiSessionsSpawn?.parameters as {
+      properties?: Record<string, unknown>;
+    };
+
+    expect(openAiParameters.properties?.resumeSessionId).toBeDefined();
+    expect(openAiParameters.properties?.attachments).toBeDefined();
+    expect(openAiParameters.properties?.attachAs).toBeDefined();
+    expect(kimiParameters.properties?.resumeSessionId).toBeUndefined();
+    expect(kimiParameters.properties?.attachments).toBeUndefined();
+    expect(kimiParameters.properties?.attachAs).toBeUndefined();
+  });
   it("applies sandbox path guards to file_path alias", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sbx-"));
     const outsidePath = path.join(os.tmpdir(), "openclaw-outside.txt");

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -1,5 +1,6 @@
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { cleanSchemaForGemini } from "./schema/clean-for-gemini.js";
+import { compactToolSchemaForKimi, isKimiSchemaCompactionTarget } from "./schema/clean-for-kimi.js";
 import { isXaiProvider, stripXaiUnsupportedKeywords } from "./schema/clean-for-xai.js";
 
 function extractEnumValues(schema: unknown): unknown[] | undefined {
@@ -89,15 +90,20 @@ export function normalizeToolParameters(
     options?.modelProvider?.toLowerCase().includes("gemini");
   const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
   const isXai = isXaiProvider(options?.modelProvider, options?.modelId);
+  const isKimiSchemaTarget = isKimiSchemaCompactionTarget(options?.modelProvider, options?.modelId);
 
   function applyProviderCleaning(s: unknown): unknown {
+    let cleaned = s;
     if (isGeminiProvider && !isAnthropicProvider) {
-      return cleanSchemaForGemini(s);
+      cleaned = cleanSchemaForGemini(cleaned);
     }
     if (isXai) {
-      return stripXaiUnsupportedKeywords(s);
+      cleaned = stripXaiUnsupportedKeywords(cleaned);
     }
-    return s;
+    if (isKimiSchemaTarget) {
+      cleaned = compactToolSchemaForKimi(cleaned, { toolName: tool.name });
+    }
+    return cleaned;
   }
 
   // If schema already has type + properties (no top-level anyOf to merge),

--- a/src/agents/schema/clean-for-kimi.test.ts
+++ b/src/agents/schema/clean-for-kimi.test.ts
@@ -59,6 +59,49 @@ describe("clean-for-kimi", () => {
     expect(count?.maximum).toBeUndefined();
   });
 
+  it("inlines local refs before dropping defs", () => {
+    const cleaned = compactToolSchemaForKimi({
+      type: "object",
+      properties: {
+        child: { $ref: "#/$defs/Child" },
+      },
+      $defs: {
+        Child: {
+          type: "object",
+          description: "Child payload",
+          properties: {
+            name: {
+              type: "string",
+              minLength: 1,
+            },
+          },
+        },
+      },
+    }) as {
+      $defs?: unknown;
+      properties?: Record<string, unknown>;
+    };
+
+    const child = cleaned.properties?.child as
+      | {
+          $ref?: unknown;
+          description?: unknown;
+          properties?: Record<string, unknown>;
+        }
+      | undefined;
+    const name = child?.properties?.name as
+      | {
+          minLength?: unknown;
+        }
+      | undefined;
+
+    expect(cleaned.$defs).toBeUndefined();
+    expect(child?.$ref).toBeUndefined();
+    expect(child?.description).toBeUndefined();
+    expect(child?.properties?.name).toBeDefined();
+    expect(name?.minLength).toBeUndefined();
+  });
+
   it("omits heavyweight sessions_spawn parameters", () => {
     const cleaned = compactToolSchemaForKimi(
       {
@@ -100,7 +143,8 @@ describe("clean-for-kimi", () => {
   it("targets Kimi-compatible OpenAI models but not kimi-coding", () => {
     expect(isKimiSchemaCompactionTarget("nvidia-nim", "moonshotai/kimi-k2.5")).toBe(true);
     expect(isKimiSchemaCompactionTarget("openrouter", "@preset/kimi-2-5")).toBe(true);
-    expect(isKimiSchemaCompactionTarget("moonshot")).toBe(true);
+    expect(isKimiSchemaCompactionTarget("moonshot")).toBe(false);
+    expect(isKimiSchemaCompactionTarget("moonshot", "kimi-k2.5")).toBe(true);
     expect(isKimiSchemaCompactionTarget("moonshot", "moonshot-v1-8k")).toBe(false);
     expect(isKimiSchemaCompactionTarget("kimi-coding", "kimi-k2.5")).toBe(false);
     expect(isKimiSchemaCompactionTarget("anthropic", "claude-sonnet-4-6")).toBe(false);

--- a/src/agents/schema/clean-for-kimi.test.ts
+++ b/src/agents/schema/clean-for-kimi.test.ts
@@ -146,6 +146,7 @@ describe("clean-for-kimi", () => {
     expect(isKimiSchemaCompactionTarget("moonshot")).toBe(false);
     expect(isKimiSchemaCompactionTarget("moonshot", "kimi-k2.5")).toBe(true);
     expect(isKimiSchemaCompactionTarget("moonshot", "moonshot-v1-8k")).toBe(false);
+    expect(isKimiSchemaCompactionTarget("kimi-code", "kimi-k2.5")).toBe(false);
     expect(isKimiSchemaCompactionTarget("kimi-coding", "kimi-k2.5")).toBe(false);
     expect(isKimiSchemaCompactionTarget("anthropic", "claude-sonnet-4-6")).toBe(false);
     expect(isKimiSchemaCompactionTarget("openai", "gpt-5")).toBe(false);

--- a/src/agents/schema/clean-for-kimi.test.ts
+++ b/src/agents/schema/clean-for-kimi.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { compactToolSchemaForKimi, isKimiSchemaCompactionTarget } from "./clean-for-kimi.js";
+
+describe("clean-for-kimi", () => {
+  it("strips verbose schema metadata and validation noise recursively", () => {
+    const cleaned = compactToolSchemaForKimi({
+      type: "object",
+      description: "Top level",
+      properties: {
+        path: {
+          type: "string",
+          description: "Filesystem path",
+          minLength: 1,
+        },
+        options: {
+          type: "object",
+          title: "Options",
+          additionalProperties: true,
+          properties: {
+            count: {
+              type: "number",
+              minimum: 1,
+              maximum: 5,
+            },
+          },
+        },
+      },
+    }) as {
+      description?: unknown;
+      properties?: Record<string, unknown>;
+    };
+
+    const path = cleaned.properties?.path as
+      | {
+          description?: unknown;
+          minLength?: unknown;
+        }
+      | undefined;
+    const options = cleaned.properties?.options as
+      | {
+          title?: unknown;
+          additionalProperties?: unknown;
+          properties?: Record<string, unknown>;
+        }
+      | undefined;
+    const count = options?.properties?.count as
+      | {
+          minimum?: unknown;
+          maximum?: unknown;
+        }
+      | undefined;
+
+    expect(cleaned.description).toBeUndefined();
+    expect(path?.description).toBeUndefined();
+    expect(path?.minLength).toBeUndefined();
+    expect(options?.title).toBeUndefined();
+    expect(options?.additionalProperties).toBeUndefined();
+    expect(count?.minimum).toBeUndefined();
+    expect(count?.maximum).toBeUndefined();
+  });
+
+  it("omits heavyweight sessions_spawn parameters", () => {
+    const cleaned = compactToolSchemaForKimi(
+      {
+        type: "object",
+        required: ["task", "attachments"],
+        properties: {
+          task: { type: "string" },
+          resumeSessionId: { type: "string", description: "resume" },
+          attachments: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+              },
+            },
+          },
+          attachAs: {
+            type: "object",
+            properties: {
+              mountPath: { type: "string" },
+            },
+          },
+        },
+      },
+      { toolName: "sessions_spawn" },
+    ) as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+
+    expect(cleaned.properties?.task).toBeDefined();
+    expect(cleaned.properties?.resumeSessionId).toBeUndefined();
+    expect(cleaned.properties?.attachments).toBeUndefined();
+    expect(cleaned.properties?.attachAs).toBeUndefined();
+    expect(cleaned.required).toEqual(["task"]);
+  });
+
+  it("targets Kimi-compatible OpenAI models but not kimi-coding", () => {
+    expect(isKimiSchemaCompactionTarget("nvidia-nim", "moonshotai/kimi-k2.5")).toBe(true);
+    expect(isKimiSchemaCompactionTarget("openrouter", "@preset/kimi-2-5")).toBe(true);
+    expect(isKimiSchemaCompactionTarget("moonshot")).toBe(true);
+    expect(isKimiSchemaCompactionTarget("moonshot", "moonshot-v1-8k")).toBe(false);
+    expect(isKimiSchemaCompactionTarget("kimi-coding", "kimi-k2.5")).toBe(false);
+    expect(isKimiSchemaCompactionTarget("anthropic", "claude-sonnet-4-6")).toBe(false);
+    expect(isKimiSchemaCompactionTarget("openai", "gpt-5")).toBe(false);
+  });
+});

--- a/src/agents/schema/clean-for-kimi.ts
+++ b/src/agents/schema/clean-for-kimi.ts
@@ -1,0 +1,137 @@
+const KIMI_NOISY_SCHEMA_KEYS = new Set([
+  "$schema",
+  "$id",
+  "$defs",
+  "definitions",
+  "description",
+  "title",
+  "default",
+  "examples",
+  "minLength",
+  "maxLength",
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "multipleOf",
+  "pattern",
+  "format",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+  "minProperties",
+  "maxProperties",
+  "contentEncoding",
+  "contentMediaType",
+]);
+
+const KIMI_SESSIONS_SPAWN_OMIT_PROPERTIES = new Set(["resumeSessionId", "attachments", "attachAs"]);
+
+function compactSchemaNode(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+  if (Array.isArray(schema)) {
+    return schema.map((entry) => compactSchemaNode(entry));
+  }
+
+  const obj = schema as Record<string, unknown>;
+  const cleaned: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (KIMI_NOISY_SCHEMA_KEYS.has(key)) {
+      continue;
+    }
+    if (key === "additionalProperties" && value === true) {
+      continue;
+    }
+    if (
+      key === "type" &&
+      Array.isArray(value) &&
+      value.every((entry) => typeof entry === "string")
+    ) {
+      const nonNullTypes = value.filter((entry) => entry !== "null");
+      cleaned[key] =
+        nonNullTypes.length === 1
+          ? nonNullTypes[0]
+          : nonNullTypes.length > 0
+            ? nonNullTypes
+            : value;
+      continue;
+    }
+    if (key === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
+      cleaned[key] = Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([propertyName, propertySchema]) => [
+          propertyName,
+          compactSchemaNode(propertySchema),
+        ]),
+      );
+      continue;
+    }
+    if (key === "items" && value && typeof value === "object") {
+      cleaned[key] = Array.isArray(value)
+        ? value.map((entry) => compactSchemaNode(entry))
+        : compactSchemaNode(value);
+      continue;
+    }
+    if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
+      cleaned[key] = value.map((entry) => compactSchemaNode(entry));
+      continue;
+    }
+    cleaned[key] = value;
+  }
+
+  return cleaned;
+}
+
+export function compactToolSchemaForKimi(
+  schema: unknown,
+  options?: { toolName?: string },
+): unknown {
+  const compacted = compactSchemaNode(schema);
+  if (
+    options?.toolName !== "sessions_spawn" ||
+    !compacted ||
+    typeof compacted !== "object" ||
+    Array.isArray(compacted)
+  ) {
+    return compacted;
+  }
+
+  const record = compacted as Record<string, unknown>;
+  const properties =
+    record.properties && typeof record.properties === "object" && !Array.isArray(record.properties)
+      ? (record.properties as Record<string, unknown>)
+      : undefined;
+
+  if (!properties) {
+    return compacted;
+  }
+
+  const nextProperties = Object.fromEntries(
+    Object.entries(properties).filter(([key]) => !KIMI_SESSIONS_SPAWN_OMIT_PROPERTIES.has(key)),
+  );
+  const nextRequired = Array.isArray(record.required)
+    ? record.required.filter(
+        (entry) => typeof entry !== "string" || !KIMI_SESSIONS_SPAWN_OMIT_PROPERTIES.has(entry),
+      )
+    : record.required;
+
+  return {
+    ...record,
+    properties: nextProperties,
+    ...(Array.isArray(nextRequired) ? { required: nextRequired } : {}),
+  };
+}
+
+export function isKimiSchemaCompactionTarget(modelProvider?: string, modelId?: string): boolean {
+  const provider = modelProvider?.trim().toLowerCase() ?? "";
+  if (provider.includes("kimi-coding") || provider.includes("anthropic")) {
+    return false;
+  }
+  const normalizedModelId = modelId?.trim().toLowerCase() ?? "";
+  if (normalizedModelId.length === 0) {
+    return provider === "moonshot";
+  }
+  return normalizedModelId.includes("kimi");
+}

--- a/src/agents/schema/clean-for-kimi.ts
+++ b/src/agents/schema/clean-for-kimi.ts
@@ -27,15 +27,82 @@ const KIMI_NOISY_SCHEMA_KEYS = new Set([
 
 const KIMI_SESSIONS_SPAWN_OMIT_PROPERTIES = new Set(["resumeSessionId", "attachments", "attachAs"]);
 
-function compactSchemaNode(schema: unknown): unknown {
+type SchemaDefs = Map<string, unknown>;
+
+function extendSchemaDefs(
+  defs: SchemaDefs | undefined,
+  schema: Record<string, unknown>,
+): SchemaDefs | undefined {
+  const defsEntry =
+    schema.$defs && typeof schema.$defs === "object" && !Array.isArray(schema.$defs)
+      ? (schema.$defs as Record<string, unknown>)
+      : undefined;
+  const legacyDefsEntry =
+    schema.definitions &&
+    typeof schema.definitions === "object" &&
+    !Array.isArray(schema.definitions)
+      ? (schema.definitions as Record<string, unknown>)
+      : undefined;
+
+  if (!defsEntry && !legacyDefsEntry) {
+    return defs;
+  }
+
+  const next = defs ? new Map(defs) : new Map<string, unknown>();
+  if (defsEntry) {
+    for (const [key, value] of Object.entries(defsEntry)) {
+      next.set(key, value);
+    }
+  }
+  if (legacyDefsEntry) {
+    for (const [key, value] of Object.entries(legacyDefsEntry)) {
+      next.set(key, value);
+    }
+  }
+  return next;
+}
+
+function decodeJsonPointerSegment(segment: string): string {
+  return segment.replaceAll("~1", "/").replaceAll("~0", "~");
+}
+
+function tryResolveLocalRef(ref: string, defs: SchemaDefs | undefined): unknown {
+  if (!defs) {
+    return undefined;
+  }
+  const match = ref.match(/^#\/(?:\$defs|definitions)\/(.+)$/);
+  if (!match) {
+    return undefined;
+  }
+  const name = decodeJsonPointerSegment(match[1] ?? "");
+  return name ? defs.get(name) : undefined;
+}
+
+function compactSchemaNode(schema: unknown, defs?: SchemaDefs, refStack?: Set<string>): unknown {
   if (!schema || typeof schema !== "object") {
     return schema;
   }
   if (Array.isArray(schema)) {
-    return schema.map((entry) => compactSchemaNode(entry));
+    return schema.map((entry) => compactSchemaNode(entry, defs, refStack));
   }
 
   const obj = schema as Record<string, unknown>;
+  const nextDefs = extendSchemaDefs(defs, obj);
+  const refValue = typeof obj.$ref === "string" ? obj.$ref : undefined;
+  if (refValue) {
+    if (refStack?.has(refValue)) {
+      return {};
+    }
+    const resolved = tryResolveLocalRef(refValue, nextDefs);
+    if (resolved !== undefined) {
+      const nextRefStack = refStack ? new Set(refStack) : new Set<string>();
+      nextRefStack.add(refValue);
+      return compactSchemaNode(resolved, nextDefs, nextRefStack);
+    }
+    const { $ref: _ignoredRef, ...rest } = obj;
+    return compactSchemaNode(rest, nextDefs, refStack);
+  }
+
   const cleaned: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(obj)) {
@@ -63,19 +130,19 @@ function compactSchemaNode(schema: unknown): unknown {
       cleaned[key] = Object.fromEntries(
         Object.entries(value as Record<string, unknown>).map(([propertyName, propertySchema]) => [
           propertyName,
-          compactSchemaNode(propertySchema),
+          compactSchemaNode(propertySchema, nextDefs, refStack),
         ]),
       );
       continue;
     }
     if (key === "items" && value && typeof value === "object") {
       cleaned[key] = Array.isArray(value)
-        ? value.map((entry) => compactSchemaNode(entry))
-        : compactSchemaNode(value);
+        ? value.map((entry) => compactSchemaNode(entry, nextDefs, refStack))
+        : compactSchemaNode(value, nextDefs, refStack);
       continue;
     }
     if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
-      cleaned[key] = value.map((entry) => compactSchemaNode(entry));
+      cleaned[key] = value.map((entry) => compactSchemaNode(entry, nextDefs, refStack));
       continue;
     }
     cleaned[key] = value;
@@ -130,8 +197,5 @@ export function isKimiSchemaCompactionTarget(modelProvider?: string, modelId?: s
     return false;
   }
   const normalizedModelId = modelId?.trim().toLowerCase() ?? "";
-  if (normalizedModelId.length === 0) {
-    return provider === "moonshot";
-  }
-  return normalizedModelId.includes("kimi");
+  return normalizedModelId.length > 0 && normalizedModelId.includes("kimi");
 }

--- a/src/agents/schema/clean-for-kimi.ts
+++ b/src/agents/schema/clean-for-kimi.ts
@@ -1,3 +1,5 @@
+import { normalizeProviderId } from "../model-selection.js";
+
 const KIMI_NOISY_SCHEMA_KEYS = new Set([
   "$schema",
   "$id",
@@ -192,7 +194,7 @@ export function compactToolSchemaForKimi(
 }
 
 export function isKimiSchemaCompactionTarget(modelProvider?: string, modelId?: string): boolean {
-  const provider = modelProvider?.trim().toLowerCase() ?? "";
+  const provider = modelProvider ? normalizeProviderId(modelProvider) : "";
   if (provider.includes("kimi-coding") || provider.includes("anthropic")) {
     return false;
   }


### PR DESCRIPTION
Fixes #44549

## Summary

Kimi models behind OpenAI-compatible providers started failing tool calls after the 2026.3.x tool-schema growth, especially on `sessions_spawn` and other large tool payloads. Compared with `v2026.2.25`, the current function schemas carry substantially more metadata and heavyweight optional branches, which appears to push `kimi-k2.5` into emitting malformed tool calls instead of standard OpenAI function-call payloads.

This change adds a Kimi-specific schema compaction pass for OpenAI-compatible tool payloads:
- strip verbose JSON Schema metadata and validation noise before sending tools to Kimi-compatible models
- omit the heaviest optional `sessions_spawn` branches (`resumeSessionId`, `attachments`, `attachAs`) for those models
- keep the full schema shape for other providers/models

## Why this approach

This keeps the 2026.3.x feature set intact for providers that handle the richer schemas correctly, while sending a smaller and more stable function schema to Kimi-compatible backends that regress on the larger payload.

## Verification

Ran targeted regression checks:

- `pnpm exec oxfmt --check src/agents/schema/clean-for-kimi.ts src/agents/schema/clean-for-kimi.test.ts src/agents/pi-tools.schema.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts`
- `pnpm exec vitest run src/agents/schema/clean-for-kimi.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts -t "clean-for-kimi|compacts tool schemas for Kimi-compatible OpenAI models"`

## Notes

AI-assisted: implemented with Codex.
