### PR TITLE
fix(gateway): restore loopback handshake timeout budget (#44714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Agents/memory bootstrap: load only one root memory file, preferring `MEMORY.md` and using `memory.md` as a fallback, so case-insensitive Docker mounts no longer inject duplicate memory context. (#26054) Thanks @Lanfei.
 - Agents/OpenAI-compatible compat overrides: respect explicit user `models[].compat` opt-ins for non-native `openai-completions` endpoints so usage-in-streaming capability overrides no longer get forced off when the endpoint actually supports them. (#44432) Thanks @cheapestinference.
 - Agents/Azure OpenAI startup prompts: rephrase the built-in `/new`, `/reset`, and post-compaction startup instruction so Azure OpenAI deployments no longer hit HTTP 400 false positives from the content filter. (#43403) Thanks @xingsy97.
+- Gateway/loopback CLI handshakes: keep the longer pre-auth timeout for direct localhost WebSocket connects while retaining the hardened shorter timeout for non-local clients, so loaded machines do not fail healthy local CLI commands with `handshake-timeout`. (#44714)
 
 ## 2026.3.12
 

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -3,6 +3,7 @@
 export const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
 export const MAX_BUFFERED_BYTES = 50 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
 export const MAX_PREAUTH_PAYLOAD_BYTES = 64 * 1024;
+export const DEFAULT_LOCAL_HANDSHAKE_TIMEOUT_MS = 10_000;
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits
 let maxChatHistoryMessagesBytes = DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES;
@@ -22,14 +23,14 @@ export const __setMaxChatHistoryMessagesBytesForTest = (value?: number) => {
   }
 };
 export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 3_000;
-export const getHandshakeTimeoutMs = () => {
+export const getHandshakeTimeoutMs = (isLocalClient = false) => {
   if (process.env.VITEST && process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS) {
     const parsed = Number(process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);
     if (Number.isFinite(parsed) && parsed > 0) {
       return parsed;
     }
   }
-  return DEFAULT_HANDSHAKE_TIMEOUT_MS;
+  return isLocalClient ? DEFAULT_LOCAL_HANDSHAKE_TIMEOUT_MS : DEFAULT_HANDSHAKE_TIMEOUT_MS;
 };
 export const TICK_INTERVAL_MS = 30_000;
 export const HEALTH_REFRESH_INTERVAL_MS = 60_000;

--- a/src/gateway/server-handshake-timeout.ts
+++ b/src/gateway/server-handshake-timeout.ts
@@ -1,0 +1,16 @@
+import type { IncomingMessage } from "node:http";
+import { isLocalDirectRequest } from "./auth.js";
+import { getHandshakeTimeoutMs } from "./server-constants.js";
+
+export function resolveHandshakeTimeoutMs(params: {
+  req: IncomingMessage;
+  trustedProxies?: string[];
+  allowRealIpFallback?: boolean;
+}): number {
+  const isLocalHandshake = isLocalDirectRequest(
+    params.req,
+    params.trustedProxies,
+    params.allowRealIpFallback === true,
+  );
+  return getHandshakeTimeoutMs(isLocalHandshake);
+}

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -32,6 +32,16 @@ describe("gateway pre-auth hardening", () => {
       resolveHandshakeTimeoutMs({
         req: createGatewayRequest({
           path: "/",
+          host: "[::1]:18789",
+          remoteAddress: "::1",
+        }),
+      }),
+    ).toBe(DEFAULT_LOCAL_HANDSHAKE_TIMEOUT_MS);
+
+    expect(
+      resolveHandshakeTimeoutMs({
+        req: createGatewayRequest({
+          path: "/",
           host: "gateway.example:18789",
           remoteAddress: "203.0.113.10",
         }),

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
+import { createGatewayRequest } from "./hooks-test-helpers.js";
+import {
+  DEFAULT_HANDSHAKE_TIMEOUT_MS,
+  DEFAULT_LOCAL_HANDSHAKE_TIMEOUT_MS,
+  MAX_PREAUTH_PAYLOAD_BYTES,
+} from "./server-constants.js";
+import { resolveHandshakeTimeoutMs } from "./server-handshake-timeout.js";
 import { createGatewaySuiteHarness, readConnectChallengeNonce } from "./test-helpers.server.js";
 
 let cleanupEnv: Array<() => void> = [];
@@ -11,6 +17,43 @@ afterEach(async () => {
 });
 
 describe("gateway pre-auth hardening", () => {
+  it("keeps the longer default timeout for direct loopback handshakes only", () => {
+    expect(
+      resolveHandshakeTimeoutMs({
+        req: createGatewayRequest({
+          path: "/",
+          host: "127.0.0.1:18789",
+          remoteAddress: "127.0.0.1",
+        }),
+      }),
+    ).toBe(DEFAULT_LOCAL_HANDSHAKE_TIMEOUT_MS);
+
+    expect(
+      resolveHandshakeTimeoutMs({
+        req: createGatewayRequest({
+          path: "/",
+          host: "gateway.example:18789",
+          remoteAddress: "203.0.113.10",
+        }),
+      }),
+    ).toBe(DEFAULT_HANDSHAKE_TIMEOUT_MS);
+
+    expect(
+      resolveHandshakeTimeoutMs({
+        req: createGatewayRequest({
+          path: "/",
+          host: "gateway.example:18789",
+          remoteAddress: "127.0.0.1",
+          headers: {
+            "x-forwarded-for": "203.0.113.10",
+            "x-forwarded-host": "gateway.example:18789",
+          },
+        }),
+        trustedProxies: ["127.0.0.1"],
+      }),
+    ).toBe(DEFAULT_HANDSHAKE_TIMEOUT_MS);
+  });
+
   it("closes idle unauthenticated sockets after the handshake timeout", async () => {
     const previous = process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS;
     process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS = "200";

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { WebSocket, WebSocketServer } from "ws";
+import { loadConfig } from "../../config/config.js";
 import { resolveCanvasHostUrl } from "../../infra/canvas-host-url.js";
 import { removeRemoteNodeInfo } from "../../infra/skills-remote.js";
 import { upsertPresence } from "../../infra/system-presence.js";
@@ -9,7 +10,7 @@ import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { isLoopbackAddress } from "../net.js";
-import { getHandshakeTimeoutMs } from "../server-constants.js";
+import { resolveHandshakeTimeoutMs } from "../server-handshake-timeout.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
 import { logWs } from "../ws-log.js";
@@ -264,7 +265,12 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       close();
     });
 
-    const handshakeTimeoutMs = getHandshakeTimeoutMs();
+    const configSnapshot = loadConfig();
+    const handshakeTimeoutMs = resolveHandshakeTimeoutMs({
+      req: upgradeReq,
+      trustedProxies: configSnapshot.gateway?.trustedProxies ?? [],
+      allowRealIpFallback: configSnapshot.gateway?.allowRealIpFallback === true,
+    });
     const handshakeTimer = setTimeout(() => {
       if (!client) {
         handshakeState = "failed";


### PR DESCRIPTION
## Summary

- Problem: PR #44089 (GHSA-jv4g-m82p-2j93) reduced `DEFAULT_HANDSHAKE_TIMEOUT_MS` from 10 s → 3 s. On loaded machines, event-loop latency pushes the pre-auth WebSocket handshake past 3 s, so every local CLI command (`openclaw logs`, `openclaw cron list`, etc.) fails with `handshake-timeout` while the gateway remains healthy.
- Why it matters: Every local CLI command that uses WebSocket is broken on busy gateways after upgrading to v2026.3.12.
- What changed: Added a loopback-aware timeout tier — direct localhost connections get 10 s (pre-hardening budget), remote/proxied clients keep 3 s (preserving the security hardening).
- What did NOT change (scope boundary): Remote client timeout, pre-auth payload limit, or any other GHSA-jv4g-m82p-2j93 hardening.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens

## Linked Issue/PR

- Closes #44714
- Closes #44901
- Related #44089

## User-visible / Behavior Changes

Local CLI commands that were failing with `handshake-timeout` on v2026.3.12 will work again. No config changes needed.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Debian 13 x64 / macOS (reported by multiple users)
- Runtime/container: Node v22+
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: Default local gateway, auth mode token

### Steps

1. Start gateway on v2026.3.12
2. Ensure some background load (active cron jobs, plugin activity)
3. Run `openclaw logs --follow` or `openclaw cron list`

### Expected

- CLI connects and works normally

### Actual

- `gateway closed (1000 normal closure)` / `handshake-timeout`

## Evidence

- Gateway log shows `{"cause":"handshake-timeout","handshakeMs":3000}` for loopback connections
- After fix: loopback connections get 10 s budget, remote connections stay at 3 s (verified by unit tests)
- Multiple users confirmed the same regression in #44714 (@taikai-zz, @timmyz, @NGLSL) and #44901

## Human Verification (required)

- Verified scenarios: Local gateway with active cron jobs, `openclaw cron list` works after patching the dist bundle with the equivalent constant change
- Edge cases checked: Remote client (3 s preserved), proxied-via-loopback (3 s preserved), direct loopback (10 s restored)
- What you did **not** verify: Full CI suite (relying on CI)

## AI-Assisted Contribution 🤖

- This PR was developed with AI assistance (Codex for implementation, Claude Code for independent review)
- Testing: Lightly tested — `pnpm check` passed locally, unit tests 3/3 passed, static analysis + dual AI review, CI pending
- I understand what the code does and can explain every line

## Review Conversations

- [x] I will reply to or resolve every bot review conversation addressed in this PR.
- [x] I will leave unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; all connections fall back to 3 s
- Files/config to restore: None
- Known bad symptoms: If loopback detection misclassifies a remote connection, it would get a longer pre-auth window (10 s vs 3 s) — still well within typical HTTP server timeouts

## Risks and Mitigations

- Risk: `isLocalDirectRequest()` misclassifies a proxied remote connection as local, giving it the longer 10 s window
  - Mitigation: Uses the existing proxy-aware `isLocalDirectRequest()` which resolves the real client IP through `trustedProxies` + `X-Forwarded-For` chain; unit test explicitly covers the proxied-via-loopback scenario