### PR TITLE
fix(agents): prevent TDZ on ANTHROPIC_MODEL_ALIASES across chunk boundaries

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -31,12 +31,21 @@ export type ModelAliasIndex = {
   byKey: Map<string, string[]>;
 };
 
-const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
-  "opus-4.6": "claude-opus-4-6",
-  "opus-4.5": "claude-opus-4-5",
-  "sonnet-4.6": "claude-sonnet-4-6",
-  "sonnet-4.5": "claude-sonnet-4-5",
-};
+// Use a getter function to avoid TDZ issues when Rollup code-splits this
+// module across multiple chunks (the const may not be initialized when
+// normalizeAnthropicModelId is called from a different chunk).
+let _anthropicModelAliases: Record<string, string> | undefined;
+function getAnthropicModelAliases(): Record<string, string> {
+  if (!_anthropicModelAliases) {
+    _anthropicModelAliases = {
+      "opus-4.6": "claude-opus-4-6",
+      "opus-4.5": "claude-opus-4-5",
+      "sonnet-4.6": "claude-sonnet-4-6",
+      "sonnet-4.5": "claude-sonnet-4-5",
+    };
+  }
+  return _anthropicModelAliases;
+}
 
 function normalizeAliasKey(value: string): string {
   return value.trim().toLowerCase();
@@ -151,7 +160,7 @@ function normalizeAnthropicModelId(model: string): string {
     return trimmed;
   }
   const lower = trimmed.toLowerCase();
-  return ANTHROPIC_MODEL_ALIASES[lower] ?? trimmed;
+  return getAnthropicModelAliases()[lower] ?? trimmed;
 }
 
 function normalizeProviderModelId(provider: string, model: string): string {


### PR DESCRIPTION
## Summary

Convert the top-level `const ANTHROPIC_MODEL_ALIASES` in `model-selection.ts` to a lazy-initialized getter function to prevent temporal dead zone (TDZ) `ReferenceError` crashes.

## Problem

In 2026.3.12, the provider-plugin architecture refactor changed Rollup entry points and chunk boundaries. This causes `normalizeAnthropicModelId()` to execute before `ANTHROPIC_MODEL_ALIASES` is initialized in several dist chunks (`reply-*.js`, `auth-profiles-*.js`, `plugin-sdk/tts-core-*.js`).

The const is correctly defined at module scope in source, but Rollup's code-splitting reorders the emitted chunks so the function reference lands in a chunk that evaluates before the chunk containing the const initializer.

## Fix

Replace the top-level `const` with a lazy getter function (`getAnthropicModelAliases()`). This ensures the aliases map is always available at call time regardless of chunk evaluation order, without changing any runtime behavior.

## Testing

- Verified the fix resolves the crash in a Docker from-source build of 2026.3.12
- The lazy getter returns identical results to the original const

Fixes #45006