### PR TITLE
fix: suppress intermediate assistant text from leaking to Mattermost channels (#45134)

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -336,6 +336,10 @@ export function handleMessageEnd(
     if (!onBlockReply) {
       return;
     }
+    if (ctx.state.suppressPreToolText) {
+      ctx.state.pendingBlockReplies.push(payload);
+      return;
+    }
     void Promise.resolve()
       .then(() => onBlockReply(payload))
       .catch((err) => {
@@ -426,6 +430,22 @@ export function handleMessageEnd(
 
   if (ctx.state.blockReplyBreak === "text_end" && onBlockReply) {
     emitSplitResultAsBlockReply(ctx.consumeReplyDirectives("", { final: true }));
+  }
+
+  if (ctx.state.pendingBlockReplies.length > 0) {
+    const stopReason = (assistantMessage as { stopReason?: string }).stopReason;
+    if (stopReason === "toolUse") {
+      ctx.state.pendingBlockReplies.length = 0;
+    } else {
+      const pending = ctx.state.pendingBlockReplies.splice(0);
+      for (const payload of pending) {
+        void Promise.resolve()
+          .then(() => onBlockReply?.(payload))
+          .catch((err) => {
+            ctx.log.warn(`block reply callback failed: ${String(err)}`);
+          });
+      }
+    }
   }
 
   ctx.state.deltaBuffer = "";

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -264,6 +264,9 @@ export function handleMessageEnd(
   const assistantMessage = msg;
   ctx.noteLastAssistant(assistantMessage);
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
+  // Capture baseline BEFORE finalizeAssistantTexts updates it so we can discard
+  // intermediate-turn texts if this turn ends with toolUse (see pendingBlockReplies logic below).
+  const preTurnAssistantTextBaseline = ctx.state.assistantTextBaseline;
   if (ctx.state.deterministicApprovalPromptSent) {
     return;
   }
@@ -436,6 +439,11 @@ export function handleMessageEnd(
     const stopReason = (assistantMessage as { stopReason?: string }).stopReason;
     if (stopReason === "toolUse") {
       ctx.state.pendingBlockReplies.length = 0;
+      // Also remove intermediate-turn texts from assistantTexts so they don't
+      // appear in the final reply payload (hasSentPayload dedup won't catch them
+      // because they were never enqueued into the block-reply pipeline).
+      ctx.state.assistantTexts.splice(preTurnAssistantTextBaseline);
+      ctx.state.assistantTextBaseline = preTurnAssistantTextBaseline;
     } else {
       const pending = ctx.state.pendingBlockReplies.splice(0);
       for (const payload of pending) {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -5,6 +5,7 @@ import type { InlineCodeState } from "../markdown/code-spans.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import type { MessagingToolSend } from "./pi-embedded-messaging.js";
+import type { BlockReplyPayload } from "./pi-embedded-payloads.js";
 import type {
   BlockReplyChunking,
   SubscribeEmbeddedPiSessionParams,
@@ -77,6 +78,8 @@ export type EmbeddedPiSubscribeState = {
   successfulCronAdds: number;
   pendingMessagingMediaUrls: Map<string, string[]>;
   deterministicApprovalPromptSent: boolean;
+  suppressPreToolText: boolean;
+  pendingBlockReplies: BlockReplyPayload[];
   lastAssistant?: AgentMessage;
 };
 

--- a/src/agents/pi-embedded-subscribe.suppress-pre-tool-text.test.ts
+++ b/src/agents/pi-embedded-subscribe.suppress-pre-tool-text.test.ts
@@ -1,3 +1,4 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 /**
  * Tests for suppressPreToolText behavior: intermediate text blocks written
  * between tool calls must NOT be delivered via onBlockReply.
@@ -6,7 +7,6 @@
  * https://github.com/openclaw/openclaw/pull/19932
  */
 import { describe, expect, it, vi } from "vitest";
-import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { createSubscribedSessionHarness } from "./pi-embedded-subscribe.e2e-harness.js";
 
 const waitForAsyncCallbacks = async () => {
@@ -30,10 +30,7 @@ function makeAssistantMessage(
   };
 }
 
-function emitTurn(
-  emit: (evt: unknown) => void,
-  message: AssistantMessage,
-) {
+function emitTurn(emit: (evt: unknown) => void, message: AssistantMessage) {
   emit({ type: "message_start", message });
   emit({ type: "message_end", message });
 }
@@ -42,10 +39,7 @@ function emitTurn(
  * Simulate a streaming turn: message_start → text_delta → text_end → message_end.
  * This matches the production path for text_end mode where onBlockReply fires on text_end.
  */
-function emitStreamingTurn(
-  emit: (evt: unknown) => void,
-  message: AssistantMessage,
-) {
+function emitStreamingTurn(emit: (evt: unknown) => void, message: AssistantMessage) {
   const textContent = message.content
     .filter((b): b is { type: "text"; text: string } => b.type === "text")
     .map((b) => b.text)
@@ -125,10 +119,7 @@ describe("suppressPreToolText", () => {
     expect(onBlockReply).not.toHaveBeenCalled();
 
     // Turn 2: final answer
-    const finalMsg = makeAssistantMessage(
-      [{ type: "text", text: "Here are the files." }],
-      "stop",
-    );
+    const finalMsg = makeAssistantMessage([{ type: "text", text: "Here are the files." }], "stop");
     emitTurn(emit, finalMsg);
     await waitForAsyncCallbacks();
 
@@ -167,5 +158,33 @@ describe("suppressPreToolText", () => {
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
     expect((onBlockReply.mock.calls[0][0] as { text: string }).text).toBe("FINAL_REPLY");
+  });
+
+  it("does not include intermediate texts in assistantTexts (final reply payload)", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-4",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    const toolMsg = (text: string, id: string) =>
+      makeAssistantMessage(
+        [
+          { type: "text", text },
+          { type: "toolCall", id, name: "exec", arguments: { command: "x" } },
+        ],
+        "toolUse",
+      );
+
+    emitStreamingTurn(emit, toolMsg("INTERMEDIATE_should_not_be_in_final", "c1"));
+    await waitForAsyncCallbacks();
+
+    emitStreamingTurn(emit, makeAssistantMessage([{ type: "text", text: "FINAL_ONLY" }], "stop"));
+    await waitForAsyncCallbacks();
+
+    // assistantTexts is the source for the final reply payload
+    expect(subscription.assistantTexts).not.toContain("INTERMEDIATE_should_not_be_in_final");
+    expect(subscription.assistantTexts).toContain("FINAL_ONLY");
   });
 });

--- a/src/agents/pi-embedded-subscribe.suppress-pre-tool-text.test.ts
+++ b/src/agents/pi-embedded-subscribe.suppress-pre-tool-text.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for suppressPreToolText behavior: intermediate text blocks written
+ * between tool calls must NOT be delivered via onBlockReply.
+ *
+ * Regression test for the Mattermost intermediate-text leak:
+ * https://github.com/openclaw/openclaw/pull/19932
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { createSubscribedSessionHarness } from "./pi-embedded-subscribe.e2e-harness.js";
+
+const waitForAsyncCallbacks = async () => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+function makeAssistantMessage(
+  content: AssistantMessage["content"],
+  stopReason: AssistantMessage["stopReason"],
+): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    stopReason,
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-opus-4-6",
+    usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+    timestamp: Date.now(),
+  };
+}
+
+function emitTurn(
+  emit: (evt: unknown) => void,
+  message: AssistantMessage,
+) {
+  emit({ type: "message_start", message });
+  emit({ type: "message_end", message });
+}
+
+/**
+ * Simulate a streaming turn: message_start → text_delta → text_end → message_end.
+ * This matches the production path for text_end mode where onBlockReply fires on text_end.
+ */
+function emitStreamingTurn(
+  emit: (evt: unknown) => void,
+  message: AssistantMessage,
+) {
+  const textContent = message.content
+    .filter((b): b is { type: "text"; text: string } => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+  emit({ type: "message_start", message: { role: "assistant" } });
+  if (textContent) {
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_delta", delta: textContent },
+    });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_end", content: textContent },
+    });
+  }
+  emit({ type: "message_end", message });
+}
+
+describe("suppressPreToolText", () => {
+  it("suppresses text blocks when stopReason is toolUse (text_end mode)", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run-1",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    // Turn 1: stream text + tool call → text_end fires but reply should be buffered,
+    // then message_end with toolUse → buffer discarded
+    const intermediateMsg = makeAssistantMessage(
+      [
+        { type: "text", text: "Let me check that for you..." },
+        { type: "toolCall", id: "call_1", name: "exec", arguments: { command: "echo hi" } },
+      ],
+      "toolUse",
+    );
+    emitStreamingTurn(emit, intermediateMsg);
+    await waitForAsyncCallbacks();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+
+    // Turn 2: stream final answer → text_end fires, buffered, then message_end with stop → flushed
+    const finalMsg = makeAssistantMessage(
+      [{ type: "text", text: "Done! The output was: hi" }],
+      "stop",
+    );
+    emitStreamingTurn(emit, finalMsg);
+    await waitForAsyncCallbacks();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect((onBlockReply.mock.calls[0][0] as { text: string }).text).toBe(
+      "Done! The output was: hi",
+    );
+  });
+
+  it("suppresses text blocks when stopReason is toolUse (message_end mode)", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run-2",
+      onBlockReply,
+      blockReplyBreak: "message_end",
+    });
+
+    // Turn 1: intermediate text + tool
+    const intermediateMsg = makeAssistantMessage(
+      [
+        { type: "text", text: "Thinking out loud..." },
+        { type: "toolCall", id: "call_1", name: "exec", arguments: { command: "ls" } },
+      ],
+      "toolUse",
+    );
+    emitTurn(emit, intermediateMsg);
+    await waitForAsyncCallbacks();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+
+    // Turn 2: final answer
+    const finalMsg = makeAssistantMessage(
+      [{ type: "text", text: "Here are the files." }],
+      "stop",
+    );
+    emitTurn(emit, finalMsg);
+    await waitForAsyncCallbacks();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect((onBlockReply.mock.calls[0][0] as { text: string }).text).toBe("Here are the files.");
+  });
+
+  it("suppresses multiple intermediate turns, delivers only final (text_end mode)", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run-3",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    const toolMsg = (text: string, id: string) =>
+      makeAssistantMessage(
+        [
+          { type: "text", text },
+          { type: "toolCall", id, name: "exec", arguments: { command: "x" } },
+        ],
+        "toolUse",
+      );
+
+    emitStreamingTurn(emit, toolMsg("INTERMEDIATE_1 — should not appear", "c1"));
+    await waitForAsyncCallbacks();
+    emitStreamingTurn(emit, toolMsg("INTERMEDIATE_2 — should not appear", "c2"));
+    await waitForAsyncCallbacks();
+    emitStreamingTurn(emit, toolMsg("INTERMEDIATE_3 — should not appear", "c3"));
+    await waitForAsyncCallbacks();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+
+    emitStreamingTurn(emit, makeAssistantMessage([{ type: "text", text: "FINAL_REPLY" }], "stop"));
+    await waitForAsyncCallbacks();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect((onBlockReply.mock.calls[0][0] as { text: string }).text).toBe("FINAL_REPLY");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -79,6 +79,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     successfulCronAdds: 0,
     pendingMessagingMediaUrls: new Map(),
     deterministicApprovalPromptSent: false,
+    suppressPreToolText: Boolean(params.onBlockReply),
+    pendingBlockReplies: [],
   };
   const usageTotals = {
     input: 0,
@@ -105,6 +107,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     payload: Parameters<NonNullable<SubscribeEmbeddedPiSessionParams["onBlockReply"]>>[0],
   ) => {
     if (!params.onBlockReply) {
+      return;
+    }
+    if (state.suppressPreToolText) {
+      state.pendingBlockReplies.push(payload);
       return;
     }
     void Promise.resolve()
@@ -134,6 +140,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.lastReasoningSent = undefined;
     state.reasoningStreamOpen = false;
     state.suppressBlockChunks = false;
+    state.pendingBlockReplies.length = 0;
     state.assistantMessageIndex += 1;
     state.lastAssistantTextMessageIndex = -1;
     state.lastAssistantTextNormalized = undefined;


### PR DESCRIPTION
Fixes #45134

## Summary

When an agent performs multi-step tool calls in `text_end` streaming mode (Mattermost's delivery path), any text written *between* tool calls leaked as standalone unthreaded messages in the Mattermost channel. This PR implements the buffering approach from #19932.

## Two-layer fix

**Layer 1 — Buffer `onBlockReply` until `stopReason` is known**

Added to `EmbeddedPiSubscribeState`:
```typescript
suppressPreToolText: boolean;
pendingBlockReplies: BlockReplyPayload[];
```

Both `emitBlockReplySafely` functions (outer in `subscribe.ts` for `text_end` mode, local in `handleMessageEnd` for `message_end` mode) now push to `pendingBlockReplies` instead of calling `onBlockReply` immediately. At `message_end`, the buffer is flushed (final turn) or discarded (`stopReason === "toolUse"`).

**Layer 2 — Remove intermediate texts from `assistantTexts`**

`emitBlockChunk` pushes text to `state.assistantTexts` independently of the `onBlockReply` path. This array is later consumed by `buildEmbeddedRunPayloads`. The `hasSentPayload` deduplication couldn't filter these out because discarded intermediate texts were never enqueued into the pipeline.

Fix: capture `preTurnAssistantTextBaseline` before `finalizeAssistantTexts` updates it, then splice `assistantTexts` back when discarding for `toolUse`.

## Tests

New file: `src/agents/pi-embedded-subscribe.suppress-pre-tool-text.test.ts`

4 tests covering:
- `text_end` mode suppression
- `message_end` mode suppression  
- Multiple sequential intermediate turns all suppressed
- `assistantTexts` regression (Layer 2)

## Known limitation

Text written by the model in the **final turn** (`stopReason=stop`) before the actual answer cannot be suppressed without a model-level signal (e.g. `enforceFinalTag`). The primary production bug (intermediate tool-call turns leaking) is fully resolved.

## Related

- #19932 — buffering approach this fix is based on
- #25659 — per-message flag approach (not per-turn; we attempted patching into compiled bundles and abandoned it)
- #41362 — Mattermost block-streaming duplicate fix