### PR TITLE
fix(web-ui): add missing CSS styles when context overlimit

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -245,7 +245,8 @@ function isTransientDirectCronDeliveryError(error: unknown): boolean {
 }
 
 function resolveDirectCronRetryDelaysMs(): readonly number[] {
-  return process.env.NODE_ENV === "test" && process.env.OPENCLAW_TEST_FAST === "1"
+  return (process.env.VITEST || process.env.NODE_ENV === "test") &&
+    process.env.OPENCLAW_TEST_FAST === "1"
     ? [8, 16, 32]
     : [5_000, 10_000, 20_000];
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -991,5 +991,36 @@
   border-color: var(--accent);
 }
 
+/* Context usage notice (shown when context usage >= 85%) */
+.context-notice {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  line-height: 1.2;
+  padding: 6px 14px;
+  margin-bottom: 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ctx-color) 30%, transparent);
+  background: var(--ctx-bg);
+  color: var(--ctx-color);
+  white-space: nowrap;
+  user-select: none;
+  align-self: flex-start;
+  animation: fade-in 0.2s var(--ease-out);
+}
+
+.context-notice__icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.context-notice__detail {
+  opacity: 0.75;
+  font-size: 12px;
+}
+
 /* Mobile dropdown toggle — hidden on desktop */
 /* Mobile gear toggle + dropdown are hidden by default in layout.css */
+


### PR DESCRIPTION
## Summary

- **Problem:** When the conversation context usage reaches 85%+, a context notice component is displayed to warn users. However, the CSS styles for `.context-notice` and `.context-notice__icon` were missing, causing the SVG icon to render at an unbounded size that covered the entire page content.

- **Root Cause:** The `renderContextNotice` function in `ui/src/ui/views/chat.ts` renders an SVG icon with class `context-notice__icon`, but no corresponding CSS styles were defined. Without explicit width and height constraints, the SVG inherited parent dimensions or defaulted to 100%, resulting in a massive icon that obscured all other UI elements.

- **Fix:** 
- Added CSS styles for `.context-notice`, `.context-notice__icon`, and `.context-notice__detail` in `ui/src/styles/chat/layout.css` with explicit sizing (`16px × 16px`), flexbox layout, and proper visual styling.
- Fix test environment detection to support VITEST env var, wont make diff noisy.

## Change Type (select all)

- [✅] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [✅] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #45260
- Related #45251
- Related #45617 
- Related #45651
- Related #45694
- Related #46207

## User-visible / Behavior Changes

- The context usage warning notice now displays as a compact pill-shaped badge with a properly sized icon (16px) instead of covering the entire page.
- The notice appears inline above the chat input when context usage reaches 85%+.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: macOS Host
- Model/provider: MiniMax M2.5
- Integration/channel: N/A
- Relevant config: Default

### Steps

1. Start a conversation with an AI model
2. Continue the conversation until context usage reaches 85%+
3. Observe the context notice component rendering

### Expected

- A small, inline warning badge appears with a 16px warning icon
- The badge shows "XX% context used" with token counts
- All other UI elements remain visible and accessible

### Actual

- Before fix: SVG icon expanded to cover entire page, obscuring all content
- After fix: Compact badge displays correctly as intended

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [✅] Screenshot/recording
- [ ] Perf numbers

## Human Verification (required)

- Verified scenarios: Context notice renders correctly at 85%+ usage threshold
- Edge cases checked: Icon sizing, text alignment, responsive behavior
- What you did **not** verify: All color variations (warning/critical states)

## Review Conversations

- [✅] I replied to or resolved every bot review conversation I addressed in this PR.
- [✅] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `3354ab974`
- Files/config to restore: `ui/src/styles/chat/layout.css` (remove lines 958-985)
- Known bad symptoms reviewers should watch for: Context notice not displaying, or icon misalignment

## Risks and Mitigations

- **Risk:** CSS specificity conflicts with existing styles
  - **Mitigation:** Used BEM-style class naming (`.context-notice__icon`) to avoid conflicts; styles are scoped to specific component classes
- **Risk:** Animation may not work in older browsers
  - **Mitigation:** Animation uses standard CSS `animation` property with existing `fade-in` keyframe defined elsewhere in the codebase