### PR TITLE
fix: respect provider-level contextWindow over model metadata

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -490,7 +490,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     const resultWithBaseUrl = resolveModel("ollama", "qwen3.5:9b", "/tmp/agent", cfgWithBaseUrl);
 
@@ -508,7 +508,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     const resultMinimal = resolveModel("ollama", "qwen3.5:9b", "/tmp/agent", cfgMinimal);
 

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -468,6 +468,55 @@ describe("resolveModel", () => {
     });
   });
 
+  it("uses provider-level contextWindow as default override over discovered metadata", () => {
+    mockDiscoveredModel({
+      provider: "ollama",
+      modelId: "qwen3.5:9b",
+      templateModel: {
+        ...makeModel("qwen3.5:9b"),
+        provider: "ollama",
+        contextWindow: 216000,
+        maxTokens: 8192,
+      },
+    });
+
+    const cfgWithBaseUrl = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://localhost:11434",
+            contextWindow: 8192,
+            models: [{ id: "qwen3.5:9b", name: "qwen3.5:9b" }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const resultWithBaseUrl = resolveModel("ollama", "qwen3.5:9b", "/tmp/agent", cfgWithBaseUrl);
+
+    expect(resultWithBaseUrl.error).toBeUndefined();
+    expect(resultWithBaseUrl.model?.contextWindow).toBe(8192);
+    // maxTokens still comes from discovered metadata when not explicitly overridden.
+    expect(resultWithBaseUrl.model?.maxTokens).toBe(8192);
+
+    const cfgMinimal = {
+      models: {
+        providers: {
+          ollama: {
+            contextWindow: 8192,
+            models: [{ id: "qwen3.5:9b", name: "qwen3.5:9b" }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const resultMinimal = resolveModel("ollama", "qwen3.5:9b", "/tmp/agent", cfgMinimal);
+
+    expect(resultMinimal.error).toBeUndefined();
+    expect(resultMinimal.model?.contextWindow).toBe(8192);
+    expect(resultMinimal.model?.maxTokens).toBe(8192);
+  });
+
   it("prefers exact provider config over normalized alias match when both keys exist", () => {
     mockDiscoveredModel({
       provider: "qwen",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -25,6 +25,7 @@ type InlineProviderConfig = {
   api?: ModelDefinitionConfig["api"];
   models?: ModelDefinitionConfig[];
   headers?: unknown;
+  contextWindow?: number;
 };
 
 function sanitizeModelHeaders(
@@ -91,7 +92,13 @@ function applyConfiguredProviderOverrides(params: {
   const configuredHeaders = sanitizeModelHeaders(configuredModel?.headers, {
     stripSecretRefMarkers: true,
   });
-  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerHeaders) {
+  if (
+    !configuredModel &&
+    !providerConfig.baseUrl &&
+    !providerConfig.api &&
+    !providerHeaders &&
+    !providerConfig.contextWindow
+  ) {
     return {
       ...discoveredModel,
       headers: discoveredHeaders,
@@ -110,7 +117,10 @@ function applyConfiguredProviderOverrides(params: {
     reasoning: configuredModel?.reasoning ?? discoveredModel.reasoning,
     input: normalizedInput,
     cost: configuredModel?.cost ?? discoveredModel.cost,
-    contextWindow: configuredModel?.contextWindow ?? discoveredModel.contextWindow,
+    contextWindow:
+      configuredModel?.contextWindow ??
+      providerConfig.contextWindow ??
+      discoveredModel.contextWindow,
     maxTokens: configuredModel?.maxTokens ?? discoveredModel.maxTokens,
     headers:
       discoveredHeaders || providerHeaders || configuredHeaders
@@ -246,6 +256,7 @@ export function resolveModelWithRegistry(params: {
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow:
           configuredModel?.contextWindow ??
+          providerConfig?.contextWindow ??
           providerConfig?.models?.[0]?.contextWindow ??
           DEFAULT_CONTEXT_TOKENS,
         maxTokens:


### PR DESCRIPTION
## Description

### Summary

Fix a bug where provider-level `contextWindow` configured in `openclaw.json` is ignored and silently overwritten by model metadata on gateway restart. After this change, provider-level `contextWindow` acts as a default override for all models under that provider, unless a per-model `contextWindow` is explicitly set.

### Background

When users configure an Ollama provider with a provider-level `contextWindow`:

```json
{
  "providers": {
    "ollama": {
      "baseUrl": "http://localhost:11434",
      "contextWindow": 8192
    }
  },
  "defaultModel": "ollama/qwen3.5:9b"
}
```

they expect this `contextWindow` to apply to all models under `ollama` by default. Instead, after `openclaw gateway restart`, the effective `contextWindow` is reset to the model’s declared `context_length` (e.g., 216k for Qwen models), and the provider-level override is lost. Only `contextWindow` set per-model inside `providers.<name>.models[]` persists across restarts.

This behavior is surprising, especially for local deployments (Ollama, vLLM, etc.) where large `context_length` values are impractical on 8–16GB VRAM, and users need to enforce smaller windows (8k–16k) to avoid OOM or extreme slowness.

Issue reference: #44786

### Changes

- **Model resolution / provider overrides** (`src/agents/pi-embedded-runner/model.ts`)
  - Extend the inline provider config used by the embedded runner to include a `contextWindow` field:

    ```ts
    type InlineProviderConfig = {
      baseUrl?: string;
      api?: ModelDefinitionConfig["api"];
      models?: ModelDefinitionConfig[];
      headers?: unknown;
      contextWindow?: number;
    };
    ```

  - Update `applyConfiguredProviderOverrides` so that it respects provider-level `contextWindow` when merging discovered registry models with user config. The new precedence is:

    ```ts
    contextWindow: configuredModel?.contextWindow ??
      providerConfig.contextWindow ??
      discoveredModel.contextWindow;
    ```

    This means:
    - Per-model `contextWindow` still has highest priority.
    - Provider-level `contextWindow` now acts as a default override.
    - Model metadata (`contextWindow` / `context_length`) is only used when neither config value is present.

  - In the provider fallback branch (when no registry model is found but a provider config exists), ensure provider-level `contextWindow` is used before falling back to any model entry or generic defaults:

    ```ts
    contextWindow: configuredModel?.contextWindow ??
      providerConfig?.contextWindow ??
      providerConfig?.models?.[0]?.contextWindow ??
      DEFAULT_CONTEXT_TOKENS;
    ```

- **Tests** (`src/agents/pi-embedded-runner/model.test.ts`)
  - Add a test that simulates the reported Ollama scenario:
    - A discovered model for `ollama/qwen3.5:9b` declares a large `contextWindow` (e.g., 216k).
    - The user configures:

      ```json
      {
        "models": {
          "providers": {
            "ollama": {
              "baseUrl": "http://localhost:11434",
              "contextWindow": 8192,
              "models": [{ "id": "qwen3.5:9b", "name": "qwen3.5:9b" }]
            }
          }
        }
      }
      ```

    - The test asserts that:
      - `resolveModel("ollama", "qwen3.5:9b", ...)` returns a model with `contextWindow === 8192`.
      - `maxTokens` continues to come from discovered metadata when not explicitly overridden.

  - Keep existing tests that verify:
    - Per-model `contextWindow` and `maxTokens` overrides are honored.
    - Provider-level `api`, `baseUrl`, and headers are preferred over discovered registry entries when configured.

### Rationale

- Provider-level `contextWindow` is an explicit user configuration and should not be silently overridden by model metadata on restart.
- The new precedence model is:
  1. Per-model `contextWindow` (most specific).
  2. Provider-level `contextWindow` (default override for all models).
  3. Model metadata (catalog-derived defaults when nothing is configured).

- This matches user expectations and mirrors how other provider-level settings (e.g., `api`, `baseUrl`, headers) behave when merging with discovered models.

### Testing

- **Unit tests**
  - Attempted to run:

    ```bash
    pnpm test -- src/agents/pi-embedded-runner/model.test.ts --run
    ```

  - On this environment, the suite fails to start due to a missing external dependency:

    ```text
    Error: Cannot find package '@mariozechner/pi-ai/oauth' imported from src/agents/auth-profiles/oauth.ts
    ```

  - This is a pre-existing environment issue unrelated to the changes in `model.ts` and `model.test.ts`. The new test is written alongside existing `resolveModel` tests and follows the same patterns/fixtures.

- **Behavioral verification**
  - Existing tests that verify model-level overrides and provider-level API/baseUrl/header merges continue to describe the intended behavior.
  - The new test specifically asserts that provider-level `contextWindow` is used as a default override over discovered metadata for local/Ollama-like providers.

### Impact

- Makes provider-level `contextWindow` behave as users expect:
  - Acts as a default for all models under that provider.
  - Survives gateway restarts without being overwritten by model metadata.
- Reduces confusion and repeated support questions for local providers with very large advertised contexts (Qwen, DeepSeek, etc.) on constrained hardware.
- No changes to public schema; this is an implementation fix to how config is merged with discovered model metadata.
- No version bump or release flow changes.

### Related

- #44786
