### PR TITLE
feat(feishu): enable streaming card replies in thread/topic mode

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -136,9 +136,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const chunkMode = core.channel.text.resolveChunkMode(cfg, "feishu");
   const tableMode = core.channel.text.resolveMarkdownTableMode({ cfg, channel: "feishu" });
   const renderMode = account.config?.renderMode ?? "auto";
-  // Card streaming may miss thread affinity in topic contexts; use direct replies there.
+  // Card streaming with rootId should route to topics correctly; enable for all modes.
   const streamingEnabled =
-    !threadReplyMode && account.config?.streaming !== false && renderMode !== "raw";
+    account.config?.streaming !== false && renderMode !== "raw";
 
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";


### PR DESCRIPTION
## Summary

Remove the `!threadReplyMode` guard from `streamingEnabled` in `reply-dispatcher.ts`, enabling streaming card replies in Feishu topic/thread mode.

## Problem

When `threadReply: true` is configured (topic group mode), streaming cards are disabled and responses fall back to plain text `reply` calls. This means users in topic groups don't get the streaming card UX that works in normal chats.

## Change

```diff
-  // Card streaming may miss thread affinity in topic contexts; use direct replies there.
-  const streamingEnabled =
-    !threadReplyMode && account.config?.streaming !== false && renderMode !== "raw";
+  // Card streaming with rootId should route to topics correctly; enable for all modes.
+  const streamingEnabled =
+    account.config?.streaming !== false && renderMode !== "raw";
```

## Why this is safe

The streaming card API already passes `root_id` for topic routing. The original guard was conservative — in practice, cards render correctly in topic groups.

## Testing

Verified locally in a Feishu topic group with `threadReply: true`:
- Streaming cards render correctly in topics
- Cards are properly threaded under the correct topic
- No regression in non-thread mode