### PR TITLE
feat(cron): add pre-hook support for shell-based job gating

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -98,6 +98,12 @@ export function registerCronAddCommand(cron: Command) {
       )
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
+      .option(
+        "--pre-hook <command>",
+        "Shell command to run before execution (exit non-zero to skip); repeatable",
+        (val: string, prev: string[]) => [...prev, val],
+        [] as string[],
+      )
       .option("--json", "Output JSON", false)
       .action(async (opts: GatewayRpcOpts & Record<string, unknown>, cmd?: Command) => {
         try {
@@ -249,6 +255,17 @@ export function registerCronAddCommand(cron: Command) {
               ? opts.sessionKey.trim()
               : undefined;
 
+          const preHookCommands = Array.isArray(opts.preHook) ? opts.preHook : [];
+          const hooks =
+            preHookCommands.length > 0
+              ? {
+                  pre: preHookCommands.map((cmd: string) => ({
+                    kind: "shell" as const,
+                    command: cmd,
+                  })),
+                }
+              : undefined;
+
           const params = {
             name,
             description,
@@ -272,6 +289,7 @@ export function registerCronAddCommand(cron: Command) {
                   bestEffort: opts.bestEffortDeliver ? true : undefined,
                 }
               : undefined,
+            hooks,
           };
 
           const res = await callGatewayFromCli("cron.add", opts, params);

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -82,6 +82,13 @@ export function registerCronEditCommand(cron: Command) {
         "--failure-alert-account-id <id>",
         "Account ID for failure alert channel (multi-account setups)",
       )
+      .option(
+        "--pre-hook <command>",
+        "Shell command to run before execution (exit non-zero to skip); repeatable",
+        (val: string, prev: string[]) => [...prev, val],
+        [] as string[],
+      )
+      .option("--clear-pre-hooks", "Remove all pre-hooks", false)
       .action(async (id, opts) => {
         try {
           if (opts.session === "main" && opts.message) {
@@ -335,6 +342,22 @@ export function registerCronEditCommand(cron: Command) {
               failureAlert.accountId = accountId ? accountId : undefined;
             }
             patch.failureAlert = failureAlert;
+          }
+
+          // Pre-hooks: --pre-hook adds/replaces hooks, --clear-pre-hooks removes all.
+          const preHookCommands = Array.isArray(opts.preHook) ? opts.preHook : [];
+          if (opts.clearPreHooks && preHookCommands.length > 0) {
+            throw new Error("Use --pre-hook or --clear-pre-hooks, not both");
+          }
+          if (opts.clearPreHooks) {
+            patch.hooks = { pre: [] };
+          } else if (preHookCommands.length > 0) {
+            patch.hooks = {
+              pre: preHookCommands.map((cmd: string) => ({
+                kind: "shell" as const,
+                command: cmd,
+              })),
+            };
           }
 
           const res = await callGatewayFromCli("cron.update", opts, {

--- a/src/cron/service/pre-hooks.test.ts
+++ b/src/cron/service/pre-hooks.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CronPreHook } from "../types-shared.js";
+import { runPreHooks, runShellHook } from "./pre-hooks.js";
+
+const noopLog = {
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+function makeLog() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+describe("runShellHook", () => {
+  it("returns proceed: true when shell exits 0", async () => {
+    const result = await runShellHook({
+      command: "exit 0",
+      timeoutMs: 5_000,
+      stdin: "{}",
+      log: noopLog,
+    });
+    expect(result).toEqual({ proceed: true });
+  });
+
+  it("returns proceed: false when shell exits non-zero", async () => {
+    const result = await runShellHook({
+      command: "exit 1",
+      timeoutMs: 5_000,
+      stdin: "{}",
+      log: noopLog,
+    });
+    expect(result.proceed).toBe(false);
+    if (!result.proceed) {
+      expect(result.reason).toContain("exited 1");
+    }
+  });
+
+  it("includes stderr in reason when shell exits non-zero", async () => {
+    const result = await runShellHook({
+      command: 'echo "check failed" >&2; exit 2',
+      timeoutMs: 5_000,
+      stdin: "{}",
+      log: noopLog,
+    });
+    expect(result.proceed).toBe(false);
+    if (!result.proceed) {
+      expect(result.reason).toContain("check failed");
+      expect(result.reason).toContain("exited 2");
+    }
+  });
+
+  it("returns proceed: false on timeout", async () => {
+    const result = await runShellHook({
+      command: "sleep 60",
+      timeoutMs: 100,
+      stdin: "{}",
+      log: noopLog,
+    });
+    expect(result.proceed).toBe(false);
+    if (!result.proceed) {
+      expect(result.reason).toContain("timed out");
+      expect(result.reason).toContain("100ms");
+    }
+  });
+
+  it("receives correct stdin JSON", async () => {
+    const metadata = JSON.stringify({ jobId: "j1", jobName: "test", schedule: { kind: "every" } });
+    // The hook reads stdin and writes it to stdout; we verify exit 0 means
+    // the shell successfully read valid JSON from stdin.
+    const result = await runShellHook({
+      command: "cat > /dev/null && exit 0",
+      timeoutMs: 5_000,
+      stdin: metadata,
+      log: noopLog,
+    });
+    expect(result).toEqual({ proceed: true });
+  });
+});
+
+describe("runPreHooks", () => {
+  it("returns proceed: true when hooks array is empty", async () => {
+    const result = await runPreHooks({
+      hooks: [],
+      jobId: "j1",
+      jobName: "test",
+      schedule: { kind: "every", everyMs: 60_000 },
+      log: makeLog(),
+    });
+    expect(result).toEqual({ proceed: true });
+  });
+
+  it("returns proceed: true when single hook passes", async () => {
+    const hooks: CronPreHook[] = [{ kind: "shell", command: "exit 0" }];
+    const result = await runPreHooks({
+      hooks,
+      jobId: "j1",
+      jobName: "test",
+      schedule: { kind: "every", everyMs: 60_000 },
+      log: makeLog(),
+    });
+    expect(result).toEqual({ proceed: true });
+  });
+
+  it("returns proceed: false when single hook fails", async () => {
+    const hooks: CronPreHook[] = [{ kind: "shell", command: "exit 1" }];
+    const result = await runPreHooks({
+      hooks,
+      jobId: "j1",
+      jobName: "test",
+      schedule: { kind: "every", everyMs: 60_000 },
+      log: makeLog(),
+    });
+    expect(result.proceed).toBe(false);
+  });
+
+  it("short-circuits on first failing hook", async () => {
+    const hooks: CronPreHook[] = [
+      { kind: "shell", command: "exit 0" },
+      { kind: "shell", command: "exit 42" },
+      { kind: "shell", command: "exit 0" },
+    ];
+    const result = await runPreHooks({
+      hooks,
+      jobId: "j1",
+      jobName: "test",
+      schedule: { kind: "every", everyMs: 60_000 },
+      log: makeLog(),
+    });
+    expect(result.proceed).toBe(false);
+    if (!result.proceed) {
+      expect(result.reason).toContain("exited 42");
+    }
+  });
+
+  it("runs all hooks when all pass", async () => {
+    const hooks: CronPreHook[] = [
+      { kind: "shell", command: "exit 0" },
+      { kind: "shell", command: "exit 0" },
+    ];
+    const result = await runPreHooks({
+      hooks,
+      jobId: "j1",
+      jobName: "test",
+      schedule: { kind: "every", everyMs: 60_000 },
+      log: makeLog(),
+    });
+    expect(result).toEqual({ proceed: true });
+  });
+
+  it("passes job metadata as stdin JSON", async () => {
+    // Verify the hook receives parseable JSON with expected fields.
+    // Use node (guaranteed available) to parse stdin.
+    const hooks: CronPreHook[] = [
+      {
+        kind: "shell",
+        command:
+          'node -e "let d=\\"\\";process.stdin.on(\\"data\\",c=>d+=c);process.stdin.on(\\"end\\",()=>{const j=JSON.parse(d);process.exit(j.jobId===\\"j1\\"?0:1)})"',
+      },
+    ];
+    const result = await runPreHooks({
+      hooks,
+      jobId: "j1",
+      jobName: "my-job",
+      schedule: { kind: "cron", expr: "0 * * * *" },
+      log: makeLog(),
+    });
+    expect(result).toEqual({ proceed: true });
+  });
+
+  it("respects per-hook timeoutMs", async () => {
+    const hooks: CronPreHook[] = [{ kind: "shell", command: "sleep 60", timeoutMs: 100 }];
+    const result = await runPreHooks({
+      hooks,
+      jobId: "j1",
+      jobName: "test",
+      schedule: { kind: "every", everyMs: 60_000 },
+      log: makeLog(),
+    });
+    expect(result.proceed).toBe(false);
+    if (!result.proceed) {
+      expect(result.reason).toContain("timed out");
+    }
+  });
+});

--- a/src/cron/service/pre-hooks.ts
+++ b/src/cron/service/pre-hooks.ts
@@ -1,0 +1,127 @@
+import { spawn } from "node:child_process";
+import type { CronPreHook } from "../types-shared.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export type PreHookResult = { proceed: true } | { proceed: false; reason: string };
+
+type PreHookLogger = {
+  info: (obj: unknown, msg?: string) => void;
+  warn: (obj: unknown, msg?: string) => void;
+};
+
+/**
+ * Run all pre-hooks sequentially.  The first hook that exits non-zero (or
+ * times out) short-circuits and returns `{ proceed: false }`.
+ */
+export async function runPreHooks(params: {
+  hooks: CronPreHook[];
+  jobId: string;
+  jobName: string;
+  schedule: unknown;
+  log: PreHookLogger;
+}): Promise<PreHookResult> {
+  for (const hook of params.hooks) {
+    if (hook.kind === "shell") {
+      const result = await runShellHook({
+        command: hook.command,
+        timeoutMs: hook.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        stdin: JSON.stringify({
+          jobId: params.jobId,
+          jobName: params.jobName,
+          schedule: params.schedule,
+        }),
+        log: params.log,
+      });
+      if (!result.proceed) {
+        return result;
+      }
+    }
+  }
+  return { proceed: true };
+}
+
+/**
+ * Execute a single shell hook command.  The command is spawned via the
+ * platform shell (`/bin/sh -c` on Unix, `cmd.exe /c` on Windows) so that
+ * inline pipes and redirects work.  Job metadata is piped to stdin as JSON.
+ */
+export async function runShellHook(params: {
+  command: string;
+  timeoutMs: number;
+  stdin: string;
+  log: PreHookLogger;
+}): Promise<PreHookResult> {
+  const { command, timeoutMs, stdin, log } = params;
+
+  return new Promise<PreHookResult>((resolve) => {
+    const isWindows = process.platform === "win32";
+    const shell = isWindows ? (process.env.ComSpec ?? "cmd.exe") : "/bin/sh";
+    const shellArgs = isWindows ? ["/c", command] : ["-c", command];
+
+    let settled = false;
+    let timedOut = false;
+
+    const child = spawn(shell, shellArgs, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    // Pipe job metadata to the hook's stdin.
+    if (child.stdin) {
+      child.stdin.write(stdin);
+      child.stdin.end();
+    }
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (err) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      const reason = `shell hook error: ${err.message}`;
+      log.warn({ command }, `cron: pre-hook failed: ${reason}`);
+      resolve({ proceed: false, reason });
+    });
+
+    child.on("close", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+
+      if (timedOut) {
+        const reason = `shell hook timed out after ${timeoutMs}ms`;
+        log.warn({ command, timeoutMs }, `cron: pre-hook timed out`);
+        resolve({ proceed: false, reason });
+        return;
+      }
+
+      if (code === 0) {
+        resolve({ proceed: true });
+        return;
+      }
+
+      const trimmedStderr = stderr.trim().slice(0, 200);
+      const reason = trimmedStderr
+        ? `shell hook exited ${code}: ${trimmedStderr}`
+        : `shell hook exited ${code}`;
+      log.info({ command, exitCode: code }, `cron: pre-hook skipped job`);
+      resolve({ proceed: false, reason });
+    });
+  });
+}

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -21,6 +21,7 @@ import {
   resolveJobPayloadTextForMain,
 } from "./jobs.js";
 import { locked } from "./locked.js";
+import { runPreHooks } from "./pre-hooks.js";
 import type { CronEvent, CronServiceState } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
 import { DEFAULT_JOB_TIMEOUT_MS, resolveCronJobTimeoutMs } from "./timeout-policy.js";
@@ -630,6 +631,30 @@ export async function onTimer(state: CronServiceState) {
       job.state.runningAtMs = startedAt;
       emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);
+
+      // Run pre-hooks (if any). Non-zero exit skips the job without API call.
+      if (job.hooks?.pre?.length) {
+        const hookResult = await runPreHooks({
+          hooks: job.hooks.pre,
+          jobId: job.id,
+          jobName: job.name,
+          schedule: job.schedule,
+          log: state.deps.log,
+        });
+        if (!hookResult.proceed) {
+          state.deps.log.info(
+            { jobId: id, jobName: job.name },
+            `cron: pre-hook skipped job: ${hookResult.reason}`,
+          );
+          return {
+            jobId: id,
+            status: "skipped",
+            error: `pre-hook: ${hookResult.reason}`,
+            startedAt,
+            endedAt: state.deps.nowMs(),
+          };
+        }
+      }
 
       try {
         const result = await executeJobCoreWithTimeout(state, job);

--- a/src/cron/types-shared.ts
+++ b/src/cron/types-shared.ts
@@ -1,3 +1,14 @@
+export type CronPreHook = {
+  kind: "shell";
+  command: string;
+  /** Timeout in milliseconds (default: 30_000). */
+  timeoutMs?: number;
+};
+
+export type CronJobHooks = {
+  pre?: CronPreHook[];
+};
+
 export type CronJobBase<TSchedule, TSessionTarget, TWakeMode, TPayload, TDelivery, TFailureAlert> =
   {
     id: string;
@@ -15,4 +26,5 @@ export type CronJobBase<TSchedule, TSessionTarget, TWakeMode, TPayload, TDeliver
     payload: TPayload;
     delivery?: TDelivery;
     failureAlert?: TFailureAlert;
+    hooks?: CronJobHooks;
   };

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -65,12 +65,29 @@ const CronFailoverReasonSchema = Type.Union([
   Type.Literal("model_not_found"),
   Type.Literal("unknown"),
 ]);
+const CronPreHookSchema = Type.Object(
+  {
+    kind: Type.Literal("shell"),
+    command: NonEmptyString,
+    timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+  },
+  { additionalProperties: false },
+);
+
+const CronJobHooksSchema = Type.Object(
+  {
+    pre: Type.Optional(Type.Array(CronPreHookSchema)),
+  },
+  { additionalProperties: false },
+);
+
 const CronCommonOptionalFields = {
   agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   description: Type.Optional(Type.String()),
   enabled: Type.Optional(Type.Boolean()),
   deleteAfterRun: Type.Optional(Type.Boolean()),
+  hooks: Type.Optional(CronJobHooksSchema),
 };
 
 function cronIdOrJobIdParams(extraFields: Record<string, TSchema>) {
@@ -256,6 +273,7 @@ export const CronJobSchema = Type.Object(
     payload: CronPayloadSchema,
     delivery: Type.Optional(CronDeliverySchema),
     failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
+    hooks: Type.Optional(CronJobHooksSchema),
     state: CronJobStateSchema,
   },
   { additionalProperties: false },


### PR DESCRIPTION
## Summary

- Add `hooks.pre` field to cron jobs allowing shell commands to gate execution before the API call
- Exit 0 proceeds normally; non-zero exit skips the job (resets `consecutiveErrors`) without wasting an API call
- Enables use cases like debounce checks (e.g. verifying new commits exist before running a converter cron job)

**Motivation:** Currently, debounce logic must live inside the agent prompt, which means the API call is already made (and billed) even when the job should be skipped. Pre-hooks solve this by running a lightweight shell check before the API call. See #9465 for the original request.

## Changes

| File | Change |
|------|--------|
| `src/cron/types-shared.ts` | New `CronPreHook`, `CronJobHooks` types; `hooks?: CronJobHooks` on `CronJobBase` |
| `src/cron/service/pre-hooks.ts` | Shell hook runner — sequential execution, short-circuit on failure, timeout via SIGKILL |
| `src/cron/service/timer.ts` | Pre-hook gate before `executeJobCoreWithTimeout`; returns `status: "skipped"` on skip |
| `src/gateway/protocol/schema/cron.ts` | `CronPreHookSchema`, `CronJobHooksSchema` wired into cron schemas |
| `src/cli/cron-cli/register.cron-add.ts` | `--pre-hook <command>` repeatable option |
| `src/cli/cron-cli/register.cron-edit.ts` | `--pre-hook <command>` + `--clear-pre-hooks` options |
| `src/cron/service/pre-hooks.test.ts` | 12 tests: exit codes, stderr capture, timeout, stdin JSON, short-circuit, per-hook timeout |

## Usage

```bash
# Add a cron job with a debounce pre-hook
openclaw cron add my-job --every 1h \
  --pre-hook 'test $(gh api repos/org/repo/compare/abc...HEAD --jq ".ahead_by") -gt 0'

# Edit to add/replace hooks
openclaw cron edit <id> --pre-hook 'my-check.sh'

# Remove all hooks
openclaw cron edit <id> --clear-pre-hooks
```

Hook stdin receives JSON with `jobId`, `jobName`, `schedule` for conditional logic.

## Test plan

- [x] `pnpm tsc --noEmit` — typecheck passes
- [x] `vitest run src/cron/service/pre-hooks.test.ts` — 12/12 tests pass
- [ ] Manual: add a cron job with `--pre-hook "exit 1"` and verify it skips without API call
- [ ] Manual: add a cron job with `--pre-hook "exit 0"` and verify normal execution

Refs: #9465

🤖 Generated with [Claude Code](https://claude.com/claude-code)