### PR TITLE
[WebUI] Use responsive CSS Tooltips for Chat Controls

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -936,7 +936,7 @@
 }
 
 .chat-controls [data-tooltip]:hover::after,
-.chat-controls [data-tooltip]:focus-visible::after {
+.chat-controls [data-tooltip]:has(:focus-visible)::after {
   content: attr(data-tooltip);
   position: absolute;
   bottom: -32px;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4,965 +4,965 @@
 
 /* Main chat card - flex column layout, transparent background */
 .chat {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	height: 100%;
-	min-height: 0; /* Allow flex shrinking */
-	overflow: hidden;
-	background: transparent !important;
-	border: none !important;
-	box-shadow: none !important;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  height: 100%;
+  min-height: 0; /* Allow flex shrinking */
+  overflow: hidden;
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
 }
 
 /* Chat header - fixed at top, transparent */
 .chat-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	gap: 12px;
-	flex-wrap: nowrap;
-	flex-shrink: 0;
-	padding-bottom: 12px;
-	margin-bottom: 12px;
-	background: transparent;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: nowrap;
+  flex-shrink: 0;
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+  background: transparent;
 }
 
 .chat-header__left {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	flex-wrap: wrap;
-	min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 .chat-header__right {
-	display: flex;
-	align-items: center;
-	gap: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .chat-session {
-	min-width: 180px;
+  min-width: 180px;
 }
 
 /* Chat thread - scrollable middle section, transparent */
 .chat-thread {
-	flex: 1 1 0; /* Grow, shrink, and use 0 base for proper scrolling */
-	overflow-y: auto;
-	overflow-x: hidden;
-	padding: 12px 4px;
-	margin: 0 -4px;
-	min-height: 0; /* Allow shrinking for flex scroll behavior */
-	border-radius: 12px;
-	background: transparent;
+  flex: 1 1 0; /* Grow, shrink, and use 0 base for proper scrolling */
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 12px 4px;
+  margin: 0 -4px;
+  min-height: 0; /* Allow shrinking for flex scroll behavior */
+  border-radius: 12px;
+  background: transparent;
 }
 
 /* Focus mode exit button */
 .chat-focus-exit {
-	position: absolute;
-	top: 12px;
-	right: 12px;
-	z-index: 100;
-	width: 32px;
-	height: 32px;
-	border-radius: 50%;
-	border: 1px solid var(--border);
-	background: var(--panel);
-	color: var(--muted);
-	font-size: 20px;
-	line-height: 1;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	transition:
-		background 150ms ease-out,
-		color 150ms ease-out,
-		border-color 150ms ease-out;
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 100;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--muted);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 150ms ease-out,
+    color 150ms ease-out,
+    border-color 150ms ease-out;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 .chat-focus-exit:hover {
-	background: var(--panel-strong);
-	color: var(--text);
-	border-color: var(--accent);
+  background: var(--panel-strong);
+  color: var(--text);
+  border-color: var(--accent);
 }
 
 .chat-focus-exit svg {
-	width: 16px;
-	height: 16px;
-	stroke: currentColor;
-	fill: none;
-	stroke-width: 2px;
-	stroke-linecap: round;
-	stroke-linejoin: round;
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 /* New messages indicator - floating pill above compose */
 .chat-new-messages {
-	align-self: center;
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	padding: 6px 14px;
-	margin: 8px auto;
-	font-size: 13px;
-	font-family: var(--font-body);
-	color: var(--text);
-	background: var(--panel-strong);
-	border: 1px solid var(--border);
-	border-radius: 999px;
-	cursor: pointer;
-	white-space: nowrap;
-	z-index: 10;
-	transition:
-		background 150ms ease-out,
-		border-color 150ms ease-out;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  margin: 8px auto;
+  font-size: 13px;
+  font-family: var(--font-body);
+  color: var(--text);
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+  z-index: 10;
+  transition:
+    background 150ms ease-out,
+    border-color 150ms ease-out;
 }
 
 .chat-new-messages:hover {
-	background: var(--panel);
-	border-color: var(--accent);
+  background: var(--panel);
+  border-color: var(--accent);
 }
 
 .chat-new-messages svg {
-	width: 16px;
-	height: 16px;
-	stroke: currentColor;
-	fill: none;
-	stroke-width: 1.5px;
-	stroke-linecap: round;
-	stroke-linejoin: round;
-	flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  flex-shrink: 0;
 }
 
 /* Chat compose - sticky at bottom */
 .chat-compose {
-	position: sticky;
-	bottom: 0;
-	flex-shrink: 0;
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
-	margin-top: auto; /* Push to bottom of flex container */
-	padding: 12px 4px 4px;
-	background: linear-gradient(to bottom, transparent, var(--bg) 20%);
-	z-index: 10;
+  position: sticky;
+  bottom: 0;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: auto; /* Push to bottom of flex container */
+  padding: 12px 4px 4px;
+  background: linear-gradient(to bottom, transparent, var(--bg) 20%);
+  z-index: 10;
 }
 
 /* Image attachments preview */
 .chat-attachments {
-	display: inline-flex;
-	flex-wrap: wrap;
-	gap: 8px;
-	padding: 8px;
-	background: var(--panel);
-	border-radius: 8px;
-	border: 1px solid var(--border);
-	width: fit-content;
-	max-width: 100%;
-	align-self: flex-start; /* Don't stretch in flex column parent */
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px;
+  background: var(--panel);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  width: fit-content;
+  max-width: 100%;
+  align-self: flex-start; /* Don't stretch in flex column parent */
 }
 
 .chat-attachment {
-	position: relative;
-	width: 80px;
-	height: 80px;
-	border-radius: 6px;
-	overflow: hidden;
-	border: 1px solid var(--border);
-	background: var(--bg);
+  position: relative;
+  width: 80px;
+  height: 80px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--bg);
 }
 
 .chat-attachment__img {
-	width: 100%;
-	height: 100%;
-	object-fit: contain;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .chat-attachment__remove {
-	position: absolute;
-	top: 4px;
-	right: 4px;
-	width: 20px;
-	height: 20px;
-	border-radius: 50%;
-	border: none;
-	background: rgba(0, 0, 0, 0.7);
-	color: #fff;
-	font-size: 12px;
-	line-height: 1;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	opacity: 0;
-	transition: opacity 150ms ease-out;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 150ms ease-out;
 }
 
 .chat-attachment:hover .chat-attachment__remove {
-	opacity: 1;
+  opacity: 1;
 }
 
 .chat-attachment__remove:hover {
-	background: rgba(220, 38, 38, 0.9);
+  background: rgba(220, 38, 38, 0.9);
 }
 
 .chat-attachment__remove svg {
-	width: 12px;
-	height: 12px;
-	stroke: currentColor;
-	fill: none;
-	stroke-width: 2px;
+  width: 12px;
+  height: 12px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2px;
 }
 
 /* Light theme attachment overrides */
 :root[data-theme-mode="light"] .chat-attachments {
-	background: #f8fafc;
-	border-color: rgba(16, 24, 40, 0.1);
+  background: #f8fafc;
+  border-color: rgba(16, 24, 40, 0.1);
 }
 
 :root[data-theme-mode="light"] .chat-attachment {
-	border-color: rgba(16, 24, 40, 0.15);
-	background: #fff;
+  border-color: rgba(16, 24, 40, 0.15);
+  background: #fff;
 }
 
 :root[data-theme-mode="light"] .chat-attachment__remove {
-	background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.6);
 }
 
 /* Message images (sent images displayed in chat) */
 .chat-message-images {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
-	margin-bottom: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 .chat-message-image {
-	max-width: 300px;
-	max-height: 200px;
-	border-radius: 8px;
-	object-fit: contain;
-	cursor: pointer;
-	transition: transform 150ms ease-out;
+  max-width: 300px;
+  max-height: 200px;
+  border-radius: 8px;
+  object-fit: contain;
+  cursor: pointer;
+  transition: transform 150ms ease-out;
 }
 
 .chat-message-image:hover {
-	transform: scale(1.02);
+  transform: scale(1.02);
 }
 
 /* User message images align right */
 .chat-group.user .chat-message-images {
-	justify-content: flex-end;
+  justify-content: flex-end;
 }
 
 /* Compose input row - horizontal layout */
 .chat-compose__row {
-	display: flex;
-	align-items: stretch;
-	gap: 12px;
-	flex: 1;
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  flex: 1;
 }
 
 :root[data-theme-mode="light"] .chat-compose {
-	background: linear-gradient(to bottom, transparent, var(--bg-content) 20%);
+  background: linear-gradient(to bottom, transparent, var(--bg-content) 20%);
 }
 
 .chat-compose__field {
-	flex: 1 1 auto;
-	min-width: 0;
-	display: flex;
-	align-items: stretch;
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: stretch;
 }
 
 /* Hide the "Message" label - keep textarea only */
 .chat-compose__field > span {
-	display: none;
+  display: none;
 }
 
 /* Override .field textarea min-height (180px) from components.css */
 .chat-compose .chat-compose__field textarea {
-	width: 100%;
-	height: 40px;
-	min-height: 40px;
-	max-height: 150px;
-	padding: 9px 12px;
-	border-radius: 8px;
-	overflow-y: auto;
-	resize: none;
-	white-space: pre-wrap;
-	font-family: var(--font-body);
-	font-size: 14px;
-	line-height: 1.45;
+  width: 100%;
+  height: 40px;
+  min-height: 40px;
+  max-height: 150px;
+  padding: 9px 12px;
+  border-radius: 8px;
+  overflow-y: auto;
+  resize: none;
+  white-space: pre-wrap;
+  font-family: var(--font-body);
+  font-size: 14px;
+  line-height: 1.45;
 }
 
 .chat-compose__field textarea:disabled {
-	opacity: 0.7;
-	cursor: not-allowed;
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 
 .chat-compose__actions {
-	flex-shrink: 0;
-	display: flex;
-	align-items: stretch;
-	gap: 8px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
 }
 
 .chat-compose .chat-compose__actions .btn {
-	padding: 0 16px;
-	font-size: 13px;
-	height: 40px;
-	min-height: 40px;
-	max-height: 40px;
-	line-height: 1;
-	white-space: nowrap;
-	box-sizing: border-box;
+  padding: 0 16px;
+  font-size: 13px;
+  height: 40px;
+  min-height: 40px;
+  max-height: 40px;
+  line-height: 1;
+  white-space: nowrap;
+  box-sizing: border-box;
 }
 
 .agent-chat__input {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	margin: 0 18px 14px;
-	padding: 0;
-	background: var(--card);
-	border: 1px solid var(--border);
-	border-radius: var(--radius-lg);
-	flex-shrink: 0;
-	overflow: hidden;
-	transition:
-		border-color var(--duration-fast) ease,
-		box-shadow var(--duration-fast) ease;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  margin: 0 18px 14px;
+  padding: 0;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  flex-shrink: 0;
+  overflow: hidden;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
 }
 
 .agent-chat__input:focus-within {
-	border-color: color-mix(in srgb, var(--accent) 40%, transparent);
-	box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 8%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 @supports (backdrop-filter: blur(1px)) {
-	.agent-chat__input {
-		backdrop-filter: blur(12px) saturate(1.6);
-		-webkit-backdrop-filter: blur(12px) saturate(1.6);
-	}
+  .agent-chat__input {
+    backdrop-filter: blur(12px) saturate(1.6);
+    -webkit-backdrop-filter: blur(12px) saturate(1.6);
+  }
 }
 
 .agent-chat__input > textarea {
-	width: 100%;
-	min-height: 40px;
-	max-height: 150px;
-	resize: none;
-	padding: 12px 14px 8px;
-	border: none;
-	background: transparent;
-	color: var(--text);
-	font-size: 0.92rem;
-	font-family: inherit;
-	line-height: 1.4;
-	outline: none;
-	box-sizing: border-box;
+  width: 100%;
+  min-height: 40px;
+  max-height: 150px;
+  resize: none;
+  padding: 12px 14px 8px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 0.92rem;
+  font-family: inherit;
+  line-height: 1.4;
+  outline: none;
+  box-sizing: border-box;
 }
 
 .agent-chat__input > textarea::placeholder {
-	color: var(--muted);
+  color: var(--muted);
 }
 
 .agent-chat__toolbar {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 6px 10px;
-	border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
 }
 
 .agent-chat__toolbar-left,
 .agent-chat__toolbar-right {
-	display: flex;
-	align-items: center;
-	gap: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .agent-chat__input-btn,
 .agent-chat__toolbar .btn-ghost {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 30px;
-	height: 30px;
-	border-radius: var(--radius-sm);
-	border: none;
-	background: transparent;
-	color: var(--muted);
-	cursor: pointer;
-	flex-shrink: 0;
-	padding: 0;
-	transition: all var(--duration-fast) ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  padding: 0;
+  transition: all var(--duration-fast) ease;
 }
 
 .agent-chat__input-btn svg,
 .agent-chat__toolbar .btn-ghost svg {
-	width: 16px;
-	height: 16px;
-	stroke: currentColor;
-	fill: none;
-	stroke-width: 1.5px;
-	stroke-linecap: round;
-	stroke-linejoin: round;
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .agent-chat__input-btn:hover:not(:disabled),
 .agent-chat__toolbar .btn-ghost:hover:not(:disabled) {
-	color: var(--text);
-	background: var(--bg-hover);
+  color: var(--text);
+  background: var(--bg-hover);
 }
 
 .agent-chat__input-btn:disabled,
 .agent-chat__toolbar .btn-ghost:disabled {
-	opacity: 0.4;
-	cursor: not-allowed;
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .agent-chat__input-btn--active {
-	color: var(--accent);
-	background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .agent-chat__input-divider {
-	width: 1px;
-	height: 16px;
-	background: var(--border);
-	margin: 0 4px;
+  width: 1px;
+  height: 16px;
+  background: var(--border);
+  margin: 0 4px;
 }
 
 .agent-chat__token-count {
-	font-size: 0.7rem;
-	color: var(--muted);
-	white-space: nowrap;
-	flex-shrink: 0;
-	align-self: center;
+  font-size: 0.7rem;
+  color: var(--muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+  align-self: center;
 }
 
 .chat-send-btn {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 30px;
-	height: 30px;
-	border-radius: var(--radius-md);
-	border: none;
-	background: var(--accent);
-	color: var(--accent-foreground);
-	cursor: pointer;
-	flex-shrink: 0;
-	transition:
-		background var(--duration-fast) ease,
-		box-shadow var(--duration-fast) ease;
-	padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+  padding: 0;
 }
 
 .chat-send-btn svg {
-	width: 15px;
-	height: 15px;
-	stroke: currentColor;
-	fill: none;
-	stroke-width: 1.5px;
-	stroke-linecap: round;
-	stroke-linejoin: round;
+  width: 15px;
+  height: 15px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .chat-send-btn:hover:not(:disabled) {
-	background: var(--accent-hover);
-	box-shadow: 0 2px 10px rgba(255, 92, 92, 0.25);
+  background: var(--accent-hover);
+  box-shadow: 0 2px 10px rgba(255, 92, 92, 0.25);
 }
 
 .chat-send-btn:disabled {
-	opacity: 0.3;
-	cursor: not-allowed;
+  opacity: 0.3;
+  cursor: not-allowed;
 }
 
 .chat-send-btn--stop {
-	background: var(--danger);
+  background: var(--danger);
 }
 
 .chat-send-btn--stop:hover:not(:disabled) {
-	background: color-mix(in srgb, var(--danger) 85%, #fff);
+  background: color-mix(in srgb, var(--danger) 85%, #fff);
 }
 
 .slash-menu {
-	position: absolute;
-	bottom: 100%;
-	left: 0;
-	right: 0;
-	max-height: 320px;
-	overflow-y: auto;
-	background: var(--popover);
-	border: 1px solid var(--border-strong);
-	border-radius: var(--radius-lg);
-	box-shadow: var(--shadow-lg);
-	z-index: 30;
-	margin-bottom: 4px;
-	padding: 6px;
-	scrollbar-width: thin;
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--popover);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  z-index: 30;
+  margin-bottom: 4px;
+  padding: 6px;
+  scrollbar-width: thin;
 }
 
 .slash-menu-group + .slash-menu-group {
-	margin-top: 4px;
-	padding-top: 4px;
-	border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
 }
 
 .slash-menu-group__label {
-	padding: 4px 10px 2px;
-	font-size: 0.68rem;
-	font-weight: 700;
-	text-transform: uppercase;
-	letter-spacing: 0.06em;
-	color: var(--accent);
-	opacity: 0.7;
+  padding: 4px 10px 2px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  opacity: 0.7;
 }
 
 .slash-menu-item {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 7px 10px;
-	border-radius: var(--radius-sm);
-	cursor: pointer;
-	transition:
-		background var(--duration-fast) ease,
-		color var(--duration-fast) ease;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
 }
 
 .slash-menu-item:hover,
 .slash-menu-item--active {
-	background: color-mix(in srgb, var(--accent) 10%, var(--bg-hover));
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-hover));
 }
 
 .slash-menu-icon {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 20px;
-	height: 20px;
-	flex-shrink: 0;
-	color: var(--accent);
-	opacity: 0.7;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--accent);
+  opacity: 0.7;
 }
 
 .slash-menu-icon svg {
-	width: 14px;
-	height: 14px;
-	stroke: currentColor;
-	fill: none;
-	stroke-width: 1.5px;
-	stroke-linecap: round;
-	stroke-linejoin: round;
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .slash-menu-item--active .slash-menu-icon,
 .slash-menu-item:hover .slash-menu-icon {
-	opacity: 1;
+  opacity: 1;
 }
 
 .slash-menu-name {
-	font-size: 0.82rem;
-	font-weight: 600;
-	font-family: var(--mono);
-	color: var(--accent);
-	white-space: nowrap;
+  font-size: 0.82rem;
+  font-weight: 600;
+  font-family: var(--mono);
+  color: var(--accent);
+  white-space: nowrap;
 }
 
 .slash-menu-args {
-	font-size: 0.75rem;
-	color: var(--muted);
-	font-family: var(--mono);
-	opacity: 0.65;
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-family: var(--mono);
+  opacity: 0.65;
 }
 
 .slash-menu-desc {
-	flex: 1;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	text-align: right;
-	font-size: 0.75rem;
-	color: var(--muted);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+  font-size: 0.75rem;
+  color: var(--muted);
 }
 
 .slash-menu-item--active .slash-menu-name {
-	color: var(--accent-hover);
+  color: var(--accent-hover);
 }
 
 .slash-menu-item--active .slash-menu-desc {
-	color: var(--text);
+  color: var(--text);
 }
 
 .chat-attachments-preview {
-	display: flex;
-	gap: 8px;
-	flex-wrap: wrap;
-	margin-bottom: 8px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
 }
 
 .chat-attachment-thumb {
-	position: relative;
-	width: 60px;
-	height: 60px;
-	border-radius: var(--radius-sm);
-	overflow: hidden;
-	border: 1px solid var(--border);
+  position: relative;
+  width: 60px;
+  height: 60px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--border);
 }
 
 .chat-attachment-thumb img {
-	width: 100%;
-	height: 100%;
-	object-fit: cover;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .chat-attachment-remove {
-	position: absolute;
-	top: 2px;
-	right: 2px;
-	width: 18px;
-	height: 18px;
-	border-radius: 50%;
-	border: none;
-	background: rgba(0, 0, 0, 0.6);
-	color: #fff;
-	font-size: 12px;
-	line-height: 1;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .chat-attachment-file {
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	padding: 4px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	font-size: 0.72rem;
-	color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.72rem;
+  color: var(--muted);
 }
 
 .agent-chat__file-input {
-	display: none;
+  display: none;
 }
 
 /* Chat controls - moved to content-header area, left aligned */
 .chat-controls {
-	display: flex;
-	align-items: center;
-	justify-content: flex-start;
-	gap: 12px;
-	flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .chat-controls__session {
-	min-width: 140px;
-	max-width: 300px;
+  min-width: 140px;
+  max-width: 300px;
 }
 
 .chat-controls__thinking {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
 }
 
 /* Icon button style */
 .btn--icon {
-	padding: 8px !important;
-	min-width: 36px;
-	height: 36px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	border: 1px solid var(--border);
-	background: rgba(255, 255, 255, 0.06);
+  padding: 8px !important;
+  min-width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.06);
 }
 
 /* Controls separator */
 .chat-controls__separator {
-	color: rgba(255, 255, 255, 0.4);
-	font-size: 18px;
-	margin: 0 8px;
-	font-weight: 300;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 18px;
+  margin: 0 8px;
+  font-weight: 300;
 }
 
 :root[data-theme-mode="light"] .chat-controls__separator {
-	color: rgba(16, 24, 40, 0.3);
+  color: rgba(16, 24, 40, 0.3);
 }
 
 .btn--icon:hover {
-	background: rgba(255, 255, 255, 0.12);
-	border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
 }
 
 /* Light theme icon button overrides */
 :root[data-theme-mode="light"] .btn--icon {
-	background: #ffffff;
-	border-color: var(--border);
-	box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
-	color: var(--muted);
+  background: #ffffff;
+  border-color: var(--border);
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
+  color: var(--muted);
 }
 
 :root[data-theme-mode="light"] .btn--icon:hover {
-	background: #ffffff;
-	border-color: var(--border-strong);
-	color: var(--text);
+  background: #ffffff;
+  border-color: var(--border-strong);
+  color: var(--text);
 }
 
 /* Light theme icon button overrides */
 :root[data-theme-mode="light"] .btn--icon {
-	background: #ffffff;
-	border-color: var(--border);
-	box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
-	color: var(--muted);
+  background: #ffffff;
+  border-color: var(--border);
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
+  color: var(--muted);
 }
 
 :root[data-theme-mode="light"] .btn--icon:hover {
-	background: #ffffff;
-	border-color: var(--border-strong);
-	color: var(--text);
+  background: #ffffff;
+  border-color: var(--border-strong);
+  color: var(--text);
 }
 
 :root[data-theme-mode="light"] .chat-controls .btn--icon.active {
-	border-color: var(--accent);
-	background: var(--accent-subtle);
-	color: var(--accent);
-	box-shadow: 0 0 0 1px var(--accent-subtle);
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+  color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-subtle);
 }
 
 .btn--icon svg {
-	display: block;
-	width: 18px;
-	height: 18px;
-	stroke: currentColor;
-	fill: none;
-	stroke-width: 1.5px;
-	stroke-linecap: round;
-	stroke-linejoin: round;
+  display: block;
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .chat-controls__session select {
-	padding: 6px 10px;
-	font-size: 13px;
-	max-width: 300px;
-	overflow: hidden;
-	text-overflow: ellipsis;
+  padding: 6px 10px;
+  font-size: 13px;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .chat-controls__thinking {
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	font-size: 12px;
-	padding: 4px 10px;
-	background: rgba(255, 255, 255, 0.04);
-	border-radius: 6px;
-	border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  padding: 4px 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 6px;
+  border: 1px solid var(--border);
 }
 
 /* Light theme thinking indicator override */
 :root[data-theme-mode="light"] .chat-controls__thinking {
-	background: rgba(255, 255, 255, 0.9);
-	border-color: rgba(16, 24, 40, 0.15);
+  background: rgba(255, 255, 255, 0.9);
+  border-color: rgba(16, 24, 40, 0.15);
 }
 
 @media (max-width: 640px) {
-	.chat-session {
-		min-width: 140px;
-	}
+  .chat-session {
+    min-width: 140px;
+  }
 
-	.chat-compose {
-		grid-template-columns: 1fr;
-	}
+  .chat-compose {
+    grid-template-columns: 1fr;
+  }
 
-	/* Mobile: stack compose row vertically */
-	.chat-compose__row {
-		flex-direction: column;
-		gap: 8px;
-	}
+  /* Mobile: stack compose row vertically */
+  .chat-compose__row {
+    flex-direction: column;
+    gap: 8px;
+  }
 
-	/* Mobile: stack action buttons vertically */
-	.chat-compose__actions {
-		flex-direction: column;
-		width: 100%;
-		gap: 8px;
-	}
+  /* Mobile: stack action buttons vertically */
+  .chat-compose__actions {
+    flex-direction: column;
+    width: 100%;
+    gap: 8px;
+  }
 
-	/* Mobile: full-width buttons */
-	.chat-compose .chat-compose__actions .btn {
-		width: 100%;
-	}
+  /* Mobile: full-width buttons */
+  .chat-compose .chat-compose__actions .btn {
+    width: 100%;
+  }
 
-	.chat-controls {
-		flex-wrap: wrap;
-		gap: 8px;
-	}
+  .chat-controls {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
 
-	.chat-controls__session {
-		min-width: 120px;
-	}
+  .chat-controls__session {
+    min-width: 120px;
+  }
 }
 
 /* Chat loading skeleton */
 .chat-loading-skeleton {
-	padding: 4px 0;
-	animation: fade-in 0.3s var(--ease-out);
+  padding: 4px 0;
+  animation: fade-in 0.3s var(--ease-out);
 }
 
 /* Welcome state (new session) */
 .agent-chat__welcome {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	text-align: center;
-	gap: 12px;
-	padding: 48px 24px;
-	flex: 1;
-	min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 12px;
+  padding: 48px 24px;
+  flex: 1;
+  min-height: 0;
 }
 
 .agent-chat__welcome-glow {
-	display: none;
+  display: none;
 }
 
 .agent-chat__welcome h2 {
-	font-size: 20px;
-	font-weight: 600;
-	margin: 0;
-	color: var(--foreground);
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--foreground);
 }
 
 .agent-chat__avatar--logo {
-	width: 48px;
-	height: 48px;
-	border-radius: 14px;
-	background: var(--panel-strong);
-	border: 1px solid var(--border);
-	display: grid;
-	place-items: center;
-	overflow: hidden;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
 }
 
 .agent-chat__avatar--logo img {
-	width: 32px;
-	height: 32px;
-	object-fit: contain;
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
 }
 
 .agent-chat__badges {
-	display: flex;
-	gap: 8px;
-	flex-wrap: wrap;
-	justify-content: center;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .agent-chat__badge {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	font-size: 12px;
-	font-weight: 500;
-	color: var(--muted);
-	background: var(--panel);
-	border: 1px solid var(--border);
-	border-radius: 100px;
-	padding: 4px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  padding: 4px 12px;
 }
 
 .agent-chat__badge img {
-	width: 14px;
-	height: 14px;
-	object-fit: contain;
+  width: 14px;
+  height: 14px;
+  object-fit: contain;
 }
 
 .agent-chat__hint {
-	font-size: 13px;
-	color: var(--muted);
-	margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0;
 }
 
 .agent-chat__hint kbd {
-	display: inline-block;
-	padding: 1px 6px;
-	font-size: 11px;
-	font-family: var(--font-mono);
-	background: var(--panel-strong);
-	border: 1px solid var(--border);
-	border-radius: 4px;
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  border-radius: 4px;
 }
 
 .agent-chat__suggestions {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
-	justify-content: center;
-	max-width: 480px;
-	margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  max-width: 480px;
+  margin-top: 8px;
 }
 
 .agent-chat__suggestion {
-	font-size: 13px;
-	padding: 8px 16px;
-	border-radius: 100px;
-	border: 1px solid var(--border);
-	background: var(--panel);
-	color: var(--foreground);
-	cursor: pointer;
-	transition:
-		background 0.15s,
-		border-color 0.15s;
+  font-size: 13px;
+  padding: 8px 16px;
+  border-radius: 100px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--foreground);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 }
 
 .agent-chat__suggestion:hover {
-	background: var(--panel-strong);
-	border-color: var(--accent);
+  background: var(--panel-strong);
+  border-color: var(--accent);
 }
 
 /* Chat Controls Custom Tooltips */
 .chat-controls [data-tooltip] {
-	position: relative;
+  position: relative;
 }
 
 .chat-controls [data-tooltip]:hover::after {
-	content: attr(data-tooltip);
-	position: absolute;
-	bottom: -32px;
-	left: 50%;
-	transform: translateX(-50%);
-	background: var(--bg);
-	color: var(--text);
-	border: 1px solid var(--border);
-	padding: 4px 8px;
-	border-radius: 4px;
-	font-size: 11px;
-	white-space: nowrap;
-	opacity: 0;
-	pointer-events: none;
-	animation: chat-tooltip-fade-in 0.15s ease-in-out forwards;
-	animation-delay: 0.1s;
-	z-index: 100;
-	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: -32px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  animation: chat-tooltip-fade-in 0.15s ease-in-out forwards;
+  animation-delay: 0.1s;
+  z-index: 100;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 @keyframes chat-tooltip-fade-in {
-	from {
-		opacity: 0;
-		transform: translateX(-50%) translateY(-4px);
-	}
-	to {
-		opacity: 1;
-		transform: translateX(-50%) translateY(0);
-	}
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -935,7 +935,24 @@
   position: relative;
 }
 
-.chat-controls [data-tooltip]:hover::after,
+.chat-controls [data-tooltip]:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: -32px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 100;
+  animation: chat-tooltip-fade-in 0.15s ease-in forwards;
+}
+
 .chat-controls [data-tooltip]:has(:focus-visible)::after {
   content: attr(data-tooltip);
   position: absolute;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4,928 +4,965 @@
 
 /* Main chat card - flex column layout, transparent background */
 .chat {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 0;
-  height: 100%;
-  min-height: 0; /* Allow flex shrinking */
-  overflow: hidden;
-  background: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0;
+	height: 100%;
+	min-height: 0; /* Allow flex shrinking */
+	overflow: hidden;
+	background: transparent !important;
+	border: none !important;
+	box-shadow: none !important;
 }
 
 /* Chat header - fixed at top, transparent */
 .chat-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: nowrap;
-  flex-shrink: 0;
-  padding-bottom: 12px;
-  margin-bottom: 12px;
-  background: transparent;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 12px;
+	flex-wrap: nowrap;
+	flex-shrink: 0;
+	padding-bottom: 12px;
+	margin-bottom: 12px;
+	background: transparent;
 }
 
 .chat-header__left {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex-wrap: wrap;
+	min-width: 0;
 }
 
 .chat-header__right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .chat-session {
-  min-width: 180px;
+	min-width: 180px;
 }
 
 /* Chat thread - scrollable middle section, transparent */
 .chat-thread {
-  flex: 1 1 0; /* Grow, shrink, and use 0 base for proper scrolling */
-  overflow-y: auto;
-  overflow-x: hidden;
-  padding: 12px 4px;
-  margin: 0 -4px;
-  min-height: 0; /* Allow shrinking for flex scroll behavior */
-  border-radius: 12px;
-  background: transparent;
+	flex: 1 1 0; /* Grow, shrink, and use 0 base for proper scrolling */
+	overflow-y: auto;
+	overflow-x: hidden;
+	padding: 12px 4px;
+	margin: 0 -4px;
+	min-height: 0; /* Allow shrinking for flex scroll behavior */
+	border-radius: 12px;
+	background: transparent;
 }
 
 /* Focus mode exit button */
 .chat-focus-exit {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  z-index: 100;
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  border: 1px solid var(--border);
-  background: var(--panel);
-  color: var(--muted);
-  font-size: 20px;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition:
-    background 150ms ease-out,
-    color 150ms ease-out,
-    border-color 150ms ease-out;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+	position: absolute;
+	top: 12px;
+	right: 12px;
+	z-index: 100;
+	width: 32px;
+	height: 32px;
+	border-radius: 50%;
+	border: 1px solid var(--border);
+	background: var(--panel);
+	color: var(--muted);
+	font-size: 20px;
+	line-height: 1;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition:
+		background 150ms ease-out,
+		color 150ms ease-out,
+		border-color 150ms ease-out;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 .chat-focus-exit:hover {
-  background: var(--panel-strong);
-  color: var(--text);
-  border-color: var(--accent);
+	background: var(--panel-strong);
+	color: var(--text);
+	border-color: var(--accent);
 }
 
 .chat-focus-exit svg {
-  width: 16px;
-  height: 16px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 2px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+	width: 16px;
+	height: 16px;
+	stroke: currentColor;
+	fill: none;
+	stroke-width: 2px;
+	stroke-linecap: round;
+	stroke-linejoin: round;
 }
 
 /* New messages indicator - floating pill above compose */
 .chat-new-messages {
-  align-self: center;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 14px;
-  margin: 8px auto;
-  font-size: 13px;
-  font-family: var(--font-body);
-  color: var(--text);
-  background: var(--panel-strong);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  cursor: pointer;
-  white-space: nowrap;
-  z-index: 10;
-  transition:
-    background 150ms ease-out,
-    border-color 150ms ease-out;
+	align-self: center;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 14px;
+	margin: 8px auto;
+	font-size: 13px;
+	font-family: var(--font-body);
+	color: var(--text);
+	background: var(--panel-strong);
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	cursor: pointer;
+	white-space: nowrap;
+	z-index: 10;
+	transition:
+		background 150ms ease-out,
+		border-color 150ms ease-out;
 }
 
 .chat-new-messages:hover {
-  background: var(--panel);
-  border-color: var(--accent);
+	background: var(--panel);
+	border-color: var(--accent);
 }
 
 .chat-new-messages svg {
-  width: 16px;
-  height: 16px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  flex-shrink: 0;
+	width: 16px;
+	height: 16px;
+	stroke: currentColor;
+	fill: none;
+	stroke-width: 1.5px;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+	flex-shrink: 0;
 }
 
 /* Chat compose - sticky at bottom */
 .chat-compose {
-  position: sticky;
-  bottom: 0;
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-top: auto; /* Push to bottom of flex container */
-  padding: 12px 4px 4px;
-  background: linear-gradient(to bottom, transparent, var(--bg) 20%);
-  z-index: 10;
+	position: sticky;
+	bottom: 0;
+	flex-shrink: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	margin-top: auto; /* Push to bottom of flex container */
+	padding: 12px 4px 4px;
+	background: linear-gradient(to bottom, transparent, var(--bg) 20%);
+	z-index: 10;
 }
 
 /* Image attachments preview */
 .chat-attachments {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 8px;
-  background: var(--panel);
-  border-radius: 8px;
-  border: 1px solid var(--border);
-  width: fit-content;
-  max-width: 100%;
-  align-self: flex-start; /* Don't stretch in flex column parent */
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	padding: 8px;
+	background: var(--panel);
+	border-radius: 8px;
+	border: 1px solid var(--border);
+	width: fit-content;
+	max-width: 100%;
+	align-self: flex-start; /* Don't stretch in flex column parent */
 }
 
 .chat-attachment {
-  position: relative;
-  width: 80px;
-  height: 80px;
-  border-radius: 6px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  background: var(--bg);
+	position: relative;
+	width: 80px;
+	height: 80px;
+	border-radius: 6px;
+	overflow: hidden;
+	border: 1px solid var(--border);
+	background: var(--bg);
 }
 
 .chat-attachment__img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
 }
 
 .chat-attachment__remove {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  border: none;
-  background: rgba(0, 0, 0, 0.7);
-  color: #fff;
-  font-size: 12px;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0;
-  transition: opacity 150ms ease-out;
+	position: absolute;
+	top: 4px;
+	right: 4px;
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	border: none;
+	background: rgba(0, 0, 0, 0.7);
+	color: #fff;
+	font-size: 12px;
+	line-height: 1;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	opacity: 0;
+	transition: opacity 150ms ease-out;
 }
 
 .chat-attachment:hover .chat-attachment__remove {
-  opacity: 1;
+	opacity: 1;
 }
 
 .chat-attachment__remove:hover {
-  background: rgba(220, 38, 38, 0.9);
+	background: rgba(220, 38, 38, 0.9);
 }
 
 .chat-attachment__remove svg {
-  width: 12px;
-  height: 12px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 2px;
+	width: 12px;
+	height: 12px;
+	stroke: currentColor;
+	fill: none;
+	stroke-width: 2px;
 }
 
 /* Light theme attachment overrides */
 :root[data-theme-mode="light"] .chat-attachments {
-  background: #f8fafc;
-  border-color: rgba(16, 24, 40, 0.1);
+	background: #f8fafc;
+	border-color: rgba(16, 24, 40, 0.1);
 }
 
 :root[data-theme-mode="light"] .chat-attachment {
-  border-color: rgba(16, 24, 40, 0.15);
-  background: #fff;
+	border-color: rgba(16, 24, 40, 0.15);
+	background: #fff;
 }
 
 :root[data-theme-mode="light"] .chat-attachment__remove {
-  background: rgba(0, 0, 0, 0.6);
+	background: rgba(0, 0, 0, 0.6);
 }
 
 /* Message images (sent images displayed in chat) */
 .chat-message-images {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 8px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-bottom: 8px;
 }
 
 .chat-message-image {
-  max-width: 300px;
-  max-height: 200px;
-  border-radius: 8px;
-  object-fit: contain;
-  cursor: pointer;
-  transition: transform 150ms ease-out;
+	max-width: 300px;
+	max-height: 200px;
+	border-radius: 8px;
+	object-fit: contain;
+	cursor: pointer;
+	transition: transform 150ms ease-out;
 }
 
 .chat-message-image:hover {
-  transform: scale(1.02);
+	transform: scale(1.02);
 }
 
 /* User message images align right */
 .chat-group.user .chat-message-images {
-  justify-content: flex-end;
+	justify-content: flex-end;
 }
 
 /* Compose input row - horizontal layout */
 .chat-compose__row {
-  display: flex;
-  align-items: stretch;
-  gap: 12px;
-  flex: 1;
+	display: flex;
+	align-items: stretch;
+	gap: 12px;
+	flex: 1;
 }
 
 :root[data-theme-mode="light"] .chat-compose {
-  background: linear-gradient(to bottom, transparent, var(--bg-content) 20%);
+	background: linear-gradient(to bottom, transparent, var(--bg-content) 20%);
 }
 
 .chat-compose__field {
-  flex: 1 1 auto;
-  min-width: 0;
-  display: flex;
-  align-items: stretch;
+	flex: 1 1 auto;
+	min-width: 0;
+	display: flex;
+	align-items: stretch;
 }
 
 /* Hide the "Message" label - keep textarea only */
 .chat-compose__field > span {
-  display: none;
+	display: none;
 }
 
 /* Override .field textarea min-height (180px) from components.css */
 .chat-compose .chat-compose__field textarea {
-  width: 100%;
-  height: 40px;
-  min-height: 40px;
-  max-height: 150px;
-  padding: 9px 12px;
-  border-radius: 8px;
-  overflow-y: auto;
-  resize: none;
-  white-space: pre-wrap;
-  font-family: var(--font-body);
-  font-size: 14px;
-  line-height: 1.45;
+	width: 100%;
+	height: 40px;
+	min-height: 40px;
+	max-height: 150px;
+	padding: 9px 12px;
+	border-radius: 8px;
+	overflow-y: auto;
+	resize: none;
+	white-space: pre-wrap;
+	font-family: var(--font-body);
+	font-size: 14px;
+	line-height: 1.45;
 }
 
 .chat-compose__field textarea:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
+	opacity: 0.7;
+	cursor: not-allowed;
 }
 
 .chat-compose__actions {
-  flex-shrink: 0;
-  display: flex;
-  align-items: stretch;
-  gap: 8px;
+	flex-shrink: 0;
+	display: flex;
+	align-items: stretch;
+	gap: 8px;
 }
 
 .chat-compose .chat-compose__actions .btn {
-  padding: 0 16px;
-  font-size: 13px;
-  height: 40px;
-  min-height: 40px;
-  max-height: 40px;
-  line-height: 1;
-  white-space: nowrap;
-  box-sizing: border-box;
+	padding: 0 16px;
+	font-size: 13px;
+	height: 40px;
+	min-height: 40px;
+	max-height: 40px;
+	line-height: 1;
+	white-space: nowrap;
+	box-sizing: border-box;
 }
 
 .agent-chat__input {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  margin: 0 18px 14px;
-  padding: 0;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  flex-shrink: 0;
-  overflow: hidden;
-  transition:
-    border-color var(--duration-fast) ease,
-    box-shadow var(--duration-fast) ease;
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	margin: 0 18px 14px;
+	padding: 0;
+	background: var(--card);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+	flex-shrink: 0;
+	overflow: hidden;
+	transition:
+		border-color var(--duration-fast) ease,
+		box-shadow var(--duration-fast) ease;
 }
 
 .agent-chat__input:focus-within {
-  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 8%, transparent);
+	border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+	box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 @supports (backdrop-filter: blur(1px)) {
-  .agent-chat__input {
-    backdrop-filter: blur(12px) saturate(1.6);
-    -webkit-backdrop-filter: blur(12px) saturate(1.6);
-  }
+	.agent-chat__input {
+		backdrop-filter: blur(12px) saturate(1.6);
+		-webkit-backdrop-filter: blur(12px) saturate(1.6);
+	}
 }
 
 .agent-chat__input > textarea {
-  width: 100%;
-  min-height: 40px;
-  max-height: 150px;
-  resize: none;
-  padding: 12px 14px 8px;
-  border: none;
-  background: transparent;
-  color: var(--text);
-  font-size: 0.92rem;
-  font-family: inherit;
-  line-height: 1.4;
-  outline: none;
-  box-sizing: border-box;
+	width: 100%;
+	min-height: 40px;
+	max-height: 150px;
+	resize: none;
+	padding: 12px 14px 8px;
+	border: none;
+	background: transparent;
+	color: var(--text);
+	font-size: 0.92rem;
+	font-family: inherit;
+	line-height: 1.4;
+	outline: none;
+	box-sizing: border-box;
 }
 
 .agent-chat__input > textarea::placeholder {
-  color: var(--muted);
+	color: var(--muted);
 }
 
 .agent-chat__toolbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 6px 10px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 6px 10px;
+	border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
 }
 
 .agent-chat__toolbar-left,
 .agent-chat__toolbar-right {
-  display: flex;
-  align-items: center;
-  gap: 4px;
+	display: flex;
+	align-items: center;
+	gap: 4px;
 }
 
 .agent-chat__input-btn,
 .agent-chat__toolbar .btn-ghost {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: var(--radius-sm);
-  border: none;
-  background: transparent;
-  color: var(--muted);
-  cursor: pointer;
-  flex-shrink: 0;
-  padding: 0;
-  transition: all var(--duration-fast) ease;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 30px;
+	height: 30px;
+	border-radius: var(--radius-sm);
+	border: none;
+	background: transparent;
+	color: var(--muted);
+	cursor: pointer;
+	flex-shrink: 0;
+	padding: 0;
+	transition: all var(--duration-fast) ease;
 }
 
 .agent-chat__input-btn svg,
 .agent-chat__toolbar .btn-ghost svg {
-  width: 16px;
-  height: 16px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+	width: 16px;
+	height: 16px;
+	stroke: currentColor;
+	fill: none;
+	stroke-width: 1.5px;
+	stroke-linecap: round;
+	stroke-linejoin: round;
 }
 
 .agent-chat__input-btn:hover:not(:disabled),
 .agent-chat__toolbar .btn-ghost:hover:not(:disabled) {
-  color: var(--text);
-  background: var(--bg-hover);
+	color: var(--text);
+	background: var(--bg-hover);
 }
 
 .agent-chat__input-btn:disabled,
 .agent-chat__toolbar .btn-ghost:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
+	opacity: 0.4;
+	cursor: not-allowed;
 }
 
 .agent-chat__input-btn--active {
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
+	color: var(--accent);
+	background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .agent-chat__input-divider {
-  width: 1px;
-  height: 16px;
-  background: var(--border);
-  margin: 0 4px;
+	width: 1px;
+	height: 16px;
+	background: var(--border);
+	margin: 0 4px;
 }
 
 .agent-chat__token-count {
-  font-size: 0.7rem;
-  color: var(--muted);
-  white-space: nowrap;
-  flex-shrink: 0;
-  align-self: center;
+	font-size: 0.7rem;
+	color: var(--muted);
+	white-space: nowrap;
+	flex-shrink: 0;
+	align-self: center;
 }
 
 .chat-send-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: var(--radius-md);
-  border: none;
-  background: var(--accent);
-  color: var(--accent-foreground);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition:
-    background var(--duration-fast) ease,
-    box-shadow var(--duration-fast) ease;
-  padding: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 30px;
+	height: 30px;
+	border-radius: var(--radius-md);
+	border: none;
+	background: var(--accent);
+	color: var(--accent-foreground);
+	cursor: pointer;
+	flex-shrink: 0;
+	transition:
+		background var(--duration-fast) ease,
+		box-shadow var(--duration-fast) ease;
+	padding: 0;
 }
 
 .chat-send-btn svg {
-  width: 15px;
-  height: 15px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+	width: 15px;
+	height: 15px;
+	stroke: currentColor;
+	fill: none;
+	stroke-width: 1.5px;
+	stroke-linecap: round;
+	stroke-linejoin: round;
 }
 
 .chat-send-btn:hover:not(:disabled) {
-  background: var(--accent-hover);
-  box-shadow: 0 2px 10px rgba(255, 92, 92, 0.25);
+	background: var(--accent-hover);
+	box-shadow: 0 2px 10px rgba(255, 92, 92, 0.25);
 }
 
 .chat-send-btn:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
+	opacity: 0.3;
+	cursor: not-allowed;
 }
 
 .chat-send-btn--stop {
-  background: var(--danger);
+	background: var(--danger);
 }
 
 .chat-send-btn--stop:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--danger) 85%, #fff);
+	background: color-mix(in srgb, var(--danger) 85%, #fff);
 }
 
 .slash-menu {
-  position: absolute;
-  bottom: 100%;
-  left: 0;
-  right: 0;
-  max-height: 320px;
-  overflow-y: auto;
-  background: var(--popover);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg);
-  z-index: 30;
-  margin-bottom: 4px;
-  padding: 6px;
-  scrollbar-width: thin;
+	position: absolute;
+	bottom: 100%;
+	left: 0;
+	right: 0;
+	max-height: 320px;
+	overflow-y: auto;
+	background: var(--popover);
+	border: 1px solid var(--border-strong);
+	border-radius: var(--radius-lg);
+	box-shadow: var(--shadow-lg);
+	z-index: 30;
+	margin-bottom: 4px;
+	padding: 6px;
+	scrollbar-width: thin;
 }
 
 .slash-menu-group + .slash-menu-group {
-  margin-top: 4px;
-  padding-top: 4px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+	margin-top: 4px;
+	padding-top: 4px;
+	border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
 }
 
 .slash-menu-group__label {
-  padding: 4px 10px 2px;
-  font-size: 0.68rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--accent);
-  opacity: 0.7;
+	padding: 4px 10px 2px;
+	font-size: 0.68rem;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	color: var(--accent);
+	opacity: 0.7;
 }
 
 .slash-menu-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 10px;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition:
-    background var(--duration-fast) ease,
-    color var(--duration-fast) ease;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 7px 10px;
+	border-radius: var(--radius-sm);
+	cursor: pointer;
+	transition:
+		background var(--duration-fast) ease,
+		color var(--duration-fast) ease;
 }
 
 .slash-menu-item:hover,
 .slash-menu-item--active {
-  background: color-mix(in srgb, var(--accent) 10%, var(--bg-hover));
+	background: color-mix(in srgb, var(--accent) 10%, var(--bg-hover));
 }
 
 .slash-menu-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-  color: var(--accent);
-  opacity: 0.7;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+	flex-shrink: 0;
+	color: var(--accent);
+	opacity: 0.7;
 }
 
 .slash-menu-icon svg {
-  width: 14px;
-  height: 14px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+	width: 14px;
+	height: 14px;
+	stroke: currentColor;
+	fill: none;
+	stroke-width: 1.5px;
+	stroke-linecap: round;
+	stroke-linejoin: round;
 }
 
 .slash-menu-item--active .slash-menu-icon,
 .slash-menu-item:hover .slash-menu-icon {
-  opacity: 1;
+	opacity: 1;
 }
 
 .slash-menu-name {
-  font-size: 0.82rem;
-  font-weight: 600;
-  font-family: var(--mono);
-  color: var(--accent);
-  white-space: nowrap;
+	font-size: 0.82rem;
+	font-weight: 600;
+	font-family: var(--mono);
+	color: var(--accent);
+	white-space: nowrap;
 }
 
 .slash-menu-args {
-  font-size: 0.75rem;
-  color: var(--muted);
-  font-family: var(--mono);
-  opacity: 0.65;
+	font-size: 0.75rem;
+	color: var(--muted);
+	font-family: var(--mono);
+	opacity: 0.65;
 }
 
 .slash-menu-desc {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: right;
-  font-size: 0.75rem;
-  color: var(--muted);
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	text-align: right;
+	font-size: 0.75rem;
+	color: var(--muted);
 }
 
 .slash-menu-item--active .slash-menu-name {
-  color: var(--accent-hover);
+	color: var(--accent-hover);
 }
 
 .slash-menu-item--active .slash-menu-desc {
-  color: var(--text);
+	color: var(--text);
 }
 
 .chat-attachments-preview {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  margin-bottom: 8px;
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+	margin-bottom: 8px;
 }
 
 .chat-attachment-thumb {
-  position: relative;
-  width: 60px;
-  height: 60px;
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-  border: 1px solid var(--border);
+	position: relative;
+	width: 60px;
+	height: 60px;
+	border-radius: var(--radius-sm);
+	overflow: hidden;
+	border: 1px solid var(--border);
 }
 
 .chat-attachment-thumb img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
 }
 
 .chat-attachment-remove {
-  position: absolute;
-  top: 2px;
-  right: 2px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  border: none;
-  background: rgba(0, 0, 0, 0.6);
-  color: #fff;
-  font-size: 12px;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	position: absolute;
+	top: 2px;
+	right: 2px;
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	border: none;
+	background: rgba(0, 0, 0, 0.6);
+	color: #fff;
+	font-size: 12px;
+	line-height: 1;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .chat-attachment-file {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 0.72rem;
-  color: var(--muted);
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 0.72rem;
+	color: var(--muted);
 }
 
 .agent-chat__file-input {
-  display: none;
+	display: none;
 }
 
 /* Chat controls - moved to content-header area, left aligned */
 .chat-controls {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 12px;
-  flex-wrap: wrap;
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 12px;
+	flex-wrap: wrap;
 }
 
 .chat-controls__session {
-  min-width: 140px;
-  max-width: 300px;
+	min-width: 140px;
+	max-width: 300px;
 }
 
 .chat-controls__thinking {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 13px;
 }
 
 /* Icon button style */
 .btn--icon {
-  padding: 8px !important;
-  min-width: 36px;
-  height: 36px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.06);
+	padding: 8px !important;
+	min-width: 36px;
+	height: 36px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border: 1px solid var(--border);
+	background: rgba(255, 255, 255, 0.06);
 }
 
 /* Controls separator */
 .chat-controls__separator {
-  color: rgba(255, 255, 255, 0.4);
-  font-size: 18px;
-  margin: 0 8px;
-  font-weight: 300;
+	color: rgba(255, 255, 255, 0.4);
+	font-size: 18px;
+	margin: 0 8px;
+	font-weight: 300;
 }
 
 :root[data-theme-mode="light"] .chat-controls__separator {
-  color: rgba(16, 24, 40, 0.3);
+	color: rgba(16, 24, 40, 0.3);
 }
 
 .btn--icon:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.2);
+	background: rgba(255, 255, 255, 0.12);
+	border-color: rgba(255, 255, 255, 0.2);
 }
 
 /* Light theme icon button overrides */
 :root[data-theme-mode="light"] .btn--icon {
-  background: #ffffff;
-  border-color: var(--border);
-  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
-  color: var(--muted);
+	background: #ffffff;
+	border-color: var(--border);
+	box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
+	color: var(--muted);
 }
 
 :root[data-theme-mode="light"] .btn--icon:hover {
-  background: #ffffff;
-  border-color: var(--border-strong);
-  color: var(--text);
+	background: #ffffff;
+	border-color: var(--border-strong);
+	color: var(--text);
 }
 
 /* Light theme icon button overrides */
 :root[data-theme-mode="light"] .btn--icon {
-  background: #ffffff;
-  border-color: var(--border);
-  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
-  color: var(--muted);
+	background: #ffffff;
+	border-color: var(--border);
+	box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
+	color: var(--muted);
 }
 
 :root[data-theme-mode="light"] .btn--icon:hover {
-  background: #ffffff;
-  border-color: var(--border-strong);
-  color: var(--text);
+	background: #ffffff;
+	border-color: var(--border-strong);
+	color: var(--text);
 }
 
 :root[data-theme-mode="light"] .chat-controls .btn--icon.active {
-  border-color: var(--accent);
-  background: var(--accent-subtle);
-  color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent-subtle);
+	border-color: var(--accent);
+	background: var(--accent-subtle);
+	color: var(--accent);
+	box-shadow: 0 0 0 1px var(--accent-subtle);
 }
 
 .btn--icon svg {
-  display: block;
-  width: 18px;
-  height: 18px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+	display: block;
+	width: 18px;
+	height: 18px;
+	stroke: currentColor;
+	fill: none;
+	stroke-width: 1.5px;
+	stroke-linecap: round;
+	stroke-linejoin: round;
 }
 
 .chat-controls__session select {
-  padding: 6px 10px;
-  font-size: 13px;
-  max-width: 300px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	padding: 6px 10px;
+	font-size: 13px;
+	max-width: 300px;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .chat-controls__thinking {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 12px;
-  padding: 4px 10px;
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 6px;
-  border: 1px solid var(--border);
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 12px;
+	padding: 4px 10px;
+	background: rgba(255, 255, 255, 0.04);
+	border-radius: 6px;
+	border: 1px solid var(--border);
 }
 
 /* Light theme thinking indicator override */
 :root[data-theme-mode="light"] .chat-controls__thinking {
-  background: rgba(255, 255, 255, 0.9);
-  border-color: rgba(16, 24, 40, 0.15);
+	background: rgba(255, 255, 255, 0.9);
+	border-color: rgba(16, 24, 40, 0.15);
 }
 
 @media (max-width: 640px) {
-  .chat-session {
-    min-width: 140px;
-  }
+	.chat-session {
+		min-width: 140px;
+	}
 
-  .chat-compose {
-    grid-template-columns: 1fr;
-  }
+	.chat-compose {
+		grid-template-columns: 1fr;
+	}
 
-  /* Mobile: stack compose row vertically */
-  .chat-compose__row {
-    flex-direction: column;
-    gap: 8px;
-  }
+	/* Mobile: stack compose row vertically */
+	.chat-compose__row {
+		flex-direction: column;
+		gap: 8px;
+	}
 
-  /* Mobile: stack action buttons vertically */
-  .chat-compose__actions {
-    flex-direction: column;
-    width: 100%;
-    gap: 8px;
-  }
+	/* Mobile: stack action buttons vertically */
+	.chat-compose__actions {
+		flex-direction: column;
+		width: 100%;
+		gap: 8px;
+	}
 
-  /* Mobile: full-width buttons */
-  .chat-compose .chat-compose__actions .btn {
-    width: 100%;
-  }
+	/* Mobile: full-width buttons */
+	.chat-compose .chat-compose__actions .btn {
+		width: 100%;
+	}
 
-  .chat-controls {
-    flex-wrap: wrap;
-    gap: 8px;
-  }
+	.chat-controls {
+		flex-wrap: wrap;
+		gap: 8px;
+	}
 
-  .chat-controls__session {
-    min-width: 120px;
-  }
+	.chat-controls__session {
+		min-width: 120px;
+	}
 }
 
 /* Chat loading skeleton */
 .chat-loading-skeleton {
-  padding: 4px 0;
-  animation: fade-in 0.3s var(--ease-out);
+	padding: 4px 0;
+	animation: fade-in 0.3s var(--ease-out);
 }
 
 /* Welcome state (new session) */
 .agent-chat__welcome {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  gap: 12px;
-  padding: 48px 24px;
-  flex: 1;
-  min-height: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	gap: 12px;
+	padding: 48px 24px;
+	flex: 1;
+	min-height: 0;
 }
 
 .agent-chat__welcome-glow {
-  display: none;
+	display: none;
 }
 
 .agent-chat__welcome h2 {
-  font-size: 20px;
-  font-weight: 600;
-  margin: 0;
-  color: var(--foreground);
+	font-size: 20px;
+	font-weight: 600;
+	margin: 0;
+	color: var(--foreground);
 }
 
 .agent-chat__avatar--logo {
-  width: 48px;
-  height: 48px;
-  border-radius: 14px;
-  background: var(--panel-strong);
-  border: 1px solid var(--border);
-  display: grid;
-  place-items: center;
-  overflow: hidden;
+	width: 48px;
+	height: 48px;
+	border-radius: 14px;
+	background: var(--panel-strong);
+	border: 1px solid var(--border);
+	display: grid;
+	place-items: center;
+	overflow: hidden;
 }
 
 .agent-chat__avatar--logo img {
-  width: 32px;
-  height: 32px;
-  object-fit: contain;
+	width: 32px;
+	height: 32px;
+	object-fit: contain;
 }
 
 .agent-chat__badges {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  justify-content: center;
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+	justify-content: center;
 }
 
 .agent-chat__badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--muted);
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 100px;
-  padding: 4px 12px;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--muted);
+	background: var(--panel);
+	border: 1px solid var(--border);
+	border-radius: 100px;
+	padding: 4px 12px;
 }
 
 .agent-chat__badge img {
-  width: 14px;
-  height: 14px;
-  object-fit: contain;
+	width: 14px;
+	height: 14px;
+	object-fit: contain;
 }
 
 .agent-chat__hint {
-  font-size: 13px;
-  color: var(--muted);
-  margin: 0;
+	font-size: 13px;
+	color: var(--muted);
+	margin: 0;
 }
 
 .agent-chat__hint kbd {
-  display: inline-block;
-  padding: 1px 6px;
-  font-size: 11px;
-  font-family: var(--font-mono);
-  background: var(--panel-strong);
-  border: 1px solid var(--border);
-  border-radius: 4px;
+	display: inline-block;
+	padding: 1px 6px;
+	font-size: 11px;
+	font-family: var(--font-mono);
+	background: var(--panel-strong);
+	border: 1px solid var(--border);
+	border-radius: 4px;
 }
 
 .agent-chat__suggestions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  justify-content: center;
