### PR TITLE
fix(macos): clear SwiftFormat blockers on latest main

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -783,7 +783,7 @@ extension AppState {
         remoteToken: String,
         remoteTokenDirty: Bool) -> [String: Any]
     {
-        Self.updatedRemoteGatewayConfig(
+        self.updatedRemoteGatewayConfig(
             current: current,
             transport: transport,
             remoteUrl: remoteUrl,
@@ -804,7 +804,7 @@ extension AppState {
         remoteToken: String,
         remoteTokenDirty: Bool) -> [String: Any]
     {
-        Self.syncedGatewayRoot(
+        self.syncedGatewayRoot(
             currentRoot: currentRoot,
             connectionMode: connectionMode,
             remoteTransport: remoteTransport,

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
@@ -89,11 +89,11 @@ final class ExecApprovalsGatewayPrompter {
     private static func shouldAsk(security: ExecSecurity, ask: ExecAsk) -> Bool {
         switch ask {
         case .always:
-            return true
+            true
         case .onMiss:
-            return security == .allowlist
+            security == .allowlist
         case .off:
-            return false
+            false
         }
     }
 
@@ -113,21 +113,21 @@ final class ExecApprovalsGatewayPrompter {
         let mode = AppStateStore.shared.connectionMode
         let activeSession = WebChatManager.shared.activeSessionKey?.trimmingCharacters(in: .whitespacesAndNewlines)
         let requestSession = request.request.sessionKey?.trimmingCharacters(in: .whitespacesAndNewlines)
-        
+
         // Read-only resolve to avoid disk writes on the MainActor
         let approvals = ExecApprovalsStore.resolveReadOnly(agentId: request.request.agentId)
         let security = approvals.agent.security
         let ask = approvals.agent.ask
-        
+
         let shouldAsk = Self.shouldAsk(security: security, ask: ask)
-        
+
         let canPresent = shouldAsk && Self.shouldPresent(
             mode: mode,
             activeSession: activeSession,
             requestSession: requestSession,
             lastInputSeconds: Self.lastInputSeconds(),
             thresholdSeconds: 120)
-        
+
         return PresentationDecision(
             shouldAsk: shouldAsk,
             canPresent: canPresent,

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift
@@ -147,7 +147,9 @@ actor MacNodeBrowserProxy {
         }
 
         if method != "GET", let body = params.body {
-            request.httpBody = try JSONSerialization.data(withJSONObject: body.foundationValue, options: [.fragmentsAllowed])
+            request.httpBody = try JSONSerialization.data(
+                withJSONObject: body.foundationValue,
+                options: [.fragmentsAllowed])
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -337,7 +337,6 @@ extension OnboardingView {
         self.remoteProbePreflightMessage == nil && self.remoteProbeState != .checking
     }
 
-    @ViewBuilder
     private func remoteConnectionSection() -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top, spacing: 12) {
@@ -503,17 +502,17 @@ extension OnboardingView {
     {
         switch issue {
         case .tokenRequired:
-            return ("key.fill", .orange)
+            ("key.fill", .orange)
         case .tokenMismatch:
-            return ("exclamationmark.triangle.fill", .orange)
+            ("exclamationmark.triangle.fill", .orange)
         case .gatewayTokenNotConfigured:
-            return ("wrench.and.screwdriver.fill", .orange)
+            ("wrench.and.screwdriver.fill", .orange)
         case .setupCodeExpired:
-            return ("qrcode.viewfinder", .orange)
+            ("qrcode.viewfinder", .orange)
         case .passwordRequired:
-            return ("lock.slash.fill", .orange)
+            ("lock.slash.fill", .orange)
         case .pairingRequired:
-            return ("link.badge.plus", .orange)
+            ("link.badge.plus", .orange)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
@@ -180,7 +180,7 @@ enum RemoteGatewayProbe {
         }
 
         do {
-            _ = try await GatewayConnection.shared.healthSnapshot(timeoutMs: 10_000)
+            _ = try await GatewayConnection.shared.healthSnapshot(timeoutMs: 10000)
             let authSource = await GatewayConnection.shared.authSource()
             return .ready(RemoteGatewayProbeSuccess(authSource: authSource))
         } catch {

--- a/apps/macos/Sources/OpenClaw/TalkModeGatewayConfig.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeGatewayConfig.swift
@@ -23,8 +23,8 @@ enum TalkModeGatewayConfigParser {
         defaultSilenceTimeoutMs: Int,
         envVoice: String?,
         sagVoice: String?,
-        envApiKey: String?
-    ) -> TalkModeGatewayConfigState {
+        envApiKey: String?) -> TalkModeGatewayConfigState
+    {
         let talk = snapshot.config?["talk"]?.dictionaryValue
         let selection = TalkConfigParsing.selectProviderConfig(talk, defaultProvider: defaultProvider)
         let activeProvider = selection?.provider ?? defaultProvider
@@ -81,8 +81,8 @@ enum TalkModeGatewayConfigParser {
         defaultSilenceTimeoutMs: Int,
         envVoice: String?,
         sagVoice: String?,
-        envApiKey: String?
-    ) -> TalkModeGatewayConfigState {
+        envApiKey: String?) -> TalkModeGatewayConfigState
+    {
         let resolvedVoice =
             (envVoice?.isEmpty == false ? envVoice : nil) ??
             (sagVoice?.isEmpty == false ? sagVoice : nil)


### PR DESCRIPTION
## Summary
- reapply the SwiftFormat cleanup on top of the latest main
- preserve the newer onboarding states added on main
- fix the newly introduced SwiftFormat blocker in ExecApprovalsGatewayPrompter

## Testing
- swiftformat --lint apps/macos/Sources --config .swiftformat
