### PR TITLE
fix: normalize openai-codex /v1/completions overrides back to codex transport

### DIFF
--- a/src/agents/pi-embedded-runner/model.provider-normalization.ts
+++ b/src/agents/pi-embedded-runner/model.provider-normalization.ts
@@ -34,7 +34,8 @@ function normalizeOpenAICodexTransport(params: {
     isOpenAICodexBaseUrl(params.model.baseUrl);
 
   const nextApi =
-    useCodexTransport && params.model.api === "openai-responses"
+    useCodexTransport &&
+    (params.model.api === "openai-responses" || params.model.api === "openai-completions")
       ? ("openai-codex-responses" as const)
       : params.model.api;
   const nextBaseUrl =

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -877,7 +877,7 @@ describe("resolveModel", () => {
     });
   });
 
-  it("does not rewrite openai baseUrl when openai-codex api stays non-codex", () => {
+  it("normalizes openai-codex gpt-5.4 overrides away from /v1/completions", () => {
     mockOpenAICodexTemplateModel();
 
     const cfg: OpenClawConfig = {
@@ -896,9 +896,34 @@ describe("resolveModel", () => {
       id: "gpt-5.4",
       cfg,
       expectedModel: {
-        api: "openai-completions",
-        baseUrl: "https://api.openai.com/v1",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
         id: "gpt-5.4",
+        provider: "openai-codex",
+      },
+    });
+  });
+
+  it("normalizes openai-codex gpt-5.3-codex overrides away from /v1/completions", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expectResolvedForwardCompatFallback({
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+      cfg,
+      expectedModel: {
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+        id: "gpt-5.3-codex",
         provider: "openai-codex",
       },
     });


### PR DESCRIPTION
## Summary

- normalize `openai-codex` models back to `openai-codex-responses` when provider overrides drift to `openai-completions` on `api.openai.com/v1`
- add regression coverage for both `openai-codex/gpt-5.4` and `openai-codex/gpt-5.3-codex`

## Why

`#38736` already normalizes the `openai-responses` drift case for `openai-codex`, but configs that still carry the older `openai-completions` override can still resolve `openai-codex` models through the generic OpenAI API path.

That breaks Codex OAuth flows in practice: the same OAuth profile works against the native Codex backend, but the drifted `/v1` completions transport can fail upstream with quota errors even though the Codex account itself is healthy.

This keeps the existing safety boundary from `#38736`: only `openai-codex` models on the default OpenAI/Codex base URLs are rewritten. Custom proxy base URLs are left untouched.

## Testing

- `pnpm vitest run src/agents/pi-embedded-runner/model.test.ts`
- `pnpm vitest run src/agents/model-forward-compat.test.ts src/commands/models/list.list-command.forward-compat.test.ts`