-  max-width: 480px;
-  margin-top: 8px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	justify-content: center;
+	max-width: 480px;
+	margin-top: 8px;
 }
 
 .agent-chat__suggestion {
-  font-size: 13px;
-  padding: 8px 16px;
-  border-radius: 100px;
-  border: 1px solid var(--border);
-  background: var(--panel);
-  color: var(--foreground);
-  cursor: pointer;
-  transition:
-    background 0.15s,
-    border-color 0.15s;
+	font-size: 13px;
+	padding: 8px 16px;
+	border-radius: 100px;
+	border: 1px solid var(--border);
+	background: var(--panel);
+	color: var(--foreground);
+	cursor: pointer;
+	transition:
+		background 0.15s,
+		border-color 0.15s;
 }
 
 .agent-chat__suggestion:hover {
-  background: var(--panel-strong);
-  border-color: var(--accent);
+	background: var(--panel-strong);
+	border-color: var(--accent);
+}
+
+/* Chat Controls Custom Tooltips */
+.chat-controls [data-tooltip] {
+	position: relative;
+}
+
+.chat-controls [data-tooltip]:hover::after {
+	content: attr(data-tooltip);
+	position: absolute;
+	bottom: -32px;
+	left: 50%;
+	transform: translateX(-50%);
+	background: var(--bg);
+	color: var(--text);
+	border: 1px solid var(--border);
+	padding: 4px 8px;
+	border-radius: 4px;
+	font-size: 11px;
+	white-space: nowrap;
+	opacity: 0;
+	pointer-events: none;
+	animation: chat-tooltip-fade-in 0.15s ease-in-out forwards;
+	animation-delay: 0.1s;
+	z-index: 100;
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+@keyframes chat-tooltip-fade-in {
+	from {
+		opacity: 0;
+		transform: translateX(-50%) translateY(-4px);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(-50%) translateY(0);
+	}
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -935,7 +935,8 @@
   position: relative;
 }
 
-.chat-controls [data-tooltip]:hover::after {
+.chat-controls [data-tooltip]:hover::after,
+.chat-controls [data-tooltip]:focus-visible::after {
   content: attr(data-tooltip);
   position: absolute;
   bottom: -32px;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -832,7 +832,8 @@
   justify-content: space-between;
   gap: 16px;
   padding: 4px 8px;
-  overflow: visible; /* allow tooltips to escape bounds */
+  overflow-x: clip;
+  overflow-y: visible; /* allow tooltips to escape bounds */
   transform-origin: top center;
   transition:
     opacity var(--shell-focus-duration) var(--shell-focus-ease),

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -832,7 +832,7 @@
   justify-content: space-between;
   gap: 16px;
   padding: 4px 8px;
-  overflow: hidden;
+  overflow: visible; /* allow tooltips to escape bounds */
   transform-origin: top center;
   transition:
     opacity var(--shell-focus-duration) var(--shell-focus-ease),
@@ -843,6 +843,7 @@
 }
 
 .shell--chat-focus .content-header {
+  overflow: hidden; /* added for collapse clipping */
   opacity: 0;
   transform: translateY(-8px);
   max-height: 0px;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -832,8 +832,7 @@
   justify-content: space-between;
   gap: 16px;
   padding: 4px 8px;
-  overflow-x: clip;
-  overflow-y: visible; /* allow tooltips to escape bounds */
+  overflow: visible; /* allow tooltips to escape bounds */
   transform-origin: top center;
   transition:
     opacity var(--shell-focus-duration) var(--shell-focus-ease),

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -228,7 +228,7 @@ export function renderChatControls(state: AppViewState) {
             });
           }
         }}
