### PR TITLE
docs(browser): use wss for Browserless cdpUrl examples

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -183,7 +183,7 @@ Example:
     remoteCdpHandshakeTimeoutMs: 4000,
     profiles: {
       browserless: {
-        cdpUrl: "https://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
+        cdpUrl: "wss://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
         color: "#00AA00",
       },
     },

--- a/docs/zh-CN/tools/browser.md
+++ b/docs/zh-CN/tools/browser.md
@@ -165,7 +165,7 @@ OpenClaw 在调用 `/json/*` 端点和连接 CDP WebSocket 时会保留认证信
     remoteCdpHandshakeTimeoutMs: 4000,
     profiles: {
       browserless: {
-        cdpUrl: "https://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
+        cdpUrl: "wss://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
         color: "#00AA00",
       },
     },


### PR DESCRIPTION
## Summary
Use `wss://` for Browserless `cdpUrl` examples in browser docs.

## Why
Browserless CDP endpoints are WebSocket endpoints. Using `https://` in examples is misleading and can cause connection failures when copied as-is.

## Changes
- `docs/tools/browser.md`
- `docs/zh-CN/tools/browser.md`

Replaced:
- `https://production-sfo.browserless.io?...`

With:
- `wss://production-sfo.browserless.io?...`

## How to test
1. Open both docs pages.
2. Verify `cdpUrl` examples now use the `wss://` scheme.
3. (Optional) Copy the sample endpoint into a remote CDP config and confirm it is accepted as a WebSocket URL.

Closes #44992
