### PR TITLE
fix: add fileId to message tool schema for Slack download-file

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -346,6 +346,12 @@ function buildChannelTargetSchema() {
 
 function buildStickerSchema() {
   return {
+    fileId: Type.Optional(
+      Type.String({
+        description:
+          "Platform-specific file identifier (e.g. Telegram sticker file_id, Slack file id for download-file).",
+      }),
+    ),
     emojiName: Type.Optional(Type.String()),
     stickerId: Type.Optional(Type.Array(Type.String())),
     stickerName: Type.Optional(Type.String()),


### PR DESCRIPTION
## Summary

Adds `fileId` as an optional string parameter to the message tool schema, fixing the Slack `download-file` action which requires it but could never receive it.

## Problem

The Slack `download-file` handler reads `fileId` via `readStringParam(params, "fileId", { required: true })` at `slack-actions.ts:295`, and the Telegram `sendSticker` handler does the same at `telegram-actions.ts:393`. However, `fileId` was never included in the message tool parameter schema (`message-tool.ts`), so the parameter was stripped as unknown before reaching any handler.

This meant agents calling `message(action="download-file", channel="slack")` could never pass a file ID — the handler always returned `"fileId required"`.

## Fix

Added `fileId` as an optional string parameter in `buildStickerSchema()`, where the related `stickerId` array already lives. This makes it available to both:
- **Slack** `download-file` action (file attachment downloads)
- **Telegram** `sendSticker` action (sticker file_id)

## Testing

All existing tests pass:
- `message-tool.test.ts` — 16/16 ✅
- `slack-actions.test.ts` — 35/35 ✅
- `slack-message-actions.test.ts` — 2/2 ✅

Closes #45574