-        title=${t("chat.refreshTitle")}
+        aria-label=${t("chat.refreshTitle")} data-tooltip=${t("chat.refreshTitle")}
       >
         ${refreshIcon}
       </button>
@@ -246,7 +246,7 @@ export function renderChatControls(state: AppViewState) {
           });
         }}
         aria-pressed=${showThinking}
-        title=${disableThinkingToggle ? t("chat.onboardingDisabled") : t("chat.thinkingToggle")}
+        aria-label=${disableThinkingToggle ? t("chat.onboardingDisabled") : t("chat.thinkingToggle")} data-tooltip=${disableThinkingToggle ? t("chat.onboardingDisabled") : t("chat.thinkingToggle")}
       >
         ${icons.brain}
       </button>
@@ -263,7 +263,7 @@ export function renderChatControls(state: AppViewState) {
           });
         }}
         aria-pressed=${focusActive}
-        title=${disableFocusToggle ? t("chat.onboardingDisabled") : t("chat.focusToggle")}
+        aria-label=${disableFocusToggle ? t("chat.onboardingDisabled") : t("chat.focusToggle")} data-tooltip=${disableFocusToggle ? t("chat.onboardingDisabled") : t("chat.focusToggle")}
       >
         ${focusIcon}
       </button>
@@ -273,13 +273,7 @@ export function renderChatControls(state: AppViewState) {
           state.sessionsHideCron = !hideCron;
         }}
         aria-pressed=${hideCron}
