### PR TITLE
fix(status): avoid misleading context usage when totalTokensFresh=false

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -654,6 +654,29 @@ describe("buildStatusMessage", () => {
 
     expect(normalizeTestText(text)).toContain("Context: ?/32k");
   });
+
+  it("ignores explicit totalTokens when marked stale", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/claude-opus-4-5",
+        contextTokens: 32_000,
+      },
+      sessionEntry: {
+        sessionId: "stale-explicit-total",
+        updatedAt: 0,
+        totalTokens: 180_000,
+        totalTokensFresh: false,
+        contextTokens: 32_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      includeTranscriptUsage: false,
+      modelAuth: "api-key",
+    });
+
+    expect(normalizeTestText(text)).toContain("Context: ?/32k");
+  });
 });
 
 describe("buildCommandsMessage", () => {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -630,6 +630,30 @@ describe("buildStatusMessage", () => {
       { prefix: "openclaw-status-" },
     );
   });
+
+  it("does not infer context usage from input/output when totalTokens is stale", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/claude-opus-4-5",
+        contextTokens: 32_000,
+      },
+      sessionEntry: {
+        sessionId: "stale-total",
+        updatedAt: 0,
+        inputTokens: 298_437,
+        outputTokens: 147,
+        totalTokensFresh: false,
+        contextTokens: 32_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      includeTranscriptUsage: false,
+      modelAuth: "api-key",
+    });
+
+    expect(normalizeTestText(text)).toContain("Context: ?/32k");
+  });
 });
 
 describe("buildCommandsMessage", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -465,7 +465,6 @@ export function buildStatusMessage(args: StatusArgs): string {
     typeof entry?.totalTokens === "number" && entry?.totalTokensFresh !== false
       ? entry.totalTokens
       : undefined;
-  let totalTokensFresh = typeof totalTokens === "number";
 
   // Prefer prompt-size tokens from the session transcript when it looks larger
   // (cached prompt tokens are often missing from agent meta/store).
@@ -479,9 +478,8 @@ export function buildStatusMessage(args: StatusArgs): string {
     );
     if (logUsage) {
       const candidate = logUsage.promptTokens || logUsage.total;
-      if (!totalTokens || !totalTokensFresh || totalTokens === 0 || candidate > totalTokens) {
+      if (!totalTokens || totalTokens === 0 || candidate > totalTokens) {
         totalTokens = candidate;
-        totalTokensFresh = true;
       }
       if (!entry?.model && logUsage.model) {
         const slashIndex = logUsage.model.indexOf("/");

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -459,7 +459,13 @@ export function buildStatusMessage(args: StatusArgs): string {
   let outputTokens = entry?.outputTokens;
   let cacheRead = entry?.cacheRead;
   let cacheWrite = entry?.cacheWrite;
-  let totalTokens = entry?.totalTokens ?? (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
+  // Never synthesize context usage from input/output when the stored total is
+  // explicitly marked stale. That overstates context and confuses compaction status.
+  let totalTokens =
+    typeof entry?.totalTokens === "number" && entry?.totalTokensFresh !== false
+      ? entry.totalTokens
+      : undefined;
+  let totalTokensFresh = typeof totalTokens === "number";
 
   // Prefer prompt-size tokens from the session transcript when it looks larger
   // (cached prompt tokens are often missing from agent meta/store).
@@ -473,8 +479,9 @@ export function buildStatusMessage(args: StatusArgs): string {
     );
     if (logUsage) {
       const candidate = logUsage.promptTokens || logUsage.total;
-      if (!totalTokens || totalTokens === 0 || candidate > totalTokens) {
+      if (!totalTokens || !totalTokensFresh || totalTokens === 0 || candidate > totalTokens) {
         totalTokens = candidate;
+        totalTokensFresh = true;
       }
       if (!entry?.model && logUsage.model) {
         const slashIndex = logUsage.model.indexOf("/");


### PR DESCRIPTION
## Summary
Fix status context rendering when session token totals are stale.

When `totalTokensFresh=false`, status previously fell back to `inputTokens + outputTokens`, which can overstate context usage and report misleading values like `299k/200k (149%)`.

This change avoids that fallback for stale totals and reports unknown context occupancy unless fresh totals (or transcript usage) are available.

## Changes
- `src/auto-reply/status.ts`
  - Stop inferring `totalTokens` from `input+output` when `totalTokensFresh` is explicitly false.
  - Preserve transcript-usage override behavior so runtime can still show a concrete usage value when available.
- `src/auto-reply/status.test.ts`
  - Add regression test covering `totalTokensFresh=false` to ensure status shows unknown context usage instead of synthetic `input+output` usage.

## User impact
- Prevents false alarms that auto-compaction is broken.
- Makes `/status` context line semantically accurate in stale-token states.

## Validation
- `pnpm vitest run src/auto-reply/status.test.ts`
- Result: all tests passed locally.

## Notes
This is a display/accounting correctness fix; it does not alter compaction trigger behavior itself.


Fixes #45268
