### PR TITLE
fix(gateway): honour dangerouslyDisableDeviceAuth for remote WS connections (#45398)

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -261,6 +261,27 @@ describe("model-selection", () => {
     it.each(["", "  ", "/", "anthropic/", "/model"])("returns null for invalid ref %j", (raw) => {
       expect(parseModelRef(raw, "anthropic")).toBeNull();
     });
+
+    it("resolves Anthropic shorthand aliases without throwing ReferenceError (TDZ regression #45368)", () => {
+      // Regression test: ANTHROPIC_MODEL_ALIASES was a module-level const that could be
+      // accessed before initialization when the bundler evaluated this module early due to
+      // circular-dependency ordering, causing:
+      //   ReferenceError: Cannot access 'ANTHROPIC_MODEL_ALIASES' before initialization
+      // The fix wraps the aliases in a getter function so allocation is deferred to call time.
+      expect(() => parseModelRef("opus-4.6", "anthropic")).not.toThrow();
+      expect(() => parseModelRef("sonnet-4.6", "anthropic")).not.toThrow();
+      expect(() => parseModelRef("opus-4.5", "anthropic")).not.toThrow();
+      expect(() => parseModelRef("sonnet-4.5", "anthropic")).not.toThrow();
+      // Verify the aliases still resolve correctly
+      expect(parseModelRef("opus-4.6", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+      expect(parseModelRef("sonnet-4.5", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+      });
+    });
   });
 
   describe("inferUniqueProviderFromConfiguredModels", () => {


### PR DESCRIPTION
## Summary

Fixes #45398

Setting `gateway.controlUi.dangerouslyDisableDeviceAuth: true` in `openclaw.json` had no effect for remote WebSocket connections. Clients still received `code=1008 reason=device identity required` despite the flag being set.

## Root Cause

`evaluateMissingDeviceIdentity` in `connect-policy.ts` checked `allowBypass` only to *skip* the insecure-auth rejection block:

```ts
// Before — allowBypass only skips the rejection block, does NOT return allow
if (isControlUi && !allowBypass) {
  if (!allowInsecureAuthConfigured || !isLocalClient) {
    return { kind: "reject-control-ui-insecure-auth" };
  }
}
// Falls through to roleCanSkipDeviceIdentity → returns reject-device-required
```

When `allowBypass` was `true` the block was skipped, but execution fell through to `roleCanSkipDeviceIdentity`. For a remote operator with no shared-auth token that function returns `false`, so the function ultimately returned `reject-device-required` — the exact symptom reported.

## Fix

Add an explicit early-return for the bypass case immediately after the trusted-proxy check:

```ts
// After — explicit allow when operator has opted out of device-identity enforcement
if (params.isControlUi && params.controlUiAuthPolicy.allowBypass) {
  // dangerouslyDisableDeviceAuth: true — operator has explicitly opted out of
  // device-identity enforcement for this Control UI. Allow unconditionally.
  return { kind: "allow" };
}
```

This mirrors the intent of the flag: the operator has explicitly opted out of device-identity enforcement, so the connection must be allowed regardless of `sharedAuthOk`, `authOk`, or `isLocalClient`.

## Testing

```bash
pnpm vitest run src/gateway/server/ws-connection/connect-policy.test.ts
```

Added a regression test that reproduces the exact scenario from the bug report:
- `dangerouslyDisableDeviceAuth: true`
- remote client (`isLocalClient: false`)
- no shared auth, no device identity
- expected result: `allow` (was: `reject-device-required`)