-        title=${
-          hideCron
-            ? hiddenCronCount > 0
-              ? t("chat.showCronSessionsHidden", { count: String(hiddenCronCount) })
-              : t("chat.showCronSessions")
-            : t("chat.hideCronSessions")
-        }
+        aria-label=${hideCron ? (hiddenCronCount > 0 ? t("chat.showCronSessionsHidden", { count: String(hiddenCronCount) }) : t("chat.showCronSessions")) : t("chat.hideCronSessions")} data-tooltip=${hideCron ? (hiddenCronCount > 0 ? t("chat.showCronSessionsHidden", { count: String(hiddenCronCount) }) : t("chat.showCronSessions")) : t("chat.hideCronSessions")}
       >
         ${renderCronFilterIcon(hiddenCronCount)}
       </button>

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -219,6 +219,7 @@ export function renderChatControls(state: AppViewState) {
 
   return html`
     <div class="chat-controls">
+      <span style="display: inline-flex" data-tooltip=${refreshLabel}>
       <button
         class="btn btn--sm btn--icon"
         ?disabled=${state.chatLoading || !state.connected}
@@ -240,11 +241,13 @@ export function renderChatControls(state: AppViewState) {
             });
           }
         }}
-        aria-label=${refreshLabel} data-tooltip=${refreshLabel}
+        aria-label=${refreshLabel}
       >
         ${refreshIcon}
       </button>
+      </span>
       <span class="chat-controls__separator">|</span>
+      <span style="display: inline-flex" data-tooltip=${thinkingLabel}>
       <button
         class="btn btn--sm btn--icon ${showThinking ? "active" : ""}"
         ?disabled=${disableThinkingToggle}
@@ -258,10 +261,12 @@ export function renderChatControls(state: AppViewState) {
           });
         }}
         aria-pressed=${showThinking}
-        aria-label=${thinkingLabel} data-tooltip=${thinkingLabel}
+        aria-label=${thinkingLabel}
       >
         ${icons.brain}
       </button>
+      </span>
+      <span style="display: inline-flex" data-tooltip=${focusLabel}>
       <button
         class="btn btn--sm btn--icon ${focusActive ? "active" : ""}"
         ?disabled=${disableFocusToggle}
@@ -275,20 +280,23 @@ export function renderChatControls(state: AppViewState) {
           });
         }}
         aria-pressed=${focusActive}
-        aria-label=${focusLabel} data-tooltip=${focusLabel}
+        aria-label=${focusLabel}
       >
         ${focusIcon}
       </button>
+      </span>
+      <span style="display: inline-flex" data-tooltip=${cronLabel}>
       <button
         class="btn btn--sm btn--icon ${hideCron ? "active" : ""}"
         @click=${() => {
           state.sessionsHideCron = !hideCron;
         }}
         aria-pressed=${hideCron}
-        aria-label=${cronLabel} data-tooltip=${cronLabel}
+        aria-label=${cronLabel}
       >
         ${renderCronFilterIcon(hiddenCronCount)}
       </button>
+      </span>
     </div>
   `;
 }

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -205,6 +205,18 @@ export function renderChatControls(state: AppViewState) {
       <circle cx="12" cy="12" r="3"></circle>
     </svg>
   `;
+
+  const refreshLabel = t("chat.refreshTitle");
+  const thinkingLabel = disableThinkingToggle
+    ? t("chat.onboardingDisabled")
+    : t("chat.thinkingToggle");
+  const focusLabel = disableFocusToggle ? t("chat.onboardingDisabled") : t("chat.focusToggle");
+  const cronLabel = hideCron
+    ? hiddenCronCount > 0
+      ? t("chat.showCronSessionsHidden", { count: String(hiddenCronCount) })
+      : t("chat.showCronSessions")
+    : t("chat.hideCronSessions");
+
   return html`
     <div class="chat-controls">
       <button
@@ -228,7 +240,7 @@ export function renderChatControls(state: AppViewState) {
             });
           }
         }}
