### PR TITLE
fix: restore new messages indicator styling in v2 UI

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2228,11 +2228,36 @@
 /* New messages indicator */
 .chat-new-messages {
   align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   margin: 8px auto 0;
   border-radius: 999px;
-  padding: 6px 12px;
-  font-size: 12px;
+  padding: 6px 14px;
+  font-size: 13px;
   line-height: 1;
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  color: var(--text);
+  white-space: nowrap;
+  z-index: 10;
+  transition: background 150ms ease-out, border-color 150ms ease-out;
+}
+
+.chat-new-messages:hover {
+  background: var(--panel);
+  border-color: var(--accent);
+}
+
+.chat-new-messages svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  flex-shrink: 0;
 }
 
 /* Chat lines */

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1169,7 +1169,7 @@ export function renderChat(props: ChatProps) {
         props.showNewMessages
           ? html`
             <button
-              class="chat-new-messages"
+              class="btn chat-new-messages"
               type="button"
               @click=${props.onScrollToBottom}
             >


### PR DESCRIPTION
Restores the proper styling for the `chat-new-messages` indicator button which was lost during the v2 UI codebase divergence. This prevents the SVG icon from blowing up and filling the entire screen.

Also re-adds the `btn` class to the element to ensure consistent base styling.

Fixes #45575
Fixes #45617