### PR TITLE
Fix: add missing context notice styles

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -70,7 +70,7 @@
 
 .context-notice__detail {
   color: var(--muted);
-  font-family: var(--font-mono);
+  font-family: var(--mono);
   font-size: 11px;
   font-weight: 500;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -47,6 +47,34 @@
   min-width: 180px;
 }
 
+.context-notice {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ctx-color) 40%, transparent);
+  background: var(--ctx-bg);
+  color: var(--ctx-color);
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+.context-notice__icon {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+}
+
+.context-notice__detail {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+}
+
 /* Chat thread - scrollable middle section, transparent */
 .chat-thread {
   flex: 1 1 0; /* Grow, shrink, and use 0 base for proper scrolling */


### PR DESCRIPTION
## Summary

- Problem: In the Control UI chat view, when the high-context usage notice is rendered, the warning SVG can expand to an oversized triangle and obscure most of the conversation pane.
- Why it matters: This makes long-running or high-context sessions effectively unreadable even though the gateway, session data, and chat APIs are healthy.
- What changed: Added the missing styling for the context usage notice so it renders as a compact inline warning pill with a fixed-size icon and secondary detail text.
- What did NOT change (scope boundary): No backend, gateway, session, auth, model, or context-management logic changed; this PR only fixes Control UI presentation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

- High-context chat sessions now show the context usage notice as a compact inline warning instead of an oversized warning icon covering the chat pane.
- No config or default behavior changed.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw gateway / Control UI
- Model/provider: reproduced on a high-context local chat session
- Integration/channel (if any): none
- Relevant config (redacted): session had context usage above the warning threshold and rendered `100% context used` with token counts like `470.8k / 272k`

### Steps

1. Open a chat session whose `inputTokens / contextTokens` is above the context warning threshold.
2. Load the Control UI chat page for that session.
3. Observe the rendered context usage warning in the chat pane.

### Expected

- The context usage warning renders as a compact inline status element and the conversation remains readable.

### Actual

- The warning SVG expands to a very large triangle and obscures most of the chat pane.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced the bug in the chat UI with a real high-context session.
  - Confirmed backend/gateway/session health independently.
  - Applied the style fix and verified the notice rendered as a compact inline pill instead of a large blocking icon.
- Edge cases checked:
  - Verified the issue was not caused by missing auth, broken session data, or gateway failure.
  - Verified the notice still displays its text and token detail after the fix.
- What you did **not** verify:
  - I did not verify all themes, all viewport sizes, or a full upstream CI/browser matrix in this environment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert the added context notice styles.
- Files/config to restore:
  - Restore the affected Control UI style/source files to their previous state.
- Known bad symptoms reviewers should watch for:
  - The context warning icon becomes oversized again.
  - The notice text disappears or becomes misaligned.
  - The chat composer/thread spacing regresses around the warning banner.

## Risks and Mitigations

- Risk:
  - The new styles could conflict with existing chat layout or theme styling in other contexts.
  - Mitigation:
    - The change is scoped to `.context-notice`, `.context-notice__icon`, and `.context-notice__detail` only, with no backend or shared logic changes.

- Risk:
  - The notice may look correct in the main reproduction case but regress in untested themes or narrow layouts.
  - Mitigation:
    - The styles are minimal, size-constrained, and use existing CSS variables for the notice colors.
