### PR TITLE
fix(agents): heartbeat/cron prompts carry stale "Current time" that never refreshes between runs

### DIFF
--- a/src/agents/current-time.test.ts
+++ b/src/agents/current-time.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { appendCronStyleCurrentTimeLine, resolveCronStyleNow } from "./current-time.js";
+
+const cfg = { agents: { defaults: { userTimezone: "UTC" } } };
+const nowMs = new Date("2026-03-13T12:00:00Z").getTime();
+
+describe("appendCronStyleCurrentTimeLine", () => {
+  it("appends a Current time line when none exists", () => {
+    const result = appendCronStyleCurrentTimeLine("Hello world", cfg, nowMs);
+    expect(result).toContain("Hello world");
+    expect(result).toContain("Current time:");
+    expect(result).toContain("2026-03-13");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(appendCronStyleCurrentTimeLine("", cfg, nowMs)).toBe("");
+    expect(appendCronStyleCurrentTimeLine("   ", cfg, nowMs)).toBe("");
+  });
+
+  it("refreshes a stale Current time line with a fresh timestamp", () => {
+    const staleMs = new Date("2026-03-12T08:00:00Z").getTime();
+    const staleText = appendCronStyleCurrentTimeLine("Check status", cfg, staleMs);
+    expect(staleText).toContain("2026-03-12");
+
+    // Now refresh with a new timestamp — must replace, not skip
+    const freshMs = new Date("2026-03-13T14:30:00Z").getTime();
+    const refreshed = appendCronStyleCurrentTimeLine(staleText, cfg, freshMs);
+    expect(refreshed).toContain("2026-03-13");
+    expect(refreshed).not.toContain("2026-03-12");
+    // Should have exactly one "Current time:" line
+    const matches = refreshed.match(/Current time:/g);
+    expect(matches).toHaveLength(1);
+  });
+
+  it("preserves surrounding text when refreshing timestamp", () => {
+    const text =
+      "Line one\nCurrent time: 2026-01-01 00:00 (UTC) / 2026-01-01 00:00 UTC\nLine three";
+    const result = appendCronStyleCurrentTimeLine(text, cfg, nowMs);
+    expect(result).toContain("Line one");
+    expect(result).toContain("Line three");
+    expect(result).toContain("2026-03-13");
+    expect(result).not.toContain("2026-01-01");
+  });
+
+  it("does not duplicate Current time line on repeated calls", () => {
+    let text = "Heartbeat prompt";
+    for (let i = 0; i < 5; i++) {
+      const ms = nowMs + i * 60_000;
+      text = appendCronStyleCurrentTimeLine(text, cfg, ms);
+    }
+    const matches = text.match(/Current time:/g);
+    expect(matches).toHaveLength(1);
+    expect(text).toContain("Heartbeat prompt");
+  });
+
+  it("refreshes when Current time is the only line", () => {
+    const staleMs = new Date("2026-01-01T00:00:00Z").getTime();
+    const { timeLine: staleLine } = resolveCronStyleNow(cfg, staleMs);
+    const refreshed = appendCronStyleCurrentTimeLine(staleLine, cfg, nowMs);
+    expect(refreshed).toContain("2026-03-13");
+    expect(refreshed).not.toContain("2026-01-01");
+  });
+
+  it("refreshed line matches resolveCronStyleNow output format", () => {
+    const staleText = appendCronStyleCurrentTimeLine("Prompt", cfg, nowMs);
+    const freshMs = new Date("2026-06-15T09:30:00Z").getTime();
+    const refreshed = appendCronStyleCurrentTimeLine(staleText, cfg, freshMs);
+    const { timeLine: expected } = resolveCronStyleNow(cfg, freshMs);
+    expect(refreshed).toContain(expected);
+  });
+
+  it("does not replace Current time embedded mid-line", () => {
+    const text = "Check the Current time: section for details";
+    const result = appendCronStyleCurrentTimeLine(text, cfg, nowMs);
+    // "Current time:" not at line start — should append, not replace
+    expect(result).toContain("Check the Current time: section for details");
+    const matches = result.match(/Current time:/g);
+    expect(matches).toHaveLength(2);
+  });
+});
+
+describe("resolveCronStyleNow", () => {
+  it("returns formatted time with timezone and UTC", () => {
+    const result = resolveCronStyleNow(cfg, nowMs);
+    expect(result.timeLine).toContain("Current time:");
+    expect(result.timeLine).toContain("UTC");
+    expect(result.userTimezone).toBeDefined();
+    expect(result.formattedTime).toBeDefined();
+  });
+});

--- a/src/agents/current-time.ts
+++ b/src/agents/current-time.ts
@@ -32,9 +32,14 @@ export function resolveCronStyleNow(cfg: TimeConfigLike, nowMs: number): CronSty
 
 export function appendCronStyleCurrentTimeLine(text: string, cfg: TimeConfigLike, nowMs: number) {
   const base = text.trimEnd();
-  if (!base || base.includes("Current time:")) {
+  if (!base) {
     return base;
   }
   const { timeLine } = resolveCronStyleNow(cfg, nowMs);
+  // Replace any existing stale "Current time:" line with a fresh one
+  const existingTimeRe = /^Current time:.*$/m;
+  if (existingTimeRe.test(base)) {
+    return base.replace(existingTimeRe, timeLine);
+  }
   return `${base}\n${timeLine}`;
 }


### PR DESCRIPTION
## Problem

`appendCronStyleCurrentTimeLine` has an early-return guard that skips timestamp injection when the text already contains a `"Current time:"` line:

```ts
if (!base || base.includes("Current time:")) {
    return base; // stale timestamp preserved
}
```

This means heartbeat and cron prompts carry the **first** timestamp indefinitely — the model sees a frozen clock that never updates between runs.

Reported in #44993 with detailed repro: heartbeat polls and cron events show timestamps from hours or days ago.

## Fix

Replace the early-return guard with a regex substitution that **refreshes** the existing `Current time:` line with the current `nowMs` value on every call. When no line exists, one is appended as before.

**Before:** `base.includes("Current time:") → return base` (stale)
**After:** `base.replace(/^Current time:.*$/m, freshTimeLine)` (refreshed)

This also fixes the same stale-timestamp path in `session-reset-prompt.ts` and `post-compaction-context.ts`, which reuse the same helper.

## Tests

Added `src/agents/current-time.test.ts` with 6 test cases:
- Appends timestamp when none exists
- Returns empty/whitespace strings unchanged
- **Refreshes a stale timestamp with a fresh one** (core regression test)
- Preserves surrounding text when refreshing
- No duplicate `Current time:` lines after repeated calls
- `resolveCronStyleNow` returns expected format

Closes #44993