### PR TITLE
fix: carry forward httpRoutes when plugin registry is replaced

### DIFF
--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -1,11 +1,20 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createEmptyPluginRegistry } from "./registry.js";
+import type { PluginHttpRouteRegistration } from "./registry.js";
 import {
+  getActivePluginRegistry,
   pinActivePluginHttpRouteRegistry,
   releasePinnedPluginHttpRouteRegistry,
   resolveActivePluginHttpRouteRegistry,
   setActivePluginRegistry,
 } from "./runtime.js";
+
+const makeRoute = (path: string): PluginHttpRouteRegistration => ({
+  path,
+  handler: () => {},
+  auth: "gateway",
+  match: "exact",
+});
 
 describe("plugin runtime route registry", () => {
   afterEach(() => {
@@ -66,5 +75,47 @@ describe("plugin runtime route registry", () => {
     pinActivePluginHttpRouteRegistry(startupRegistry);
 
     expect(resolveActivePluginHttpRouteRegistry(explicitRegistry)).toBe(startupRegistry);
+  });
+});
+
+describe("setActivePluginRegistry", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    releasePinnedPluginHttpRouteRegistry();
+  });
+
+  it("carries forward httpRoutes when new registry has none", () => {
+    const oldRegistry = createEmptyPluginRegistry();
+    const fakeRoute = makeRoute("/test");
+    oldRegistry.httpRoutes.push(fakeRoute);
+    setActivePluginRegistry(oldRegistry);
+    expect(getActivePluginRegistry()?.httpRoutes).toHaveLength(1);
+
+    const newRegistry = createEmptyPluginRegistry();
+    expect(newRegistry.httpRoutes).toHaveLength(0);
+    setActivePluginRegistry(newRegistry);
+    expect(getActivePluginRegistry()?.httpRoutes).toHaveLength(1);
+    expect(getActivePluginRegistry()?.httpRoutes[0]).toEqual(fakeRoute);
+  });
+
+  it("does not carry forward when new registry already has routes", () => {
+    const oldRegistry = createEmptyPluginRegistry();
+    oldRegistry.httpRoutes.push(makeRoute("/old"));
+    setActivePluginRegistry(oldRegistry);
+
+    const newRegistry = createEmptyPluginRegistry();
+    const newRoute = makeRoute("/new");
+    newRegistry.httpRoutes.push(newRoute);
+    setActivePluginRegistry(newRegistry);
+    expect(getActivePluginRegistry()?.httpRoutes).toHaveLength(1);
+    expect(getActivePluginRegistry()?.httpRoutes[0]).toEqual(newRoute);
+  });
+
+  it("does not carry forward when same registry is set again", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.httpRoutes.push(makeRoute("/test"));
+    setActivePluginRegistry(registry);
+    setActivePluginRegistry(registry);
+    expect(getActivePluginRegistry()?.httpRoutes).toHaveLength(1);
   });
 });

--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -83,6 +83,10 @@ describe("setActivePluginRegistry", () => {
     setActivePluginRegistry(createEmptyPluginRegistry());
     releasePinnedPluginHttpRouteRegistry();
   });
