### PR TITLE
fix(control-ui): use fresh totals for context usage notice

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -105,6 +105,7 @@ Cron jobs panel notes:
 - `chat.send` is **non-blocking**: it acks immediately with `{ runId, status: "started" }` and the response streams via `chat` events.
 - Re-sending with the same `idempotencyKey` returns `{ status: "in_flight" }` while running, and `{ status: "ok" }` after completion.
 - `chat.history` responses are size-bounded for UI safety. When transcript entries are too large, Gateway may truncate long text fields, omit heavy metadata blocks, and replace oversized messages with a placeholder (`[chat.history omitted: message too large]`).
+- Context usage percentages in Chat and `/usage` prefer fresh `totalTokens` snapshots when available (`totalTokensFresh !== false`). The UI only falls back to accumulated `inputTokens` when no fresh total is available, because accumulated input can overstate current context-window usage after long tool loops.
 - `chat.inject` appends an assistant note to the session transcript and broadcasts a `chat` event for UI-only updates (no agent run, no channel delivery).
 - Stop:
   - Click **Stop** (calls `chat.abort`)

--- a/docs/zh-CN/web/control-ui.md
+++ b/docs/zh-CN/web/control-ui.md
@@ -84,7 +84,6 @@ openclaw devices approve <requestId>
 
 - `chat.send` 是**非阻塞的**：它立即以 `{ runId, status: "started" }` 确认，响应通过 `chat` 事件流式传输。
 - 使用相同的 `idempotencyKey` 重新发送在运行时返回 `{ status: "in_flight" }`，完成后返回 `{ status: "ok" }`。
-- 聊天里的上下文百分比和 `/usage` 优先使用新鲜的 `totalTokens` 快照（`totalTokensFresh !== false` 时）。只有在没有新鲜总量时，UI 才回退到累计 `inputTokens`，因为长工具循环后的累计输入很容易高估当前上下文窗口占用。
 - `chat.inject` 将助手备注附加到会话转录，并为仅 UI 更新广播 `chat` 事件（无智能体运行，无渠道投递）。
 - 停止：
   - 点击**停止**（调用 `chat.abort`）

--- a/docs/zh-CN/web/control-ui.md
+++ b/docs/zh-CN/web/control-ui.md
@@ -84,6 +84,7 @@ openclaw devices approve <requestId>
 
 - `chat.send` 是**非阻塞的**：它立即以 `{ runId, status: "started" }` 确认，响应通过 `chat` 事件流式传输。
 - 使用相同的 `idempotencyKey` 重新发送在运行时返回 `{ status: "in_flight" }`，完成后返回 `{ status: "ok" }`。
+- 聊天里的上下文百分比和 `/usage` 优先使用新鲜的 `totalTokens` 快照（`totalTokensFresh !== false` 时）。只有在没有新鲜总量时，UI 才回退到累计 `inputTokens`，因为长工具循环后的累计输入很容易高估当前上下文窗口占用。
 - `chat.inject` 将助手备注附加到会话转录，并为仅 UI 更新广播 `chat` 事件（无智能体运行，无渠道投递）。
 - 停止：
   - 点击**停止**（调用 `chat.abort`）

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1272,6 +1272,42 @@
   border-color: rgba(34, 197, 94, 0.35);
 }
 
+/* Context window usage notice */
+.context-notice {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ctx-color, var(--warn)) 35%, transparent);
+  background: var(--ctx-bg, var(--warn-subtle));
+  color: var(--ctx-color, var(--warn));
+  font-size: 13px;
+  line-height: 1.2;
+  white-space: nowrap;
+  user-select: none;
+  animation: fade-in 0.2s var(--ease-out);
+}
+
+.context-notice__icon {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.75px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  flex-shrink: 0;
+}
+
+.context-notice__detail {
+  color: color-mix(in srgb, currentColor 75%, var(--text));
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
 @keyframes compaction-spin {
   to {
     transform: rotate(360deg);

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -275,6 +275,7 @@ describe("executeSlashCommand directives", () => {
               inputTokens: 1200,
               outputTokens: 300,
               totalTokens: 1500,
+              totalTokensFresh: false,
               contextTokens: 4000,
             }),
           ],
@@ -292,6 +293,38 @@ describe("executeSlashCommand directives", () => {
 
     expect(result.content).toBe(
       "**Session Usage**\nInput: **1.2k** tokens\nOutput: **300** tokens\nTotal: **1.5k** tokens\nContext: **30%** of 4k\nModel: `gpt-4.1-mini`",
+    );
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+  });
+
+  it("uses fresh total tokens for /usage context percent when input tokens are accumulated", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("agent:warden:main", {
+              model: "gpt-5.4",
+              inputTokens: 529_712,
+              outputTokens: 1_576,
+              totalTokens: 130_364,
+              totalTokensFresh: true,
+              contextTokens: 272_000,
+            }),
+          ],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:warden:main",
+      "usage",
+      "",
+    );
+
+    expect(result.content).toBe(
+      "**Session Usage**\nInput: **529.7k** tokens\nOutput: **1.6k** tokens\nTotal: **130.4k** tokens\nContext: **48%** of 272k\nModel: `gpt-5.4`",
     );
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
   });

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -17,6 +17,7 @@ import {
   parseAgentSessionKey,
 } from "../../../../src/routing/session-key.js";
 import type { GatewayBrowserClient } from "../gateway.ts";
