### PR TITLE
fix(feishu): resolve tool account by session accountId before config defaultAccount

### DIFF
--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -79,7 +79,10 @@ describe("feishu tool account routing", () => {
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
   });
 
-  test("wiki tool prefers configured defaultAccount over inherited default account context", async () => {
+  test("wiki tool routes to agentAccountId even when defaultAccount is configured", async () => {
+    // Session-level accountId (ctx.agentAccountId) must take priority over the global
+    // defaultAccount config so that each bot uses its own account's credentials in
+    // multi-account setups. Fixes #40691.
     const { api, resolveTool } = createToolFactoryHarness(
       createConfig({
         defaultAccount: "b",
@@ -90,6 +93,23 @@ describe("feishu tool account routing", () => {
     registerFeishuWikiTools(api);
 
     const tool = resolveTool("feishu_wiki", { agentAccountId: "a" });
+    await tool.execute("call", { action: "search" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-a");
+  });
+
+  test("wiki tool falls back to configured defaultAccount when no agentAccountId is set", async () => {
+    // When no session accountId is available, defaultAccount config should be used.
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        defaultAccount: "b",
+        toolsA: { wiki: true },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: undefined });
     await tool.execute("call", { action: "search" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -30,30 +30,33 @@ function resolveImplicitToolAccountId(params: {
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
 }): string | undefined {
+  // Priority order (highest → lowest):
+  // 1. Explicit accountId from the tool call params
+  // 2. Session/contextual accountId (agentAccountId from the inbound message route)
+  // 3. Configured defaultAccount in feishu config
+  //
+  // Session accountId must outrank the config default so that each bot in a
+  // multi-account setup uses its own account's credentials. Fixes #40691.
   const explicitAccountId = normalizeOptionalAccountId(params.executeParams?.accountId);
   if (explicitAccountId) {
     return explicitAccountId;
   }
 
-  const configuredDefaultAccountId = readConfiguredDefaultAccountId(params.api.config);
-  if (configuredDefaultAccountId) {
-    return configuredDefaultAccountId;
-  }
-
   const contextualAccountId = normalizeOptionalAccountId(params.defaultAccountId);
-  if (!contextualAccountId) {
-    return undefined;
+  if (contextualAccountId) {
+    if (!listFeishuAccountIds(params.api.config).includes(contextualAccountId)) {
+      return undefined;
+    }
+    const contextualAccount = resolveFeishuAccount({
+      cfg: params.api.config,
+      accountId: contextualAccountId,
+    });
+    if (contextualAccount.enabled) {
+      return contextualAccountId;
+    }
   }
 
-  if (!listFeishuAccountIds(params.api.config).includes(contextualAccountId)) {
-    return undefined;
-  }
-
-  const contextualAccount = resolveFeishuAccount({
-    cfg: params.api.config,
-    accountId: contextualAccountId,
-  });
-  return contextualAccount.enabled ? contextualAccountId : undefined;
+  return readConfiguredDefaultAccountId(params.api.config);
 }
 
 export function resolveFeishuToolAccount(params: {


### PR DESCRIPTION
Fixes #40691

## Problem

When using the Feishu plugin with multiple accounts, tool calls always resolved to the config's `defaultAccountId` instead of the account associated with the current session. The priority in `resolveToolAccountId` was inverted: the static config default was checked first, and the session's `accountId` (e.g. from inbound message routing) was only tried as a fallback.

## Fix

Swap the priority in `resolveToolAccountId` so the dynamic session `accountId` (passed via `params.defaultAccountId`) is checked first, falling back to `readConfiguredDefaultAccountId` only when no session account is present.

**Before:**
```
1. readConfiguredDefaultAccountId (static config default)
2. params.defaultAccountId        (session / inbound account)
```

**After:**
```
1. params.defaultAccountId        (session / inbound account)  ← first
2. readConfiguredDefaultAccountId (static config default)      ← fallback
```

## Tests

Updated existing test to assert the new priority order; added a new test that verifies `params.defaultAccountId` (session account) takes precedence over a configured default account.