### PR TITLE
fix: support custom image-capable provider models in image tool

### DIFF
--- a/src/agents/pi-embedded-runner/model.image-input.test.ts
+++ b/src/agents/pi-embedded-runner/model.image-input.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveModelWithRegistry } from "./model.js";
+
+describe("resolveModelWithRegistry image input preservation", () => {
+  it("preserves configured image capability for custom provider fallback models", () => {
+    const cfg = {
+      models: {
+        providers: {
+          litellm: {
+            baseUrl: "http://localhost:4000",
+            api: "openai-completions",
+            models: [
+              {
+                id: "azure-gpt-5-mini",
+                name: "Azure GPT-5 Mini",
+                reasoning: false,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const modelRegistry = {
+      find: () => null,
+    } as { find: (provider: string, modelId: string) => null };
+
+    const model = resolveModelWithRegistry({
+      provider: "litellm",
+      modelId: "azure-gpt-5-mini",
+      modelRegistry: modelRegistry as never,
+      cfg,
+    });
+
+    expect(model).toBeDefined();
+    expect(model?.provider).toBe("litellm");
+    expect(model?.id).toBe("azure-gpt-5-mini");
+    expect(model?.input).toEqual(["text", "image"]);
+    expect(model?.api).toBe("openai-completions");
+    expect(model?.baseUrl).toBe("http://localhost:4000");
+  });
+});

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -242,7 +242,10 @@ export function resolveModelWithRegistry(params: {
         provider,
         baseUrl: providerConfig?.baseUrl,
         reasoning: configuredModel?.reasoning ?? false,
-        input: ["text"],
+        input:
+          Array.isArray(configuredModel?.input) && configuredModel.input.length > 0
+            ? configuredModel.input.filter((item) => item === "text" || item === "image")
+            : (["text"] as Array<"text" | "image">),
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow:
           configuredModel?.contextWindow ??

--- a/src/agents/tools/image-tool.custom-provider-fallback.test.ts
+++ b/src/agents/tools/image-tool.custom-provider-fallback.test.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import { createImageTool } from "./image-tool.js";
+
+const ONE_PIXEL_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+
+async function withTempAgentDir<T>(run: (agentDir: string) => Promise<T>): Promise<T> {
+  const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-custom-provider-"));
+  try {
+    return await run(agentDir);
+  } finally {
+    await fs.rm(agentDir, { recursive: true, force: true });
+  }
+}
+
+async function withTempWorkspacePng(
+  cb: (args: { workspaceDir: string; imagePath: string }) => Promise<void>,
+) {
+  const workspaceParent = await fs.mkdtemp(path.join(process.cwd(), ".openclaw-workspace-image-"));
+  try {
+    const workspaceDir = path.join(workspaceParent, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const imagePath = path.join(workspaceDir, "photo.png");
+    await fs.writeFile(imagePath, Buffer.from(ONE_PIXEL_PNG_B64, "base64"));
+    await cb({ workspaceDir, imagePath });
+  } finally {
+    await fs.rm(workspaceParent, { recursive: true, force: true });
+  }
+}
+
+function stubOpenAiCompletionsOkFetch(text = "ok") {
+  const fetch = vi.fn().mockResolvedValue(
+    new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          const encoder = new TextEncoder();
+          const chunks = [
+            `data: ${JSON.stringify({
+              id: "chatcmpl-test",
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: "azure-gpt-5-mini",
+              choices: [
+                {
+                  index: 0,
+                  delta: { role: "assistant", content: text },
+                  finish_reason: null,
+                },
+              ],
+            })}\n\n`,
+            `data: ${JSON.stringify({
+              id: "chatcmpl-test",
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: "azure-gpt-5-mini",
+              choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            })}\n\n`,
+            "data: [DONE]\n\n",
+          ];
+          for (const chunk of chunks) {
+            controller.enqueue(encoder.encode(chunk));
+          }
+          controller.close();
+        },
+      }),
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    ),
+  );
+  global.fetch = withFetchPreconnect(fetch);
+  return fetch;
+}
+
+describe("image tool custom provider fallback", () => {
+  const priorFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    vi.stubEnv("MINIMAX_API_KEY", "");
+    vi.stubEnv("LITELLM_API_KEY", "litellm-test");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    global.fetch = priorFetch;
+  });
+
+  it("uses configured custom provider image model even when registry lookup misses", async () => {
+    stubOpenAiCompletionsOkFetch("custom provider ok");
+
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          litellm: {
+            baseUrl: "http://localhost:4000",
+            api: "openai-completions",
+            models: [
+              {
+                id: "azure-gpt-5-mini",
+                name: "Azure GPT-5 Mini",
+                reasoning: false,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "litellm/azure-gpt-5-mini",
+          },
+        },
+      },
+    };
+
+    await withTempAgentDir(async (agentDir) => {
+      await withTempWorkspacePng(async ({ workspaceDir, imagePath }) => {
+        const tool = createImageTool({ config: cfg, agentDir, workspaceDir });
+        expect(tool).not.toBeNull();
+        if (!tool) {
+          throw new Error("expected image tool");
+        }
+
+        await expect(
+          tool.execute("t1", {
+            prompt: "Describe the image.",
+            image: imagePath,
+          }),
+        ).resolves.toMatchObject({
+          content: [{ type: "text", text: "custom provider ok" }],
+        });
+      });
+    });
+  });
+});

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -217,7 +217,12 @@ async function runImagePrompt(params: {
     cfg: effectiveCfg,
     modelOverride: params.modelOverride,
     run: async (provider, modelId) => {
-      const model = resolveModelFromRegistry({ modelRegistry, provider, modelId });
+      const model = resolveModelFromRegistry({
+        modelRegistry,
+        provider,
+        modelId,
+        cfg: effectiveCfg,
+      });
       if (!model.input?.includes("image")) {
         throw new Error(`Model does not support images: ${provider}/${modelId}`);
       }

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -1,6 +1,7 @@
 import { type Api, type Model } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getDefaultLocalRoots } from "../../web/media.js";
+import { resolveModelWithRegistry } from "../pi-embedded-runner/model.js";
 import type { ImageModelConfig } from "./image-tool.helpers.js";
 import { getApiKeyForModel, normalizeWorkspaceDir, requireApiKey } from "./tool-runtime.helpers.js";
 
@@ -86,8 +87,14 @@ export function resolveModelFromRegistry(params: {
   modelRegistry: { find: (provider: string, modelId: string) => unknown };
   provider: string;
   modelId: string;
+  cfg?: OpenClawConfig;
 }): Model<Api> {
-  const model = params.modelRegistry.find(params.provider, params.modelId) as Model<Api> | null;
+  const model = resolveModelWithRegistry({
+    provider: params.provider,
+    modelId: params.modelId,
+    modelRegistry: params.modelRegistry as never,
+    cfg: params.cfg,
+  });
   if (!model) {
     throw new Error(`Unknown model: ${params.provider}/${params.modelId}`);
   }


### PR DESCRIPTION
## Summary

Fix `image` tool support for custom image-capable provider models referenced via `agents.defaults.imageModel`.

This PR addresses a case where a custom provider model (for example `litellm/azure-gpt-5-mini`) is configured with `input: ["text", "image"]`, but the image tool still fails with `Unknown model`.

Closes #45240.

## What changed

### 1. Preserve configured image capability in fallback model resolution
In `src/agents/pi-embedded-runner/model.ts`, the provider-config fallback path previously normalized models with:

```ts
input: ["text"]
```

That discarded explicit image capability declared in config.

This PR changes that path to preserve `configuredModel.input` when present, while still defaulting safely to `['text']`.

### 2. Let the image tool reuse config-backed model resolution
The image tool previously relied on a strict registry lookup path via `modelRegistry.find(...)`, which meant a config-declared custom model could still fail with `Unknown model` if it was not present in the runtime registry.

This PR updates the shared media-tool model resolution helper to reuse `resolveModelWithRegistry(...)`, allowing image-tool execution to benefit from the same config-aware fallback logic as the main model resolution path.

## Tests

Added targeted tests for both layers:

- `src/agents/pi-embedded-runner/model.image-input.test.ts`
  - verifies that provider-config fallback model resolution preserves `input: ['text', 'image']`
- `src/agents/tools/image-tool.custom-provider-fallback.test.ts`
  - verifies that the `image` tool can use a configured custom image-capable provider model even when registry lookup misses

## Validation

Ran locally in an isolated development checkout (not against the production OpenClaw install):

```bash
pnpm vitest run \
  src/agents/pi-embedded-runner/model.image-input.test.ts \
  src/agents/tools/image-tool.custom-provider-fallback.test.ts
```

Both tests pass.
