### PR TITLE
fix(outbound): suppress ANNOUNCE_SKIP / REPLY_SKIP from external delivery

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -91,3 +91,28 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 });
+
+describe("buildEmbeddedRunPayloads ANNOUNCE_SKIP / REPLY_SKIP suppression (#45084)", () => {
+  it("drops payloads whose text is exactly ANNOUNCE_SKIP", () => {
+    const payloads = buildPayloads({ assistantTexts: ["ANNOUNCE_SKIP"] });
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("drops payloads whose text is exactly REPLY_SKIP", () => {
+    const payloads = buildPayloads({ assistantTexts: ["REPLY_SKIP"] });
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("drops ANNOUNCE_SKIP even with surrounding whitespace", () => {
+    const payloads = buildPayloads({ assistantTexts: ["  ANNOUNCE_SKIP  "] });
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("does not suppress substantive text that happens to contain ANNOUNCE_SKIP", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Task done. ANNOUNCE_SKIP"],
+    });
+    // The text is not an exact-match token, so the payload should pass through
+    expect(payloads).not.toHaveLength(0);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -115,4 +115,32 @@ describe("buildEmbeddedRunPayloads ANNOUNCE_SKIP / REPLY_SKIP suppression (#4508
     // The text is not an exact-match token, so the payload should pass through
     expect(payloads).not.toHaveLength(0);
   });
+
+  it("does not count ANNOUNCE_SKIP as a user-facing reply when deciding to show tool-error warnings", () => {
+    // An ANNOUNCE_SKIP-only reply must NOT suppress mutating-tool failure warnings.
+    // Previously the token was only filtered at the end of the pipeline, after
+    // hasUserFacingAssistantReply was already set to true, which caused the
+    // tool-error warning to be hidden (CWE-841 / aisle-research-bot finding).
+    const payloads = buildPayloads({
+      assistantTexts: ["ANNOUNCE_SKIP"],
+      lastToolError: { toolName: "write", error: "permission denied" },
+      verboseLevel: "on",
+    });
+    expectSingleToolErrorPayload(payloads, {
+      title: "Write",
+      detail: "permission denied",
+    });
+  });
+
+  it("does not count REPLY_SKIP as a user-facing reply when deciding to show tool-error warnings", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["REPLY_SKIP"],
+      lastToolError: { toolName: "write", error: "permission denied" },
+      verboseLevel: "on",
+    });
+    expectSingleToolErrorPayload(payloads, {
+      title: "Write",
+      detail: "permission denied",
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -277,6 +277,20 @@ export function buildEmbeddedRunPayloads(params: {
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
       continue;
     }
+    // Treat ANNOUNCE_SKIP / REPLY_SKIP as silent *before* evaluating
+    // hasUserFacingAssistantReply.  Checking here (not in the trailing .filter())
+    // ensures these tokens never suppress tool-error warnings by being counted
+    // as a user-facing reply.  Text-only payloads are skipped entirely; payloads
+    // that also carry media are kept so the media still reaches the user.
+    if (
+      cleanedText &&
+      !mediaUrls?.length &&
+      !audioAsVoice &&
+      (isSilentReplyText(cleanedText, ANNOUNCE_SKIP_TOKEN) ||
+        isSilentReplyText(cleanedText, REPLY_SKIP_TOKEN))
+    ) {
+      continue;
+    }
     replyItems.push({
       text: cleanedText,
       media: mediaUrls,

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -2,7 +2,12 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { parseReplyDirectives } from "../../../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
+import {
+  ANNOUNCE_SKIP_TOKEN,
+  isSilentReplyText,
+  REPLY_SKIP_TOKEN,
+  SILENT_REPLY_TOKEN,
+} from "../../../auto-reply/tokens.js";
 import { formatToolAggregate } from "../../../auto-reply/tool-meta.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
@@ -341,6 +346,13 @@ export function buildEmbeddedRunPayloads(params: {
         return false;
       }
       if (p.text && isSilentReplyText(p.text, SILENT_REPLY_TOKEN)) {
+        return false;
+      }
+      if (
+        p.text &&
+        (isSilentReplyText(p.text, ANNOUNCE_SKIP_TOKEN) ||
+          isSilentReplyText(p.text, REPLY_SKIP_TOKEN))
+      ) {
         return false;
       }
       return true;

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -1,12 +1,10 @@
+import { ANNOUNCE_SKIP_TOKEN, REPLY_SKIP_TOKEN } from "../../auto-reply/tokens.js";
 import {
   getChannelPlugin,
   normalizeChannelId as normalizeAnyChannelId,
 } from "../../channels/plugins/index.js";
 import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
-
-const ANNOUNCE_SKIP_TOKEN = "ANNOUNCE_SKIP";
-const REPLY_SKIP_TOKEN = "REPLY_SKIP";
 const DEFAULT_PING_PONG_TURNS = 5;
 const MAX_PING_PONG_TURNS = 5;
 

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -5,6 +5,7 @@ import {
 } from "../../channels/plugins/index.js";
 import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
+
 const DEFAULT_PING_PONG_TURNS = 5;
 const MAX_PING_PONG_TURNS = 5;
 

--- a/src/auto-reply/reply/normalize-reply.test.ts
+++ b/src/auto-reply/reply/normalize-reply.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { normalizeReplyPayload } from "./normalize-reply.js";
+
+describe("normalizeReplyPayload", () => {
+  describe("NO_REPLY suppression", () => {
+    it("returns null for exact NO_REPLY token", () => {
+      expect(normalizeReplyPayload({ text: "NO_REPLY" })).toBeNull();
+    });
+
+    it("returns null for NO_REPLY with surrounding whitespace", () => {
+      expect(normalizeReplyPayload({ text: "  NO_REPLY  " })).toBeNull();
+    });
+
+    it("passes through normal text", () => {
+      const result = normalizeReplyPayload({ text: "Hello, world!" });
+      expect(result?.text).toBe("Hello, world!");
+    });
+  });
+
+  describe("ANNOUNCE_SKIP suppression (#45084)", () => {
+    it("returns null for exact ANNOUNCE_SKIP token", () => {
+      expect(normalizeReplyPayload({ text: "ANNOUNCE_SKIP" })).toBeNull();
+    });
+
+    it("returns null for ANNOUNCE_SKIP with surrounding whitespace", () => {
+      expect(normalizeReplyPayload({ text: "  ANNOUNCE_SKIP  " })).toBeNull();
+      expect(normalizeReplyPayload({ text: "\nANNOUNCE_SKIP\n" })).toBeNull();
+    });
+
+    it("does not suppress text that merely contains ANNOUNCE_SKIP", () => {
+      const result = normalizeReplyPayload({ text: "The task is done. ANNOUNCE_SKIP" });
+      // Not an exact-match — should still produce a payload (text delivery at caller's discretion)
+      expect(result).not.toBeNull();
+    });
+
+    it("invokes onSkip callback with 'silent' reason for ANNOUNCE_SKIP", () => {
+      const reasons: string[] = [];
+      normalizeReplyPayload({ text: "ANNOUNCE_SKIP" }, { onSkip: (r) => reasons.push(r) });
+      expect(reasons).toEqual(["silent"]);
+    });
+
+    it("preserves media-only payload when text is ANNOUNCE_SKIP", () => {
+      // When there is attached media, the token should clear text but not drop the payload
+      const result = normalizeReplyPayload({
+        text: "ANNOUNCE_SKIP",
+        mediaUrl: "https://example.com/img.png",
+      });
+      expect(result).not.toBeNull();
+      expect(result?.text).toBe("");
+      expect(result?.mediaUrl).toBe("https://example.com/img.png");
+    });
+  });
+
+  describe("REPLY_SKIP suppression (#45084)", () => {
+    it("returns null for exact REPLY_SKIP token", () => {
+      expect(normalizeReplyPayload({ text: "REPLY_SKIP" })).toBeNull();
+    });
+
+    it("returns null for REPLY_SKIP with surrounding whitespace", () => {
+      expect(normalizeReplyPayload({ text: "  REPLY_SKIP  " })).toBeNull();
+    });
+
+    it("invokes onSkip callback with 'silent' reason for REPLY_SKIP", () => {
+      const reasons: string[] = [];
+      normalizeReplyPayload({ text: "REPLY_SKIP" }, { onSkip: (r) => reasons.push(r) });
+      expect(reasons).toEqual(["silent"]);
+    });
+  });
+});

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -75,7 +75,7 @@ export function normalizeReplyPayload(
     text &&
     (isSilentReplyText(text, ANNOUNCE_SKIP_TOKEN) || isSilentReplyText(text, REPLY_SKIP_TOKEN))
   ) {
-    if (!hasMedia && !hasChannelData) {
+    if (!hasContent("")) {
       opts.onSkip?.("silent");
       return null;
     }

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -65,6 +65,12 @@ export function normalizeReplyPayload(
   // These are internal protocol tokens the main session returns to opt out of
   // rebroadcasting a subagent announce summary or ending a ping-pong exchange.
   // They must never reach the end-user channel, matching the NO_REPLY contract.
+  //
+  // Unlike NO_REPLY, mixed-content trailing stripping is intentionally NOT
+  // applied here.  These tokens are only emitted as the sole content in the
+  // internal protocol (the model is instructed to return them in isolation),
+  // so "Task done. ANNOUNCE_SKIP" is not a valid output pattern and does not
+  // need a stripping path — treating it as opaque text is the safer default.
   if (
     text &&
     (isSilentReplyText(text, ANNOUNCE_SKIP_TOKEN) || isSilentReplyText(text, REPLY_SKIP_TOKEN))

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -2,8 +2,10 @@ import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers.js";
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import {
+  ANNOUNCE_SKIP_TOKEN,
   HEARTBEAT_TOKEN,
   isSilentReplyText,
+  REPLY_SKIP_TOKEN,
   SILENT_REPLY_TOKEN,
   stripSilentToken,
 } from "../tokens.js";
@@ -54,6 +56,20 @@ export function normalizeReplyPayload(
   let text = payload.text ?? undefined;
   if (text && isSilentReplyText(text, silentToken)) {
     if (!hasContent("")) {
+      opts.onSkip?.("silent");
+      return null;
+    }
+    text = "";
+  }
+  // Suppress agent-to-agent conversation stop tokens (ANNOUNCE_SKIP, REPLY_SKIP).
+  // These are internal protocol tokens the main session returns to opt out of
+  // rebroadcasting a subagent announce summary or ending a ping-pong exchange.
+  // They must never reach the end-user channel, matching the NO_REPLY contract.
+  if (
+    text &&
+    (isSilentReplyText(text, ANNOUNCE_SKIP_TOKEN) || isSilentReplyText(text, REPLY_SKIP_TOKEN))
+  ) {
+    if (!hasMedia && !hasChannelData) {
       opts.onSkip?.("silent");
       return null;
     }

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -2,6 +2,18 @@ import { escapeRegExp } from "../utils.js";
 
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
+/**
+ * Agent-to-agent token: main session opts out of rebroadcasting a subagent
+ * announce summary.  When delivered with `deliver:true` the agent returns this
+ * token to signal silence; the outbound pipeline must suppress it just like
+ * NO_REPLY so the token never reaches the end-user channel.
+ */
+export const ANNOUNCE_SKIP_TOKEN = "ANNOUNCE_SKIP";
+/**
+ * Agent-to-agent token: signals the end of a ping-pong conversation turn.
+ * Same suppression requirement as ANNOUNCE_SKIP_TOKEN.
+ */
+export const REPLY_SKIP_TOKEN = "REPLY_SKIP";
 
 const silentExactRegexByToken = new Map<string, RegExp>();
 const silentTrailingRegexByToken = new Map<string, RegExp>();


### PR DESCRIPTION
Fixes #45084

## Root cause

When a cron job uses `delivery: announce` targeting an external channel (e.g. Telegram), `sendSubagentAnnounceDirectly` calls the gateway with `deliver: true` and `channel: "telegram"`. The main session receives the announce-step prompt and replies `ANNOUNCE_SKIP` (or `REPLY_SKIP`) to opt out of re-broadcasting.

Neither token was listed as a silent/suppressed payload token, so the literal string leaked to the user's Telegram chat.

The same issue affects `REPLY_SKIP` which ends ping-pong exchanges.

## Fix

**`src/auto-reply/tokens.ts`** — promote `ANNOUNCE_SKIP_TOKEN` and `REPLY_SKIP_TOKEN` to exported constants (alongside `NO_REPLY` and `HEARTBEAT_OK`, the canonical home for all system-level silent tokens).

**`src/agents/tools/sessions-send-helpers.ts`** — import the new constants instead of duplicating the string literals.

**`src/auto-reply/reply/normalize-reply.ts`** — treat both tokens as silent in the ACP delivery path, matching the existing `NO_REPLY` contract: return `null` for text-only payloads so `deliverAgentCommandResult` never queues them for outbound dispatch.

**`src/agents/pi-embedded-runner/run/payloads.ts`** — add the same filter so the Pi runner result payloads list is empty for these tokens, preventing outbound delivery via `deliverOutboundPayloads`.

## Tests

- `normalize-reply.test.ts` (new): exact-match, whitespace variants, mixed-content passthrough, and `onSkip` callback for both `ANNOUNCE_SKIP` and `REPLY_SKIP`.
- `payloads.test.ts`: new describe block verifying the Pi runner drops `ANNOUNCE_SKIP` / `REPLY_SKIP` payloads and preserves substantive text.