### PR TITLE
fix: restore multi-line input support in Web UI chat box

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1054,9 +1054,16 @@ export function renderChat(props: ChatProps) {
       if (canCompose) {
         if (props.draft.trim()) {
           inputHistory.push(props.draft);
+          inputHistoryIndex = -1;
+          props.onSend();
         }
-        props.onSend();
       }
+      return;
+    }
+
+    // Allow Shift+Enter to fall through to default behavior (insert newline)
+    if (e.key === "Enter" && e.shiftKey) {
+      return;
     }
   };
 


### PR DESCRIPTION
Restores multi-line input capability in the Web UI. Previously, pressing `Shift+Enter` would be blocked by a missing return statement or prevented default behavior in the textarea keydown handler, preventing newlines from being added.

This fix explicitly allows `Shift+Enter` to fall through to the default browser behavior, inserting a newline.

Fixes #45591