### PR TITLE
fix(discord): honor raw mention tokens in preflight

### DIFF
--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -220,6 +220,7 @@ async function runGuildPreflight(params: {
   discordConfig: DiscordConfig;
   cfg?: import("../../config/config.js").OpenClawConfig;
   guildEntries?: Parameters<typeof preflightDiscordMessage>[0]["guildEntries"];
+  botUserId?: string;
 }) {
   return preflightDiscordMessage({
     ...createPreflightArgs({
@@ -233,6 +234,7 @@ async function runGuildPreflight(params: {
       }),
       client: createGuildTextClient(params.channelId),
     }),
+    botUserId: params.botUserId ?? "openclaw-bot",
     guildEntries: params.guildEntries,
   });
 }
@@ -434,6 +436,33 @@ describe("preflightDiscordMessage", () => {
     });
 
     expect(result).not.toBeNull();
+  });
+
+  it("accepts raw Discord mention tokens even when mentionedUsers is empty", async () => {
+    const channelId = "channel-raw-mention-token";
+    const guildId = "guild-raw-mention-token";
+    const message = createMessage({
+      id: "m-raw-mention-token",
+      channelId,
+      content: "hi <@ops-bot>",
+      mentionedUsers: [],
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    });
+
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      botUserId: "ops-bot",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.wasMentioned).toBe(true);
+    expect(result?.hasAnyMention).toBe(true);
   });
 
   it("drops guild messages that mention another user when ignoreOtherMentions=true", async () => {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -95,6 +95,19 @@ function isBoundThreadBotSystemMessage(params: {
   return DISCORD_BOUND_THREAD_SYSTEM_PREFIXES.some((prefix) => text.startsWith(prefix));
 }
 
+function discordRawTextMentionsBot(text: string | undefined, botId: string | undefined): boolean {
+  const normalizedBotId = botId?.trim();
+  if (!normalizedBotId) {
+    return false;
+  }
+  const body = text?.trim();
+  if (!body) {
+    return false;
+  }
+  const mentionPattern = new RegExp(`<@!?${normalizedBotId}>`);
+  return mentionPattern.test(body);
+}
+
 export function resolvePreflightMentionRequirement(params: {
   shouldRequireMention: boolean;
   isBoundThreadSession: boolean;
@@ -405,13 +418,16 @@ export async function preflightDiscordMessage(
   }
   const mentionRegexes = buildMentionRegexes(params.cfg, effectiveRoute.agentId);
   const explicitlyMentioned = Boolean(
-    botId && message.mentionedUsers?.some((user: User) => user.id === botId),
+    botId &&
+    (message.mentionedUsers?.some((user: User) => user.id === botId) ||
+      discordRawTextMentionsBot(baseText, botId)),
   );
   const hasAnyMention = Boolean(
     !isDirectMessage &&
     ((message.mentionedUsers?.length ?? 0) > 0 ||
       (message.mentionedRoles?.length ?? 0) > 0 ||
-      (message.mentionedEveryone && (!author.bot || sender.isPluralKit))),
+      (message.mentionedEveryone && (!author.bot || sender.isPluralKit)) ||
+      discordRawTextMentionsBot(baseText, botId)),
   );
   const hasUserOrRoleMention = Boolean(
     !isDirectMessage &&


### PR DESCRIPTION
## Summary
- fall back to raw Discord `<@id>` / `<@!id>` token detection when `mentionedUsers` is empty during preflight
- count that fallback for both explicit bot-mention detection and generic mention presence in guild messages
- add a regression test covering the multi-account `requireMention` failure mode

## Why
Fixes #45300.

In multi-account Discord setups, some messages can carry the raw mention token in content while `mentionedUsers` is empty at preflight time. That made `requireMention: true` misclassify explicitly-mentioned guild messages as `no-mention` and drop them before routing.

## Testing
- `pnpm exec vitest run src/discord/monitor/message-handler.preflight.test.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts src/channels/plugins/group-mentions.test.ts`
- `pnpm exec oxfmt --check src/discord/monitor/message-handler.preflight.ts src/discord/monitor/message-handler.preflight.test.ts`
- `git diff --check`

## AI assistance
AI-assisted; targeted, locally verified change.
