### PR TITLE
docs: add n8n-as-code community plugin listing

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -59,6 +59,20 @@ while reducing token usage.
 openclaw plugins install @martian-engineering/lossless-claw
 ```
 
+### n8n-as-code
+
+Build, update, and manage n8n workflows entirely through conversation. Ships a
+prebuilt knowledge base of 537 nodes, 10k+ properties, and 7,700 community
+templates so the AI never hallucinates a schema. Supports pull/push,
+validation against live n8n, and GitOps-ready TypeScript workflow files.
+
+- **npm:** `@n8n-as-code/openclaw-plugin`
+- **repo:** [github.com/EtienneLescot/n8n-as-code](https://github.com/EtienneLescot/n8n-as-code)
+
+```bash
+openclaw plugins install @n8n-as-code/openclaw-plugin
+```
+
 ### Opik
 
 Official plugin that exports agent traces to Opik. Monitor agent behavior,


### PR DESCRIPTION
## Summary

Add [`@n8n-as-code/openclaw-plugin`](https://www.npmjs.com/package/@n8n-as-code/openclaw-plugin) to the community plugins page (`docs/plugins/community.md`).

**n8n-as-code** turns OpenClaw into a full workflow-automation engineer for [n8n](https://n8n.io), the open-source workflow-automation platform (50k+ GitHub stars).

### What it does

| Capability | Detail |
|---|---|
| **Conversational workflow editing** | Create, update, and fix n8n workflows by just talking — no JSON or UI clicks required |
| **Local knowledge base** | Ships 537 node schemas, 10k+ properties, 1,243 doc pages, and 7,700 community templates at install time — zero external calls, zero hallucination |
| **Pull / Push / Validate** | Bidirectional sync with live n8n instances; schema validation _before_ deployment catches errors early |
| **GitOps-ready** | Workflows stored as `.workflow.ts` files — diffable, reviewable, mergeable with 3-way conflict detection |
| **Setup wizard** | `openclaw n8nac:setup` walks through credentials, project selection, and AI context generation |

### Why it matters

n8n has 400+ integration nodes but its JSON workflow format is notoriously hard to hand-edit. This plugin gives OpenClaw users **exact** node schemas and docs so the AI can make surgical edits confidently — no guessing, no hallucinations.

### Links

- npm: https://www.npmjs.com/package/@n8n-as-code/openclaw-plugin
- repo: https://github.com/EtienneLescot/n8n-as-code
- docs: https://n8nascode.dev/docs/usage/openclaw/

## Checklist

- [x] Plugin published on npm
- [x] Source code on GitHub (public repo)
- [x] README with setup/usage docs
- [x] Issue tracker enabled