### PR TITLE
fix(sessions): use copyFile instead of rename in rotateSessionFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Docs: https://docs.openclaw.ai
 
 ## Unreleased
+
 ### Changes
 
 - Android/chat settings: redesign the chat settings sheet with grouped device and media sections, refresh the Connect and Voice tabs, and tighten the chat composer/session header for a denser mobile layout. (#44894) Thanks @obviyus.
@@ -28,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Security/exec approvals: fail closed for Perl `-M` and `-I` approval flows so preload and load-path module resolution stays outside approval-backed runtime execution unless the operator uses a broader explicit trust path.
 - Control UI/insecure auth: preserve explicit shared token and password auth on plain-HTTP Control UI connects so LAN and reverse-proxy sessions no longer drop shared auth before the first WebSocket handshake. (#45088) Thanks @velvet-shark.
 - macOS/onboarding: avoid self-restarting freshly bootstrapped launchd gateways and give new daemon installs longer to become healthy, so `openclaw onboard --install-daemon` no longer false-fails on slower Macs and fresh VM snapshots.
+
 ## 2026.3.12
 
 ### Changes

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -269,7 +269,7 @@ async function getSessionFileSize(storePath: string): Promise<number | null> {
 
 /**
  * Rotate the sessions file if it exceeds the configured size threshold.
- * Renames the current file to `sessions.json.bak.{timestamp}` and cleans up
+ * Copies the current file to `sessions.json.bak.{timestamp}` and cleans up
  * old rotation backups, keeping only the 3 most recent `.bak.*` files.
  */
 export async function rotateSessionFile(

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -288,16 +288,26 @@ export async function rotateSessionFile(
     return false;
   }
 
-  // Rotate: rename current file to .bak.{timestamp}
+  // Rotate: copy current file to .bak.{timestamp} (NOT rename).
+  //
+  // Using copyFile instead of rename is intentional: rename would remove
+  // sessions.json for the brief period until writeSessionStoreAtomic creates
+  // the replacement.  Any inbound message processed during that window would
+  // find the file missing, fall back to an empty store, and generate a new
+  // sessionId — causing a "memory wipe" mid-conversation (issue #18572).
+  //
+  // copyFile leaves the original in place so readers always see a valid file.
+  // The subsequent atomic write (tmp → sessions.json) will overwrite it with
+  // the pruned/updated content, keeping disk usage bounded.
   const backupPath = `${storePath}.bak.${Date.now()}`;
   try {
-    await fs.promises.rename(storePath, backupPath);
+    await fs.promises.copyFile(storePath, backupPath);
     log.info("rotated session store file", {
       backupPath: path.basename(backupPath),
       sizeBytes: fileSize,
     });
   } catch {
-    // If rename fails (e.g. file disappeared), skip rotation.
+    // If copy fails (e.g. file disappeared), skip rotation.
     return false;
   }
 

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -79,19 +79,55 @@ describe("rotateSessionFile", () => {
     storePath = path.join(testDir, "sessions.json");
   });
 
-  it("file over maxBytes: renamed to .bak.{timestamp}, returns true", async () => {
+  it("file over maxBytes: copied to .bak.{timestamp}, original preserved, returns true", async () => {
     const bigContent = "x".repeat(200);
     await fs.writeFile(storePath, bigContent, "utf-8");
 
     const rotated = await rotateSessionFile(storePath, 100);
 
     expect(rotated).toBe(true);
-    await expect(fs.stat(storePath)).rejects.toThrow();
+    // Original file must still exist so concurrent readers never see a missing
+    // file (issue #18572: rename caused a race window that wiped session memory).
+    await expect(fs.stat(storePath)).resolves.toBeTruthy();
+    const originalContent = await fs.readFile(storePath, "utf-8");
+    expect(originalContent).toBe(bigContent);
+    // Backup must also exist with the same content.
     const files = await fs.readdir(testDir);
     const bakFiles = files.filter((f) => f.startsWith("sessions.json.bak."));
     expect(bakFiles).toHaveLength(1);
     const bakContent = await fs.readFile(path.join(testDir, bakFiles[0]), "utf-8");
     expect(bakContent).toBe(bigContent);
+  });
+
+  it("race-condition regression: sessions.json readable throughout rotation (issue #18572)", async () => {
+    // With the old rename-based approach, sessions.json disappeared between
+    // rename and the subsequent atomic write.  Any inbound message processed
+    // during that window would find the file missing, fall back to {}, and
+    // generate a new sessionId — a "memory wipe".  copyFile keeps the
+    // original present so concurrent readers always see valid data.
+    const content = JSON.stringify({ "user:123": { sessionId: "sess-abc", updatedAt: Date.now() } });
+    await fs.writeFile(storePath, content, "utf-8");
+
+    let contentDuringRotation: string | undefined;
+    const realCopyFile = (fs.copyFile as typeof fs.copyFile).bind(fs);
+    const spy = vi.spyOn(fs, "copyFile").mockImplementation(async (...args) => {
+      // Simulate a concurrent reader at the exact moment the backup is written.
+      try {
+        contentDuringRotation = await fs.readFile(storePath, "utf-8");
+      } catch {
+        contentDuringRotation = "(missing)";
+      }
+      return realCopyFile(...(args as Parameters<typeof fs.copyFile>));
+    });
+
+    try {
+      await rotateSessionFile(storePath, 10);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // Concurrent reader must have seen valid JSON, not a missing/empty file.
+    expect(contentDuringRotation).toBe(content);
   });
 
   it("multiple rotations: only keeps 3 most recent .bak files", async () => {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -105,7 +105,9 @@ describe("rotateSessionFile", () => {
     // during that window would find the file missing, fall back to {}, and
     // generate a new sessionId — a "memory wipe".  copyFile keeps the
     // original present so concurrent readers always see valid data.
-    const content = JSON.stringify({ "user:123": { sessionId: "sess-abc", updatedAt: Date.now() } });
+    const content = JSON.stringify({
+      "user:123": { sessionId: "sess-abc", updatedAt: Date.now() },
+    });
     await fs.writeFile(storePath, content, "utf-8");
 
     let contentDuringRotation: string | undefined;


### PR DESCRIPTION
## Summary

- Problem: `rotateSessionFile` used `fs.promises.rename` to back up `sessions.json`, which removed the file from disk for a brief window between the rename and the subsequent atomic write of the new content.
- Why it matters: Any inbound message (Discord, Telegram, etc.) processed during that window calls `loadSessionStore`, finds the file missing, falls back to `{}`, and generates a fresh `sessionId` — a silent mid-session memory wipe with no `/new` or `/reset` invoked. Issue reporter observed 772 rotations in one day (store repeatedly hitting the 10 MB `rotateBytes` threshold), making the race window hit constantly.
- What changed: `rename` → `copyFile` in `rotateSessionFile`. The original `sessions.json` stays present throughout rotation; the subsequent `writeTextAtomic` call (already part of `saveSessionStoreUnlocked`) overwrites it with the pruned content.
- What did NOT change: Backup file format, cleanup logic (keep 3 most recent `.bak.*`), `rotateBytes` threshold, or any other maintenance behavior.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #18572

## User-visible / Behavior Changes

Sessions on high-traffic Discord/Telegram deployments will no longer randomly lose context mid-conversation when `sessions.json` exceeds `rotateBytes`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (reported); race is platform-independent
- Runtime/container: Node.js
- Model/provider: Any
- Integration/channel: Discord / Telegram (any gateway channel with concurrent inbound messages)
- Relevant config: `session.maintenance.rotateBytes` at or below default 10 MB

### Steps

1. Run a high-traffic gateway deployment until `sessions.json` exceeds `rotateBytes` (10 MB default)
2. Send a message at the exact moment `rotateSessionFile` is running
3. (Old behavior) Agent responds with zero context — new `sessionId` generated silently

### Expected

- Agent retains session context across rotation events

### Actual (before fix)

- Agent loses all context; session effectively reset with no archive and no user action

## Evidence

- [x] Failing test/log before + passing after — updated `rotateSessionFile` unit test now asserts original file is preserved; new regression test intercepts `copyFile` to simulate a concurrent reader and verifies it always sees valid JSON

## Human Verification (required)

- Verified scenarios: `rotateSessionFile` with content above threshold — `.bak` file created, original file still present and readable with identical content
- Edge cases checked: copy failure (returns `false`, skips rotation as before); file below threshold (no-op, unchanged)
- What I did **not** verify: actual high-traffic Discord/Telegram deployment at scale; Windows-specific behavior (Windows already has a separate 5-retry path in `saveSessionStoreUnlocked`)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the one-line change in `rotateSessionFile` back to `fs.promises.rename`
- Files/config to restore: `src/config/sessions/store-maintenance.ts`
- Known bad symptoms: If `copyFile` is unexpectedly slow on a deployment (e.g. cross-device path), rotation may take longer — raise `rotateBytes` threshold as a workaround

## Risks and Mitigations

- Risk: `copyFile` uses more I/O than `rename` for large files (data is physically copied rather than a directory entry moved)
  - Mitigation: Rotation only triggers when the file exceeds `rotateBytes`; the copy is immediately followed by an atomic overwrite with the smaller post-prune content, so the extra I/O is bounded and one-time per rotation event