### PR TITLE
fix(ios): respect explicit TLS choice for manual gateway connections

### DIFF
--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -189,6 +189,7 @@ final class ShareViewController: UIViewController {
             try await gateway.connect(
                 url: url,
                 token: config.token,
+                bootstrapToken: nil,
                 password: config.password,
                 connectOptions: makeOptions("openclaw-ios"),
                 sessionBox: nil,
@@ -208,6 +209,7 @@ final class ShareViewController: UIViewController {
             try await gateway.connect(
                 url: url,
                 token: config.token,
+                bootstrapToken: nil,
                 password: config.password,
                 connectOptions: makeOptions("moltbot-ios"),
                 sessionBox: nil,

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -678,8 +678,10 @@ final class GatewayConnectionController {
         return components.url
     }
 
-    private func resolveManualUseTLS(host: String, useTLS: Bool) -> Bool {
-        useTLS || self.shouldRequireTLS(host: host)
+    // Manual gateway connections carry an explicit TLS choice from the user or setup code.
+    // Do not silently upgrade based on the host, or ws:// LAN gateways become unreachable.
+    private func resolveManualUseTLS(host _: String, useTLS: Bool) -> Bool {
+        return useTLS
     }
 
     private func shouldRequireTLS(host: String) -> Bool {

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -5,6 +5,7 @@ import Testing
 @testable import OpenClaw
 
 @Suite(.serialized) struct GatewayConnectionSecurityTests {
+    @MainActor
     private func makeController() -> GatewayConnectionController {
         GatewayConnectionController(appModel: NodeAppModel(), startDiscovery: false)
     }
@@ -103,12 +104,13 @@ import Testing
         #expect(controller._test_didAutoConnect() == false)
     }
 
-    @Test @MainActor func manualConnectionsForceTLSForNonLoopbackHosts() async {
+    @Test @MainActor func manualConnectionsRespectExplicitTLSChoice() async {
         let controller = makeController()
 
-        #expect(controller._test_resolveManualUseTLS(host: "gateway.example.com", useTLS: false) == true)
-        #expect(controller._test_resolveManualUseTLS(host: "openclaw.local", useTLS: false) == true)
-        #expect(controller._test_resolveManualUseTLS(host: "127.attacker.example", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "gateway.example.com", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "openclaw.local", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "127.attacker.example", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "gateway.example.com", useTLS: true) == true)
 
         #expect(controller._test_resolveManualUseTLS(host: "localhost", useTLS: false) == false)
         #expect(controller._test_resolveManualUseTLS(host: "127.0.0.1", useTLS: false) == false)


### PR DESCRIPTION
## Summary

- Problem: manual iOS gateway connections forced TLS for non-loopback hosts even when the user or setup code explicitly set `tls=false`.
- Why it matters: setup-code pairing against LAN `ws://` gateways failed before bootstrap because the app tried `wss://...` instead.
- What changed: manual connections now respect the explicit TLS choice, and a regression test covers this case.
- What did NOT change (scope boundary): discovered gateway trust / pinning behavior is unchanged.
- This PR also includes the minimal `bootstrapToken: nil` ShareExtension call-site fix required to keep the iOS build green with the current `GatewayNodeSession.connect(...)` signature.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: none
- Related: none

## User-visible / Behavior Changes

- iOS manual gateway/setup-code connections now honor explicit `tls=false` instead of silently switching to TLS for non-loopback hosts.
- Plaintext LAN `ws://` gateways can now bootstrap and pair from iOS as intended.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Xcode test runner
- Model/provider: N/A
- Integration/channel (if any): iOS app connecting to a local OpenClaw Gateway over LAN
- Relevant config (redacted): setup code with explicit `tls=false`; gateway reachable via `ws://<lan-host>:18789`

### Steps

1. Run a local gateway over `ws://`.
2. Generate a setup code with `tls=false`.
3. Connect from the iOS app using that setup code.

### Expected

- The app should respect the explicit TLS choice, connect over `ws://`, and complete bootstrap/pairing.

### Actual

- The app upgraded the manual connection to `wss://...` and failed before bootstrap.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted verification command:

```bash
cd apps/ios && xcodebuild test -project OpenClaw.xcodeproj -scheme OpenClaw -destination 'id=3531FE90-17C2-465C-8DE6-FAD22800FDB2' -only-testing:OpenClawTests/GatewayConnectionSecurityTests
```

Result: `5/5` tests passed, `** TEST SUCCEEDED **`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: setup-code connection to a LAN `ws://` gateway succeeds after the fix; targeted regression tests pass.
- Edge cases checked: explicit `useTLS=true` still stays true; existing manual tailnet TLS port behavior test still passes.
- What you did **not** verify: full-repo `pnpm build && pnpm check && pnpm test`.

## AI Assistance

- [x] AI-assisted
- Testing: targeted real-device/manual repro plus targeted regression coverage

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `apps/ios/Sources/Gateway/GatewayConnectionController.swift`, `apps/ios/Tests/GatewayConnectionSecurityTests.swift`, `apps/ios/ShareExtension/ShareViewController.swift`
- Known bad symptoms reviewers should watch for: manual iOS gateway connections unexpectedly switch to `wss://` when explicitly configured for `ws://`.

## Risks and Mitigations

- Risk: manual non-loopback connections no longer auto-upgrade to TLS.
  - Mitigation: this path now follows the explicit user/setup-code choice; discovered gateway trust behavior is unchanged.
