### PR TITLE
auth-profiles: normalize provider key when persisting lastGood

### DIFF
--- a/src/agents/auth-profiles.markauthprofilegood.test.ts
+++ b/src/agents/auth-profiles.markauthprofilegood.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  ensureAuthProfileStore,
+  markAuthProfileGood,
+  resolveAuthProfileOrder,
+} from "./auth-profiles.js";
+
+describe("markAuthProfileGood", () => {
+  it("stores lastGood under the normalized provider key so fallback success affects future selection", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-lastgood-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const authPath = path.join(agentDir, "auth-profiles.json");
+
+    try {
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        authPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "z-ai:default": {
+                type: "api_key",
+                provider: "z-ai",
+                key: "sk-a",
+              },
+              "z-ai:account2": {
+                type: "api_key",
+                provider: "z-ai",
+                key: "sk-b",
+              },
+            },
+            order: {
+              zai: ["z-ai:default", "z-ai:account2"],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      await markAuthProfileGood({
+        store,
+        provider: "zai",
+        profileId: "z-ai:account2",
+        agentDir,
+      });
+
+      const persisted = JSON.parse(await fs.readFile(authPath, "utf8")) as {
+        lastGood?: Record<string, string>;
+      };
+
+      expect(persisted.lastGood).toEqual({ zai: "z-ai:account2" });
+      expect(
+        resolveAuthProfileOrder({
+          cfg: {},
+          store,
+          provider: "zai",
+          preferredProfile: persisted.lastGood?.zai,
+        }),
+      ).toEqual(["z-ai:account2", "z-ai:default"]);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -91,14 +91,15 @@ export async function markAuthProfileGood(params: {
   agentDir?: string;
 }): Promise<void> {
   const { store, provider, profileId, agentDir } = params;
+  const providerKey = normalizeProviderId(provider);
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
     updater: (freshStore) => {
       const profile = freshStore.profiles[profileId];
-      if (!profile || profile.provider !== provider) {
+      if (!profile || normalizeProviderId(profile.provider) !== providerKey) {
         return false;
       }
-      freshStore.lastGood = { ...freshStore.lastGood, [provider]: profileId };
+      freshStore.lastGood = { ...freshStore.lastGood, [providerKey]: profileId };
       return true;
     },
   });
@@ -107,9 +108,9 @@ export async function markAuthProfileGood(params: {
     return;
   }
   const profile = store.profiles[profileId];
-  if (!profile || profile.provider !== provider) {
+  if (!profile || normalizeProviderId(profile.provider) !== providerKey) {
     return;
   }
-  store.lastGood = { ...store.lastGood, [provider]: profileId };
+  store.lastGood = { ...store.lastGood, [providerKey]: profileId };
   saveAuthProfileStore(store, agentDir);
 }


### PR DESCRIPTION
## Summary

- Problem: successful fallback runs could update `lastGood` under a raw provider key that did not match the normalized provider key later used by selection logic.
- Why it matters: a profile could succeed in practice, but the persisted `lastGood` state could remain stale or land under the wrong key, so future runs would fail to benefit from that success.
- What changed: `markAuthProfileGood()` now normalizes the provider id for both comparison and persistence, and writes `lastGood` back under the normalized provider key.
- What did NOT change (scope boundary): this PR does not change initial profile selection behavior, does not prefer `lastGood` during selection, and does not persist the final winning auth profile back into session overrides after a successful fallback run.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Auth / tokens
- [x] Agents
- [ ] Gateway / orchestration
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #45462
- Related #46642
- Split from the broader auth fallback investigation so persistence can be reviewed independently

## User-visible / Behavior Changes

When a successful fallback run marks an auth profile as good, the stored `lastGood` entry now uses the same normalized provider key that later readers expect. This prevents successful profiles from being silently ignored because of provider-alias key mismatches.

## Security Impact

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: Linux / local repo checkout
- Runtime/container: Node + pnpm test runner
- Model/provider: auth-profile persistence logic only
- Integration/channel (if any): N/A
- Relevant config (redacted): auth-profile store with aliased provider ids and normalized selection lookup

### Steps

1. Store an auth profile under an aliased provider id.
2. Call `markAuthProfileGood()` with that provider context after a successful run.
3. Read `lastGood` through the normalized provider key used by selection code.

### Expected

- `lastGood` is persisted under the normalized provider key, so future selection logic can find it reliably.

### Actual

- Before this change, `lastGood` could be skipped or written under a mismatched raw provider key.
- After this change, the provider id is normalized before comparison and persistence.

## Evidence

- [x] Focused regression test added
- [x] Small, single-file logic change plus matching test coverage
- [ ] Screenshot/recording
- [ ] Perf numbers

Covered regression case:
- a profile stored under an aliased provider id still persists `lastGood` under the normalized provider key

## Human Verification

- Verified the targeted regression test for `markAuthProfileGood()`.
- Verified this PR stays strictly about persistence in `profiles.ts`.
- Verified selection behavior and final session persistence remain intentionally outside this PR.

## Review Conversations

- [x] Kept this PR persistence-only after splitting broader auth fallback work into separate PRs.
- [x] Added focused regression coverage for normalized provider-key persistence.
- [x] Left selection behavior and final winner persistence to their dedicated PRs.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/agents/auth-profiles/profiles.ts`, `src/agents/auth-profiles.markauthprofilegood.test.ts`
- Known bad symptoms reviewers should watch for: successful profiles still failing to update `lastGood`, or `lastGood` being written under a provider alias that later selection code does not read.

## Risks and Mitigations

- Risk: legacy stores may still contain stale alias-key entries alongside the canonical key.
  - Mitigation: this PR ensures new writes use the normalized key consistently; selection/final-state follow-ups stay in separate PRs.
- Risk: reviewers may conflate this with the broader sticky-selection work.
  - Mitigation: this PR intentionally stays persistence-only, with selection in #45462 and final winning-profile persistence in #46642.
