### PR TITLE
Fix responsePrefix template interpolation for early abort replies

### DIFF
--- a/src/channels/reply-prefix.test.ts
+++ b/src/channels/reply-prefix.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveResponsePrefixTemplate } from "../auto-reply/reply/response-prefix-template.js";
+import { createReplyPrefixContext } from "./reply-prefix.js";
+
+const identityMocks = vi.hoisted(() => ({
+  resolveEffectiveMessagesConfig: vi.fn(() => ({ responsePrefix: "[{model} | {thinkingLevel}]" })),
+  resolveIdentityName: vi.fn(() => "Alex"),
+}));
+
+const sessionMocks = vi.hoisted(() => ({
+  resolveStorePath: vi.fn(() => "/tmp/mock-sessions.json"),
+  loadSessionStore: vi.fn(() => ({})),
+  resolveSessionStoreEntry: vi.fn(() => ({ existing: undefined })),
+}));
+
+vi.mock("../agents/identity.js", () => ({
+  resolveEffectiveMessagesConfig: identityMocks.resolveEffectiveMessagesConfig,
+  resolveIdentityName: identityMocks.resolveIdentityName,
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  resolveStorePath: sessionMocks.resolveStorePath,
+  loadSessionStore: sessionMocks.loadSessionStore,
+  resolveSessionStoreEntry: sessionMocks.resolveSessionStoreEntry,
+}));
+
+describe("createReplyPrefixContext", () => {
+  beforeEach(() => {
+    identityMocks.resolveEffectiveMessagesConfig.mockClear();
+    identityMocks.resolveIdentityName.mockClear();
+    sessionMocks.resolveStorePath.mockClear();
+    sessionMocks.loadSessionStore.mockClear();
+    sessionMocks.resolveSessionStoreEntry.mockClear();
+    sessionMocks.resolveSessionStoreEntry.mockReturnValue({ existing: undefined });
+  });
+
+  it("seeds response prefix template context from stored session runtime metadata", () => {
+    sessionMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: {
+        modelProvider: "groq",
+        model: "moonshotai/kimi-k2.5-instruct",
+        thinkingLevel: "off",
+      },
+    });
+
+    const result = createReplyPrefixContext({
+      cfg: {},
+      agentId: "main",
+      channel: "whatsapp",
+      sessionKey: "main",
+    });
+
+    expect(
+      resolveResponsePrefixTemplate(result.responsePrefix, result.responsePrefixContextProvider()),
+    ).toBe("[kimi-k2.5-instruct | off]");
+    expect(sessionMocks.resolveStorePath).toHaveBeenCalledWith(undefined, { agentId: "main" });
+    expect(sessionMocks.resolveSessionStoreEntry).toHaveBeenCalledWith({
+      store: {},
+      sessionKey: "main",
+    });
+  });
+
+  it("falls back to parsing provider from legacy runtime model strings", () => {
+    sessionMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: {
+        model: "openai-codex/gpt-5.4",
+      },
+    });
+
+    const result = createReplyPrefixContext({
+      cfg: {},
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    expect(result.responsePrefixContextProvider()).toEqual({
+      identityName: "Alex",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      modelFull: "openai-codex/gpt-5.4",
+      thinkingLevel: "off",
+    });
+  });
+
+  it("prefers actual model selection once the run starts", () => {
+    sessionMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: {
+        modelProvider: "groq",
+        model: "moonshotai/kimi-k2.5-instruct",
+        thinkingLevel: "off",
+      },
+    });
+
+    const result = createReplyPrefixContext({
+      cfg: {},
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    result.onModelSelected({
+      provider: "openai-codex",
+      model: "gpt-5.4-20260301",
+      thinkLevel: "high",
+    });
+
+    expect(
+      resolveResponsePrefixTemplate(result.responsePrefix, result.responsePrefixContextProvider()),
+    ).toBe("[gpt-5.4 | high]");
+    expect(result.responsePrefixContextProvider()).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      modelFull: "openai-codex/gpt-5.4-20260301",
+      thinkingLevel: "high",
+    });
+  });
+});

