### PR TITLE
fix(cli): exit cleanly on hooks update --all when no npm-installed hooks exist

### DIFF
--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -1,7 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { Command } from "commander";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { HookStatusReport } from "../hooks/hooks-status.js";
 import { formatHooksCheck, formatHooksList } from "./hooks-cli.js";
 import { createEmptyInstallChecks } from "./requirements-test-fixtures.js";
+
+/* ── mocks for hooks update tests ── */
+const updateMocks = vi.hoisted(() => ({
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(() => {
+      throw new Error("exit");
+    }),
+  },
+  loadConfig: vi.fn(),
+}));
+
+vi.mock("../runtime.js", () => ({ defaultRuntime: updateMocks.runtime }));
+vi.mock("../config/io.js", () => ({
+  loadConfig: updateMocks.loadConfig,
+  writeConfigFile: vi.fn(),
+}));
+
+const { registerHooksCli } = await import("./hooks-cli.js");
 
 const report: HookStatusReport = {
   workspaceDir: "/tmp/workspace",
@@ -68,5 +89,31 @@ describe("hooks cli formatting", () => {
 
     const output = formatHooksList(pluginReport, {});
     expect(output).toContain("plugin:voice-call");
+  });
+});
+
+describe("hooks update --all with no npm-installed hooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exits cleanly with a friendly message when --all is passed but no npm-installed hooks exist", async () => {
+    updateMocks.loadConfig.mockReturnValue({ hooks: { internal: { installs: {} } } });
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${String(code)})`);
+    }) as typeof process.exit);
+
+    const program = new Command();
+    program.exitOverride();
+    registerHooksCli(program);
+
+    await program.parseAsync(["hooks", "update", "--all"], { from: "user" });
+
+    expect(updateMocks.runtime.log).toHaveBeenCalledWith("No npm-installed hooks to update.");
+    expect(updateMocks.runtime.error).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
   });
 });

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -708,6 +708,10 @@ export function registerHooksCli(program: Command): void {
       const targets = opts.all ? Object.keys(installs) : id ? [id] : [];
 
       if (targets.length === 0) {
+        if (opts.all) {
+          defaultRuntime.log("No npm-installed hooks to update.");
+          return;
+        }
         defaultRuntime.error("Provide a hook id or use --all.");
         process.exit(1);
       }


### PR DESCRIPTION
## Summary

- Problem: `openclaw hooks update --all` falls through to "Provide a hook id or use --all" error (exit code 1) when no npm-installed hooks exist, even though the user already passed `--all`.
- Why it matters: misleading error message confuses users.
- What changed: when `--all` is passed but the installs map is empty, print "No npm-installed hooks to update." and return cleanly (exit code 0).
- What did NOT change (scope boundary): all other `hooks update` paths (single hook, missing id, installed hooks) are untouched.

## AI Assistance

- Tools used: Claude Code
- Testing level: fully tested (new unit test + manual verification of both paths)
- Codex review: ran `codex review --base origin/main` locally — no issues found
- I understand what the code does: yes

## Change Type (select all)

- [x] Bug fix

## Linked Issue/PR

- Closes #45447

## User-visible / Behavior Changes

- `openclaw hooks update --all` now prints "No npm-installed hooks to update." and exits 0 when no hooks are installed, instead of erroring with "Provide a hook id or use --all." (exit 1).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Ensure no hooks installed via `openclaw hooks install`.
2. Run `openclaw hooks update --all`.

### Expected

- Prints "No npm-installed hooks to update." and exits 0.

### Actual (before fix)

- Prints "Provide a hook id or use --all." and exits 1.

## Evidence

- [x] Failing test/log before + passing after
- New test in `src/cli/hooks-cli.test.ts` covers this case.
- Manual verification of both empty-installs and installed-hook paths.
- Full suite: `pnpm build && pnpm check && pnpm test` — 918 test files, 7,599 tests passed, 0 lint warnings/errors.

## Human Verification (required)

- Verified scenarios: ran `openclaw hooks update --all` with no hooks (got friendly message), then installed `openclaw-face-cost-tracker` via `openclaw hooks install` and ran `--all` again (update ran normally).
- Edge cases checked: the existing "Provide a hook id or use --all" error still fires when `--all` is NOT passed and no id is given.