### PR TITLE
ui(chat): remove unsupported line-clamp declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram/streaming: sanitize tool-progress draft preview backticks before shared compaction, so long backtick-heavy progress text still renders inside the safe code-formatted preview instead of collapsing to an ellipsis.
+- UI/chat: remove the unsupported `line-clamp` declaration from the chat queue text rule to eliminate Firefox console noise without changing visible truncation behavior. Thanks @ZanderH-code.
 - Agents/Pi: suppress persistence for synthetic mid-turn overflow continuation prompts, so transcript-retry recovery does not write the "continue from transcript" prompt as a new user turn. Thanks @vincentkoc.
 - Telegram: keep reply-dispatch lazy provider runtime chunks behind stable dist names and delete `/reasoning stream` previews after final delivery so package updates and live reasoning drafts do not leave Telegram turns broken or noisy. Thanks @BunsDev.
 - Exec approvals: detect `env -S` split-string command-carrier risks when `-S`/`-s` is combined with other env short options, so approval explanations do not miss split payloads hidden behind `env -iS...`. Thanks @vincentkoc.

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2763,7 +2763,6 @@ td.data-table-key-col {
   white-space: pre-wrap;
   overflow: hidden;
   display: -webkit-box;
-  line-clamp: 3;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 }


### PR DESCRIPTION
## Summary
Remove the non-standard `line-clamp` CSS declaration from chat queue text styles.

## Why
Issue #45020 reports Firefox console errors (`Unknown property 'line-clamp'. Declaration dropped.`) on the chat page. The standard-compatible behavior here is already provided by:
- `display: -webkit-box`
- `-webkit-line-clamp: 3`
- `-webkit-box-orient: vertical`

So the extra `line-clamp: 3` declaration is unnecessary and triggers noisy CSS parsing errors in Firefox.

## Changes
- `ui/src/styles/components.css`
  - Removed `line-clamp: 3;` from `.chat-queue__text`

## Validation
- Open chat UI in Firefox.
- Confirm the previous `Unknown property 'line-clamp'` warning for this rule no longer appears.
- Confirm queue text still visually clamps to 3 lines where supported.

Closes #45020