+  afterEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    releasePinnedPluginHttpRouteRegistry();
+  });
 
   it("carries forward httpRoutes when new registry has none", () => {
     const oldRegistry = createEmptyPluginRegistry();
@@ -117,5 +121,53 @@ describe("setActivePluginRegistry", () => {
     setActivePluginRegistry(registry);
     setActivePluginRegistry(registry);
     expect(getActivePluginRegistry()?.httpRoutes).toHaveLength(1);
+  });
+
+  it("carries forward when cacheKey is the same", () => {
+    const oldRegistry = createEmptyPluginRegistry();
+    const carriedRoute = makeRoute("/same-key");
+    oldRegistry.httpRoutes.push(carriedRoute);
+    setActivePluginRegistry(oldRegistry, "shared-key");
+
+    const newRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(newRegistry, "shared-key");
+
+    expect(getActivePluginRegistry()?.httpRoutes).toHaveLength(1);
+    expect(getActivePluginRegistry()?.httpRoutes[0]).toBe(carriedRoute);
+  });
+
+  it("does not carry forward when cacheKey is different", () => {
+    const oldRegistry = createEmptyPluginRegistry();
+    oldRegistry.httpRoutes.push(makeRoute("/old-key"));
+    setActivePluginRegistry(oldRegistry, "key-a");
+
+    const newRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(newRegistry, "key-b");
+
+    expect(getActivePluginRegistry()?.httpRoutes).toHaveLength(0);
+  });
+
+  it("treats omitted/undefined cacheKey as null and carries forward", () => {
+    const oldRegistry = createEmptyPluginRegistry();
+    const carriedRoute = makeRoute("/null-key");
+    oldRegistry.httpRoutes.push(carriedRoute);
+    setActivePluginRegistry(oldRegistry);
+
+    const newRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(newRegistry, undefined);
+
+    expect(getActivePluginRegistry()?.httpRoutes).toHaveLength(1);
+    expect(getActivePluginRegistry()?.httpRoutes[0]).toBe(carriedRoute);
+  });
+
+  it("does not carry forward when previous key is null and next key is explicit", () => {
+    const oldRegistry = createEmptyPluginRegistry();
+    oldRegistry.httpRoutes.push(makeRoute("/null-to-explicit"));
+    setActivePluginRegistry(oldRegistry);
+
+    const newRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(newRegistry, "k1");
+
+    expect(getActivePluginRegistry()?.httpRoutes).toHaveLength(0);
   });
 });

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -27,6 +27,10 @@ const state: RegistryState = (() => {
 })();
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
+  const prev = state.registry;
+  if (prev && prev !== registry && prev.httpRoutes.length > 0 && registry.httpRoutes.length === 0) {
+    registry.httpRoutes = [...prev.httpRoutes];
+  }
   state.registry = registry;
   if (!state.httpRouteRegistryPinned) {
     state.httpRouteRegistry = registry;

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -27,15 +27,23 @@ const state: RegistryState = (() => {
 })();
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
+  const nextKey = cacheKey ?? null;
+  const prevKey = state.key;
   const prev = state.registry;
-  if (prev && prev !== registry && prev.httpRoutes.length > 0 && registry.httpRoutes.length === 0) {
+  if (
+    prev &&
+    prev !== registry &&
+    prev.httpRoutes.length > 0 &&
+    registry.httpRoutes.length === 0 &&
+    prevKey === nextKey
+  ) {
     registry.httpRoutes = prev.httpRoutes;
   }
   state.registry = registry;
   if (!state.httpRouteRegistryPinned) {
     state.httpRouteRegistry = registry;
   }
-  state.key = cacheKey ?? null;
+  state.key = nextKey;
   state.version += 1;
 }
 

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -29,7 +29,7 @@ const state: RegistryState = (() => {
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
   const prev = state.registry;
   if (prev && prev !== registry && prev.httpRoutes.length > 0 && registry.httpRoutes.length === 0) {
-    registry.httpRoutes = [...prev.httpRoutes];
+    registry.httpRoutes = prev.httpRoutes;
   }
   state.registry = registry;
   if (!state.httpRouteRegistryPinned) {


### PR DESCRIPTION
## Summary
Fixes webhook 404s caused by httpRoutes being lost when `setActivePluginRegistry` replaces the active registry at runtime.

Ref #45445

## Root cause
When `loadOpenClawPlugins` is called at runtime (config schema lookups, channel status probes, etc.), it creates a fresh registry with an empty `httpRoutes` array and sets it as active. Webhook routes registered by channel plugins (LINE, Google Chat, etc.) on the previous registry are lost, causing 404s.

## What changed
- `setActivePluginRegistry` in `src/plugins/runtime.ts` now carries forward `httpRoutes` from the previous registry when the new registry has an empty `httpRoutes` array.
- Carry-forward only triggers when: previous registry exists, is a different object, has routes, and new registry has none.

## Tests added
- Carries forward httpRoutes when new registry has none
- Does not carry forward when new registry already has its own routes
- Does not duplicate routes when same registry is set again

## Relationship to other PRs
- This is complementary to #45150 (getter injection fix for Issue 1 in #45445)
- This PR addresses Issue 2 in #45445 (routes lost on registry swap)
- Both PRs are needed for a complete fix; they modify different files and do not conflict