-        aria-label=${t("chat.refreshTitle")} data-tooltip=${t("chat.refreshTitle")}
+        aria-label=${refreshLabel} data-tooltip=${refreshLabel}
       >
         ${refreshIcon}
       </button>
@@ -246,7 +258,7 @@ export function renderChatControls(state: AppViewState) {
           });
         }}
         aria-pressed=${showThinking}
-        aria-label=${disableThinkingToggle ? t("chat.onboardingDisabled") : t("chat.thinkingToggle")} data-tooltip=${disableThinkingToggle ? t("chat.onboardingDisabled") : t("chat.thinkingToggle")}
+        aria-label=${thinkingLabel} data-tooltip=${thinkingLabel}
       >
         ${icons.brain}
       </button>
@@ -263,7 +275,7 @@ export function renderChatControls(state: AppViewState) {
           });
         }}
         aria-pressed=${focusActive}
-        aria-label=${disableFocusToggle ? t("chat.onboardingDisabled") : t("chat.focusToggle")} data-tooltip=${disableFocusToggle ? t("chat.onboardingDisabled") : t("chat.focusToggle")}
+        aria-label=${focusLabel} data-tooltip=${focusLabel}
       >
         ${focusIcon}
       </button>
@@ -273,7 +285,7 @@ export function renderChatControls(state: AppViewState) {
           state.sessionsHideCron = !hideCron;
         }}
         aria-pressed=${hideCron}
-        aria-label=${hideCron ? (hiddenCronCount > 0 ? t("chat.showCronSessionsHidden", { count: String(hiddenCronCount) }) : t("chat.showCronSessions")) : t("chat.hideCronSessions")} data-tooltip=${hideCron ? (hiddenCronCount > 0 ? t("chat.showCronSessionsHidden", { count: String(hiddenCronCount) }) : t("chat.showCronSessions")) : t("chat.hideCronSessions")}
+        aria-label=${cronLabel} data-tooltip=${cronLabel}
       >
         ${renderCronFilterIcon(hiddenCronCount)}
       </button>


### PR DESCRIPTION
In environments where native `title` attribute tooltips are sluggish or completely ignored (e.g. macOS desktop wrappers losing immediate hover focus), the top right Chat Controls (Refresh, Thinking Mode, Focus, Hide Cron) provide zero user feedback about what they do.

This PR migrates these 4 specific icons away from `title=` into `data-tooltip=` with a custom pure CSS animation layer that matches the standard app theme:
1. They display almost instantly (0.1s delay) avoiding the typical OS ~1-2s delay.
2. The browser accessibility is preserved via fallback `aria-label=` for screen readers.
