### PR TITLE
auth-profiles: prefer last successful profile during initial selection

### DIFF
--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -6,18 +6,36 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import { resolveSessionAuthProfileOverride } from "./session-override.js";
 
-async function writeAuthStore(agentDir: string) {
+type AuthStoreFixture = {
+  version?: number;
+  profiles: Record<string, { type: string; provider: string; key: string }>;
+  order: Record<string, string[]>;
+  lastGood?: Record<string, string>;
+  usageStats?: Record<string, { cooldownUntil?: number; disabledUntil?: number }>;
+};
+
+async function writeAuthStore(agentDir: string, fixture?: Partial<AuthStoreFixture>) {
   const authPath = path.join(agentDir, "auth-profiles.json");
-  const payload = {
+  const payload: AuthStoreFixture = {
     version: 1,
     profiles: {
-      "zai:work": { type: "api_key", provider: "zai", key: "sk-test" },
+      "zai:work": { type: "api_key", provider: "zai", key: "sk-work" },
+      "zai:backup": { type: "api_key", provider: "zai", key: "sk-backup" },
     },
     order: {
-      zai: ["zai:work"],
+      zai: ["zai:work", "zai:backup"],
     },
+    ...fixture,
   };
   await fs.writeFile(authPath, JSON.stringify(payload), "utf-8");
+}
+
+function createSessionEntry(overrides?: Partial<SessionEntry>): SessionEntry {
+  return {
+    sessionId: "s1",
+    updatedAt: Date.now(),
+    ...overrides,
+  };
 }
 
 describe("resolveSessionAuthProfileOverride", () => {
@@ -27,12 +45,10 @@ describe("resolveSessionAuthProfileOverride", () => {
       await fs.mkdir(agentDir, { recursive: true });
       await writeAuthStore(agentDir);
 
-      const sessionEntry: SessionEntry = {
-        sessionId: "s1",
-        updatedAt: Date.now(),
+      const sessionEntry = createSessionEntry({
         authProfileOverride: "zai:work",
         authProfileOverrideSource: "user",
-      };
+      });
       const sessionStore = { "agent:main:main": sessionEntry };
 
       const resolved = await resolveSessionAuthProfileOverride({
@@ -48,6 +64,177 @@ describe("resolveSessionAuthProfileOverride", () => {
 
       expect(resolved).toBe("zai:work");
       expect(sessionEntry.authProfileOverride).toBe("zai:work");
+    });
+  });
+
+  it("prefers lastGood when it is selectable", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, { lastGood: { zai: "zai:backup" } });
+
+      const sessionEntry = createSessionEntry();
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "zai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("zai:backup");
+    });
+  });
+
+  it("falls back to first available profile when lastGood is missing", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir);
+
+      const sessionEntry = createSessionEntry();
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "zai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("zai:work");
+    });
+  });
+
+  it("ignores lastGood when it is not in provider order", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        lastGood: { zai: "zai:orphan" },
+        profiles: {
+          "zai:work": { type: "api_key", provider: "zai", key: "sk-work" },
+          "zai:backup": { type: "api_key", provider: "zai", key: "sk-backup" },
+          "zai:orphan": { type: "api_key", provider: "zai", key: "sk-orphan" },
+        },
+      });
+
+      const sessionEntry = createSessionEntry();
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "zai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("zai:work");
+    });
+  });
+
+  it("ignores lastGood when it is in cooldown", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        lastGood: { zai: "zai:work" },
+        profiles: {
+          "zai:work": { type: "api_key", provider: "zai", key: "sk-work" },
+          "zai:backup": { type: "api_key", provider: "zai", key: "sk-backup" },
+        },
+        usageStats: {
+          "zai:work": { cooldownUntil: Date.now() + 60_000 },
+        },
+      });
+
+      const sessionEntry = createSessionEntry();
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "zai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("zai:backup");
+    });
+  });
+
+  it("preserves existing fallback when all profiles are unavailable", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      const cooldownUntil = Date.now() + 60_000;
+      await writeAuthStore(agentDir, {
+        lastGood: { zai: "zai:backup" },
+        profiles: {
+          "zai:work": { type: "api_key", provider: "zai", key: "sk-work" },
+          "zai:backup": { type: "api_key", provider: "zai", key: "sk-backup" },
+        },
+        usageStats: {
+          "zai:work": { cooldownUntil },
+          "zai:backup": { cooldownUntil },
+        },
+      });
+
+      const sessionEntry = createSessionEntry();
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "zai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("zai:work");
+    });
+  });
+
+  it("accepts legacy alias keys when reading lastGood", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, { lastGood: { "z.ai": "zai:backup" } });
+
+      const sessionEntry = createSessionEntry();
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "zai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("zai:backup");
     });
   });
 });

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -5,7 +5,7 @@ import {
   isProfileInCooldown,
   resolveAuthProfileOrder,
 } from "../auth-profiles.js";
