### PR TITLE
fix: use live plugin registry for HTTP route matching after reload

### DIFF
--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -5,6 +5,7 @@ import { type CanvasHostHandler, createCanvasHostHandler } from "../canvas-host/
 import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
+import { setGatewayPluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -124,6 +125,7 @@ export async function createGatewayRuntimeState(params: {
     logHooks: params.logHooks,
   });
 
+  setGatewayPluginRegistry(params.pluginRegistry);
   const handlePluginRequest = createGatewayPluginRequestHandler({
     registry: params.pluginRegistry,
     log: params.logPlugins,

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
+import { registerPluginHttpRoute } from "../../plugins/http-registry.js";
+import { setGatewayPluginRegistry } from "../../plugins/runtime.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "../server-methods/types.js";
 import { makeMockHttpResponse } from "../test-http-response.js";
@@ -281,6 +283,40 @@ describe("createGatewayPluginRequestHandler", () => {
     const handled = await handler({ url: "/API//demo" } as IncomingMessage, res);
     expect(handled).toBe(true);
     expect(routeHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("sees routes registered via registerPluginHttpRoute after handler creation", async () => {
+    // Simulate the gateway startup: stash the registry globally, then create
+    // the handler. This mirrors what createGatewayRuntimeState does.
+    const gatewayRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/existing", auth: "plugin" })],
+    });
+    setGatewayPluginRegistry(gatewayRegistry);
+    const handler = createGatewayPluginRequestHandler({
+      registry: gatewayRegistry,
+      log: createPluginLog(),
+    });
+
+    // Simulate a channel provider registering a webhook route after startup
+    // via registerPluginHttpRoute (no explicit registry). This is the code
+    // path BlueBubbles uses via registerWebhookTargetWithPluginRoute.
+    const lateHandler = vi.fn(async () => true);
+    const unregister = registerPluginHttpRoute({
+      path: "/late-webhook",
+      handler: lateHandler,
+      auth: "plugin",
+      match: "exact",
+      pluginId: "late-plugin",
+      source: "test",
+    });
+
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/late-webhook" } as IncomingMessage, res);
+    expect(handled).toBe(true);
+    expect(lateHandler).toHaveBeenCalledTimes(1);
+
+    unregister();
+    setGatewayPluginRegistry(null as never);
   });
 
   it("logs and responds with 500 when a route throws", async () => {

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerPluginHttpRoute } from "./http-registry.js";
 import { createEmptyPluginRegistry } from "./registry.js";
+import { setGatewayPluginRegistry } from "./runtime.js";
 
 function expectRouteRegistrationDenied(params: {
   replaceExisting: boolean;
@@ -38,6 +39,11 @@ function expectRouteRegistrationDenied(params: {
 }
 
 describe("registerPluginHttpRoute", () => {
+  afterEach(() => {
+    // Clear gateway registry so tests don't leak into each other.
+    setGatewayPluginRegistry(null as never);
+  });
+
   it("registers route and unregisters it", () => {
     const registry = createEmptyPluginRegistry();
     const handler = vi.fn();
@@ -163,5 +169,31 @@ describe("registerPluginHttpRoute", () => {
 
     unregister();
     expect(registry.httpRoutes).toHaveLength(1);
+  });
+
+  it("prefers the gateway plugin registry over the active singleton", () => {
+    const gatewayRegistry = createEmptyPluginRegistry();
+    const singletonRegistry = createEmptyPluginRegistry();
+
+    // Simulate the gateway stashing its registry at startup.
+    setGatewayPluginRegistry(gatewayRegistry);
+
+    // Register a route without an explicit registry. It should target the
+    // gateway registry, not the singleton (which would be a different object
+    // when the build duplicates the singleton across chunk boundaries).
+    const handler = vi.fn();
+    const unregister = registerPluginHttpRoute({
+      path: "/webhook",
+      auth: "plugin",
+      handler,
+      pluginId: "bb",
+    });
+
+    expect(gatewayRegistry.httpRoutes).toHaveLength(1);
+    expect(gatewayRegistry.httpRoutes[0]?.path).toBe("/webhook");
+    expect(singletonRegistry.httpRoutes).toHaveLength(0);
+
+    unregister();
+    expect(gatewayRegistry.httpRoutes).toHaveLength(0);
   });
 });

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
 import type { PluginHttpRouteRegistration, PluginRegistry } from "./registry.js";
-import { requireActivePluginRegistry } from "./runtime.js";
+import { getGatewayPluginRegistry, requireActivePluginRegistry } from "./runtime.js";
 
 export type PluginHttpRouteHandler = (
   req: IncomingMessage,
@@ -22,7 +22,7 @@ export function registerPluginHttpRoute(params: {
   log?: (message: string) => void;
   registry?: PluginRegistry;
 }): () => void {
-  const registry = params.registry ?? requireActivePluginRegistry();
+  const registry = params.registry ?? getGatewayPluginRegistry() ?? requireActivePluginRegistry();
   const routes = registry.httpRoutes ?? [];
   registry.httpRoutes = routes;
 

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -47,3 +47,18 @@ export function getActivePluginRegistryKey(): string | null {
 export function getActivePluginRegistryVersion(): number {
   return state.version;
 }
+
+// The gateway's HTTP request handler captures a registry object by reference at
+// creation time. When the build system duplicates the registry singleton across
+// chunk boundaries, `requireActivePluginRegistry()` in a plugin-sdk chunk may
+// return a different object than the one the handler captured. This dedicated
+// global ensures `registerPluginHttpRoute` always targets the gateway's registry.
+const GATEWAY_REGISTRY = Symbol.for("openclaw.gatewayPluginRegistry");
+
+export function setGatewayPluginRegistry(registry: PluginRegistry): void {
+  (globalThis as Record<symbol, unknown>)[GATEWAY_REGISTRY] = registry;
+}
+
+export function getGatewayPluginRegistry(): PluginRegistry | null {
+  return ((globalThis as Record<symbol, unknown>)[GATEWAY_REGISTRY] as PluginRegistry) ?? null;
+}


### PR DESCRIPTION
## Summary

- Fix BlueBubbles (and other channel webhook) routes returning 404 due to plugin registry singleton divergence across compiled chunk boundaries
- Introduce a `globalThis`-backed registry bridge so `registerPluginHttpRoute` always targets the gateway handler's registry
- Add regression tests in both `http-registry.test.ts` and `plugins-http.test.ts`

## Problem

`createGatewayPluginRequestHandler` captures a `registry` object by closure at creation time. Channel plugins that register webhook routes later via `registerPluginHttpRoute()` (without an explicit `registry` parameter) fall back to `requireActivePluginRegistry()`. In the source, this is a single module (`src/plugins/runtime.ts`), so it returns the same object. But in the compiled output, the build system (rolldown) duplicates the registry singleton IIFE across chunk boundaries. Each chunk gets its own `state` variable. Although all are initialized from the same `globalThis[Symbol.for(...)]` entry, the entry itself can be replaced during startup, causing the `state` variables in different chunks to reference different registry objects.

The result: `registerPluginHttpRoute` adds the BlueBubbles webhook route to a registry object that the gateway handler never checks. POST requests to `/bluebubbles-webhook` return 404.

Confirmed with instrumentation:
```
[bb] live=1 captured=1 same=false
```
Both the handler's captured registry and the global singleton have only 1 route (twilio-whatsapp). The BlueBubbles route was added to a third registry object held by a different chunk's `state` variable.

Plugins that register routes during plugin loading via `api.registerHttpRoute()` (e.g., twilio-whatsapp) are unaffected because they write directly to the captured registry.

## Fix

Three files changed:

1. **`src/plugins/runtime.ts`**: Add `setGatewayPluginRegistry()` / `getGatewayPluginRegistry()` backed by a dedicated `globalThis[Symbol.for("openclaw.gatewayPluginRegistry")]`. This bypasses chunk-boundary singleton divergence entirely.

2. **`src/gateway/server-runtime-state.ts`**: Call `setGatewayPluginRegistry(params.pluginRegistry)` before creating the HTTP request handler, stashing the gateway's registry on the global bridge.

3. **`src/plugins/http-registry.ts`**: `registerPluginHttpRoute` now checks `getGatewayPluginRegistry()` before falling back to `requireActivePluginRegistry()`, ensuring routes always land in the registry the handler checks.

## Test plan

- [x] `src/plugins/http-registry.test.ts`: "prefers the gateway plugin registry over the active singleton" (verifies routes go to the gateway registry, not the singleton)
- [x] `src/gateway/server/plugins-http.test.ts`: "sees routes registered via registerPluginHttpRoute after handler creation" (end-to-end: handler finds late-registered routes)
- [x] All existing tests pass: `plugins-http.test.ts` (14/14), `http-registry.test.ts` (11/11), `webhook-targets.test.ts` (16/16)
- [x] `pnpm build` passes (type-check + rolldown)
- [x] Verified locally on macOS: iMessage inbound via BlueBubbles works after applying equivalent runtime patch

Fixes #45598

🤖 Generated with [Claude Code](https://claude.com/claude-code)