### PR TITLE
fix(agents): restore Grok tool calls by stripping xAI strict field

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -412,6 +412,49 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]).not.toHaveProperty("reasoning_effort");
   });
 
+  it("removes unsupported function.strict from xAI tool payloads", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "write",
+              parameters: { type: "object", properties: {} },
+              strict: false,
+            },
+          },
+        ],
+      };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "xai", "grok-4.1-fast");
+
+    const model = {
+      api: "openai-completions",
+      provider: "xai",
+      id: "grok-4.1-fast",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "write",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ]);
+  });
+
   it("injects parallel_tool_calls for openai-completions payloads when configured", () => {
     const payload = runParallelToolCallsPayloadMutationCase({
       applyProvider: "nvidia-nim",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -3,6 +3,7 @@ import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { isXaiProvider } from "../schema/clean-for-xai.js";
 import {
   createAnthropicBetaHeadersWrapper,
   createAnthropicFastModeWrapper,
@@ -321,6 +322,40 @@ function createParallelToolCallsWrapper(
   };
 }
 
+function stripXaiStrictToolSchemas(payload: unknown): void {
+  if (!payload || typeof payload !== "object") {
+    return;
+  }
+  const payloadObj = payload as { tools?: unknown };
+  if (!Array.isArray(payloadObj.tools)) {
+    return;
+  }
+  for (const tool of payloadObj.tools) {
+    if (!tool || typeof tool !== "object") {
+      continue;
+    }
+    const functionDef = (tool as { function?: unknown }).function;
+    if (!functionDef || typeof functionDef !== "object") {
+      continue;
+    }
+    delete (functionDef as Record<string, unknown>).strict;
+  }
+}
+
+function createXaiToolSchemaWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        stripXaiStrictToolSchemas(payload);
+        return originalOnPayload?.(payload, model);
+      },
+    });
+  };
+}
+
 /**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
@@ -435,6 +470,11 @@ export function applyExtraParamsToAgent(
       log.debug(`enabling Z.AI tool_stream for ${provider}/${modelId}`);
       agent.streamFn = createZaiToolStreamWrapper(agent.streamFn, true);
     }
+  }
+
+  if (isXaiProvider(provider, modelId)) {
+    log.debug(`removing unsupported function.strict tool fields for ${provider}/${modelId}`);
+    agent.streamFn = createXaiToolSchemaWrapper(agent.streamFn);
   }
 
   // Guard Google payloads against invalid negative thinking budgets emitted by


### PR DESCRIPTION
## Summary

- Problem: Grok models on the xAI OpenAI-compatible path were not producing tool calls in OpenClaw at all.
- Why it matters: tool-enabled agents fail on Grok even for explicit requests to use tools like `write`, while other providers work.
- What changed:
  - Strip `function.strict` from xAI/Grok tool definitions before sending the payload.
  - Add a regression test that asserts Grok payloads keep tools but omit the unsupported field.
- What did NOT change (scope boundary): No changes to tool execution semantics, transcript repair, or non-xAI provider payloads.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Grok/xAI models on the OpenAI-compatible chat-completions path can issue tool calls again when tools are enabled.
- No behavior change for other providers.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js via pnpm workspace
- Model/provider: xAI / Grok (`grok-4.1-fast`)
- Integration/channel (if any): agent runtime
- Relevant config (redacted): tool-enabled Grok model via OpenAI-compatible path

### Steps

1. Configure an agent to use an xAI/Grok model with tools enabled.
2. Ask it to use a tool explicitly, for example `write`.
3. Observe provider payload and runtime behavior.

### Expected

- Grok returns tool calls and the tool loop proceeds normally.

### Actual

- Tool-enabled Grok requests fail before tool calls are produced.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/agents/pi-embedded-runner-extraparams.test.ts`
  - `pnpm build`
  - Confirmed the xAI payload wrapper removes `function.strict` while preserving tool definitions.
- Edge cases checked:
  - Non-xAI providers remain on the existing payload path.
- What you did **not** verify:
  - Live Grok API call against a real xAI key in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two commits in this branch.
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`, `src/agents/pi-embedded-runner-extraparams.test.ts`
- Known bad symptoms reviewers should watch for: missing or malformed `tools` payloads for xAI models.

## Risks and Mitigations

- Risk: xAI accepts `strict` on some newer endpoints and this wrapper becomes unnecessary.
  - Mitigation: The wrapper is narrowly scoped to xAI/Grok detection and only removes one field while leaving the tool schema intact.

## AI-Assisted

- [x] AI-assisted
- Testing level: lightly tested locally (`pnpm vitest run src/agents/pi-embedded-runner-extraparams.test.ts`, `pnpm build`)
