### PR TITLE
fix(gateway): reject weak/default tokens at startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,10 @@
 # -----------------------------------------------------------------------------
 # Gateway auth + paths
 # -----------------------------------------------------------------------------
-# Recommended if the gateway binds beyond loopback.
-OPENCLAW_GATEWAY_TOKEN=change-me-to-a-long-random-token
-# Example generator: openssl rand -hex 32
+# REQUIRED if the gateway binds beyond loopback.
+# [HARDENED] Left intentionally empty — predictable placeholder values are rejected at startup.
+# Generate a strong token before starting: openssl rand -hex 32
+OPENCLAW_GATEWAY_TOKEN=
 
 # Optional alternative auth mode (use token OR password).
 # OPENCLAW_GATEWAY_PASSWORD=change-me-to-a-strong-password

--- a/openclaw.podman.env
+++ b/openclaw.podman.env
@@ -17,7 +17,9 @@ OPENCLAW_PODMAN_GATEWAY_HOST_PORT=18789
 OPENCLAW_PODMAN_BRIDGE_HOST_PORT=18790
 
 # Gateway bind (used by the launch script)
-OPENCLAW_GATEWAY_BIND=lan
+# [HARDENED] "lan" exposes the gateway on all LAN interfaces — use "loopback" unless
+# you explicitly need remote access and have token auth configured above.
+OPENCLAW_GATEWAY_BIND=loopback
 
 # Optional: LLM provider API keys (for zero cost use Ollama locally or Groq free tier)
 # OLLAMA_API_KEY=ollama-local

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -174,7 +174,7 @@ describe("gateway run option collisions", () => {
       "gateway",
       "run",
       "--token",
-      "tok_run",
+      "0123456789abcdef0123456789abcdef",
       "--allow-unconfigured",
       "--ws-log",
       "full",
@@ -191,7 +191,7 @@ describe("gateway run option collisions", () => {
       18789,
       expect.objectContaining({
         auth: expect.objectContaining({
-          token: "tok_run",
+          token: "0123456789abcdef0123456789abcdef",
         }),
       }),
     );
@@ -345,6 +345,25 @@ describe("gateway run option collisions", () => {
     expect(runtimeErrors).toContain(
       "Warning: --password can be exposed via process listings. Prefer --password-file or OPENCLAW_GATEWAY_PASSWORD.",
     );
+  });
+
+  it.each(["change-me-to-a-long-random-token", "change-me", "changeme", "secret", "password"])(
+    "rejects weak/placeholder gateway token: %s",
+    async (weakToken) => {
+      await expect(
+        runGatewayCli(["gateway", "run", "--token", weakToken, "--allow-unconfigured"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(runtimeErrors.some((e) => e.includes("[HARDENED]"))).toBe(true);
+    },
+  );
+
+  it("rejects gateway token shorter than 32 characters", async () => {
+    await expect(
+      runGatewayCli(["gateway", "run", "--token", "short-but-not-weak", "--allow-unconfigured"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors.some((e) => e.includes("[HARDENED]"))).toBe(true);
   });
 
   it("rejects using both --password and --password-file", async () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -463,10 +463,22 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
     "your-token-here",
     "replace-me",
   ]);
-  if (hasToken && WEAK_TOKENS.has(tokenValue.trim())) {
+  if (hasToken && WEAK_TOKENS.has(tokenValue.trim().toLowerCase())) {
     defaultRuntime.error(
       [
         "[HARDENED] Gateway token is a known weak/placeholder value and has been rejected.",
+        "Generate a strong token: openssl rand -hex 32",
+        "Then set OPENCLAW_GATEWAY_TOKEN or gateway.auth.token in your config.",
+      ].join("\n"),
+    );
+    defaultRuntime.exit(1);
+    return;
+  }
+  const MIN_TOKEN_LENGTH = 16;
+  if (hasToken && tokenValue.trim().length < MIN_TOKEN_LENGTH) {
+    defaultRuntime.error(
+      [
+        `[HARDENED] Gateway token is too short (minimum ${MIN_TOKEN_LENGTH} characters).`,
         "Generate a strong token: openssl rand -hex 32",
         "Then set OPENCLAW_GATEWAY_TOKEN or gateway.auth.token in your config.",
       ].join("\n"),

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -452,6 +452,28 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   const passwordValue = resolvedAuth.password;
   const hasToken = typeof tokenValue === "string" && tokenValue.trim().length > 0;
   const hasPassword = typeof passwordValue === "string" && passwordValue.trim().length > 0;
+  // [HARDENED] Reject known weak/predictable token values copied from example files.
+  const WEAK_TOKENS = new Set([
+    "change-me-to-a-long-random-token",
+    "change-me",
+    "changeme",
+    "secret",
+    "password",
+    "token",
+    "your-token-here",
+    "replace-me",
+  ]);
+  if (hasToken && WEAK_TOKENS.has(tokenValue.trim())) {
+    defaultRuntime.error(
+      [
+        "[HARDENED] Gateway token is a known weak/placeholder value and has been rejected.",
+        "Generate a strong token: openssl rand -hex 32",
+        "Then set OPENCLAW_GATEWAY_TOKEN or gateway.auth.token in your config.",
+      ].join("\n"),
+    );
+    defaultRuntime.exit(1);
+    return;
+  }
   const tokenConfigured =
     hasToken ||
     hasConfiguredSecretInput(


### PR DESCRIPTION
## Summary
Reject weak/default gateway tokens at startup to prevent accidental insecure deployments.

Tokens matching a blocklist (`change-me`, `changeme`, `secret`, `token`, …) or shorter than a minimum length now cause the gateway to exit with an explicit error instead of starting silently with a compromised credential.

Also:
- `.env.example`: cleared `OPENCLAW_GATEWAY_TOKEN` default value, strengthened warning comment
- `openclaw.podman.env`: changed default `OPENCLAW_GATEWAY_BIND` from `lan` to `loopback`

## Motivation
Deployed instances with default/weak tokens are a common attack vector. Fail-fast at startup is safer than a runtime warning that may be missed.

## Testing
Tested on a self-hosted EC2 deployment (Ubuntu 24.04, v2026.3.12 base).

---
- [x] AI-assisted (Claude Code / claude-sonnet-4-6)
- [x] Lightly tested on self-hosted deployment
- [x] Author understands what the code does