### PR TITLE
fix(config): move Anthropic aliases to own module to prevent TDZ on startup

### DIFF
--- a/src/agents/anthropic-model-aliases.ts
+++ b/src/agents/anthropic-model-aliases.ts
@@ -1,0 +1,18 @@
+/**
+ * Short-form aliases for Anthropic model identifiers.
+ *
+ * Lives in its own module to avoid a Temporal Dead Zone crash in the
+ * production bundle.  The bundler emits this const after the config
+ * loader that needs it, so co-locating it in model-selection.ts
+ * triggers `ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES'
+ * before initialization` on gateway startup.
+ */
+
+const ALIASES: Record<string, string> = {
+  "opus-4.6": "claude-opus-4-6",
+  "opus-4.5": "claude-opus-4-5",
+  "sonnet-4.6": "claude-sonnet-4-6",
+  "sonnet-4.5": "claude-sonnet-4-5",
+};
+
+export { ALIASES as ANTHROPIC_MODEL_ALIASES };

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -12,6 +12,7 @@ import {
   resolveAgentEffectiveModelPrimary,
   resolveAgentModelFallbacksOverride,
 } from "./agent-scope.js";
+import { ANTHROPIC_MODEL_ALIASES } from "./anthropic-model-aliases.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
@@ -29,13 +30,6 @@ export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh"
 export type ModelAliasIndex = {
   byAlias: Map<string, { alias: string; ref: ModelRef }>;
   byKey: Map<string, string[]>;
-};
-
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
 };
 
 function normalizeAliasKey(value: string): string {


### PR DESCRIPTION
Fixes #44977

## Problem

After upgrading to v2026.3.12, gateway fails at startup:

```
ReferenceError: Cannot access ANTHROPIC_MODEL_ALIASES before initialization
```

## Root Cause

The production single-file bundle emits the `ANTHROPIC_MODEL_ALIASES` const declaration well after the config-loading code that references it during `parseModelRef`. This creates a Temporal Dead Zone — the variable exists but has not been initialized when it is first read.

## Fix

Move the alias map into a dedicated leaf module (`anthropic-model-aliases.ts`) so the bundler can place it early in the output. The map is re-exported under the same name so all existing call sites work without changes.

Closes #44977