### PR TITLE
fix(imessage): stop injecting visible reply tags into sent text

### DIFF
--- a/src/imessage/send.test.ts
+++ b/src/imessage/send.test.ts
@@ -90,31 +90,31 @@ describe("sendMessageIMessage", () => {
     expect(result.messageId).toBe("123");
   });
 
-  it("prepends reply tag as the first token when replyToId is provided", async () => {
+  it("does not inject a visible reply tag when replyToId is provided", async () => {
     await sendWithDefaults("chat_id:123", "  hello\nworld", {
       replyToId: "abc-123",
     });
     const params = getSentParams();
-    expect(params.text).toBe("[[reply_to:abc-123]] hello\nworld");
+    expect(params.text).toBe("  hello\nworld");
   });
 
-  it("rewrites an existing leading reply tag to keep the requested id first", async () => {
+  it("strips an existing leading reply tag instead of sending it visibly", async () => {
     await sendWithDefaults("chat_id:123", " [[reply_to:old-id]] hello", {
       replyToId: "new-id",
     });
     const params = getSentParams();
-    expect(params.text).toBe("[[reply_to:new-id]] hello");
+    expect(params.text).toBe("hello");
   });
 
-  it("sanitizes replyToId before writing the leading reply tag", async () => {
+  it("ignores replyToId sanitation for visible message text", async () => {
     await sendWithDefaults("chat_id:123", "hello", {
       replyToId: " [ab]\n\u0000c\td ] ",
     });
     const params = getSentParams();
-    expect(params.text).toBe("[[reply_to:abcd]] hello");
+    expect(params.text).toBe("hello");
   });
 
-  it("skips reply tagging when sanitized replyToId is empty", async () => {
+  it("leaves plain messages unchanged when replyToId is empty", async () => {
     await sendWithDefaults("chat_id:123", "hello", {
       replyToId: "[]\u0000\n\r",
     });

--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -35,37 +35,8 @@ export type IMessageSendResult = {
 };
 
 const LEADING_REPLY_TAG_RE = /^\s*\[\[\s*reply_to\s*:\s*([^\]\n]+)\s*\]\]\s*/i;
-const MAX_REPLY_TO_ID_LENGTH = 256;
 
-function stripUnsafeReplyTagChars(value: string): string {
-  let next = "";
-  for (const ch of value) {
-    const code = ch.charCodeAt(0);
-    if ((code >= 0 && code <= 31) || code === 127 || ch === "[" || ch === "]") {
-      continue;
-    }
-    next += ch;
-  }
-  return next;
-}
-
-function sanitizeReplyToId(rawReplyToId?: string): string | undefined {
-  const trimmed = rawReplyToId?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const sanitized = stripUnsafeReplyTagChars(trimmed).trim();
-  if (!sanitized) {
-    return undefined;
-  }
-  if (sanitized.length > MAX_REPLY_TO_ID_LENGTH) {
-    return sanitized.slice(0, MAX_REPLY_TO_ID_LENGTH);
-  }
-  return sanitized;
-}
-
-function prependReplyTagIfNeeded(message: string, replyToId?: string): string {
-  void sanitizeReplyToId(replyToId);
+function stripLeadingReplyTag(message: string): string {
   const existingLeadingTag = message.match(LEADING_REPLY_TAG_RE);
   if (existingLeadingTag) {
     return message.slice(existingLeadingTag[0].length).trimStart();
@@ -141,7 +112,7 @@ export async function sendMessageIMessage(
     });
     message = convertMarkdownTables(message, tableMode);
   }
-  message = prependReplyTagIfNeeded(message, opts.replyToId);
+  message = stripLeadingReplyTag(message);
 
   const params: Record<string, unknown> = {
     text: message,

--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -65,18 +65,12 @@ function sanitizeReplyToId(rawReplyToId?: string): string | undefined {
 }
 
 function prependReplyTagIfNeeded(message: string, replyToId?: string): string {
-  const resolvedReplyToId = sanitizeReplyToId(replyToId);
-  if (!resolvedReplyToId) {
-    return message;
-  }
-  const replyTag = `[[reply_to:${resolvedReplyToId}]]`;
+  void sanitizeReplyToId(replyToId);
   const existingLeadingTag = message.match(LEADING_REPLY_TAG_RE);
   if (existingLeadingTag) {
-    const remainder = message.slice(existingLeadingTag[0].length).trimStart();
-    return remainder ? `${replyTag} ${remainder}` : replyTag;
+    return message.slice(existingLeadingTag[0].length).trimStart();
   }
-  const trimmedMessage = message.trimStart();
-  return trimmedMessage ? `${replyTag} ${trimmedMessage}` : replyTag;
+  return message;
 }
 
 function resolveMessageId(result: Record<string, unknown> | null | undefined): string | null {


### PR DESCRIPTION
## Summary\nStop iMessage outbound sends from prepending visible \ tags into message text.\n\n## Root cause\nThe iMessage sender () was explicitly injecting reply tags into the outgoing text body whenever  was present. If the downstream transport did not convert that pseudo-tag into a native reply bubble, recipients saw the raw tag text.\n\n## Changes\n- stop prepending  into outbound iMessage text\n- strip an existing leading reply tag from visible text instead of sending it\n- update iMessage sender tests to assert clean visible text\n\n## Validation\nRan:\n- \n\nAll targeted tests passed.\n\n## User impact\nFixes visible reply-tag junk leaking into iMessage messages. This prefers clean user-visible text over fake text-based reply threading.