### PR TITLE
ui(chat): constrain empty-session SVG placeholder size

### DIFF
--- a/ui/public/favicon.svg
+++ b/ui/public/favicon.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="lobster-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#ff4d4d"/>

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -864,6 +864,16 @@
   color: var(--foreground);
 }
 
+.agent-chat__welcome-avatar {
+  width: 56px;
+  height: 56px;
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  flex: 0 0 auto;
+}
+
 .agent-chat__avatar--logo {
   width: 48px;
   height: 48px;
@@ -878,6 +888,8 @@
 .agent-chat__avatar--logo img {
   width: 32px;
   height: 32px;
+  max-width: 100%;
+  max-height: 100%;
   object-fit: contain;
 }
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -579,7 +579,7 @@ function renderWelcomeState(props: ChatProps): TemplateResult {
       <div class="agent-chat__welcome-glow"></div>
       ${
         avatar
-          ? html`<img src=${avatar} alt=${name} style="width:56px; height:56px; border-radius:50%; object-fit:cover;" />`
+          ? html`<img class="agent-chat__welcome-avatar" src=${avatar} alt=${name} />`
           : html`<div class="agent-chat__avatar agent-chat__avatar--logo"><img src=${logoUrl} alt="OpenClaw" /></div>`
       }
       <h2>${name}</h2>


### PR DESCRIPTION
## Summary
Fixes oversized placeholder avatar/logo in empty chat sessions by adding intrinsic SVG dimensions and explicit UI size constraints.

## Root cause
- `ui/public/favicon.svg` only had a `viewBox` with no intrinsic `width`/`height`.
- In empty-session welcome state, SVG-based images could scale unexpectedly under flex layout when sizing was not fully constrained.

## Changes
- Add intrinsic dimensions to `ui/public/favicon.svg`:
  - `width="120" height="120"`
- Move welcome avatar sizing from inline style to class and keep it constrained:
  - `.agent-chat__welcome-avatar` (`56x56`, `max-width:100%`, `max-height:100%`, `object-fit:cover`)
- Add defensive image constraints for logo fallback:
  - `.agent-chat__avatar--logo img` adds `max-width:100%` and `max-height:100%`

## Before / After
- Before: SVG placeholder could render overly large in empty sessions.
- After: welcome avatar/logo remains bounded and consistent in size.

## Verification
### Manual
1. Open Web UI with a fresh/empty session.
2. Confirm welcome placeholder avatar/logo appears at normal bounded size.
3. Confirm no oversized SVG placeholder in fullscreen/large viewport.

### Notes
- Local automated test run was not executed in this environment because `ui/node_modules` are not installed (`vitest` missing).

Fixes #45148
