### PR TITLE
fix(gateway): normalize IPv6 in isLocalGatewayAddress tailnet check

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { makeNetworkInterfacesSnapshot } from "../test-helpers/network-interfaces.js";
 import {
+  isLocalGatewayAddress,
   isLocalishHost,
   isPrivateOrLoopbackAddress,
   isPrivateOrLoopbackHost,
@@ -536,5 +537,48 @@ describe("isSecureWebSocketUrl", () => {
     for (const input of disallowedWhenOptedIn) {
       expect(isSecureWebSocketUrl(input, { allowPrivateWs: true }), input).toBe(false);
     }
+  });
+});
+
+describe("isLocalGatewayAddress", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("matches tailnet IPv6 regardless of canonical form", async () => {
+    // Simulate a tailnet IPv6 address returned by the OS in short form
+    const tailnetModule = await import("../infra/tailnet.js");
+    vi.spyOn(tailnetModule, "pickPrimaryTailnetIPv4").mockReturnValue(undefined);
+    vi.spyOn(tailnetModule, "pickPrimaryTailnetIPv6").mockReturnValue("fd7a:115c:a1e0::1");
+
+    // Non-canonical (expanded) form of the same address must match
+    expect(isLocalGatewayAddress("fd7a:115c:a1e0:0:0:0:0:1")).toBe(true);
+    // Canonical short form must also match
+    expect(isLocalGatewayAddress("fd7a:115c:a1e0::1")).toBe(true);
+    // Uppercase must match
+    expect(isLocalGatewayAddress("FD7A:115C:A1E0::1")).toBe(true);
+    // Unrelated address must not match
+    expect(isLocalGatewayAddress("fd7a:115c:a1e0::2")).toBe(false);
+  });
+
+  it("matches tailnet IPv4 via normalized comparison", async () => {
+    const tailnetModule = await import("../infra/tailnet.js");
+    vi.spyOn(tailnetModule, "pickPrimaryTailnetIPv4").mockReturnValue("100.100.100.100");
+    vi.spyOn(tailnetModule, "pickPrimaryTailnetIPv6").mockReturnValue(undefined);
+
+    expect(isLocalGatewayAddress("100.100.100.100")).toBe(true);
+    // IPv4-mapped IPv6 form of the same address must match
+    expect(isLocalGatewayAddress("::ffff:100.100.100.100")).toBe(true);
+    expect(isLocalGatewayAddress("100.100.100.101")).toBe(false);
+  });
+
+  it("accepts loopback addresses", () => {
+    expect(isLocalGatewayAddress("127.0.0.1")).toBe(true);
+    expect(isLocalGatewayAddress("::1")).toBe(true);
+  });
+
+  it("rejects undefined and empty", () => {
+    expect(isLocalGatewayAddress(undefined)).toBe(false);
+    expect(isLocalGatewayAddress("")).toBe(false);
   });
 });

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet.js";
 import { makeNetworkInterfacesSnapshot } from "../test-helpers/network-interfaces.js";
 import {
   isLocalGatewayAddress,
@@ -13,6 +14,15 @@ import {
   resolveGatewayListenHosts,
   resolveHostName,
 } from "./net.js";
+
+vi.mock("../infra/tailnet.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/tailnet.js")>();
+  return {
+    ...actual,
+    pickPrimaryTailnetIPv4: vi.fn(actual.pickPrimaryTailnetIPv4),
+    pickPrimaryTailnetIPv6: vi.fn(actual.pickPrimaryTailnetIPv6),
+  };
+});
 
 describe("resolveHostName", () => {
   it("normalizes IPv4/hostname and IPv6 host forms", () => {
@@ -542,14 +552,14 @@ describe("isSecureWebSocketUrl", () => {
 
 describe("isLocalGatewayAddress", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.mocked(pickPrimaryTailnetIPv4).mockReset();
+    vi.mocked(pickPrimaryTailnetIPv6).mockReset();
   });
 
-  it("matches tailnet IPv6 regardless of canonical form", async () => {
+  it("matches tailnet IPv6 regardless of canonical form", () => {
     // Simulate a tailnet IPv6 address returned by the OS in short form
-    const tailnetModule = await import("../infra/tailnet.js");
-    vi.spyOn(tailnetModule, "pickPrimaryTailnetIPv4").mockReturnValue(undefined);
-    vi.spyOn(tailnetModule, "pickPrimaryTailnetIPv6").mockReturnValue("fd7a:115c:a1e0::1");
+    vi.mocked(pickPrimaryTailnetIPv4).mockReturnValue(undefined);
+    vi.mocked(pickPrimaryTailnetIPv6).mockReturnValue("fd7a:115c:a1e0::1");
 
     // Non-canonical (expanded) form of the same address must match
     expect(isLocalGatewayAddress("fd7a:115c:a1e0:0:0:0:0:1")).toBe(true);
@@ -561,10 +571,9 @@ describe("isLocalGatewayAddress", () => {
     expect(isLocalGatewayAddress("fd7a:115c:a1e0::2")).toBe(false);
   });
 
-  it("matches tailnet IPv4 via normalized comparison", async () => {
-    const tailnetModule = await import("../infra/tailnet.js");
-    vi.spyOn(tailnetModule, "pickPrimaryTailnetIPv4").mockReturnValue("100.100.100.100");
-    vi.spyOn(tailnetModule, "pickPrimaryTailnetIPv6").mockReturnValue(undefined);
+  it("matches tailnet IPv4 via normalized comparison", () => {
+    vi.mocked(pickPrimaryTailnetIPv4).mockReturnValue("100.100.100.100");
+    vi.mocked(pickPrimaryTailnetIPv6).mockReturnValue(undefined);
 
     expect(isLocalGatewayAddress("100.100.100.100")).toBe(true);
     // IPv4-mapped IPv6 form of the same address must match

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -212,12 +212,18 @@ export function isLocalGatewayAddress(ip: string | undefined): boolean {
     return false;
   }
   const tailnetIPv4 = pickPrimaryTailnetIPv4();
-  if (tailnetIPv4 && normalized === tailnetIPv4.toLowerCase()) {
-    return true;
+  if (tailnetIPv4) {
+    const normalizedTailnetIPv4 = normalizeIp(tailnetIPv4);
+    if (normalizedTailnetIPv4 && normalized === normalizedTailnetIPv4) {
+      return true;
+    }
   }
   const tailnetIPv6 = pickPrimaryTailnetIPv6();
-  if (tailnetIPv6 && ip.trim().toLowerCase() === tailnetIPv6.toLowerCase()) {
-    return true;
+  if (tailnetIPv6) {
+    const normalizedTailnetIPv6 = normalizeIp(tailnetIPv6);
+    if (normalizedTailnetIPv6 && normalized === normalizedTailnetIPv6) {
+      return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
## Bug

`isLocalGatewayAddress` in `src/gateway/net.ts` compares IPv6 addresses using raw strings instead of normalized values. For example, `fd7a:115c:a1e0:0:0:0:0:1` and `fd7a:115c:a1e0::1` are the same address but would fail to match.

## Fix

Normalize IPv6 addresses before comparison to ensure equivalent addresses are correctly identified as local gateway addresses.

## Testing

Added test cases for IPv6 normalization in `src/gateway/net.test.ts`.