+import { resolveSessionContextUsageTokens } from "../presenter.ts";
 import type { AgentsListResult, GatewaySessionRow, SessionsListResult } from "../types.ts";
 import { SLASH_COMMANDS } from "./slash-commands.ts";
 
@@ -290,7 +291,8 @@ async function executeUsage(
     const output = session.outputTokens ?? 0;
     const total = session.totalTokens ?? input + output;
     const ctx = session.contextTokens ?? 0;
-    const pct = ctx > 0 ? Math.round((input / ctx) * 100) : null;
+    const pct =
+      ctx > 0 ? Math.round((resolveSessionContextUsageTokens(session) / ctx) * 100) : null;
 
     const lines = [
       "**Session Usage**",

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -36,6 +36,8 @@ export function resolveSessionContextUsageTokens(
 ) {
   const total = row?.totalTokens;
   if (typeof total === "number" && Number.isFinite(total) && row?.totalTokensFresh !== false) {
+    // Legacy rows may omit totalTokensFresh; still prefer totalTokens as the best
+    // available proxy for current context usage over accumulated inputTokens.
     return total;
   }
   const input = row?.inputTokens;

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -31,6 +31,20 @@ export function formatSessionTokens(row: GatewaySessionRow) {
   return ctx ? `${total} / ${ctx}` : String(total);
 }
 
+export function resolveSessionContextUsageTokens(
+  row?: Pick<GatewaySessionRow, "totalTokens" | "totalTokensFresh" | "inputTokens"> | null,
+) {
+  const total = row?.totalTokens;
+  if (typeof total === "number" && Number.isFinite(total) && row?.totalTokensFresh !== false) {
+    return total;
+  }
+  const input = row?.inputTokens;
+  if (typeof input === "number" && Number.isFinite(input)) {
+    return input;
+  }
+  return 0;
+}
+
 export function formatEventPayload(payload: unknown): string {
   if (payload == null) {
     return "";

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -386,6 +386,7 @@ export type GatewaySessionRow = {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  totalTokensFresh?: boolean;
   model?: string;
   modelProvider?: string;
   contextTokens?: number;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -382,6 +382,70 @@ describe("chat view", () => {
     expect(container.querySelector(".context-notice")).toBeNull();
   });
 
+  it("renders the context notice from fresh total tokens when the fresh snapshot is above threshold", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          sessionKey: "agent:warden:main",
+          sessions: {
+            ...createSessions(),
+            defaults: { model: null, contextTokens: 272_000 },
+            sessions: [
+              {
+                key: "agent:warden:main",
+                kind: "direct",
+                updatedAt: Date.now(),
+                inputTokens: 529_712,
+                totalTokens: 240_000,
+                totalTokensFresh: true,
+                contextTokens: 272_000,
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+
+    const notice = container.querySelector(".context-notice");
+    expect(notice).not.toBeNull();
+    expect(notice?.textContent).toContain("88% context used");
+    expect(notice?.textContent).toContain("240k / 272k");
+  });
+
+  it("falls back to accumulated input tokens for the context notice when fresh totals are unavailable", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          sessionKey: "agent:warden:main",
+          sessions: {
+            ...createSessions(),
+            defaults: { model: null, contextTokens: 272_000 },
+            sessions: [
+              {
+                key: "agent:warden:main",
+                kind: "direct",
+                updatedAt: Date.now(),
+                inputTokens: 240_000,
+                totalTokens: 130_364,
+                totalTokensFresh: false,
+                contextTokens: 272_000,
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+
+    const notice = container.querySelector(".context-notice");
+    expect(notice).not.toBeNull();
+    expect(notice?.textContent).toContain("88% context used");
+    expect(notice?.textContent).toContain("240k / 272k");
+  });
+
   it("renders fallback-cleared indicator shortly after transition", () => {
     const container = document.createElement("div");
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -353,6 +353,35 @@ describe("chat view", () => {
     nowSpy.mockRestore();
   });
 
+  it("uses fresh total tokens for the context notice instead of accumulated input tokens", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          sessionKey: "agent:warden:main",
+          sessions: {
+            ...createSessions(),
+            defaults: { model: null, contextTokens: 272_000 },
+            sessions: [
+              {
+                key: "agent:warden:main",
+                kind: "direct",
+                updatedAt: Date.now(),
+                inputTokens: 529_712,
+                totalTokens: 130_364,
+                totalTokensFresh: true,
+                contextTokens: 272_000,
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".context-notice")).toBeNull();
+  });
+
   it("renders fallback-cleared indicator shortly after transition", () => {
     const container = document.createElement("div");
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -27,6 +27,7 @@ import {
 } from "../chat/slash-commands.ts";
 import { isSttSupported, startStt, stopStt } from "../chat/speech.ts";
 import { icons } from "../icons.ts";
+import { resolveSessionContextUsageTokens } from "../presenter.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../types.ts";
 import type { ChatItem, MessageGroup } from "../types/chat-types.ts";
@@ -254,7 +255,7 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  const used = session?.inputTokens ?? 0;
+  const used = resolveSessionContextUsageTokens(session);
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
## Summary
- Fix the Control UI chat context warning so it uses fresh `totalTokens` snapshots when available instead of accumulated `inputTokens`
- Keep `/usage` aligned with the same context-usage calculation rule
- Add missing `.context-notice` styles so the warning icon renders as a compact inline notice instead of a giant raw SVG
- Add targeted regression tests and document the calculation rule in Control UI docs

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- None

## User-visible / Behavior Changes
- High-context warnings in Control UI chat no longer render as a full-page warning triangle when they appear
- Chat context usage and `/usage` now prefer fresh `totalTokens` snapshots, so long tool loops do not overstate current context-window usage
- When no fresh total snapshot exists, the UI still falls back to accumulated `inputTokens`

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: None

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: `gpt-5.4` session snapshot in Control UI
- Integration/channel (if any): Control UI chat
- Relevant config (redacted): local gateway token auth

### Steps
1. Open a Control UI chat session whose accumulated `inputTokens` greatly exceed the fresh `totalTokens` snapshot after long tool loops.
2. Observe the chat context warning or run `/usage`.
3. Compare the reported context percentage and the warning rendering.

### Expected
- Context usage should reflect the current context snapshot, not the accumulated input across prior tool loops
- The warning icon should render as a compact inline notice

### Actual
- After this change, chat and `/usage` report context usage from fresh `totalTokens` when available
- The warning notice renders as a styled inline pill with a constrained icon size

## Evidence
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted verification run locally:
- `pnpm exec vitest ui/src/ui/views/chat.test.ts --run` -> `15/15` passed
- `pnpm exec vitest --config vitest.config.ts --project unit-node src/ui/chat/slash-command-executor.node.test.ts --run` -> `14/14` passed
- Live Control UI check confirmed the selected session was `agent:warden:main`, `.context-notice` count was `0`, and a style probe reported `.context-notice__icon` at `16px x 16px`

## Human Verification
- Verified scenarios: live Control UI session selection and context notice state; targeted unit tests for chat notice and `/usage`
- Edge cases checked: fallback to `inputTokens` when `totalTokensFresh` is false; legacy `main` alias handling for `/usage`
- What you did **not** verify: full `pnpm build && pnpm check && pnpm test`; screenshot attachments were not added to this PR form

## Review Conversations
- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: None

## Failure Recovery
- How to disable/revert this change quickly: revert this commit
- Files/config to restore: restore the previous versions of the touched Control UI files
- Known bad symptoms reviewers should watch for: context percentage regressing to accumulated-input behavior; warning icon rendering without CSS constraints

## Risks and Mitigations
- Risk: sessions without fresh totals still need a fallback path
- Mitigation: keep explicit fallback to `inputTokens` when `totalTokensFresh === false`
- Risk: session selector naming ambiguity (`main` vs `agent:warden:main`) is not addressed in this PR
- Mitigation: kept scope limited to warning correctness/rendering; follow-up can address session-label disambiguation

## AI disclosure
AI-assisted change. Final code and targeted verification were reviewed locally.