### PR TITLE
fix: migrate legacy :dm: session store keys to :direct:

### DIFF
--- a/src/config/sessions/explicit-session-key-normalization.test.ts
+++ b/src/config/sessions/explicit-session-key-normalization.test.ts
@@ -52,7 +52,7 @@ describe("normalizeExplicitSessionKey", () => {
     ).toBe("agent:fina:discord:direct:123456");
   });
 
-  it("lowercases and passes through unknown providers unchanged", () => {
+  it("migrates legacy :dm: to :direct: for all channels", () => {
     expect(
       normalizeExplicitSessionKey(
         "Agent:Fina:Slack:DM:ABC",
@@ -61,6 +61,42 @@ describe("normalizeExplicitSessionKey", () => {
           From: "slack:U123",
         }),
       ),
-    ).toBe("agent:fina:slack:dm:abc");
+    ).toBe("agent:fina:slack:direct:abc");
+  });
+
+  it("migrates whatsapp :dm: keys to :direct:", () => {
+    expect(
+      normalizeExplicitSessionKey(
+        "agent:main:whatsapp:dm:+61419009073",
+        makeCtx({
+          Surface: "whatsapp",
+          From: "+61419009073",
+        }),
+      ),
+    ).toBe("agent:main:whatsapp:direct:+61419009073");
+  });
+
+  it("migrates telegram :dm: keys to :direct:", () => {
+    expect(
+      normalizeExplicitSessionKey(
+        "telegram:dm:123456",
+        makeCtx({
+          Surface: "telegram",
+          From: "telegram:123456",
+        }),
+      ),
+    ).toBe("telegram:direct:123456");
+  });
+
+  it("preserves :thread: suffix during :dm: migration", () => {
+    expect(
+      normalizeExplicitSessionKey(
+        "agent:main:slack:dm:C0123ABC:thread:1234567890.123",
+        makeCtx({
+          Surface: "slack",
+          From: "slack:U123",
+        }),
+      ),
+    ).toBe("agent:main:slack:direct:c0123abc:thread:1234567890.123");
   });
 });

--- a/src/config/sessions/explicit-session-key-normalization.ts
+++ b/src/config/sessions/explicit-session-key-normalization.ts
@@ -44,7 +44,8 @@ function resolveExplicitSessionKeyNormalizer(
 }
 
 export function normalizeExplicitSessionKey(sessionKey: string, ctx: MsgContext): string {
-  const normalized = sessionKey.trim().toLowerCase();
+  // Pre-pass: migrate legacy `:dm:` → `:direct:` for all channels.
+  const normalized = sessionKey.trim().toLowerCase().replace(/:dm:/g, ":direct:");
   const normalize = resolveExplicitSessionKeyNormalizer(normalized, ctx);
   return normalize ? normalize(normalized, ctx) : normalized;
 }

--- a/src/config/sessions/store-migrations.test.ts
+++ b/src/config/sessions/store-migrations.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { applySessionStoreMigrations } from "./store-migrations.js";
+import type { SessionEntry } from "./types.js";
+
+function makeEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "sid-1",
+    updatedAt: Date.now(),
+    ...overrides,
+  } as SessionEntry;
+}
+
+describe("applySessionStoreMigrations", () => {
+  describe("legacy :dm: → :direct: key migration", () => {
+    it("renames :dm: keys to :direct:", () => {
+      const store: Record<string, SessionEntry> = {
+        "agent:main:whatsapp:dm:+61419009073": makeEntry(),
+      };
+      applySessionStoreMigrations(store);
+      expect(store["agent:main:whatsapp:direct:+61419009073"]).toBeDefined();
+      expect(store["agent:main:whatsapp:dm:+61419009073"]).toBeUndefined();
+    });
+
+    it("handles multiple channels and lowercases keys", () => {
+      const store: Record<string, SessionEntry> = {
+        "agent:main:telegram:dm:123456": makeEntry(),
+        "agent:main:slack:dm:C0123ABC": makeEntry(),
+      };
+      applySessionStoreMigrations(store);
+      expect(store["agent:main:telegram:direct:123456"]).toBeDefined();
+      expect(store["agent:main:slack:direct:c0123abc"]).toBeDefined();
+      expect(store["agent:main:telegram:dm:123456"]).toBeUndefined();
+      expect(store["agent:main:slack:dm:C0123ABC"]).toBeUndefined();
+    });
+
+    it("keeps newer :direct: entry on collision", () => {
+      const oldEntry = makeEntry({ updatedAt: 1000 });
+      const newEntry = makeEntry({ updatedAt: 2000 });
+      const store: Record<string, SessionEntry> = {
+        "agent:main:whatsapp:dm:+123": oldEntry,
+        "agent:main:whatsapp:direct:+123": newEntry,
+      };
+      applySessionStoreMigrations(store);
+      expect(store["agent:main:whatsapp:direct:+123"]).toBe(newEntry);
+      expect(store["agent:main:whatsapp:dm:+123"]).toBeUndefined();
+    });
+
+    it("keeps newer :dm: entry on collision", () => {
+      const oldEntry = makeEntry({ updatedAt: 1000 });
+      const newEntry = makeEntry({ updatedAt: 2000 });
+      const store: Record<string, SessionEntry> = {
+        "agent:main:whatsapp:dm:+123": newEntry,
+        "agent:main:whatsapp:direct:+123": oldEntry,
+      };
+      applySessionStoreMigrations(store);
+      expect(store["agent:main:whatsapp:direct:+123"]).toBe(newEntry);
+      expect(store["agent:main:whatsapp:dm:+123"]).toBeUndefined();
+    });
+
+    it("preserves thread-suffixed keys and lowercases", () => {
+      const store: Record<string, SessionEntry> = {
+        "agent:main:slack:dm:C012:thread:1234567890.123": makeEntry(),
+      };
+      applySessionStoreMigrations(store);
+      expect(store["agent:main:slack:direct:c012:thread:1234567890.123"]).toBeDefined();
+      expect(store["agent:main:slack:dm:C012:thread:1234567890.123"]).toBeUndefined();
+    });
+
+    it("leaves keys without :dm: untouched", () => {
+      const entry = makeEntry();
+      const store: Record<string, SessionEntry> = {
+        "agent:main:main": entry,
+        "agent:main:whatsapp:group:123@g.us": makeEntry(),
+        "agent:main:whatsapp:direct:+123": makeEntry(),
+      };
+      applySessionStoreMigrations(store);
+      expect(store["agent:main:main"]).toBe(entry);
+      expect(store["agent:main:whatsapp:group:123@g.us"]).toBeDefined();
+      expect(store["agent:main:whatsapp:direct:+123"]).toBeDefined();
+    });
+  });
+});