-import { normalizeProviderId } from "../model-selection.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 
 function isProfileForProvider(params: {
   provider: string;
@@ -85,14 +85,13 @@ export async function resolveSessionAuthProfileOverride(params: {
     return undefined;
   }
 
-  const providerKey = normalizeProviderId(provider);
-
   /**
    * Prefer the last successful profile to avoid repeatedly retrying
    * a known-bad first entry when order[0] has hit quota/rate limits.
+   * Accept normalized and legacy alias keys from lastGood.
    */
   const pickPreferredAvailableProfile = () => {
-    const lastGoodProfile = store.lastGood?.[providerKey];
+    const lastGoodProfile = findNormalizedProviderValue(store.lastGood, provider);
     if (
       lastGoodProfile &&
       order.includes(lastGoodProfile) &&

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -85,12 +85,28 @@ export async function resolveSessionAuthProfileOverride(params: {
     return undefined;
   }
 
-  const pickFirstAvailable = () =>
-    order.find((profileId) => !isProfileInCooldown(store, profileId)) ?? order[0];
+  const providerKey = normalizeProviderId(provider);
+
+  /**
+   * Prefer the last successful profile to avoid repeatedly retrying
+   * a known-bad first entry when order[0] has hit quota/rate limits.
+   */
+  const pickPreferredAvailableProfile = () => {
+    const lastGoodProfile = store.lastGood?.[providerKey];
+    if (
+      lastGoodProfile &&
+      order.includes(lastGoodProfile) &&
+      !isProfileInCooldown(store, lastGoodProfile)
+    ) {
+      return lastGoodProfile;
+    }
+    return order.find((profileId) => !isProfileInCooldown(store, profileId)) ?? order[0];
+  };
+
   const pickNextAvailable = (active: string) => {
     const startIndex = order.indexOf(active);
     if (startIndex < 0) {
-      return pickFirstAvailable();
+      return pickPreferredAvailableProfile();
     }
     for (let offset = 1; offset <= order.length; offset += 1) {
       const candidate = order[(startIndex + offset) % order.length];
@@ -120,11 +136,11 @@ export async function resolveSessionAuthProfileOverride(params: {
 
   let next = current;
   if (isNewSession) {
-    next = current ? pickNextAvailable(current) : pickFirstAvailable();
+    next = current ? pickNextAvailable(current) : pickPreferredAvailableProfile();
   } else if (current && compactionCount > storedCompaction) {
     next = pickNextAvailable(current);
   } else if (!current || isProfileInCooldown(store, current)) {
-    next = pickFirstAvailable();
+    next = pickPreferredAvailableProfile();
   }
 
   if (!next) {


### PR DESCRIPTION
## Summary

- Problem: initial auth-profile selection always started from the first selectable entry in provider order, even when a different profile had already proven to be the last successful choice.
- Why it matters: after quota / rate-limit failures on the first profile, later runs could still retry that same known-bad starting point before recovering on the previously successful profile.
- What changed: initial selection now prefers `lastGood` when it is still present in provider order and currently selectable; otherwise it preserves the existing order-based fallback behavior.
- What did NOT change (scope boundary): this PR does not change how `lastGood` is written, does not persist final winning profiles after fallback, and does not change user-locked auth-profile behavior.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Auth / tokens
- [x] Agents
- [ ] Gateway / orchestration
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #45699
- Related #46642
- Supersedes the selection portion that was previously discussed in #45757

## User-visible / Behavior Changes

When a provider order contains multiple auth profiles and one of them was the last successful profile, new selection prefers that previously successful profile if it is still selectable. This avoids unnecessary first-attempt retries against a profile that already hit cooldown / rate limits.

## Security Impact

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: Linux / local repo checkout
- Runtime/container: Node + pnpm test runner
- Model/provider: auth-profile selection logic only
- Integration/channel (if any): N/A
- Relevant config (redacted): multi-profile provider order with `lastGood` populated

### Steps

1. Configure provider order with at least two profiles.
2. Set `lastGood` to a profile that is still in order and not in cooldown.
3. Resolve session auth-profile override for a fresh auto-selected run.

### Expected

- Selection starts from `lastGood` instead of blindly retrying the first profile in order.

### Actual

- Before this change, selection always started from the first selectable ordered profile.
- After this change, selection prefers `lastGood` when it is valid, and falls back to the previous behavior otherwise.

## Evidence

- [x] Failing logic path covered by regression tests
- [x] Passing test coverage for fallback cases
- [ ] Screenshot/recording
- [ ] Perf numbers

Covered regression cases:
- prefer `lastGood` when still selectable
- fall back when `lastGood` is missing
- ignore `lastGood` when it is no longer in order
- ignore `lastGood` when it is in cooldown / disabled
- preserve existing `order.find(...) ?? order[0]` fallback when all profiles are unavailable
- cover alias-key lookup compatibility for legacy provider keys

## Human Verification

- Verified targeted `session-override` tests locally.
- Verified the change stays scoped to selection logic and its immediate fallback helper behavior.
- Verified that persistence of `lastGood` and persistence of the final winning profile remain intentionally outside this PR.

## Review Conversations

- [x] Added targeted regression coverage for the new selection behavior.
- [x] Clarified the small helper-level behavior change where `pickNextAvailable()` falls back through the same preferred-selection helper.
- [x] Split follow-up persistence work into separate PRs instead of expanding this PR's scope.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/agents/auth-profiles/session-override.ts`, `src/agents/auth-profiles/session-override.test.ts`
- Known bad symptoms reviewers should watch for: selection unexpectedly ignoring a valid `lastGood`, or selecting a stale profile that is no longer in order / available.

## Risks and Mitigations

- Risk: if `lastGood` is stale or unusable, selection could incorrectly prefer it.
  - Mitigation: the code only prefers `lastGood` when it still exists in `order` and is not in cooldown / disabled; otherwise it falls back to the prior behavior.
- Risk: reviewers could confuse this with the separate persistence fixes.
  - Mitigation: this PR intentionally stays selection-only, while persistence is tracked separately in #45699 and #46642.
