### PR TITLE
fix: remove unknown line-clamp property to resolve CSS error

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2213,7 +2213,6 @@
   white-space: pre-wrap;
   overflow: hidden;
   display: -webkit-box;
-  line-clamp: 3;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 }


### PR DESCRIPTION
Removes the un-prefixed `line-clamp` property which causes "Unknown property" errors in some environments, while keeping the functional `-webkit-line-clamp`.

Fixes #45020