### PR TITLE
fix: use globalThis singleton for agent-events to prevent cross-chunk listener isolation

### DIFF
--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -19,10 +19,27 @@ export type AgentRunContext = {
   isControlUiVisible?: boolean;
 };
 
-// Keep per-run counters so streams stay strictly monotonic per runId.
-const seqByRun = new Map<string, number>();
-const listeners = new Set<(evt: AgentEventPayload) => void>();
-const runContextById = new Map<string, AgentRunContext>();
+// ─── Global singleton ────────────────────────────────────────────────
+// tsdown inlines this module into multiple chunks, each getting its own
+// module-level state.  Using globalThis ensures every chunk shares the
+// same listeners Set, seqByRun Map and runContextById Map – which is
+// the intended design (global pub/sub bus within a single gateway process).
+const GLOBAL_KEY = Symbol.for("__openclaw_agent_events_v1__");
+
+type AgentEventsGlobal = {
+  seqByRun: Map<string, number>;
+  listeners: Set<(evt: AgentEventPayload) => void>;
+  runContextById: Map<string, AgentRunContext>;
+};
+
+const _global: AgentEventsGlobal = ((globalThis as Record<symbol, unknown>)[GLOBAL_KEY] ??= {
+  seqByRun: new Map<string, number>(),
+  listeners: new Set<(evt: AgentEventPayload) => void>(),
+  runContextById: new Map<string, AgentRunContext>(),
+}) as AgentEventsGlobal;
+
+const { seqByRun, listeners, runContextById } = _global;
+// ─────────────────────────────────────────────────────────────────────
 
 export function registerAgentRunContext(runId: string, context: AgentRunContext) {
   if (!runId) {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -74,6 +74,8 @@ export function clearAgentRunContext(runId: string) {
 
 export function resetAgentRunContextForTest() {
   runContextById.clear();
+  seqByRun.clear();
+  listeners.clear();
 }
 
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {


### PR DESCRIPTION
## Problem

`agent-events.ts` maintains module-level state (`listeners` Set, `seqByRun` Map, `runContextById` Map) that is intended to serve as a process-wide pub/sub bus. However, the tsdown bundler inlines this module into **6 separate dist chunks**, each receiving its own independent copy of these state objects.

When `emitAgentEvent()` executes from one chunk and `onAgentEvent()` registers a listener in a different chunk, events are never delivered because they operate on **separate `Set` instances**.

### Impact

This breaks the **ACP stream relay** feature (`startAcpSpawnParentStreamRelay`):

1. The relay registers its listener via `onAgentEvent()` in the sessions-spawn tool chunk
2. ACP lifecycle events (`phase: "start"` / `phase: "end"`) are emitted via `emitAgentEvent()` in the agent-command chunk  
3. The relay never receives the `"end"` event → **60s timeout** instead of proper completion detection
4. Parent sessions never get the completion notification or final output from child ACP sessions

There is also a latent bug: per-run sequence counters (`seqByRun`) are independently tracked per chunk, producing **duplicate `seq` numbers** for events emitted from different chunks for the same `runId`.

## Fix

Store the three shared state objects on `globalThis` behind a versioned `Symbol.for()` key:

```typescript
const GLOBAL_KEY = Symbol.for("__openclaw_agent_events_v1__");
const _global = (globalThis[GLOBAL_KEY] ??= {
  seqByRun: new Map(),
  listeners: new Set(),
  runContextById: new Map(),
});
const { seqByRun, listeners, runContextById } = _global;
```

`Symbol.for()` guarantees a process-wide unique symbol, so all inlined copies of `agent-events.ts` converge on the **same** Maps/Set regardless of which chunk they live in. The `??=` pattern ensures the first chunk to execute initializes the state, and all subsequent chunks reuse it.

### Why this is safe

- **Single-threaded**: Node.js event loop means no concurrent access concerns
- **Correct by design**: `agent-events.ts` was always intended as a process-wide singleton; the per-chunk duplication was an unintended bundler artifact
- **Versioned key**: The `_v1__` suffix allows future schema migrations without collisions
- **No API changes**: All exports (`emitAgentEvent`, `onAgentEvent`, `registerAgentRunContext`, etc.) remain identical

## Verification

Tested by spawning ACP child sessions (Codex) from a parent agent session via `sessions_spawn`. Before the fix, the stream relay timed out after 60s with no completion event. After the fix, the relay correctly receives the lifecycle `end` event and forwards the completion notification to the parent session within seconds.