### PR TITLE
Cron: honor server_error retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- Cron/failover: classify structured OpenAI-compatible `server_error` payloads as `server_error`, expose that reason in cron state, and let one-shot cron retry policy honor `retryOn: ["server_error"]` without requiring raw `5xx` text. (#45594) Thanks @clovericbot.
+
+## 2026.5.8
+
 ### Changes
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,11 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
-### Fixes
-
-- Cron/failover: classify structured OpenAI-compatible `server_error` payloads as `server_error`, expose that reason in cron state, and let one-shot cron retry policy honor `retryOn: ["server_error"]` without requiring raw `5xx` text. (#45594) Thanks @clovericbot.
-
-## 2026.5.8
-
 ### Changes
 
 ### Fixes
 
+- Cron/failover: classify structured OpenAI-compatible `server_error` payloads as `server_error`, expose that reason in cron state, and let one-shot cron retry policy honor `retryOn: ["server_error"]` without requiring raw `5xx` text. (#45594) Thanks @clovericbot.
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Cron/failover: classify structured OpenAI-compatible `server_error` payloads as `server_error`, expose that reason in cron state, and let one-shot cron retry policy honor `retryOn: ["server_error"]` without requiring raw `5xx` text. (#45594) Thanks @clovericbot.
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.
+- Cron/failover: classify structured OpenAI-compatible `server_error` payloads as `server_error`, expose that reason in cron state, and let one-shot cron retry policy honor `retryOn: ["server_error"]` without requiring raw `5xx` text. (#45594) Thanks @clovericbot.
 
 ## 2026.5.9
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -44,6 +44,9 @@ const GROQ_TOO_MANY_REQUESTS_MESSAGE =
   "429 Too Many Requests: Too many requests were sent in a given timeframe.";
 const GROQ_SERVICE_UNAVAILABLE_MESSAGE =
   "503 Service Unavailable: The server is temporarily unable to handle the request due to overloading or maintenance.";
+// Structured OpenAI-compatible server_error payload shape seen in Codex/OpenAI runs.
+const OPENAI_SERVER_ERROR_PAYLOAD =
+  'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}';
 
 describe("failover-error", () => {
   it("infers failover reason from HTTP status", () => {
@@ -866,6 +869,10 @@ describe("failover-error", () => {
     expect(resolveFailoverStatus("overloaded")).toBe(503);
   });
 
+  it("maps server_error to a 500 fallback status", () => {
+    expect(resolveFailoverStatus("server_error")).toBe(500);
+  });
+
   it("coerces format errors with a 400 status", () => {
     const err = coerceToFailoverError("invalid request format", {
       provider: "google",
@@ -971,6 +978,32 @@ describe("failover-error", () => {
     const described = describeFailoverError(123);
     expect(described.message).toBe("123");
     expect(described.reason).toBeUndefined();
+  });
+
+  it("classifies OpenAI-compatible server_error payloads at the error boundary", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: OPENAI_SERVER_ERROR_PAYLOAD,
+      }),
+    ).toBe("server_error");
+
+    const err = coerceToFailoverError(
+      {
+        message: OPENAI_SERVER_ERROR_PAYLOAD,
+      },
+      { provider: "openai-codex", model: "gpt-5.4" },
+    );
+    expect(err?.reason).toBe("server_error");
+    expect(err?.status).toBe(500);
+  });
+
+  it("keeps explicit 4xx classification ahead of server_error markers", () => {
+    const payload = '{"type":"error","error":{"type":"server_error","code":"server_error"}}';
+
+    expect(resolveFailoverReasonFromError({ status: 401, message: payload })).toBe("auth");
+    expect(resolveFailoverReasonFromError({ status: 402, message: payload })).toBe("billing");
+    expect(resolveFailoverReasonFromError({ status: 422, message: payload })).toBe("format");
+    expect(resolveFailoverReasonFromError(`402 Payment Required ${payload}`)).toBe("billing");
   });
 
   it("propagates sessionId/lane/provider attribution through FailoverError (#42713)", () => {

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -986,9 +986,16 @@ describe("failover-error", () => {
         message: OPENAI_SERVER_ERROR_PAYLOAD,
       }),
     ).toBe("server_error");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 500,
+        message: OPENAI_SERVER_ERROR_PAYLOAD,
+      }),
+    ).toBe("server_error");
 
     const err = coerceToFailoverError(
       {
+        status: 500,
         message: OPENAI_SERVER_ERROR_PAYLOAD,
       },
       { provider: "openai-codex", model: "gpt-5.4" },

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -76,6 +76,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
   switch (reason) {
     case "billing":
       return 402;
+    case "server_error":
+      return 500;
     case "rate_limit":
       return 429;
     case "overloaded":

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -48,6 +48,8 @@ const GROQ_SERVICE_UNAVAILABLE_MESSAGE =
 const PLAIN_INTERNAL_SERVER_ERROR_STATUS_SAMPLE = "Proxy notice: Status: Internal Server Error";
 const MIXED_INTERNAL_SERVER_ERROR_STATUS_SAMPLE = `${PLAIN_INTERNAL_SERVER_ERROR_STATUS_SAMPLE}; upstream connect error`;
 const INTERNAL_SERVER_ERROR_STATUS_WITH_500_SAMPLE = `${PLAIN_INTERNAL_SERVER_ERROR_STATUS_SAMPLE}; code:500`;
+const OPENAI_SERVER_ERROR_PAYLOAD =
+  'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}';
 
 function expectMessageMatches(
   matcher: (message: string) => boolean,
@@ -673,6 +675,14 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
     ).toBe("overloaded");
   });
 
+  it("does not let structured server_error markers override 4xx status handling", () => {
+    const payload = '{"type":"error","error":{"type":"server_error","code":"server_error"}}';
+
+    expect(classifyFailoverReasonFromHttpStatus(401, payload)).toBe("auth");
+    expect(classifyFailoverReasonFromHttpStatus(402, payload)).toBe("billing");
+    expect(classifyFailoverReasonFromHttpStatus(422, payload)).toBe("format");
+  });
+
   it("treats generic HTTP 410 responses as retryable timeouts", () => {
     expect(classifyFailoverReasonFromHttpStatus(410)).toBe("timeout");
     expect(classifyFailoverReasonFromHttpStatus(410, "")).toBe("timeout");
@@ -1148,11 +1158,10 @@ describe("classifyFailoverReason provider messages", () => {
         "521 <!DOCTYPE html><html><head><title>Web server is down</title></head><body>Cloudflare</body></html>",
       ),
     ).toBe("timeout");
-    expect(
-      classifyFailoverReason(
-        'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
-      ),
-    ).toBe("timeout");
+    expect(classifyFailoverReason(OPENAI_SERVER_ERROR_PAYLOAD)).toBe("server_error");
+    expect(classifyFailoverReason(`402 Payment Required ${OPENAI_SERVER_ERROR_PAYLOAD}`)).toBe(
+      "billing",
+    );
     expect(classifyFailoverReason("string should match pattern")).toBe("format");
     expect(
       classifyFailoverReason(

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -683,6 +683,19 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
     expect(classifyFailoverReasonFromHttpStatus(422, payload)).toBe("format");
   });
 
+  it("preserves structured server_error markers on explicit HTTP 5xx statuses", () => {
+    expect(classifyFailoverReasonFromHttpStatus(500, OPENAI_SERVER_ERROR_PAYLOAD)).toBe(
+      "server_error",
+    );
+    expect(classifyFailoverReasonFromHttpStatus(502, OPENAI_SERVER_ERROR_PAYLOAD)).toBe(
+      "server_error",
+    );
+    expect(classifyFailoverReasonFromHttpStatus(504, OPENAI_SERVER_ERROR_PAYLOAD)).toBe(
+      "server_error",
+    );
+    expect(classifyFailoverReasonFromHttpStatus(500)).toBe("timeout");
+  });
+
   it("treats generic HTTP 410 responses as retryable timeouts", () => {
     expect(classifyFailoverReasonFromHttpStatus(410)).toBe("timeout");
     expect(classifyFailoverReasonFromHttpStatus(410, "")).toBe("timeout");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -697,6 +697,9 @@ function classifyFailoverClassificationFromHttpStatus(
     return toReasonClassification("timeout");
   }
   if (status === 500 || status === 502 || status === 504) {
+    if (messageReason === "server_error") {
+      return messageClassification;
+    }
     return toReasonClassification("timeout");
   }
   if (status === 529) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -706,7 +706,7 @@ function classifyFailoverClassificationFromHttpStatus(
     // 400/422 are ambiguous: inspect the payload first so provider-specific
     // rate limits, auth failures, model-not-found errors, and billing signals
     // are not collapsed into generic "format" failures.
-    if (messageClassification) {
+    if (messageClassification && messageReason !== "server_error") {
       return messageClassification;
     }
     // When the response has no body at all, or only surfaces as an HTTP wrapper
@@ -814,6 +814,14 @@ function classifyFailoverClassificationFromMessage(
   }
   if (isOverloadedErrorMessage(raw)) {
     return toReasonClassification("overloaded");
+  }
+  if (
+    isStructuredServerErrorMessage(raw) &&
+    !isBillingErrorMessage(raw) &&
+    !isAuthPermanentErrorMessage(raw) &&
+    !isAuthErrorMessage(raw)
+  ) {
+    return toReasonClassification("server_error");
   }
   if (isTransientHttpError(raw)) {
     const status = extractLeadingHttpStatus(raw.trim());
@@ -1205,6 +1213,14 @@ function isJsonApiInternalServerError(raw: string): boolean {
   // with non-transient messages (e.g. context overflow, schema validation) should
   // fall through to more specific classifiers or remain unclassified.
   return API_ERROR_TRANSIENT_SIGNALS_RE.test(raw);
+}
+
+function isStructuredServerErrorMessage(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const value = normalizeLowercaseStringOrEmpty(raw);
+  return value.includes('"type":"server_error"') || value.includes('"code":"server_error"');
 }
 
 export function parseImageDimensionError(raw: string): {

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -7,6 +7,7 @@ export type FailoverReason =
   | "rate_limit"
   | "overloaded"
   | "billing"
+  | "server_error"
   | "timeout"
   | "model_not_found"
   | "session_expired"

--- a/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
@@ -32,10 +32,15 @@ describe("resolveAuthProfileFailureReason", () => {
     ).toBeNull();
   });
 
-  it("does not persist transport timeouts as auth-profile health", () => {
+  it("does not persist transport or server failures as auth-profile health", () => {
     expect(
       resolveAuthProfileFailureReason({
         failoverReason: "timeout",
+      }),
+    ).toBeNull();
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "server_error",
       }),
     ).toBeNull();
   });

--- a/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts
@@ -6,7 +6,7 @@ export function resolveAuthProfileFailureReason(params: {
   failoverReason: FailoverReason | null;
   policy?: AuthProfileFailurePolicy;
 }): AuthProfileFailureReason | null {
-  // Helper-local runs, transport timeouts, and request-shape ("format") rejections
+  // Helper-local runs, transport/server failures, and request-shape ("format") rejections
   // should not poison shared provider auth health. A `format` failure means the
   // provider rejected the request payload (e.g. an assistant-prefill 400 from a
   // strict provider when a session transcript ends with a stream-error placeholder
@@ -19,6 +19,7 @@ export function resolveAuthProfileFailureReason(params: {
     params.policy === "local" ||
     !params.failoverReason ||
     params.failoverReason === "timeout" ||
+    params.failoverReason === "server_error" ||
     params.failoverReason === "format"
   ) {
     return null;

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -29,6 +29,7 @@ export type AgentRuntimeFailoverReason =
   | "rate_limit"
   | "overloaded"
   | "billing"
+  | "server_error"
   | "timeout"
   | "model_not_found"
   | "session_expired"

--- a/src/cron/cron-protocol-conformance.test.ts
+++ b/src/cron/cron-protocol-conformance.test.ts
@@ -108,6 +108,7 @@ describe("cron protocol conformance", () => {
       "format",
       "rate_limit",
       "billing",
+      "server_error",
       "timeout",
       "model_not_found",
       "empty_response",

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -318,6 +318,55 @@ describe("cron service timer regressions", () => {
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
   });
 
+  it("retries OpenAI-compatible server_error payloads when retryOn only includes server_error", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-03-14T00:00:00.000Z");
+    const serverErrorPayload =
+      'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}';
+
+    const cronJob = createIsolatedRegressionJob({
+      id: "oneshot-server-error-only",
+      name: "reminder",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "remind me" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "error", error: serverErrorPayload })
+      .mockResolvedValueOnce({ status: "ok", summary: "done" });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+      cronConfig: {
+        retry: { maxAttempts: 1, backoffMs: [1000], retryOn: ["server_error"] },
+      },
+    });
+
+    await onTimer(state);
+    const jobAfterRetry = requireJob(state, "oneshot-server-error-only");
+    expect(jobAfterRetry.enabled).toBe(true);
+    expect(jobAfterRetry.state.lastStatus).toBe("error");
+    expect(jobAfterRetry.state.lastErrorReason).toBe("server_error");
+    expect(jobAfterRetry.state.nextRunAtMs).toBeGreaterThan(scheduledAt);
+
+    now = requireTimestamp(jobAfterRetry.state.nextRunAtMs, "server_error retry next run") + 1;
+    await onTimer(state);
+
+    const finishedJob = requireJob(state, "oneshot-server-error-only");
+    expect(finishedJob.state.lastStatus).toBe("ok");
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+  });
+
   it("#38822: one-shot job retries Bedrock too-many-tokens-per-day errors", async () => {
     const store = timerRegressionFixtures.makeStorePath();
     const scheduledAt = Date.parse("2026-03-08T10:00:00.000Z");

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -311,6 +311,10 @@ function isTransientCronError(error: string | undefined, retryOn?: CronRetryOn[]
     return false;
   }
   const keys = retryOn?.length ? retryOn : (Object.keys(TRANSIENT_PATTERNS) as CronRetryOn[]);
+  const classified = resolveFailoverReasonFromError(error);
+  if (classified && keys.includes(classified as CronRetryOn)) {
+    return true;
+  }
   return keys.some((k) => TRANSIENT_PATTERNS[k]?.test(error));
 }
 

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -67,6 +67,7 @@ const CronFailoverReasonSchema = Type.Union([
   Type.Literal("format"),
   Type.Literal("rate_limit"),
   Type.Literal("billing"),
+  Type.Literal("server_error"),
   Type.Literal("timeout"),
   Type.Literal("model_not_found"),
   Type.Literal("empty_response"),

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -149,6 +149,14 @@ describe("version resolution", () => {
     ).toBe("9.9.9");
   });
 
+  function restoreEnvValue(key: string, value: string | undefined) {
+    if (value === undefined) {
+      delete process.env[key];
+      return;
+    }
+    process.env[key] = value;
+  }
+
   it("prefers runtime VERSION over stale OPENCLAW_VERSION for compatibility checks", () => {
     const previous = process.env.OPENCLAW_VERSION;
     const previousService = process.env.OPENCLAW_SERVICE_VERSION;
@@ -159,9 +167,9 @@ describe("version resolution", () => {
       process.env.npm_package_version = "2026.3.25-package";
       expect(resolveCompatibilityHostVersion()).toBe(VERSION);
     } finally {
-      process.env.OPENCLAW_VERSION = previous;
-      process.env.OPENCLAW_SERVICE_VERSION = previousService;
-      process.env.npm_package_version = previousPackage;
+      restoreEnvValue("OPENCLAW_VERSION", previous);
+      restoreEnvValue("OPENCLAW_SERVICE_VERSION", previousService);
+      restoreEnvValue("npm_package_version", previousPackage);
     }
   });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: `cron.retry.retryOn` documents `server_error`, but `FailoverReason` did not include it, so OpenAI/Codex payloads like `{"error":{"type":"server_error","code":"server_error"}}` classified as `null`.
- Why it matters: one-shot cron jobs using `retryOn: ["server_error"]` disabled immediately instead of retrying, and cron state/schema could not surface `lastErrorReason: "server_error"`.
- What changed: added structured `server_error` classification, mapped it to fallback status 500, exposed it through cron protocol schema/state, and taught cron retry detection to honor classifier output before falling back to raw regex matching.
- What did NOT change (scope boundary): generic status-only 5xx handling, existing timeout/overloaded heuristics, and regex fallback for raw status text remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Cron jobs can now record `lastErrorReason: "server_error"`.
- `cron.retry.retryOn: ["server_error"]` now retries structured OpenAI/Codex `server_error` payloads even when the raw message does not contain an explicit `5xx` status code.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 / Apple Silicon
- Runtime/container: Node 22, pnpm 10, Vitest 4
- Model/provider: OpenAI-compatible / Codex payload shape
- Integration/channel (if any): cron isolated `agentTurn`
- Relevant config (redacted): `cron.retry.retryOn: ["server_error"]`

### Steps

1. Configure a one-shot cron `agentTurn` job with `retry.maxAttempts: 1`, `retry.backoffMs: [1000]`, and `retryOn: ["server_error"]`.
2. Make the isolated run return `Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."}}`.
3. Observe cron state and retry scheduling.

### Expected

- The job stays enabled for one retry.
- `lastErrorReason` is stored as `server_error`.
- A retry is scheduled according to the configured backoff.

### Actual

- The payload classified as `null`, not `server_error`.
- `lastErrorReason` could not surface `server_error` in the exposed schema.
- `retryOn: ["server_error"]` did not match because cron only looked for raw `5xx` digits.

## Real behavior proof

- **Behavior or issue addressed**: One-shot cron jobs configured with `cron.retry.retryOn: ["server_error"]` should treat structured OpenAI/Codex `server_error` payloads as transient, keep the job enabled, schedule the configured retry, then complete on a successful retry.
- **Real environment tested**: Local PR checkout at `69667bf577a8074a8458ed64235f7cf6459c413e` on macOS 15 / Apple Silicon with Node 22 and pnpm dependencies installed. The proof used production `CronService`, real persisted temp cron store files, and the isolated cron runner boundary; the upstream provider payload was injected at that boundary to avoid depending on a live provider outage.
- **Exact steps or command run after this patch**: From the PR checkout, ran `node --import tsx .local/proof/server-error-cron-proof.ts`. The script created a one-shot isolated `agentTurn` cron job with `retry.maxAttempts: 1`, `retry.backoffMs: [1000]`, and `retryOn: ["server_error"]`; first isolated-run result returned `{"type":"server_error","code":"server_error"}`, second result returned `ok`.
- **Evidence after fix**: Terminal output from the real cron runtime path:

```json
{
  "scenario": "production CronService + persisted temp cron store; isolated runner returned structured server_error once, then success",
  "firstRun": { "ok": true, "ran": true },
  "afterFirst": {
    "enabled": true,
    "lastRunStatus": "error",
    "lastErrorReason": "server_error",
    "consecutiveErrors": 1,
    "retryScheduled": true,
    "nextRunAtMs": 1778328001000,
    "lastRunAtMs": 1778328000000
  },
  "secondRun": { "ok": true, "ran": true },
  "afterSecond": null,
  "jobRemovedAfterSuccessfulRetry": true,
  "runnerCalls": 2,
  "persistedJobs": 0,
  "eventSummary": [
    { "action": "added", "nextRunAtMs": 1778328000000 },
    { "action": "started" },
    { "action": "finished", "status": "error", "nextRunAtMs": 1778328001000 },
    { "action": "started" },
    { "action": "finished", "status": "ok", "nextRunAtMs": 1778328001000 },
    { "action": "removed" }
  ],
  "relevantLogs": [
    { "level": "warn", "msg": "cron: job run returned error status" },
    { "level": "info", "msg": "cron: scheduling one-shot retry after transient error", "obj": { "consecutiveErrors": 1, "backoffMs": 1000, "nextRunAtMs": 1778328001000 } }
  ]
}
```

- **Observed result after fix**: The first production cron run classified the structured payload as `lastErrorReason: "server_error"`, kept the one-shot job enabled, and scheduled a retry at `1778328001000`. Advancing the real cron clock past that retry time caused the second run to execute; it succeeded, then the default delete-after-run one-shot cleanup removed the job from the persisted store.
- **What was not tested**: A live upstream OpenAI/Codex outage was not forced. The provider failure was injected through OpenClaw's isolated cron runner boundary; production cron scheduling, persistence, classification, retry, and cleanup behavior were exercised after the patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
  - `src/agents/failover-error.test.ts`
  - `src/cron/cron-protocol-conformance.test.ts`
  - `src/cron/service.issue-regressions.test.ts -t "retries OpenAI-compatible server_error payloads when retryOn only includes server_error"`
  - `node --import tsx .local/proof/server-error-cron-proof.ts`
- Edge cases checked:
  - structured `server_error` payloads without explicit `5xx` digits now retry via classifier
  - existing status-only `529` / regex-based retry path is left in place
  - `server_error` does not persist auth-profile cooldown state like hard auth/quota failures do
  - a default delete-after-run one-shot job is retained for the transient retry and removed only after the successful retry
- What you did **not** verify:
  - full repo test suite
  - live provider calls against upstream OpenAI/Codex

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `c3122580e050148d102933a47f742ac0e957e4b0`
- Files/config to restore: failover classifier and cron retry logic in `src/agents/*` and `src/cron/service/timer.ts`
- Known bad symptoms reviewers should watch for: structured provider `server_error` payloads falling back to `timeout`/`unknown`, or one-shot jobs with `retryOn: ["server_error"]` disabling immediately again

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: structured payload detection could over-match unrelated strings containing `"server_error"`.
  - Mitigation: matching is limited to explicit structured markers (`"type":"server_error"` or `"code":"server_error"`), and existing generic 5xx heuristics remain unchanged as the fallback path.
