### PR TITLE
fix(feishu): add wsConfig with PingInterval/PingTimeout to WSClient

### DIFF
--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -163,6 +163,10 @@ export function createFeishuWSClient(account: ResolvedFeishuAccount): Lark.WSCli
     appSecret,
     domain: resolveDomain(domain),
     loggerLevel: Lark.LoggerLevel.info,
+    wsConfig: {
+      PingInterval: 30,
+      PingTimeout: 5,
+    },
     ...(agent ? { agent } : {}),
   });
 }


### PR DESCRIPTION
## Summary

Fixes the Feishu WebSocket long connection failure that blocks all enterprise users from using WebSocket mode (100% reproducible).

## Root Cause

`createFeishuWSClient()` in `extensions/feishu/src/client.ts` creates a `Lark.WSClient` without the `wsConfig` parameter. The Lark SDK expects `wsConfig.PingInterval` and `wsConfig.PingTimeout` to be set — without them, the SDK throws:
```
[error]: [ '[ws]', 'code: 1000040351, system busy' ]
[error]: [ '[ws]', "Cannot read properties of undefined (reading 'PingInterval')" ]
[error]: [ '[ws]', 'connect failed' ]
```

This makes WebSocket mode completely non-functional, forcing users to fall back to webhook mode which requires a public URL.

## Fix

Added `wsConfig: { PingInterval: 30, PingTimeout: 5 }` to the WSClient constructor, matching the Lark SDK's expected configuration.

## Testing

- `pnpm build` passes (note: pre-existing `chrome-mcp.ts` type errors unrelated to this change)
- Linting passes clean

Fixes #42354