### PR TITLE
feat(feishu): add configuration toggle for Bitable tools

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -2,7 +2,7 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
 import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuToolClient } from "./tool-account.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 
 // ============ Helpers ============
 
@@ -541,6 +541,12 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
   const accounts = listEnabledFeishuAccounts(api.config);
   if (accounts.length === 0) {
     api.logger.debug?.("feishu_bitable: No Feishu accounts configured, skipping bitable tools");
+    return;
+  }
+
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  if (!toolsCfg.bitable) {
+    api.logger.debug?.("feishu_bitable: Bitable tools disabled by config");
     return;
   }
 

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -90,6 +90,7 @@ const FeishuToolsConfigSchema = z
     chat: z.boolean().optional(), // Chat info + member query operations (default: true)
     wiki: z.boolean().optional(), // Knowledge base operations (default: true, requires doc)
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
+    bitable: z.boolean().optional(), // Bitable operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
   })

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -54,6 +54,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     chat: false,
     wiki: false,
     drive: false,
+    bitable: false,
     perm: false,
     scopes: false,
   };
@@ -63,6 +64,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.chat = merged.chat || cfg.chat;
     merged.wiki = merged.wiki || cfg.wiki;
     merged.drive = merged.drive || cfg.drive;
+    merged.bitable = merged.bitable || cfg.bitable;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
   }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -10,6 +10,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   chat: true,
   wiki: true,
   drive: true,
+  bitable: true,
   perm: false,
   scopes: true,
 };

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -91,6 +91,7 @@ export type FeishuToolsConfig = {
   chat?: boolean;
   wiki?: boolean;
   drive?: boolean;
+  bitable?: boolean;
   perm?: boolean;
   scopes?: boolean;
 };


### PR DESCRIPTION
This PR adds a configuration toggle for Feishu Bitable tools `feishu_bitable_*`. By default, these tools are enabled `true`. Users can now disable them via `tools.bitable: false` to reduce prompt size and token usage. Closes #45195