--- a/src/config/sessions/store-migrations.ts
+++ b/src/config/sessions/store-migrations.ts
@@ -24,4 +24,36 @@ export function applySessionStoreMigrations(store: Record<string, SessionEntry>)
       delete rec.room;
     }
   }
+
+  // Migrate legacy `:dm:` store keys → `:direct:` (all channels).
+  migrateLegacyDmStoreKeys(store);
+}
+
+function migrateLegacyDmStoreKeys(store: Record<string, SessionEntry>): void {
+  for (const key of Object.keys(store)) {
+    if (!key.toLowerCase().includes(":dm:")) {
+      continue;
+    }
+    // Replace :dm: (case-insensitive) with :direct: and lowercase the entire key.
+    const newKey = key.toLowerCase().replace(/:dm:/g, ":direct:");
+    if (newKey === key) {
+      continue;
+    }
+    const oldEntry = store[key];
+    const existingEntry = store[newKey];
+    if (!oldEntry) {
+      continue;
+    }
+    if (existingEntry) {
+      // Both keys exist — keep the most recently updated entry.
+      const oldTime = oldEntry.updatedAt ?? 0;
+      const newTime = existingEntry.updatedAt ?? 0;
+      if (oldTime > newTime) {
+        store[newKey] = oldEntry;
+      }
+    } else {
+      store[newKey] = oldEntry;
+    }
+    delete store[key];
+  }
 }

--- a/src/config/sessions/store-migrations.ts
+++ b/src/config/sessions/store-migrations.ts
@@ -36,9 +36,6 @@ function migrateLegacyDmStoreKeys(store: Record<string, SessionEntry>): void {
     }
     // Replace :dm: (case-insensitive) with :direct: and lowercase the entire key.
     const newKey = key.toLowerCase().replace(/:dm:/g, ":direct:");
-    if (newKey === key) {
-      continue;
-    }
     const oldEntry = store[key];
     const existingEntry = store[newKey];
     if (!oldEntry) {

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -10,7 +10,8 @@ import {
   updateLastRoute,
 } from "../sessions.js";
 
-const CANONICAL_KEY = "agent:main:webchat:dm:mixed-user";
+// After store migration, :dm: keys are renamed to :direct:
+const CANONICAL_KEY = "agent:main:webchat:direct:mixed-user";
 const MIXED_CASE_KEY = "Agent:Main:WebChat:DM:MiXeD-User";
 
 function createInboundContext(): MsgContext {


### PR DESCRIPTION
## Summary

- Adds `migrateLegacyDmStoreKeys()` to `applySessionStoreMigrations()` — renames any `:dm:` store keys to `:direct:` on load, handling case-insensitive matching and collision resolution (keeps most recently updated entry)
- Adds a `:dm:` → `:direct:` pre-pass in `normalizeExplicitSessionKey()` so incoming explicit session keys are canonicalized before channel-specific normalizers run
- Updates existing tests and adds new coverage for the migration logic

## Context

The codebase renamed the `dm` chat type to `direct` but never migrated existing session store keys. This causes duplicate/orphaned sessions when a user has legacy `:dm:` keys that don't match the canonical `:direct:` keys produced by `buildAgentPeerSessionKey()`.

The store migration runs on load (same as existing `provider` → `channel` migration), so existing deployments self-heal on next gateway start.

## Test plan

- [x] New `store-migrations.test.ts` — 6 tests covering basic rename, multiple channels, collision in both directions, thread-suffixed keys, and no-op for non-`:dm:` keys
- [x] Updated `explicit-session-key-normalization.test.ts` — 4 new/updated tests for WhatsApp, Telegram, Slack, and thread suffix preservation
- [x] Updated `store.session-key-normalization.test.ts` — canonical key expectation updated to `:direct:`
- [x] All 41 tests pass across 5 test files