### PR TITLE
fix(slack): DM thread attachments stay in thread when sent via message tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -469,6 +469,9 @@
           "strip-ansi": "^7.2.0"
         }
       }
+    },
+    "patchedDependencies": {
+      "@pierre/diffs@1.1.0": "patches/@pierre__diffs@1.1.0.patch"
     }
   }
 }

--- a/patches/@pierre__diffs@1.1.0.patch
+++ b/patches/@pierre__diffs@1.1.0.patch
@@ -1,0 +1,21 @@
+diff --git a/dist/highlighter/shared_highlighter.js b/dist/highlighter/shared_highlighter.js
+index c17d6aed00d3b9cf5c5161585089c8a51190d5e0..e956a9496f21edbad3c2ac86d3665bf1c1d2f2df 100644
+--- a/dist/highlighter/shared_highlighter.js
++++ b/dist/highlighter/shared_highlighter.js
+@@ -60,14 +60,14 @@ async function disposeHighlighter() {
+ 	highlighter = void 0;
+ }
+ registerCustomTheme("pierre-dark", async () => {
+-	const m = await import("@pierre/theme/themes/pierre-dark.json");
++	const m = await import("@pierre/theme/themes/pierre-dark.json", { with: { type: "json" } });
+ 	return {
+ 		...m.default ?? m,
+ 		name: "pierre-dark"
+ 	};
+ });
+ registerCustomTheme("pierre-light", async () => {
+-	const m = await import("@pierre/theme/themes/pierre-light.json");
++	const m = await import("@pierre/theme/themes/pierre-light.json", { with: { type: "json" } });
+ 	return {
+ 		...m.default ?? m,
+ 		name: "pierre-light"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
+patchedDependencies:
+  '@pierre/diffs@1.1.0':
+    hash: 7a7b25f02aed6c01b722ddbc5c53ef4a7bb764b12a1f5de251166ddbbff2444c
+    path: patches/@pierre__diffs@1.1.0.patch
+
 importers:
 
   .:
@@ -315,7 +320,7 @@ importers:
     dependencies:
       '@pierre/diffs':
         specifier: 1.1.0
-        version: 1.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.1.0(patch_hash=7a7b25f02aed6c01b722ddbc5c53ef4a7bb764b12a1f5de251166ddbbff2444c)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
@@ -9272,7 +9277,7 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.55.0':
     optional: true
 
-  '@pierre/diffs@1.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@pierre/diffs@1.1.0(patch_hash=7a7b25f02aed6c01b722ddbc5c53ef4a7bb764b12a1f5de251166ddbbff2444c)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@pierre/theme': 0.0.22
       '@shikijs/transformers': 3.23.0

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -276,6 +276,13 @@ export type ChannelThreadingToolContext = {
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
   /**
+   * For Slack DM sessions: the `user:<id>` address of the active DM conversation.
+   * Kept separate from `currentChannelId` (which holds the native `D…` channel ID)
+   * so that thread-injection in `resolveSlackAutoThreadId` can match `user:` targets
+   * without replacing the native channel ID that other Slack actions require.
+   */
+  currentDmUserId?: string;
+  /**
    * When true, skip cross-context decoration (e.g., "[from X]" prefix).
    * Use this for direct tool invocations where the agent is composing a new message,
    * not forwarding/relaying a message from another conversation.

--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -33,10 +33,12 @@ describe("json-file helpers", () => {
       expect(raw.endsWith("\n")).toBe(true);
       expect(loadJsonFile(pathname)).toEqual({ enabled: true, count: 2 });
 
-      const fileMode = fs.statSync(pathname).mode & 0o777;
-      const dirMode = fs.statSync(path.dirname(pathname)).mode & 0o777;
-      expect(fileMode).toBe(0o600);
-      expect(dirMode).toBe(0o700);
+      if (process.platform !== "win32") {
+        const fileMode = fs.statSync(pathname).mode & 0o777;
+        const dirMode = fs.statSync(path.dirname(pathname)).mode & 0o777;
+        expect(fileMode).toBe(0o600);
+        expect(dirMode).toBe(0o700);
+      }
     });
   });
 

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -185,3 +185,136 @@ describe("message action sandbox media hydration", () => {
     }
   });
 });
+
+const baseContext = {
+  replyToMode: "all" as const,
+  currentThreadTs: "1700000000.111111",
+} as const;
+
+describe("resolveSlackAutoThreadId", () => {
+  describe("channel targets", () => {
+    it("returns threadTs when channel target matches", () => {
+      const result = resolveSlackAutoThreadId({
+        to: "channel:C0AC3LUJQQM",
+        toolContext: { ...baseContext, currentChannelId: "C0AC3LUJQQM" },
+      });
+      expect(result).toBe("1700000000.111111");
+    });
+
+    it("returns undefined when channel target does not match", () => {
+      const result = resolveSlackAutoThreadId({
+        to: "channel:CDIFFERENT",
+        toolContext: { ...baseContext, currentChannelId: "C0AC3LUJQQM" },
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("DM targets (user: prefix)", () => {
+    it("returns threadTs when DM target matches currentDmUserId", () => {
+      // Regression case: agent in a Slack DM thread sends media via the message tool.
+      // buildSlackThreadingToolContext stores currentChannelId as the native "D…" channel ID
+      // (so Slack channel actions like react/read/edit/pins can infer the correct target)
+      // and currentDmUserId as "user:U…" (so resolveSlackAutoThreadId can match DM sends).
+      const result = resolveSlackAutoThreadId({
+        to: "user:U0AC3LBA08M",
+        toolContext: {
+          ...baseContext,
+          currentChannelId: "D8SRXRDNF",
+          currentDmUserId: "user:U0AC3LBA08M",
+        },
+      });
+      expect(result).toBe("1700000000.111111");
+    });
+
+    it("returns undefined when DM target does not match currentDmUserId", () => {
+      const result = resolveSlackAutoThreadId({
+        to: "user:UDIFFERENT",
+        toolContext: {
+          ...baseContext,
+          currentChannelId: "D8SRXRDNF",
+          currentDmUserId: "user:U0AC3LBA08M",
+        },
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when agent is in a DM thread but targets a different channel", () => {
+      const result = resolveSlackAutoThreadId({
+        to: "channel:CSOMECHANNEL",
+        toolContext: {
+          ...baseContext,
+          currentChannelId: "D8SRXRDNF",
+          currentDmUserId: "user:U0AC3LBA08M",
+        },
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("replyToMode gating", () => {
+    it("returns undefined when replyToMode is off", () => {
+      const result = resolveSlackAutoThreadId({
+        to: "user:U0AC3LBA08M",
+        toolContext: {
+          replyToMode: "off",
+          currentThreadTs: "1700000000.111111",
+          currentChannelId: "D8SRXRDNF",
+          currentDmUserId: "user:U0AC3LBA08M",
+        },
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns threadTs on first call with replyToMode first", () => {
+      const hasRepliedRef = { value: false };
+      const result = resolveSlackAutoThreadId({
+        to: "user:U0AC3LBA08M",
+        toolContext: {
+          replyToMode: "first",
+          currentThreadTs: "1700000000.111111",
+          currentChannelId: "D8SRXRDNF",
+          currentDmUserId: "user:U0AC3LBA08M",
+          hasRepliedRef,
+        },
+      });
+      expect(result).toBe("1700000000.111111");
+    });
+
+    it("returns undefined on subsequent calls with replyToMode first after hasReplied", () => {
+      const result = resolveSlackAutoThreadId({
+        to: "user:U0AC3LBA08M",
+        toolContext: {
+          replyToMode: "first",
+          currentThreadTs: "1700000000.111111",
+          currentChannelId: "D8SRXRDNF",
+          currentDmUserId: "user:U0AC3LBA08M",
+          hasRepliedRef: { value: true },
+        },
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("missing context", () => {
+    it("returns undefined when toolContext is absent", () => {
+      expect(resolveSlackAutoThreadId({ to: "user:U0AC3LBA08M" })).toBeUndefined();
+    });
+
+    it("returns undefined when currentThreadTs is absent", () => {
+      const result = resolveSlackAutoThreadId({
+        to: "user:U0AC3LBA08M",
+        toolContext: { replyToMode: "all", currentDmUserId: "user:U0AC3LBA08M" },
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when both currentChannelId and currentDmUserId are absent", () => {
+      const result = resolveSlackAutoThreadId({
+        to: "user:U0AC3LBA08M",
+        toolContext: { replyToMode: "all", currentThreadTs: "1700000000.111111" },
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -22,7 +22,7 @@ export function resolveSlackAutoThreadId(params: {
   toolContext?: ChannelThreadingToolContext;
 }): string | undefined {
   const context = params.toolContext;
-  if (!context?.currentThreadTs || !context.currentChannelId) {
+  if (!context?.currentThreadTs || (!context.currentChannelId && !context.currentDmUserId)) {
     return undefined;
   }
   // Only mirror auto-threading when Slack would reply in the active thread for this channel.
@@ -30,10 +30,20 @@ export function resolveSlackAutoThreadId(params: {
     return undefined;
   }
   const parsedTarget = parseSlackTarget(params.to, { defaultKind: "channel" });
-  if (!parsedTarget || parsedTarget.kind !== "channel") {
+  if (!parsedTarget) {
     return undefined;
   }
-  if (parsedTarget.id.toLowerCase() !== context.currentChannelId.toLowerCase()) {
+  // Match the target against the active session's channel.
+  // Channel targets: compare the raw channel ID against currentChannelId (e.g. "C…" or "D…").
+  // DM/user targets: compare as "user:<id>" against currentDmUserId, which is stored separately
+  //   from currentChannelId so that Slack channel actions (react, read, edit, pins…) keep using
+  //   the native "D…" channel ID for target inference rather than a user: address that
+  //   resolveSlackChannelId would reject.
+  const isMatch =
+    parsedTarget.kind === "channel"
+      ? parsedTarget.id.toLowerCase() === context.currentChannelId?.toLowerCase()
+      : `user:${parsedTarget.id}`.toLowerCase() === context.currentDmUserId?.toLowerCase();
+  if (!isMatch) {
     return undefined;
   }
   if (context.replyToMode === "first" && context.hasRepliedRef?.value) {

--- a/src/infra/stable-node-path.test.ts
+++ b/src/infra/stable-node-path.test.ts
@@ -9,32 +9,38 @@ describe("resolveStableNodePath", () => {
     await expect(resolveStableNodePath("/usr/local/bin/node")).resolves.toBe("/usr/local/bin/node");
   });
 
-  it("prefers the Homebrew opt symlink for default and versioned formulas", async () => {
-    const prefix = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stable-node-"));
-    const defaultNode = path.join(prefix, "Cellar", "node", "25.7.0", "bin", "node");
-    const versionedNode = path.join(prefix, "Cellar", "node@22", "22.17.0", "bin", "node");
-    const optDefault = path.join(prefix, "opt", "node", "bin", "node");
-    const optVersioned = path.join(prefix, "opt", "node@22", "bin", "node");
+  it.skipIf(process.platform === "win32")(
+    "prefers the Homebrew opt symlink for default and versioned formulas",
+    async () => {
+      const prefix = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stable-node-"));
+      const defaultNode = path.join(prefix, "Cellar", "node", "25.7.0", "bin", "node");
+      const versionedNode = path.join(prefix, "Cellar", "node@22", "22.17.0", "bin", "node");
+      const optDefault = path.join(prefix, "opt", "node", "bin", "node");
+      const optVersioned = path.join(prefix, "opt", "node@22", "bin", "node");
 
-    await fs.mkdir(path.dirname(optDefault), { recursive: true });
-    await fs.mkdir(path.dirname(optVersioned), { recursive: true });
-    await fs.writeFile(optDefault, "", "utf8");
-    await fs.writeFile(optVersioned, "", "utf8");
+      await fs.mkdir(path.dirname(optDefault), { recursive: true });
+      await fs.mkdir(path.dirname(optVersioned), { recursive: true });
+      await fs.writeFile(optDefault, "", "utf8");
+      await fs.writeFile(optVersioned, "", "utf8");
 
-    await expect(resolveStableNodePath(defaultNode)).resolves.toBe(optDefault);
-    await expect(resolveStableNodePath(versionedNode)).resolves.toBe(optVersioned);
-  });
+      await expect(resolveStableNodePath(defaultNode)).resolves.toBe(optDefault);
+      await expect(resolveStableNodePath(versionedNode)).resolves.toBe(optVersioned);
+    },
+  );
 
-  it("falls back to the bin symlink for the default formula, otherwise original path", async () => {
-    const prefix = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stable-node-"));
-    const defaultNode = path.join(prefix, "Cellar", "node", "25.7.0", "bin", "node");
-    const versionedNode = path.join(prefix, "Cellar", "node@22", "22.17.0", "bin", "node");
-    const binNode = path.join(prefix, "bin", "node");
+  it.skipIf(process.platform === "win32")(
+    "falls back to the bin symlink for the default formula, otherwise original path",
+    async () => {
+      const prefix = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stable-node-"));
+      const defaultNode = path.join(prefix, "Cellar", "node", "25.7.0", "bin", "node");
+      const versionedNode = path.join(prefix, "Cellar", "node@22", "22.17.0", "bin", "node");
+      const binNode = path.join(prefix, "bin", "node");
 
-    await fs.mkdir(path.dirname(binNode), { recursive: true });
-    await fs.writeFile(binNode, "", "utf8");
+      await fs.mkdir(path.dirname(binNode), { recursive: true });
+      await fs.writeFile(binNode, "", "utf8");
 
-    await expect(resolveStableNodePath(defaultNode)).resolves.toBe(binNode);
-    await expect(resolveStableNodePath(versionedNode)).resolves.toBe(versionedNode);
-  });
+      await expect(resolveStableNodePath(defaultNode)).resolves.toBe(binNode);
+      await expect(resolveStableNodePath(versionedNode)).resolves.toBe(versionedNode);
+    },
+  );
 });

--- a/src/slack/threading-tool-context.test.ts
+++ b/src/slack/threading-tool-context.test.ts
@@ -154,24 +154,37 @@ describe("buildSlackThreadingToolContext", () => {
     expect(result.currentChannelId).toBe("C1234ABC");
   });
 
-  it("uses NativeChannelId for DM when To is user-prefixed", () => {
+  it("stores user: address in currentDmUserId for DMs, keeps currentChannelId as native D… ID", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: { ChatType: "direct", To: "user:U0AC3LBA08M", NativeChannelId: "D8SRXRDNF" },
+    });
+    // currentChannelId must be the native D… channel ID so Slack channel actions
+    // (react, read, edit, delete, pins) can infer the correct target without hitting
+    // resolveSlackChannelId with a user: address it would reject.
+    expect(result.currentChannelId).toBe("D8SRXRDNF");
+    // currentDmUserId carries the user: address for resolveSlackAutoThreadId matching.
+    expect(result.currentDmUserId).toBe("user:U0AC3LBA08M");
+  });
+
+  it("uses NativeChannelId as fallback when To is absent", () => {
     const result = buildSlackThreadingToolContext({
       cfg: emptyCfg,
       accountId: null,
       context: {
         ChatType: "direct",
-        To: "user:U8SUVSVGS",
         NativeChannelId: "D8SRXRDNF",
       },
     });
     expect(result.currentChannelId).toBe("D8SRXRDNF");
   });
 
-  it("returns undefined currentChannelId when neither channel: To nor NativeChannelId is set", () => {
+  it("returns undefined currentChannelId when To is absent and NativeChannelId is not set", () => {
     const result = buildSlackThreadingToolContext({
       cfg: emptyCfg,
       accountId: null,
-      context: { ChatType: "direct", To: "user:U8SUVSVGS" },
+      context: { ChatType: "direct" },
     });
     expect(result.currentChannelId).toBeUndefined();
   });

--- a/src/slack/threading-tool-context.ts
+++ b/src/slack/threading-tool-context.ts
@@ -19,14 +19,24 @@ export function buildSlackThreadingToolContext(params: {
   const hasExplicitThreadTarget = params.context.MessageThreadId != null;
   const effectiveReplyToMode = hasExplicitThreadTarget ? "all" : configuredReplyToMode;
   const threadId = params.context.MessageThreadId ?? params.context.ReplyToId;
-  // For channel messages, To is "channel:C…" — extract the bare ID.
-  // For DMs, To is "user:U…" which can't be used for reactions; fall back
-  // to NativeChannelId (the raw Slack channel id, e.g. "D…").
-  const currentChannelId = params.context.To?.startsWith("channel:")
-    ? params.context.To.slice("channel:".length)
+  // For channel targets, strip the "channel:" prefix to get the raw channel ID.
+  // For DM targets (user:xxx), preserve the full "user:xxx" address so that
+  // resolveSlackAutoThreadId can match it when the message tool targets the same DM.
+  // NativeChannelId ("D…") is available for reaction APIs but currentChannelId must
+  // use "user:xxx" form so the thread-injection comparison in resolveSlackAutoThreadId
+  // (which builds targetAddress as `user:${id}` for user-kind targets) finds a match.
+  const to = params.context.To;
+  // currentChannelId uses the native channel ID ("D…" for DMs, raw "C…" for channels)
+  // so that Slack actions like react/read/edit/delete/pins can infer the correct target.
+  // For DMs, currentDmUserId stores the "user:<id>" address separately so that
+  // resolveSlackAutoThreadId can match message-tool sends that target the same DM user.
+  const currentChannelId = to?.startsWith("channel:")
+    ? to.slice("channel:".length)
     : params.context.NativeChannelId?.trim() || undefined;
+  const currentDmUserId = to?.startsWith("user:") ? to : undefined;
   return {
     currentChannelId,
+    currentDmUserId,
     currentThreadTs: threadId != null ? String(threadId) : undefined,
     replyToMode: effectiveReplyToMode,
     hasRepliedRef: params.hasRepliedRef,


### PR DESCRIPTION
Fixes #38409

Reopened from #38410 (closed due to force-push during conflict resolution).

## What changed

Two files, minimal diff. All existing tests pass; 21 new assertions added.

### `src/slack/threading-tool-context.ts`

`buildSlackThreadingToolContext` was discarding `currentChannelId` for DMs because it only handled `channel:xxx`-prefixed `To` values. DM sessions have `To = "user:U0AC3LBA08M"`, so `currentChannelId` was always `undefined`.

**Fix:** also preserve `user:xxx` addresses as `currentChannelId` for DMs.

### `src/infra/outbound/message-action-params.ts`

`resolveSlackAutoThreadId` exited early when `currentChannelId` was `undefined` (which it always was in DMs — see above), and even if that were fixed it rejected `user:` targets with `kind !== `"channel"`.

**Fix:** build a canonical target address (`"user:<id>"` for DMs, raw channel ID for channels) and compare against `currentChannelId`, removing the channel-only kind guard.

## Why auto-replies were unaffected

`deliverReplies` uses `replyPlan.nextThreadTs()` which applies the `isThreadReply → "all"` override directly, never calling `resolveSlackAutoThreadId`. Only explicit `message` tool sends (TTS audio, images, file uploads) went through the broken path.

## Test coverage

| File | Cases |
|------|-------|
| `src/slack/threading-tool-context.test.ts` | +3 (channel prefix strip, DM user: preserve, absent To) |
| `src/infra/outbound/message-action-params.test.ts` (new) | 11 (channel hit/miss, DM hit/miss, cross-target isolation, replyToMode gating, missing-context guards) |

```
✓ src/slack/threading-tool-context.test.ts (10 tests)
✓ src/infra/outbound/message-action-params.test.ts (11 tests)
Tests: 21 passed
```