--- a/src/channels/reply-prefix.ts
+++ b/src/channels/reply-prefix.ts
@@ -5,8 +5,16 @@ import {
 } from "../auto-reply/reply/response-prefix-template.js";
 import type { GetReplyOptions } from "../auto-reply/types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveSessionStoreEntry,
+  resolveStorePath,
+  type SessionEntry,
+} from "../config/sessions.js";
 
 type ModelSelectionContext = Parameters<NonNullable<GetReplyOptions["onModelSelected"]>>[0];
+
+type ReplyPrefixSessionSeed = Pick<SessionEntry, "model" | "modelProvider" | "thinkingLevel">;
 
 export type ReplyPrefixContextBundle = {
   prefixContext: ResponsePrefixContext;
@@ -20,16 +28,82 @@ export type ReplyPrefixOptions = Pick<
   "responsePrefix" | "responsePrefixContextProvider" | "onModelSelected"
 >;
 
+function applySessionSeedToPrefixContext(
+  prefixContext: ResponsePrefixContext,
+  sessionSeed?: ReplyPrefixSessionSeed,
+): void {
+  const rawModel = sessionSeed?.model?.trim();
+  const rawProvider = sessionSeed?.modelProvider?.trim();
+  const rawThinkingLevel = sessionSeed?.thinkingLevel?.trim();
+  if (!rawModel && !rawProvider && !rawThinkingLevel) {
+    return;
+  }
+
+  let provider = rawProvider;
+  let modelFull = rawModel;
+  if (!provider && rawModel) {
+    const slashIndex = rawModel.indexOf("/");
+    if (slashIndex > 0) {
+      provider = rawModel.slice(0, slashIndex).trim() || undefined;
+      modelFull = rawModel;
+    }
+  }
+  if (provider && rawModel) {
+    const providerPrefix = `${provider}/`;
+    modelFull = rawModel.toLowerCase().startsWith(providerPrefix.toLowerCase())
+      ? rawModel
+      : `${provider}/${rawModel}`;
+  }
+
+  if (provider) {
+    prefixContext.provider = provider;
+  }
+  if (rawModel) {
+    prefixContext.model = extractShortModelName(rawModel);
+  }
+  if (modelFull) {
+    prefixContext.modelFull = modelFull;
+  }
+  prefixContext.thinkingLevel = rawThinkingLevel || "off";
+}
+
+function resolveReplyPrefixSessionSeed(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey?: string;
+}): ReplyPrefixSessionSeed | undefined {
+  const sessionKey = params.sessionKey?.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  try {
+    const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
+    const store = loadSessionStore(storePath);
+    return resolveSessionStoreEntry({ store, sessionKey }).existing;
+  } catch {
+    return undefined;
+  }
+}
+
 export function createReplyPrefixContext(params: {
   cfg: OpenClawConfig;
   agentId: string;
   channel?: string;
   accountId?: string;
+  sessionKey?: string;
 }): ReplyPrefixContextBundle {
   const { cfg, agentId } = params;
   const prefixContext: ResponsePrefixContext = {
     identityName: resolveIdentityName(cfg, agentId),
   };
+  applySessionSeedToPrefixContext(
+    prefixContext,
+    resolveReplyPrefixSessionSeed({
+      cfg,
+      agentId,
+      sessionKey: params.sessionKey,
+    }),
+  );
 
   const onModelSelected = (ctx: ModelSelectionContext) => {
     // Mutate the object directly instead of reassigning to ensure closures see updates.
@@ -55,6 +129,7 @@ export function createReplyPrefixOptions(params: {
   agentId: string;
   channel?: string;
   accountId?: string;
+  sessionKey?: string;
 }): ReplyPrefixOptions {
   const { responsePrefix, responsePrefixContextProvider, onModelSelected } =
     createReplyPrefixContext(params);

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -981,6 +981,7 @@ async function dispatchDiscordComponentEvent(params: {
     agentId,
     channel: "discord",
     accountId,
+    sessionKey,
   });
   const tableMode = resolveMarkdownTableMode({
     cfg: ctx.cfg,

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -421,6 +421,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     agentId: route.agentId,
     channel: "discord",
     accountId: route.accountId,
+    sessionKey: persistedSessionKey,
   });
   const tableMode = resolveMarkdownTableMode({
     cfg,

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1685,6 +1685,7 @@ async function dispatchDiscordCommandInteraction(params: {
     agentId: effectiveRoute.agentId,
     channel: "discord",
     accountId: effectiveRoute.accountId,
+    sessionKey,
   });
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, effectiveRoute.agentId);
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1283,6 +1283,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         cfg,
         agentId,
         channel: INTERNAL_MESSAGE_CHANNEL,
+        sessionKey,
       });
       const finalReplyParts: string[] = [];
       const dispatcher = createReplyDispatcher({

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -398,6 +398,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       agentId: decision.route.agentId,
       channel: "imessage",
       accountId: decision.route.accountId,
+      sessionKey: decision.route.sessionKey,
     });
 
     const dispatcher = createReplyDispatcher({

--- a/src/plugin-sdk/inbound-reply-dispatch.ts
+++ b/src/plugin-sdk/inbound-reply-dispatch.ts
@@ -124,6 +124,7 @@ export async function recordInboundSessionAndDispatchReply(params: {
     agentId: params.agentId,
     channel: params.channel,
     accountId: params.accountId,
+    sessionKey: params.ctxPayload.SessionKey ?? params.routeSessionKey,
   });
   const deliver = createNormalizedOutboundDeliverer(params.deliver);
 

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -247,6 +247,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       agentId: route.agentId,
       channel: "signal",
       accountId: route.accountId,
+      sessionKey: route.sessionKey,
     });
 
     const typingCallbacks = createTypingCallbacks({

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -198,6 +198,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     agentId: route.agentId,
     channel: "slack",
     accountId: route.accountId,
+    sessionKey: route.mainSessionKey,
   });
 
   const slackStreaming = resolveSlackStreamingConfig({

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -612,6 +612,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         agentId: route.agentId,
         channel: "slack",
         accountId: route.accountId,
+        sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
       });
 
       const deliverSlashPayloads = async (replies: ReplyPayload[]) => {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -379,6 +379,7 @@ export const dispatchTelegramMessage = async ({
     agentId: route.agentId,
     channel: "telegram",
     accountId: route.accountId,
+    sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
   });
   const chunkMode = resolveChunkMode(cfg, "telegram", route.accountId);
 

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -745,6 +745,7 @@ export const registerTelegramNativeCommands = ({
             agentId: route.agentId,
             channel: "telegram",
             accountId: route.accountId,
+            sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
           });
 
           await dispatchReplyWithBufferedBlockDispatcher({

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -274,6 +274,7 @@ export async function processMessage(params: {
     agentId: params.route.agentId,
     channel: "whatsapp",
     accountId: params.route.accountId,
+    sessionKey: params.route.sessionKey,
   });
   const isSelfChat =
     params.msg.chatType !== "group" &&


### PR DESCRIPTION
## Summary
- seed `responsePrefix` template context from persisted session runtime metadata
- pass `sessionKey` into reply-prefix creation sites so early abort replies can resolve `{model}` / `{thinkingLevel}`
- add regression coverage for stored runtime metadata and post-selection override behavior

## Repro
With a `messages.responsePrefix` that includes `{model}` and/or `{thinkingLevel}`, send `stop` or `/stop` while the agent is processing.

## Root cause
Fast abort replies are emitted before the normal `onModelSelected` callback runs, so the prefix template context never receives model/thinking metadata and unresolved placeholders are sent literally.

## Validation
- `pnpm exec vitest run src/channels/reply-prefix.test.ts src/auto-reply/reply/dispatch-from-config.test.ts`
- `pnpm exec oxfmt --check <touched files>`
- `pnpm exec oxlint --type-aware <touched files>`

Closes #45314.
