### PR TITLE
fix: pre-compact near-threshold sessions before next turn

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -131,7 +131,7 @@ export type CompactEmbeddedPiSessionParams = {
   customInstructions?: string;
   tokenBudget?: number;
   force?: boolean;
-  trigger?: "overflow" | "manual";
+  trigger?: "overflow" | "manual" | "threshold";
   diagId?: string;
   attempt?: number;
   maxAttempts?: number;

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -12,6 +12,7 @@ import type { FollowupRun, QueueSettings } from "./queue.js";
 import { createMockTypingController } from "./test-helpers.js";
 
 const runEmbeddedPiAgentMock = vi.fn();
+const compactEmbeddedPiSessionMock = vi.fn();
 const runCliAgentMock = vi.fn();
 const runWithModelFallbackMock = vi.fn();
 const runtimeErrorMock = vi.fn();
@@ -31,6 +32,7 @@ vi.mock("../../agents/pi-embedded.js", async () => {
   return {
     ...actual,
     queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+    compactEmbeddedPiSession: (params: unknown) => compactEmbeddedPiSessionMock(params),
     runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
   };
 });
@@ -86,6 +88,12 @@ type RunWithModelFallbackParams = {
 
 beforeEach(() => {
   runEmbeddedPiAgentMock.mockClear();
+  compactEmbeddedPiSessionMock.mockClear();
+  compactEmbeddedPiSessionMock.mockResolvedValue({
+    ok: true,
+    compacted: false,
+    reason: "below threshold",
+  });
   runCliAgentMock.mockClear();
   runWithModelFallbackMock.mockClear();
   runtimeErrorMock.mockClear();
@@ -453,6 +461,80 @@ describe("runReplyAgent auto-compaction token update", () => {
     expect(stored[sessionKey].totalTokens).toBe(10_000);
     // compactionCount should be incremented
     expect(stored[sessionKey].compactionCount).toBe(1);
+  });
+
+  it("proactively compacts near-threshold sessions before the next turn", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-precompact-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 253_816,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+
+    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+    compactEmbeddedPiSessionMock.mockResolvedValue({
+      ok: true,
+      compacted: true,
+      result: { tokensAfter: 8_000 },
+    });
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          lastCallUsage: { input: 8_000, output: 500, total: 8_500 },
+        },
+      },
+    });
+
+    const config = {
+      agents: { defaults: { compaction: { memoryFlush: { enabled: false } } } },
+    };
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath,
+      sessionEntry,
+      config,
+    });
+
+    await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-5",
+      agentCfgContextTokens: 272_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(compactEmbeddedPiSessionMock.mock.calls[0]?.[0]).toMatchObject({
+      sessionId: "session",
+      currentTokenCount: 253_816,
+      trigger: "threshold",
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].compactionCount).toBe(1);
+    expect(stored[sessionKey].totalTokens).toBe(8_000);
   });
 
   it("updates totalTokens from lastCallUsage even without compaction", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -3,10 +3,12 @@ import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
-import { queueEmbeddedPiMessage } from "../../agents/pi-embedded.js";
+import { compactEmbeddedPiSession, queueEmbeddedPiMessage } from "../../agents/pi-embedded.js";
+import { resolveCompactionReserveTokensFloor } from "../../agents/pi-settings.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import {
   resolveAgentIdFromSessionKey,
+  resolveFreshSessionTotalTokens,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   resolveSessionTranscriptPath,
@@ -55,10 +57,28 @@ import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queu
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
+import { incrementCompactionCount } from "./session-updates.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
+
+function shouldPrecompactBeforeTurn(params: {
+  sessionEntry?: Pick<SessionEntry, "totalTokens" | "totalTokensFresh">;
+  contextTokens: number;
+  reserveTokensFloor: number;
+}): { shouldCompact: boolean; totalTokens?: number; threshold: number } {
+  const totalTokens = resolveFreshSessionTotalTokens(params.sessionEntry);
+  const threshold = Math.max(0, params.contextTokens - Math.max(0, params.reserveTokensFloor));
+  if (!totalTokens || threshold <= 0) {
+    return { shouldCompact: false, totalTokens, threshold };
+  }
+  return {
+    shouldCompact: totalTokens >= threshold,
+    totalTokens,
+    threshold,
+  };
+}
 
 export async function runReplyAgent(params: {
   commandBody: string;
@@ -239,6 +259,65 @@ export async function runReplyAgent(params: {
     storePath,
     isHeartbeat,
   });
+
+  const preTurnContextTokens =
+    agentCfgContextTokens ??
+    lookupContextTokens(followupRun.run.model ?? defaultModel) ??
+    activeSessionEntry?.contextTokens ??
+    DEFAULT_CONTEXT_TOKENS;
+  const reserveTokensFloor = resolveCompactionReserveTokensFloor(cfg);
+  const precompact = shouldPrecompactBeforeTurn({
+    sessionEntry: activeSessionEntry,
+    contextTokens: preTurnContextTokens,
+    reserveTokensFloor,
+  });
+  const preTurnProvider = (followupRun.run.provider ?? "").trim();
+  const shouldAttemptPrecompaction =
+    !isHeartbeat &&
+    !isCliProvider(preTurnProvider, cfg) &&
+    !!activeSessionEntry?.sessionId &&
+    precompact.shouldCompact;
+
+  if (shouldAttemptPrecompaction) {
+    const result = await compactEmbeddedPiSession({
+      sessionId: activeSessionEntry!.sessionId,
+      sessionKey,
+      messageChannel: followupRun.run.messageChannel,
+      messageProvider: followupRun.run.messageProvider,
+      agentAccountId: followupRun.run.agentAccountId,
+      groupId: activeSessionEntry?.groupId,
+      groupChannel: activeSessionEntry?.groupChannel,
+      groupSpace: activeSessionEntry?.space,
+      spawnedBy: activeSessionEntry?.spawnedBy,
+      senderIsOwner: followupRun.run.senderIsOwner,
+      sessionFile: followupRun.run.sessionFile,
+      currentTokenCount: precompact.totalTokens,
+      workspaceDir: followupRun.run.workspaceDir,
+      agentDir: followupRun.run.agentDir,
+      config: cfg,
+      skillsSnapshot: followupRun.run.skillsSnapshot,
+      provider: followupRun.run.provider,
+      model: followupRun.run.model,
+      thinkLevel: followupRun.run.thinkLevel,
+      reasoningLevel: followupRun.run.reasoningLevel,
+      bashElevated: followupRun.run.bashElevated,
+      trigger: "threshold",
+      ownerNumbers: followupRun.run.ownerNumbers,
+    });
+
+    if (result.ok && result.compacted) {
+      await incrementCompactionCount({
+        sessionEntry: activeSessionEntry,
+        sessionStore: activeSessionStore,
+        sessionKey,
+        storePath,
+        tokensAfter: result.result?.tokensAfter,
+      });
+      activeSessionEntry = sessionKey
+        ? (activeSessionStore?.[sessionKey] ?? activeSessionEntry)
+        : activeSessionEntry;
+    }
+  }
 
   const runFollowupTurn = createFollowupRunner({
     opts,


### PR DESCRIPTION
What: proactively compact near-threshold sessions before the next turn.

Why: right now long-lived main sessions can sit near the limit until overflow/manual /compact.

Proof: added a targeted test for the near-threshold path and it passes.