### PR TITLE
fix(config): prevent ANTHROPIC_MODEL_ALIASES TDZ ReferenceError on config load (#45368)

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -268,14 +268,19 @@ describe("model-selection", () => {
       // circular-dependency ordering, causing:
       //   ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization
       // The fix wraps the aliases in a getter function so allocation is deferred to call time.
-      expect(() => parseModelRef("opus-4.6", "anthropic")).not.toThrow();
-      expect(() => parseModelRef("sonnet-4.6", "anthropic")).not.toThrow();
-      expect(() => parseModelRef("opus-4.5", "anthropic")).not.toThrow();
-      expect(() => parseModelRef("sonnet-4.5", "anthropic")).not.toThrow();
-      // Verify the aliases still resolve correctly
+      // A non-null return value already proves no throw was raised, so .not.toThrow()
+      // wrappers are omitted — asserting all four canonical mappings gives tighter coverage.
       expect(parseModelRef("opus-4.6", "anthropic")).toEqual({
         provider: "anthropic",
         model: "claude-opus-4-6",
+      });
+      expect(parseModelRef("sonnet-4.6", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+      expect(parseModelRef("opus-4.5", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-5",
       });
       expect(parseModelRef("sonnet-4.5", "anthropic")).toEqual({
         provider: "anthropic",

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -261,6 +261,27 @@ describe("model-selection", () => {
     it.each(["", "  ", "/", "anthropic/", "/model"])("returns null for invalid ref %j", (raw) => {
       expect(parseModelRef(raw, "anthropic")).toBeNull();
     });
+
+    it("resolves Anthropic shorthand aliases without throwing ReferenceError (TDZ regression #45368)", () => {
+      // Regression test: ANTHROPIC_MODEL_ALIASES was a module-level const that could be
+      // accessed before initialization when the bundler evaluated this module early due to
+      // circular-dependency ordering, causing:
+      //   ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization
+      // The fix wraps the aliases in a getter function so allocation is deferred to call time.
+      expect(() => parseModelRef("opus-4.6", "anthropic")).not.toThrow();
+      expect(() => parseModelRef("sonnet-4.6", "anthropic")).not.toThrow();
+      expect(() => parseModelRef("opus-4.5", "anthropic")).not.toThrow();
+      expect(() => parseModelRef("sonnet-4.5", "anthropic")).not.toThrow();
+      // Verify the aliases still resolve correctly
+      expect(parseModelRef("opus-4.6", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+      expect(parseModelRef("sonnet-4.5", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+      });
+    });
   });
 
   describe("inferUniqueProviderFromConfiguredModels", () => {


### PR DESCRIPTION
## Summary

Fixes #45368
Fixes #45363

Two separate bug reports describe the same crash:

```
ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization
    at normalizeAnthropicModelId (...)
    at loadConfigSnapshot (...)
```

This error occurs at startup (or on `openclaw status`) and prevents the gateway from loading config correctly.

## Root Cause

`ANTHROPIC_MODEL_ALIASES` was declared as a module-level `const` in `model-selection.ts`. When the bundler flattens the module graph it may evaluate this module before the `const` binding is live, due to a circular dependency:

```
model-selection.ts
  → config/config.js          (re-exports config/io.js)
    → config/io.js
      → config/defaults.ts
        → agents/model-selection.js   ← cycle closes here
```

In ES modules, `const` bindings are subject to the Temporal Dead Zone (TDZ): accessing them before the module that declares them has finished evaluating throws a `ReferenceError`. Because `normalizeAnthropicModelId` is called during config parsing (via `parseModelRef` → `normalizeModelRef`), and config parsing is triggered early in the startup path, the TDZ is hit before `ANTHROPIC_MODEL_ALIASES` is initialised.

## Fix

Replace the module-level `const` with a getter function `getAnthropicModelAliases()`. The object is now allocated at **call time**, which is always after all module-level bindings have been initialised, regardless of the bundler's module evaluation order.

```ts
// Before (TDZ-prone)
const ANTHROPIC_MODEL_ALIASES: Record<string, string> = { ... };

// After (safe)
function getAnthropicModelAliases(): Record<string, string> {
  return { ... };
}
```

This is the minimal, lowest-risk fix: no imports change, no module boundaries move, no behaviour changes for callers.

## Testing

```bash
pnpm vitest run src/agents/model-selection.test.ts
```

Added a regression test that:
- Calls `parseModelRef` with all four Anthropic shorthand aliases
- Asserts no `ReferenceError` is thrown
- Verifies the aliases still resolve to the correct canonical model IDs