### PR TITLE
fix: keep heartbeat turns from polluting main session metadata

### DIFF
--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -53,4 +53,27 @@ describe("session delivery direct-session routing overrides", () => {
       }),
     ).toBe("group:12345");
   });
+
+  it("keeps persisted webchat destination for synthetic heartbeat turns", () => {
+    expect(
+      resolveLastToRaw({
+        providerRaw: "heartbeat",
+        toRaw: "heartbeat",
+        persistedLastChannel: "webchat",
+        persistedLastTo: "openclaw-control-ui",
+        sessionKey: "agent:main:main",
+      }),
+    ).toBe("openclaw-control-ui");
+  });
+
+  it("does not synthesize heartbeat as lastTo when no prior destination exists", () => {
+    expect(
+      resolveLastToRaw({
+        providerRaw: "heartbeat",
+        toRaw: "heartbeat",
+        persistedLastChannel: "webchat",
+        sessionKey: "agent:main:main",
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -11,6 +11,7 @@ import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { isSyntheticSessionEventProvider } from "../../utils/system-turn-provider.js";
 import type { MsgContext } from "../templating.js";
 
 export type LegacyMainDeliveryRetirement = {
@@ -116,6 +117,7 @@ export function resolveLastChannelRaw(params: {
 export function resolveLastToRaw(params: {
   originatingChannelRaw?: string;
   originatingToRaw?: string;
+  providerRaw?: string;
   toRaw?: string;
   persistedLastTo?: string;
   persistedLastChannel?: string;
@@ -130,6 +132,12 @@ export function resolveLastToRaw(params: {
   }
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
   const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
+  const ignoreSyntheticSystemTarget =
+    !originatingChannel && isSyntheticSessionEventProvider(params.providerRaw);
+
+  if (ignoreSyntheticSystemTarget) {
+    return params.originatingToRaw || params.persistedLastTo;
+  }
 
   // When the turn originates from an internal/non-deliverable source, do not
   // replace an established external destination with internal routing ids

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2132,4 +2132,53 @@ describe("initSessionState internal channel routing preservation", () => {
     expect(result.sessionEntry.deliveryContext?.channel).toBe("webchat");
     expect(result.sessionEntry.deliveryContext?.to).toBe("session:webchat-main");
   });
+
+  it("does not let synthetic heartbeat turns overwrite main-session route or origin", async () => {
+    const storePath = await createStorePath("heartbeat-main-route-origin-");
+    const sessionKey = "agent:main:main";
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "sess-heartbeat-main-1",
+        updatedAt: Date.now(),
+        lastChannel: "webchat",
+        lastTo: "openclaw-control-ui",
+        deliveryContext: {
+          channel: "webchat",
+          to: "openclaw-control-ui",
+        },
+        origin: {
+          provider: "webchat",
+          surface: "webchat",
+          label: "openclaw-control-ui",
+          from: "openclaw-control-ui",
+          to: "openclaw-control-ui",
+        },
+      },
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "Read HEARTBEAT.md and reply HEARTBEAT_OK if nothing needs attention.",
+        SessionKey: sessionKey,
+        Provider: "heartbeat",
+        From: "heartbeat",
+        To: "heartbeat",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.lastChannel).toBe("webchat");
+    expect(result.sessionEntry.lastTo).toBe("openclaw-control-ui");
+    expect(result.sessionEntry.deliveryContext?.channel).toBe("webchat");
+    expect(result.sessionEntry.deliveryContext?.to).toBe("openclaw-control-ui");
+    expect(result.sessionEntry.origin).toEqual({
+      provider: "webchat",
+      surface: "webchat",
+      label: "openclaw-control-ui",
+      from: "openclaw-control-ui",
+      to: "openclaw-control-ui",
+    });
+  });
 });

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -405,6 +405,7 @@ export async function initSessionState(params: {
   const lastToRaw = resolveLastToRaw({
     originatingChannelRaw,
     originatingToRaw: ctx.OriginatingTo,
+    providerRaw: ctx.Provider,
     toRaw: ctx.To,
     persistedLastTo: baseEntry?.lastTo,
     persistedLastChannel: baseEntry?.lastChannel,

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -4,6 +4,7 @@ import { resolveConversationLabel } from "../../channels/conversation-label.js";
 import { getChannelDock } from "../../channels/dock.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import { isSyntheticSessionEventProvider } from "../../utils/system-turn-provider.js";
 import { buildGroupDisplayName, resolveGroupSessionKey } from "./group.js";
 import type { GroupKeyResolution, SessionEntry, SessionOrigin } from "./types.js";
 
@@ -43,17 +44,26 @@ const mergeOrigin = (
 };
 
 export function deriveSessionOrigin(ctx: MsgContext): SessionOrigin | undefined {
-  const label = resolveConversationLabel(ctx)?.trim();
-  const providerRaw =
-    (typeof ctx.OriginatingChannel === "string" && ctx.OriginatingChannel) ||
-    ctx.Surface ||
-    ctx.Provider;
+  const originatingChannel = normalizeMessageChannel(ctx.OriginatingChannel);
+  const ignoreSyntheticSystemOrigin =
+    !originatingChannel && isSyntheticSessionEventProvider(ctx.Provider);
+  const label = ignoreSyntheticSystemOrigin ? undefined : resolveConversationLabel(ctx)?.trim();
+  const providerRaw = ignoreSyntheticSystemOrigin
+    ? undefined
+    : (typeof ctx.OriginatingChannel === "string" && ctx.OriginatingChannel) ||
+      ctx.Surface ||
+      ctx.Provider;
   const provider = normalizeMessageChannel(providerRaw);
   const surface = ctx.Surface?.trim().toLowerCase();
   const chatType = normalizeChatType(ctx.ChatType) ?? undefined;
-  const from = ctx.From?.trim();
-  const to =
-    (typeof ctx.OriginatingTo === "string" ? ctx.OriginatingTo : ctx.To)?.trim() ?? undefined;
+  const from = ignoreSyntheticSystemOrigin ? undefined : ctx.From?.trim();
+  const to = (
+    ignoreSyntheticSystemOrigin
+      ? ctx.OriginatingTo
+      : typeof ctx.OriginatingTo === "string"
+        ? ctx.OriginatingTo
+        : ctx.To
+  )?.trim();
   const accountId = ctx.AccountId?.trim();
   const threadId = ctx.MessageThreadId ?? undefined;
 

--- a/src/utils/system-turn-provider.ts
+++ b/src/utils/system-turn-provider.ts
@@ -1,0 +1,6 @@
+const SYNTHETIC_SESSION_EVENT_PROVIDERS = new Set(["heartbeat", "cron-event", "exec-event"]);
+
+export function isSyntheticSessionEventProvider(provider?: string): boolean {
+  const normalized = provider?.trim().toLowerCase();
+  return normalized ? SYNTHETIC_SESSION_EVENT_PROVIDERS.has(normalized) : false;
+}


### PR DESCRIPTION
## Summary
- prevent synthetic heartbeat/cron/exec turns from overwriting main-session lastTo when there is no real originating channel
- preserve existing main-session origin metadata instead of replacing it with synthetic heartbeat provider/to labels
- add regression coverage for session routing and heartbeat delivery interactions

## Testing
- pnpm exec vitest run src/auto-reply/reply/session-delivery.test.ts src/auto-reply/reply/session.test.ts
- pnpm exec vitest run --config vitest.unit.config.ts src/infra/outbound/targets.test.ts src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts