### PR TITLE
feat(telegram): support Local Bot API Server

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -751,6 +751,9 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `channels.telegram.textChunkLimit` default is 4000.
     - `channels.telegram.chunkMode="newline"` prefers paragraph boundaries (blank lines) before length splitting.
     - `channels.telegram.mediaMaxMb` (default 100) caps inbound and outbound Telegram media size.
+    - `channels.telegram.apiRoot` overrides the Telegram Bot API root (default `https://api.telegram.org`). Use this for a Local Bot API Server, for example `http://127.0.0.1:8081`.
+    - When `apiRoot` points at a Local Bot API Server, inbound `getFile` results that are absolute paths or `file://` URIs are read from disk directly instead of being downloaded over HTTP.
+    - When `apiRoot` points at a loopback Local Bot API Server, outbound local media paths can be passed through as local file references instead of being preloaded into memory first.
     - `channels.telegram.timeoutSeconds` overrides Telegram API client timeout (if unset, grammY default applies).
     - group context history uses `channels.telegram.historyLimit` or `messages.groupChat.historyLimit` (default 50); `0` disables.
     - DM history controls:
@@ -900,6 +903,7 @@ Primary reference:
 - `channels.telegram.enabled`: enable/disable channel startup.
 - `channels.telegram.botToken`: bot token (BotFather).
 - `channels.telegram.tokenFile`: read token from a regular file path. Symlinks are rejected.
