### PR TITLE
fix(hooks): handle empty hooks update --all

### DIFF
--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { HookStatusReport } from "../hooks/hooks-status.js";
-import { formatHooksCheck, formatHooksList } from "./hooks-cli.js";
+import { formatHooksCheck, formatHooksList, resolveHooksUpdateTargets } from "./hooks-cli.js";
 import { createEmptyInstallChecks } from "./requirements-test-fixtures.js";
 
 const report: HookStatusReport = {
@@ -68,5 +68,28 @@ describe("hooks cli formatting", () => {
 
     const output = formatHooksList(pluginReport, {});
     expect(output).toContain("plugin:voice-call");
+  });
+});
+
+describe("resolveHooksUpdateTargets", () => {
+  it("marks empty --all as a no-op instead of a usage error", () => {
+    expect(resolveHooksUpdateTargets({}, undefined, true)).toEqual({
+      targets: [],
+      emptyAll: true,
+    });
+  });
+
+  it("returns tracked installs when --all is set", () => {
+    expect(resolveHooksUpdateTargets({ alpha: {}, beta: {} }, undefined, true)).toEqual({
+      targets: ["alpha", "beta"],
+      emptyAll: false,
+    });
+  });
+
+  it("preserves explicit id behavior when --all is not set", () => {
+    expect(resolveHooksUpdateTargets({}, "hook-pack", false)).toEqual({
+      targets: ["hook-pack"],
+      emptyAll: false,
+    });
   });
 });

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -52,6 +52,17 @@ export type HooksUpdateOptions = {
   dryRun?: boolean;
 };
 
+export function resolveHooksUpdateTargets(installs: Record<string, unknown>, id?: string, all?: boolean): {
+  targets: string[];
+  emptyAll: boolean;
+} {
+  if (all) {
+    const targets = Object.keys(installs);
+    return { targets, emptyAll: targets.length === 0 };
+  }
+  return { targets: id ? [id] : [], emptyAll: false };
+}
+
 function mergeHookEntries(pluginEntries: HookEntry[], workspaceEntries: HookEntry[]): HookEntry[] {
   const merged = new Map<string, HookEntry>();
   for (const entry of pluginEntries) {
@@ -705,9 +716,13 @@ export function registerHooksCli(program: Command): void {
     .action(async (id: string | undefined, opts: HooksUpdateOptions) => {
       const cfg = loadConfig();
       const installs = cfg.hooks?.internal?.installs ?? {};
-      const targets = opts.all ? Object.keys(installs) : id ? [id] : [];
+      const { targets, emptyAll } = resolveHooksUpdateTargets(installs, id, opts.all);
 
       if (targets.length === 0) {
+        if (emptyAll) {
+          defaultRuntime.log("No npm-installed hooks to update.");
+          process.exit(0);
+        }
         defaultRuntime.error("Provide a hook id or use --all.");
         process.exit(1);
       }


### PR DESCRIPTION
## Summary
- treat `openclaw hooks update --all` with zero tracked installs as a clean no-op
- keep the existing usage error for the truly invalid case where neither an id nor `--all` is provided
- add focused unit coverage for the target-resolution behavior

## Root cause
The CLI resolved `targets` to an empty array both when the user made a usage mistake and when `--all` was provided against an empty installs map. That made the empty-`--all` case fall through to the generic usage error.

## Validation
- `npx --yes pnpm install --ignore-scripts`
- `npx --yes pnpm exec vitest run --config vitest.unit.config.ts src/cli/hooks-cli.test.ts`
- PASS (`src/cli/hooks-cli.test.ts`, 6 tests)

Fixes #45447
