### PR TITLE
fix: ANTHROPIC_MODEL_ALIASES TDZ ReferenceError

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -31,13 +31,6 @@ export type ModelAliasIndex = {
   byKey: Map<string, string[]>;
 };
 
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
-};
-
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();
 }
@@ -146,6 +139,12 @@ export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
 }
 
 function normalizeAnthropicModelId(model: string): string {
+  const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
+    "opus-4.6": "claude-opus-4-6",
+    "opus-4.5": "claude-opus-4-5",
+    "sonnet-4.6": "claude-sonnet-4-6",
+    "sonnet-4.5": "claude-sonnet-4-5",
+  };
   const trimmed = model.trim();
   if (!trimmed) {
     return trimmed;

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -139,7 +139,7 @@ export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
 }
 
 function normalizeAnthropicModelId(model: string): string {
-  const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
+  const anthropicModelAliases: Record<string, string> = {
     "opus-4.6": "claude-opus-4-6",
     "opus-4.5": "claude-opus-4-5",
     "sonnet-4.6": "claude-sonnet-4-6",
@@ -150,7 +150,7 @@ function normalizeAnthropicModelId(model: string): string {
     return trimmed;
   }
   const lower = trimmed.toLowerCase();
-  return ANTHROPIC_MODEL_ALIASES[lower] ?? trimmed;
+  return anthropicModelAliases[lower] ?? trimmed;
 }
 
 function normalizeProviderModelId(provider: string, model: string): string {


### PR DESCRIPTION
## Summary

- Fixes #44854 — every CLI invocation after upgrading to 2026.3.12 logs `ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization`
- Root cause: circular dependency between `src/config/defaults.ts` and `src/agents/model-selection.ts` causes the bundler to evaluate `normalizeAnthropicModelId` (hoisted function declaration) before the module-level `const ANTHROPIC_MODEL_ALIASES` is initialized (TDZ)
- Fix: move `ANTHROPIC_MODEL_ALIASES` inside `normalizeAnthropicModelId` so the map is initialized at call time, not module-init time — eliminates the TDZ regardless of bundle evaluation order

## Test plan

- [x] `pnpm build` succeeds with no warnings
- [x] `pnpm check` passes (lint + format)
- [x] `pnpm test` — all 917 test files pass (7579 tests)
- [ ] Manual: build and run `openclaw status` — ReferenceError no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>