### PR TITLE
docs(zh-CN): convert bare ClawHub URL to markdown link

### DIFF
--- a/docs/zh-CN/tools/skills.md
+++ b/docs/zh-CN/tools/skills.md
@@ -274,6 +274,6 @@ OpenClaw 作为安装的一部分（npm 包或 OpenClaw.app）发布一组基线
 
 ## 寻找更多 Skills？
 
-浏览 https://clawhub.com。
+浏览 [ClawHub](https://clawhub.com)。
 
 ---


### PR DESCRIPTION
1-line docs fix: converts bare `https://clawhub.com` to `[ClawHub](https://clawhub.com)` in zh-CN skills page for consistent markdown formatting.