### PR TITLE
feat: add embedded attempt failover signals

### DIFF
--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -171,6 +171,7 @@ async function writeAuthStore(
       failureCounts?: Partial<Record<AuthProfileFailureReason, number>>;
     }
   >,
+  extraProfiles?: Record<string, { type: "api_key"; provider: string; key: string }>,
 ) {
   await fs.writeFile(
     path.join(agentDir, "auth-profiles.json"),
@@ -178,12 +179,21 @@ async function writeAuthStore(
       version: 1,
       profiles: {
         "openai:p1": { type: "api_key", provider: "openai", key: "sk-openai" },
+        ...extraProfiles,
         "groq:p1": { type: "api_key", provider: "groq", key: "sk-groq" },
       },
       usageStats:
         usageStats ??
         ({
           "openai:p1": { lastUsed: 1 },
+          ...(extraProfiles
+            ? Object.fromEntries(
+                Object.keys(extraProfiles).map((profileId, index) => [
+                  profileId,
+                  { lastUsed: index + 2 },
+                ]),
+              )
+            : {}),
           "groq:p1": { lastUsed: 2 },
         } as const),
     }),
@@ -421,6 +431,71 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
       expect(usageStats["openai:p1"]?.failureCounts).toMatchObject({ overloaded: 2 });
       expect(computeBackoffMock).toHaveBeenCalledTimes(1);
       expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("falls back after router preflight opens on repeated overloaded primary profiles", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await writeAuthStore(agentDir, undefined, {
+        "openai:p2": { type: "api_key", provider: "openai", key: "sk-openai-2" },
+      });
+      runEmbeddedAttemptMock.mockImplementation(async (params: unknown) => {
+        const attemptParams = params as {
+          provider: string;
+          authProfileId?: string;
+          modelId: string;
+        };
+        if (attemptParams.provider === "openai") {
+          return makeAttempt({
+            assistantTexts: [],
+            lastAssistant: buildAssistant({
+              provider: "openai",
+              model: "mock-1",
+              stopReason: "error",
+              errorMessage: OVERLOADED_ERROR_PAYLOAD,
+            }),
+          });
+        }
+        if (attemptParams.provider === "groq") {
+          return makeAttempt({
+            assistantTexts: ["fallback ok"],
+            lastAssistant: buildAssistant({
+              provider: "groq",
+              model: "mock-2",
+              stopReason: "stop",
+              content: [{ type: "text", text: "fallback ok" }],
+            }),
+          });
+        }
+        throw new Error(`Unexpected provider ${attemptParams.provider}`);
+      });
+
+      const result = await runEmbeddedFallback({
+        agentDir,
+        workspaceDir,
+        sessionKey: "agent:test:router-preflight-fallback",
+        runId: "run:router-preflight-fallback",
+      });
+
+      expect(result.provider).toBe("groq");
+      expect(result.model).toBe("mock-2");
+      expect(result.attempts).toHaveLength(1);
+      expect(result.attempts[0]).toMatchObject({
+        provider: "openai",
+        model: "mock-1",
+        reason: "overloaded",
+      });
+      expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(3);
+      expect(
+        runEmbeddedAttemptMock.mock.calls.map((call) =>
+          (call[0] as { provider?: string; authProfileId?: string } | undefined)?.provider ===
+          "openai"
+            ? (call[0] as { authProfileId?: string }).authProfileId
+            : "groq:p1",
+        ),
+      ).toEqual(["openai:p1", "openai:p2", "groq:p1"]);
+      expect(computeBackoffMock).toHaveBeenCalledTimes(2);
+      expect(sleepWithAbortMock).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -7,7 +7,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import { registerLogTransport, resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { redactIdentifier } from "../logging/redact-identifier.js";
 import type { AuthProfileFailureReason } from "./auth-profiles.js";
-import type { EmbeddedRunAttemptResult } from "./pi-embedded-runner/run/types.js";
+import type {
+  EmbeddedRunAttemptFailoverSignal,
+  EmbeddedRunAttemptResult,
+} from "./pi-embedded-runner/run/types.js";
 
 const runEmbeddedAttemptMock = vi.fn<(params: unknown) => Promise<EmbeddedRunAttemptResult>>();
 const resolveCopilotApiTokenMock = vi.fn();
@@ -294,11 +297,15 @@ const mockFailedThenSuccessfulAttempt = (errorMessage = "rate limit") => {
     );
 };
 
-const mockPromptErrorThenSuccessfulAttempt = (errorMessage: string) => {
+const mockPromptErrorThenSuccessfulAttempt = (
+  errorMessage: string,
+  promptFailureSignal?: EmbeddedRunAttemptFailoverSignal,
+) => {
   runEmbeddedAttemptMock
     .mockResolvedValueOnce(
       makeAttempt({
         promptError: new Error(errorMessage),
+        promptFailureSignal,
       }),
     )
     .mockResolvedValueOnce(
@@ -384,11 +391,12 @@ async function runAutoPinnedPromptErrorRotationCase(params: {
   errorMessage: string;
   sessionKey: string;
   runId: string;
+  promptFailureSignal?: EmbeddedRunAttemptFailoverSignal;
 }) {
   runEmbeddedAttemptMock.mockClear();
   return withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
     await writeAuthStore(agentDir);
-    mockPromptErrorThenSuccessfulAttempt(params.errorMessage);
+    mockPromptErrorThenSuccessfulAttempt(params.errorMessage, params.promptFailureSignal);
     await runAutoPinnedOpenAiTurn({
       agentDir,
       workspaceDir,
@@ -818,6 +826,28 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
     );
     expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
     expect(sleepWithAbortMock).toHaveBeenCalledWith(321, undefined);
+  });
+
+  it("uses prompt failover signal when prompt error text is generic", async () => {
+    const { usageStats } = await runAutoPinnedPromptErrorRotationCase({
+      errorMessage: "request failed",
+      promptFailureSignal: {
+        stage: "prompt",
+        source: "stream_call",
+        provider: "openai",
+        model: "mock-1",
+        reason: "overloaded",
+        status: 503,
+        rawError: "request failed",
+      },
+      sessionKey: "agent:test:structured-overloaded-prompt-rotation",
+      runId: "run:structured-overloaded-prompt-rotation",
+    });
+
+    expect(typeof usageStats["openai:p2"]?.lastUsed).toBe("number");
+    expect(typeof usageStats["openai:p1"]?.cooldownUntil).toBe("number");
+    expect(computeBackoffMock).toHaveBeenCalledTimes(1);
+    expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
   });
 
   it("rotates on timeout without cooling down the timed-out profile", async () => {

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -61,7 +61,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   vi.useRealTimers();
-  runEmbeddedAttemptMock.mockClear();
+  runEmbeddedAttemptMock.mockReset();
   resolveCopilotApiTokenMock.mockReset();
   computeBackoffMock.mockClear();
   sleepWithAbortMock.mockClear();
@@ -213,6 +213,7 @@ const writeAuthStore = async (
   agentDir: string,
   opts?: {
     includeAnthropic?: boolean;
+    extraOpenAiProfiles?: string[];
     usageStats?: Record<
       string,
       {
@@ -226,11 +227,22 @@ const writeAuthStore = async (
   },
 ) => {
   const authPath = path.join(agentDir, "auth-profiles.json");
+  const extraOpenAiProfiles = opts?.extraOpenAiProfiles ?? [];
+  const extraProfileEntries = Object.fromEntries(
+    extraOpenAiProfiles.map((profileId, index) => [
+      profileId,
+      { type: "api_key", provider: "openai", key: `sk-extra-${index + 1}` },
+    ]),
+  );
+  const extraUsageStats = Object.fromEntries(
+    extraOpenAiProfiles.map((profileId, index) => [profileId, { lastUsed: index + 3 }]),
+  );
   const payload = {
     version: 1,
     profiles: {
       "openai:p1": { type: "api_key", provider: "openai", key: "sk-one" },
       "openai:p2": { type: "api_key", provider: "openai", key: "sk-two" },
+      ...extraProfileEntries,
       ...(opts?.includeAnthropic
         ? { "anthropic:default": { type: "api_key", provider: "anthropic", key: "sk-anth" } }
         : {}),
@@ -240,6 +252,7 @@ const writeAuthStore = async (
       ({
         "openai:p1": { lastUsed: 1 },
         "openai:p2": { lastUsed: 2 },
+        ...extraUsageStats,
       } as Record<string, { lastUsed?: number }>),
   };
   await fs.writeFile(authPath, JSON.stringify(payload));
@@ -827,6 +840,74 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
     });
     expect(typeof usageStats["openai:p2"]?.lastUsed).toBe("number");
     expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
+  });
+
+  it("opens model circuit after repeated overloaded failures when fallbacks are configured", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await writeAuthStore(agentDir, {
+        extraOpenAiProfiles: ["openai:p3"],
+      });
+
+      runEmbeddedAttemptMock
+        .mockResolvedValueOnce(
+          makeAttempt({
+            assistantTexts: [],
+            lastAssistant: buildAssistant({
+              stopReason: "error",
+              errorMessage:
+                '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+            }),
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeAttempt({
+            assistantTexts: [],
+            lastAssistant: buildAssistant({
+              stopReason: "error",
+              errorMessage:
+                '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+            }),
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeAttempt({
+            assistantTexts: ["should not reach third profile"],
+            lastAssistant: buildAssistant({
+              stopReason: "stop",
+              content: [{ type: "text", text: "should not reach third profile" }],
+            }),
+          }),
+        );
+
+      await expect(
+        runEmbeddedPiAgent({
+          sessionId: "session:test",
+          sessionKey: "agent:test:opens-model-circuit",
+          sessionFile: path.join(workspaceDir, "session.jsonl"),
+          workspaceDir,
+          agentDir,
+          config: makeConfig({ fallbacks: ["openai/mock-2"] }),
+          prompt: "hello",
+          provider: "openai",
+          model: "mock-1",
+          authProfileIdSource: "auto",
+          timeoutMs: 5_000,
+          runId: "run:opens-model-circuit",
+        }),
+      ).rejects.toMatchObject({
+        name: "FailoverError",
+        reason: "overloaded",
+        provider: "openai",
+        model: "mock-1",
+      });
+
+      expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2);
+      expect(
+        runEmbeddedAttemptMock.mock.calls.map(
+          ([params]) => (params as { authProfileId?: string }).authProfileId,
+        ),
+      ).toEqual(["openai:p1", "openai:p2"]);
+    });
   });
 
   it("does not rotate for compaction timeouts", async () => {

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -326,7 +326,7 @@ async function runAutoPinnedOpenAiTurn(params: {
   runId: string;
   authProfileId?: string;
 }) {
-  await runEmbeddedPiAgent({
+  return await runEmbeddedPiAgent({
     sessionId: "session:test",
     sessionKey: params.sessionKey,
     sessionFile: path.join(params.workspaceDir, "session.jsonl"),

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1039,7 +1039,11 @@ export async function compactEmbeddedPiSession(
   params: CompactEmbeddedPiSessionParams,
 ): Promise<EmbeddedPiCompactResult> {
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
-  const globalLane = resolveGlobalLane(params.lane);
+  const { sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.sessionKey,
+    config: params.config,
+  });
+  const globalLane = resolveGlobalLane(params.lane, sessionAgentId);
   const enqueueGlobal =
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
   return enqueueCommandInLane(sessionLane, () =>
@@ -1072,10 +1076,6 @@ export async function compactEmbeddedPiSession(
         const engineOwnsCompaction = contextEngine.info.ownsCompaction === true;
         const hookRunner = engineOwnsCompaction ? getGlobalHookRunner() : null;
         const hookSessionKey = params.sessionKey?.trim() || params.sessionId;
-        const { sessionAgentId } = resolveSessionAgentIds({
-          sessionKey: params.sessionKey,
-          config: params.config,
-        });
         const resolvedMessageProvider = params.messageChannel ?? params.messageProvider;
         const hookCtx = {
           sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/lanes.test.ts
+++ b/src/agents/pi-embedded-runner/lanes.test.ts
@@ -9,6 +9,12 @@ describe("resolveGlobalLane", () => {
     expect(resolveGlobalLane("  ")).toBe(CommandLane.Main);
   });
 
+  it("partitions default global lane by agent when agent id is provided", () => {
+    expect(resolveGlobalLane(undefined, "risk")).toBe("agent:risk");
+    expect(resolveGlobalLane("", "gateway")).toBe("agent:gateway");
+    expect(resolveGlobalLane("  ", "ops")).toBe("agent:ops");
+  });
+
   it("maps cron lane to nested lane to prevent deadlocks", () => {
     // When cron jobs trigger nested agent runs, the outer execution holds
     // the cron lane slot. Inner work must use a separate lane to avoid
@@ -23,6 +29,11 @@ describe("resolveGlobalLane", () => {
     expect(resolveGlobalLane("nested")).toBe(CommandLane.Nested);
     expect(resolveGlobalLane("custom-lane")).toBe("custom-lane");
     expect(resolveGlobalLane(" custom ")).toBe("custom");
+  });
+
+  it("keeps explicit lane higher priority than inferred agent lane", () => {
+    expect(resolveGlobalLane("main", "risk")).toBe(CommandLane.Main);
+    expect(resolveGlobalLane("custom", "gateway")).toBe("custom");
   });
 });
 

--- a/src/agents/pi-embedded-runner/lanes.ts
+++ b/src/agents/pi-embedded-runner/lanes.ts
@@ -5,13 +5,18 @@ export function resolveSessionLane(key: string) {
   return cleaned.startsWith("session:") ? cleaned : `session:${cleaned}`;
 }
 
-export function resolveGlobalLane(lane?: string) {
+function resolveAgentGlobalLane(agentId?: string) {
+  const cleaned = agentId?.trim();
+  return cleaned ? `agent:${cleaned}` : CommandLane.Main;
+}
+
+export function resolveGlobalLane(lane?: string, agentId?: string) {
   const cleaned = lane?.trim();
   // Cron jobs hold the cron lane slot; inner operations must use nested to avoid deadlock.
   if (cleaned === CommandLane.Cron) {
     return CommandLane.Nested;
   }
-  return cleaned ? cleaned : CommandLane.Main;
+  return cleaned ? cleaned : resolveAgentGlobalLane(agentId);
 }
 
 export function resolveEmbeddedSessionLane(key: string) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -257,7 +257,7 @@ export async function runEmbeddedPiAgent(
   params: RunEmbeddedPiAgentParams,
 ): Promise<EmbeddedPiRunResult> {
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
-  const globalLane = resolveGlobalLane(params.lane);
+  const globalLane = resolveGlobalLane(params.lane, params.agentId);
   const enqueueGlobal =
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
   const enqueueSession =

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1234,7 +1234,8 @@ export async function runEmbeddedPiAgent(
           }
 
           if (promptError && !aborted) {
-            const errorText = describeUnknownError(promptError);
+            const promptFailureSignal = attempt.promptFailureSignal;
+            const errorText = promptFailureSignal?.rawError || describeUnknownError(promptError);
             if (await maybeRefreshCopilotForAuthError(errorText, copilotAuthRetry)) {
               authRetryPending = true;
               continue;
@@ -1298,25 +1299,29 @@ export async function runEmbeddedPiAgent(
                 },
               };
             }
-            const promptFailoverReason = classifyFailoverReason(errorText);
+            const promptFailoverReason =
+              promptFailureSignal?.reason ?? classifyFailoverReason(errorText);
             const promptProfileFailureReason =
               resolveAuthProfileFailureReason(promptFailoverReason);
             await maybeMarkAuthProfileFailure({
               profileId: lastProfileId,
               reason: promptProfileFailureReason,
             });
-            const promptFailoverFailure = isFailoverErrorMessage(errorText);
+            const promptFailoverFailure =
+              Boolean(promptFailureSignal) || isFailoverErrorMessage(errorText);
             // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
             const failedPromptProfileId = lastProfileId;
+            const promptFailureProvider = promptFailureSignal?.provider ?? provider;
+            const promptFailureModel = promptFailureSignal?.model ?? modelId;
             const promptRoute =
               promptFailoverFailure || promptFailoverReason
                 ? failoverRouter.route({
-                    provider,
-                    model: modelId,
+                    provider: promptFailureProvider,
+                    model: promptFailureModel,
                     profileId: failedPromptProfileId,
                     reason: promptFailoverReason,
                     canRotateProfile:
-                      promptFailoverFailure &&
+                      (promptFailoverFailure || Boolean(promptFailureSignal)) &&
                       promptFailoverReason !== "timeout" &&
                       hasRotatableAuthProfile(),
                     fallbackConfigured,
@@ -1328,8 +1333,8 @@ export async function runEmbeddedPiAgent(
               rawError: errorText,
               failoverReason: promptFailoverReason,
               profileFailureReason: promptProfileFailureReason,
-              provider,
-              model: modelId,
+              provider: promptFailureProvider,
+              model: promptFailureModel,
               profileId: failedPromptProfileId,
               fallbackConfigured,
               aborted,
@@ -1366,7 +1371,9 @@ export async function runEmbeddedPiAgent(
               promptFailoverFailure &&
               promptRoute?.decision === "fallback_model"
             ) {
-              const status = resolveFailoverStatus(promptFailoverReason ?? "unknown");
+              const status =
+                promptFailureSignal?.status ??
+                resolveFailoverStatus(promptFailoverReason ?? "unknown");
               logPromptFailoverDecision("fallback_model", {
                 status,
                 circuitOpen: promptRoute.circuitOpen,
@@ -1377,8 +1384,8 @@ export async function runEmbeddedPiAgent(
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
               throw new FailoverError(errorText, {
                 reason: promptFailoverReason ?? "unknown",
-                provider,
-                model: modelId,
+                provider: promptFailureProvider,
+                model: promptFailureModel,
                 profileId: lastProfileId,
                 status,
               });
@@ -1409,22 +1416,32 @@ export async function runEmbeddedPiAgent(
           const authFailure = isAuthAssistantError(lastAssistant);
           const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
           const billingFailure = isBillingAssistantError(lastAssistant);
-          const failoverFailure = isFailoverAssistantError(lastAssistant);
-          const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
+          const assistantFailureSignal = attempt.assistantFailureSignal;
+          const assistantFailoverReason =
+            assistantFailureSignal?.reason ??
+            classifyFailoverReason(lastAssistant?.errorMessage ?? "");
           const assistantProfileFailureReason =
             resolveAuthProfileFailureReason(assistantFailoverReason);
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
           const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
           // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
           const failedAssistantProfileId = lastProfileId;
+          const assistantErrorContext = assistantFailureSignal
+            ? {
+                provider: assistantFailureSignal.provider,
+                model: assistantFailureSignal.model,
+              }
+            : activeErrorContext;
+          const failoverFailure =
+            Boolean(assistantFailureSignal) || isFailoverAssistantError(lastAssistant);
           const logAssistantFailoverDecision = createFailoverDecisionLogger({
             stage: "assistant",
             runId: params.runId,
-            rawError: lastAssistant?.errorMessage?.trim(),
+            rawError: assistantFailureSignal?.rawError ?? lastAssistant?.errorMessage?.trim(),
             failoverReason: assistantFailoverReason,
             profileFailureReason: assistantProfileFailureReason,
-            provider: activeErrorContext.provider,
-            model: activeErrorContext.model,
+            provider: assistantErrorContext.provider,
+            model: assistantErrorContext.model,
             profileId: failedAssistantProfileId,
             fallbackConfigured,
             timedOut,
@@ -1467,8 +1484,8 @@ export async function runEmbeddedPiAgent(
           const routedAssistantReason = timedOut ? "timeout" : assistantFailoverReason;
           const assistantRoute = shouldRotate
             ? failoverRouter.route({
-                provider: activeErrorContext.provider,
-                model: activeErrorContext.model,
+                provider: assistantErrorContext.provider,
+                model: assistantErrorContext.model,
                 profileId: failedAssistantProfileId,
                 reason: routedAssistantReason,
                 canRotateProfile: hasRotatableAuthProfile(),
@@ -1518,10 +1535,11 @@ export async function runEmbeddedPiAgent(
                   ? formatAssistantErrorText(lastAssistant, {
                       cfg: params.config,
                       sessionKey: params.sessionKey ?? params.sessionId,
-                      provider: activeErrorContext.provider,
-                      model: activeErrorContext.model,
+                      provider: assistantErrorContext.provider,
+                      model: assistantErrorContext.model,
                     })
                   : undefined) ||
+                assistantFailureSignal?.rawError ||
                 lastAssistant?.errorMessage?.trim() ||
                 (timedOut
                   ? "LLM request timed out."
@@ -1529,13 +1547,14 @@ export async function runEmbeddedPiAgent(
                     ? "LLM request rate limited."
                     : billingFailure
                       ? formatBillingErrorMessage(
-                          activeErrorContext.provider,
-                          activeErrorContext.model,
+                          assistantErrorContext.provider,
+                          assistantErrorContext.model,
                         )
                       : authFailure
                         ? "LLM request unauthorized."
                         : "LLM request failed.");
               const status =
+                assistantFailureSignal?.status ??
                 resolveFailoverStatus(routedAssistantReason ?? "unknown") ??
                 (isTimeoutErrorMessage(message) ? 408 : undefined);
               logAssistantFailoverDecision("fallback_model", {
@@ -1547,8 +1566,8 @@ export async function runEmbeddedPiAgent(
               });
               throw new FailoverError(message, {
                 reason: routedAssistantReason ?? "unknown",
-                provider: activeErrorContext.provider,
-                model: activeErrorContext.model,
+                provider: assistantErrorContext.provider,
+                model: assistantErrorContext.model,
                 profileId: lastProfileId,
                 status,
               });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -63,6 +63,7 @@ import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
 import { createFailoverDecisionLogger } from "./run/failover-observation.js";
+import { createEmbeddedFailoverRouter } from "./run/failover-router.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import {
@@ -658,6 +659,22 @@ export async function runEmbeddedPiAgent(
         return false;
       };
 
+      const hasRotatableAuthProfile = (): boolean => {
+        if (lockedProfileId) {
+          return false;
+        }
+        let nextIndex = profileIndex + 1;
+        while (nextIndex < profileCandidates.length) {
+          const candidate = profileCandidates[nextIndex];
+          if (candidate && isProfileInCooldown(authStore, candidate)) {
+            nextIndex += 1;
+            continue;
+          }
+          return true;
+        }
+        return false;
+      };
+
       try {
         const autoProfileCandidates = profileCandidates.filter(
           (candidate): candidate is string =>
@@ -749,6 +766,7 @@ export async function runEmbeddedPiAgent(
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
       let overloadFailoverAttempts = 0;
+      const failoverRouter = createEmbeddedFailoverRouter();
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
         reason?: AuthProfileFailureReason | null;
@@ -1290,6 +1308,20 @@ export async function runEmbeddedPiAgent(
             const promptFailoverFailure = isFailoverErrorMessage(errorText);
             // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
             const failedPromptProfileId = lastProfileId;
+            const promptRoute =
+              promptFailoverFailure || promptFailoverReason
+                ? failoverRouter.route({
+                    provider,
+                    model: modelId,
+                    profileId: failedPromptProfileId,
+                    reason: promptFailoverReason,
+                    canRotateProfile:
+                      promptFailoverFailure &&
+                      promptFailoverReason !== "timeout" &&
+                      hasRotatableAuthProfile(),
+                    fallbackConfigured,
+                  })
+                : null;
             const logPromptFailoverDecision = createFailoverDecisionLogger({
               stage: "prompt",
               runId: params.runId,
@@ -1302,14 +1334,18 @@ export async function runEmbeddedPiAgent(
               fallbackConfigured,
               aborted,
             });
-            if (
-              promptFailoverFailure &&
-              promptFailoverReason !== "timeout" &&
-              (await advanceAuthProfile())
-            ) {
-              logPromptFailoverDecision("rotate_profile");
-              await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
-              continue;
+            if (promptRoute?.decision === "rotate_profile") {
+              const advanced = await advanceAuthProfile();
+              if (advanced) {
+                logPromptFailoverDecision("rotate_profile", {
+                  circuitOpen: promptRoute.circuitOpen,
+                  failureCount: promptRoute.failureCount,
+                  threshold: promptRoute.threshold,
+                  scope: promptRoute.scope,
+                });
+                await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
+                continue;
+              }
             }
             const fallbackThinking = pickFallbackThinkingLevel({
               message: errorText,
@@ -1325,9 +1361,19 @@ export async function runEmbeddedPiAgent(
             // Throw FailoverError for prompt-side failover reasons when fallbacks
             // are configured so outer model fallback can continue on overload,
             // rate-limit, auth, or billing failures.
-            if (fallbackConfigured && promptFailoverFailure) {
+            if (
+              fallbackConfigured &&
+              promptFailoverFailure &&
+              promptRoute?.decision === "fallback_model"
+            ) {
               const status = resolveFailoverStatus(promptFailoverReason ?? "unknown");
-              logPromptFailoverDecision("fallback_model", { status });
+              logPromptFailoverDecision("fallback_model", {
+                status,
+                circuitOpen: promptRoute.circuitOpen,
+                failureCount: promptRoute.failureCount,
+                threshold: promptRoute.threshold,
+                scope: promptRoute.scope,
+              });
               await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
               throw new FailoverError(errorText, {
                 reason: promptFailoverReason ?? "unknown",
@@ -1338,7 +1384,12 @@ export async function runEmbeddedPiAgent(
               });
             }
             if (promptFailoverFailure || promptFailoverReason) {
-              logPromptFailoverDecision("surface_error");
+              logPromptFailoverDecision("surface_error", {
+                circuitOpen: promptRoute?.circuitOpen,
+                failureCount: promptRoute?.failureCount,
+                threshold: promptRoute?.threshold,
+                scope: promptRoute?.scope,
+              });
             }
             throw promptError;
           }
@@ -1413,6 +1464,17 @@ export async function runEmbeddedPiAgent(
           // but exclude post-prompt compaction timeouts (model succeeded; no profile issue).
           const shouldRotate =
             (!aborted && failoverFailure) || (timedOut && !timedOutDuringCompaction);
+          const routedAssistantReason = timedOut ? "timeout" : assistantFailoverReason;
+          const assistantRoute = shouldRotate
+            ? failoverRouter.route({
+                provider: activeErrorContext.provider,
+                model: activeErrorContext.model,
+                profileId: failedAssistantProfileId,
+                reason: routedAssistantReason,
+                canRotateProfile: hasRotatableAuthProfile(),
+                fallbackConfigured,
+              })
+            : null;
 
           if (shouldRotate) {
             if (lastProfileId) {
@@ -1434,15 +1496,22 @@ export async function runEmbeddedPiAgent(
               }
             }
 
-            const rotated = await advanceAuthProfile();
-            if (rotated) {
-              logAssistantFailoverDecision("rotate_profile");
-              await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
-              continue;
+            if (assistantRoute?.decision === "rotate_profile") {
+              const rotated = await advanceAuthProfile();
+              if (rotated) {
+                logAssistantFailoverDecision("rotate_profile", {
+                  circuitOpen: assistantRoute.circuitOpen,
+                  failureCount: assistantRoute.failureCount,
+                  threshold: assistantRoute.threshold,
+                  scope: assistantRoute.scope,
+                });
+                await maybeBackoffBeforeOverloadFailover(routedAssistantReason);
+                continue;
+              }
             }
 
-            if (fallbackConfigured) {
-              await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
+            if (fallbackConfigured && assistantRoute?.decision === "fallback_model") {
+              await maybeBackoffBeforeOverloadFailover(routedAssistantReason);
               // Prefer formatted error message (user-friendly) over raw errorMessage
               const message =
                 (lastAssistant
@@ -1467,18 +1536,29 @@ export async function runEmbeddedPiAgent(
                         ? "LLM request unauthorized."
                         : "LLM request failed.");
               const status =
-                resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
+                resolveFailoverStatus(routedAssistantReason ?? "unknown") ??
                 (isTimeoutErrorMessage(message) ? 408 : undefined);
-              logAssistantFailoverDecision("fallback_model", { status });
+              logAssistantFailoverDecision("fallback_model", {
+                status,
+                circuitOpen: assistantRoute.circuitOpen,
+                failureCount: assistantRoute.failureCount,
+                threshold: assistantRoute.threshold,
+                scope: assistantRoute.scope,
+              });
               throw new FailoverError(message, {
-                reason: assistantFailoverReason ?? "unknown",
+                reason: routedAssistantReason ?? "unknown",
                 provider: activeErrorContext.provider,
                 model: activeErrorContext.model,
                 profileId: lastProfileId,
                 status,
               });
             }
-            logAssistantFailoverDecision("surface_error");
+            logAssistantFailoverDecision("surface_error", {
+              circuitOpen: assistantRoute?.circuitOpen,
+              failureCount: assistantRoute?.failureCount,
+              threshold: assistantRoute?.threshold,
+              scope: assistantRoute?.scope,
+            });
           }
 
           const usage = toNormalizedUsage(usageAccumulator);

--- a/src/agents/pi-embedded-runner/run/attempt-router.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-router.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { createEmbeddedAttemptRouter } from "./attempt-router.js";
+
+describe("createEmbeddedAttemptRouter", () => {
+  it("opens an overloaded breaker after repeated failures and blocks preflight calls", () => {
+    let now = 1_000;
+    const router = createEmbeddedAttemptRouter({
+      now: () => now,
+    });
+
+    expect(
+      router.recordFailure({
+        provider: "openai",
+        model: "gpt-5.4",
+        reason: "overloaded",
+        status: 503,
+        rawError: "provider overloaded",
+      }),
+    ).toMatchObject({
+      circuitOpen: false,
+      failureCount: 1,
+      threshold: 2,
+    });
+
+    expect(
+      router.recordFailure({
+        provider: "openai",
+        model: "gpt-5.4",
+        reason: "overloaded",
+        status: 503,
+        rawError: "provider overloaded again",
+      }),
+    ).toMatchObject({
+      circuitOpen: true,
+      failureCount: 2,
+      threshold: 2,
+    });
+
+    expect(
+      router.inspect({
+        provider: "openai",
+        model: "gpt-5.4",
+      }),
+    ).toMatchObject({
+      reason: "overloaded",
+      status: 503,
+      failureCount: 2,
+      threshold: 2,
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+  });
+
+  it("lets calls through again after the breaker TTL expires", () => {
+    let now = 5_000;
+    const router = createEmbeddedAttemptRouter({
+      now: () => now,
+      breakerTtlMs: {
+        overloaded: 200,
+      },
+    });
+
+    router.recordFailure({
+      provider: "openai",
+      model: "gpt-5.4",
+      reason: "overloaded",
+      status: 503,
+      rawError: "provider overloaded",
+    });
+    router.recordFailure({
+      provider: "openai",
+      model: "gpt-5.4",
+      reason: "overloaded",
+      status: 503,
+      rawError: "provider overloaded again",
+    });
+
+    expect(
+      router.inspect({
+        provider: "openai",
+        model: "gpt-5.4",
+      }),
+    ).not.toBeNull();
+
+    now += 250;
+
+    expect(
+      router.inspect({
+        provider: "openai",
+        model: "gpt-5.4",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps breaker state isolated per provider/model", () => {
+    const router = createEmbeddedAttemptRouter();
+
+    router.recordFailure({
+      provider: "openai",
+      model: "gpt-5.4",
+      reason: "timeout",
+      status: 408,
+      rawError: "timed out",
+    });
+    router.recordFailure({
+      provider: "openai",
+      model: "gpt-5.4",
+      reason: "timeout",
+      status: 408,
+      rawError: "timed out again",
+    });
+
+    expect(
+      router.inspect({
+        provider: "openai",
+        model: "gpt-5.2",
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt-router.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-router.ts
@@ -1,0 +1,187 @@
+import { resolveFailoverStatus } from "../../failover-error.js";
+import type { FailoverReason } from "../../pi-embedded-helpers.js";
+
+type EmbeddedAttemptBreakerReason = Extract<FailoverReason, "overloaded" | "timeout">;
+
+type EmbeddedAttemptRouterState = {
+  provider: string;
+  model: string;
+  reason: EmbeddedAttemptBreakerReason;
+  failureCount: number;
+  threshold: number;
+  status?: number;
+  rawError: string;
+  lastFailureAt: number;
+  openUntil?: number;
+};
+
+export type EmbeddedAttemptRouterInspection = {
+  provider: string;
+  model: string;
+  reason: EmbeddedAttemptBreakerReason;
+  status?: number;
+  rawError: string;
+  failureCount: number;
+  threshold: number;
+  remainingMs: number;
+};
+
+export type EmbeddedAttemptRouterFailureRecord = {
+  provider: string;
+  model: string;
+  reason: FailoverReason | null;
+  status?: number;
+  rawError: string;
+};
+
+export type EmbeddedAttemptRouterFailureResult = {
+  circuitOpen: boolean;
+  failureCount: number;
+  threshold: number;
+};
+
+const BREAKER_REASONS: EmbeddedAttemptBreakerReason[] = ["overloaded", "timeout"];
+
+const DEFAULT_BREAKER_THRESHOLDS: Record<EmbeddedAttemptBreakerReason, number> = {
+  overloaded: 2,
+  timeout: 2,
+};
+
+const DEFAULT_BREAKER_TTLS_MS: Record<EmbeddedAttemptBreakerReason, number> = {
+  overloaded: 1_500,
+  timeout: 1_500,
+};
+
+function isBreakerReason(reason: FailoverReason | null): reason is EmbeddedAttemptBreakerReason {
+  return reason === "overloaded" || reason === "timeout";
+}
+
+function buildReasonKey(params: {
+  provider: string;
+  model: string;
+  reason: EmbeddedAttemptBreakerReason;
+}) {
+  return `${params.provider}:${params.model}:${params.reason}`;
+}
+
+function buildOpenCircuitMessage(params: {
+  provider: string;
+  model: string;
+  reason: EmbeddedAttemptBreakerReason;
+  remainingMs: number;
+}) {
+  return (
+    `embedded attempt circuit open for ${params.provider}/${params.model} ` +
+    `after repeated ${params.reason} failures; retry in ${params.remainingMs}ms`
+  );
+}
+
+export function createEmbeddedAttemptRouter(options?: {
+  now?: () => number;
+  breakerThresholds?: Partial<Record<EmbeddedAttemptBreakerReason, number>>;
+  breakerTtlMs?: Partial<Record<EmbeddedAttemptBreakerReason, number>>;
+}) {
+  const now = options?.now ?? (() => Date.now());
+  const breakerThresholds = {
+    ...DEFAULT_BREAKER_THRESHOLDS,
+    ...options?.breakerThresholds,
+  };
+  const breakerTtlMs = {
+    ...DEFAULT_BREAKER_TTLS_MS,
+    ...options?.breakerTtlMs,
+  };
+  const states = new Map<string, EmbeddedAttemptRouterState>();
+
+  const clearExpired = (provider: string, model: string, currentNow: number) => {
+    for (const reason of BREAKER_REASONS) {
+      const key = buildReasonKey({ provider, model, reason });
+      const state = states.get(key);
+      if (!state) {
+        continue;
+      }
+      if (state.openUntil !== undefined && state.openUntil <= currentNow) {
+        states.delete(key);
+      }
+    }
+  };
+
+  return {
+    inspect(input: { provider: string; model: string }): EmbeddedAttemptRouterInspection | null {
+      const currentNow = now();
+      clearExpired(input.provider, input.model, currentNow);
+      for (const reason of BREAKER_REASONS) {
+        const key = buildReasonKey({
+          provider: input.provider,
+          model: input.model,
+          reason,
+        });
+        const state = states.get(key);
+        if (!state || state.openUntil === undefined || state.openUntil <= currentNow) {
+          continue;
+        }
+        const remainingMs = Math.max(1, state.openUntil - currentNow);
+        return {
+          provider: state.provider,
+          model: state.model,
+          reason: state.reason,
+          status: state.status,
+          rawError: buildOpenCircuitMessage({
+            provider: state.provider,
+            model: state.model,
+            reason: state.reason,
+            remainingMs,
+          }),
+          failureCount: state.failureCount,
+          threshold: state.threshold,
+          remainingMs,
+        };
+      }
+      return null;
+    },
+
+    recordFailure(
+      input: EmbeddedAttemptRouterFailureRecord,
+    ): EmbeddedAttemptRouterFailureResult | null {
+      if (!isBreakerReason(input.reason)) {
+        return null;
+      }
+      const currentNow = now();
+      const key = buildReasonKey({
+        provider: input.provider,
+        model: input.model,
+        reason: input.reason,
+      });
+      const threshold = breakerThresholds[input.reason];
+      const nextFailureCount = (states.get(key)?.failureCount ?? 0) + 1;
+      const circuitOpen = nextFailureCount >= threshold;
+      states.set(key, {
+        provider: input.provider,
+        model: input.model,
+        reason: input.reason,
+        failureCount: nextFailureCount,
+        threshold,
+        status: input.status ?? resolveFailoverStatus(input.reason),
+        rawError: input.rawError,
+        lastFailureAt: currentNow,
+        ...(circuitOpen ? { openUntil: currentNow + breakerTtlMs[input.reason] } : {}),
+      });
+      return {
+        circuitOpen,
+        failureCount: nextFailureCount,
+        threshold,
+      };
+    },
+
+    recordSuccess(input: { provider: string; model: string }) {
+      for (const reason of BREAKER_REASONS) {
+        states.delete(
+          buildReasonKey({
+            provider: input.provider,
+            model: input.model,
+            reason,
+          }),
+        );
+      }
+    },
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -4,6 +4,7 @@ import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";
 import {
   buildAfterTurnRuntimeContext,
   composeSystemPromptWithHookContext,
+  wrapStreamFnCaptureFailoverSignal,
   isOllamaCompatProvider,
   prependSystemPromptAddition,
   resolveAttemptFsWorkspaceOnly,
@@ -103,6 +104,42 @@ describe("resolvePromptBuildHookResult", () => {
     expect(result.prependContext).toBe("prompt context\n\nlegacy context");
     expect(result.prependSystemContext).toBe("prompt prepend\n\nlegacy prepend");
     expect(result.appendSystemContext).toBe("prompt append\n\nlegacy append");
+  });
+});
+
+describe("wrapStreamFnCaptureFailoverSignal", () => {
+  it("captures prompt failover signal from stream failures", async () => {
+    const failures: Array<Record<string, unknown>> = [];
+    const baseFn = vi.fn(async () => {
+      const err = new Error("request failed");
+      Object.assign(err, { status: 429 });
+      throw err;
+    });
+
+    const wrapped = wrapStreamFnCaptureFailoverSignal(baseFn as never, {
+      stage: "prompt",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.4",
+      onFailure: (failure) => {
+        failures.push(failure as unknown as Record<string, unknown>);
+      },
+    });
+
+    await expect(
+      wrapped({ provider: "openai", id: "gpt-5.4" } as never, {} as never, {} as never),
+    ).rejects.toThrow("request failed");
+
+    expect(failures).toEqual([
+      expect.objectContaining({
+        stage: "prompt",
+        source: "stream_call",
+        provider: "openai",
+        model: "gpt-5.4",
+        reason: "rate_limit",
+        status: 429,
+        rawError: "request failed",
+      }),
+    ]);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveOllamaBaseUrlForRun } from "../../ollama-stream.js";
+import { createEmbeddedAttemptRouter } from "./attempt-router.js";
 import {
   buildAfterTurnRuntimeContext,
   composeSystemPromptWithHookContext,
@@ -140,6 +141,50 @@ describe("wrapStreamFnCaptureFailoverSignal", () => {
         rawError: "request failed",
       }),
     ]);
+  });
+
+  it("short-circuits repeated overloaded calls through the attempt router preflight", async () => {
+    const failures: Array<Record<string, unknown>> = [];
+    const baseFn = vi.fn(async () => {
+      const err = new Error("provider overloaded");
+      Object.assign(err, { status: 503 });
+      throw err;
+    });
+    const router = createEmbeddedAttemptRouter({
+      now: () => 1_000,
+    });
+
+    const wrapped = wrapStreamFnCaptureFailoverSignal(baseFn as never, {
+      stage: "prompt",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.4",
+      router,
+      onFailure: (failure) => {
+        failures.push(failure as unknown as Record<string, unknown>);
+      },
+    });
+
+    await expect(
+      wrapped({ provider: "openai", id: "gpt-5.4" } as never, {} as never, {} as never),
+    ).rejects.toThrow("provider overloaded");
+    await expect(
+      wrapped({ provider: "openai", id: "gpt-5.4" } as never, {} as never, {} as never),
+    ).rejects.toThrow("provider overloaded");
+    expect(() =>
+      wrapped({ provider: "openai", id: "gpt-5.4" } as never, {} as never, {} as never),
+    ).toThrow(/circuit open/i);
+
+    expect(baseFn).toHaveBeenCalledTimes(2);
+    expect(failures.at(-1)).toEqual(
+      expect.objectContaining({
+        stage: "prompt",
+        source: "router_preflight",
+        provider: "openai",
+        model: "gpt-5.4",
+        reason: "overloaded",
+        status: 503,
+      }),
+    );
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -49,7 +49,7 @@ import {
 import { ensureCustomApiRegistered } from "../../custom-api-registry.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawDocsPath } from "../../docs-path.js";
-import { isTimeoutError, resolveFailoverStatus } from "../../failover-error.js";
+import { FailoverError, isTimeoutError, resolveFailoverStatus } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { normalizeProviderId, resolveDefaultModelForAgent } from "../../model-selection.js";
@@ -130,6 +130,7 @@ import { installToolResultContextGuard } from "../tool-result-context-guard.js";
 import { splitSdkTools } from "../tool-split.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
+import { createEmbeddedAttemptRouter } from "./attempt-router.js";
 import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
 import {
   selectCompactionTimeoutSnapshot,
@@ -857,11 +858,12 @@ export function buildEmbeddedAttemptFailoverSignal(params: {
   error?: unknown;
   rawError?: string | null;
   timedOut?: boolean;
+  status?: number;
 }): EmbeddedRunAttemptFailoverSignal | undefined {
   const rawError = (
     params.rawError?.trim() || (params.error ? describeUnknownError(params.error) : "")
   ).trim();
-  const status = extractErrorStatus(params.error);
+  const status = params.status ?? extractErrorStatus(params.error);
   const timedOut =
     params.timedOut === true ||
     (params.error ? isTimeoutError(params.error) : false) ||
@@ -899,6 +901,7 @@ function wrapStreamCaptureFailoverSignal(
     defaultProvider: string;
     defaultModel: string;
     model: { provider?: string; id?: string };
+    router?: ReturnType<typeof createEmbeddedAttemptRouter>;
     onFailure: (failure: EmbeddedRunAttemptFailoverSignal) => void;
   },
 ): ReturnType<typeof streamSimple> {
@@ -924,6 +927,13 @@ function wrapStreamCaptureFailoverSignal(
     if (!failure) {
       return;
     }
+    params.router?.recordFailure({
+      provider: failure.provider,
+      model: failure.model,
+      reason: failure.reason,
+      status: failure.status,
+      rawError: failure.rawError,
+    });
     reported = true;
     params.onFailure(failure);
   };
@@ -931,7 +941,9 @@ function wrapStreamCaptureFailoverSignal(
   const originalResult = stream.result.bind(stream);
   stream.result = async () => {
     try {
-      return await originalResult();
+      const result = await originalResult();
+      params.router?.recordSuccess(resolveAttemptSignalModelRef(params));
+      return result;
     } catch (error) {
       reportFailure(error, "stream_result");
       throw error;
@@ -945,7 +957,11 @@ function wrapStreamCaptureFailoverSignal(
       return {
         async next() {
           try {
-            return await iterator.next();
+            const result = await iterator.next();
+            if (result.done) {
+              params.router?.recordSuccess(resolveAttemptSignalModelRef(params));
+            }
+            return result;
           } catch (error) {
             reportFailure(error, "stream_iterator");
             throw error;
@@ -969,20 +985,57 @@ export function wrapStreamFnCaptureFailoverSignal(
     stage: EmbeddedRunAttemptFailoverSignal["stage"];
     defaultProvider: string;
     defaultModel: string;
+    router?: ReturnType<typeof createEmbeddedAttemptRouter>;
     onFailure: (failure: EmbeddedRunAttemptFailoverSignal) => void;
   },
 ): StreamFn {
   return (model, context, options) => {
+    const modelRef = model as { provider?: string; id?: string };
+    const resolvedModelRef = resolveAttemptSignalModelRef({
+      model: modelRef,
+      defaultProvider: params.defaultProvider,
+      defaultModel: params.defaultModel,
+    });
+    const preflight = params.router?.inspect(resolvedModelRef);
+    if (preflight) {
+      const failure = buildEmbeddedAttemptFailoverSignal({
+        stage: params.stage,
+        source: "router_preflight",
+        defaultProvider: params.defaultProvider,
+        defaultModel: params.defaultModel,
+        model: resolvedModelRef,
+        rawError: preflight.rawError,
+        timedOut: preflight.reason === "timeout",
+        status: preflight.status,
+      });
+      if (failure) {
+        params.onFailure(failure);
+        throw new FailoverError(failure.rawError, {
+          reason: failure.reason ?? "unknown",
+          provider: failure.provider,
+          model: failure.model,
+          status: failure.status,
+        });
+      }
+    }
+
     const reportCallFailure = (error: unknown) => {
       const failure = buildEmbeddedAttemptFailoverSignal({
         stage: params.stage,
         source: "stream_call",
         defaultProvider: params.defaultProvider,
         defaultModel: params.defaultModel,
-        model: model as { provider?: string; id?: string },
+        model: modelRef,
         error,
       });
       if (failure) {
+        params.router?.recordFailure({
+          provider: failure.provider,
+          model: failure.model,
+          reason: failure.reason,
+          status: failure.status,
+          rawError: failure.rawError,
+        });
         params.onFailure(failure);
       }
     };
@@ -993,7 +1046,7 @@ export function wrapStreamFnCaptureFailoverSignal(
           (stream) =>
             wrapStreamCaptureFailoverSignal(stream, {
               ...params,
-              model: model as { provider?: string; id?: string },
+              model: modelRef,
             }),
           (error) => {
             reportCallFailure(error);
@@ -1003,7 +1056,7 @@ export function wrapStreamFnCaptureFailoverSignal(
       }
       return wrapStreamCaptureFailoverSignal(maybeStream, {
         ...params,
-        model: model as { provider?: string; id?: string },
+        model: modelRef,
       });
     } catch (error) {
       reportCallFailure(error);
@@ -2292,12 +2345,14 @@ export async function runEmbeddedAttempt(
       }
 
       let promptFailureSignal: EmbeddedRunAttemptFailoverSignal | undefined;
+      const attemptRouter = createEmbeddedAttemptRouter();
       activeSession.agent.streamFn = wrapStreamFnCaptureFailoverSignal(
         activeSession.agent.streamFn,
         {
           stage: "prompt",
           defaultProvider: params.provider,
           defaultModel: params.modelId,
+          router: attemptRouter,
           onFailure: (failure) => {
             promptFailureSignal ??= failure;
           },

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -49,7 +49,7 @@ import {
 import { ensureCustomApiRegistered } from "../../custom-api-registry.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawDocsPath } from "../../docs-path.js";
-import { isTimeoutError } from "../../failover-error.js";
+import { isTimeoutError, resolveFailoverStatus } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { normalizeProviderId, resolveDefaultModelForAgent } from "../../model-selection.js";
@@ -58,11 +58,14 @@ import { createConfiguredOllamaStreamFn } from "../../ollama-stream.js";
 import { createOpenAIWebSocketStreamFn, releaseWsSession } from "../../openai-ws-stream.js";
 import { resolveOwnerDisplaySetting } from "../../owner-display.js";
 import {
+  classifyFailoverReason,
   downgradeOpenAIFunctionCallReasoningPairs,
   isCloudCodeAssistFormatError,
+  isTimeoutErrorMessage,
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
+  type FailoverReason,
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../../pi-embedded-helpers.js";
@@ -134,7 +137,11 @@ import {
 } from "./compaction-timeout.js";
 import { pruneProcessedHistoryImages } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
-import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
+import type {
+  EmbeddedRunAttemptFailoverSignal,
+  EmbeddedRunAttemptParams,
+  EmbeddedRunAttemptResult,
+} from "./types.js";
 
 type PromptBuildHookRunner = {
   hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
@@ -778,6 +785,230 @@ export function wrapStreamFnTrimToolCallNames(
       );
     }
     return wrapStreamTrimToolCallNames(maybeStream, allowedToolNames);
+  };
+}
+
+function extractErrorStatus(error: unknown): number | undefined {
+  const statusCandidates = [
+    (error as { status?: unknown } | null)?.status,
+    (error as { statusCode?: unknown } | null)?.statusCode,
+    (error as { cause?: { status?: unknown; statusCode?: unknown } } | null)?.cause?.status,
+    (error as { cause?: { status?: unknown; statusCode?: unknown } } | null)?.cause?.statusCode,
+  ];
+  for (const candidate of statusCandidates) {
+    if (typeof candidate === "number" && Number.isFinite(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function resolveFailoverReasonFromStatus(status: number | undefined): FailoverReason | null {
+  switch (status) {
+    case 401:
+      return "auth";
+    case 402:
+      return "billing";
+    case 408:
+      return "timeout";
+    case 429:
+      return "rate_limit";
+    case 503:
+      return "overloaded";
+    default:
+      return null;
+  }
+}
+
+function resolveAttemptFailoverReason(params: {
+  rawError: string;
+  status?: number;
+  timedOut?: boolean;
+}): FailoverReason | null {
+  if (params.timedOut) {
+    return "timeout";
+  }
+  return resolveFailoverReasonFromStatus(params.status) ?? classifyFailoverReason(params.rawError);
+}
+
+function resolveAttemptSignalModelRef(params: {
+  model: { provider?: string; id?: string };
+  defaultProvider: string;
+  defaultModel: string;
+}) {
+  return {
+    provider:
+      typeof params.model.provider === "string" && params.model.provider.trim().length > 0
+        ? params.model.provider
+        : params.defaultProvider,
+    model:
+      typeof params.model.id === "string" && params.model.id.trim().length > 0
+        ? params.model.id
+        : params.defaultModel,
+  };
+}
+
+export function buildEmbeddedAttemptFailoverSignal(params: {
+  stage: EmbeddedRunAttemptFailoverSignal["stage"];
+  source: EmbeddedRunAttemptFailoverSignal["source"];
+  defaultProvider: string;
+  defaultModel: string;
+  model?: { provider?: string; id?: string };
+  error?: unknown;
+  rawError?: string | null;
+  timedOut?: boolean;
+}): EmbeddedRunAttemptFailoverSignal | undefined {
+  const rawError = (
+    params.rawError?.trim() || (params.error ? describeUnknownError(params.error) : "")
+  ).trim();
+  const status = extractErrorStatus(params.error);
+  const timedOut =
+    params.timedOut === true ||
+    (params.error ? isTimeoutError(params.error) : false) ||
+    isTimeoutErrorMessage(rawError);
+  const reason = resolveAttemptFailoverReason({
+    rawError,
+    status,
+    timedOut,
+  });
+  const effectiveStatus = status ?? (reason ? resolveFailoverStatus(reason) : undefined);
+  if (!reason && !timedOut) {
+    return undefined;
+  }
+  const modelRef = resolveAttemptSignalModelRef({
+    model: params.model ?? {},
+    defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
+  });
+  return {
+    stage: params.stage,
+    source: params.source,
+    provider: modelRef.provider,
+    model: modelRef.model,
+    reason,
+    status: effectiveStatus,
+    rawError,
+    timedOut: timedOut || undefined,
+  };
+}
+
+function wrapStreamCaptureFailoverSignal(
+  stream: ReturnType<typeof streamSimple>,
+  params: {
+    stage: EmbeddedRunAttemptFailoverSignal["stage"];
+    defaultProvider: string;
+    defaultModel: string;
+    model: { provider?: string; id?: string };
+    onFailure: (failure: EmbeddedRunAttemptFailoverSignal) => void;
+  },
+): ReturnType<typeof streamSimple> {
+  let reported = false;
+  const reportFailure = (
+    error: unknown,
+    source: Extract<
+      EmbeddedRunAttemptFailoverSignal["source"],
+      "stream_result" | "stream_iterator"
+    >,
+  ) => {
+    if (reported) {
+      return;
+    }
+    const failure = buildEmbeddedAttemptFailoverSignal({
+      stage: params.stage,
+      source,
+      defaultProvider: params.defaultProvider,
+      defaultModel: params.defaultModel,
+      model: params.model,
+      error,
+    });
+    if (!failure) {
+      return;
+    }
+    reported = true;
+    params.onFailure(failure);
+  };
+
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    try {
+      return await originalResult();
+    } catch (error) {
+      reportFailure(error, "stream_result");
+      throw error;
+    }
+  };
+
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
+    function () {
+      const iterator = originalAsyncIterator();
+      return {
+        async next() {
+          try {
+            return await iterator.next();
+          } catch (error) {
+            reportFailure(error, "stream_iterator");
+            throw error;
+          }
+        },
+        async return(value?: unknown) {
+          return iterator.return?.(value) ?? { done: true as const, value: undefined };
+        },
+        async throw(error?: unknown) {
+          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+        },
+      };
+    };
+
+  return stream;
+}
+
+export function wrapStreamFnCaptureFailoverSignal(
+  baseFn: StreamFn,
+  params: {
+    stage: EmbeddedRunAttemptFailoverSignal["stage"];
+    defaultProvider: string;
+    defaultModel: string;
+    onFailure: (failure: EmbeddedRunAttemptFailoverSignal) => void;
+  },
+): StreamFn {
+  return (model, context, options) => {
+    const reportCallFailure = (error: unknown) => {
+      const failure = buildEmbeddedAttemptFailoverSignal({
+        stage: params.stage,
+        source: "stream_call",
+        defaultProvider: params.defaultProvider,
+        defaultModel: params.defaultModel,
+        model: model as { provider?: string; id?: string },
+        error,
+      });
+      if (failure) {
+        params.onFailure(failure);
+      }
+    };
+    try {
+      const maybeStream = baseFn(model, context, options);
+      if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+        return Promise.resolve(maybeStream).then(
+          (stream) =>
+            wrapStreamCaptureFailoverSignal(stream, {
+              ...params,
+              model: model as { provider?: string; id?: string },
+            }),
+          (error) => {
+            reportCallFailure(error);
+            throw error;
+          },
+        );
+      }
+      return wrapStreamCaptureFailoverSignal(maybeStream, {
+        ...params,
+        model: model as { provider?: string; id?: string },
+      });
+    } catch (error) {
+      reportCallFailure(error);
+      throw error;
+    }
   };
 }
 
@@ -2060,6 +2291,19 @@ export async function runEmbeddedAttempt(
         );
       }
 
+      let promptFailureSignal: EmbeddedRunAttemptFailoverSignal | undefined;
+      activeSession.agent.streamFn = wrapStreamFnCaptureFailoverSignal(
+        activeSession.agent.streamFn,
+        {
+          stage: "prompt",
+          defaultProvider: params.provider,
+          defaultModel: params.modelId,
+          onFailure: (failure) => {
+            promptFailureSignal ??= failure;
+          },
+        },
+      );
+
       try {
         const prior = await sanitizeSessionHistory({
           messages: activeSession.messages,
@@ -2724,6 +2968,33 @@ export async function runEmbeddedAttempt(
         .slice()
         .toReversed()
         .find((m) => m.role === "assistant");
+      const resolvedPromptFailureSignal =
+        !timedOutDuringCompaction && promptError
+          ? (promptFailureSignal ??
+            buildEmbeddedAttemptFailoverSignal({
+              stage: "prompt",
+              source: "prompt_error",
+              defaultProvider: params.provider,
+              defaultModel: params.modelId,
+              error: promptError,
+            }))
+          : undefined;
+      const assistantFailureSignal =
+        !timedOutDuringCompaction && (timedOut || lastAssistant?.errorMessage)
+          ? buildEmbeddedAttemptFailoverSignal({
+              stage: "assistant",
+              source: timedOut ? "timeout" : "assistant_error",
+              defaultProvider: params.provider,
+              defaultModel: params.modelId,
+              model: {
+                provider:
+                  typeof lastAssistant?.provider === "string" ? lastAssistant.provider : undefined,
+                id: typeof lastAssistant?.model === "string" ? lastAssistant.model : undefined,
+              },
+              rawError: lastAssistant?.errorMessage?.trim(),
+              timedOut: timedOut && !timedOutDuringCompaction,
+            })
+          : undefined;
 
       const toolMetasNormalized = toolMetas
         .filter(
@@ -2781,6 +3052,8 @@ export async function runEmbeddedAttempt(
         cloudCodeAssistFormatError: Boolean(
           lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),
         ),
+        promptFailureSignal: resolvedPromptFailureSignal,
+        assistantFailureSignal,
         attemptUsage: getUsageTotals(),
         compactionCount: getCompactionCount(),
         // Client tool call detected (OpenResponses hosted tools)

--- a/src/agents/pi-embedded-runner/run/failover-observation.ts
+++ b/src/agents/pi-embedded-runner/run/failover-observation.ts
@@ -35,11 +35,14 @@ export function normalizeFailoverDecisionObservationBase(
   };
 }
 
-export function createFailoverDecisionLogger(
-  base: FailoverDecisionLoggerBase,
-): (
+export function createFailoverDecisionLogger(base: FailoverDecisionLoggerBase): (
   decision: FailoverDecisionLoggerInput["decision"],
-  extra?: Pick<FailoverDecisionLoggerInput, "status">,
+  extra?: Pick<FailoverDecisionLoggerInput, "status"> & {
+    circuitOpen?: boolean;
+    failureCount?: number;
+    threshold?: number | null;
+    scope?: "model" | "profile";
+  },
 ) => void {
   const normalizedBase = normalizeFailoverDecisionObservationBase(base);
   const safeProfileId = normalizedBase.profileId
@@ -67,10 +70,17 @@ export function createFailoverDecisionLogger(
       timedOut: normalizedBase.timedOut,
       aborted: normalizedBase.aborted,
       status: extra?.status,
+      circuitOpen: extra?.circuitOpen,
+      failureCount: extra?.failureCount,
+      threshold: extra?.threshold,
+      scope: extra?.scope,
       ...observedError,
       consoleMessage:
         `embedded run failover decision: runId=${safeRunId} stage=${normalizedBase.stage} decision=${decision} ` +
-        `reason=${reasonText} provider=${safeProvider}/${safeModel} profile=${profileText}`,
+        `reason=${reasonText} provider=${safeProvider}/${safeModel} profile=${profileText}` +
+        (extra?.circuitOpen
+          ? ` circuit=open scope=${extra.scope ?? "-"} count=${extra.failureCount ?? "-"} threshold=${extra.threshold ?? "-"}`
+          : ""),
     });
   };
 }

--- a/src/agents/pi-embedded-runner/run/failover-router.test.ts
+++ b/src/agents/pi-embedded-runner/run/failover-router.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { createEmbeddedFailoverRouter } from "./failover-router.js";
+
+describe("createEmbeddedFailoverRouter", () => {
+  it("opens a model circuit after repeated overloaded failures on the same model", () => {
+    const router = createEmbeddedFailoverRouter();
+
+    expect(
+      router.route({
+        provider: "openai",
+        model: "gpt-5.4",
+        profileId: "openai:p1",
+        reason: "overloaded",
+        canRotateProfile: true,
+        fallbackConfigured: true,
+      }),
+    ).toMatchObject({
+      decision: "rotate_profile",
+      circuitOpen: false,
+      failureCount: 1,
+      threshold: 2,
+      scope: "model",
+    });
+
+    expect(
+      router.route({
+        provider: "openai",
+        model: "gpt-5.4",
+        profileId: "openai:p2",
+        reason: "overloaded",
+        canRotateProfile: true,
+        fallbackConfigured: true,
+      }),
+    ).toMatchObject({
+      decision: "fallback_model",
+      circuitOpen: true,
+      failureCount: 2,
+      threshold: 2,
+      scope: "model",
+    });
+  });
+
+  it("opens a model circuit after repeated timeout failures on the same model", () => {
+    const router = createEmbeddedFailoverRouter();
+
+    router.route({
+      provider: "openai",
+      model: "gpt-5.4",
+      profileId: "openai:p1",
+      reason: "timeout",
+      canRotateProfile: true,
+      fallbackConfigured: true,
+    });
+
+    expect(
+      router.route({
+        provider: "openai",
+        model: "gpt-5.4",
+        profileId: "openai:p2",
+        reason: "timeout",
+        canRotateProfile: true,
+        fallbackConfigured: true,
+      }),
+    ).toMatchObject({
+      decision: "fallback_model",
+      circuitOpen: true,
+      failureCount: 2,
+      threshold: 2,
+      scope: "model",
+    });
+  });
+
+  it("keeps non-breaker reasons on profile rotation path", () => {
+    const router = createEmbeddedFailoverRouter();
+
+    expect(
+      router.route({
+        provider: "openai",
+        model: "gpt-5.4",
+        profileId: "openai:p1",
+        reason: "rate_limit",
+        canRotateProfile: true,
+        fallbackConfigured: true,
+      }),
+    ).toMatchObject({
+      decision: "rotate_profile",
+      circuitOpen: false,
+      failureCount: 1,
+      threshold: null,
+      scope: "profile",
+    });
+  });
+
+  it("isolates model-level circuit counts by provider/model", () => {
+    const router = createEmbeddedFailoverRouter();
+
+    router.route({
+      provider: "openai",
+      model: "gpt-5.4",
+      profileId: "openai:p1",
+      reason: "overloaded",
+      canRotateProfile: true,
+      fallbackConfigured: true,
+    });
+
+    expect(
+      router.route({
+        provider: "openai",
+        model: "gpt-5.2",
+        profileId: "openai:p2",
+        reason: "overloaded",
+        canRotateProfile: true,
+        fallbackConfigured: true,
+      }),
+    ).toMatchObject({
+      decision: "rotate_profile",
+      circuitOpen: false,
+      failureCount: 1,
+      threshold: 2,
+      scope: "model",
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run/failover-router.ts
+++ b/src/agents/pi-embedded-runner/run/failover-router.ts
@@ -1,0 +1,100 @@
+import type { FailoverReason } from "../../pi-embedded-helpers.js";
+
+export type EmbeddedFailoverRouteDecision = "rotate_profile" | "fallback_model" | "surface_error";
+export type EmbeddedFailoverRouteScope = "model" | "profile";
+
+export type EmbeddedFailoverRouteInput = {
+  provider: string;
+  model: string;
+  profileId?: string;
+  reason: FailoverReason | null;
+  canRotateProfile: boolean;
+  fallbackConfigured: boolean;
+};
+
+export type EmbeddedFailoverRouteResult = {
+  decision: EmbeddedFailoverRouteDecision;
+  scope: EmbeddedFailoverRouteScope;
+  circuitOpen: boolean;
+  failureCount: number;
+  threshold: number | null;
+  key: string;
+};
+
+const MODEL_CIRCUIT_THRESHOLDS: Partial<Record<FailoverReason, number>> = {
+  overloaded: 2,
+  timeout: 2,
+};
+
+function buildFailureKey(params: {
+  scope: EmbeddedFailoverRouteScope;
+  provider: string;
+  model: string;
+  profileId?: string;
+  reason: FailoverReason | null;
+}) {
+  const reason = params.reason ?? "unknown";
+  if (params.scope === "model") {
+    return `model:${params.provider}:${params.model}:${reason}`;
+  }
+  return `profile:${params.provider}:${params.model}:${params.profileId ?? "-"}:${reason}`;
+}
+
+function resolveScope(reason: FailoverReason | null): {
+  scope: EmbeddedFailoverRouteScope;
+  threshold: number | null;
+} {
+  if (!reason) {
+    return {
+      scope: "profile",
+      threshold: null,
+    };
+  }
+  const threshold = MODEL_CIRCUIT_THRESHOLDS[reason] ?? null;
+  return {
+    scope: threshold ? "model" : "profile",
+    threshold,
+  };
+}
+
+export function createEmbeddedFailoverRouter() {
+  const failureCounts = new Map<string, number>();
+
+  return {
+    route(input: EmbeddedFailoverRouteInput): EmbeddedFailoverRouteResult {
+      const { scope, threshold } = resolveScope(input.reason);
+      const key = buildFailureKey({
+        scope,
+        provider: input.provider,
+        model: input.model,
+        profileId: input.profileId,
+        reason: input.reason,
+      });
+      const failureCount = (failureCounts.get(key) ?? 0) + 1;
+      failureCounts.set(key, failureCount);
+
+      const circuitOpen = threshold !== null && failureCount >= threshold;
+      const decision = (() => {
+        if (circuitOpen && input.fallbackConfigured) {
+          return "fallback_model";
+        }
+        if (input.canRotateProfile) {
+          return "rotate_profile";
+        }
+        if (input.fallbackConfigured) {
+          return "fallback_model";
+        }
+        return "surface_error";
+      })();
+
+      return {
+        decision,
+        scope,
+        circuitOpen,
+        failureCount,
+        threshold,
+        key,
+      };
+    },
+  };
+}

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -5,6 +5,7 @@ import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
 import type { ContextEngine } from "../../../context-engine/types.js";
 import type { PluginHookBeforeAgentStartResult } from "../../../plugins/types.js";
+import type { FailoverReason } from "../../pi-embedded-helpers.js";
 import type { MessagingToolSend } from "../../pi-embedded-messaging.js";
 import type { NormalizedUsage } from "../../usage.js";
 import type { RunEmbeddedPiAgentParams } from "./params.js";
@@ -30,6 +31,23 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   modelRegistry: ModelRegistry;
   thinkLevel: ThinkLevel;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
+};
+
+export type EmbeddedRunAttemptFailoverSignal = {
+  stage: "prompt" | "assistant";
+  source:
+    | "stream_call"
+    | "stream_result"
+    | "stream_iterator"
+    | "prompt_error"
+    | "assistant_error"
+    | "timeout";
+  provider: string;
+  model: string;
+  reason: FailoverReason | null;
+  status?: number;
+  rawError: string;
+  timedOut?: boolean;
 };
 
 export type EmbeddedRunAttemptResult = {
@@ -60,6 +78,8 @@ export type EmbeddedRunAttemptResult = {
   messagingToolSentTargets: MessagingToolSend[];
   successfulCronAdds?: number;
   cloudCodeAssistFormatError: boolean;
+  promptFailureSignal?: EmbeddedRunAttemptFailoverSignal;
+  assistantFailureSignal?: EmbeddedRunAttemptFailoverSignal;
   attemptUsage?: NormalizedUsage;
   compactionCount?: number;
   /** Client tool call detected (OpenResponses hosted tools). */

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -36,6 +36,7 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
 export type EmbeddedRunAttemptFailoverSignal = {
   stage: "prompt" | "assistant";
   source:
+    | "router_preflight"
     | "stream_call"
     | "stream_result"
     | "stream_iterator"

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -205,6 +205,15 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "quantd",
+    description: "Run and inspect the local quantd trading data guard",
+    hasSubcommands: true,
+    register: async (program) => {
+      const mod = await import("../quantd-cli.js");
+      mod.registerQuantdCli(program);
+    },
+  },
+  {
     name: "clawbot",
     description: "Legacy clawbot command aliases",
     hasSubcommands: true,

--- a/src/cli/quantd-cli.test.ts
+++ b/src/cli/quantd-cli.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { runRegisteredCli } from "../test-utils/command-runner.js";
+
+const defaultRuntime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(() => {
+    throw new Error("exit");
+  }),
+};
+
+const createQuantdClientMock = vi.fn();
+const snapshotMock = vi.fn();
+const healthMock = vi.fn();
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime,
+}));
+
+vi.mock("../quantd/client.js", () => ({
+  createQuantdClient: (...args: unknown[]) => createQuantdClientMock(...args),
+  DEFAULT_QUANTD_BASE_URL: "http://127.0.0.1:19891",
+}));
+
+let registerQuantdCli: typeof import("./quantd-cli.js").registerQuantdCli;
+
+beforeAll(async () => {
+  ({ registerQuantdCli } = await import("./quantd-cli.js"));
+});
+
+beforeEach(() => {
+  defaultRuntime.log.mockClear();
+  defaultRuntime.error.mockClear();
+  defaultRuntime.exit.mockClear();
+  createQuantdClientMock.mockReset();
+  snapshotMock.mockReset();
+  healthMock.mockReset();
+  createQuantdClientMock.mockReturnValue({
+    snapshot: snapshotMock,
+    health: healthMock,
+  });
+});
+
+describe("quantd cli", () => {
+  it("prints snapshot json", async () => {
+    snapshotMock.mockResolvedValueOnce({
+      health: { status: "ok", reasons: [] },
+      replay: { lastSequence: 2 },
+    });
+
+    await runRegisteredCli({
+      register: registerQuantdCli,
+      argv: ["quantd", "snapshot", "--url", "http://127.0.0.1:19891"],
+    });
+
+    expect(createQuantdClientMock).toHaveBeenCalledWith({
+      baseUrl: "http://127.0.0.1:19891",
+      socketPath: undefined,
+    });
+    expect(defaultRuntime.log).toHaveBeenCalledWith(expect.stringContaining('"lastSequence": 2'));
+  });
+
+  it("prints health summary", async () => {
+    healthMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      body: "degraded",
+    });
+
+    await runRegisteredCli({
+      register: registerQuantdCli,
+      argv: ["quantd", "health", "--url", "http://127.0.0.1:19891"],
+    });
+
+    expect(defaultRuntime.log).toHaveBeenCalledWith(expect.stringContaining("degraded"));
+  });
+});

--- a/src/cli/quantd-cli.ts
+++ b/src/cli/quantd-cli.ts
@@ -1,0 +1,1 @@
+export { registerQuantdCli } from "./quantd-cli/register.js";

--- a/src/cli/quantd-cli/register.ts
+++ b/src/cli/quantd-cli/register.ts
@@ -1,0 +1,107 @@
+import type { Command } from "commander";
+import { createQuantdClient, DEFAULT_QUANTD_BASE_URL } from "../../quantd/client.js";
+import { resolveQuantdWalPath, startQuantdServer } from "../../quantd/server.js";
+import { defaultRuntime } from "../../runtime.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
+
+function parsePort(raw: unknown, fallback: number): number {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.max(0, Math.floor(raw));
+  }
+  if (typeof raw === "string" && raw.trim() !== "") {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, Math.floor(parsed));
+    }
+  }
+  return fallback;
+}
+
+function parseMs(raw: unknown, fallback: number): number {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.max(1, Math.floor(raw));
+  }
+  if (typeof raw === "string" && raw.trim() !== "") {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed)) {
+      return Math.max(1, Math.floor(parsed));
+    }
+  }
+  return fallback;
+}
+
+function resolveClientOptions(opts: { url?: string; socket?: string }) {
+  return {
+    baseUrl: opts.socket ? undefined : (opts.url ?? DEFAULT_QUANTD_BASE_URL),
+    socketPath: opts.socket?.trim() || undefined,
+  };
+}
+
+export function registerQuantdCli(program: Command) {
+  const quantd = program.command("quantd").description("Run and inspect the local quantd guard");
+
+  quantd
+    .command("run")
+    .description("Run the quantd local guard daemon")
+    .option("--host <host>", "Bind host", "127.0.0.1")
+    .option("--port <port>", "Bind port", "19891")
+    .option("--socket <path>", "Unix socket path")
+    .option("--wal <path>", "WAL file path")
+    .option("--heartbeat-stale-ms <ms>", "Heartbeat stale threshold", "5000")
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const started = await startQuantdServer({
+          host: opts.host,
+          port: parsePort(opts.port, 19_891),
+          socketPath: opts.socket,
+          walPath: resolveQuantdWalPath(opts.wal),
+          heartbeatStaleAfterMs: parseMs(opts.heartbeatStaleMs, 5_000),
+        });
+        defaultRuntime.log(
+          started.socketPath
+            ? `quantd listening on socket ${started.socketPath}`
+            : `quantd listening on ${started.baseUrl}`,
+        );
+        await new Promise<void>((resolve, reject) => {
+          let stopping = false;
+          const shutdown = () => {
+            if (stopping) {
+              return;
+            }
+            stopping = true;
+            process.off("SIGINT", shutdown);
+            process.off("SIGTERM", shutdown);
+            void started.close().then(resolve, reject);
+          };
+          process.once("SIGINT", shutdown);
+          process.once("SIGTERM", shutdown);
+        });
+      });
+    });
+
+  quantd
+    .command("health")
+    .description("Read quantd health")
+    .option("--url <url>", "quantd base URL", DEFAULT_QUANTD_BASE_URL)
+    .option("--socket <path>", "Unix socket path")
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const client = createQuantdClient(resolveClientOptions(opts));
+        const health = await client.health();
+        defaultRuntime.log(`status=${health.status} body=${health.body}`);
+      });
+    });
+
+  quantd
+    .command("snapshot")
+    .description("Read quantd snapshot")
+    .option("--url <url>", "quantd base URL", DEFAULT_QUANTD_BASE_URL)
+    .option("--socket <path>", "Unix socket path")
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const client = createQuantdClient(resolveClientOptions(opts));
+        const snapshot = await client.snapshot();
+        defaultRuntime.log(JSON.stringify(snapshot, null, 2));
+      });
+    });
+}

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -148,6 +148,16 @@ describe("getHealthSnapshot", () => {
     expect(snap.sessions.recent[0]?.key).toBe("foo");
     expect(snap.quantd?.status).toBe("disabled");
     expect(snap.monitoring?.agents.total).toBeGreaterThan(0);
+    expect(snap.monitoring?.issueCounts).toEqual({
+      P0: 0,
+      P1: 1,
+      P2: 1,
+      INFO: 0,
+    });
+    expect(snap.monitoring?.issues.map((issue) => issue.code)).toEqual([
+      "agents.default_idle",
+      "agents.all_idle",
+    ]);
   });
 
   it("probes telegram getMe + webhook info when configured", async () => {

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -35,6 +35,10 @@ vi.mock("../web/auth-store.js", () => ({
   logoutWeb: vi.fn(),
 }));
 
+vi.mock("../telegram/fetch.js", () => ({
+  resolveTelegramFetch: () => globalThis.fetch,
+}));
+
 function stubTelegramFetchOk(calls: string[]) {
   vi.stubGlobal(
     "fetch",
@@ -86,7 +90,7 @@ async function runSuccessfulTelegramProbe(
   const calls: string[] = [];
   stubTelegramFetchOk(calls);
 
-  const snap = await getHealthSnapshot({ timeoutMs: 25 });
+  const snap = await getHealthSnapshot({ timeoutMs: 250 });
   const telegram = snap.channels.telegram as {
     configured?: boolean;
     probe?: {
@@ -142,6 +146,8 @@ describe("getHealthSnapshot", () => {
     expect(telegram.probe).toBeUndefined();
     expect(snap.sessions.count).toBe(2);
     expect(snap.sessions.recent[0]?.key).toBe("foo");
+    expect(snap.quantd?.status).toBe("disabled");
+    expect(snap.monitoring?.agents.total).toBeGreaterThan(0);
   });
 
   it("probes telegram getMe + webhook info when configured", async () => {
@@ -190,7 +196,7 @@ describe("getHealthSnapshot", () => {
       }),
     );
 
-    const snap = await getHealthSnapshot({ timeoutMs: 25 });
+    const snap = await getHealthSnapshot({ timeoutMs: 250 });
     const telegram = snap.channels.telegram as {
       configured?: boolean;
       probe?: { ok?: boolean; status?: number; error?: string };
@@ -213,7 +219,7 @@ describe("getHealthSnapshot", () => {
       }),
     );
 
-    const snap = await getHealthSnapshot({ timeoutMs: 25 });
+    const snap = await getHealthSnapshot({ timeoutMs: 250 });
     const telegram = snap.channels.telegram as {
       configured?: boolean;
       probe?: { ok?: boolean; error?: string };

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -7,6 +7,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig, readBestEffortConfig } from "../config/config.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import {
+  buildFormalRuntimeMonitoringSummary,
+  type FormalRuntimeMonitoringSummary,
+} from "../gateway/runtime-monitoring.js";
 import { info } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -14,6 +18,7 @@ import {
   type HeartbeatSummary,
   resolveHeartbeatSummaryForAgent,
 } from "../infra/heartbeat-runner.js";
+import { getQuantdRuntimeSummary, type QuantdRuntimeSummary } from "../quantd/runtime-summary.js";
 import { buildChannelAccountBindings, resolvePreferredAccountId } from "../routing/bindings.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -69,6 +74,8 @@ export type HealthSummary = {
       age: number | null;
     }>;
   };
+  quantd?: QuantdRuntimeSummary;
+  monitoring?: FormalRuntimeMonitoringSummary;
 };
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -502,6 +509,7 @@ export async function getHealthSnapshot(params?: {
     }
   }
 
+  const quantd = await getQuantdRuntimeSummary({ timeoutMs: cappedTimeout });
   const summary: HealthSummary = {
     ok: true,
     ts: Date.now(),
@@ -517,7 +525,24 @@ export async function getHealthSnapshot(params?: {
       count: sessions.count,
       recent: sessions.recent,
     },
+    quantd,
   };
+  summary.monitoring = buildFormalRuntimeMonitoringSummary({
+    defaultAgentId,
+    agents: agents.map((agent) => ({
+      agentId: agent.agentId,
+      name: agent.name,
+      isDefault: agent.isDefault,
+      heartbeat: {
+        enabled: agent.heartbeat.enabled,
+        everyMs: agent.heartbeat.everyMs,
+      },
+      sessions: {
+        recent: agent.sessions.recent,
+      },
+    })),
+    quantd,
+  });
 
   return summary;
 }
@@ -715,6 +740,25 @@ export async function healthCommand(
       .filter(Boolean);
     if (heartbeatParts.length > 0) {
       runtime.log(info(`Heartbeat interval: ${heartbeatParts.join(", ")}`));
+    }
+    if (summary.quantd) {
+      const quantdParts = [`status ${summary.quantd.status}`];
+      if (summary.quantd.health?.reasons?.length) {
+        quantdParts.push(`reasons ${summary.quantd.health.reasons.join(",")}`);
+      }
+      if (summary.quantd.metrics) {
+        quantdParts.push(
+          `hb ${summary.quantd.metrics.heartbeats} · market ${summary.quantd.metrics.marketEvents} · order ${summary.quantd.metrics.orderEvents}`,
+        );
+      }
+      runtime.log(info(`Quantd: ${quantdParts.join(" · ")}`));
+    }
+    if (summary.monitoring) {
+      runtime.log(
+        info(
+          `Agent activity: active ${summary.monitoring.agents.active} · quiet ${summary.monitoring.agents.quiet} · idle ${summary.monitoring.agents.idle} · hb on ${summary.monitoring.agents.heartbeatEnabled} / off ${summary.monitoring.agents.heartbeatDisabled}`,
+        ),
+      );
     }
     if (displayAgents.length === 0) {
       runtime.log(

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -754,9 +754,13 @@ export async function healthCommand(
       runtime.log(info(`Quantd: ${quantdParts.join(" · ")}`));
     }
     if (summary.monitoring) {
+      const issueLead =
+        summary.monitoring.issues.length > 0
+          ? ` · issues ${summary.monitoring.issues.length} · top ${summary.monitoring.issues[0]?.code}`
+          : "";
       runtime.log(
         info(
-          `Agent activity: active ${summary.monitoring.agents.active} · quiet ${summary.monitoring.agents.quiet} · idle ${summary.monitoring.agents.idle} · hb on ${summary.monitoring.agents.heartbeatEnabled} / off ${summary.monitoring.agents.heartbeatDisabled}`,
+          `Agent activity: active ${summary.monitoring.agents.active} · quiet ${summary.monitoring.agents.quiet} · idle ${summary.monitoring.agents.idle} · hb on ${summary.monitoring.agents.heartbeatEnabled} / off ${summary.monitoring.agents.heartbeatDisabled}${issueLead}`,
         ),
       );
     }

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -357,7 +357,11 @@ export async function statusCommand(
     if (!monitoring) {
       return muted("unknown");
     }
-    return `${monitoring.status} · active ${monitoring.agents.active} · quiet ${monitoring.agents.quiet} · idle ${monitoring.agents.idle}`;
+    const issueLead =
+      monitoring.issues.length > 0
+        ? ` · issues ${monitoring.issues.length} · top ${monitoring.issues[0]?.code}`
+        : "";
+    return `${monitoring.status} · active ${monitoring.agents.active} · quiet ${monitoring.agents.quiet} · idle ${monitoring.agents.idle}${issueLead}`;
   })();
   const lastHeartbeatValue = (() => {
     if (!opts.deep) {

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -336,6 +336,29 @@ export async function statusCommand(
       .filter(Boolean);
     return parts.length > 0 ? parts.join(", ") : "disabled";
   })();
+  const quantdValue = (() => {
+    const quantd = summary.quantd;
+    if (!quantd) {
+      return muted("unknown");
+    }
+    const parts = [quantd.status];
+    if (quantd.health?.reasons?.length) {
+      parts.push(`reasons ${quantd.health.reasons.join(",")}`);
+    }
+    if (quantd.metrics) {
+      parts.push(
+        `hb ${quantd.metrics.heartbeats} · market ${quantd.metrics.marketEvents} · order ${quantd.metrics.orderEvents}`,
+      );
+    }
+    return parts.join(" · ");
+  })();
+  const monitoringValue = (() => {
+    const monitoring = summary.monitoring;
+    if (!monitoring) {
+      return muted("unknown");
+    }
+    return `${monitoring.status} · active ${monitoring.agents.active} · quiet ${monitoring.agents.quiet} · idle ${monitoring.agents.idle}`;
+  })();
   const lastHeartbeatValue = (() => {
     if (!opts.deep) {
       return null;
@@ -435,6 +458,8 @@ export async function statusCommand(
     { Item: "Probes", Value: probesValue },
     { Item: "Events", Value: eventsValue },
     { Item: "Heartbeat", Value: heartbeatValue },
+    { Item: "Quantd", Value: quantdValue },
+    { Item: "Runtime", Value: monitoringValue },
     ...(lastHeartbeatValue ? [{ Item: "Last heartbeat", Value: lastHeartbeatValue }] : []),
     {
       Item: "Sessions",

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -83,5 +83,15 @@ describe("getStatusSummary", () => {
     expect(summary.channelSummary).toEqual(["ok"]);
     expect(summary.quantd?.status).toBe("disabled");
     expect(summary.monitoring?.agents.total).toBe(1);
+    expect(summary.monitoring?.issueCounts).toEqual({
+      P0: 0,
+      P1: 1,
+      P2: 1,
+      INFO: 0,
+    });
+    expect(summary.monitoring?.issues.map((issue) => issue.code)).toEqual([
+      "agents.default_idle",
+      "agents.all_idle",
+    ]);
   });
 });

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -81,5 +81,7 @@ describe("getStatusSummary", () => {
     expect(summary.runtimeVersion).toBe("2026.3.8");
     expect(summary.heartbeat.defaultAgentId).toBe("main");
     expect(summary.channelSummary).toEqual(["ok"]);
+    expect(summary.quantd?.status).toBe("disabled");
+    expect(summary.monitoring?.agents.total).toBe(1);
   });
 });

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -10,6 +10,7 @@ import {
   resolveStorePath,
   type SessionEntry,
 } from "../config/sessions.js";
+import { buildFormalRuntimeMonitoringSummary } from "../gateway/runtime-monitoring.js";
 import {
   classifySessionKey,
   listAgentsForGateway,
@@ -18,6 +19,7 @@ import {
 import { buildChannelSummary } from "../infra/channel-summary.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-runner.js";
 import { peekSystemEvents } from "../infra/system-events.js";
+import { getQuantdRuntimeSummary } from "../quantd/runtime-summary.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import { resolveLinkChannelContext } from "./status.link-channel.js";
@@ -105,6 +107,7 @@ export async function getStatusSummary(
     includeAllowFrom: true,
     sourceConfig: options.sourceConfig,
   });
+  const quantd = await getQuantdRuntimeSummary();
   const mainSessionKey = resolveMainSessionKey(cfg);
   const queuedSystemEvents = peekSystemEvents(mainSessionKey);
 
@@ -230,6 +233,30 @@ export async function getStatusSummary(
     },
     channelSummary,
     queuedSystemEvents,
+    quantd,
+    monitoring: buildFormalRuntimeMonitoringSummary({
+      defaultAgentId: agentList.defaultId,
+      agents: agentList.agents.map((agent) => {
+        const heartbeat = heartbeatAgents.find((entry) => entry.agentId === agent.id);
+        const sessionsForAgent = byAgent.find((entry) => entry.agentId === agent.id);
+        return {
+          agentId: agent.id,
+          name: agent.name,
+          isDefault: agent.id === agentList.defaultId,
+          heartbeat: {
+            enabled: heartbeat?.enabled ?? false,
+            everyMs: heartbeat?.everyMs ?? null,
+          },
+          sessions: {
+            recent:
+              sessionsForAgent?.recent.map((entry) => ({
+                updatedAt: entry.updatedAt,
+              })) ?? [],
+          },
+        };
+      }),
+      quantd,
+    }),
     sessions: {
       paths: Array.from(paths),
       count: totalSessions,

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -347,6 +347,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
   return {
     ...actual,
     loadConfig: mocks.loadConfig,
+    readBestEffortConfig: vi.fn(async () => mocks.loadConfig()),
   };
 });
 vi.mock("../daemon/service.js", () => ({

--- a/src/commands/status.types.ts
+++ b/src/commands/status.types.ts
@@ -1,4 +1,6 @@
 import type { ChannelId } from "../channels/plugins/types.js";
+import type { FormalRuntimeMonitoringSummary } from "../gateway/runtime-monitoring.js";
+import type { QuantdRuntimeSummary } from "../quantd/runtime-summary.js";
 
 export type SessionStatus = {
   agentId?: string;
@@ -48,6 +50,8 @@ export type StatusSummary = {
   };
   channelSummary: string[];
   queuedSystemEvents: string[];
+  quantd?: QuantdRuntimeSummary;
+  monitoring?: FormalRuntimeMonitoringSummary;
   sessions: {
     paths: string[];
     count: number;

--- a/src/gateway/events.ts
+++ b/src/gateway/events.ts
@@ -1,6 +1,7 @@
 import type { UpdateAvailable } from "../infra/update-startup.js";
 
 export const GATEWAY_EVENT_UPDATE_AVAILABLE = "update.available" as const;
+export const GATEWAY_EVENT_RUNTIME_FORMAL = "runtime.formal" as const;
 
 export type GatewayUpdateAvailableEventPayload = {
   updateAvailable: UpdateAvailable | null;

--- a/src/gateway/runtime-monitoring-alerts.test.ts
+++ b/src/gateway/runtime-monitoring-alerts.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { diffFormalRuntimeMonitoringIssues } from "./runtime-monitoring-alerts.js";
+import type { FormalRuntimeMonitoringSummary } from "./runtime-monitoring.js";
+
+function createSummary(
+  overrides: Partial<FormalRuntimeMonitoringSummary> = {},
+): FormalRuntimeMonitoringSummary {
+  return {
+    status: "ok",
+    agents: {
+      defaultAgentId: "gateway",
+      total: 1,
+      active: 1,
+      quiet: 0,
+      idle: 0,
+      heartbeatEnabled: 1,
+      heartbeatDisabled: 0,
+      entries: [],
+    },
+    quantd: {
+      status: "ok",
+    },
+    issues: [],
+    issueCounts: {
+      P0: 0,
+      P1: 0,
+      P2: 0,
+      INFO: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("diffFormalRuntimeMonitoringIssues", () => {
+  it("returns opened events for newly raised issues", () => {
+    const next = createSummary({
+      status: "degraded",
+      issues: [
+        {
+          code: "quantd.unreachable",
+          priority: "P0",
+          summary: "quantd currently unreachable",
+        },
+      ],
+      issueCounts: { P0: 1, P1: 0, P2: 0, INFO: 0 },
+    });
+
+    expect(diffFormalRuntimeMonitoringIssues(undefined, next)).toEqual([
+      expect.objectContaining({
+        transition: "opened",
+        issue: expect.objectContaining({
+          code: "quantd.unreachable",
+          priority: "P0",
+        }),
+      }),
+    ]);
+  });
+
+  it("returns resolved events when an issue clears", () => {
+    const previous = createSummary({
+      status: "degraded",
+      issues: [
+        {
+          code: "agents.default_idle",
+          priority: "P1",
+          summary: "default agent gateway is idle",
+        },
+      ],
+      issueCounts: { P0: 0, P1: 1, P2: 0, INFO: 0 },
+    });
+    const next = createSummary();
+
+    expect(diffFormalRuntimeMonitoringIssues(previous, next)).toEqual([
+      expect.objectContaining({
+        transition: "resolved",
+        issue: expect.objectContaining({
+          code: "agents.default_idle",
+          priority: "P1",
+        }),
+      }),
+    ]);
+  });
+
+  it("does not re-emit unchanged issues", () => {
+    const previous = createSummary({
+      status: "degraded",
+      issues: [
+        {
+          code: "agents.heartbeat_disabled",
+          priority: "P2",
+          summary: "1 formal agents have heartbeat disabled",
+        },
+      ],
+      issueCounts: { P0: 0, P1: 0, P2: 1, INFO: 0 },
+    });
+    const next = createSummary({
+      status: "degraded",
+      issues: [
+        {
+          code: "agents.heartbeat_disabled",
+          priority: "P2",
+          summary: "1 formal agents have heartbeat disabled",
+        },
+      ],
+      issueCounts: { P0: 0, P1: 0, P2: 1, INFO: 0 },
+    });
+
+    expect(diffFormalRuntimeMonitoringIssues(previous, next)).toEqual([]);
+  });
+});

--- a/src/gateway/runtime-monitoring-alerts.ts
+++ b/src/gateway/runtime-monitoring-alerts.ts
@@ -1,0 +1,51 @@
+import type { FormalRuntimeIssue, FormalRuntimeMonitoringSummary } from "./runtime-monitoring.js";
+
+export type FormalRuntimeIssueTransition = "opened" | "resolved";
+
+export type FormalRuntimeIssueAlert = {
+  transition: FormalRuntimeIssueTransition;
+  issue: FormalRuntimeIssue;
+  text: string;
+};
+
+function formatAlertText(
+  transition: FormalRuntimeIssueTransition,
+  issue: FormalRuntimeIssue,
+): string {
+  const prefix =
+    transition === "opened" ? "Formal runtime issue opened" : "Formal runtime issue resolved";
+  return `${prefix}: [${issue.priority}] ${issue.code} - ${issue.summary}`;
+}
+
+export function diffFormalRuntimeMonitoringIssues(
+  previous: FormalRuntimeMonitoringSummary | undefined,
+  next: FormalRuntimeMonitoringSummary,
+): FormalRuntimeIssueAlert[] {
+  const previousIssues = new Map((previous?.issues ?? []).map((issue) => [issue.code, issue]));
+  const nextIssues = new Map(next.issues.map((issue) => [issue.code, issue]));
+  const alerts: FormalRuntimeIssueAlert[] = [];
+
+  for (const issue of next.issues) {
+    if (previousIssues.has(issue.code)) {
+      continue;
+    }
+    alerts.push({
+      transition: "opened",
+      issue,
+      text: formatAlertText("opened", issue),
+    });
+  }
+
+  for (const issue of previous?.issues ?? []) {
+    if (nextIssues.has(issue.code)) {
+      continue;
+    }
+    alerts.push({
+      transition: "resolved",
+      issue,
+      text: formatAlertText("resolved", issue),
+    });
+  }
+
+  return alerts;
+}

--- a/src/gateway/runtime-monitoring.test.ts
+++ b/src/gateway/runtime-monitoring.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildAgentActivitySummary } from "./runtime-monitoring.js";
+import {
+  buildAgentActivitySummary,
+  buildFormalRuntimeMonitoringSummary,
+} from "./runtime-monitoring.js";
 
 describe("buildAgentActivitySummary", () => {
   it("rolls agents into active, quiet, and idle buckets", () => {
@@ -43,5 +46,89 @@ describe("buildAgentActivitySummary", () => {
       ["risk", "quiet"],
       ["news", "idle"],
     ]);
+  });
+});
+
+describe("buildFormalRuntimeMonitoringSummary", () => {
+  it("raises structured issues for quantd unreachable and idle default agent", () => {
+    const now = new Date("2026-03-14T12:00:00.000Z").getTime();
+    const summary = buildFormalRuntimeMonitoringSummary({
+      defaultAgentId: "gateway",
+      now: () => now,
+      agents: [
+        {
+          agentId: "gateway",
+          isDefault: true,
+          heartbeat: { enabled: true, everyMs: 60_000 },
+          sessions: { recent: [] },
+        },
+        {
+          agentId: "risk",
+          isDefault: false,
+          heartbeat: { enabled: false, everyMs: null },
+          sessions: { recent: [] },
+        },
+      ],
+      quantd: {
+        enabled: true,
+        status: "unreachable",
+        error: "connect ECONNREFUSED",
+      },
+    });
+
+    expect(summary.status).toBe("degraded");
+    expect(summary.issueCounts).toEqual({
+      P0: 1,
+      P1: 1,
+      P2: 2,
+      INFO: 0,
+    });
+    expect(summary.issues).toEqual([
+      expect.objectContaining({
+        code: "quantd.unreachable",
+        priority: "P0",
+      }),
+      expect.objectContaining({
+        code: "agents.default_idle",
+        priority: "P1",
+      }),
+      expect.objectContaining({
+        code: "agents.all_idle",
+        priority: "P2",
+      }),
+      expect.objectContaining({
+        code: "agents.heartbeat_disabled",
+        priority: "P2",
+      }),
+    ]);
+  });
+
+  it("stays ok when quantd is disabled and the default agent is active", () => {
+    const now = new Date("2026-03-14T12:00:00.000Z").getTime();
+    const summary = buildFormalRuntimeMonitoringSummary({
+      defaultAgentId: "gateway",
+      now: () => now,
+      agents: [
+        {
+          agentId: "gateway",
+          isDefault: true,
+          heartbeat: { enabled: true, everyMs: 60_000 },
+          sessions: { recent: [{ updatedAt: now - 60_000 }] },
+        },
+      ],
+      quantd: {
+        enabled: false,
+        status: "disabled",
+      },
+    });
+
+    expect(summary.status).toBe("ok");
+    expect(summary.issueCounts).toEqual({
+      P0: 0,
+      P1: 0,
+      P2: 0,
+      INFO: 0,
+    });
+    expect(summary.issues).toEqual([]);
   });
 });

--- a/src/gateway/runtime-monitoring.test.ts
+++ b/src/gateway/runtime-monitoring.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentActivitySummary } from "./runtime-monitoring.js";
+
+describe("buildAgentActivitySummary", () => {
+  it("rolls agents into active, quiet, and idle buckets", () => {
+    const now = new Date("2026-03-14T12:00:00.000Z").getTime();
+    const summary = buildAgentActivitySummary({
+      defaultAgentId: "gateway",
+      now: () => now,
+      agents: [
+        {
+          agentId: "gateway",
+          isDefault: true,
+          heartbeat: { enabled: true, everyMs: 60_000 },
+          sessions: { recent: [{ key: "a", updatedAt: now - 2 * 60_000, age: 2 * 60_000 }] },
+        },
+        {
+          agentId: "risk",
+          isDefault: false,
+          heartbeat: { enabled: true, everyMs: 60_000 },
+          sessions: { recent: [{ key: "b", updatedAt: now - 30 * 60_000, age: 30 * 60_000 }] },
+        },
+        {
+          agentId: "news",
+          isDefault: false,
+          heartbeat: { enabled: false, everyMs: null },
+          sessions: { recent: [] },
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      defaultAgentId: "gateway",
+      total: 3,
+      active: 1,
+      quiet: 1,
+      idle: 1,
+      heartbeatEnabled: 2,
+      heartbeatDisabled: 1,
+    });
+    expect(summary.entries.map((entry) => [entry.agentId, entry.status])).toEqual([
+      ["gateway", "active"],
+      ["risk", "quiet"],
+      ["news", "idle"],
+    ]);
+  });
+});

--- a/src/gateway/runtime-monitoring.ts
+++ b/src/gateway/runtime-monitoring.ts
@@ -1,6 +1,18 @@
 import type { QuantdRuntimeSummary } from "../quantd/runtime-summary.js";
 
 export type AgentActivityStatus = "active" | "quiet" | "idle";
+export type FormalRuntimeIssuePriority = "P0" | "P1" | "P2" | "INFO";
+
+export type FormalRuntimeIssue = {
+  code:
+    | "quantd.unreachable"
+    | "quantd.degraded"
+    | "agents.default_idle"
+    | "agents.all_idle"
+    | "agents.heartbeat_disabled";
+  priority: FormalRuntimeIssuePriority;
+  summary: string;
+};
 
 export type AgentActivityEntry = {
   agentId: string;
@@ -30,10 +42,18 @@ export type FormalRuntimeMonitoringSummary = {
   quantd: {
     status: QuantdRuntimeSummary["status"];
   };
+  issues: FormalRuntimeIssue[];
+  issueCounts: Record<FormalRuntimeIssuePriority, number>;
 };
 
 const ACTIVE_WINDOW_MS = 15 * 60_000;
 const QUIET_WINDOW_MS = 60 * 60_000;
+const EMPTY_ISSUE_COUNTS: Record<FormalRuntimeIssuePriority, number> = {
+  P0: 0,
+  P1: 0,
+  P2: 0,
+  INFO: 0,
+};
 
 function resolveAgentActivityStatus(ageMs: number | null): AgentActivityStatus {
   if (ageMs === null) {
@@ -115,14 +135,59 @@ export function buildFormalRuntimeMonitoringSummary(params: {
     agents: params.agents,
     now: params.now,
   });
+  const issues: FormalRuntimeIssue[] = [];
+  if (params.quantd.status === "unreachable") {
+    issues.push({
+      code: "quantd.unreachable",
+      priority: "P0",
+      summary: "quantd currently unreachable",
+    });
+  } else if (params.quantd.status === "degraded") {
+    issues.push({
+      code: "quantd.degraded",
+      priority: "P1",
+      summary: "quantd is degraded",
+    });
+  }
+
+  const defaultAgent = agents.entries.find((entry) => entry.isDefault);
+  if (defaultAgent?.status === "idle") {
+    issues.push({
+      code: "agents.default_idle",
+      priority: "P1",
+      summary: `default agent ${defaultAgent.agentId} is idle`,
+    });
+  }
+  if (agents.total > 0 && agents.idle === agents.total) {
+    issues.push({
+      code: "agents.all_idle",
+      priority: "P2",
+      summary: "all formal agents are idle",
+    });
+  }
+  if (agents.heartbeatDisabled > 0) {
+    issues.push({
+      code: "agents.heartbeat_disabled",
+      priority: "P2",
+      summary: `${agents.heartbeatDisabled} formal agents have heartbeat disabled`,
+    });
+  }
+
+  const issueCounts = issues.reduce<Record<FormalRuntimeIssuePriority, number>>(
+    (counts, issue) => {
+      counts[issue.priority] += 1;
+      return counts;
+    },
+    { ...EMPTY_ISSUE_COUNTS },
+  );
+
   return {
-    status:
-      params.quantd.status === "degraded" || params.quantd.status === "unreachable"
-        ? "degraded"
-        : "ok",
+    status: issueCounts.P0 > 0 || issueCounts.P1 > 0 || issueCounts.P2 > 0 ? "degraded" : "ok",
     agents,
     quantd: {
       status: params.quantd.status,
     },
+    issues,
+    issueCounts,
   };
 }

--- a/src/gateway/runtime-monitoring.ts
+++ b/src/gateway/runtime-monitoring.ts
@@ -1,0 +1,128 @@
+import type { QuantdRuntimeSummary } from "../quantd/runtime-summary.js";
+
+export type AgentActivityStatus = "active" | "quiet" | "idle";
+
+export type AgentActivityEntry = {
+  agentId: string;
+  name?: string;
+  isDefault: boolean;
+  heartbeatEnabled: boolean;
+  heartbeatEveryMs: number | null;
+  lastSessionAt: number | null;
+  lastSessionAgeMs: number | null;
+  status: AgentActivityStatus;
+};
+
+export type AgentActivitySummary = {
+  defaultAgentId: string;
+  total: number;
+  active: number;
+  quiet: number;
+  idle: number;
+  heartbeatEnabled: number;
+  heartbeatDisabled: number;
+  entries: AgentActivityEntry[];
+};
+
+export type FormalRuntimeMonitoringSummary = {
+  status: "ok" | "degraded";
+  agents: AgentActivitySummary;
+  quantd: {
+    status: QuantdRuntimeSummary["status"];
+  };
+};
+
+const ACTIVE_WINDOW_MS = 15 * 60_000;
+const QUIET_WINDOW_MS = 60 * 60_000;
+
+function resolveAgentActivityStatus(ageMs: number | null): AgentActivityStatus {
+  if (ageMs === null) {
+    return "idle";
+  }
+  if (ageMs <= ACTIVE_WINDOW_MS) {
+    return "active";
+  }
+  if (ageMs <= QUIET_WINDOW_MS) {
+    return "quiet";
+  }
+  return "idle";
+}
+
+export function buildAgentActivitySummary(params: {
+  defaultAgentId: string;
+  agents: Array<{
+    agentId: string;
+    name?: string;
+    isDefault: boolean;
+    heartbeat: { enabled: boolean; everyMs: number | null };
+    sessions: {
+      recent: Array<{
+        updatedAt: number | null;
+      }>;
+    };
+  }>;
+  now?: () => number;
+}): AgentActivitySummary {
+  const now = params.now ?? (() => Date.now());
+  const entries = params.agents.map((agent) => {
+    const lastSessionAt = agent.sessions.recent.find(
+      (entry) => typeof entry.updatedAt === "number",
+    )?.updatedAt;
+    const lastSessionAgeMs =
+      typeof lastSessionAt === "number" ? Math.max(0, now() - lastSessionAt) : null;
+    return {
+      agentId: agent.agentId,
+      name: agent.name,
+      isDefault: agent.isDefault,
+      heartbeatEnabled: agent.heartbeat.enabled,
+      heartbeatEveryMs: agent.heartbeat.everyMs,
+      lastSessionAt: lastSessionAt ?? null,
+      lastSessionAgeMs,
+      status: resolveAgentActivityStatus(lastSessionAgeMs),
+    } satisfies AgentActivityEntry;
+  });
+
+  return {
+    defaultAgentId: params.defaultAgentId,
+    total: entries.length,
+    active: entries.filter((entry) => entry.status === "active").length,
+    quiet: entries.filter((entry) => entry.status === "quiet").length,
+    idle: entries.filter((entry) => entry.status === "idle").length,
+    heartbeatEnabled: entries.filter((entry) => entry.heartbeatEnabled).length,
+    heartbeatDisabled: entries.filter((entry) => !entry.heartbeatEnabled).length,
+    entries,
+  };
+}
+
+export function buildFormalRuntimeMonitoringSummary(params: {
+  defaultAgentId: string;
+  agents: Array<{
+    agentId: string;
+    name?: string;
+    isDefault: boolean;
+    heartbeat: { enabled: boolean; everyMs: number | null };
+    sessions: {
+      recent: Array<{
+        updatedAt: number | null;
+      }>;
+    };
+  }>;
+  quantd: QuantdRuntimeSummary;
+  now?: () => number;
+}): FormalRuntimeMonitoringSummary {
+  const agents = buildAgentActivitySummary({
+    defaultAgentId: params.defaultAgentId,
+    agents: params.agents,
+    now: params.now,
+  });
+  return {
+    status:
+      params.quantd.status === "degraded" || params.quantd.status === "unreachable"
+        ? "degraded"
+        : "ok",
+    agents,
+    quantd: {
+      status: params.quantd.status,
+    },
+  };
+}

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGatewayCloseHandler } from "./server-close.js";
+
+describe("createGatewayCloseHandler", () => {
+  it("stops quantd sidecar during gateway shutdown", async () => {
+    const quantdClose = vi.fn(async () => {});
+    const stop = createGatewayCloseHandler({
+      bonjourStop: null,
+      tailscaleCleanup: null,
+      canvasHost: null,
+      canvasHostServer: null,
+      stopChannel: vi.fn(async () => {}),
+      pluginServices: null,
+      quantd: { close: quantdClose },
+      cron: { stop: vi.fn() },
+      heartbeatRunner: { stop: vi.fn() } as { stop: () => void },
+      updateCheckStop: null,
+      nodePresenceTimers: new Map(),
+      broadcast: vi.fn(),
+      tickInterval: setInterval(() => {}, 1000),
+      healthInterval: setInterval(() => {}, 1000),
+      dedupeCleanup: setInterval(() => {}, 1000),
+      mediaCleanup: null,
+      agentUnsub: null,
+      heartbeatUnsub: null,
+      chatRunState: { clear: vi.fn() },
+      clients: new Set(),
+      configReloader: { stop: vi.fn(async () => {}) },
+      browserControl: null,
+      wss: { close: (cb: () => void) => cb() } as { close: (cb: () => void) => void },
+      httpServer: { close: (cb: (err?: Error) => void) => cb() } as {
+        close: (cb: (err?: Error) => void) => void;
+      },
+    });
+
+    await stop();
+
+    expect(quantdClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -13,6 +13,7 @@ export function createGatewayCloseHandler(params: {
   canvasHostServer: CanvasHostServer | null;
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServices: PluginServicesHandle | null;
+  quantd: { close: () => Promise<void> } | null;
   cron: { stop: () => void };
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
@@ -68,6 +69,9 @@ export function createGatewayCloseHandler(params: {
     }
     if (params.pluginServices) {
       await params.pluginServices.stop().catch(() => {});
+    }
+    if (params.quantd) {
+      await params.quantd.close().catch(() => {});
     }
     await stopGmailWatcher();
     params.cron.stop();

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -123,4 +123,79 @@ describe("startGatewayMaintenanceTimers", () => {
 
     stopMaintenanceTimers(timers);
   });
+
+  it("broadcasts runtime.formal and emits system events for opened/resolved runtime issues", async () => {
+    const { applyFormalRuntimeMonitoringUpdate } = await import("./server-maintenance.js");
+    const broadcast = vi.fn();
+    const nodeSendToAllSubscribed = vi.fn();
+    const enqueueRuntimeSystemEvent = vi.fn();
+
+    const degraded = {
+      status: "degraded",
+      agents: {
+        defaultAgentId: "gateway",
+        total: 1,
+        active: 0,
+        quiet: 0,
+        idle: 1,
+        heartbeatEnabled: 1,
+        heartbeatDisabled: 0,
+        entries: [],
+      },
+      quantd: { status: "unreachable" },
+      issues: [
+        {
+          code: "quantd.unreachable",
+          priority: "P0",
+          summary: "quantd currently unreachable",
+        },
+      ],
+      issueCounts: { P0: 1, P1: 0, P2: 0, INFO: 0 },
+    } as NonNullable<HealthSummary["monitoring"]>;
+    const healthy = {
+      ...degraded,
+      status: "ok",
+      quantd: { status: "ok" },
+      issues: [],
+      issueCounts: { P0: 0, P1: 0, P2: 0, INFO: 0 },
+    } as NonNullable<HealthSummary["monitoring"]>;
+
+    const first = applyFormalRuntimeMonitoringUpdate({
+      previous: undefined,
+      monitoring: degraded,
+      broadcast,
+      nodeSendToAllSubscribed,
+      enqueueRuntimeSystemEvent,
+      getPresenceVersion: () => 2,
+      getHealthVersion: () => 3,
+    });
+    expect(first).toBe(degraded);
+    expect(broadcast).toHaveBeenCalledWith(
+      "runtime.formal",
+      degraded,
+      expect.objectContaining({
+        stateVersion: { presence: 2, health: 3 },
+      }),
+    );
+    expect(nodeSendToAllSubscribed).toHaveBeenCalledWith("runtime.formal", degraded);
+    expect(enqueueRuntimeSystemEvent).toHaveBeenCalledWith(
+      expect.stringContaining("quantd.unreachable"),
+    );
+
+    broadcast.mockClear();
+    nodeSendToAllSubscribed.mockClear();
+    enqueueRuntimeSystemEvent.mockClear();
+
+    const second = applyFormalRuntimeMonitoringUpdate({
+      previous: first,
+      monitoring: healthy,
+      broadcast,
+      nodeSendToAllSubscribed,
+      enqueueRuntimeSystemEvent,
+      getPresenceVersion: () => 2,
+      getHealthVersion: () => 4,
+    });
+    expect(second).toBe(healthy);
+    expect(enqueueRuntimeSystemEvent).toHaveBeenCalledWith(expect.stringContaining("resolved"));
+  });
 });

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -1,6 +1,9 @@
 import type { HealthSummary } from "../commands/health.js";
 import { cleanOldMedia } from "../media/store.js";
 import { abortChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
+import { GATEWAY_EVENT_RUNTIME_FORMAL } from "./events.js";
+import { diffFormalRuntimeMonitoringIssues } from "./runtime-monitoring-alerts.js";
+import type { FormalRuntimeMonitoringSummary } from "./runtime-monitoring.js";
 import type { ChatRunEntry } from "./server-chat.js";
 import {
   DEDUPE_MAX,
@@ -11,6 +14,36 @@ import {
 import type { DedupeEntry } from "./server-shared.js";
 import { formatError } from "./server-utils.js";
 import { setBroadcastHealthUpdate } from "./server/health-state.js";
+
+export function applyFormalRuntimeMonitoringUpdate(params: {
+  previous: FormalRuntimeMonitoringSummary | undefined;
+  monitoring: FormalRuntimeMonitoringSummary;
+  broadcast: (
+    event: string,
+    payload: unknown,
+    opts?: {
+      dropIfSlow?: boolean;
+      stateVersion?: { presence?: number; health?: number };
+    },
+  ) => void;
+  nodeSendToAllSubscribed: (event: string, payload: unknown) => void;
+  enqueueRuntimeSystemEvent?: (text: string) => void;
+  getPresenceVersion: () => number;
+  getHealthVersion: () => number;
+}): FormalRuntimeMonitoringSummary {
+  params.broadcast(GATEWAY_EVENT_RUNTIME_FORMAL, params.monitoring, {
+    stateVersion: {
+      presence: params.getPresenceVersion(),
+      health: params.getHealthVersion(),
+    },
+  });
+  params.nodeSendToAllSubscribed(GATEWAY_EVENT_RUNTIME_FORMAL, params.monitoring);
+  const alerts = diffFormalRuntimeMonitoringIssues(params.previous, params.monitoring);
+  for (const alert of alerts) {
+    params.enqueueRuntimeSystemEvent?.(alert.text);
+  }
+  return params.monitoring;
+}
 
 export function startGatewayMaintenanceTimers(params: {
   broadcast: (
@@ -39,12 +72,14 @@ export function startGatewayMaintenanceTimers(params: {
   agentRunSeq: Map<string, number>;
   nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
   mediaCleanupTtlMs?: number;
+  enqueueRuntimeSystemEvent?: (text: string) => void;
 }): {
   tickInterval: ReturnType<typeof setInterval>;
   healthInterval: ReturnType<typeof setInterval>;
   dedupeCleanup: ReturnType<typeof setInterval>;
   mediaCleanup: ReturnType<typeof setInterval> | null;
 } {
+  let previousMonitoring: FormalRuntimeMonitoringSummary | undefined;
   setBroadcastHealthUpdate((snap: HealthSummary) => {
     params.broadcast("health", snap, {
       stateVersion: {
@@ -53,6 +88,17 @@ export function startGatewayMaintenanceTimers(params: {
       },
     });
     params.nodeSendToAllSubscribed("health", snap);
+    if (snap.monitoring) {
+      previousMonitoring = applyFormalRuntimeMonitoringUpdate({
+        previous: previousMonitoring,
+        monitoring: snap.monitoring,
+        broadcast: params.broadcast,
+        nodeSendToAllSubscribed: params.nodeSendToAllSubscribed,
+        enqueueRuntimeSystemEvent: params.enqueueRuntimeSystemEvent,
+        getPresenceVersion: params.getPresenceVersion,
+        getHealthVersion: params.getHealthVersion,
+      });
+    }
   });
 
   // periodic keepalive

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -1,5 +1,5 @@
 import { listChannelPlugins } from "../channels/plugins/index.js";
-import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
+import { GATEWAY_EVENT_RUNTIME_FORMAL, GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 
 const BASE_METHODS = [
   "health",
@@ -129,5 +129,6 @@ export const GATEWAY_EVENTS = [
   "voicewake.changed",
   "exec.approval.requested",
   "exec.approval.resolved",
+  GATEWAY_EVENT_RUNTIME_FORMAL,
   GATEWAY_EVENT_UPDATE_AVAILABLE,
 ];

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -60,6 +60,13 @@ vi.mock("../infra/device-identity.js", () => ({
 vi.mock("./session-utils.js", () => ({
   loadSessionEntry: vi.fn((sessionKey: string) => buildSessionLookup(sessionKey)),
   pruneLegacyStoreKeys: vi.fn(),
+  migrateAndPruneGatewaySessionStoreKey: vi.fn(
+    ({ key, store }: { key: string; store: Record<string, unknown> }) => ({
+      target: { canonicalKey: key, storeKeys: [key] },
+      primaryKey: key,
+      entry: store[key],
+    }),
+  ),
   resolveGatewaySessionStoreTarget: vi.fn(({ key }: { key: string }) => ({
     canonicalKey: key,
     storeKeys: [key],

--- a/src/gateway/server-startup-quantd.test.ts
+++ b/src/gateway/server-startup-quantd.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { startQuantdServerMock } = vi.hoisted(() => ({
+  startQuantdServerMock: vi.fn(),
+}));
+
+vi.mock("../quantd/server.js", () => ({
+  startQuantdServer: (options: unknown) => startQuantdServerMock(options),
+}));
+
+import { startGatewayQuantdSidecar } from "./server-startup-quantd.js";
+
+describe("startGatewayQuantdSidecar", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    startQuantdServerMock.mockReset();
+    process.env = { ...originalEnv };
+    delete process.env.OPENCLAW_QUANTD_ENABLED;
+    delete process.env.OPENCLAW_QUANTD_HOST;
+    delete process.env.OPENCLAW_QUANTD_PORT;
+    delete process.env.OPENCLAW_QUANTD_SOCKET_PATH;
+    delete process.env.OPENCLAW_QUANTD_WAL_PATH;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns null when quantd sidecar is disabled", async () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    await expect(startGatewayQuantdSidecar({ log })).resolves.toBeNull();
+
+    expect(startQuantdServerMock).not.toHaveBeenCalled();
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("starts quantd sidecar with env overrides when enabled", async () => {
+    process.env.OPENCLAW_QUANTD_ENABLED = "1";
+    process.env.OPENCLAW_QUANTD_HOST = "127.0.0.9";
+    process.env.OPENCLAW_QUANTD_PORT = "21001";
+    process.env.OPENCLAW_QUANTD_WAL_PATH = "/tmp/openclaw-quantd.jsonl";
+    startQuantdServerMock.mockResolvedValue({
+      baseUrl: "http://127.0.0.9:21001",
+      socketPath: undefined,
+      walPath: "/tmp/openclaw-quantd.jsonl",
+      close: vi.fn(),
+    });
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    const handle = await startGatewayQuantdSidecar({ log });
+
+    expect(startQuantdServerMock).toHaveBeenCalledWith({
+      host: "127.0.0.9",
+      port: 21001,
+      walPath: "/tmp/openclaw-quantd.jsonl",
+      socketPath: undefined,
+    });
+    expect(handle).toMatchObject({
+      baseUrl: "http://127.0.0.9:21001",
+      walPath: "/tmp/openclaw-quantd.jsonl",
+    });
+    expect(log.info).toHaveBeenCalledWith(
+      "quantd sidecar started at http://127.0.0.9:21001 (wal=/tmp/openclaw-quantd.jsonl)",
+    );
+  });
+
+  it("falls back to the default port when env port is invalid", async () => {
+    process.env.OPENCLAW_QUANTD_ENABLED = "1";
+    process.env.OPENCLAW_QUANTD_PORT = "invalid";
+    startQuantdServerMock.mockResolvedValue({
+      baseUrl: "http://127.0.0.1:19891",
+      socketPath: undefined,
+      walPath: "/tmp/quantd.jsonl",
+      close: vi.fn(),
+    });
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    await startGatewayQuantdSidecar({ log });
+
+    expect(startQuantdServerMock).toHaveBeenCalledWith({
+      host: "127.0.0.1",
+      port: 19891,
+      walPath: undefined,
+      socketPath: undefined,
+    });
+    expect(log.warn).toHaveBeenCalledWith('invalid OPENCLAW_QUANTD_PORT "invalid"; using 19891');
+  });
+});

--- a/src/gateway/server-startup-quantd.ts
+++ b/src/gateway/server-startup-quantd.ts
@@ -1,0 +1,52 @@
+import { isTruthyEnvValue } from "../infra/env.js";
+import { startQuantdServer } from "../quantd/server.js";
+
+const DEFAULT_GATEWAY_QUANTD_HOST = "127.0.0.1";
+const DEFAULT_GATEWAY_QUANTD_PORT = 19_891;
+
+function parseQuantdPort(params: {
+  raw: string | undefined;
+  fallback: number;
+  warn: (message: string) => void;
+}) {
+  const value = params.raw?.trim();
+  if (!value) {
+    return params.fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65_535) {
+    params.warn(`invalid OPENCLAW_QUANTD_PORT "${value}"; using ${params.fallback}`);
+    return params.fallback;
+  }
+  return parsed;
+}
+
+export async function startGatewayQuantdSidecar(params: {
+  log: {
+    info: (message: string) => void;
+    warn: (message: string) => void;
+  };
+}) {
+  if (!isTruthyEnvValue(process.env.OPENCLAW_QUANTD_ENABLED)) {
+    return null;
+  }
+
+  const host = process.env.OPENCLAW_QUANTD_HOST?.trim() || DEFAULT_GATEWAY_QUANTD_HOST;
+  const port = parseQuantdPort({
+    raw: process.env.OPENCLAW_QUANTD_PORT,
+    fallback: DEFAULT_GATEWAY_QUANTD_PORT,
+    warn: params.log.warn,
+  });
+  const socketPath = process.env.OPENCLAW_QUANTD_SOCKET_PATH?.trim() || undefined;
+  const walPath = process.env.OPENCLAW_QUANTD_WAL_PATH?.trim() || undefined;
+
+  const handle = await startQuantdServer({
+    host,
+    port,
+    socketPath,
+    walPath,
+  });
+  const listenTarget = handle.baseUrl ?? handle.socketPath ?? `http://${host}:${port}`;
+  params.log.info(`quantd sidecar started at ${listenTarget} (wal=${handle.walPath})`);
+  return handle;
+}

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -28,6 +28,7 @@ import {
   shouldWakeFromRestartSentinel,
 } from "./server-restart-sentinel.js";
 import { startGatewayMemoryBackend } from "./server-startup-memory.js";
+import { startGatewayQuantdSidecar } from "./server-startup-quantd.js";
 
 const SESSION_LOCK_STALE_MS = 30 * 60 * 1000;
 
@@ -37,7 +38,7 @@ export async function startGatewaySidecars(params: {
   defaultWorkspaceDir: string;
   deps: CliDeps;
   startChannels: () => Promise<void>;
-  log: { warn: (msg: string) => void };
+  log: { info: (msg: string) => void; warn: (msg: string) => void };
   logHooks: {
     info: (msg: string) => void;
     warn: (msg: string) => void;
@@ -181,11 +182,18 @@ export async function startGatewaySidecars(params: {
     params.log.warn(`qmd memory startup initialization failed: ${String(err)}`);
   });
 
+  let quantd = null;
+  try {
+    quantd = await startGatewayQuantdSidecar({ log: params.log });
+  } catch (err) {
+    params.log.warn(`quantd sidecar failed to start: ${String(err)}`);
+  }
+
   if (shouldWakeFromRestartSentinel()) {
     setTimeout(() => {
       void scheduleRestartSentinelWake({ deps: params.deps });
     }, 750);
   }
 
-  return { browserControl, pluginServices };
+  return { browserControl, pluginServices, quantd };
 }

--- a/src/gateway/server.health.test.ts
+++ b/src/gateway/server.health.test.ts
@@ -57,6 +57,13 @@ describe("gateway server health/presence", () => {
       const status = await statusP;
       const presence = await presenceP;
       expect(health.ok).toBe(true);
+      expect((health.payload as { quantd?: { status?: string } } | undefined)?.quantd?.status).toBe(
+        "disabled",
+      );
+      expect(
+        (health.payload as { monitoring?: { agents?: { total?: number } } } | undefined)?.monitoring
+          ?.agents?.total,
+      ).toBeGreaterThan(0);
       expect(status.ok).toBe(true);
       expect(presence.ok).toBe(true);
       expect(Array.isArray(presence.payload)).toBe(true);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -721,6 +721,10 @@ export async function startGatewayServer(
       removeChatRun,
       agentRunSeq,
       nodeSendToSession,
+      enqueueRuntimeSystemEvent: (text: string) =>
+        enqueueSystemEvent(text, {
+          sessionKey: resolveMainSessionKey(cfgAtStart),
+        }),
       ...(typeof cfgAtStart.media?.ttlHours === "number"
         ? { mediaCleanupTtlMs: resolveMediaCleanupTtlMs(cfgAtStart.media.ttlHours) }
         : {}),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -925,8 +925,9 @@ export async function startGatewayServer(
       });
 
   let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
+  let quantd: { close: () => Promise<void> } | null = null;
   if (!minimalTestGateway) {
-    ({ browserControl, pluginServices } = await startGatewaySidecars({
+    ({ browserControl, pluginServices, quantd } = await startGatewaySidecars({
       cfg: cfgAtStart,
       pluginRegistry,
       defaultWorkspaceDir,
@@ -1024,6 +1025,7 @@ export async function startGatewayServer(
     canvasHostServer,
     stopChannel,
     pluginServices,
+    quantd,
     cron,
     heartbeatRunner,
     updateCheckStop: stopGatewayUpdateCheck,

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -557,9 +557,14 @@ vi.mock("../agents/pi-embedded.js", async () => {
   };
 });
 
-vi.mock("../commands/health.js", () => ({
-  getHealthSnapshot: vi.fn().mockResolvedValue({ ok: true, stub: true }),
-}));
+vi.mock("../commands/health.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../commands/health.js")>("../commands/health.js");
+  return {
+    ...actual,
+    getHealthSnapshot: vi.fn(actual.getHealthSnapshot),
+  };
+});
 vi.mock("../commands/status.js", () => ({
   getStatusSummary: vi.fn().mockResolvedValue({ ok: true }),
 }));

--- a/src/quantd/client.ts
+++ b/src/quantd/client.ts
@@ -1,0 +1,150 @@
+import http from "node:http";
+import https from "node:https";
+import type {
+  QuantdHeartbeatEvent,
+  QuantdIngestResult,
+  QuantdMarketEvent,
+  QuantdOrderEvent,
+  QuantdSnapshot,
+} from "./types.js";
+
+export const DEFAULT_QUANTD_BASE_URL = "http://127.0.0.1:19891";
+
+type QuantdRequestResult = {
+  status: number;
+  body: string;
+};
+
+function requestQuantd(params: {
+  baseUrl?: string;
+  socketPath?: string;
+  path: string;
+  method?: string;
+  body?: Record<string, unknown>;
+  timeoutMs?: number;
+}): Promise<QuantdRequestResult> {
+  const method = params.method ?? "GET";
+  const timeoutMs = params.timeoutMs ?? 5_000;
+  const rawBody = params.body ? JSON.stringify(params.body) : undefined;
+
+  return new Promise((resolve, reject) => {
+    const url = new URL(params.baseUrl ?? DEFAULT_QUANTD_BASE_URL);
+    const transport = url.protocol === "https:" ? https : http;
+    const req = transport.request(
+      {
+        protocol: params.socketPath ? "http:" : url.protocol,
+        hostname: params.socketPath ? undefined : url.hostname,
+        port: params.socketPath ? undefined : url.port,
+        socketPath: params.socketPath,
+        path: params.path,
+        method,
+        headers: rawBody
+          ? {
+              "Content-Type": "application/json; charset=utf-8",
+              "Content-Length": Buffer.byteLength(rawBody),
+            }
+          : undefined,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 500,
+            body: Buffer.concat(chunks).toString("utf-8"),
+          });
+        });
+      },
+    );
+
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`quantd request timed out after ${timeoutMs}ms`));
+    });
+    req.on("error", reject);
+    if (rawBody) {
+      req.write(rawBody);
+    }
+    req.end();
+  });
+}
+
+function parseJsonResponse<T>(result: QuantdRequestResult): T {
+  if (result.status >= 400) {
+    throw new Error(result.body || `quantd request failed with status ${result.status}`);
+  }
+  return JSON.parse(result.body) as T;
+}
+
+export function createQuantdClient(options?: {
+  baseUrl?: string;
+  socketPath?: string;
+  timeoutMs?: number;
+}) {
+  const baseUrl = options?.baseUrl ?? DEFAULT_QUANTD_BASE_URL;
+  const socketPath = options?.socketPath;
+  const timeoutMs = options?.timeoutMs;
+
+  return {
+    async health(): Promise<{ ok: boolean; status: number; body: string }> {
+      const result = await requestQuantd({
+        baseUrl,
+        socketPath,
+        path: "/healthz",
+        timeoutMs,
+      });
+      return {
+        ok: result.status < 400,
+        status: result.status,
+        body: result.body,
+      };
+    },
+
+    async snapshot(): Promise<QuantdSnapshot> {
+      const result = await requestQuantd({
+        baseUrl,
+        socketPath,
+        path: "/v1/snapshot",
+        timeoutMs,
+      });
+      return parseJsonResponse<QuantdSnapshot>(result);
+    },
+
+    async ingestHeartbeat(event: QuantdHeartbeatEvent): Promise<QuantdIngestResult> {
+      const result = await requestQuantd({
+        baseUrl,
+        socketPath,
+        path: "/v1/heartbeat",
+        method: "POST",
+        body: event,
+        timeoutMs,
+      });
+      return parseJsonResponse<QuantdIngestResult>(result);
+    },
+
+    async ingestMarketEvent(event: QuantdMarketEvent): Promise<QuantdIngestResult> {
+      const result = await requestQuantd({
+        baseUrl,
+        socketPath,
+        path: "/v1/market-events",
+        method: "POST",
+        body: event,
+        timeoutMs,
+      });
+      return parseJsonResponse<QuantdIngestResult>(result);
+    },
+
+    async ingestOrderEvent(event: QuantdOrderEvent): Promise<QuantdIngestResult> {
+      const result = await requestQuantd({
+        baseUrl,
+        socketPath,
+        path: "/v1/order-events",
+        method: "POST",
+        body: event,
+        timeoutMs,
+      });
+      return parseJsonResponse<QuantdIngestResult>(result);
+    },
+  };
+}

--- a/src/quantd/runtime-summary.test.ts
+++ b/src/quantd/runtime-summary.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createQuantdClientMock, snapshotMock } = vi.hoisted(() => ({
+  createQuantdClientMock: vi.fn(),
+  snapshotMock: vi.fn(),
+}));
+
+vi.mock("./client.js", () => ({
+  createQuantdClient: (options: unknown) => createQuantdClientMock(options),
+}));
+
+import { getQuantdRuntimeSummary } from "./runtime-summary.js";
+
+describe("getQuantdRuntimeSummary", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.OPENCLAW_QUANTD_ENABLED;
+    delete process.env.OPENCLAW_QUANTD_HOST;
+    delete process.env.OPENCLAW_QUANTD_PORT;
+    delete process.env.OPENCLAW_QUANTD_SOCKET_PATH;
+    snapshotMock.mockReset();
+    createQuantdClientMock.mockReset();
+    createQuantdClientMock.mockReturnValue({
+      snapshot: snapshotMock,
+    });
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns disabled summary when quantd is not enabled", async () => {
+    await expect(getQuantdRuntimeSummary()).resolves.toMatchObject({
+      enabled: false,
+      status: "disabled",
+    });
+
+    expect(createQuantdClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns ok summary from quantd snapshot when enabled", async () => {
+    process.env.OPENCLAW_QUANTD_ENABLED = "1";
+    process.env.OPENCLAW_QUANTD_HOST = "127.0.0.9";
+    process.env.OPENCLAW_QUANTD_PORT = "21001";
+    snapshotMock.mockResolvedValue({
+      health: {
+        status: "ok",
+        reasons: [],
+        lastHeartbeatAt: "2026-03-14T00:00:00.000Z",
+      },
+      wal: { path: "/tmp/quantd.jsonl", records: 5 },
+      replay: { lastSequence: 5, replayedRecords: 5 },
+      metrics: {
+        heartbeats: 2,
+        marketEvents: 2,
+        orderEvents: 1,
+        duplicateEvents: 0,
+      },
+      recentEvents: [{ sequence: 5, kind: "order_event", receivedAt: "x", summary: "filled" }],
+    });
+
+    await expect(getQuantdRuntimeSummary({ timeoutMs: 4321 })).resolves.toMatchObject({
+      enabled: true,
+      status: "ok",
+      baseUrl: "http://127.0.0.9:21001",
+      health: {
+        status: "ok",
+      },
+      metrics: {
+        heartbeats: 2,
+        orderEvents: 1,
+      },
+      wal: {
+        path: "/tmp/quantd.jsonl",
+      },
+    });
+
+    expect(createQuantdClientMock).toHaveBeenCalledWith({
+      baseUrl: "http://127.0.0.9:21001",
+      socketPath: undefined,
+      timeoutMs: 4321,
+    });
+  });
+
+  it("returns unreachable summary when quantd snapshot fetch fails", async () => {
+    process.env.OPENCLAW_QUANTD_ENABLED = "1";
+    snapshotMock.mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+    await expect(getQuantdRuntimeSummary()).resolves.toMatchObject({
+      enabled: true,
+      status: "unreachable",
+      error: expect.stringContaining("ECONNREFUSED"),
+    });
+  });
+});

--- a/src/quantd/runtime-summary.ts
+++ b/src/quantd/runtime-summary.ts
@@ -1,0 +1,81 @@
+import { isTruthyEnvValue } from "../infra/env.js";
+import { createQuantdClient, DEFAULT_QUANTD_BASE_URL } from "./client.js";
+import type { QuantdSnapshot } from "./types.js";
+
+export type QuantdRuntimeStatus = "disabled" | "ok" | "degraded" | "unreachable";
+
+export type QuantdRuntimeSummary = {
+  enabled: boolean;
+  status: QuantdRuntimeStatus;
+  baseUrl?: string;
+  socketPath?: string;
+  error?: string;
+  health?: QuantdSnapshot["health"];
+  wal?: QuantdSnapshot["wal"];
+  replay?: QuantdSnapshot["replay"];
+  metrics?: QuantdSnapshot["metrics"];
+  recentEvents?: QuantdSnapshot["recentEvents"];
+};
+
+const DEFAULT_QUANTD_TIMEOUT_MS = 1_500;
+
+function resolveQuantdPort(raw: string | undefined) {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return 19_891;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65_535) {
+    return 19_891;
+  }
+  return parsed;
+}
+
+function resolveQuantdBaseUrlFromEnv(): string {
+  const host = process.env.OPENCLAW_QUANTD_HOST?.trim() || "127.0.0.1";
+  const port = resolveQuantdPort(process.env.OPENCLAW_QUANTD_PORT);
+  return `http://${host}:${port}`;
+}
+
+export async function getQuantdRuntimeSummary(options?: {
+  timeoutMs?: number;
+}): Promise<QuantdRuntimeSummary> {
+  if (!isTruthyEnvValue(process.env.OPENCLAW_QUANTD_ENABLED)) {
+    return {
+      enabled: false,
+      status: "disabled",
+    };
+  }
+
+  const socketPath = process.env.OPENCLAW_QUANTD_SOCKET_PATH?.trim() || undefined;
+  const baseUrl = socketPath ? undefined : resolveQuantdBaseUrlFromEnv();
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_QUANTD_TIMEOUT_MS;
+
+  try {
+    const client = createQuantdClient({
+      baseUrl: baseUrl ?? DEFAULT_QUANTD_BASE_URL,
+      socketPath,
+      timeoutMs,
+    });
+    const snapshot = await client.snapshot();
+    return {
+      enabled: true,
+      status: snapshot.health.status === "ok" ? "ok" : "degraded",
+      baseUrl,
+      socketPath,
+      health: snapshot.health,
+      wal: snapshot.wal,
+      replay: snapshot.replay,
+      metrics: snapshot.metrics,
+      recentEvents: snapshot.recentEvents,
+    };
+  } catch (error) {
+    return {
+      enabled: true,
+      status: "unreachable",
+      baseUrl,
+      socketPath,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/quantd/server.test.ts
+++ b/src/quantd/server.test.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createQuantdClient } from "./client.js";
+import { startQuantdServer } from "./server.js";
+
+describe("quantd server", () => {
+  const cleanupPaths: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      cleanupPaths.splice(0).map(async (target) => {
+        await fs.rm(target, { recursive: true, force: true });
+      }),
+    );
+  });
+
+  it("writes events, returns snapshot, and replays WAL on restart", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-quantd-server-"));
+    cleanupPaths.push(root);
+    const walPath = path.join(root, "quantd.jsonl");
+
+    const started = await startQuantdServer({
+      host: "127.0.0.1",
+      port: 0,
+      walPath,
+      heartbeatStaleAfterMs: 10_000,
+    });
+
+    const client = createQuantdClient({
+      baseUrl: started.baseUrl,
+    });
+
+    await expect(
+      client.ingestHeartbeat({
+        eventId: "hb-1",
+        source: "gateway",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      applied: true,
+      replayed: false,
+      sequence: 1,
+    });
+
+    await expect(
+      client.ingestMarketEvent({
+        eventId: "mkt-1",
+        symbol: "EURUSD",
+        signal: "enter_long",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      applied: true,
+      replayed: false,
+      sequence: 2,
+    });
+
+    await expect(
+      client.ingestMarketEvent({
+        eventId: "mkt-1",
+        symbol: "EURUSD",
+        signal: "enter_long",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      applied: false,
+      replayed: true,
+      sequence: 2,
+    });
+
+    await expect(client.snapshot()).resolves.toMatchObject({
+      health: {
+        status: "ok",
+      },
+      wal: {
+        path: walPath,
+        records: 2,
+      },
+      metrics: {
+        heartbeats: 1,
+        marketEvents: 1,
+        duplicateEvents: 1,
+      },
+      replay: {
+        lastSequence: 2,
+      },
+    });
+
+    await started.close();
+
+    const restarted = await startQuantdServer({
+      host: "127.0.0.1",
+      port: 0,
+      walPath,
+      heartbeatStaleAfterMs: 10_000,
+    });
+
+    const restartedClient = createQuantdClient({
+      baseUrl: restarted.baseUrl,
+    });
+
+    await expect(restartedClient.snapshot()).resolves.toMatchObject({
+      wal: {
+        records: 2,
+      },
+      replay: {
+        lastSequence: 2,
+        replayedRecords: 2,
+      },
+      metrics: {
+        heartbeats: 1,
+        marketEvents: 1,
+      },
+    });
+
+    await restarted.close();
+  });
+});

--- a/src/quantd/server.test.ts
+++ b/src/quantd/server.test.ts
@@ -117,4 +117,52 @@ describe("quantd server", () => {
 
     await restarted.close();
   });
+
+  it("rejects non-object JSON bodies for event ingestion", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-quantd-server-invalid-"));
+    cleanupPaths.push(root);
+    const walPath = path.join(root, "quantd.jsonl");
+    const started = await startQuantdServer({
+      host: "127.0.0.1",
+      port: 0,
+      walPath,
+    });
+
+    const baseUrl = started.baseUrl ?? "";
+
+    await expect(
+      fetch(`${baseUrl}/v1/market-events`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "[]",
+      }).then(async (res) => ({ status: res.status, body: await res.json() })),
+    ).resolves.toMatchObject({
+      status: 400,
+      body: { error: "request body must be a JSON object" },
+    });
+
+    await expect(
+      fetch(`${baseUrl}/v1/order-events`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: '"x"',
+      }).then(async (res) => ({ status: res.status, body: await res.json() })),
+    ).resolves.toMatchObject({
+      status: 400,
+      body: { error: "request body must be a JSON object" },
+    });
+
+    await expect(
+      fetch(`${baseUrl}/v1/heartbeat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "123",
+      }).then(async (res) => ({ status: res.status, body: await res.json() })),
+    ).resolves.toMatchObject({
+      status: 400,
+      body: { error: "request body must be a JSON object" },
+    });
+
+    await started.close();
+  });
 });

--- a/src/quantd/server.ts
+++ b/src/quantd/server.ts
@@ -1,0 +1,245 @@
+import fs from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
+import path from "node:path";
+import { STATE_DIR } from "../config/paths.js";
+import { readJsonBodyWithLimit } from "../infra/http-body.js";
+import { createQuantdStateStore } from "./state.js";
+import type {
+  QuantdEventKind,
+  QuantdEventPayload,
+  QuantdHeartbeatEvent,
+  QuantdIngestResult,
+  QuantdMarketEvent,
+  QuantdOrderEvent,
+  QuantdSnapshot,
+} from "./types.js";
+import { appendQuantdWalRecord, readQuantdWalRecords } from "./wal.js";
+
+const DEFAULT_QUANTD_MAX_BODY_BYTES = 256 * 1024;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toEventPayload<T extends QuantdEventPayload>(value: unknown): T {
+  if (!isRecord(value)) {
+    throw new Error("request body must be a JSON object");
+  }
+  return value as T;
+}
+
+function sendJson(res: ServerResponse, status: number, value: unknown) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(value));
+}
+
+function sendText(res: ServerResponse, status: number, value: string) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  res.end(value);
+}
+
+async function listenQuantdServer(params: {
+  server: ReturnType<typeof createServer>;
+  host: string;
+  port: number;
+  socketPath?: string;
+}) {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      params.server.off("error", onError);
+      reject(error);
+    };
+    params.server.once("error", onError);
+    if (params.socketPath) {
+      params.server.listen(params.socketPath, () => {
+        params.server.off("error", onError);
+        resolve();
+      });
+      return;
+    }
+    params.server.listen(params.port, params.host, () => {
+      params.server.off("error", onError);
+      resolve();
+    });
+  });
+}
+
+async function ingestEvent(params: {
+  kind: QuantdEventKind;
+  body: unknown;
+  walPath: string;
+  store: ReturnType<typeof createQuantdStateStore>;
+}): Promise<QuantdIngestResult> {
+  const payload = toEventPayload<QuantdEventPayload>(params.body);
+  const prepared = params.store.prepareEvent(params.kind, payload);
+  if (prepared.duplicate) {
+    return {
+      ok: true,
+      applied: false,
+      replayed: true,
+      sequence: prepared.existingSequence,
+      kind: params.kind,
+    };
+  }
+
+  await appendQuantdWalRecord({
+    walPath: params.walPath,
+    record: prepared.record,
+  });
+  params.store.commitRecord(prepared.record);
+  return {
+    ok: true,
+    applied: true,
+    replayed: false,
+    sequence: prepared.record.sequence,
+    kind: params.kind,
+  };
+}
+
+export function resolveQuantdWalPath(input?: string): string {
+  const trimmed = input?.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  return path.join(STATE_DIR, "quantd", "events.jsonl");
+}
+
+export async function startQuantdServer(options?: {
+  host?: string;
+  port?: number;
+  socketPath?: string;
+  walPath?: string;
+  heartbeatStaleAfterMs?: number;
+  recentEventLimit?: number;
+  bodyLimitBytes?: number;
+  now?: () => number;
+}) {
+  const host = options?.host ?? "127.0.0.1";
+  const port = options?.port ?? 19_891;
+  const socketPath = options?.socketPath?.trim() || undefined;
+  const walPath = resolveQuantdWalPath(options?.walPath);
+  const store = createQuantdStateStore({
+    walPath,
+    heartbeatStaleAfterMs: options?.heartbeatStaleAfterMs,
+    recentEventLimit: options?.recentEventLimit,
+    now: options?.now,
+  });
+
+  const replayRecords = await readQuantdWalRecords({ walPath });
+  for (const record of replayRecords) {
+    store.commitRecord(record, { fromReplay: true });
+  }
+
+  if (socketPath) {
+    await fs.mkdir(path.dirname(socketPath), { recursive: true });
+    await fs.rm(socketPath, { force: true });
+  }
+
+  const server = createServer((req, res) => {
+    const route = `${req.method ?? "GET"} ${req.url ?? "/"}`;
+    const bodyLimitBytes = options?.bodyLimitBytes ?? DEFAULT_QUANTD_MAX_BODY_BYTES;
+    if (route === "GET /healthz") {
+      const snapshot = store.snapshot();
+      const statusCode = snapshot.health.status === "ok" ? 200 : 503;
+      sendText(res, statusCode, snapshot.health.status === "ok" ? "ok" : "degraded");
+      return;
+    }
+    if (route === "GET /v1/snapshot") {
+      sendJson(res, 200, store.snapshot());
+      return;
+    }
+    if (
+      route === "POST /v1/heartbeat" ||
+      route === "POST /v1/market-events" ||
+      route === "POST /v1/order-events"
+    ) {
+      void (async () => {
+        const parsed = await readJsonBodyWithLimit(req, {
+          maxBytes: bodyLimitBytes,
+          emptyObjectOnEmpty: false,
+        });
+        if (!parsed.ok) {
+          const status =
+            parsed.code === "PAYLOAD_TOO_LARGE"
+              ? 413
+              : parsed.code === "REQUEST_BODY_TIMEOUT"
+                ? 408
+                : 400;
+          sendJson(res, status, {
+            error: parsed.error,
+          });
+          return;
+        }
+        try {
+          const result =
+            route === "POST /v1/heartbeat"
+              ? await ingestEvent({
+                  kind: "heartbeat",
+                  body: parsed.value as QuantdHeartbeatEvent,
+                  walPath,
+                  store,
+                })
+              : route === "POST /v1/market-events"
+                ? await ingestEvent({
+                    kind: "market_event",
+                    body: parsed.value as QuantdMarketEvent,
+                    walPath,
+                    store,
+                  })
+                : await ingestEvent({
+                    kind: "order_event",
+                    body: parsed.value as QuantdOrderEvent,
+                    walPath,
+                    store,
+                  });
+          sendJson(res, 200, result);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          sendJson(res, /json object/i.test(message) ? 400 : 500, {
+            error: message,
+          });
+        }
+      })();
+      return;
+    }
+    sendText(res, 404, "not found");
+  });
+
+  await listenQuantdServer({
+    server,
+    host,
+    port,
+    socketPath,
+  });
+
+  const address = server.address();
+  const baseUrl =
+    socketPath || !address || typeof address === "string"
+      ? undefined
+      : `http://${host}:${address.port}`;
+
+  return {
+    baseUrl,
+    socketPath,
+    walPath,
+    snapshot(): QuantdSnapshot {
+      return store.snapshot();
+    },
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+      if (socketPath) {
+        await fs.rm(socketPath, { force: true });
+      }
+    },
+  };
+}

--- a/src/quantd/state.test.ts
+++ b/src/quantd/state.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { createQuantdStateStore } from "./state.js";
+
+describe("quantd state", () => {
+  it("replays duplicate ids without allocating a new record", () => {
+    const store = createQuantdStateStore();
+
+    const first = store.prepareEvent("market_event", {
+      eventId: "evt-1",
+      symbol: "EURUSD",
+      signal: "enter_long",
+    });
+
+    expect(first.duplicate).toBe(false);
+    if (first.duplicate || !first.record) {
+      throw new Error("expected first record");
+    }
+
+    store.commitRecord(first.record);
+
+    const duplicate = store.prepareEvent("market_event", {
+      eventId: "evt-1",
+      symbol: "EURUSD",
+      signal: "enter_long",
+    });
+
+    expect(duplicate).toEqual({
+      duplicate: true,
+      existingSequence: 1,
+    });
+    expect(store.snapshot().metrics.duplicateEvents).toBe(1);
+  });
+
+  it("marks health degraded when heartbeat becomes stale", () => {
+    let now = 1_000;
+    const store = createQuantdStateStore({
+      now: () => now,
+      heartbeatStaleAfterMs: 250,
+    });
+
+    const heartbeat = store.prepareEvent("heartbeat", {
+      eventId: "hb-1",
+      source: "gateway",
+    });
+    if (heartbeat.duplicate || !heartbeat.record) {
+      throw new Error("expected heartbeat record");
+    }
+    store.commitRecord(heartbeat.record);
+
+    expect(store.snapshot().health).toMatchObject({
+      status: "ok",
+      reasons: [],
+    });
+
+    now += 400;
+
+    expect(store.snapshot().health).toMatchObject({
+      status: "degraded",
+      reasons: ["heartbeat_stale"],
+    });
+  });
+});

--- a/src/quantd/state.ts
+++ b/src/quantd/state.ts
@@ -1,0 +1,180 @@
+import type {
+  QuantdCommitRecordOptions,
+  QuantdEventKind,
+  QuantdEventPayload,
+  QuantdPrepareEventResult,
+  QuantdRecentEvent,
+  QuantdSnapshot,
+  QuantdWalRecord,
+} from "./types.js";
+
+function formatSummaryValue(value: unknown): string {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "-";
+}
+
+function normalizeDedupeKey(payload: QuantdEventPayload): string | null {
+  const eventId = payload.eventId?.trim();
+  if (eventId) {
+    return `event:${eventId}`;
+  }
+  const idempotencyKey = payload.idempotencyKey?.trim();
+  if (idempotencyKey) {
+    return `idempotency:${idempotencyKey}`;
+  }
+  return null;
+}
+
+function summarizeRecord(record: QuantdWalRecord): string {
+  switch (record.kind) {
+    case "heartbeat":
+      return `heartbeat:${String(record.source ?? "unknown")}`;
+    case "market_event":
+      return `market:${formatSummaryValue(record.payload.symbol)}:${formatSummaryValue(record.payload.signal)}`;
+    case "order_event":
+      return `order:${formatSummaryValue(record.payload.orderId)}:${formatSummaryValue(record.payload.status)}`;
+  }
+}
+
+export function createQuantdStateStore(options?: {
+  walPath?: string;
+  now?: () => number;
+  heartbeatStaleAfterMs?: number;
+  recentEventLimit?: number;
+}) {
+  const now = options?.now ?? (() => Date.now());
+  const heartbeatStaleAfterMs = Math.max(1, options?.heartbeatStaleAfterMs ?? 5_000);
+  const recentEventLimit = Math.max(1, options?.recentEventLimit ?? 25);
+  const walPath = options?.walPath ?? "";
+
+  let lastSequence = 0;
+  let replayedRecords = 0;
+  let walRecords = 0;
+  let lastHeartbeatAt: number | undefined;
+  let lastMarketEventAt: number | undefined;
+  let lastOrderEventAt: number | undefined;
+
+  const dedupeIndex = new Map<string, number>();
+  const recentEvents: QuantdRecentEvent[] = [];
+  const metrics = {
+    heartbeats: 0,
+    marketEvents: 0,
+    orderEvents: 0,
+    duplicateEvents: 0,
+  };
+
+  return {
+    getLastSequence() {
+      return lastSequence;
+    },
+
+    prepareEvent(kind: QuantdEventKind, payload: QuantdEventPayload): QuantdPrepareEventResult {
+      const dedupeKey = normalizeDedupeKey(payload);
+      if (dedupeKey) {
+        const existingSequence = dedupeIndex.get(dedupeKey);
+        if (existingSequence !== undefined) {
+          metrics.duplicateEvents += 1;
+          return {
+            duplicate: true,
+            existingSequence,
+          };
+        }
+      }
+
+      return {
+        duplicate: false,
+        record: {
+          sequence: lastSequence + 1,
+          kind,
+          receivedAt: new Date(now()).toISOString(),
+          eventId: payload.eventId?.trim() || undefined,
+          idempotencyKey: payload.idempotencyKey?.trim() || undefined,
+          source: payload.source?.trim() || undefined,
+          occurredAt: payload.occurredAt?.trim() || undefined,
+          payload: { ...payload },
+        },
+      };
+    },
+
+    commitRecord(record: QuantdWalRecord, commitOptions?: QuantdCommitRecordOptions) {
+      const options = commitOptions ?? {};
+      lastSequence = Math.max(lastSequence, record.sequence);
+      walRecords += 1;
+      if (options.fromReplay) {
+        replayedRecords += 1;
+      }
+
+      const dedupeKey = normalizeDedupeKey(record.payload as QuantdEventPayload);
+      if (dedupeKey) {
+        dedupeIndex.set(dedupeKey, record.sequence);
+      }
+
+      const receivedAtMs = Date.parse(record.receivedAt);
+      switch (record.kind) {
+        case "heartbeat":
+          metrics.heartbeats += 1;
+          lastHeartbeatAt = receivedAtMs;
+          break;
+        case "market_event":
+          metrics.marketEvents += 1;
+          lastMarketEventAt = receivedAtMs;
+          break;
+        case "order_event":
+          metrics.orderEvents += 1;
+          lastOrderEventAt = receivedAtMs;
+          break;
+      }
+
+      recentEvents.unshift({
+        sequence: record.sequence,
+        kind: record.kind,
+        receivedAt: record.receivedAt,
+        eventId: record.eventId,
+        summary: summarizeRecord(record),
+      });
+      recentEvents.splice(recentEventLimit);
+    },
+
+    snapshot(): QuantdSnapshot {
+      const currentNow = now();
+      const reasons: string[] = [];
+      if (lastHeartbeatAt === undefined) {
+        reasons.push("heartbeat_missing");
+      } else if (currentNow - lastHeartbeatAt > heartbeatStaleAfterMs) {
+        reasons.push("heartbeat_stale");
+      }
+      return {
+        health: {
+          status: reasons.length > 0 ? "degraded" : "ok",
+          reasons,
+          ...(lastHeartbeatAt !== undefined
+            ? { lastHeartbeatAt: new Date(lastHeartbeatAt).toISOString() }
+            : {}),
+          ...(lastMarketEventAt !== undefined
+            ? { lastMarketEventAt: new Date(lastMarketEventAt).toISOString() }
+            : {}),
+          ...(lastOrderEventAt !== undefined
+            ? { lastOrderEventAt: new Date(lastOrderEventAt).toISOString() }
+            : {}),
+        },
+        wal: {
+          path: walPath,
+          records: walRecords,
+        },
+        replay: {
+          lastSequence,
+          replayedRecords,
+        },
+        metrics: {
+          ...metrics,
+        },
+        recentEvents: [...recentEvents],
+      };
+    },
+  };
+}

--- a/src/quantd/types.ts
+++ b/src/quantd/types.ts
@@ -1,0 +1,96 @@
+export type QuantdEventKind = "heartbeat" | "market_event" | "order_event";
+
+export type QuantdEventInputBase = {
+  eventId?: string;
+  idempotencyKey?: string;
+  source?: string;
+  occurredAt?: string;
+};
+
+export type QuantdHeartbeatEvent = QuantdEventInputBase & {
+  status?: string;
+  note?: string;
+};
+
+export type QuantdMarketEvent = QuantdEventInputBase & {
+  symbol?: string;
+  signal?: string;
+  price?: number;
+};
+
+export type QuantdOrderEvent = QuantdEventInputBase & {
+  orderId?: string;
+  accountId?: string;
+  symbol?: string;
+  status?: string;
+  side?: string;
+  quantity?: number;
+};
+
+export type QuantdEventPayload = QuantdHeartbeatEvent | QuantdMarketEvent | QuantdOrderEvent;
+
+export type QuantdWalRecord = {
+  sequence: number;
+  kind: QuantdEventKind;
+  receivedAt: string;
+  eventId?: string;
+  idempotencyKey?: string;
+  source?: string;
+  occurredAt?: string;
+  payload: Record<string, unknown>;
+};
+
+export type QuantdPrepareEventResult =
+  | {
+      duplicate: true;
+      existingSequence: number;
+    }
+  | {
+      duplicate: false;
+      record: QuantdWalRecord;
+    };
+
+export type QuantdCommitRecordOptions = {
+  fromReplay?: boolean;
+};
+
+export type QuantdRecentEvent = {
+  sequence: number;
+  kind: QuantdEventKind;
+  receivedAt: string;
+  eventId?: string;
+  summary: string;
+};
+
+export type QuantdSnapshot = {
+  health: {
+    status: "ok" | "degraded";
+    reasons: string[];
+    lastHeartbeatAt?: string;
+    lastMarketEventAt?: string;
+    lastOrderEventAt?: string;
+  };
+  wal: {
+    path: string;
+    records: number;
+  };
+  replay: {
+    lastSequence: number;
+    replayedRecords: number;
+  };
+  metrics: {
+    heartbeats: number;
+    marketEvents: number;
+    orderEvents: number;
+    duplicateEvents: number;
+  };
+  recentEvents: QuantdRecentEvent[];
+};
+
+export type QuantdIngestResult = {
+  ok: true;
+  applied: boolean;
+  replayed: boolean;
+  sequence: number;
+  kind: QuantdEventKind;
+};

--- a/src/quantd/wal.test.ts
+++ b/src/quantd/wal.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { QuantdWalRecord } from "./types.js";
+import { appendQuantdWalRecord, readQuantdWalRecords } from "./wal.js";
+
+describe("quantd wal", () => {
+  const cleanupPaths: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      cleanupPaths.splice(0).map(async (target) => {
+        await fs.rm(target, { recursive: true, force: true });
+      }),
+    );
+  });
+
+  it("appends and replays records in order", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-quantd-wal-"));
+    cleanupPaths.push(root);
+    const walPath = path.join(root, "quantd.jsonl");
+
+    const records: QuantdWalRecord[] = [
+      {
+        sequence: 1,
+        kind: "heartbeat",
+        receivedAt: "2026-03-14T09:00:00.000Z",
+        eventId: "hb-1",
+        payload: { source: "gateway" },
+      },
+      {
+        sequence: 2,
+        kind: "market_event",
+        receivedAt: "2026-03-14T09:00:01.000Z",
+        eventId: "mkt-1",
+        payload: { symbol: "EURUSD", signal: "enter_long" },
+      },
+    ];
+
+    for (const record of records) {
+      await appendQuantdWalRecord({ walPath, record });
+    }
+
+    await expect(readQuantdWalRecords({ walPath })).resolves.toEqual(records);
+  });
+});

--- a/src/quantd/wal.ts
+++ b/src/quantd/wal.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { QuantdWalRecord } from "./types.js";
+
+export async function appendQuantdWalRecord(params: {
+  walPath: string;
+  record: QuantdWalRecord;
+}): Promise<void> {
+  await fs.mkdir(path.dirname(params.walPath), { recursive: true });
+  await fs.appendFile(params.walPath, `${JSON.stringify(params.record)}\n`, "utf-8");
+}
+
+export async function readQuantdWalRecords(params: {
+  walPath: string;
+}): Promise<QuantdWalRecord[]> {
+  try {
+    const raw = await fs.readFile(params.walPath, "utf-8");
+    return raw
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as QuantdWalRecord)
+      .toSorted((a, b) => a.sequence - b.sequence);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

- Problem: embedded failover routing in `run.ts` still depended on raw prompt/assistant error text, so generic provider errors at the `run/attempt.ts` boundary could bypass profile rotation and model fallback.
- Why it matters: prompt-side 429/timeout/overload failures should route immediately and deterministically inside a single run, especially when the actual provider call failed before a provider-specific error string reached the outer loop.
- What changed: added typed attempt-level failover signals, captured prompt-side provider failures at the stream function boundary in `run/attempt.ts`, and made `run.ts` prefer those signals for routing, cooldown, circuit-breaker logging, and fallback decisions.
- What did NOT change (scope boundary): this PR does not add persistent cross-run model health storage, does not change fallback ordering, and does not introduce new execution capabilities.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Prompt-side provider failures can now trigger the same embedded failover routing even when the outer error text is generic.
- Embedded attempts now return structured failover metadata for prompt/assistant failures, improving routing and audit consistency.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm wrapper via `corepack`
- Model/provider: mocked embedded runner providers in Vitest
- Integration/channel (if any): embedded Pi runner
- Relevant config (redacted): embedded auth profiles with provider fallbacks enabled

### Steps

1. Mock `runEmbeddedAttempt()` to return a generic prompt error plus a structured prompt failover signal.
2. Run `runEmbeddedPiAgent()` with auto-pinned auth profiles and fallback-enabled config.
3. Verify the runner rotates/falls back from the structured signal instead of relying on the raw error text.

### Expected

- Structured prompt failures trigger the same failover path as explicit provider error strings.

### Actual

- Verified by tests below.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `run/attempt.ts` captures prompt-side failover signals from stream-call failures.
  - `run.ts` uses typed prompt failover signals when prompt error text is generic.
  - Existing embedded auth-profile rotation, model fallback, failover router, and failover observation tests still pass.
- Edge cases checked:
  - Unknown statuses do not create failover signals unless they map to a known failover reason.
  - Compaction timeouts remain excluded from assistant rotation.
- What you did **not** verify:
  - Live provider traffic.
  - Cross-run persistent model circuit state.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `dd6ee47aa`.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/run.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/agents/pi-embedded-runner/run/types.ts`
- Known bad symptoms reviewers should watch for:
  - Generic prompt errors rotating/falling back when they should surface directly.
  - Duplicate failover logging from a single prompt failure.

## Risks and Mitigations

- Risk:
  - Attempt-level signal capture could over-classify unknown provider failures.
  - Mitigation:
    - Only known failover reasons produce typed signals; unknown statuses no longer route automatically.
