### PR TITLE
fix: send auth token in insecure context (LAN HTTP)

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -262,6 +262,17 @@ export class GatewayBrowserClient {
       if (this.pendingDeviceTokenRetry && selectedAuth.authDeviceToken) {
         this.pendingDeviceTokenRetry = false;
       }
+    } else {
+      // In insecure context (HTTP/LAN), skip device identity but still use
+      // explicit token/password if provided. Gateways may reject this unless
+      // gateway.controlUi.allowInsecureAuth is enabled.
+      const explicitToken = this.opts.token?.trim() || undefined;
+      const explicitPassword = this.opts.password?.trim() || undefined;
+      selectedAuth = {
+        authToken: explicitToken,
+        authPassword: explicitPassword,
+        canFallbackToShared: false,
+      };
     }
     const authToken = selectedAuth.authToken;
     const deviceToken = selectedAuth.authDeviceToken ?? selectedAuth.resolvedDeviceToken;


### PR DESCRIPTION
In insecure context (HTTP/LAN), the gateway was not sending the explicitly provided token or password in the connect request, causing 'device identity required' errors even when allowInsecureAuth is enabled.

This fix adds an else branch for insecure context that populates selectedAuth with the explicit token/password from opts, while still skipping device identity (which requires secure context).

Fixes #45481

AI-ASSISTED