### PR TITLE
feat(exec): propagate NO_DNA to child commands

### DIFF
--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -276,6 +276,7 @@ Security note:
   - local mode: env (`OPENCLAW_GATEWAY_*`) -> `gateway.auth.*` -> `gateway.remote.*` fallback only when `gateway.auth.*` is unset (configured-but-unresolved local SecretRefs fail closed)
   - remote mode: `gateway.remote.*` with env/config fallback per remote precedence rules
   - `--url` is override-safe and does not reuse implicit config/env credentials; pass explicit `--token`/`--password` (or file variants)
+- ACP child processes spawned by OpenClaw receive `NO_DNA=1` and `OPENCLAW_CLI=1`.
 - ACP runtime backend child processes receive `OPENCLAW_SHELL=acp`, which can be used for context-specific shell/profile rules.
 - `openclaw acp client` sets `OPENCLAW_SHELL=acp-client` on the spawned bridge process.
 

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -60,6 +60,8 @@ Env var equivalents:
 
 OpenClaw also injects context markers into spawned child processes:
 
+- `NO_DNA=1`: set for child commands spawned by OpenClaw command runners.
+- `OPENCLAW_CLI=1`: set for child commands spawned by OpenClaw command runners.
 - `OPENCLAW_SHELL=exec`: set for commands run through the `exec` tool.
 - `OPENCLAW_SHELL=acp`: set for ACP runtime backend process spawns (for example `acpx`).
 - `OPENCLAW_SHELL=acp-client`: set for `openclaw acp client` when it spawns the ACP bridge process.
@@ -67,6 +69,9 @@ OpenClaw also injects context markers into spawned child processes:
 
 These are runtime markers (not required user config). They can be used in shell/profile logic
 to apply context-specific rules.
+
+OpenClaw adds these markers to spawned child processes only. It does not set `NO_DNA` on startup
+unless the parent environment already exported it.
 
 ## UI env vars
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -40,7 +40,8 @@ Notes:
   then falls back to Windows PowerShell 5.1.
 - Host execution (`gateway`/`node`) rejects `env.PATH` and loader overrides (`LD_*`/`DYLD_*`) to
   prevent binary hijacking or injected code.
-- OpenClaw sets `OPENCLAW_SHELL=exec` in the spawned command environment (including PTY and sandbox execution) so shell/profile rules can detect exec-tool context.
+- OpenClaw sets `NO_DNA=1` and `OPENCLAW_CLI=1` in the spawned command environment (including PTY and sandbox execution).
+- OpenClaw sets `OPENCLAW_SHELL=exec` in the spawned command environment so shell/profile rules can detect exec-tool context.
 - Important: sandboxing is **off by default**. If sandboxing is off and `host=sandbox` is explicitly
   configured/requested, exec now fails closed instead of silently running on the gateway host.
   Enable sandboxing or use `host=gateway` with approvals.

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -114,6 +114,7 @@ Other Gateway slash commands (for example, `/context`) are forwarded to the Gate
 - Prefix a line with `!` to run a local shell command on the TUI host.
 - The TUI prompts once per session to allow local execution; declining keeps `!` disabled for the session.
 - Commands run in a fresh, non-interactive shell in the TUI working directory (no persistent `cd`/env).
+- Local shell commands receive `NO_DNA=1` and `OPENCLAW_CLI=1` in their environment.
 - Local shell commands receive `OPENCLAW_SHELL=tui-local` in their environment.
 - A lone `!` is sent as a normal message; leading spaces do not trigger local exec.
 

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { NO_DNA_ENV_VALUE, OPENCLAW_CLI_ENV_VALUE } from "../infra/openclaw-exec-env.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
   buildAcpClientStripKeys,
@@ -54,6 +55,8 @@ describe("resolveAcpClientSpawnEnv", () => {
     });
 
     expect(env.OPENCLAW_SHELL).toBe("acp-client");
