### PR TITLE
fix(ui): raise tool output inline threshold to reduce sidebar popups (fixes #45040)

### DIFF
--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -142,7 +142,7 @@
   border-color: var(--border-strong);
 }
 
-/* Short inline output */
+/* Short inline output - capped height to avoid very long cards near threshold */
 .chat-tool-card__inline {
   font-size: 11px;
   color: var(--text);
@@ -152,6 +152,8 @@
   border-radius: var(--radius-sm);
   white-space: pre-wrap;
   word-break: break-word;
+  max-height: 12em;
+  overflow-y: auto;
 }
 
 /* Reading Indicator */

--- a/ui/src/ui/chat/constants.ts
+++ b/ui/src/ui/chat/constants.ts
@@ -3,7 +3,7 @@
  */
 
 /** Character threshold for showing tool output inline vs collapsed */
-export const TOOL_INLINE_THRESHOLD = 80;
+export const TOOL_INLINE_THRESHOLD = 600;
 
 /** Maximum lines to show in collapsed preview */
 export const PREVIEW_MAX_LINES = 2;


### PR DESCRIPTION
## Problem
Long tool output (e.g. ~30 lines) in the Web UI triggers the tool output sidebar when viewing a card, which blocks the chat on mobile and narrow viewports.

## Solution
Raise `TOOL_INLINE_THRESHOLD` from 80 to 600 characters so more output is shown inline in the tool card. Only outputs over ~600 characters use the collapsed preview and require opening the sidebar.

## Changes
- `ui/src/ui/chat/constants.ts`: `TOOL_INLINE_THRESHOLD` 80 → 600

## Testing
- Tool output ≤600 chars: shows inline, no sidebar
- Tool output >600 chars: shows collapsed preview with "View" to open sidebar (existing behavior)

fixes #45040