### PR TITLE
feat(DX): Add Out-of-the-Box Support for Debugging in VSCode-Based IDEs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Rebuild and Debug Gateway",
+      "type": "node",
+      "request": "launch",
+      "preLaunchTask": "debug:rebuild",
+      "program": "${workspaceFolder}/openclaw.mjs",
+      "args": ["gateway", "run"],
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**", "node_modules/**"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "sourceMaps": true,
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "name": "Debug Gateway",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/openclaw.mjs",
+      "args": ["gateway", "run"],
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**", "node_modules/**"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "sourceMaps": true,
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+  "version": "2.0.0",
+  "options": {
+    "env": {
+      "OUTPUT_SOURCE_MAPS": "1"
+    }
+  },
+  "tasks": [
+    {
+      "label": "debug:rebuild",
+      "type": "shell",
+      "command": "pnpm clean:dist && pnpm build",
+      "group": "none",
+      "problemMatcher": [],
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared"
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Docs: https://docs.openclaw.ai
 - Dependencies: refresh runtime and provider packages including Pi 0.73.0, ACPX adapters, OpenAI, Anthropic, Slack, and TypeScript native preview, while keeping the Bedrock runtime installer override pinned below the Windows ARM Node 24 npm resolver failure.
 - Contributor PRs: require external pull requests to include after-fix real behavior proof from a real OpenClaw setup, with terminal screenshots, console output, redacted runtime logs, linked artifacts, and copied live output treated as valid evidence while unit tests, mocks, lint, typechecks, snapshots, and CI remain supplemental only.
 - Plugins/catalog: add an `@tencent-weixin/openclaw-weixin` external entry pinned to `2.4.1` so onboarding and `openclaw channels add` can install the Tencent Weixin (personal WeChat) channel by default. (#77269) Thanks @pumpkinxing1.
+- Developer tooling: add checked-in VS Code Gateway debugging configs and an opt-in `OUTPUT_SOURCE_MAPS=1` source-map build path for breakpoints in TypeScript source. (#45710) Thanks @SwissArmyBud.
 
 ### Fixes
 

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -306,6 +306,38 @@ Default file:
 - Keep logs local and delete them after debugging.
 - If you share logs, scrub secrets and PII first.
 
+## Debugging in VSCode
+
+Source maps are required to enable debugging in VSCode-based IDEs because many of the generated files end up with hashed names as part of the build process. The included `launch.json` configurations target the Gateway service, but can be adapted quickly for other purposes:
+
+1. **Rebuild and Debug Gateway** - Debugs the Gateway service after creating a new build
+2. **Debug Gateway** - Debugs the Gateway service of a pre-existing build
+
+### Setup
+
+The default **Rebuild and Debug Gateway** configuration is batteries-included, it will automatically delete the `/dist` folder and rebuild the project with debugging enabled:
+
+1. Open the **Run and Debug** panel from the Activity Bar or press `Ctrl`+`Shift`+`D`
+2. In the IDE, ensure **Rebuild and Debug Gateway** is selected in the configuration dropdown and then press the **Start Debugging** button
+
+Alternatively - if you prefer to manage the build and debug processes manually:
+
+1. Open a terminal and enable source maps:
+   - **Linux/macOS**: `export OUTPUT_SOURCE_MAPS=1`
+   - **Windows (PowerShell)**: `$env:OUTPUT_SOURCE_MAPS="1"`
+   - **Windows (CMD)**: `set OUTPUT_SOURCE_MAPS=1`
+2. In the same terminal, rebuild the project: `pnpm clean:dist && pnpm build`
+3. In the IDE, select the **Debug Gateway** option in the **Run and Debug** configuration dropdown and then press the **Start Debugging** button
+
+You can now set breakpoints in your TypeScript source files (`src/` directory) and the debugger will correctly map breakpoints to the compiled JavaScript via source maps. You'll be able to inspect variables, step through code, and examine call stacks as expected.
+
+### Notes
+
+- If using the **"Rebuild and Debug Gateway"** option - each time the debugger is launched it will completely delete the `/dist` folder and run a full `pnpm build` with source maps enabled before starting the Gateway
+- If using the **"Debug Gateway"** option - debug sessions can be started and stopped at any time without affecting the `/dist` folder, but you must use a separate terminal process to both enable debugging and manage the build cycle
+- Modify the `launch.json` settings for `args` to debug other sections of the project
+- If you need to use the built OpenClaw CLI for other tasks (i.e. `dashboard --no-open` if your debug session spawns a new auth token), you can execute it in another terminal as `node ./openclaw.mjs` or create a shell alias like `alias openclaw-build="node $(pwd)/openclaw.mjs"`
+
 ## Related
 
 - [Troubleshooting](/help/troubleshooting)

--- a/package.json
+++ b/package.json
@@ -1330,6 +1330,7 @@
     "ci:full-release": "node scripts/full-release-validation-at-sha.mjs",
     "ci:timings": "node scripts/ci-run-timings.mjs --latest-main",
     "ci:timings:recent": "node scripts/ci-run-timings.mjs --recent 10",
+    "clean:dist": "node -e \"require('fs').rmSync('dist', {recursive: true, force: true})\"",
     "codex-app-server:protocol:check": "node --import tsx scripts/check-codex-app-server-protocol.ts",
     "codex-app-server:protocol:sync": "node --import tsx scripts/sync-codex-app-server-protocol.ts",
     "config:channels:check": "node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -32,6 +32,7 @@ type ExternalOptionFunction = (
 const env = {
   NODE_ENV: "production",
 };
+const OUTPUT_SOURCE_MAPS = process.env.OUTPUT_SOURCE_MAPS === "1";
 
 const SUPPRESSED_EVAL_WARNING_PATHS = [
   "@protobufjs/inquire/index.js",
@@ -122,6 +123,7 @@ function nodeBuildConfig(config: UserConfig): UserConfig {
     env,
     fixedExtension: false,
     platform: "node",
+    sourcemap: OUTPUT_SOURCE_MAPS,
     inputOptions: buildInputOptions,
   };
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Missing debugging support for OpenClaw developers using  VSCode-based IDEs
- Why it matters: Developers should have an out-of-the-box path to debug TypeScript source code available for their most-used IDE
- What changed: 
    - Added config toggle for source map generation (debugger requirement) to `tsdown.config.ts`
    - Added default debugger configs as `.vscode/launch.json`
    - Added VSCode section to `docs/help/debugging.md`
- What did NOT change (scope boundary): 
    - No changes to default build or other functionality

## Changes

### Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

### Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX (Developer Experience)

### Linked Issue/PR

- Closes: `None`
- Related: `None`

### User-visible / Behavior Changes

`None` (disabled-by-default debug and related documentation, only)

### Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

If any `Yes`, explain risk + mitigation: `None`

### AI Usage

- [x] AI used to generate code/PR? (both)
- [x] AI used, if any: [Claude Code](https://github.com/anthropics/claude-code) with [Claude Code Router](https://github.com/musistudio/claude-code-router) pushing conversations to [Nemotron 3 via OpenRouter](https://openrouter.ai/nvidia/nemotron-3-super-120b-a12b:free)
- [x] Degree of testing (fully tested)
- [x] Include prompts or session logs if possible:
  - `I'm having problems in this repo - the project calls a script on startup that builds the /dist folder with hashed file names, but the source TS files all internally reference their regular transpiled JS names as imports. Because of this, VSCode is having trouble setting up a debug launch.json file - can you help get this working?`
- [x] Confirm you understand what the code does (Yes)
- [x] If you have access to Codex, run codex review (No)
- [x] Resolve or reply to bot review conversations after you address them (all/resolved)


## Repro + Verification

### Environment

- OS: `Ubuntu 24.04.3 LTS` VM, via Proxmox
- Runtime/container: NodeJS (`v24.13.0`) on host, w/ agent sandboxes in Docker
- Model/provider: OpenRouter
- Integration/channel (if any): Whatsapp
- Relevant config (redacted): `None`

### Steps/Reproduction

1. Run `pnpm install && pnpm build && code .`
2. Launch a new VSCode debug session and wait for the gateway to load
3. Note that any breakpoints set in `/src` files are considered `Unbound`
4. Stop the debug session, and update the environment variable `OUTPUT_SOURCE_MAPS` to `1`
5. Rebuild the project and launch another debug session
6. Note that when the gateway finishes loading that all breakpoints in `/src` are now bound

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

### Without source maps emitted during build, all breakpoints are `Unbound`:
<img width="1229" height="798" alt="Screenshot from 2026-03-13 20-22-16" src="https://github.com/user-attachments/assets/c5ee6bc8-f79a-4d50-b81a-0cf4d0bf47f4" />


### With source maps enabled, debugger connects to breakpoints and allows variable evaluation:
<img width="1229" height="798" alt="Screenshot from 2026-03-13 20-35-18" src="https://github.com/user-attachments/assets/5472f541-eafe-4927-86c8-33928de7c98c" />


### Human Verification (required)

- Verified scenarios:
  - Reviewed the added VSCode debugging documentation for accuracy
  - Confirmed that tsdown.config.ts contains `OUTPUT_SOURCE_MAPS` setting
  - Verified that `launch.json` contains appropriate debug configurations
  - Checked that doc formatting uses tags consistent with existing material
  - Ensured no existing content was modified or removed
  - Actual VSCode debugging functionality (hooray!)

- What I did **not** verify:
  - Different OS-specific behavior, should work in `win32` but unverified

## Compatibility / Migration

- Backward compatible? (Yes, fully)
- Config/env changes? (Yes, to build system)
- Migration needed? (No)
- If yes, exact upgrade steps: `None`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
    - Remove the `sourcemap` parameter from the config builder in `tsdown.config.ts`
    - Run `rm -rf ./dist && pnpm build`
- Files/config to restore: `tsdown.config.ts`
- Known bad symptoms reviewers should watch for: `None`

## Risks and Mitigations

`None`
