### PR TITLE
Memory: add Gemini multimodal video and PDF indexing

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -285,12 +285,12 @@ Notes:
 - Paths can be absolute or workspace-relative.
 - Directories are scanned recursively for `.md` files.
 - By default, only Markdown files are indexed.
-- If `memorySearch.multimodal.enabled = true`, OpenClaw also indexes supported image/audio files under `extraPaths` only. Default memory roots (`MEMORY.md`, `memory.md`, `memory/**/*.md`) stay Markdown-only.
+- If `memorySearch.multimodal.enabled = true`, OpenClaw also indexes supported image/audio/video/PDF files under `extraPaths` only. Default memory roots (`MEMORY.md`, `memory.md`, `memory/**/*.md`) stay Markdown-only.
 - Symlinks are ignored (files or directories).
 
-### Multimodal memory files (Gemini image + audio)
+### Multimodal memory files (Gemini image + audio + video + PDF)
 
-OpenClaw can index image and audio files from `memorySearch.extraPaths` when using Gemini embedding 2:
+OpenClaw can index image, audio, video, and PDF files from `memorySearch.extraPaths` when using Gemini embedding 2:
 
 ```json5
 agents: {
@@ -301,7 +301,7 @@ agents: {
       extraPaths: ["assets/reference", "voice-notes"],
       multimodal: {
         enabled: true,
-        modalities: ["image", "audio"], // or ["all"]
+        modalities: ["image", "audio", "video", "pdf"], // or ["all"]
         maxFileBytes: 10000000
       },
       remote: {
@@ -316,13 +316,16 @@ Notes:
 
 - Multimodal memory is currently supported only for `gemini-embedding-2-preview`.
 - Multimodal indexing applies only to files discovered through `memorySearch.extraPaths`.
-- Supported modalities in this phase: image and audio.
+- Supported modalities in this phase: image, audio, video, and PDF.
 - `memorySearch.fallback` must stay `"none"` while multimodal memory is enabled.
-- Matching image/audio file bytes are uploaded to the configured Gemini embedding endpoint during indexing.
+- Matching image/audio/video/PDF file bytes are uploaded to the configured Gemini embedding endpoint during indexing.
 - Supported image extensions: `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`, `.heic`, `.heif`.
 - Supported audio extensions: `.mp3`, `.wav`, `.ogg`, `.opus`, `.m4a`, `.aac`, `.flac`.
-- Search queries remain text, but Gemini can compare those text queries against indexed image/audio embeddings.
+- Supported video extensions: `.mp4`, `.mov`.
+- Supported PDF extensions: `.pdf`.
+- Search queries remain text, but Gemini can compare those text queries against indexed image/audio/video/PDF embeddings.
 - `memory_get` still reads Markdown only; binary files are searchable but not returned as raw file contents.
+- `maxFileBytes` defaults to 10 MB, so you may need to raise it for larger PDFs or short video clips.
 
 ### Gemini embeddings (native)
 

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -150,7 +150,7 @@ describe("memory search config", () => {
     const resolved = resolveMemorySearchConfig(cfg, "main");
     expect(resolved?.multimodal).toEqual({
       enabled: true,
-      modalities: ["image", "audio"],
+      modalities: ["image", "audio", "video", "pdf"],
       maxFileBytes: 8192,
     });
   });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -790,15 +790,15 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.sources":
     'Chooses which sources are indexed: "memory" reads MEMORY.md + memory files, and "sessions" includes transcript history. Keep ["memory"] unless you need recall from prior chat transcripts.',
   "agents.defaults.memorySearch.extraPaths":
-    "Adds extra directories or .md files to the memory index beyond default memory files. Use this when key reference docs live elsewhere in your repo; when multimodal memory is enabled, matching image/audio files under these paths are also eligible for indexing.",
+    "Adds extra directories or .md files to the memory index beyond default memory files. Use this when key reference docs live elsewhere in your repo; when multimodal memory is enabled, matching image/audio/video/PDF files under these paths are also eligible for indexing.",
   "agents.defaults.memorySearch.multimodal":
-    'Optional multimodal memory settings for indexing image and audio files from configured extra paths. Keep this off unless your embedding model explicitly supports cross-modal embeddings, and set `memorySearch.fallback` to "none" while it is enabled. Matching files are uploaded to the configured remote embedding provider during indexing.',
+    'Optional multimodal memory settings for indexing image, audio, video, and PDF files from configured extra paths. Keep this off unless your embedding model explicitly supports cross-modal embeddings, and set `memorySearch.fallback` to "none" while it is enabled. Matching files are uploaded to the configured remote embedding provider during indexing.',
   "agents.defaults.memorySearch.multimodal.enabled":
-    "Enables image/audio memory indexing from extraPaths. This currently requires Gemini embedding-2, keeps the default memory roots Markdown-only, disables memory-search fallback providers, and uploads matching binary content to the configured remote embedding provider.",
+    "Enables image/audio/video/PDF memory indexing from extraPaths. This currently requires Gemini embedding-2, keeps the default memory roots Markdown-only, disables memory-search fallback providers, and uploads matching binary content to the configured remote embedding provider.",
   "agents.defaults.memorySearch.multimodal.modalities":
-    'Selects which multimodal file types are indexed from extraPaths: "image", "audio", or "all". Keep this narrow to avoid indexing large binary corpora unintentionally.',
+    'Selects which multimodal file types are indexed from extraPaths: "image", "audio", "video", "pdf", or "all". Keep this narrow to avoid indexing large binary corpora unintentionally.',
   "agents.defaults.memorySearch.multimodal.maxFileBytes":
-    "Sets the maximum bytes allowed per multimodal file before it is skipped during memory indexing. Use this to cap upload cost and indexing latency, or raise it for short high-quality audio clips.",
+    "Sets the maximum bytes allowed per multimodal file before it is skipped during memory indexing. Use this to cap upload cost and indexing latency, or raise it when indexing larger PDFs or short video clips.",
   "agents.defaults.memorySearch.experimental.sessionMemory":
     "Indexes session transcripts into memory search so responses can reference prior chat turns. Keep this off unless transcript recall is needed, because indexing cost and storage usage both increase.",
   "agents.defaults.memorySearch.provider":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -321,10 +321,10 @@ export type MemorySearchConfig = {
   extraPaths?: string[];
   /** Optional multimodal file indexing for selected extra paths. */
   multimodal?: {
-    /** Enable image/audio embeddings from extraPaths. */
+    /** Enable image/audio/video/PDF embeddings from extraPaths. */
     enabled?: boolean;
     /** Which non-text file types to index. */
-    modalities?: Array<"image" | "audio" | "all">;
+    modalities?: Array<"image" | "audio" | "video" | "pdf" | "all">;
     /** Max bytes allowed per multimodal file before it is skipped. */
     maxFileBytes?: number;
   };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -569,7 +569,15 @@ export const MemorySearchSchema = z
       .object({
         enabled: z.boolean().optional(),
         modalities: z
-          .array(z.union([z.literal("image"), z.literal("audio"), z.literal("all")]))
+          .array(
+            z.union([
+              z.literal("image"),
+              z.literal("audio"),
+              z.literal("video"),
+              z.literal("pdf"),
+              z.literal("all"),
+            ]),
+          )
           .optional(),
         maxFileBytes: z.number().int().positive().optional(),
       })

--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -17,7 +17,9 @@ vi.mock("./embeddings.js", () => {
     const beta = lower.split("beta").length - 1;
     const image = lower.split("image").length - 1;
     const audio = lower.split("audio").length - 1;
-    return [alpha, beta, image, audio];
+    const video = lower.split("video").length - 1;
+    const pdf = lower.split("pdf").length - 1;
+    return [alpha, beta, image, audio, video, pdf];
   };
   return {
     createEmbeddingProvider: async (options: {
@@ -61,11 +63,26 @@ vi.mock("./embeddings.js", () => {
                     }
                     const mimeType =
                       inlineData?.type === "inline-data" ? inlineData.mimeType : undefined;
+                    if (input.text.toLowerCase().includes("reject.pdf")) {
+                      throw new Error("400 pdf page limit exceeded");
+                    }
+                    if (input.text.toLowerCase().includes("generic400.pdf")) {
+                      throw new Error("400 bad request");
+                    }
+                    if (input.text.toLowerCase().includes("outage.mp4")) {
+                      throw new Error("503 upstream unavailable");
+                    }
                     if (mimeType?.startsWith("image/")) {
-                      return [0, 0, 1, 0];
+                      return [0, 0, 1, 0, 0, 0];
                     }
                     if (mimeType?.startsWith("audio/")) {
-                      return [0, 0, 0, 1];
+                      return [0, 0, 0, 1, 0, 0];
+                    }
+                    if (mimeType?.startsWith("video/")) {
+                      return [0, 0, 0, 0, 1, 0];
+                    }
+                    if (mimeType === "application/pdf") {
+                      return [0, 0, 0, 0, 0, 1];
                     }
                     return embedText(input.text);
                   });
@@ -188,7 +205,7 @@ describe("memory index", () => {
     outputDimensionality?: number;
     multimodal?: {
       enabled?: boolean;
-      modalities?: Array<"image" | "audio" | "all">;
+      modalities?: Array<"image" | "audio" | "video" | "pdf" | "all">;
       maxFileBytes?: number;
     };
     vectorEnabled?: boolean;
@@ -290,18 +307,20 @@ describe("memory index", () => {
     );
   });
 
-  it("indexes multimodal image and audio files from extra paths with Gemini structured inputs", async () => {
+  it("indexes multimodal image, audio, video, and PDF files from extra paths with Gemini structured inputs", async () => {
     const mediaDir = path.join(workspaceDir, "media-memory");
     await fs.mkdir(mediaDir, { recursive: true });
     await fs.writeFile(path.join(mediaDir, "diagram.png"), Buffer.from("png"));
     await fs.writeFile(path.join(mediaDir, "meeting.wav"), Buffer.from("wav"));
+    await fs.writeFile(path.join(mediaDir, "clip.mp4"), Buffer.from("mp4"));
+    await fs.writeFile(path.join(mediaDir, "brief.pdf"), Buffer.from("%PDF-1.4"));
 
     const cfg = createCfg({
       storePath: indexMultimodalPath,
       provider: "gemini",
       model: "gemini-embedding-2-preview",
       extraPaths: [mediaDir],
-      multimodal: { enabled: true, modalities: ["image", "audio"] },
+      multimodal: { enabled: true, modalities: ["image", "audio", "video", "pdf"] },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
@@ -313,6 +332,12 @@ describe("memory index", () => {
 
     const audioResults = await manager.search("audio");
     expect(audioResults.some((result) => result.path.endsWith("meeting.wav"))).toBe(true);
+
+    const videoResults = await manager.search("video");
+    expect(videoResults.some((result) => result.path.endsWith("clip.mp4"))).toBe(true);
+
+    const pdfResults = await manager.search("pdf");
+    expect(pdfResults.some((result) => result.path.endsWith("brief.pdf"))).toBe(true);
   });
 
   it("skips oversized multimodal inputs without aborting sync", async () => {
@@ -336,6 +361,72 @@ describe("memory index", () => {
 
     const alphaResults = await manager.search("alpha");
     expect(alphaResults.some((result) => result.path.endsWith("memory/2026-01-12.md"))).toBe(true);
+
+    await manager.close?.();
+  });
+
+  it("skips multimodal provider validation errors without aborting sync", async () => {
+    const mediaDir = path.join(workspaceDir, "media-validation-skip");
+    await fs.mkdir(mediaDir, { recursive: true });
+    await fs.writeFile(path.join(mediaDir, "reject.pdf"), Buffer.from("%PDF-1.4"));
+    await fs.writeFile(path.join(mediaDir, "diagram.png"), Buffer.from("png"));
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, `index-validation-${randomUUID()}.sqlite`),
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      extraPaths: [mediaDir],
+      multimodal: { enabled: true, modalities: ["image", "pdf"] },
+    });
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    await manager.sync({ reason: "test" });
+
+    const pdfResults = await manager.search("pdf");
+    expect(pdfResults.some((result) => result.path.endsWith("reject.pdf"))).toBe(false);
+
+    const imageResults = await manager.search("image");
+    expect(imageResults.some((result) => result.path.endsWith("diagram.png"))).toBe(true);
+
+    const alphaResults = await manager.search("alpha");
+    expect(alphaResults.some((result) => result.path.endsWith("memory/2026-01-12.md"))).toBe(true);
+
+    await manager.close?.();
+  });
+
+  it("preserves sync failure behavior for multimodal systemic provider errors", async () => {
+    const mediaDir = path.join(workspaceDir, "media-systemic-error");
+    await fs.mkdir(mediaDir, { recursive: true });
+    await fs.writeFile(path.join(mediaDir, "outage.mp4"), Buffer.from("mp4"));
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, `index-systemic-${randomUUID()}.sqlite`),
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      extraPaths: [mediaDir],
+      multimodal: { enabled: true, modalities: ["video"] },
+    });
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+
+    await expect(manager.sync({ reason: "test" })).rejects.toThrow(/503 upstream unavailable/);
+
+    await manager.close?.();
+  });
+
+  it("fails sync for generic multimodal 400 provider errors", async () => {
+    const mediaDir = path.join(workspaceDir, "media-generic-400");
+    await fs.mkdir(mediaDir, { recursive: true });
+    await fs.writeFile(path.join(mediaDir, "generic400.pdf"), Buffer.from("%PDF-1.4"));
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, `index-generic-400-${randomUUID()}.sqlite`),
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      extraPaths: [mediaDir],
+      multimodal: { enabled: true, modalities: ["pdf"] },
+    });
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+
+    await expect(manager.sync({ reason: "test" })).rejects.toThrow(/400 bad request/);
 
     await manager.close?.();
   });

--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -81,6 +81,9 @@ vi.mock("./embeddings.js", () => {
                     if (input.text.toLowerCase().includes("limitbytes.mp4")) {
                       throw new Error("400 maximum 5242880 bytes");
                     }
+                    if (input.text.toLowerCase().includes("plain413.mp4")) {
+                      throw new Error("gemini embeddings failed: 413");
+                    }
                     if (input.text.toLowerCase().includes("outage.mp4")) {
                       throw new Error("503 upstream unavailable");
                     }
@@ -486,6 +489,31 @@ describe("memory index", () => {
 
     const videoResults = await manager.search("video");
     expect(videoResults.some((result) => result.path.endsWith("limitbytes.mp4"))).toBe(false);
+
+    const imageResults = await manager.search("image");
+    expect(imageResults.some((result) => result.path.endsWith("diagram.png"))).toBe(true);
+
+    await manager.close?.();
+  });
+
+  it("skips plain 413 multimodal errors without aborting sync", async () => {
+    const mediaDir = path.join(workspaceDir, "media-plain-413");
+    await fs.mkdir(mediaDir, { recursive: true });
+    await fs.writeFile(path.join(mediaDir, "plain413.mp4"), Buffer.from("mp4"));
+    await fs.writeFile(path.join(mediaDir, "diagram.png"), Buffer.from("png"));
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, `index-plain-413-${randomUUID()}.sqlite`),
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      extraPaths: [mediaDir],
+      multimodal: { enabled: true, modalities: ["image", "video"] },
+    });
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    await manager.sync({ reason: "test" });
+
+    const videoResults = await manager.search("video");
+    expect(videoResults.some((result) => result.path.endsWith("plain413.mp4"))).toBe(false);
 
     const imageResults = await manager.search("image");
     expect(imageResults.some((result) => result.path.endsWith("diagram.png"))).toBe(true);

--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -66,6 +66,9 @@ vi.mock("./embeddings.js", () => {
                     if (input.text.toLowerCase().includes("reject.pdf")) {
                       throw new Error("400 pdf page limit exceeded");
                     }
+                    if (input.text.toLowerCase().includes("limitpages.pdf")) {
+                      throw new Error("400 max 500 pages");
+                    }
                     if (input.text.toLowerCase().includes("generic400.pdf")) {
                       throw new Error("400 bad request");
                     }
@@ -74,6 +77,9 @@ vi.mock("./embeddings.js", () => {
                     }
                     if (input.text.toLowerCase().includes("durationerr.mp4")) {
                       throw new Error("deadline exceeded, request duration: 30.5s");
+                    }
+                    if (input.text.toLowerCase().includes("limitbytes.mp4")) {
+                      throw new Error("400 maximum 5242880 bytes");
                     }
                     if (input.text.toLowerCase().includes("outage.mp4")) {
                       throw new Error("503 upstream unavailable");
@@ -433,6 +439,56 @@ describe("memory index", () => {
     const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
 
     await expect(manager.sync({ reason: "test" })).rejects.toThrow(/400 bad request/);
+
+    await manager.close?.();
+  });
+
+  it("skips numeric page-limit validation errors without aborting sync", async () => {
+    const mediaDir = path.join(workspaceDir, "media-page-limit");
+    await fs.mkdir(mediaDir, { recursive: true });
+    await fs.writeFile(path.join(mediaDir, "limitpages.pdf"), Buffer.from("%PDF-1.4"));
+    await fs.writeFile(path.join(mediaDir, "diagram.png"), Buffer.from("png"));
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, `index-page-limit-${randomUUID()}.sqlite`),
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      extraPaths: [mediaDir],
+      multimodal: { enabled: true, modalities: ["image", "pdf"] },
+    });
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    await manager.sync({ reason: "test" });
+
+    const pdfResults = await manager.search("pdf");
+    expect(pdfResults.some((result) => result.path.endsWith("limitpages.pdf"))).toBe(false);
+
+    const imageResults = await manager.search("image");
+    expect(imageResults.some((result) => result.path.endsWith("diagram.png"))).toBe(true);
+
+    await manager.close?.();
+  });
+
+  it("skips numeric byte-limit validation errors without aborting sync", async () => {
+    const mediaDir = path.join(workspaceDir, "media-byte-limit");
+    await fs.mkdir(mediaDir, { recursive: true });
+    await fs.writeFile(path.join(mediaDir, "limitbytes.mp4"), Buffer.from("mp4"));
+    await fs.writeFile(path.join(mediaDir, "diagram.png"), Buffer.from("png"));
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, `index-byte-limit-${randomUUID()}.sqlite`),
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      extraPaths: [mediaDir],
+      multimodal: { enabled: true, modalities: ["image", "video"] },
+    });
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    await manager.sync({ reason: "test" });
+
+    const videoResults = await manager.search("video");
+    expect(videoResults.some((result) => result.path.endsWith("limitbytes.mp4"))).toBe(false);
+
+    const imageResults = await manager.search("image");
+    expect(imageResults.some((result) => result.path.endsWith("diagram.png"))).toBe(true);
 
     await manager.close?.();
   });

--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -69,6 +69,12 @@ vi.mock("./embeddings.js", () => {
                     if (input.text.toLowerCase().includes("generic400.pdf")) {
                       throw new Error("400 bad request");
                     }
+                    if (input.text.toLowerCase().includes("codecerr.mp4")) {
+                      throw new Error("http2: client connection force closed, codec error");
+                    }
+                    if (input.text.toLowerCase().includes("durationerr.mp4")) {
+                      throw new Error("deadline exceeded, request duration: 30.5s");
+                    }
                     if (input.text.toLowerCase().includes("outage.mp4")) {
                       throw new Error("503 upstream unavailable");
                     }
@@ -427,6 +433,46 @@ describe("memory index", () => {
     const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
 
     await expect(manager.sync({ reason: "test" })).rejects.toThrow(/400 bad request/);
+
+    await manager.close?.();
+  });
+
+  it("fails sync for non-media codec errors", async () => {
+    const mediaDir = path.join(workspaceDir, "media-codec-error");
+    await fs.mkdir(mediaDir, { recursive: true });
+    await fs.writeFile(path.join(mediaDir, "codecerr.mp4"), Buffer.from("mp4"));
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, `index-codec-error-${randomUUID()}.sqlite`),
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      extraPaths: [mediaDir],
+      multimodal: { enabled: true, modalities: ["video"] },
+    });
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+
+    await expect(manager.sync({ reason: "test" })).rejects.toThrow(/codec error/);
+
+    await manager.close?.();
+  });
+
+  it("fails sync for deadline duration errors", async () => {
+    const mediaDir = path.join(workspaceDir, "media-duration-error");
+    await fs.mkdir(mediaDir, { recursive: true });
+    await fs.writeFile(path.join(mediaDir, "durationerr.mp4"), Buffer.from("mp4"));
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, `index-duration-error-${randomUUID()}.sqlite`),
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      extraPaths: [mediaDir],
+      multimodal: { enabled: true, modalities: ["video"] },
+    });
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+
+    await expect(manager.sync({ reason: "test" })).rejects.toThrow(
+      /deadline exceeded, request duration: 30\.5s/,
+    );
 
     await manager.close?.();
   });

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -45,7 +45,7 @@ describe("listMemoryFiles", () => {
   const getTmpDir = setupTempDirLifecycle("memory-test-");
   const multimodal: MemoryMultimodalSettings = {
     enabled: true,
-    modalities: ["image", "audio"],
+    modalities: ["image", "audio", "video", "pdf"],
     maxFileBytes: DEFAULT_MEMORY_MULTIMODAL_MAX_FILE_BYTES,
   };
 
@@ -142,17 +142,27 @@ describe("listMemoryFiles", () => {
     expect(memoryMatches).toHaveLength(1);
   });
 
-  it("includes image and audio files from extra paths when multimodal is enabled", async () => {
+  it("includes image, audio, video, and PDF files from extra paths when multimodal is enabled", async () => {
     const tmpDir = getTmpDir();
     const extraDir = path.join(tmpDir, "media");
     await fs.mkdir(extraDir, { recursive: true });
     await fs.writeFile(path.join(extraDir, "diagram.png"), Buffer.from("png"));
     await fs.writeFile(path.join(extraDir, "note.wav"), Buffer.from("wav"));
+    await fs.writeFile(path.join(extraDir, "clip.mp4"), Buffer.from("mp4"));
+    await fs.writeFile(path.join(extraDir, "brief.pdf"), Buffer.from("%PDF-1.4"));
+    await fs.writeFile(path.join(extraDir, "UPPER.MP4"), Buffer.from("mp4"));
+    await fs.writeFile(path.join(extraDir, "TRAILER.MOV"), Buffer.from("mov"));
+    await fs.writeFile(path.join(extraDir, "REPORT.PDF"), Buffer.from("%PDF-1.4"));
     await fs.writeFile(path.join(extraDir, "ignore.bin"), Buffer.from("bin"));
 
     const files = await listMemoryFiles(tmpDir, [extraDir], multimodal);
     expect(files.some((file) => file.endsWith("diagram.png"))).toBe(true);
     expect(files.some((file) => file.endsWith("note.wav"))).toBe(true);
+    expect(files.some((file) => file.endsWith("clip.mp4"))).toBe(true);
+    expect(files.some((file) => file.endsWith("brief.pdf"))).toBe(true);
+    expect(files.some((file) => file.endsWith("UPPER.MP4"))).toBe(true);
+    expect(files.some((file) => file.endsWith("TRAILER.MOV"))).toBe(true);
+    expect(files.some((file) => file.endsWith("REPORT.PDF"))).toBe(true);
     expect(files.some((file) => file.endsWith("ignore.bin"))).toBe(false);
   });
 });
@@ -161,7 +171,7 @@ describe("buildFileEntry", () => {
   const getTmpDir = setupTempDirLifecycle("memory-build-entry-");
   const multimodal: MemoryMultimodalSettings = {
     enabled: true,
-    modalities: ["image", "audio"],
+    modalities: ["image", "audio", "video", "pdf"],
     maxFileBytes: DEFAULT_MEMORY_MULTIMODAL_MAX_FILE_BYTES,
   };
 
@@ -197,6 +207,70 @@ describe("buildFileEntry", () => {
       modality: "image",
       mimeType: "image/png",
       contentText: "Image file: diagram.png",
+    });
+  });
+
+  it("returns multimodal metadata for eligible PDF files", async () => {
+    const tmpDir = getTmpDir();
+    const target = path.join(tmpDir, "brief.pdf");
+    await fs.writeFile(target, Buffer.from("%PDF-1.4"));
+
+    const entry = await buildFileEntry(target, tmpDir, multimodal);
+
+    expect(entry).toMatchObject({
+      path: "brief.pdf",
+      kind: "multimodal",
+      modality: "pdf",
+      mimeType: "application/pdf",
+      contentText: "PDF file: brief.pdf",
+    });
+  });
+
+  it("returns multimodal metadata for eligible uppercase PDF files", async () => {
+    const tmpDir = getTmpDir();
+    const target = path.join(tmpDir, "REPORT.PDF");
+    await fs.writeFile(target, Buffer.from("%PDF-1.4"));
+
+    const entry = await buildFileEntry(target, tmpDir, multimodal);
+
+    expect(entry).toMatchObject({
+      path: "REPORT.PDF",
+      kind: "multimodal",
+      modality: "pdf",
+      mimeType: "application/pdf",
+      contentText: "PDF file: REPORT.PDF",
+    });
+  });
+
+  it("returns multimodal metadata for eligible video files", async () => {
+    const tmpDir = getTmpDir();
+    const target = path.join(tmpDir, "clip.mp4");
+    await fs.writeFile(target, Buffer.from("mp4"));
+
+    const entry = await buildFileEntry(target, tmpDir, multimodal);
+
+    expect(entry).toMatchObject({
+      path: "clip.mp4",
+      kind: "multimodal",
+      modality: "video",
+      mimeType: "video/mp4",
+      contentText: "Video file: clip.mp4",
+    });
+  });
+
+  it("returns multimodal metadata for eligible uppercase MOV files", async () => {
+    const tmpDir = getTmpDir();
+    const target = path.join(tmpDir, "TRAILER.MOV");
+    await fs.writeFile(target, Buffer.from("mov"));
+
+    const entry = await buildFileEntry(target, tmpDir, multimodal);
+
+    expect(entry).toMatchObject({
+      path: "TRAILER.MOV",
+      kind: "multimodal",
+      modality: "video",
+      mimeType: "video/quicktime",
+      contentText: "Video file: TRAILER.MOV",
     });
   });
 

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -10,6 +10,7 @@ import { isFileMissingError } from "./fs-utils.js";
 import {
   buildMemoryMultimodalLabel,
   classifyMemoryMultimodalPath,
+  isSupportedMemoryMultimodalMimeType,
   type MemoryMultimodalModality,
   type MemoryMultimodalSettings,
 } from "./multimodal.js";
@@ -216,7 +217,7 @@ export async function buildFileEntry(
       throw err;
     }
     const mimeType = await detectMime({ buffer: buffer.subarray(0, 512), filePath: absPath });
-    if (!mimeType || !mimeType.startsWith(`${modality}/`)) {
+    if (!mimeType || !isSupportedMemoryMultimodalMimeType(modality, mimeType)) {
       return null;
     }
     const contentText = buildMemoryMultimodalLabel(modality, normalizedPath);

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -796,7 +796,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   private isStructuredInputTooLargeError(message: string): boolean {
-    return /(payload too large|request too large|input too large|too many tokens|input limit|request size|max(?:imum)?\D+\d[\d,]*\D+bytes|\d[\d,]*\D+bytes\D+max|limit\D+\d[\d,]*\D+bytes)/i.test(
+    return /(\b413\b|payload too large|request too large|input too large|too many tokens|input limit|request size|max(?:imum)?\D+\d[\d,]*\D+bytes|\d[\d,]*\D+bytes\D+max|limit\D+\d[\d,]*\D+bytes)/i.test(
       message,
     );
   }

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -801,6 +801,26 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     );
   }
 
+  private isMultimodalProviderValidationError(message: string): boolean {
+    return /(page limit|too many pages|mime type|unsupported (file|media|mime|codec|format)|invalid (mime|codec|format|duration|media|file)|codec|duration|media type|file type|(audio|video).*(too long|duration)|(too long|duration).*(audio|video))/i.test(
+      message,
+    );
+  }
+
+  private isSkippableMultimodalInputError(message: string): boolean {
+    if (
+      /(401|403|429|quota|rate[_ ]limit|too many requests|5\d\d|timed? out|timeout|network|econn|enotfound|service unavailable|unavailable)/i.test(
+        message,
+      )
+    ) {
+      return false;
+    }
+    return (
+      this.isStructuredInputTooLargeError(message) ||
+      this.isMultimodalProviderValidationError(message)
+    );
+  }
+
   protected async indexFile(
     entry: MemoryFileEntry | SessionFileEntry,
     options: { source: MemorySource; content?: string },
@@ -848,9 +868,12 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       if (
         "kind" in entry &&
         entry.kind === "multimodal" &&
-        this.isStructuredInputTooLargeError(message)
+        this.isSkippableMultimodalInputError(message)
       ) {
-        log.warn("memory embeddings: skipping multimodal file rejected as too large", {
+        const skipReason = this.isStructuredInputTooLargeError(message)
+          ? "rejected as too large"
+          : "rejected by provider validation";
+        log.warn(`memory embeddings: skipping multimodal file ${skipReason}`, {
           path: entry.path,
           bytes: structuredInputBytes,
           provider: this.provider.id,

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -796,20 +796,20 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   private isStructuredInputTooLargeError(message: string): boolean {
-    return /(413|payload too large|request too large|input too large|too many tokens|input limit|request size)/i.test(
+    return /(payload too large|request too large|input too large|too many tokens|input limit|request size|max(?:imum)?\D+\d[\d,]*\D+bytes|\d[\d,]*\D+bytes\D+max|limit\D+\d[\d,]*\D+bytes)/i.test(
       message,
     );
   }
 
   private isMultimodalProviderValidationError(message: string): boolean {
-    return /(page limit|too many pages|mime type|unsupported (file|media|mime|codec|format)|invalid (mime|codec|format|duration|media|file)|media type|file type|(audio|video).*(codec|too long|duration)|(codec|too long|duration).*(audio|video))/i.test(
+    return /(page limit|too many pages|mime type|unsupported (file|media|mime|codec|format)|invalid (mime|codec|format|duration|media|file)|media type|file type|(audio|video).*(codec|too long|duration)|(codec|too long|duration).*(audio|video)|max(?:imum)?\D+\d[\d,]*\D+pages|\d[\d,]*\D+pages\D+max|limit\D+\d[\d,]*\D+pages)/i.test(
       message,
     );
   }
 
   private isSkippableMultimodalInputError(message: string): boolean {
     if (
-      /(401|403|429|quota|rate[_ ]limit|too many requests|5\d\d|timed? out|timeout|deadline|network|econn|enotfound|service unavailable|unavailable)/i.test(
+      /(quota|rate[_ ]limit|too many requests|timed? out|timeout|deadline(?: exceeded)?|network|econn|enotfound|service unavailable|upstream unavailable|bad gateway|gateway timeout|internal server error|server error|backend down)/i.test(
         message,
       )
     ) {

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -802,14 +802,14 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   private isMultimodalProviderValidationError(message: string): boolean {
-    return /(page limit|too many pages|mime type|unsupported (file|media|mime|codec|format)|invalid (mime|codec|format|duration|media|file)|codec|duration|media type|file type|(audio|video).*(too long|duration)|(too long|duration).*(audio|video))/i.test(
+    return /(page limit|too many pages|mime type|unsupported (file|media|mime|codec|format)|invalid (mime|codec|format|duration|media|file)|media type|file type|(audio|video).*(codec|too long|duration)|(codec|too long|duration).*(audio|video))/i.test(
       message,
     );
   }
 
   private isSkippableMultimodalInputError(message: string): boolean {
     if (
-      /(401|403|429|quota|rate[_ ]limit|too many requests|5\d\d|timed? out|timeout|network|econn|enotfound|service unavailable|unavailable)/i.test(
+      /(401|403|429|quota|rate[_ ]limit|too many requests|5\d\d|timed? out|timeout|deadline|network|econn|enotfound|service unavailable|unavailable)/i.test(
         message,
       )
     ) {

--- a/src/memory/manager.watcher-config.test.ts
+++ b/src/memory/manager.watcher-config.test.ts
@@ -126,7 +126,7 @@ describe("memory watcher config", () => {
             sync: { watch: true, watchDebounceMs: 25, onSessionStart: false, onSearch: false },
             query: { minScore: 0, hybrid: { enabled: false } },
             extraPaths: [extraDir],
-            multimodal: { enabled: true, modalities: ["image", "audio"] },
+            multimodal: { enabled: true, modalities: ["image", "audio", "video", "pdf"] },
           },
         },
         list: [{ id: "main", default: true }],
@@ -149,6 +149,9 @@ describe("memory watcher config", () => {
       expect.arrayContaining([
         path.join(extraDir, "**", "*.[pP][nN][gG]"),
         path.join(extraDir, "**", "*.[wW][aA][vV]"),
+        path.join(extraDir, "**", "*.[mM][pP][44]"),
+        path.join(extraDir, "**", "*.[mM][oO][vV]"),
+        path.join(extraDir, "**", "*.[pP][dD][fF]"),
       ]),
     );
   });

--- a/src/memory/multimodal.ts
+++ b/src/memory/multimodal.ts
@@ -1,13 +1,31 @@
+type MemoryMultimodalSpec = {
+  labelPrefix: string;
+  extensions: string[];
+  matchesMimeType: (mimeType: string) => boolean;
+};
+
 const MEMORY_MULTIMODAL_SPECS = {
   image: {
     labelPrefix: "Image file",
     extensions: [".jpg", ".jpeg", ".png", ".webp", ".gif", ".heic", ".heif"],
+    matchesMimeType: (mimeType: string) => mimeType.startsWith("image/"),
   },
   audio: {
     labelPrefix: "Audio file",
     extensions: [".mp3", ".wav", ".ogg", ".opus", ".m4a", ".aac", ".flac"],
+    matchesMimeType: (mimeType: string) => mimeType.startsWith("audio/"),
   },
-} as const;
+  video: {
+    labelPrefix: "Video file",
+    extensions: [".mp4", ".mov"],
+    matchesMimeType: (mimeType: string) => mimeType.startsWith("video/"),
+  },
+  pdf: {
+    labelPrefix: "PDF file",
+    extensions: [".pdf"],
+    matchesMimeType: (mimeType: string) => mimeType === "application/pdf",
+  },
+} satisfies Record<string, MemoryMultimodalSpec>;
 
 export type MemoryMultimodalModality = keyof typeof MEMORY_MULTIMODAL_SPECS;
 export const MEMORY_MULTIMODAL_MODALITIES = Object.keys(
@@ -31,7 +49,7 @@ export function normalizeMemoryMultimodalModalities(
   }
   const normalized = new Set<MemoryMultimodalModality>();
   for (const value of raw) {
-    if (value === "image" || value === "audio") {
+    if (value !== "all" && value in MEMORY_MULTIMODAL_SPECS) {
       normalized.add(value);
     }
   }
@@ -70,6 +88,13 @@ export function buildMemoryMultimodalLabel(
   normalizedPath: string,
 ): string {
   return `${MEMORY_MULTIMODAL_SPECS[modality].labelPrefix}: ${normalizedPath}`;
+}
+
+export function isSupportedMemoryMultimodalMimeType(
+  modality: MemoryMultimodalModality,
+  mimeType: string,
+): boolean {
+  return MEMORY_MULTIMODAL_SPECS[modality].matchesMimeType(mimeType);
 }
 
 export function buildCaseInsensitiveExtensionGlob(extension: string): string {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `memorySearch.multimodal` only indexed Gemini image/audio files even though Gemini Embeddings 2 supports additional native modalities, and the first pass of the change treated generic multimodal `400` provider failures as skippable file-local errors.
- Why it matters: users could not index video/PDF assets from `extraPaths`, and generic request failures could be silently downgraded instead of surfacing as sync failures.
- What changed: expanded multimodal memory indexing to cover `video` and `pdf`, updated modality validation/discovery/docs/tests, and narrowed the multimodal skip classifier so only explicit size/media-validation failures are skipped per file.
- What did NOT change (scope boundary): no new config surface, no File API support, no non-PDF document conversion, no page/segment chunking, and no change to `memory_get` returning binary contents.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None.

## User-visible / Behavior Changes

- `memorySearch.multimodal.modalities` now supports `video` and `pdf` in addition to `image`, `audio`, and `all`.
- Gemini multimodal memory indexing now discovers and indexes supported `.mp4`, `.mov`, and `.pdf` files from `memorySearch.extraPaths`.
- `all` now expands to image + audio + video + pdf.
- Generic multimodal `400 bad request` failures now fail the sync instead of being silently skipped.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:

This expands the existing opt-in Gemini multimodal memory capability to allow video/PDF uploads from `memorySearch.extraPaths`. The destination and auth model are unchanged, but selected extra-path files can now include `.mp4`, `.mov`, and `.pdf`. Risk is bounded by existing guardrails: multimodal remains off by default, Gemini-only, `extraPaths`-only, `fallback = "none"`, MIME-validated, and capped by `maxFileBytes`.

## Repro + Verification

### Environment

- OS: Darwin 25.2.0 arm64
- Runtime/container: Node v24.11.1, local workspace
- Model/provider: Gemini `gemini-embedding-2-preview`
- Integration/channel (if any): None
- Relevant config (redacted): `memorySearch.provider = "gemini"`, `memorySearch.model = "gemini-embedding-2-preview"`, `memorySearch.multimodal.enabled = true`, `memorySearch.multimodal.modalities = ["image", "audio", "video", "pdf"]`, `memorySearch.fallback = "none"`

### Steps

1. Configure `memorySearch` for Gemini Embeddings 2 with multimodal enabled and `extraPaths` pointing at media files.
2. Add supported image/audio/video/PDF files under `extraPaths` and run `manager.sync()` / memory indexing.
3. Search the memory index with text queries such as `video` or `pdf`, and exercise failure cases with oversized inputs, explicit media validation errors, and generic `400 bad request` errors.

### Expected

- Supported `.mp4`, `.mov`, and `.pdf` files are discovered and indexed alongside existing image/audio support.
- Explicit size/media-validation failures skip only the affected multimodal file.
- Generic `400 bad request`, auth/quota/network, and `5xx` failures still fail the sync.

### Actual

- Verified by tests and local checks; behavior matched the expected results above.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Vitest coverage for multimodal normalization, watcher globs, lower/upper-case file discovery, video/PDF indexing, per-file validation skips, generic `400` sync failure, and systemic `503` sync failure.
- Edge cases checked: uppercase `.PDF`, `.MP4`, `.MOV`; `all` modality expansion; oversize multimodal rejection; generic `400 bad request` not being swallowed.
- What you did **not** verify: live Gemini API calls against a real account; this was validated through the repo's mock embedding provider and full `build`/`check` passes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `memorySearch.multimodal.enabled = false`, or restrict `memorySearch.multimodal.modalities` back to a narrower set.
- Files/config to restore: `agents.defaults.memorySearch.multimodal.*` config and the memory subsystem changes in this PR.
- Known bad symptoms reviewers should watch for: unexpected sync failures on multimodal files, supported video/PDF files not appearing in search results, or generic provider `400` errors being skipped instead of surfacing.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: MIME detection for some video/PDF fixtures or real files may differ from extension-based discovery.
  - Mitigation: indexing still requires modality-aware MIME validation, and tests now cover uppercase direct discovery/classification paths.
- Risk: provider error classification still relies on message text.
  - Mitigation: this PR narrows the skip path to explicit size/media-validation phrases and preserves hard failures for generic/systemic provider errors.
