### PR TITLE
fix(deps): add missing packages to onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -447,10 +447,12 @@
       "tough-cookie": "4.1.3"
     },
     "onlyBuiltDependencies": [
+      "@discordjs/opus",
       "@lydell/node-pty",
       "@matrix-org/matrix-sdk-crypto-nodejs",
       "@napi-rs/canvas",
       "@tloncorp/api",
+      "@tloncorp/tlon-skill",
       "@whiskeysockets/baileys",
       "authenticate-pam",
       "esbuild",


### PR DESCRIPTION
## Summary

- Add `@discordjs/opus` and `@tloncorp/tlon-skill` to `pnpm.onlyBuiltDependencies` in `package.json`

These two packages have native build scripts that pnpm currently skips because they are not in the `onlyBuiltDependencies` allowlist:

- **`@discordjs/opus`** — native Opus audio codec binding used by Discord voice (`@discordjs/voice`). Without its build step, the native addon is not compiled and voice features fail at runtime.
- **`@tloncorp/tlon-skill`** — Tlon/Urbit integration package with a postinstall build step. Skipping it causes the package to be incomplete.

Both produce "Ignored build scripts" warnings on `pnpm install`. Adding them to the allowlist lets pnpm run their build scripts as intended.

## Test plan

- [ ] Run `pnpm install` and confirm no "Ignored build scripts" warnings for `@discordjs/opus` or `@tloncorp/tlon-skill`
- [ ] Verify the `onlyBuiltDependencies` array remains alphabetically sorted