### PR TITLE
docs: fix build order in install guide (pnpm build before pnpm ui:build)

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -125,8 +125,8 @@ For VPS/cloud hosts, avoid third-party "1-click" marketplace images when possibl
         git clone https://github.com/openclaw/openclaw.git
         cd openclaw
         pnpm install
-        pnpm ui:build
         pnpm build
+        pnpm ui:build
         ```
       </Step>
       <Step title="Link the CLI">

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -228,8 +228,8 @@ Follow the Linux Getting Started flow inside WSL:
 git clone https://github.com/openclaw/openclaw.git
 cd openclaw
 pnpm install
-pnpm ui:build # auto-installs UI deps on first run
 pnpm build
+pnpm ui:build # auto-installs UI deps on first run
 openclaw onboard
 ```
 

--- a/docs/zh-CN/install/index.md
+++ b/docs/zh-CN/install/index.md
@@ -132,8 +132,8 @@ x-i18n:
         git clone https://github.com/openclaw/openclaw.git
         cd openclaw
         pnpm install
-        pnpm ui:build
         pnpm build
+        pnpm ui:build # 首次运行时自动安装 UI 依赖
         ```
       </Step>
       <Step title="链接 CLI">

--- a/docs/zh-CN/platforms/windows.md
+++ b/docs/zh-CN/platforms/windows.md
@@ -234,8 +234,8 @@ systemctl --user status
 git clone https://github.com/openclaw/openclaw.git
 cd openclaw
 pnpm install
-pnpm ui:build # 首次运行时会自动安装 UI 依赖
 pnpm build
+pnpm ui:build # 首次运行时自动安装 UI 依赖
 openclaw onboard
 ```
 

--- a/docs/zh-CN/start/openclaw.md
+++ b/docs/zh-CN/start/openclaw.md
@@ -48,8 +48,8 @@ npm install -g openclaw@latest
 git clone https://github.com/openclaw/openclaw.git
 cd openclaw
 pnpm install
-pnpm ui:build # 首次运行时自动安装 UI 依赖
 pnpm build
+pnpm ui:build # 首次运行时自动安装 UI 依赖
 pnpm link --global
 ```
 

--- a/docs/zh-CN/start/quickstart.md
+++ b/docs/zh-CN/start/quickstart.md
@@ -64,8 +64,8 @@ OpenClaw 需要 Node 22 或更新版本。
 git clone https://github.com/openclaw/openclaw.git
 cd openclaw
 pnpm install
-pnpm ui:build # 首次运行时会自动安装 UI 依赖
 pnpm build
+pnpm ui:build # 首次运行时会自动安装 UI 依赖
 openclaw onboard --install-daemon
 ```
 


### PR DESCRIPTION
## Problem

The install guides list `pnpm ui:build` before `pnpm build`, but this order causes `pnpm ui:build` output to be silently deleted.

`pnpm build` uses **tsdown**, which by default **cleans the entire `dist/` directory** before building. Since `pnpm ui:build` writes its output to `dist/control-ui/`, running it first means tsdown will wipe it out when `pnpm build` runs next.

## Fix

Swap the order to:
```bash
pnpm install
pnpm build
pnpm ui:build
```

This ensures the Control UI assets are built after tsdown has finished (and cleaned) `dist/`, so nothing gets lost.

Verified by the user during a fresh source install and confirmed by inspecting `tsdown.config.ts` and `scripts/ui.js`.