+    expect(env.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
+    expect(env.NO_DNA).toBe(NO_DNA_ENV_VALUE);
     expect(env.PATH).toBe("/usr/bin");
     expect(env.USER).toBe("openclaw");
   });

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -14,6 +14,7 @@ import {
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import { isKnownCoreToolId } from "../agents/tool-catalog.js";
+import { markOpenClawChildCommandEnv } from "../infra/openclaw-exec-env.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import {
   materializeWindowsSpawnProgram,
@@ -373,7 +374,9 @@ export function resolveAcpClientSpawnEnv(
   baseEnv: NodeJS.ProcessEnv = process.env,
   options: AcpClientSpawnEnvOptions = {},
 ): NodeJS.ProcessEnv {
-  const env = omitEnvKeysCaseInsensitive(baseEnv, options.stripKeys ?? []);
+  const env = markOpenClawChildCommandEnv(
+    omitEnvKeysCaseInsensitive(baseEnv, options.stripKeys ?? []),
+  );
   env.OPENCLAW_SHELL = "acp-client";
   return env;
 }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -4,6 +4,7 @@ import { Type } from "@sinclair/typebox";
 import { type ExecHost } from "../infra/exec-approvals.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
+import { markOpenClawChildCommandEnv } from "../infra/openclaw-exec-env.js";
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
@@ -310,10 +311,10 @@ export async function runExecProcess(opts: {
   const sessionId = createSessionSlug();
   const execCommand = opts.execCommand ?? opts.command;
   const supervisor = getProcessSupervisor();
-  const shellRuntimeEnv: Record<string, string> = {
+  const shellRuntimeEnv: Record<string, string> = markOpenClawChildCommandEnv({
     ...opts.env,
     OPENCLAW_SHELL: "exec",
-  };
+  });
 
   const session: ProcessSession = {
     id: sessionId,

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -109,6 +109,20 @@ describe("exec PATH login shell merge", () => {
     expect(value).toBe("exec");
   });
 
+  it("sets NO_DNA for host=gateway commands", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+    const result = await tool.execute("call-no-dna", {
+      command: 'printf "%s" "${NO_DNA:-}"',
+    });
+    const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(value).toBe("1");
+  });
+
   it("throws security violation when env.PATH is provided", async () => {
     if (isWin) {
       return;

--- a/src/agents/bash-tools.exec.pty.test.ts
+++ b/src/agents/bash-tools.exec.pty.test.ts
@@ -29,3 +29,15 @@ test("exec sets OPENCLAW_SHELL in pty mode", async () => {
   const text = result.content?.find((item) => item.type === "text")?.text ?? "";
   expect(text).toContain("exec");
 });
+
+test("exec sets NO_DNA in pty mode", async () => {
+  const tool = createExecTool({ allowBackground: false, security: "full", ask: "off" });
+  const result = await tool.execute("toolcall-no-dna", {
+    command: "node -e \"process.stdout.write('NO_DNA=' + (process.env.NO_DNA || ''))\"",
+    pty: true,
+  });
+
+  expect(result.details.status).toBe("completed");
+  const text = result.content?.find((item) => item.type === "text")?.text ?? "";
+  expect(text).toContain("NO_DNA=1");
+});

--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -122,6 +122,7 @@ describe("buildSandboxCreateArgs", () => {
         `OPENCLAW_CLI=${OPENCLAW_CLI_ENV_VALUE}`,
       ]),
     );
+    expect(args).not.toContain("NO_DNA=1");
 
     const ulimitValues: string[] = [];
     for (let i = 0; i < args.length; i += 1) {
@@ -162,6 +163,7 @@ describe("buildSandboxCreateArgs", () => {
         `OPENCLAW_CLI=${OPENCLAW_CLI_ENV_VALUE}`,
       ]),
     );
+    expect(args).not.toContain("NO_DNA=1");
   });
 
   it("emits -v flags for safe custom binds", () => {

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -163,7 +163,7 @@ export function execDockerRaw(
 }
 
 import { formatCliCommand } from "../../cli/command-format.js";
-import { markOpenClawExecEnv } from "../../infra/openclaw-exec-env.js";
+import { markOpenClawCliEnv } from "../../infra/openclaw-exec-env.js";
 import { defaultRuntime } from "../../runtime.js";
 import { computeSandboxConfigHash } from "./config-hash.js";
 import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
@@ -375,7 +375,7 @@ export function buildSandboxCreateArgs(params: {
   if (envSanitization.warnings.length > 0) {
     log.warn(`Suspicious environment variables: ${envSanitization.warnings.join(", ")}`);
   }
-  for (const [key, value] of Object.entries(markOpenClawExecEnv(envSanitization.allowed))) {
+  for (const [key, value] of Object.entries(markOpenClawCliEnv(envSanitization.allowed))) {
     args.push("--env", `${key}=${value}`);
   }
   for (const cap of params.cfg.capDrop) {

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -11,7 +11,7 @@ import {
   sanitizeHostExecEnvWithDiagnostics,
   sanitizeSystemRunEnvOverrides,
 } from "./host-env-security.js";
-import { OPENCLAW_CLI_ENV_VALUE } from "./openclaw-exec-env.js";
+import { NO_DNA_ENV_VALUE, OPENCLAW_CLI_ENV_VALUE } from "./openclaw-exec-env.js";
 
 function getSystemGitPath() {
   if (process.platform === "win32") {
@@ -90,6 +90,7 @@ describe("sanitizeHostExecEnv", () => {
     });
 
     expect(env).toEqual({
+      NO_DNA: NO_DNA_ENV_VALUE,
       OPENCLAW_CLI: OPENCLAW_CLI_ENV_VALUE,
       PATH: "/usr/bin:/bin",
       OK: "1",
@@ -125,6 +126,7 @@ describe("sanitizeHostExecEnv", () => {
 
     expect(env.PATH).toBe("/usr/bin:/bin");
     expect(env.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
+    expect(env.NO_DNA).toBe(NO_DNA_ENV_VALUE);
     expect(env.BASH_ENV).toBeUndefined();
     expect(env.GIT_SSH_COMMAND).toBeUndefined();
     expect(env.GIT_EXEC_PATH).toBeUndefined();
@@ -154,6 +156,7 @@ describe("sanitizeHostExecEnv", () => {
 
     expect(env.PATH).toBe("/usr/bin:/bin");
     expect(env.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
+    expect(env.NO_DNA).toBe(NO_DNA_ENV_VALUE);
     expect(env.OK).toBe("1");
     expect(env.SHELLOPTS).toBeUndefined();
     expect(env.PS4).toBeUndefined();
@@ -173,10 +176,10 @@ describe("sanitizeHostExecEnv", () => {
 
     expect(env.GOOD_KEY).toBe("ok");
     expect(env.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
+    expect(env.NO_DNA).toBe(NO_DNA_ENV_VALUE);
     expect(env[" BAD KEY"]).toBeUndefined();
     expect(env["NOT-PORTABLE"]).toBeUndefined();
   });
-
   it("can allow PATH overrides when explicitly opted out of blocking", () => {
     const env = sanitizeHostExecEnv({
       baseEnv: {
@@ -190,6 +193,7 @@ describe("sanitizeHostExecEnv", () => {
 
     expect(env.PATH).toBe("/custom/bin");
     expect(env.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
+    expect(env.NO_DNA).toBe(NO_DNA_ENV_VALUE);
   });
 
   it("drops non-string inherited values while preserving non-portable inherited keys", () => {
@@ -205,12 +209,31 @@ describe("sanitizeHostExecEnv", () => {
     });
 
     expect(env).toEqual({
+      NO_DNA: NO_DNA_ENV_VALUE,
       OPENCLAW_CLI: OPENCLAW_CLI_ENV_VALUE,
       PATH: "/usr/bin:/bin",
       GOOD: "1",
       "NOT-PORTABLE": "x",
       "ProgramFiles(x86)": "C:\\Program Files (x86)",
     });
+  });
+
+  it("strips inherited NO_DNA when includeNoDna is false", () => {
+    const env = sanitizeHostExecEnv({
+      baseEnv: {
+        NO_DNA: NO_DNA_ENV_VALUE,
+        PATH: "/usr/bin:/bin",
+      },
+      includeNoDna: false,
+      overrides: {
+        no_dna: "override",
+      },
+    });
+
+    expect(env.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
+    expect(env.NO_DNA).toBeUndefined();
+    expect(env.no_dna).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin:/bin");
   });
 });
 

--- a/src/infra/host-env-security.ts
+++ b/src/infra/host-env-security.ts
@@ -1,5 +1,9 @@
 import HOST_ENV_SECURITY_POLICY_JSON from "./host-env-security-policy.json" with { type: "json" };
-import { markOpenClawExecEnv } from "./openclaw-exec-env.js";
+import {
+  markOpenClawChildCommandEnv,
+  markOpenClawCliEnv,
+  NO_DNA_ENV_VAR,
+} from "./openclaw-exec-env.js";
 
 const PORTABLE_ENV_VAR_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const WINDOWS_COMPAT_OVERRIDE_ENV_VAR_KEY = /^[A-Za-z_][A-Za-z0-9_()]*$/;
@@ -128,6 +132,7 @@ function sortUnique(values: Iterable<string>): string[] {
 function sanitizeHostEnvOverridesWithDiagnostics(params?: {
   overrides?: Record<string, string> | null;
   blockPathOverrides?: boolean;
+  includeNoDna?: boolean;
 }): {
   acceptedOverrides?: Record<string, string>;
   rejectedOverrideBlockedKeys: string[];
@@ -158,6 +163,10 @@ function sanitizeHostEnvOverridesWithDiagnostics(params?: {
       continue;
     }
     const upper = normalized.toUpperCase();
+    if (params?.includeNoDna === false && upper === NO_DNA_ENV_VAR) {
+      rejectedBlocked.push(upper);
+      continue;
+    }
     // PATH is part of the security boundary (command resolution + safe-bin checks). Never allow
     // request-scoped PATH overrides from agents/gateways.
     if (blockPathOverrides && upper === "PATH") {
@@ -182,18 +191,25 @@ export function sanitizeHostExecEnvWithDiagnostics(params?: {
   baseEnv?: Record<string, string | undefined>;
   overrides?: Record<string, string> | null;
   blockPathOverrides?: boolean;
+  includeNoDna?: boolean;
 }): HostExecEnvSanitizationResult {
   const baseEnv = params?.baseEnv ?? process.env;
+  const markExecEnv =
+    params?.includeNoDna === false ? markOpenClawCliEnv : markOpenClawChildCommandEnv;
 
   const merged: Record<string, string> = {};
   for (const [key, value] of listNormalizedEnvEntries(baseEnv)) {
     if (isDangerousHostEnvVarName(key)) {
       continue;
     }
+    if (params?.includeNoDna === false && key.toUpperCase() === NO_DNA_ENV_VAR) {
+      continue;
+    }
     merged[key] = value;
   }
 
   const overrideResult = sanitizeHostEnvOverridesWithDiagnostics({
+    includeNoDna: params?.includeNoDna,
     overrides: params?.overrides ?? undefined,
     blockPathOverrides: params?.blockPathOverrides ?? true,
   });
@@ -204,7 +220,7 @@ export function sanitizeHostExecEnvWithDiagnostics(params?: {
   }
 
   return {
-    env: markOpenClawExecEnv(merged),
+    env: markExecEnv(merged),
     rejectedOverrideBlockedKeys: overrideResult.rejectedOverrideBlockedKeys,
     rejectedOverrideInvalidKeys: overrideResult.rejectedOverrideInvalidKeys,
   };
@@ -213,6 +229,7 @@ export function sanitizeHostExecEnvWithDiagnostics(params?: {
 export function inspectHostExecEnvOverrides(params?: {
   overrides?: Record<string, string> | null;
   blockPathOverrides?: boolean;
+  includeNoDna?: boolean;
 }): HostExecEnvOverrideDiagnostics {
   const result = sanitizeHostEnvOverridesWithDiagnostics(params);
   return {
@@ -225,6 +242,7 @@ export function sanitizeHostExecEnv(params?: {
   baseEnv?: Record<string, string | undefined>;
   overrides?: Record<string, string> | null;
   blockPathOverrides?: boolean;
+  includeNoDna?: boolean;
 }): Record<string, string> {
   return sanitizeHostExecEnvWithDiagnostics(params).env;
 }

--- a/src/infra/openclaw-exec-env.test.ts
+++ b/src/infra/openclaw-exec-env.test.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
   ensureOpenClawExecMarkerOnProcess,
-  markOpenClawExecEnv,
+  markOpenClawChildCommandEnv,
+  markOpenClawCliEnv,
+  NO_DNA_ENV_VALUE,
   OPENCLAW_CLI_ENV_VALUE,
   OPENCLAW_CLI_ENV_VAR,
 } from "./openclaw-exec-env.js";
 
-describe("markOpenClawExecEnv", () => {
-  it("returns a cloned env object with the exec marker set", () => {
+describe("markOpenClawCliEnv", () => {
+  it("returns a cloned env object with the cli marker set", () => {
     const env = { PATH: "/usr/bin", OPENCLAW_CLI: "0" };
-    const marked = markOpenClawExecEnv(env);
+    const marked = markOpenClawCliEnv(env);
 
     expect(marked).toEqual({
       PATH: "/usr/bin",
@@ -20,26 +22,45 @@ describe("markOpenClawExecEnv", () => {
   });
 });
 
+describe("markOpenClawChildCommandEnv", () => {
+  it("adds child command markers", () => {
+    expect(markOpenClawChildCommandEnv({ PATH: "/usr/bin" })).toEqual({
+      NO_DNA: NO_DNA_ENV_VALUE,
+      OPENCLAW_CLI: OPENCLAW_CLI_ENV_VALUE,
+      PATH: "/usr/bin",
+    });
+  });
+});
+
 describe("ensureOpenClawExecMarkerOnProcess", () => {
   it("mutates and returns the provided process env", () => {
     const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
 
     expect(ensureOpenClawExecMarkerOnProcess(env)).toBe(env);
     expect(env[OPENCLAW_CLI_ENV_VAR]).toBe(OPENCLAW_CLI_ENV_VALUE);
+    expect(env.NO_DNA).toBeUndefined();
   });
 
   it("defaults to mutating process.env when no env object is provided", () => {
     const previous = process.env[OPENCLAW_CLI_ENV_VAR];
+    const previousNoDna = process.env.NO_DNA;
     delete process.env[OPENCLAW_CLI_ENV_VAR];
+    delete process.env.NO_DNA;
 
     try {
       expect(ensureOpenClawExecMarkerOnProcess()).toBe(process.env);
       expect(process.env[OPENCLAW_CLI_ENV_VAR]).toBe(OPENCLAW_CLI_ENV_VALUE);
+      expect(process.env.NO_DNA).toBeUndefined();
     } finally {
       if (previous === undefined) {
         delete process.env[OPENCLAW_CLI_ENV_VAR];
       } else {
         process.env[OPENCLAW_CLI_ENV_VAR] = previous;
+      }
+      if (previousNoDna === undefined) {
+        delete process.env.NO_DNA;
+      } else {
+        process.env.NO_DNA = previousNoDna;
       }
     }
   });

--- a/src/infra/openclaw-exec-env.ts
+++ b/src/infra/openclaw-exec-env.ts
@@ -1,10 +1,21 @@
 export const OPENCLAW_CLI_ENV_VAR = "OPENCLAW_CLI";
 export const OPENCLAW_CLI_ENV_VALUE = "1";
+export const NO_DNA_ENV_VAR = "NO_DNA";
+export const NO_DNA_ENV_VALUE = "1";
 
-export function markOpenClawExecEnv<T extends Record<string, string | undefined>>(env: T): T {
+export function markOpenClawCliEnv<T extends Record<string, string | undefined>>(env: T): T {
   return {
     ...env,
     [OPENCLAW_CLI_ENV_VAR]: OPENCLAW_CLI_ENV_VALUE,
+  };
+}
+
+export function markOpenClawChildCommandEnv<T extends Record<string, string | undefined>>(
+  env: T,
+): T {
+  return {
+    ...markOpenClawCliEnv(env),
+    [NO_DNA_ENV_VAR]: NO_DNA_ENV_VALUE,
   };
 }
 

--- a/src/infra/shell-env.ts
+++ b/src/infra/shell-env.ts
@@ -13,7 +13,7 @@ let cachedShellPath: string | null | undefined;
 let cachedEtcShells: Set<string> | null | undefined;
 
 function resolveShellExecEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const execEnv = sanitizeHostExecEnv({ baseEnv: env });
+  const execEnv = sanitizeHostExecEnv({ baseEnv: env, includeNoDna: false });
 
   // Startup-file resolution must stay pinned to the real user home.
   const home = os.homedir().trim();

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -33,6 +33,7 @@ describe("runCommandWithTimeout", () => {
     expect(resolved.OPENCLAW_TEST_ENV).toBe("ok");
     expect(resolved.OPENCLAW_TO_REMOVE).toBeUndefined();
     expect(resolved.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
+    expect(resolved.NO_DNA).toBeUndefined();
   });
 
   it("suppresses npm fund prompts for npm argv", async () => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 import { danger, shouldLogVerbose } from "../globals.js";
-import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
+import { markOpenClawCliEnv } from "../infra/openclaw-exec-env.js";
 import { logDebug, logError } from "../logger.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
 import { resolveWindowsCommandShim } from "./windows-command.js";
@@ -206,7 +206,7 @@ export function resolveCommandEnv(params: {
       resolvedEnv.npm_config_fund = "false";
     }
   }
-  return markOpenClawExecEnv(resolvedEnv);
+  return markOpenClawCliEnv(resolvedEnv);
 }
 
 export async function runCommandWithTimeout(

--- a/src/tui/tui-local-shell.test.ts
+++ b/src/tui/tui-local-shell.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
+import { NO_DNA_ENV_VALUE, OPENCLAW_CLI_ENV_VALUE } from "../infra/openclaw-exec-env.js";
 import { createLocalShellRunner } from "./tui-local-shell.js";
 
 const createSelector = () => {
@@ -97,6 +98,8 @@ describe("createLocalShellRunner", () => {
     expect(harness.createSelectorSpy).toHaveBeenCalledTimes(1);
     expect(spawnCommand).toHaveBeenCalledTimes(1);
     const spawnOptions = spawnCommand.mock.calls[0]?.[1] as { env?: Record<string, string> };
+    expect(spawnOptions.env?.NO_DNA).toBe(NO_DNA_ENV_VALUE);
+    expect(spawnOptions.env?.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
     expect(spawnOptions.env?.OPENCLAW_SHELL).toBe("tui-local");
     expect(spawnOptions.env?.PATH).toBe("/tmp/bin");
     expect(harness.messages).toContain("local shell: enabled for this session");

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import type { Component, SelectItem } from "@mariozechner/pi-tui";
+import { markOpenClawChildCommandEnv } from "../infra/openclaw-exec-env.js";
 import { createSearchableSelectList } from "./components/selectors.js";
 
 type LocalShellDeps = {
@@ -111,7 +112,7 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
         // and is gated behind an explicit in-session approval prompt.
         shell: true,
         cwd: getCwd(),
-        env: { ...env, OPENCLAW_SHELL: "tui-local" },
+        env: markOpenClawChildCommandEnv({ ...env, OPENCLAW_SHELL: "tui-local" }),
       });
 
       let stdout = "";


### PR DESCRIPTION
## Summary

- Problem: child processes spawned by OpenClaw did not receive the new proposed standard [`NO_DNA`](https://no-dna.org/) marker, so downstream tools could not reliably detect non-human-operated execution.
- Why it matters: tools that honor `NO_DNA` can suppress interactive prompts and other human-targeted UX only when that marker is present.
- What changed: OpenClaw now injects `NO_DNA=1` with `OPENCLAW_CLI=1` into child command environments for exec, node-host/system.run, sandbox, ACP client, and TUI local shell paths; tests and English docs were updated.
- What did NOT change (scope boundary): OpenClaw does not set `NO_DNA` on its own parent process, and login-shell env probing still excludes it.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A

## User-visible / Behavior Changes

- Child commands launched by `exec`, node-host/system-run paths, sandbox containers, `openclaw acp client`, and TUI `!` local shell now receive `NO_DNA=1`.
- Those child commands continue to receive `OPENCLAW_CLI=1`, and path-specific `OPENCLAW_SHELL=*` markers remain intact.
- OpenClaw startup behavior is unchanged: the parent OpenClaw process does not auto-set `NO_DNA`, and shell-env import still omits it.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  The child-process environment contract changed because supported command runners now export `NO_DNA=1`. The risk is that downstream tools may switch into non-interactive/headless behavior when they detect the marker. Mitigation: the change is intentionally scoped to spawned child commands only, parent OpenClaw startup remains unchanged, shell-env probing explicitly excludes `NO_DNA`, and targeted tests cover each execution path.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local `pnpm` + Vitest; no live container or remote node-host verification
- Model/provider: N/A
- Integration/channel (if any): exec, ACP client, sandbox env construction, TUI local shell
- Relevant config (redacted): default local test configuration; no special credentials

### Steps

1. Before this change, run a spawned child command through a supported execution path that prints `$NO_DNA`.
2. Observe that `NO_DNA` is unset even though OpenClaw is launching the command.
3. Apply this patch and rerun the same command or the targeted test suite.

### Expected

- Supported child-command paths receive `NO_DNA=1`.
- Parent OpenClaw startup and shell-env probing do not gain `NO_DNA`.

### Actual

- Before the patch, child commands did not receive `NO_DNA`.
- After the patch, targeted runtime and unit tests confirm `NO_DNA=1` on supported child-command paths and confirm the parent-process boundary remains intact.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm exec vitest run src/process/exec.test.ts src/infra/host-env-security.test.ts src/infra/openclaw-exec-env.test.ts src/agents/sandbox-create-args.test.ts src/acp/client.test.ts src/tui/tui-local-shell.test.ts src/agents/bash-tools.exec.path.test.ts src/agents/bash-tools.exec.pty.test.ts`
- Edge cases checked: parent-process marker does not inject `NO_DNA`; shell-env probing excludes `NO_DNA`; exec host and PTY runtime assertions read back `NO_DNA=1`; ACP and TUI still preserve their `OPENCLAW_SHELL` markers.
- What you did **not** verify: manual live ACP client session, manual TUI `!` execution, real Docker sandbox execution, and live node-host/system.run execution outside the targeted tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes`
- Migration needed? `No`
- If yes, exact upgrade steps: None

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit, or temporarily remove the child-command `NO_DNA` marker wiring and fall back to the prior `OPENCLAW_CLI`-only behavior.
- Files/config to restore: `src/infra/openclaw-exec-env.ts`, `src/infra/host-env-security.ts`, `src/process/exec.ts`, `src/agents/bash-tools.exec-runtime.ts`, `src/agents/sandbox/docker.ts`, `src/acp/client.ts`, `src/tui/tui-local-shell.ts`, `src/infra/shell-env.ts`
- Known bad symptoms reviewers should watch for: downstream commands unexpectedly suppress prompts, switch into CI/headless mode, or branch on `NO_DNA` in contexts where they previously behaved interactively.

## Risks and Mitigations

- Risk: downstream tools may interpret `NO_DNA=1` more aggressively than expected.
- Mitigation: the marker is limited to spawned child commands, not the parent OpenClaw process, and shell-env probing still excludes it.

- Risk: different execution paths could drift and stop applying the same marker set.
- Mitigation: a shared helper now owns the marker behavior, and regression tests cover exec, PTY, sandbox env creation, ACP client, TUI local shell, host env sanitization, and the parent-process negative case.

https://docs.openclaw.ai/tools/exec
https://docs.openclaw.ai/help/environment
https://docs.openclaw.ai/cli/acp
https://docs.openclaw.ai/web/tui