+- `channels.telegram.apiRoot`: custom Telegram Bot API root URL. Defaults to `https://api.telegram.org`. Named accounts inherit the top-level value unless `channels.telegram.accounts.<account>.apiRoot` is set.
 - `channels.telegram.dmPolicy`: `pairing | allowlist | open | disabled` (default: pairing).
 - `channels.telegram.allowFrom`: DM allowlist (numeric Telegram user IDs). `allowlist` requires at least one sender ID. `open` requires `"*"`. `openclaw doctor --fix` can resolve legacy `@username` entries to IDs and can recover allowlist entries from pairing-store files in allowlist migration flows.
 - `channels.telegram.actions.poll`: enable or disable Telegram poll creation (default: enabled; still requires `sendMessage`).

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -157,6 +157,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
     telegram: {
       enabled: true,
       botToken: "your-bot-token",
+      apiRoot: "http://127.0.0.1:8081",
       dmPolicy: "pairing",
       allowFrom: ["tg:123456789"],
       groups: {
@@ -204,6 +205,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 ```
 
 - Bot token: `channels.telegram.botToken` or `channels.telegram.tokenFile` (regular file only; symlinks rejected), with `TELEGRAM_BOT_TOKEN` as fallback for the default account.
+- `channels.telegram.apiRoot` overrides the Bot API root (default `https://api.telegram.org`). Set this to a Local Bot API Server root such as `http://127.0.0.1:8081` when you want Telegram sends, probes, lookups, and file downloads to use that server. Loopback Local Bot API roots also let outbound local media paths stay as file references instead of being fully preloaded into memory first.
 - Optional `channels.telegram.defaultAccount` overrides default account selection when it matches a configured account id.
 - In multi-account setups (2+ account ids), set an explicit default (`channels.telegram.defaultAccount` or `channels.telegram.accounts.default`) to avoid fallback routing; `openclaw doctor` warns when this is missing or invalid.
 - `configWrites: false` blocks Telegram-initiated config writes (supergroup ID migrations, `/config set|unset`).

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -6,6 +6,7 @@ import {
   createScopedAccountConfigAccessors,
   formatAllowFromLowercase,
 } from "openclaw/plugin-sdk/compat";
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import {
   applyAccountNameToChannelSection,
   buildComputedAccountStatusSnapshot,
@@ -37,7 +38,6 @@ import {
   type ChannelPlugin,
   type ResolvedDiscordAccount,
 } from "openclaw/plugin-sdk/discord";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { getDiscordRuntime } from "./runtime.js";
 
 type DiscordSendFn = ReturnType<

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -1,8 +1,8 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import { sendTextMediaPayload } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import type { OutboundIdentity } from "../../../src/infra/outbound/identity.js";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { getThreadBindingManager, type ThreadBindingRecord } from "./monitor/thread-bindings.js";
 import { normalizeDiscordOutboundTarget } from "./normalize.js";
 import { sendMessageDiscord, sendPollDiscord, sendWebhookMessageDiscord } from "./send.js";

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -2,6 +2,7 @@ import {
   buildAccountScopedDmSecurityPolicy,
   collectAllowlistProviderRestrictSendersWarnings,
 } from "openclaw/plugin-sdk/compat";
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import {
   applyAccountNameToChannelSection,
   buildChannelConfigSchema,
@@ -29,7 +30,6 @@ import {
   type ChannelPlugin,
   type ResolvedIMessageAccount,
 } from "openclaw/plugin-sdk/imessage";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { buildPassiveProbedChannelStatusSummary } from "../../shared/channel-status-summary.js";
 import { getIMessageRuntime } from "./runtime.js";
 

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -1,5 +1,5 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/matrix";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { sendMessageMatrix, sendPollMatrix } from "./matrix/send.js";
 import { getMatrixRuntime } from "./runtime.js";
 

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -1,5 +1,5 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/msteams";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { createMSTeamsPollStoreFs } from "./polls.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { sendMessageMSTeams, sendPollMSTeams } from "./send.js";

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -3,6 +3,7 @@ import {
   createScopedAccountConfigAccessors,
   collectAllowlistProviderRestrictSendersWarnings,
 } from "openclaw/plugin-sdk/compat";
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import {
   applyAccountNameToChannelSection,
   buildBaseAccountStatusSnapshot,
@@ -30,7 +31,6 @@ import {
   type ChannelPlugin,
   type ResolvedSignalAccount,
 } from "openclaw/plugin-sdk/signal";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { getSignalRuntime } from "./runtime.js";
 
 const signalMessageActions: ChannelMessageActionAdapter = {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -6,6 +6,7 @@ import {
   createScopedAccountConfigAccessors,
   formatAllowFromLowercase,
 } from "openclaw/plugin-sdk/compat";
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import {
   applyAccountNameToChannelSection,
   buildComputedAccountStatusSnapshot,
@@ -38,7 +39,6 @@ import {
   type ChannelPlugin,
   type ResolvedSlackAccount,
 } from "openclaw/plugin-sdk/slack";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { buildPassiveProbedChannelStatusSummary } from "../../shared/channel-status-summary.js";
 import { getSlackRuntime } from "./runtime.js";
 

--- a/extensions/telegram/src/account-inspect.ts
+++ b/extensions/telegram/src/account-inspect.ts
@@ -21,6 +21,7 @@ export type InspectedTelegramAccount = {
   accountId: string;
   enabled: boolean;
   name?: string;
+  baseUrl?: string;
   token: string;
   tokenSource: "env" | "tokenFile" | "config" | "none";
   tokenStatus: TelegramCredentialStatus;
@@ -132,6 +133,7 @@ function inspectTelegramAccountPrimary(params: {
       accountId,
       enabled,
       name: merged.name?.trim() || undefined,
+      baseUrl: merged.apiRoot?.trim() || undefined,
       token: accountTokenFile.token,
       tokenSource: accountTokenFile.tokenSource,
       tokenStatus: accountTokenFile.tokenStatus,
@@ -146,6 +148,7 @@ function inspectTelegramAccountPrimary(params: {
       accountId,
       enabled,
       name: merged.name?.trim() || undefined,
+      baseUrl: merged.apiRoot?.trim() || undefined,
       token: accountToken.token,
       tokenSource: accountToken.tokenSource,
       tokenStatus: accountToken.tokenStatus,
@@ -160,6 +163,7 @@ function inspectTelegramAccountPrimary(params: {
       accountId,
       enabled,
       name: merged.name?.trim() || undefined,
+      baseUrl: merged.apiRoot?.trim() || undefined,
       token: channelTokenFile.token,
       tokenSource: channelTokenFile.tokenSource,
       tokenStatus: channelTokenFile.tokenStatus,
@@ -177,6 +181,7 @@ function inspectTelegramAccountPrimary(params: {
       accountId,
       enabled,
       name: merged.name?.trim() || undefined,
+      baseUrl: merged.apiRoot?.trim() || undefined,
       token: channelToken.token,
       tokenSource: channelToken.tokenSource,
       tokenStatus: channelToken.tokenStatus,
@@ -192,6 +197,7 @@ function inspectTelegramAccountPrimary(params: {
       accountId,
       enabled,
       name: merged.name?.trim() || undefined,
+      baseUrl: merged.apiRoot?.trim() || undefined,
       token: envToken,
       tokenSource: "env",
       tokenStatus: "available",
@@ -204,6 +210,7 @@ function inspectTelegramAccountPrimary(params: {
     accountId,
     enabled,
     name: merged.name?.trim() || undefined,
+    baseUrl: merged.apiRoot?.trim() || undefined,
     token: "",
     tokenSource: "none",
     tokenStatus: "missing",

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -312,6 +312,49 @@ describe("resolveTelegramAccount allowFrom precedence", () => {
   });
 });
 
+describe("resolveTelegramAccount apiRoot precedence", () => {
+  it("inherits top-level apiRoot when account override is unset", () => {
+    const resolved = resolveTelegramAccount({
+      cfg: {
+        channels: {
+          telegram: {
+            apiRoot: "http://127.0.0.1:8081/",
+            accounts: {
+              work: { botToken: "123:work" },
+            },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(resolved.config.apiRoot).toBe("http://127.0.0.1:8081/");
+    expect(resolved.baseUrl).toBe("http://127.0.0.1:8081/");
+  });
+
+  it("prefers per-account apiRoot over the top-level value", () => {
+    const resolved = resolveTelegramAccount({
+      cfg: {
+        channels: {
+          telegram: {
+            apiRoot: "http://127.0.0.1:8081/",
+            accounts: {
+              work: {
+                botToken: "123:work",
+                apiRoot: "http://127.0.0.1:8082/",
+              },
+            },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(resolved.config.apiRoot).toBe("http://127.0.0.1:8082/");
+    expect(resolved.baseUrl).toBe("http://127.0.0.1:8082/");
+  });
+});
+
 describe("resolveTelegramPollActionGateState", () => {
   it("requires both sendMessage and poll actions", () => {
     const state = resolveTelegramPollActionGateState((key) => key !== "poll");

--- a/extensions/telegram/src/accounts.ts
+++ b/extensions/telegram/src/accounts.ts
@@ -44,6 +44,7 @@ export type ResolvedTelegramAccount = {
   accountId: string;
   enabled: boolean;
   name?: string;
+  baseUrl?: string;
   token: string;
   tokenSource: "env" | "tokenFile" | "config" | "none";
   config: TelegramAccountConfig;
@@ -186,6 +187,7 @@ export function resolveTelegramAccount(params: {
       accountId,
       enabled,
       name: merged.name?.trim() || undefined,
+      baseUrl: merged.apiRoot?.trim() || undefined,
       token: tokenResolution.token,
       tokenSource: tokenResolution.source,
       config: merged,

--- a/extensions/telegram/src/api-fetch.test.ts
+++ b/extensions/telegram/src/api-fetch.test.ts
@@ -54,4 +54,23 @@ describe("fetchTelegramChatId", () => {
       undefined,
     );
   });
+
+  it("uses a custom Telegram Bot API root when provided", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: true, result: { id: 12345 } }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchTelegramChatId({
+      token: "abc",
+      chatId: "@user",
+      apiRoot: "http://127.0.0.1:8081/",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8081/botabc/getChat?chat_id=%40user",
+      undefined,
+    );
+  });
 });

--- a/extensions/telegram/src/api-fetch.ts
+++ b/extensions/telegram/src/api-fetch.ts
@@ -1,9 +1,16 @@
+import { buildTelegramBotApiUrl } from "./api-root.js";
+
 export async function fetchTelegramChatId(params: {
   token: string;
   chatId: string;
+  apiRoot?: string;
   signal?: AbortSignal;
 }): Promise<string | null> {
-  const url = `https://api.telegram.org/bot${params.token}/getChat?chat_id=${encodeURIComponent(params.chatId)}`;
+  const url = `${buildTelegramBotApiUrl({
+    token: params.token,
+    method: "getChat",
+    apiRoot: params.apiRoot,
+  })}?chat_id=${encodeURIComponent(params.chatId)}`;
   try {
     const res = await fetch(url, params.signal ? { signal: params.signal } : undefined);
     if (!res.ok) {

--- a/extensions/telegram/src/api-root.ts
+++ b/extensions/telegram/src/api-root.ts
@@ -1,0 +1,107 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { SsrFPolicy } from "../../../src/infra/net/ssrf.js";
+
+export const DEFAULT_TELEGRAM_API_ROOT = "https://api.telegram.org";
+
+function trimTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export function resolveTelegramApiRoot(apiRoot?: string | null): string {
+  const trimmed = apiRoot?.trim();
+  if (!trimmed) {
+    return DEFAULT_TELEGRAM_API_ROOT;
+  }
+  return trimTrailingSlashes(trimmed);
+}
+
+export function buildTelegramBotApiBase(params: {
+  token: string;
+  apiRoot?: string | null;
+}): string {
+  return `${resolveTelegramApiRoot(params.apiRoot)}/bot${params.token}`;
+}
+
+export function buildTelegramBotApiUrl(params: {
+  token: string;
+  method: string;
+  apiRoot?: string | null;
+}): string {
+  const method = params.method.replace(/^\/+/, "");
+  return `${buildTelegramBotApiBase(params)}/${method}`;
+}
+
+export function buildTelegramFileDownloadUrl(params: {
+  token: string;
+  filePath: string;
+  apiRoot?: string | null;
+}): string {
+  const filePath = params.filePath.replace(/^\/+/, "");
+  return `${resolveTelegramApiRoot(params.apiRoot)}/file/bot${params.token}/${filePath}`;
+}
+
+export function resolveTelegramApiOriginDetails(apiRoot?: string | null): {
+  hostname: string;
+  protocol: "http:" | "https:";
+  port?: number;
+} | null {
+  try {
+    const parsed = new URL(resolveTelegramApiRoot(apiRoot));
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    const port = parsed.port ? Number.parseInt(parsed.port, 10) : undefined;
+    return {
+      hostname: parsed.hostname.toLowerCase(),
+      protocol: parsed.protocol,
+      ...(port ? { port } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isTelegramApiRootLoopback(apiRoot?: string | null): boolean {
+  const details = resolveTelegramApiOriginDetails(apiRoot);
+  if (!details) {
+    return false;
+  }
+  return (
+    details.hostname === "localhost" ||
+    details.hostname === "127.0.0.1" ||
+    details.hostname === "::1"
+  );
+}
+
+export function resolveTelegramMediaSsrFPolicy(apiRoot?: string | null): SsrFPolicy {
+  const details = resolveTelegramApiOriginDetails(apiRoot);
+  return {
+    // Explicit apiRoot hostnames are allowed so local Bot API servers can be used
+    // without relaxing SSRF checks globally.
+    allowedHostnames: [details?.hostname ?? "api.telegram.org"],
+    allowRfc2544BenchmarkRange: true,
+  };
+}
+
+export function resolveTelegramLocalFilePath(filePath?: string | null): string | null {
+  const trimmed = filePath?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^file:/i.test(trimmed)) {
+    try {
+      const parsed = new URL(trimmed);
+      if (parsed.protocol !== "file:") {
+        return null;
+      }
+      if (parsed.hostname && parsed.hostname !== "localhost") {
+        return null;
+      }
+      return fileURLToPath(parsed);
+    } catch {
+      return null;
+    }
+  }
+  return path.isAbsolute(trimmed) ? trimmed : null;
+}

--- a/extensions/telegram/src/api-root.ts
+++ b/extensions/telegram/src/api-root.ts
@@ -52,8 +52,9 @@ export function resolveTelegramApiOriginDetails(apiRoot?: string | null): {
       return null;
     }
     const port = parsed.port ? Number.parseInt(parsed.port, 10) : undefined;
+    const hostname = parsed.hostname.replace(/^\[(.*)\]$/, "$1").toLowerCase();
     return {
-      hostname: parsed.hostname.toLowerCase(),
+      hostname,
       protocol: parsed.protocol,
       ...(port ? { port } : {}),
     };

--- a/extensions/telegram/src/audit-membership-runtime.ts
+++ b/extensions/telegram/src/audit-membership-runtime.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "../../../src/utils.js";
 import { fetchWithTimeout } from "../../../src/utils/fetch-timeout.js";
+import { buildTelegramBotApiBase } from "./api-root.js";
 import type {
   AuditTelegramGroupMembershipParams,
   TelegramGroupMembershipAudit,
@@ -7,8 +8,6 @@ import type {
 } from "./audit.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { makeProxyFetch } from "./proxy.js";
-
-const TELEGRAM_API_BASE = "https://api.telegram.org";
 
 type TelegramApiOk<T> = { ok: true; result: T };
 type TelegramApiErr = { ok: false; description?: string };
@@ -18,8 +17,11 @@ export async function auditTelegramGroupMembershipImpl(
   params: AuditTelegramGroupMembershipParams,
 ): Promise<TelegramGroupMembershipAuditData> {
   const proxyFetch = params.proxyUrl ? makeProxyFetch(params.proxyUrl) : undefined;
-  const fetcher = resolveTelegramFetch(proxyFetch, { network: params.network });
-  const base = `${TELEGRAM_API_BASE}/bot${params.token}`;
+  const fetcher = resolveTelegramFetch(proxyFetch, {
+    apiRoot: params.apiRoot,
+    network: params.network,
+  });
+  const base = buildTelegramBotApiBase({ token: params.token, apiRoot: params.apiRoot });
   const groups: TelegramGroupMembershipAuditEntry[] = [];
 
   for (const chatId of params.groupIds) {

--- a/extensions/telegram/src/audit.test.ts
+++ b/extensions/telegram/src/audit.test.ts
@@ -21,11 +21,12 @@ function mockGetChatMemberStatus(status: string) {
   );
 }
 
-async function auditSingleGroup() {
+async function auditSingleGroup(options?: { apiRoot?: string }) {
   return auditTelegramGroupMembership({
     token: "t",
     botId: 123,
     groupIds: ["-1001"],
+    apiRoot: options?.apiRoot,
     timeoutMs: 5000,
   });
 }
@@ -67,5 +68,13 @@ describe("telegram audit", () => {
     expect(res.ok).toBe(false);
     expect(res.groups[0]?.ok).toBe(false);
     expect(res.groups[0]?.status).toBe("left");
+  });
+
+  it("uses a custom Telegram Bot API root for membership checks", async () => {
+    mockGetChatMemberStatus("member");
+    await auditSingleGroup({ apiRoot: "http://127.0.0.1:8081/" });
+    expect(undiciFetch.mock.calls[0]?.[0]).toBe(
+      "http://127.0.0.1:8081/bott/getChatMember?chat_id=-1001&user_id=123",
+    );
   });
 });

--- a/extensions/telegram/src/audit.ts
+++ b/extensions/telegram/src/audit.ts
@@ -64,6 +64,7 @@ export type AuditTelegramGroupMembershipParams = {
   token: string;
   botId: number;
   groupIds: string[];
+  apiRoot?: string;
   proxyUrl?: string;
   network?: TelegramNetworkConfig;
   timeoutMs: number;

--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -379,7 +379,13 @@ export const registerTelegramHandlers = ({
       for (const { ctx } of entry.messages) {
         let media;
         try {
-          media = await resolveMedia(ctx, mediaMaxBytes, opts.token, telegramTransport);
+          media = await resolveMedia(
+            ctx,
+            mediaMaxBytes,
+            opts.token,
+            telegramTransport,
+            telegramCfg.apiRoot,
+          );
         } catch (mediaErr) {
           if (!isRecoverableMediaGroupError(mediaErr)) {
             throw mediaErr;
@@ -484,6 +490,7 @@ export const registerTelegramHandlers = ({
         mediaMaxBytes,
         opts.token,
         telegramTransport,
+        telegramCfg.apiRoot,
       );
       if (!media) {
         return [];
@@ -994,7 +1001,13 @@ export const registerTelegramHandlers = ({
 
     let media: Awaited<ReturnType<typeof resolveMedia>> = null;
     try {
-      media = await resolveMedia(ctx, mediaMaxBytes, opts.token, telegramTransport);
+      media = await resolveMedia(
+        ctx,
+        mediaMaxBytes,
+        opts.token,
+        telegramTransport,
+        telegramCfg.apiRoot,
+      );
     } catch (mediaErr) {
       if (isMediaSizeLimitError(mediaErr)) {
         if (sendOversizeWarning) {

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -174,7 +174,9 @@ vi.mock("grammy", () => ({
     catch = vi.fn();
     constructor(
       public token: string,
-      public options?: { client?: { fetch?: typeof fetch } },
+      public options?: {
+        client?: { apiRoot?: string; fetch?: typeof fetch; timeoutSeconds?: number };
+      },
     ) {
       grammySpies.botCtorSpy(token, options);
     }

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -112,6 +112,45 @@ describe("createTelegramBot", () => {
       }),
     );
   });
+  it("applies global and per-account apiRoot", () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          apiRoot: "http://127.0.0.1:8081/",
+        },
+      },
+    });
+    createTelegramBot({ token: "tok" });
+    expect(botCtorSpy).toHaveBeenCalledWith(
+      "tok",
+      expect.objectContaining({
+        client: expect.objectContaining({ apiRoot: "http://127.0.0.1:8081" }),
+      }),
+    );
+    botCtorSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          apiRoot: "http://127.0.0.1:8081/",
+          accounts: {
+            foo: { apiRoot: "http://127.0.0.1:8082/" },
+          },
+        },
+      },
+    });
+    createTelegramBot({ token: "tok", accountId: "foo" });
+    expect(botCtorSpy).toHaveBeenCalledWith(
+      "tok",
+      expect.objectContaining({
+        client: expect.objectContaining({ apiRoot: "http://127.0.0.1:8082" }),
+      }),
+    );
+  });
   it("sequentializes updates by chat and thread", () => {
     createTelegramBot({ token: "tok" });
     expect(sequentializeSpy).toHaveBeenCalledTimes(1);
@@ -815,7 +854,7 @@ describe("createTelegramBot", () => {
     expect(payload.SessionKey).toBe("agent:opie:main");
   });
 
-  it("routes non-default account DMs to the per-account fallback session without explicit bindings", async () => {
+  it("routes non-default account DMs to isolated per-account sessions without explicit bindings", async () => {
     loadConfig.mockReturnValue({
       channels: {
         telegram: {
@@ -845,9 +884,9 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = replySpy.mock.calls[0]?.[0];
+    const payload = replySpy.mock.calls[0]?.[0] as { AccountId?: string; SessionKey?: string };
     expect(payload.AccountId).toBe("opie");
-    expect(payload.SessionKey).toContain("agent:main:telegram:opie:");
+    expect(payload.SessionKey).toBe("agent:main:telegram:opie:direct:999");
   });
 
   it("applies group mention overrides and fallback behavior", async () => {
@@ -1864,7 +1903,11 @@ describe("createTelegramBot", () => {
 
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
-      createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+      createTelegramBot({
+        token: "tok",
+        testTimings: TELEGRAM_TEST_TIMINGS,
+        proxyFetch: fetchSpy as unknown as typeof fetch,
+      });
       const handler = getOnHandler("channel_post") as (
         ctx: Record<string, unknown>,
       ) => Promise<void>;
@@ -2091,7 +2134,11 @@ describe("createTelegramBot", () => {
 
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
-      createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+      createTelegramBot({
+        token: "tok",
+        testTimings: TELEGRAM_TEST_TIMINGS,
+        proxyFetch: fetchSpy as unknown as typeof fetch,
+      });
       const handler = getOnHandler("channel_post") as (
         ctx: Record<string, unknown>,
       ) => Promise<void>;

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -31,6 +31,7 @@ import { getChildLogger } from "../../../src/logging.js";
 import { createSubsystemLogger } from "../../../src/logging/subsystem.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../../src/runtime.js";
 import { resolveTelegramAccount } from "./accounts.js";
+import { resolveTelegramApiRoot } from "./api-root.js";
 import { registerTelegramHandlers } from "./bot-handlers.js";
 import { createTelegramMessageProcessor } from "./bot-message.js";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
@@ -136,6 +137,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   const telegramCfg = account.config;
 
   const telegramTransport = resolveTelegramTransport(opts.proxyFetch, {
+    apiRoot: telegramCfg.apiRoot,
     network: telegramCfg.network,
   });
   const shouldProvideFetch = Boolean(telegramTransport.fetch);
@@ -211,11 +213,15 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
+  const apiRoot = telegramCfg.apiRoot?.trim()
+    ? resolveTelegramApiRoot(telegramCfg.apiRoot)
+    : undefined;
   const client: ApiClientOptions | undefined =
-    finalFetch || timeoutSeconds
+    finalFetch || timeoutSeconds || apiRoot
       ? {
           ...(finalFetch ? { fetch: finalFetch } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(apiRoot ? { apiRoot } : {}),
         }
       : undefined;
 

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -5,6 +5,7 @@ import type { TelegramContext } from "./types.js";
 
 const saveMediaBuffer = vi.fn();
 const fetchRemoteMedia = vi.fn();
+const readLocalFileSafely = vi.fn();
 
 vi.mock("../../../../src/media/store.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../../src/media/store.js")>();
@@ -17,6 +18,15 @@ vi.mock("../../../../src/media/store.js", async (importOriginal) => {
 vi.mock("../../../../src/media/fetch.js", () => ({
   fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMedia(...args),
 }));
+
+vi.mock("../../../../src/infra/fs-safe.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../../src/infra/fs-safe.js")>();
+  return {
+    ...actual,
+    readLocalFileSafely: (...args: unknown[]) => readLocalFileSafely(...args),
+  };
+});
 
 vi.mock("../../../../src/globals.js", () => ({
   danger: (s: string) => s,
@@ -168,6 +178,7 @@ describe("resolveMedia getFile retry", () => {
     vi.useFakeTimers();
     fetchRemoteMedia.mockClear();
     saveMediaBuffer.mockClear();
+    readLocalFileSafely.mockClear();
   });
 
   afterEach(() => {
@@ -354,6 +365,87 @@ describe("resolveMedia getFile retry", () => {
         fetchImpl: callerFetch,
       }),
     );
+  });
+
+  it("builds file download URLs from a custom Telegram Bot API root", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "documents/file_42.pdf" });
+    const callerFetch = vi.fn() as unknown as typeof fetch;
+    const callerTransport = { fetch: callerFetch, sourceFetch: callerFetch };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("pdf-data"),
+      contentType: "application/pdf",
+      fileName: "file_42.pdf",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_42---uuid.pdf",
+      contentType: "application/pdf",
+    });
+
+    await resolveMedia(
+      makeCtx("document", getFile),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+      callerTransport,
+      "http://127.0.0.1:8081/",
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: `http://127.0.0.1:8081/file/bot${BOT_TOKEN}/documents/file_42.pdf`,
+        ssrfPolicy: {
+          allowRfc2544BenchmarkRange: true,
+          allowedHostnames: ["127.0.0.1"],
+        },
+      }),
+    );
+  });
+
+  it("reads absolute local getFile paths from disk without HTTP", async () => {
+    const localFilePath = "/tmp/openclaw-local-bot-api/file_42.pdf";
+    const getFile = vi.fn().mockResolvedValue({ file_path: localFilePath });
+    readLocalFileSafely.mockResolvedValueOnce({
+      buffer: Buffer.from("pdf-data"),
+      realPath: localFilePath,
+      stat: { size: 8 },
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_42---uuid.pdf",
+      contentType: "application/pdf",
+    });
+
+    const result = await resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+
+    expect(result).not.toBeNull();
+    expect(readLocalFileSafely).toHaveBeenCalledWith({
+      filePath: localFilePath,
+      maxBytes: MAX_MEDIA_BYTES,
+    });
+    expect(fetchRemoteMedia).not.toHaveBeenCalled();
+  });
+
+  it("reads file:// getFile paths from disk without HTTP", async () => {
+    const localFilePath = "/tmp/openclaw local/file 42.pdf";
+    const getFile = vi
+      .fn()
+      .mockResolvedValue({ file_path: "file:///tmp/openclaw%20local/file%2042.pdf" });
+    readLocalFileSafely.mockResolvedValueOnce({
+      buffer: Buffer.from("pdf-data"),
+      realPath: localFilePath,
+      stat: { size: 8 },
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_42---uuid.pdf",
+      contentType: "application/pdf",
+    });
+
+    const result = await resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+
+    expect(result).not.toBeNull();
+    expect(readLocalFileSafely).toHaveBeenCalledWith({
+      filePath: localFilePath,
+      maxBytes: MAX_MEDIA_BYTES,
+    });
+    expect(fetchRemoteMedia).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -21,8 +21,7 @@ vi.mock("../../../../src/media/fetch.js", () => ({
 }));
 
 vi.mock("../../../../src/infra/fs-safe.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../../src/infra/fs-safe.js")>();
+  const actual = await importOriginal<typeof import("../../../../src/infra/fs-safe.js")>();
   return {
     ...actual,
     readLocalFileSafely: (...args: unknown[]) => readLocalFileSafely(...args),

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -1,6 +1,7 @@
 import type { Message } from "@grammyjs/types";
 import { GrammyError } from "grammy";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SafeOpenError } from "../../../../src/infra/fs-safe.js";
 import type { TelegramContext } from "./types.js";
 
 const saveMediaBuffer = vi.fn();
@@ -400,7 +401,7 @@ describe("resolveMedia getFile retry", () => {
     );
   });
 
-  it("reads absolute local getFile paths from disk without HTTP", async () => {
+  it("reads absolute local getFile paths from disk without HTTP when apiRoot is set", async () => {
     const localFilePath = "/tmp/openclaw-local-bot-api/file_42.pdf";
     const getFile = vi.fn().mockResolvedValue({ file_path: localFilePath });
     readLocalFileSafely.mockResolvedValueOnce({
@@ -413,7 +414,13 @@ describe("resolveMedia getFile retry", () => {
       contentType: "application/pdf",
     });
 
-    const result = await resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+    const result = await resolveMedia(
+      makeCtx("document", getFile),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+      undefined,
+      "http://127.0.0.1:8081",
+    );
 
     expect(result).not.toBeNull();
     expect(readLocalFileSafely).toHaveBeenCalledWith({
@@ -423,7 +430,7 @@ describe("resolveMedia getFile retry", () => {
     expect(fetchRemoteMedia).not.toHaveBeenCalled();
   });
 
-  it("reads file:// getFile paths from disk without HTTP", async () => {
+  it("reads file:// getFile paths from disk without HTTP when apiRoot is set", async () => {
     const localFilePath = "/tmp/openclaw local/file 42.pdf";
     const getFile = vi
       .fn()
@@ -438,7 +445,13 @@ describe("resolveMedia getFile retry", () => {
       contentType: "application/pdf",
     });
 
-    const result = await resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+    const result = await resolveMedia(
+      makeCtx("document", getFile),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+      undefined,
+      "http://127.0.0.1:8081",
+    );
 
     expect(result).not.toBeNull();
     expect(readLocalFileSafely).toHaveBeenCalledWith({
@@ -446,6 +459,48 @@ describe("resolveMedia getFile retry", () => {
       maxBytes: MAX_MEDIA_BYTES,
     });
     expect(fetchRemoteMedia).not.toHaveBeenCalled();
+  });
+
+  it("does not read absolute local getFile paths from disk without explicit apiRoot opt-in", async () => {
+    const localFilePath = "/tmp/openclaw-local-bot-api/file_42.pdf";
+    const getFile = vi.fn().mockResolvedValue({ file_path: localFilePath });
+    mockPdfFetchAndSave("file_42.pdf");
+
+    const result = await resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+
+    expect(result).not.toBeNull();
+    expect(readLocalFileSafely).not.toHaveBeenCalled();
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: `https://api.telegram.org/file/bot${BOT_TOKEN}/tmp/openclaw-local-bot-api/file_42.pdf`,
+      }),
+    );
+  });
+
+  it("falls back to HTTP download when local file_path cannot be read", async () => {
+    const localFilePath = "/tmp/openclaw-local-bot-api/file_42.pdf";
+    const getFile = vi.fn().mockResolvedValue({ file_path: localFilePath });
+    readLocalFileSafely.mockRejectedValueOnce(new SafeOpenError("not-found", "file not found"));
+    mockPdfFetchAndSave("file_42.pdf");
+
+    const result = await resolveMedia(
+      makeCtx("document", getFile),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+      undefined,
+      "http://127.0.0.1:8081",
+    );
+
+    expect(result).not.toBeNull();
+    expect(readLocalFileSafely).toHaveBeenCalledWith({
+      filePath: localFilePath,
+      maxBytes: MAX_MEDIA_BYTES,
+    });
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: `http://127.0.0.1:8081/file/bot${BOT_TOKEN}/tmp/openclaw-local-bot-api/file_42.pdf`,
+      }),
+    );
   });
 });
 

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -1,21 +1,22 @@
+import path from "node:path";
 import { GrammyError } from "grammy";
 import { logVerbose, warn } from "../../../../src/globals.js";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
+import { SafeOpenError, readLocalFileSafely } from "../../../../src/infra/fs-safe.js";
 import { retryAsync } from "../../../../src/infra/retry.js";
 import { fetchRemoteMedia } from "../../../../src/media/fetch.js";
 import { saveMediaBuffer } from "../../../../src/media/store.js";
+import {
+  buildTelegramFileDownloadUrl,
+  resolveTelegramLocalFilePath,
+  resolveTelegramMediaSsrFPolicy,
+} from "../api-root.js";
 import { shouldRetryTelegramIpv4Fallback, type TelegramTransport } from "../fetch.js";
 import { cacheSticker, getCachedSticker } from "../sticker-cache.js";
 import { resolveTelegramMediaPlaceholder } from "./helpers.js";
 import type { StickerMetadata, TelegramContext } from "./types.js";
 
 const FILE_TOO_BIG_RE = /file is too big/i;
-const TELEGRAM_MEDIA_SSRF_POLICY = {
-  // Telegram file downloads should trust api.telegram.org even when DNS/proxy
-  // resolution maps to private/internal ranges in restricted networks.
-  allowedHostnames: ["api.telegram.org"],
-  allowRfc2544BenchmarkRange: true,
-};
 
 /**
  * Returns true if the error is Telegram's "file is too big" error.
@@ -121,21 +122,59 @@ const TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
 async function downloadAndSaveTelegramFile(params: {
   filePath: string;
   token: string;
-  transport: TelegramTransport;
+  transport?: TelegramTransport;
   maxBytes: number;
   telegramFileName?: string;
+  apiRoot?: string;
 }) {
-  const url = `https://api.telegram.org/file/bot${params.token}/${params.filePath}`;
+  const localFilePath = params.apiRoot ? resolveTelegramLocalFilePath(params.filePath) : null;
+  if (localFilePath) {
+    try {
+      const localFile = await readLocalFileSafely({
+        filePath: localFilePath,
+        maxBytes: params.maxBytes,
+      });
+      const originalName = params.telegramFileName ?? path.basename(localFilePath);
+      return await saveMediaBuffer(
+        localFile.buffer,
+        undefined,
+        "inbound",
+        params.maxBytes,
+        originalName,
+      );
+    } catch (err) {
+      if (err instanceof SafeOpenError) {
+        if (err.code === "too-large") {
+          throw new Error(
+            `Media exceeds ${(params.maxBytes / (1024 * 1024)).toFixed(0)}MB limit`,
+            { cause: err },
+          );
+        }
+        logVerbose(
+          `telegram: local file_path unreadable, falling back to HTTP download: ${localFilePath} (${err.code})`,
+        );
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  const resolvedTransport = resolveRequiredTelegramTransport(params.transport);
+  const url = buildTelegramFileDownloadUrl({
+    token: params.token,
+    filePath: params.filePath,
+    apiRoot: params.apiRoot,
+  });
   const fetched = await fetchRemoteMedia({
     url,
-    fetchImpl: params.transport.sourceFetch,
-    dispatcherPolicy: params.transport.pinnedDispatcherPolicy,
-    fallbackDispatcherPolicy: params.transport.fallbackPinnedDispatcherPolicy,
+    fetchImpl: resolvedTransport.sourceFetch,
+    dispatcherPolicy: resolvedTransport.pinnedDispatcherPolicy,
+    fallbackDispatcherPolicy: resolvedTransport.fallbackPinnedDispatcherPolicy,
     shouldRetryFetchError: shouldRetryTelegramIpv4Fallback,
     filePathHint: params.filePath,
     maxBytes: params.maxBytes,
     readIdleTimeoutMs: TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS,
-    ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
+    ssrfPolicy: resolveTelegramMediaSsrFPolicy(params.apiRoot),
   });
   const originalName = params.telegramFileName ?? fetched.fileName ?? params.filePath;
   return saveMediaBuffer(
@@ -153,6 +192,7 @@ async function resolveStickerMedia(params: {
   maxBytes: number;
   token: string;
   transport?: TelegramTransport;
+  apiRoot?: string;
 }): Promise<
   | {
       path: string;
@@ -163,7 +203,7 @@ async function resolveStickerMedia(params: {
   | null
   | undefined
 > {
-  const { msg, ctx, maxBytes, token, transport } = params;
+  const { msg, ctx, maxBytes, token, transport, apiRoot } = params;
   if (!msg.sticker) {
     return undefined;
   }
@@ -183,16 +223,20 @@ async function resolveStickerMedia(params: {
       logVerbose("telegram: getFile returned no file_path for sticker");
       return null;
     }
-    const resolvedTransport = resolveOptionalTelegramTransport(transport);
-    if (!resolvedTransport) {
+    const isLocalFilePath = Boolean(resolveTelegramLocalFilePath(file.file_path));
+    const resolvedTransport = isLocalFilePath
+      ? undefined
+      : resolveOptionalTelegramTransport(transport);
+    if (!isLocalFilePath && !resolvedTransport) {
       logVerbose("telegram: fetch not available for sticker download");
       return null;
     }
     const saved = await downloadAndSaveTelegramFile({
       filePath: file.file_path,
       token,
-      transport: resolvedTransport,
+      transport: resolvedTransport ?? undefined,
       maxBytes,
+      apiRoot,
     });
 
     // Check sticker cache for existing description
@@ -248,6 +292,7 @@ export async function resolveMedia(
   maxBytes: number,
   token: string,
   transport?: TelegramTransport,
+  apiRoot?: string,
 ): Promise<{
   path: string;
   contentType?: string;
@@ -261,6 +306,7 @@ export async function resolveMedia(
     maxBytes,
     token,
     transport,
+    apiRoot,
   });
   if (stickerResolved !== undefined) {
     return stickerResolved;
@@ -281,9 +327,10 @@ export async function resolveMedia(
   const saved = await downloadAndSaveTelegramFile({
     filePath: file.file_path,
     token,
-    transport: resolveRequiredTelegramTransport(transport),
+    transport,
     maxBytes,
     telegramFileName: resolveTelegramFileName(msg),
+    apiRoot,
   });
   const placeholder = resolveTelegramMediaPlaceholder(msg) ?? "<media:document>";
   return { path: saved.path, contentType: saved.contentType, placeholder };

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -145,10 +145,9 @@ async function downloadAndSaveTelegramFile(params: {
     } catch (err) {
       if (err instanceof SafeOpenError) {
         if (err.code === "too-large") {
-          throw new Error(
-            `Media exceeds ${(params.maxBytes / (1024 * 1024)).toFixed(0)}MB limit`,
-            { cause: err },
-          );
+          throw new Error(`Media exceeds ${(params.maxBytes / (1024 * 1024)).toFixed(0)}MB limit`, {
+            cause: err,
+          });
         }
         logVerbose(
           `telegram: local file_path unreadable, falling back to HTTP download: ${localFilePath} (${err.code})`,

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -6,6 +6,7 @@ import {
   createScopedDmSecurityResolver,
   formatAllowFromLowercase,
 } from "openclaw/plugin-sdk/compat";
+import { type OutboundSendDeps, resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import {
   applyAccountNameToChannelSection,
   buildChannelConfigSchema,
@@ -40,10 +41,6 @@ import {
   type ResolvedTelegramAccount,
   type TelegramProbe,
 } from "openclaw/plugin-sdk/telegram";
-import {
-  type OutboundSendDeps,
-  resolveOutboundSendDep,
-} from "../../../src/infra/outbound/send-deps.js";
 import { getTelegramRuntime } from "./runtime.js";
 
 type TelegramSendFn = ReturnType<

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -5,6 +5,7 @@ import { resolveFetch } from "../../../src/infra/fetch.js";
 import { hasEnvHttpProxyConfigured } from "../../../src/infra/net/proxy-env.js";
 import type { PinnedDispatcherPolicy } from "../../../src/infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../../src/logging/subsystem.js";
+import { resolveTelegramApiOriginDetails } from "./api-root.js";
 import {
   resolveTelegramAutoSelectFamilyDecision,
   resolveTelegramDnsResultOrderDecision,
@@ -14,7 +15,7 @@ import { getProxyUrlFromFetch } from "./proxy.js";
 const log = createSubsystemLogger("telegram/network");
 
 const TELEGRAM_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 300;
-const TELEGRAM_API_HOSTNAME = "api.telegram.org";
+const DEFAULT_TELEGRAM_API_HOSTNAME = "api.telegram.org";
 
 type RequestInitWithDispatcher = RequestInit & {
   dispatcher?: unknown;
@@ -138,7 +139,24 @@ function buildTelegramConnectOptions(params: {
   return Object.keys(connect).length > 0 ? connect : null;
 }
 
-function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
+function resolveTelegramApiProxyTarget(apiRoot?: string | null): {
+  protocol: "http" | "https";
+  hostname: string;
+  port: number;
+} {
+  const resolved = resolveTelegramApiOriginDetails(apiRoot);
+  const protocol = resolved?.protocol === "http:" ? "http" : "https";
+  return {
+    protocol,
+    hostname: resolved?.hostname ?? DEFAULT_TELEGRAM_API_HOSTNAME,
+    port: resolved?.port ?? (protocol === "http" ? 80 : 443),
+  };
+}
+
+function shouldBypassEnvProxyForTelegramApi(
+  apiRoot?: string | null,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
   // We need this classification before dispatch to decide whether sticky IPv4 fallback
   // can safely arm. EnvHttpProxyAgent does not expose route decisions (proxy vs direct
   // NO_PROXY bypass), so we mirror undici's parsing/matching behavior for this host.
@@ -154,8 +172,9 @@ function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env
   if (noProxyValue === "*") {
     return true;
   }
-  const targetHostname = TELEGRAM_API_HOSTNAME.toLowerCase();
-  const targetPort = 443;
+  const target = resolveTelegramApiProxyTarget(apiRoot);
+  const targetHostname = target.hostname.toLowerCase();
+  const targetPort = target.port;
   const noProxyEntries = noProxyValue.split(/[,\s]/);
   for (let i = 0; i < noProxyEntries.length; i++) {
     const entry = noProxyEntries[i];
@@ -178,8 +197,11 @@ function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env
   return false;
 }
 
-function hasEnvHttpProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
-  return hasEnvHttpProxyConfigured("https", env);
+function hasEnvHttpProxyForTelegramApi(
+  apiRoot?: string | null,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return hasEnvHttpProxyConfigured(resolveTelegramApiProxyTarget(apiRoot).protocol, env);
 }
 
 function resolveTelegramDispatcherPolicy(params: {
@@ -403,7 +425,7 @@ export type TelegramTransport = {
 
 export function resolveTelegramTransport(
   proxyFetch?: typeof fetch,
-  options?: { network?: TelegramNetworkConfig },
+  options?: { network?: TelegramNetworkConfig; apiRoot?: string },
 ): TelegramTransport {
   const autoSelectDecision = resolveTelegramAutoSelectFamilyDecision({
     network: options?.network,
@@ -429,7 +451,7 @@ export function resolveTelegramTransport(
     return { fetch: sourceFetch, sourceFetch };
   }
 
-  const useEnvProxy = !explicitProxyUrl && hasEnvHttpProxyForTelegramApi();
+  const useEnvProxy = !explicitProxyUrl && hasEnvHttpProxyForTelegramApi(options?.apiRoot);
   const defaultDispatcherResolution = resolveTelegramDispatcherPolicy({
     autoSelectFamily: autoSelectDecision.value,
     dnsResultOrder,
@@ -438,7 +460,7 @@ export function resolveTelegramTransport(
     proxyUrl: explicitProxyUrl,
   });
   const defaultDispatcher = createTelegramDispatcher(defaultDispatcherResolution.policy);
-  const shouldBypassEnvProxy = shouldBypassEnvProxyForTelegramApi();
+  const shouldBypassEnvProxy = shouldBypassEnvProxyForTelegramApi(options?.apiRoot);
   const allowStickyIpv4Fallback =
     defaultDispatcher.mode === "direct" ||
     (defaultDispatcher.mode === "env-proxy" && shouldBypassEnvProxy);
@@ -508,7 +530,7 @@ export function resolveTelegramTransport(
 
 export function resolveTelegramFetch(
   proxyFetch?: typeof fetch,
-  options?: { network?: TelegramNetworkConfig },
+  options?: { network?: TelegramNetworkConfig; apiRoot?: string },
 ): typeof fetch {
   return resolveTelegramTransport(proxyFetch, options).fetch;
 }

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -129,7 +129,7 @@ function mockRunOnceAndAbort(abort: AbortController) {
   runSpy.mockImplementationOnce(() => makeAbortRunner(abort));
 }
 
-async function expectOffsetConfirmationSkipped(offset: number | null) {
+async function expectStartupGetUpdatesSkipped(offset: number | null) {
   readTelegramUpdateOffsetSpy.mockResolvedValueOnce(offset);
   const abort = new AbortController();
   api.getUpdates.mockReset();
@@ -154,12 +154,6 @@ async function runMonitorAndCaptureStartupOrder(params?: { persistedOffset?: num
     order.push("deleteWebhook");
     return true;
   });
-  if (typeof params?.persistedOffset === "number") {
-    api.getUpdates.mockImplementationOnce(async () => {
-      order.push("getUpdates");
-      return [];
-    });
-  }
   runSpy.mockImplementationOnce(() => {
     order.push("run");
     return makeAbortRunner(abort);
@@ -604,25 +598,25 @@ describe("monitorTelegramProvider (grammY)", () => {
     vi.useRealTimers();
   });
 
-  it("confirms persisted offset with Telegram before starting runner", async () => {
+  it("does not preflight getUpdates before starting runner when a persisted offset exists", async () => {
     const { order } = await runMonitorAndCaptureStartupOrder({
       persistedOffset: 549076203,
     });
 
-    expect(api.getUpdates).toHaveBeenCalledWith({ offset: 549076204, limit: 1, timeout: 0 });
-    expect(order).toEqual(["deleteWebhook", "getUpdates", "run"]);
+    expect(api.getUpdates).not.toHaveBeenCalled();
+    expect(order).toEqual(["deleteWebhook", "run"]);
   });
 
-  it("skips offset confirmation when no persisted offset exists", async () => {
-    await expectOffsetConfirmationSkipped(null);
+  it("skips startup getUpdates preflight when no persisted offset exists", async () => {
+    await expectStartupGetUpdatesSkipped(null);
   });
 
-  it("skips offset confirmation when persisted offset is invalid", async () => {
-    await expectOffsetConfirmationSkipped(-1);
+  it("skips startup getUpdates preflight when persisted offset is invalid", async () => {
+    await expectStartupGetUpdatesSkipped(-1);
   });
 
-  it("skips offset confirmation when persisted offset cannot be safely incremented", async () => {
-    await expectOffsetConfirmationSkipped(Number.MAX_SAFE_INTEGER);
+  it("skips startup getUpdates preflight when persisted offset cannot be safely incremented", async () => {
+    await expectStartupGetUpdatesSkipped(Number.MAX_SAFE_INTEGER);
   });
 
   it("resets webhookCleared latch on 409 conflict so deleteWebhook re-runs", async () => {

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -128,11 +128,12 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     const persistedOffsetRaw = await readTelegramUpdateOffset({
       accountId: account.accountId,
       botToken: token,
+      apiRoot: account.config.apiRoot,
     });
     let lastUpdateId = normalizePersistedUpdateId(persistedOffsetRaw);
     if (persistedOffsetRaw !== null && lastUpdateId === null) {
       log(
-        `[telegram] Ignoring invalid persisted update offset (${String(persistedOffsetRaw)}); starting without offset confirmation.`,
+        `[telegram] Ignoring invalid persisted update offset (${String(persistedOffsetRaw)}); starting without a persisted offset seed.`,
       );
     }
 
@@ -151,6 +152,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           accountId: account.accountId,
           updateId: normalizedUpdateId,
           botToken: token,
+          apiRoot: account.config.apiRoot,
         });
       } catch (err) {
         (opts.runtime?.error ?? console.error)(

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -102,6 +102,33 @@ function getErrorCode(err: unknown): string | undefined {
   return undefined;
 }
 
+function getRetryAfterSeconds(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const direct =
+    "parameters" in err && err.parameters && typeof err.parameters === "object"
+      ? (err.parameters as { retry_after?: unknown }).retry_after
+      : undefined;
+  if (typeof direct === "number" && Number.isFinite(direct)) {
+    return direct;
+  }
+  const response =
+    "response" in err && err.response && typeof err.response === "object"
+      ? (err.response as { parameters?: { retry_after?: unknown } }).parameters?.retry_after
+      : undefined;
+  if (typeof response === "number" && Number.isFinite(response)) {
+    return response;
+  }
+  const nestedError =
+    "error" in err && err.error && typeof err.error === "object"
+      ? (err.error as { parameters?: { retry_after?: unknown } }).parameters?.retry_after
+      : undefined;
+  return typeof nestedError === "number" && Number.isFinite(nestedError)
+    ? nestedError
+    : undefined;
+}
+
 export type TelegramNetworkErrorContext = "polling" | "send" | "webhook" | "unknown";
 export type TelegramNetworkErrorOrigin = {
   method?: string | null;
@@ -151,8 +178,9 @@ export function isTelegramPollingNetworkError(err: unknown): boolean {
 
 /**
  * Returns true if the error is safe to retry for a non-idempotent Telegram send operation
- * (e.g. sendMessage). Only matches errors that are guaranteed to have occurred *before*
- * the request reached Telegram's servers, preventing duplicate message delivery.
+ * (e.g. sendMessage). This is intentionally stricter than generic Telegram retries:
+ * it only allows pre-connect failures, explicit rate-limit rejections, and grammY's
+ * failed-after network envelope, all of which indicate the send was not accepted.
  *
  * Use this instead of isRecoverableTelegramNetworkError for sendMessage/sendPhoto/etc.
  * calls where a retry would create a duplicate visible message.
@@ -166,8 +194,15 @@ export function isSafeToRetrySendError(err: unknown): boolean {
     if (code && PRE_CONNECT_ERROR_CODES.has(code)) {
       return true;
     }
+    if (typeof getRetryAfterSeconds(candidate) === "number") {
+      return true;
+    }
+    const message = formatErrorMessage(candidate).trim();
+    if (message && GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE.test(message)) {
+      return true;
+    }
   }
-  return false;
+  return hasTelegramErrorCode(err, (code) => code === 429);
 }
 
 function hasTelegramErrorCode(err: unknown, matches: (code: number) => boolean): boolean {

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -124,9 +124,7 @@ function getRetryAfterSeconds(err: unknown): number | undefined {
     "error" in err && err.error && typeof err.error === "object"
       ? (err.error as { parameters?: { retry_after?: unknown } }).parameters?.retry_after
       : undefined;
-  return typeof nestedError === "number" && Number.isFinite(nestedError)
-    ? nestedError
-    : undefined;
+  return typeof nestedError === "number" && Number.isFinite(nestedError) ? nestedError : undefined;
 }
 
 export type TelegramNetworkErrorContext = "polling" | "send" | "webhook" | "unknown";
@@ -179,8 +177,8 @@ export function isTelegramPollingNetworkError(err: unknown): boolean {
 /**
  * Returns true if the error is safe to retry for a non-idempotent Telegram send operation
  * (e.g. sendMessage). This is intentionally stricter than generic Telegram retries:
- * it only allows pre-connect failures, explicit rate-limit rejections, and grammY's
- * failed-after network envelope, all of which indicate the send was not accepted.
+ * it only allows pre-connect failures and explicit rate-limit rejections where Telegram
+ * confirmed the send was not accepted.
  *
  * Use this instead of isRecoverableTelegramNetworkError for sendMessage/sendPhoto/etc.
  * calls where a retry would create a duplicate visible message.
@@ -195,10 +193,6 @@ export function isSafeToRetrySendError(err: unknown): boolean {
       return true;
     }
     if (typeof getRetryAfterSeconds(candidate) === "number") {
-      return true;
-    }
-    const message = formatErrorMessage(candidate).trim();
-    if (message && GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE.test(message)) {
       return true;
     }
   }

--- a/extensions/telegram/src/onboarding.ts
+++ b/extensions/telegram/src/onboarding.ts
@@ -47,7 +47,7 @@ async function noteTelegramUserIdHelp(prompter: WizardPrompter): Promise<void> {
   await prompter.note(
     [
       `1) DM your bot, then read from.id in \`${formatCliCommand("openclaw logs --follow")}\` (safest)`,
-      "2) Or call https://api.telegram.org/bot<bot_token>/getUpdates and read message.from.id",
+      "2) Or call <your Bot API root>/bot<bot_token>/getUpdates (default: https://api.telegram.org) and read message.from.id",
       "3) Third-party: DM @userinfobot or @getidsbot",
       `Docs: ${formatDocsLink("/telegram")}`,
       "Website: https://openclaw.ai",
@@ -106,7 +106,11 @@ async function promptTelegramAllowFrom(params: {
             return { input: entry, resolved: false, id: null };
           }
           const username = stripped.startsWith("@") ? stripped : `@${stripped}`;
-          const id = await fetchTelegramChatId({ token: tokenValue, chatId: username });
+          const id = await fetchTelegramChatId({
+            token: tokenValue,
+            chatId: username,
+            apiRoot: resolved.config.apiRoot,
+          });
           return { input: entry, resolved: Boolean(id), id };
         }),
       );

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -1,13 +1,10 @@
+import { resolveOutboundSendDep, type OutboundSendDeps } from "openclaw/plugin-sdk/compat";
 import type { ReplyPayload } from "../../../src/auto-reply/types.js";
 import {
   resolvePayloadMediaUrls,
   sendPayloadMediaSequence,
 } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
-import {
-  resolveOutboundSendDep,
-  type OutboundSendDeps,
-} from "../../../src/infra/outbound/send-deps.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { markdownToTelegramHtmlChunks } from "./format.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -49,10 +49,14 @@ const pollingState = vi.hoisted(() => {
     stop,
   };
 
+  let runnerTask = async () => {
+    await bot.api.getUpdates({ offset: 0, limit: 1, timeout: 30 });
+    abortController?.abort();
+  };
+
   const run = vi.fn(() => ({
     task: async () => {
-      await bot.api.getUpdates({ offset: 0, limit: 1, timeout: 30 });
-      abortController?.abort();
+      await runnerTask();
     },
     stop: vi.fn(async () => undefined),
     isRunning: () => false,
@@ -65,6 +69,10 @@ const pollingState = vi.hoisted(() => {
     reset: () => {
       abortController = undefined;
       middlewares.length = 0;
+      runnerTask = async () => {
+        await bot.api.getUpdates({ offset: 0, limit: 1, timeout: 30 });
+        abortController?.abort();
+      };
       getUpdatesBase.mockReset().mockResolvedValue([]);
       deleteWebhookBase.mockReset().mockResolvedValue(true);
       stop.mockReset().mockResolvedValue(undefined);
@@ -74,6 +82,9 @@ const pollingState = vi.hoisted(() => {
     run,
     setAbortController: (controller: AbortController) => {
       abortController = controller;
+    },
+    setRunnerTask: (task: () => Promise<void>) => {
+      runnerTask = task;
     },
   };
 });
@@ -142,6 +153,48 @@ describe("TelegramPollingSession", () => {
 
     expect(pollingState.getUpdatesBase).toHaveBeenCalledWith({
       offset: 0,
+      limit: 1,
+      timeout: 30,
+    });
+  });
+
+  it("reuses the seeded offset until the first getUpdates succeeds", async () => {
+    const abort = new AbortController();
+    pollingState.setAbortController(abort);
+    pollingState.getUpdatesBase
+      .mockRejectedValueOnce(new Error("transient getUpdates failure"))
+      .mockResolvedValueOnce([]);
+    pollingState.setRunnerTask(async () => {
+      await expect(
+        pollingState.bot.api.getUpdates({ offset: 0, limit: 1, timeout: 30 }),
+      ).rejects.toThrow(/transient getUpdates failure/i);
+      await pollingState.bot.api.getUpdates({ offset: 0, limit: 1, timeout: 30 });
+      abort.abort();
+    });
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: undefined,
+      accountId: "default",
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => 549_076_203,
+      persistUpdateId: vi.fn(async () => undefined),
+      log: vi.fn(),
+      proxyFetch: undefined,
+      runtime: undefined,
+    });
+
+    await session.runUntilAbort();
+
+    expect(pollingState.getUpdatesBase).toHaveBeenCalledTimes(2);
+    expect(pollingState.getUpdatesBase).toHaveBeenNthCalledWith(1, {
+      offset: 549_076_204,
+      limit: 1,
+      timeout: 30,
+    });
+    expect(pollingState.getUpdatesBase).toHaveBeenNthCalledWith(2, {
+      offset: 549_076_204,
       limit: 1,
       timeout: 30,
     });

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TelegramPollingSession } from "./polling-session.js";
+
+const pollingState = vi.hoisted(() => {
+  type ApiMethod = "deleteWebhook" | "getUpdates";
+  type ApiPayload = Record<string, unknown>;
+  type ApiCall = (method: ApiMethod, payload: ApiPayload, signal?: AbortSignal) => Promise<unknown>;
+  type ApiMiddleware = (
+    prev: ApiCall,
+    method: ApiMethod,
+    payload: ApiPayload,
+    signal?: AbortSignal,
+  ) => Promise<unknown>;
+
+  let abortController: AbortController | undefined;
+  const middlewares: ApiMiddleware[] = [];
+  const getUpdatesBase = vi.fn(async (_payload: ApiPayload) => []);
+  const deleteWebhookBase = vi.fn(async (_payload: ApiPayload) => true);
+  const stop = vi.fn(async () => undefined);
+
+  const callApi = (method: ApiMethod, payload: ApiPayload, signal?: AbortSignal) => {
+    const invokeBase: ApiCall = async (nextMethod, nextPayload) => {
+      if (nextMethod === "getUpdates") {
+        return getUpdatesBase(nextPayload);
+      }
+      return deleteWebhookBase(nextPayload);
+    };
+    const chain = middlewares.reduceRight<ApiCall>((next, middleware) => {
+      return (nextMethod, nextPayload, nextSignal) =>
+        middleware(next, nextMethod, nextPayload, nextSignal);
+    }, invokeBase);
+    return chain(method, payload, signal);
+  };
+
+  const bot = {
+    api: {
+      config: {
+        use: vi.fn((middleware: ApiMiddleware) => {
+          middlewares.push(middleware);
+        }),
+      },
+      deleteWebhook: (payload: ApiPayload) => {
+        return callApi("deleteWebhook", payload);
+      },
+      getUpdates: (payload: ApiPayload, signal?: AbortSignal) => {
+        return callApi("getUpdates", payload, signal) as Promise<unknown[]>;
+      },
+    },
+    stop,
+  };
+
+  const run = vi.fn(() => ({
+    task: async () => {
+      await bot.api.getUpdates({ offset: 0, limit: 1, timeout: 30 });
+      abortController?.abort();
+    },
+    stop: vi.fn(async () => undefined),
+    isRunning: () => false,
+  }));
+
+  return {
+    bot,
+    deleteWebhookBase,
+    getUpdatesBase,
+    reset: () => {
+      abortController = undefined;
+      middlewares.length = 0;
+      getUpdatesBase.mockReset().mockResolvedValue([]);
+      deleteWebhookBase.mockReset().mockResolvedValue(true);
+      stop.mockReset().mockResolvedValue(undefined);
+      bot.api.config.use.mockClear();
+      run.mockClear();
+    },
+    run,
+    setAbortController: (controller: AbortController) => {
+      abortController = controller;
+    },
+  };
+});
+
+vi.mock("@grammyjs/runner", () => ({
+  run: pollingState.run,
+}));
+
+vi.mock("./bot.js", () => ({
+  createTelegramBot: vi.fn(() => pollingState.bot),
+}));
+
+vi.mock("./api-logging.js", () => ({
+  withTelegramApiErrorLogging: vi.fn(async ({ fn }: { fn: () => Promise<unknown> }) => await fn()),
+}));
+
+describe("TelegramPollingSession", () => {
+  beforeEach(() => {
+    pollingState.reset();
+  });
+
+  it("seeds the runner's first getUpdates call from the persisted offset", async () => {
+    const abort = new AbortController();
+    pollingState.setAbortController(abort);
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: undefined,
+      accountId: "default",
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => 549_076_203,
+      persistUpdateId: vi.fn(async () => undefined),
+      log: vi.fn(),
+      proxyFetch: undefined,
+      runtime: undefined,
+    });
+
+    await session.runUntilAbort();
+
+    expect(pollingState.deleteWebhookBase).toHaveBeenCalledTimes(1);
+    expect(pollingState.getUpdatesBase).toHaveBeenCalledTimes(1);
+    expect(pollingState.getUpdatesBase).toHaveBeenCalledWith({
+      offset: 549_076_204,
+      limit: 1,
+      timeout: 30,
+    });
+  });
+
+  it("leaves the first getUpdates call unchanged when no persisted offset exists", async () => {
+    const abort = new AbortController();
+    pollingState.setAbortController(abort);
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: undefined,
+      accountId: "default",
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: vi.fn(async () => undefined),
+      log: vi.fn(),
+      proxyFetch: undefined,
+      runtime: undefined,
+    });
+
+    await session.runUntilAbort();
+
+    expect(pollingState.getUpdatesBase).toHaveBeenCalledWith({
+      offset: 0,
+      limit: 1,
+      timeout: 30,
+    });
+  });
+});

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -172,11 +172,10 @@ export class TelegramPollingSession {
       return;
     }
     let seeded = false;
-    bot.api.config.use((prev, method, payload, signal) => {
+    bot.api.config.use(async (prev, method, payload, signal) => {
       if (method !== "getUpdates" || seeded) {
-        return prev(method, payload, signal);
+        return await prev(method, payload, signal);
       }
-      seeded = true;
       const requestPayload =
         payload && typeof payload === "object"
           ? { ...(payload as Record<string, unknown>) }
@@ -187,7 +186,9 @@ export class TelegramPollingSession {
       // Let the runner receive the first batch itself, instead of consuming it in a
       // separate confirmation call that can drop updates on some Local Bot API setups.
       requestPayload.offset = Math.max(currentOffset ?? 0, lastUpdateId + 1);
-      return prev(method, requestPayload as typeof payload, signal);
+      const result = await prev(method, requestPayload as typeof payload, signal);
+      seeded = true;
+      return result;
     });
   }
 

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -166,20 +166,33 @@ export class TelegramPollingSession {
     }
   }
 
-  async #confirmPersistedOffset(bot: TelegramBot): Promise<void> {
+  #seedInitialPollingOffset(bot: TelegramBot): void {
     const lastUpdateId = this.opts.getLastUpdateId();
     if (lastUpdateId === null || lastUpdateId >= Number.MAX_SAFE_INTEGER) {
       return;
     }
-    try {
-      await bot.api.getUpdates({ offset: lastUpdateId + 1, limit: 1, timeout: 0 });
-    } catch {
-      // Non-fatal: runner middleware still skips duplicates via shouldSkipUpdate.
-    }
+    let seeded = false;
+    bot.api.config.use((prev, method, payload, signal) => {
+      if (method !== "getUpdates" || seeded) {
+        return prev(method, payload, signal);
+      }
+      seeded = true;
+      const requestPayload =
+        payload && typeof payload === "object"
+          ? { ...(payload as Record<string, unknown>) }
+          : ({} as Record<string, unknown>);
+      const currentOffset =
+        typeof requestPayload.offset === "number" ? requestPayload.offset : undefined;
+
+      // Let the runner receive the first batch itself, instead of consuming it in a
+      // separate confirmation call that can drop updates on some Local Bot API setups.
+      requestPayload.offset = Math.max(currentOffset ?? 0, lastUpdateId + 1);
+      return prev(method, requestPayload as typeof payload, signal);
+    });
   }
 
   async #runPollingCycle(bot: TelegramBot): Promise<"continue" | "exit"> {
-    await this.#confirmPersistedOffset(bot);
+    this.#seedInitialPollingOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
     bot.api.config.use((prev, method, payload, signal) => {

--- a/extensions/telegram/src/probe.test.ts
+++ b/extensions/telegram/src/probe.test.ts
@@ -177,6 +177,7 @@ describe("probeTelegram retry logic", () => {
     mockGetWebhookInfoSuccess(fetchMock);
 
     await probeTelegram(token, timeoutMs, {
+      apiRoot: "http://127.0.0.1:8081/",
       proxyUrl: "http://127.0.0.1:8888",
       network: {
         autoSelectFamily: false,
@@ -186,11 +187,25 @@ describe("probeTelegram retry logic", () => {
 
     expect(makeProxyFetch).toHaveBeenCalledWith("http://127.0.0.1:8888");
     expect(resolveTelegramFetch).toHaveBeenCalledWith(fetchMock, {
+      apiRoot: "http://127.0.0.1:8081/",
       network: {
         autoSelectFamily: false,
         dnsResultOrder: "ipv4first",
       },
     });
+  });
+
+  it("builds probe requests from a custom Telegram Bot API root", async () => {
+    const fetchMock = installFetchMock();
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+
+    await probeTelegram(token, timeoutMs, {
+      apiRoot: "http://127.0.0.1:8081/",
+    });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.1:8081/bottest-token/getMe");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://127.0.0.1:8081/bottest-token/getWebhookInfo");
   });
 
   it("reuses probe fetcher across repeated probes for the same account transport settings", async () => {
@@ -240,6 +255,26 @@ describe("probeTelegram retry logic", () => {
         autoSelectFamily: false,
         dnsResultOrder: "ipv4first",
       },
+    });
+
+    expect(resolveTelegramFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse probe fetcher cache when apiRoot differs", async () => {
+    const fetchMock = installFetchMock();
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-cache-root`, timeoutMs, {
+      apiRoot: "http://127.0.0.1:8081/",
+    });
+
+    mockGetMeSuccess(fetchMock);
+    mockGetWebhookInfoSuccess(fetchMock);
+    await probeTelegram(`${token}-cache-root`, timeoutMs, {
+      apiRoot: "http://127.0.0.1:8082/",
     });
 
     expect(resolveTelegramFetch).toHaveBeenCalledTimes(2);

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -1,10 +1,9 @@
 import type { BaseProbeResult } from "../../../src/channels/plugins/types.js";
 import type { TelegramNetworkConfig } from "../../../src/config/types.telegram.js";
 import { fetchWithTimeout } from "../../../src/utils/fetch-timeout.js";
+import { buildTelegramBotApiBase } from "./api-root.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { makeProxyFetch } from "./proxy.js";
-
-const TELEGRAM_API_BASE = "https://api.telegram.org";
 
 export type TelegramProbe = BaseProbeResult & {
   status?: number | null;
@@ -23,6 +22,7 @@ export type TelegramProbeOptions = {
   proxyUrl?: string;
   network?: TelegramNetworkConfig;
   accountId?: string;
+  apiRoot?: string;
 };
 
 const probeFetcherCache = new Map<string, typeof fetch>();
@@ -51,12 +51,13 @@ function shouldUseProbeFetcherCache(): boolean {
 function buildProbeFetcherCacheKey(token: string, options?: TelegramProbeOptions): string {
   const cacheIdentity = options?.accountId?.trim() || token;
   const cacheIdentityKind = options?.accountId?.trim() ? "account" : "token";
+  const apiRootKey = options?.apiRoot?.trim() ?? "";
   const proxyKey = options?.proxyUrl?.trim() ?? "";
   const autoSelectFamily = options?.network?.autoSelectFamily;
   const autoSelectFamilyKey =
     typeof autoSelectFamily === "boolean" ? String(autoSelectFamily) : "default";
   const dnsResultOrderKey = options?.network?.dnsResultOrder ?? "default";
-  return `${cacheIdentityKind}:${cacheIdentity}::${proxyKey}::${autoSelectFamilyKey}::${dnsResultOrderKey}`;
+  return `${cacheIdentityKind}:${cacheIdentity}::${apiRootKey}::${proxyKey}::${autoSelectFamilyKey}::${dnsResultOrderKey}`;
 }
 
 function setCachedProbeFetcher(cacheKey: string, fetcher: typeof fetch): typeof fetch {
@@ -82,7 +83,10 @@ function resolveProbeFetcher(token: string, options?: TelegramProbeOptions): typ
 
   const proxyUrl = options?.proxyUrl?.trim();
   const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
-  const resolved = resolveTelegramFetch(proxyFetch, { network: options?.network });
+  const resolved = resolveTelegramFetch(proxyFetch, {
+    apiRoot: options?.apiRoot,
+    network: options?.network,
+  });
 
   if (cacheKey) {
     return setCachedProbeFetcher(cacheKey, resolved);
@@ -100,7 +104,7 @@ export async function probeTelegram(
   const deadlineMs = started + timeoutBudgetMs;
   const options = resolveProbeOptions(proxyOrOptions);
   const fetcher = resolveProbeFetcher(token, options);
-  const base = `${TELEGRAM_API_BASE}/bot${token}`;
+  const base = buildTelegramBotApiBase({ token, apiRoot: options?.apiRoot });
   const retryDelayMs = Math.max(50, Math.min(1000, Math.floor(timeoutBudgetMs / 5)));
   const resolveRemainingBudgetMs = () => Math.max(0, deadlineMs - Date.now());
 

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -20,8 +20,9 @@ const { botApi, botCtorSpy } = vi.hoisted(() => ({
   botCtorSpy: vi.fn(),
 }));
 
-const { loadWebMedia } = vi.hoisted(() => ({
+const { loadWebMedia, resolveLocalMediaSource } = vi.hoisted(() => ({
   loadWebMedia: vi.fn(),
+  resolveLocalMediaSource: vi.fn(),
 }));
 
 const { loadConfig } = vi.hoisted(() => ({
@@ -37,11 +38,13 @@ type TelegramSendTestMocks = {
   botCtorSpy: MockFn;
   loadConfig: MockFn;
   loadWebMedia: MockFn;
+  resolveLocalMediaSource: MockFn;
   maybePersistResolvedTelegramTarget: MockFn;
 };
 
 vi.mock("../../whatsapp/src/media.js", () => ({
   loadWebMedia,
+  resolveLocalMediaSource,
 }));
 
 vi.mock("grammy", () => ({
@@ -51,7 +54,7 @@ vi.mock("grammy", () => ({
     constructor(
       public token: string,
       public options?: {
-        client?: { fetch?: typeof fetch; timeoutSeconds?: number };
+        client?: { apiRoot?: string; fetch?: typeof fetch; timeoutSeconds?: number };
       },
     ) {
       botCtorSpy(token, options);
@@ -73,13 +76,22 @@ vi.mock("./target-writeback.js", () => ({
 }));
 
 export function getTelegramSendTestMocks(): TelegramSendTestMocks {
-  return { botApi, botCtorSpy, loadConfig, loadWebMedia, maybePersistResolvedTelegramTarget };
+  return {
+    botApi,
+    botCtorSpy,
+    loadConfig,
+    loadWebMedia,
+    resolveLocalMediaSource,
+    maybePersistResolvedTelegramTarget,
+  };
 }
 
 export function installTelegramSendTestHooks() {
   beforeEach(() => {
     loadConfig.mockReturnValue({});
     loadWebMedia.mockReset();
+    resolveLocalMediaSource.mockReset();
+    resolveLocalMediaSource.mockResolvedValue(null);
     maybePersistResolvedTelegramTarget.mockReset();
     maybePersistResolvedTelegramTarget.mockResolvedValue(undefined);
     botCtorSpy.mockReset();

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -10,8 +10,14 @@ import { clearSentMessageCache, recordSentMessage, wasSentByBot } from "./sent-m
 
 installTelegramSendTestHooks();
 
-const { botApi, botCtorSpy, loadConfig, loadWebMedia, maybePersistResolvedTelegramTarget } =
-  getTelegramSendTestMocks();
+const {
+  botApi,
+  botCtorSpy,
+  loadConfig,
+  loadWebMedia,
+  resolveLocalMediaSource,
+  maybePersistResolvedTelegramTarget,
+} = getTelegramSendTestMocks();
 const {
   buildInlineKeyboard,
   createForumTopicTelegram,
@@ -252,6 +258,127 @@ describe("sendMessageTelegram", () => {
         }),
       );
     }
+  });
+
+  it("applies apiRoot config precedence", async () => {
+    const cases = [
+      {
+        name: "global telegram apiRoot",
+        cfg: { channels: { telegram: { apiRoot: "http://127.0.0.1:8081/" } } },
+        opts: { token: "tok" },
+        expectedApiRoot: "http://127.0.0.1:8081",
+      },
+      {
+        name: "per-account apiRoot override",
+        cfg: {
+          channels: {
+            telegram: {
+              apiRoot: "http://127.0.0.1:8081/",
+              accounts: { foo: { apiRoot: "http://127.0.0.1:8082/" } },
+            },
+          },
+        },
+        opts: { token: "tok", accountId: "foo" },
+        expectedApiRoot: "http://127.0.0.1:8082",
+      },
+    ] as const;
+    for (const testCase of cases) {
+      botCtorSpy.mockClear();
+      loadConfig.mockReturnValue(testCase.cfg);
+      botApi.sendMessage.mockResolvedValue({
+        message_id: 1,
+        chat: { id: "123" },
+      });
+      await sendMessageTelegram("123", "hi", testCase.opts);
+      expect(botCtorSpy, testCase.name).toHaveBeenCalledWith(
+        "tok",
+        expect.objectContaining({
+          client: expect.objectContaining({ apiRoot: testCase.expectedApiRoot }),
+        }),
+      );
+    }
+  });
+
+  it("uses direct local-path sends for loopback Local Bot API roots", async () => {
+    const chatId = "123";
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 12,
+      chat: { id: chatId },
+    });
+    const api = { sendPhoto } as unknown as {
+      sendPhoto: typeof sendPhoto;
+    };
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          apiRoot: "http://127.0.0.1:8081/",
+        },
+      },
+    });
+    resolveLocalMediaSource.mockResolvedValueOnce({
+      filePath: "/tmp/photo.jpg",
+      fileName: "photo.jpg",
+      contentType: "image/jpeg",
+      kind: "image",
+    });
+
+    const res = await sendMessageTelegram(chatId, "caption", {
+      token: "tok",
+      api,
+      mediaUrl: "file:///tmp/photo.jpg",
+    });
+
+    expect(resolveLocalMediaSource).toHaveBeenCalledWith(
+      "file:///tmp/photo.jpg",
+      expect.objectContaining({ maxBytes: 100 * 1024 * 1024 }),
+    );
+    expect(loadWebMedia).not.toHaveBeenCalled();
+    expect(sendPhoto).toHaveBeenCalledWith(chatId, "/tmp/photo.jpg", {
+      caption: "caption",
+      parse_mode: "HTML",
+    });
+    expect(res.messageId).toBe("12");
+  });
+
+  it("keeps buffer uploads for non-loopback custom apiRoot values", async () => {
+    const chatId = "123";
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 13,
+      chat: { id: chatId },
+    });
+    const api = { sendPhoto } as unknown as {
+      sendPhoto: typeof sendPhoto;
+    };
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          apiRoot: "https://botapi.example.com",
+        },
+      },
+    });
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/jpeg",
+      fileName: "photo.jpg",
+    });
+
+    await sendMessageTelegram(chatId, "caption", {
+      token: "tok",
+      api,
+      mediaUrl: "/tmp/photo.jpg",
+    });
+
+    expect(resolveLocalMediaSource).not.toHaveBeenCalled();
+    expect(loadWebMedia).toHaveBeenCalledWith(
+      "/tmp/photo.jpg",
+      expect.objectContaining({ maxBytes: 100 * 1024 * 1024 }),
+    );
+    expect(sendPhoto).toHaveBeenCalledWith(chatId, expect.anything(), {
+      caption: "caption",
+      parse_mode: "HTML",
+    });
   });
 
   it("falls back to plain text when Telegram rejects HTML and preserves send params", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -299,47 +299,50 @@ describe("sendMessageTelegram", () => {
     }
   });
 
-  it("uses direct local-path sends for loopback Local Bot API roots", async () => {
-    const chatId = "123";
-    const sendPhoto = vi.fn().mockResolvedValue({
-      message_id: 12,
-      chat: { id: chatId },
-    });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+  it.each(["http://127.0.0.1:8081/", "http://[::1]:8081/"])(
+    "uses direct local-path sends for loopback Local Bot API roots (%s)",
+    async (apiRoot) => {
+      const chatId = "123";
+      const sendPhoto = vi.fn().mockResolvedValue({
+        message_id: 12,
+        chat: { id: chatId },
+      });
+      const api = { sendPhoto } as unknown as {
+        sendPhoto: typeof sendPhoto;
+      };
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          apiRoot: "http://127.0.0.1:8081/",
+      loadConfig.mockReturnValue({
+        channels: {
+          telegram: {
+            apiRoot,
+          },
         },
-      },
-    });
-    resolveLocalMediaSource.mockResolvedValueOnce({
-      filePath: "/tmp/photo.jpg",
-      fileName: "photo.jpg",
-      contentType: "image/jpeg",
-      kind: "image",
-    });
+      });
+      resolveLocalMediaSource.mockResolvedValueOnce({
+        filePath: "/tmp/photo.jpg",
+        fileName: "photo.jpg",
+        contentType: "image/jpeg",
+        kind: "image",
+      });
 
-    const res = await sendMessageTelegram(chatId, "caption", {
-      token: "tok",
-      api,
-      mediaUrl: "file:///tmp/photo.jpg",
-    });
+      const res = await sendMessageTelegram(chatId, "caption", {
+        token: "tok",
+        api,
+        mediaUrl: "file:///tmp/photo.jpg",
+      });
 
-    expect(resolveLocalMediaSource).toHaveBeenCalledWith(
-      "file:///tmp/photo.jpg",
-      expect.objectContaining({ maxBytes: 100 * 1024 * 1024 }),
-    );
-    expect(loadWebMedia).not.toHaveBeenCalled();
-    expect(sendPhoto).toHaveBeenCalledWith(chatId, "/tmp/photo.jpg", {
-      caption: "caption",
-      parse_mode: "HTML",
-    });
-    expect(res.messageId).toBe("12");
-  });
+      expect(resolveLocalMediaSource).toHaveBeenCalledWith(
+        "file:///tmp/photo.jpg",
+        expect.objectContaining({ maxBytes: 100 * 1024 * 1024 }),
+      );
+      expect(loadWebMedia).not.toHaveBeenCalled();
+      expect(sendPhoto).toHaveBeenCalledWith(chatId, "/tmp/photo.jpg", {
+        caption: "caption",
+        parse_mode: "HTML",
+      });
+      expect(res.messageId).toBe("12");
+    },
+  );
 
   it("keeps buffer uploads for non-loopback custom apiRoot values", async () => {
     const chatId = "123";

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -19,9 +19,10 @@ import type { MediaKind } from "../../../src/media/constants.js";
 import { buildOutboundMediaLoadOptions } from "../../../src/media/load-options.js";
 import { isGifMedia, kindFromMime } from "../../../src/media/mime.js";
 import { normalizePollInput, type PollInput } from "../../../src/polls.js";
-import { loadWebMedia } from "../../whatsapp/src/media.js";
+import { loadWebMedia, resolveLocalMediaSource } from "../../whatsapp/src/media.js";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
+import { isTelegramApiRootLoopback, resolveTelegramApiRoot } from "./api-root.js";
 import { buildTelegramThreadParams, buildTypingThreadParams } from "./bot/helpers.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
@@ -187,6 +188,7 @@ function buildTelegramClientOptionsCacheKey(params: {
   account: ResolvedTelegramAccount;
   timeoutSeconds?: number;
 }): string {
+  const apiRootKey = params.account.config.apiRoot?.trim() ?? "";
   const proxyKey = params.account.config.proxy?.trim() ?? "";
   const autoSelectFamily = params.account.config.network?.autoSelectFamily;
   const autoSelectFamilyKey =
@@ -194,7 +196,7 @@ function buildTelegramClientOptionsCacheKey(params: {
   const dnsResultOrderKey = params.account.config.network?.dnsResultOrder ?? "default";
   const timeoutSecondsKey =
     typeof params.timeoutSeconds === "number" ? String(params.timeoutSeconds) : "default";
-  return `${params.account.accountId}::${proxyKey}::${autoSelectFamilyKey}::${dnsResultOrderKey}::${timeoutSecondsKey}`;
+  return `${params.account.accountId}::${apiRootKey}::${proxyKey}::${autoSelectFamilyKey}::${dnsResultOrderKey}::${timeoutSecondsKey}`;
 }
 
 function setCachedTelegramClientOptions(
@@ -234,13 +236,18 @@ function resolveTelegramClientOptions(
   const proxyUrl = account.config.proxy?.trim();
   const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
   const fetchImpl = resolveTelegramFetch(proxyFetch, {
+    apiRoot: account.config.apiRoot,
     network: account.config.network,
   });
+  const apiRoot = account.config.apiRoot?.trim()
+    ? resolveTelegramApiRoot(account.config.apiRoot)
+    : undefined;
   const clientOptions =
-    fetchImpl || timeoutSeconds
+    fetchImpl || timeoutSeconds || apiRoot
       ? {
           ...(fetchImpl ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(apiRoot ? { apiRoot } : {}),
         }
       : undefined;
   if (cacheKey) {
@@ -760,23 +767,29 @@ export async function sendMessageTelegram(
     await sendTelegramTextChunks(buildChunkedTextPlan(rawText, context), context);
 
   if (mediaUrl) {
-    const media = await loadWebMedia(
-      mediaUrl,
-      buildOutboundMediaLoadOptions({
-        maxBytes: mediaMaxBytes,
-        mediaLocalRoots: opts.mediaLocalRoots,
-        optimizeImages: opts.forceDocument ? false : undefined,
-      }),
-    );
-    const kind = kindFromMime(media.contentType ?? undefined);
+    const outboundMediaLoadOptions = buildOutboundMediaLoadOptions({
+      maxBytes: mediaMaxBytes,
+      mediaLocalRoots: opts.mediaLocalRoots,
+      optimizeImages: opts.forceDocument ? false : undefined,
+    });
+    const localMedia = isTelegramApiRootLoopback(account.config.apiRoot)
+      ? await resolveLocalMediaSource(mediaUrl, outboundMediaLoadOptions)
+      : null;
+    const media = localMedia
+      ? null
+      : await loadWebMedia(mediaUrl, outboundMediaLoadOptions);
+    const kind = localMedia?.kind ?? kindFromMime(media?.contentType ?? undefined);
     const isGif = isGifMedia({
-      contentType: media.contentType,
-      fileName: media.fileName,
+      contentType: localMedia?.contentType ?? media?.contentType,
+      fileName: localMedia?.fileName ?? media?.fileName,
     });
     const isVideoNote = kind === "video" && opts.asVideoNote === true;
     const fileName =
-      media.fileName ?? (isGif ? "animation.gif" : inferFilename(kind ?? "document")) ?? "file";
-    const file = new InputFile(media.buffer, fileName);
+      localMedia?.fileName ??
+      media?.fileName ??
+      (isGif ? "animation.gif" : inferFilename(kind ?? "document")) ??
+      "file";
+    const mediaInput = localMedia?.filePath ?? new InputFile(media!.buffer, fileName);
     let caption: string | undefined;
     let followUpText: string | undefined;
 
@@ -824,7 +837,7 @@ export async function sendMessageTelegram(
           sender: (effectiveParams: Record<string, unknown> | undefined) =>
             api.sendAnimation(
               chatId,
-              file,
+              mediaInput,
               effectiveParams as Parameters<typeof api.sendAnimation>[2],
             ) as Promise<TelegramMessageLike>,
         };
@@ -835,7 +848,7 @@ export async function sendMessageTelegram(
           sender: (effectiveParams: Record<string, unknown> | undefined) =>
             api.sendPhoto(
               chatId,
-              file,
+              mediaInput,
               effectiveParams as Parameters<typeof api.sendPhoto>[2],
             ) as Promise<TelegramMessageLike>,
         };
@@ -847,7 +860,7 @@ export async function sendMessageTelegram(
             sender: (effectiveParams: Record<string, unknown> | undefined) =>
               api.sendVideoNote(
                 chatId,
-                file,
+                mediaInput,
                 effectiveParams as Parameters<typeof api.sendVideoNote>[2],
               ) as Promise<TelegramMessageLike>,
           };
@@ -857,7 +870,7 @@ export async function sendMessageTelegram(
           sender: (effectiveParams: Record<string, unknown> | undefined) =>
             api.sendVideo(
               chatId,
-              file,
+              mediaInput,
               effectiveParams as Parameters<typeof api.sendVideo>[2],
             ) as Promise<TelegramMessageLike>,
         };
@@ -865,7 +878,7 @@ export async function sendMessageTelegram(
       if (kind === "audio") {
         const { useVoice } = resolveTelegramVoiceSend({
           wantsVoice: opts.asVoice === true, // default false (backward compatible)
-          contentType: media.contentType,
+          contentType: localMedia?.contentType ?? media?.contentType,
           fileName,
           logFallback: logVerbose,
         });
@@ -875,7 +888,7 @@ export async function sendMessageTelegram(
             sender: (effectiveParams: Record<string, unknown> | undefined) =>
               api.sendVoice(
                 chatId,
-                file,
+                mediaInput,
                 effectiveParams as Parameters<typeof api.sendVoice>[2],
               ) as Promise<TelegramMessageLike>,
           };
@@ -885,7 +898,7 @@ export async function sendMessageTelegram(
           sender: (effectiveParams: Record<string, unknown> | undefined) =>
             api.sendAudio(
               chatId,
-              file,
+              mediaInput,
               effectiveParams as Parameters<typeof api.sendAudio>[2],
             ) as Promise<TelegramMessageLike>,
         };
@@ -895,7 +908,7 @@ export async function sendMessageTelegram(
         sender: (effectiveParams: Record<string, unknown> | undefined) =>
           api.sendDocument(
             chatId,
-            file,
+            mediaInput,
             // Only force Telegram to keep the uploaded media type when callers explicitly
             // opt into document delivery for image/GIF uploads.
             (opts.forceDocument

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -775,9 +775,7 @@ export async function sendMessageTelegram(
     const localMedia = isTelegramApiRootLoopback(account.config.apiRoot)
       ? await resolveLocalMediaSource(mediaUrl, outboundMediaLoadOptions)
       : null;
-    const media = localMedia
-      ? null
-      : await loadWebMedia(mediaUrl, outboundMediaLoadOptions);
+    const media = localMedia ? null : await loadWebMedia(mediaUrl, outboundMediaLoadOptions);
     const kind = localMedia?.kind ?? kindFromMime(media?.contentType ?? undefined);
     const isGif = isGifMedia({
       contentType: localMedia?.contentType ?? media?.contentType,

--- a/extensions/telegram/src/update-offset-store.test.ts
+++ b/extensions/telegram/src/update-offset-store.test.ts
@@ -60,6 +60,34 @@ describe("deleteTelegramUpdateOffset", () => {
     });
   });
 
+  it("returns null when stored offset was written for a different apiRoot", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async () => {
+      await writeTelegramUpdateOffset({
+        accountId: "default",
+        updateId: 654,
+        apiRoot: "http://127.0.0.1:8081/",
+      });
+
+      expect(
+        await readTelegramUpdateOffset({
+          accountId: "default",
+          apiRoot: "http://127.0.0.1:8082/",
+        }),
+      ).toBeNull();
+      expect(
+        await readTelegramUpdateOffset({
+          accountId: "default",
+        }),
+      ).toBeNull();
+      expect(
+        await readTelegramUpdateOffset({
+          accountId: "default",
+          apiRoot: "http://127.0.0.1:8081",
+        }),
+      ).toBe(654);
+    });
+  });
+
   it("treats legacy offset records without bot identity as stale when token is provided", async () => {
     await withStateDirEnv("openclaw-tg-offset-", async ({ stateDir }) => {
       const legacyPath = path.join(stateDir, "telegram", "update-offset-default.json");
@@ -79,20 +107,40 @@ describe("deleteTelegramUpdateOffset", () => {
     });
   });
 
+  it("treats legacy offset records without apiRoot identity as stale when apiRoot is provided", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async ({ stateDir }) => {
+      const legacyPath = path.join(stateDir, "telegram", "update-offset-default.json");
+      await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+      await fs.writeFile(
+        legacyPath,
+        `${JSON.stringify({ version: 2, lastUpdateId: 777, botId: "333333" }, null, 2)}\n`,
+        "utf-8",
+      );
+
+      expect(
+        await readTelegramUpdateOffset({
+          accountId: "default",
+          apiRoot: "http://127.0.0.1:8081",
+        }),
+      ).toBeNull();
+      expect(await readTelegramUpdateOffset({ accountId: "default" })).toBe(777);
+    });
+  });
+
   it("ignores invalid persisted update IDs from disk", async () => {
     await withStateDirEnv("openclaw-tg-offset-", async ({ stateDir }) => {
       const offsetPath = path.join(stateDir, "telegram", "update-offset-default.json");
       await fs.mkdir(path.dirname(offsetPath), { recursive: true });
       await fs.writeFile(
         offsetPath,
-        `${JSON.stringify({ version: 2, lastUpdateId: -1, botId: "111111" }, null, 2)}\n`,
+        `${JSON.stringify({ version: 3, lastUpdateId: -1, botId: "111111", apiRoot: null }, null, 2)}\n`,
         "utf-8",
       );
       expect(await readTelegramUpdateOffset({ accountId: "default" })).toBeNull();
 
       await fs.writeFile(
         offsetPath,
-        `${JSON.stringify({ version: 2, lastUpdateId: Number.POSITIVE_INFINITY, botId: "111111" }, null, 2)}\n`,
+        `${JSON.stringify({ version: 3, lastUpdateId: Number.POSITIVE_INFINITY, botId: "111111", apiRoot: null }, null, 2)}\n`,
         "utf-8",
       );
       expect(await readTelegramUpdateOffset({ accountId: "default" })).toBeNull();

--- a/extensions/telegram/src/update-offset-store.ts
+++ b/extensions/telegram/src/update-offset-store.ts
@@ -3,13 +3,19 @@ import os from "node:os";
 import path from "node:path";
 import { resolveStateDir } from "../../../src/config/paths.js";
 import { writeJsonAtomic } from "../../../src/infra/json-files.js";
+import { resolveTelegramApiRoot } from "./api-root.js";
 
-const STORE_VERSION = 2;
+const STORE_VERSION = 3;
 
 type TelegramUpdateOffsetState = {
   version: number;
   lastUpdateId: number | null;
   botId: string | null;
+  apiRoot: string | null;
+};
+
+type ParsedTelegramUpdateOffsetState = TelegramUpdateOffsetState & {
+  hasApiRootIdentity: boolean;
 };
 
 function isValidUpdateId(value: unknown): value is number {
@@ -45,14 +51,23 @@ function extractBotIdFromToken(token?: string): string | null {
   return rawBotId;
 }
 
-function safeParseState(raw: string): TelegramUpdateOffsetState | null {
+function normalizeApiRootKey(apiRoot?: string | null): string | null {
+  const trimmed = apiRoot?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return resolveTelegramApiRoot(trimmed);
+}
+
+function safeParseState(raw: string): ParsedTelegramUpdateOffsetState | null {
   try {
     const parsed = JSON.parse(raw) as {
       version?: number;
       lastUpdateId?: number | null;
       botId?: string | null;
+      apiRoot?: string | null;
     };
-    if (parsed?.version !== STORE_VERSION && parsed?.version !== 1) {
+    if (parsed?.version !== STORE_VERSION && parsed?.version !== 2 && parsed?.version !== 1) {
       return null;
     }
     if (parsed.lastUpdateId !== null && !isValidUpdateId(parsed.lastUpdateId)) {
@@ -65,10 +80,19 @@ function safeParseState(raw: string): TelegramUpdateOffsetState | null {
     ) {
       return null;
     }
+    if (
+      parsed.version === STORE_VERSION &&
+      parsed.apiRoot !== null &&
+      typeof parsed.apiRoot !== "string"
+    ) {
+      return null;
+    }
     return {
       version: STORE_VERSION,
       lastUpdateId: parsed.lastUpdateId ?? null,
-      botId: parsed.version === STORE_VERSION ? (parsed.botId ?? null) : null,
+      botId: parsed.version >= 2 ? (parsed.botId ?? null) : null,
+      apiRoot: parsed.version === STORE_VERSION ? (parsed.apiRoot ?? null) : null,
+      hasApiRootIdentity: parsed.version === STORE_VERSION,
     };
   } catch {
     return null;
@@ -78,6 +102,7 @@ function safeParseState(raw: string): TelegramUpdateOffsetState | null {
 export async function readTelegramUpdateOffset(params: {
   accountId?: string;
   botToken?: string;
+  apiRoot?: string | null;
   env?: NodeJS.ProcessEnv;
 }): Promise<number | null> {
   const filePath = resolveTelegramUpdateOffsetPath(params.accountId, params.env);
@@ -85,10 +110,18 @@ export async function readTelegramUpdateOffset(params: {
     const raw = await fs.readFile(filePath, "utf-8");
     const parsed = safeParseState(raw);
     const expectedBotId = extractBotIdFromToken(params.botToken);
+    const expectedApiRoot = normalizeApiRootKey(params.apiRoot);
     if (expectedBotId && parsed?.botId && parsed.botId !== expectedBotId) {
       return null;
     }
     if (expectedBotId && parsed?.botId === null) {
+      return null;
+    }
+    if (parsed?.hasApiRootIdentity) {
+      if (parsed.apiRoot !== expectedApiRoot) {
+        return null;
+      }
+    } else if (expectedApiRoot !== null) {
       return null;
     }
     return parsed?.lastUpdateId ?? null;
@@ -105,6 +138,7 @@ export async function writeTelegramUpdateOffset(params: {
   accountId?: string;
   updateId: number;
   botToken?: string;
+  apiRoot?: string | null;
   env?: NodeJS.ProcessEnv;
 }): Promise<void> {
   if (!isValidUpdateId(params.updateId)) {
@@ -115,6 +149,7 @@ export async function writeTelegramUpdateOffset(params: {
     version: STORE_VERSION,
     lastUpdateId: params.updateId,
     botId: extractBotIdFromToken(params.botToken),
+    apiRoot: normalizeApiRootKey(params.apiRoot),
   };
   await writeJsonAtomic(filePath, payload, {
     mode: 0o600,

--- a/extensions/whatsapp/src/media.test.ts
+++ b/extensions/whatsapp/src/media.test.ts
@@ -14,6 +14,7 @@ import {
   loadWebMedia,
   loadWebMediaRaw,
   optimizeImageToJpeg,
+  resolveLocalMediaSource,
 } from "./media.js";
 
 const convertHeicToJpegMock = vi.fn();
@@ -34,6 +35,8 @@ let largeJpegBuffer: Buffer;
 let largeJpegFile = "";
 let tinyPngBuffer: Buffer;
 let tinyPngFile = "";
+let tinyPngNoExtFile = "";
+let tinyPngTextExtFile = "";
 let tinyPngWrongExtFile = "";
 let fakeHeicFile = "";
 let alphaPngBuffer: Buffer;
@@ -88,6 +91,8 @@ beforeAll(async () => {
     .png()
     .toBuffer();
   tinyPngFile = await writeTempFile(tinyPngBuffer, ".png");
+  tinyPngNoExtFile = await writeTempFile(tinyPngBuffer, "");
+  tinyPngTextExtFile = await writeTempFile(tinyPngBuffer, ".txt");
   tinyPngWrongExtFile = await writeTempFile(tinyPngBuffer, ".bin");
   fakeHeicFile = await writeTempFile(Buffer.from("fake-heic"), ".heic");
   alphaPngBuffer = await sharp({
@@ -190,6 +195,38 @@ describe("web media loading", () => {
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");
+  });
+
+  it("sniffs loopback local media bytes for extensionless files", async () => {
+    const result = await resolveLocalMediaSource(tinyPngNoExtFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: [resolvePreferredOpenClawTmpDir()],
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        filePath: tinyPngNoExtFile,
+        fileName: path.basename(tinyPngNoExtFile),
+        kind: "image",
+        contentType: "image/png",
+      }),
+    );
+  });
+
+  it("sniffs loopback local media bytes when a file is misnamed as text", async () => {
+    const result = await resolveLocalMediaSource(tinyPngTextExtFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: [resolvePreferredOpenClawTmpDir()],
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        filePath: tinyPngTextExtFile,
+        fileName: path.basename(tinyPngTextExtFile),
+        kind: "image",
+        contentType: "image/png",
+      }),
+    );
   });
 
   it("normalizes HEIC local files to JPEG output", async () => {

--- a/extensions/whatsapp/src/media.ts
+++ b/extensions/whatsapp/src/media.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { logVerbose, shouldLogVerbose } from "../../../src/globals.js";
 import {
   SafeOpenError,
+  readLocalFileHeadSafely,
   readLocalFileSafely,
   statLocalFileSafely,
 } from "../../../src/infra/fs-safe.js";
@@ -84,6 +85,8 @@ export type LocalMediaSource = {
   fileName?: string;
   kind: MediaKind | undefined;
 };
+
+const LOCAL_MEDIA_SNIFF_BYTES = 8 * 1024;
 
 export function getDefaultLocalRoots(): readonly string[] {
   return getDefaultMediaLocalRoots();
@@ -203,12 +206,30 @@ export async function resolveLocalMediaSource(
     throw err;
   }
 
-  const contentType = await detectMime({ filePath: mediaUrl });
+  const fileName = path.basename(mediaUrl) || undefined;
+  let contentType = await detectMime({ filePath: mediaUrl });
+  let kind = kindFromMime(contentType);
+
+  if (!path.extname(mediaUrl) || kind === undefined || kind === "document") {
+    const sniffedHead = await readLocalFileHeadSafely({
+      filePath: mediaUrl,
+      bytes: LOCAL_MEDIA_SNIFF_BYTES,
+    });
+    const sniffedContentType = await detectMime({
+      buffer: sniffedHead.buffer,
+      filePath: mediaUrl,
+    });
+    if (sniffedContentType) {
+      contentType = sniffedContentType;
+      kind = kindFromMime(sniffedContentType);
+    }
+  }
+
   return {
     filePath: mediaUrl,
     contentType,
-    fileName: path.basename(mediaUrl) || undefined,
-    kind: kindFromMime(contentType),
+    fileName,
+    kind,
   };
 }
 

--- a/extensions/whatsapp/src/media.ts
+++ b/extensions/whatsapp/src/media.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { logVerbose, shouldLogVerbose } from "../../../src/globals.js";
-import { SafeOpenError, readLocalFileSafely } from "../../../src/infra/fs-safe.js";
+import {
+  SafeOpenError,
+  readLocalFileSafely,
+  statLocalFileSafely,
+} from "../../../src/infra/fs-safe.js";
 import type { SsrFPolicy } from "../../../src/infra/net/ssrf.js";
 import { type MediaKind, maxBytesForKind } from "../../../src/media/constants.js";
 import { fetchRemoteMedia } from "../../../src/media/fetch.js";
@@ -74,6 +78,13 @@ export class LocalMediaAccessError extends Error {
   }
 }
 
+export type LocalMediaSource = {
+  filePath: string;
+  contentType?: string;
+  fileName?: string;
+  kind: MediaKind | undefined;
+};
+
 export function getDefaultLocalRoots(): readonly string[] {
   return getDefaultMediaLocalRoots();
 }
@@ -135,6 +146,69 @@ async function assertLocalMediaAllowed(
     "path-not-allowed",
     `Local media path is not under an allowed directory: ${mediaPath}`,
   );
+}
+
+export async function resolveLocalMediaSource(
+  mediaUrl: string,
+  options: Pick<WebMediaOptions, "maxBytes" | "localRoots"> = {},
+): Promise<LocalMediaSource | null> {
+  mediaUrl = mediaUrl.replace(/^\s*MEDIA\s*:\s*/i, "").trim();
+  if (!mediaUrl || /^https?:\/\//i.test(mediaUrl)) {
+    return null;
+  }
+
+  if (mediaUrl.startsWith("file://")) {
+    try {
+      mediaUrl = fileURLToPath(mediaUrl);
+    } catch {
+      throw new LocalMediaAccessError("invalid-file-url", `Invalid file:// URL: ${mediaUrl}`);
+    }
+  }
+
+  if (mediaUrl.startsWith("~")) {
+    mediaUrl = resolveUserPath(mediaUrl);
+  }
+
+  await assertLocalMediaAllowed(mediaUrl, options.localRoots);
+
+  try {
+    await statLocalFileSafely({
+      filePath: mediaUrl,
+      maxBytes: options.maxBytes,
+    });
+  } catch (err) {
+    if (err instanceof SafeOpenError) {
+      if (err.code === "too-large") {
+        throw new Error(
+          `Media exceeds ${((options.maxBytes ?? 0) / (1024 * 1024)).toFixed(0)}MB limit`,
+          { cause: err },
+        );
+      }
+      if (err.code === "not-found") {
+        throw new LocalMediaAccessError("not-found", `Local media file not found: ${mediaUrl}`, {
+          cause: err,
+        });
+      }
+      if (err.code === "not-file") {
+        throw new LocalMediaAccessError("not-file", `Local media path is not a file: ${mediaUrl}`,
+          { cause: err });
+      }
+      throw new LocalMediaAccessError(
+        "invalid-path",
+        `Local media path is not safe to read: ${mediaUrl}`,
+        { cause: err },
+      );
+    }
+    throw err;
+  }
+
+  const contentType = await detectMime({ filePath: mediaUrl });
+  return {
+    filePath: mediaUrl,
+    contentType,
+    fileName: path.basename(mediaUrl) || undefined,
+    kind: kindFromMime(contentType),
+  };
 }
 
 const HEIC_MIME_RE = /^image\/hei[cf]$/i;

--- a/extensions/whatsapp/src/media.ts
+++ b/extensions/whatsapp/src/media.ts
@@ -190,8 +190,9 @@ export async function resolveLocalMediaSource(
         });
       }
       if (err.code === "not-file") {
-        throw new LocalMediaAccessError("not-file", `Local media path is not a file: ${mediaUrl}`,
-          { cause: err });
+        throw new LocalMediaAccessError("not-file", `Local media path is not a file: ${mediaUrl}`, {
+          cause: err,
+        });
       }
       throw new LocalMediaAccessError(
         "invalid-path",

--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -252,7 +252,7 @@ describe("web monitor inbox", () => {
     });
   });
 
-  it("handles append messages by marking them read but skipping auto-reply", async () => {
+  it("handles stale append messages by marking them read but skipping auto-reply", async () => {
     const { onMessage, listener, sock } = await openInboxMonitor();
     const staleTs = Math.floor(Date.now() / 1000) - 300;
 

--- a/extensions/whatsapp/src/outbound-adapter.ts
+++ b/extensions/whatsapp/src/outbound-adapter.ts
@@ -1,8 +1,8 @@
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/compat";
 import { chunkText } from "../../../src/auto-reply/chunk.js";
 import { sendTextMediaPayload } from "../../../src/channels/plugins/outbound/direct-text-media.js";
 import type { ChannelOutboundAdapter } from "../../../src/channels/plugins/types.js";
 import { shouldLogVerbose } from "../../../src/globals.js";
-import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
 import { resolveWhatsAppOutboundTarget } from "../../../src/whatsapp/resolve-outbound-target.js";
 import { sendMessageWhatsApp, sendPollWhatsApp } from "./send.js";
 

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -336,17 +336,22 @@ async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig): Promi
     const inspected = inspectTelegramAccount({ cfg, accountId });
     return inspected.enabled && inspected.tokenStatus === "configured_unavailable";
   });
-  const tokens = Array.from(
+  const apiClients = Array.from(
     new Set(
       listTelegramAccountIds(resolvedConfig)
         .map((accountId) => resolveTelegramAccount({ cfg: resolvedConfig, accountId }))
-        .map((account) => (account.tokenSource === "none" ? "" : account.token))
-        .map((token) => token.trim())
+        .filter((account) => account.tokenSource !== "none")
+        .map((account) => ({
+          token: account.token.trim(),
+          apiRoot: account.config.apiRoot?.trim() || undefined,
+        }))
+        .filter((entry) => entry.token)
+        .map((entry) => JSON.stringify(entry))
         .filter(Boolean),
     ),
-  );
+  ).map((entry) => JSON.parse(entry) as { token: string; apiRoot?: string });
 
-  if (tokens.length === 0) {
+  if (apiClients.length === 0) {
     return {
       config: cfg,
       changes: [
@@ -373,13 +378,14 @@ async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig): Promi
       return null;
     }
     const username = stripped.startsWith("@") ? stripped : `@${stripped}`;
-    for (const token of tokens) {
+    for (const client of apiClients) {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 4000);
       try {
         const id = await fetchTelegramChatId({
-          token,
+          token: client.token,
           chatId: username,
+          apiRoot: client.apiRoot,
           signal: controller.signal,
         });
         if (id) {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1518,6 +1518,8 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.telegram.retry.jitter": "Jitter factor (0-1) applied to Telegram retry delays.",
   "channels.telegram.network.autoSelectFamily":
     "Override Node autoSelectFamily for Telegram (true=enable, false=disable).",
+  "channels.telegram.apiRoot":
+    "Custom Telegram Bot API root URL. Defaults to https://api.telegram.org. Set this to a local Bot API Server root such as http://127.0.0.1:8081 when you want probes, sends, lookups, and file downloads to use that server.",
   "channels.telegram.timeoutSeconds":
     "Max seconds before Telegram API requests are aborted (default: 500 per grammY).",
   "channels.telegram.threadBindings.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -734,6 +734,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.telegram.retry.maxDelayMs": "Telegram Retry Max Delay (ms)",
   "channels.telegram.retry.jitter": "Telegram Retry Jitter",
   "channels.telegram.network.autoSelectFamily": "Telegram autoSelectFamily",
+  "channels.telegram.apiRoot": "Telegram Bot API Root URL",
   "channels.telegram.timeoutSeconds": "Telegram API Timeout (seconds)",
   "channels.telegram.capabilities.inlineButtons": "Telegram Inline Buttons",
   "channels.telegram.execApprovals": "Telegram Exec Approvals",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -147,6 +147,8 @@ export type TelegramAccountConfig = {
   mediaMaxMb?: number;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;
+  /** Custom Telegram Bot API root URL (grammY ApiClientOptions.apiRoot). */
+  apiRoot?: string;
   /** Retry policy for outbound Telegram API calls. */
   retry?: OutboundRetryConfig;
   /** Network transport overrides for Telegram. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -53,6 +53,16 @@ const DiscordIdListSchema = z.array(DiscordIdSchema);
 
 const TelegramInlineButtonsScopeSchema = z.enum(["off", "dm", "group", "all", "allowlist"]);
 const TelegramIdListSchema = z.array(z.union([z.string(), z.number()]));
+const TelegramApiRootSchema = z
+  .string()
+  .url()
+  .refine((value) => {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  }, "Expected http:// or https:// URL")
+  .describe(
+    "Custom Telegram Bot API root URL. Defaults to https://api.telegram.org; set to a local Bot API Server root such as http://127.0.0.1:8081 when applicable.",
+  );
 
 const TelegramCapabilitiesSchema = z.union([
   z.array(z.string()),
@@ -203,6 +213,7 @@ export const TelegramAccountSchemaBase = z
     streamMode: z.enum(["off", "partial", "block"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
+    apiRoot: TelegramApiRootSchema.optional(),
     retry: RetryConfigSchema,
     network: z
       .object({

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -263,6 +263,27 @@ export function createRootScopedReadFile(params: {
   };
 }
 
+export async function statLocalFileSafely(params: {
+  filePath: string;
+  maxBytes?: number;
+}): Promise<Omit<SafeLocalReadResult, "buffer">> {
+  const opened = await openVerifiedLocalFile(params.filePath);
+  try {
+    if (params.maxBytes !== undefined && opened.stat.size > params.maxBytes) {
+      throw new SafeOpenError(
+        "too-large",
+        `file exceeds limit of ${params.maxBytes} bytes (got ${opened.stat.size})`,
+      );
+    }
+    return {
+      realPath: opened.realPath,
+      stat: opened.stat,
+    };
+  } finally {
+    await opened.handle.close().catch(() => {});
+  }
+}
+
 export async function readLocalFileSafely(params: {
   filePath: string;
   maxBytes?: number;

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -296,6 +296,41 @@ export async function readLocalFileSafely(params: {
   }
 }
 
+export async function readLocalFileHeadSafely(params: {
+  filePath: string;
+  bytes: number;
+  maxBytes?: number;
+}): Promise<SafeLocalReadResult> {
+  const opened = await openVerifiedLocalFile(params.filePath);
+  try {
+    if (params.maxBytes !== undefined && opened.stat.size > params.maxBytes) {
+      throw new SafeOpenError(
+        "too-large",
+        `file exceeds limit of ${params.maxBytes} bytes (got ${opened.stat.size})`,
+      );
+    }
+
+    const bytesToRead = Math.max(0, Math.min(params.bytes, opened.stat.size));
+    const buffer = Buffer.alloc(bytesToRead);
+    if (bytesToRead > 0) {
+      const { bytesRead } = await opened.handle.read(buffer, 0, bytesToRead, 0);
+      return {
+        buffer: buffer.subarray(0, bytesRead),
+        realPath: opened.realPath,
+        stat: opened.stat,
+      };
+    }
+
+    return {
+      buffer,
+      realPath: opened.realPath,
+      stat: opened.stat,
+    };
+  } finally {
+    await opened.handle.close().catch(() => {});
+  }
+}
+
 async function readOpenedFileSafely(params: {
   opened: SafeOpenResult;
   maxBytes?: number;

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -129,6 +129,8 @@ export type { OpenClawConfig } from "../config/config.js";
 /** @deprecated Use OpenClawConfig instead */
 export type { OpenClawConfig as ClawdbotConfig } from "../config/config.js";
 export { isDangerousNameMatchingEnabled } from "../config/dangerous-name-matching.js";
+export { resolveOutboundSendDep } from "../infra/outbound/send-deps.js";
+export type { OutboundSendDeps } from "../infra/outbound/send-deps.js";
 
 export type { FileLockHandle, FileLockOptions } from "./file-lock.js";
 export { acquireFileLock, withFileLock } from "./file-lock.js";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram support assumed `https://api.telegram.org` in several paths, so configuring a Local Bot API Server would only partially work.
- Why it matters: Local Bot API users need more than a client `apiRoot` override — probes, membership audits, username/chat lookups, and inbound media/file handling all need to honor the same endpoint semantics.
- What changed: added `channels.telegram.apiRoot` / per-account override support, threaded it through grammY client creation and Telegram helper paths, updated hardcoded Bot API callers, and taught inbound media handling to consume absolute `file_path` / `file://` results directly from disk.
- What changed: outbound Telegram local-media sends now preserve local file references for loopback Local Bot API roots instead of always preloading files into memory first.
- What did NOT change (scope boundary): no non-Telegram channels were changed, and default `api.telegram.org` behavior remains the same when `apiRoot` is unset.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related # N/A

## User-visible / Behavior Changes

- Added optional `channels.telegram.apiRoot` and `channels.telegram.accounts.<id>.apiRoot`.
- Telegram send helpers, probe/status paths, group membership audit, onboarding username lookup, and chat-id lookup now honor the configured Telegram Bot API root.
- Inbound Telegram `getFile.file_path` values that are absolute paths or `file://` URIs are read directly from disk when using a Local Bot API Server.
- For loopback Local Bot API roots, outbound local media paths can stay as file references instead of always being fully buffered first.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - `apiRoot` allows Telegram traffic to target an explicitly configured Bot API host instead of only `api.telegram.org`.
  - Inbound Local Bot API file paths can now be read from disk, but only after explicit `apiRoot` opt-in and via safe local file open logic with symlink/path safety checks.
  - Outbound local-path shortcut is limited to loopback Bot API roots and existing local path allowlist validation.

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: local Node.js workspace
- Model/provider: n/a
- Integration/channel (if any): Telegram / grammY
- Relevant config (redacted): `channels.telegram.apiRoot: "http://127.0.0.1:8081"`

### Steps

1. Configure `channels.telegram.apiRoot` (or account-level `apiRoot`) to a Local Bot API Server root.
2. Start Telegram integration and exercise send/probe/lookup/media paths.
3. Verify calls use the custom root and that inbound absolute `file_path` results are read directly from disk.

### Expected

- Telegram paths honor the configured Bot API root consistently.
- Local Bot API `file_path` results work without constructing `api.telegram.org/file/...` URLs.
- Default behavior remains unchanged when `apiRoot` is unset.

### Actual

- Verified by targeted local tests and successful build.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `apiRoot` config is threaded into grammY client options for bot startup and send helpers.
  - Bot API URL builders for probe/audit/chat lookup now use the configured root.
  - Inbound absolute `file_path` / `file://` handling reads from disk.
  - Loopback Local Bot API roots preserve outbound local-path references.
- Edge cases checked:
  - default behavior without `apiRoot`
  - per-account `apiRoot` override
  - retry regressions in Telegram send path
  - channel post media-group regressions
- What you did **not** verify:
  - live end-to-end against a running `telegram-bot-api` server
  - installed-package hotfix flow (handled separately from this PR)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:
  - Optional only: set `channels.telegram.apiRoot` (or per-account override) if you use a custom/local Bot API server.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: unset `channels.telegram.apiRoot` to return to `https://api.telegram.org`, or revert this branch.
- Files/config to restore: Telegram config section and changed Telegram source files.
- Known bad symptoms reviewers should watch for: chat-id lookups or media/file handling unexpectedly targeting the wrong Bot API root, or local-path sends being attempted against non-loopback custom roots.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: custom `apiRoot` could point to a non-standard host and change Telegram network behavior.
  - Mitigation: behavior is opt-in, default root is unchanged, and helper/test coverage now exercises the custom-root paths.
- Risk: Local Bot API absolute `file_path` reads expand disk access behavior.
  - Mitigation: path reads go through safe local file open logic, and the feature only activates when callers explicitly trust a Local Bot API root.
- Risk: outbound local-path optimization could fail when the Bot API server is not on the same host.
  - Mitigation: the optimization is restricted to loopback `apiRoot` values; other custom roots keep the existing buffered-upload behavior.
