### PR TITLE
fix(failover): classify codex server_error payloads as retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 - macOS/runtime locator: require Node >=22.16.0 during macOS runtime discovery so the app no longer accepts Node versions that the main runtime guard rejects later. Thanks @sumleo.
 - Agents/custom providers: preserve blank API keys for loopback OpenAI-compatible custom providers by clearing the synthetic Authorization header at runtime, while keeping explicit apiKey and oauth/token config from silently downgrading into fake bearer auth. (#45631) Thanks @xinhuagu.
 - Models/google-vertex Gemini flash-lite normalization: apply existing bare-ID preview normalization to `google-vertex` model refs and provider configs so `google-vertex/gemini-3.1-flash-lite` resolves as `gemini-3.1-flash-lite-preview`. (#42435) thanks @scoootscooob.
+- Agents/failover: classify raw OpenAI Codex `server_error` JSON payloads as retryable timeouts so configured fallback models engage instead of surfacing hard-stop errors.
 
 ## 2026.3.12
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -853,10 +853,20 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("key has been disabled")).toBe("auth_permanent");
     expect(classifyFailoverReason("account has been deactivated")).toBe("auth_permanent");
   });
-  it("classifies JSON api_error internal server failures as timeout", () => {
+  it("classifies retryable JSON server failures as timeout", () => {
     expect(
       classifyFailoverReason(
         '{"type":"error","error":{"type":"api_error","message":"Internal server error"}}',
+      ),
+    ).toBe("timeout");
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"API_Error","message":"Internal server error"}}',
+      ),
+    ).toBe("timeout");
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"api_error","code":"server_error","message":"Internal server error"}}',
       ),
     ).toBe("timeout");
     expect(

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -859,5 +859,10 @@ describe("classifyFailoverReason", () => {
         '{"type":"error","error":{"type":"api_error","message":"Internal server error"}}',
       ),
     ).toBe("timeout");
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID c69ab225-9c66-48c4-87c9-2a46bf07e104 in your message.","param":null},"sequence_number":2}',
+      ),
+    ).toBe("timeout");
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -581,6 +581,7 @@ export function isRawApiErrorPayload(raw?: string): boolean {
 export type ApiErrorInfo = {
   httpCode?: string;
   type?: string;
+  code?: string;
   message?: string;
   requestId?: string;
 };
@@ -616,17 +617,22 @@ export function parseApiErrorInfo(raw?: string): ApiErrorInfo | null {
         : undefined;
 
   const topType = typeof payload.type === "string" ? payload.type : undefined;
+  const topCode = typeof payload.code === "string" ? payload.code : undefined;
   const topMessage = typeof payload.message === "string" ? payload.message : undefined;
 
   let errType: string | undefined;
+  let errCode: string | undefined;
   let errMessage: string | undefined;
   if (payload.error && typeof payload.error === "object" && !Array.isArray(payload.error)) {
     const err = payload.error as Record<string, unknown>;
     if (typeof err.type === "string") {
       errType = err.type;
     }
-    if (typeof err.code === "string" && !errType) {
-      errType = err.code;
+    if (typeof err.code === "string") {
+      errCode = err.code;
+      if (!errType) {
+        errType = err.code;
+      }
     }
     if (typeof err.message === "string") {
       errMessage = err.message;
@@ -636,6 +642,7 @@ export function parseApiErrorInfo(raw?: string): ApiErrorInfo | null {
   return {
     httpCode,
     type: errType ?? topType,
+    code: errCode ?? topCode,
     message: errMessage ?? topMessage,
     requestId,
   };
@@ -857,12 +864,14 @@ function isRetryableJsonApiServerError(raw: string): boolean {
 
   // OpenAI/Codex can surface transient failures as raw payloads like:
   // {"type":"error","error":{"type":"server_error","message":"An error occurred while processing your request."}}
-  if (info.type === "server_error") {
+  const type = info.type?.toLowerCase();
+  const code = info.code?.toLowerCase();
+  if (type === "server_error" || code === "server_error") {
     return true;
   }
 
   const message = info.message?.toLowerCase() ?? "";
-  return info.type === "api_error" && message.includes("internal server error");
+  return type === "api_error" && message.includes("internal server error");
 }
 
 export function parseImageDimensionError(raw: string): {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -846,14 +846,23 @@ export function isBillingAssistantError(msg: AssistantMessage | undefined): bool
   return isBillingErrorMessage(msg.errorMessage ?? "");
 }
 
-function isJsonApiInternalServerError(raw: string): boolean {
+function isRetryableJsonApiServerError(raw: string): boolean {
   if (!raw) {
     return false;
   }
-  const value = raw.toLowerCase();
-  // Anthropic often wraps transient 500s in JSON payloads like:
-  // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  const info = parseApiErrorInfo(raw);
+  if (!info) {
+    return false;
+  }
+
+  // OpenAI/Codex can surface transient failures as raw payloads like:
+  // {"type":"error","error":{"type":"server_error","message":"An error occurred while processing your request."}}
+  if (info.type === "server_error") {
+    return true;
+  }
+
+  const message = info.message?.toLowerCase() ?? "";
+  return info.type === "api_error" && message.includes("internal server error");
 }
 
 export function parseImageDimensionError(raw: string): {
@@ -1006,7 +1015,7 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     // Treat remaining transient 5xx provider failures as retryable transport issues.
     return "timeout";
   }
-  if (isJsonApiInternalServerError(raw)) {
+  if (isRetryableJsonApiServerError(raw)) {
     return "timeout";
   }
   if (isCloudCodeAssistFormatError(raw)) {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -118,4 +118,57 @@ describe("handleSendChat", () => {
     });
     expect(host.chatModelOverrides.main).toBe("gpt-5-mini");
   });
+
+  it("does not throw when deferred chat scroll runs on a plain chat host", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 1;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({}),
+      }) as unknown as typeof fetch,
+    );
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.patch") {
+        return { ok: true, key: "main" };
+      }
+      if (method === "chat.history") {
+        return { messages: [], thinkingLevel: null };
+      }
+      if (method === "sessions.list") {
+        return {
+          ts: 0,
+          path: "",
+          count: 0,
+          defaults: { model: "gpt-5", contextTokens: null },
+          sessions: [],
+        };
+      }
+      if (method === "models.list") {
+        return {
+          models: [{ id: "gpt-5-mini", name: "GPT-5 Mini", provider: "openai" }],
+        };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "main",
+      chatMessage: "/model gpt-5-mini",
+    });
+
+    try {
+      await handleSendChat(host);
+      await Promise.resolve();
+      vi.runAllTimers();
+      expect(host.chatModelOverrides.main).toBe("gpt-5-mini");
+    } finally {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    }
+  });
 });

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -255,6 +255,45 @@ describe("streaming scroll behavior", () => {
 
     expect(container.scrollTop).toBe(container.scrollHeight);
   });
+
+  it("falls back to the document scroll target when the host is not a DOM element", async () => {
+    const target = {
+      scrollHeight: 900,
+      scrollTop: 0,
+      clientHeight: 300,
+    };
+    const originalScrollingElement = Object.getOwnPropertyDescriptor(document, "scrollingElement");
+    Object.defineProperty(document, "scrollingElement", {
+      configurable: true,
+      get: () => target as unknown as Element,
+    });
+
+    const host = {
+      updateComplete: Promise.resolve(),
+      style: { setProperty: vi.fn() } as unknown as CSSStyleDeclaration,
+      chatScrollFrame: null as number | null,
+      chatScrollTimeout: null as number | null,
+      chatHasAutoScrolled: false,
+      chatUserNearBottom: true,
+      chatNewMessagesBelow: false,
+      logsScrollFrame: null as number | null,
+      logsAtBottom: true,
+      topbarObserver: null as ResizeObserver | null,
+    };
+
+    try {
+      scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
+      await host.updateComplete;
+
+      expect(target.scrollTop).toBe(target.scrollHeight);
+    } finally {
+      if (originalScrollingElement) {
+        Object.defineProperty(document, "scrollingElement", originalScrollingElement);
+      } else {
+        delete (document as { scrollingElement?: Element }).scrollingElement;
+      }
+    }
+  });
 });
 
 /* ------------------------------------------------------------------ */

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -15,6 +15,14 @@ type ScrollHost = {
   topbarObserver: ResizeObserver | null;
 };
 
+function queryHostElement(host: unknown, selectors: string): Element | null {
+  const querySelector = (host as { querySelector?: unknown } | null)?.querySelector;
+  if (typeof querySelector !== "function") {
+    return null;
+  }
+  return querySelector.call(host, selectors) as Element | null;
+}
+
 export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
   if (host.chatScrollFrame) {
     cancelAnimationFrame(host.chatScrollFrame);
@@ -24,7 +32,7 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
     host.chatScrollTimeout = null;
   }
   const pickScrollTarget = () => {
-    const container = host.querySelector(".chat-thread") as HTMLElement | null;
+    const container = queryHostElement(host, ".chat-thread") as HTMLElement | null;
     if (container) {
       const overflowY = getComputedStyle(container).overflowY;
       const canScroll =
@@ -104,7 +112,7 @@ export function scheduleLogsScroll(host: ScrollHost, force = false) {
   void host.updateComplete.then(() => {
     host.logsScrollFrame = requestAnimationFrame(() => {
       host.logsScrollFrame = null;
-      const container = host.querySelector(".log-stream") as HTMLElement | null;
+      const container = queryHostElement(host, ".log-stream") as HTMLElement | null;
       if (!container) {
         return;
       }
@@ -165,7 +173,7 @@ export function observeTopbar(host: ScrollHost) {
   if (typeof ResizeObserver === "undefined") {
     return;
   }
-  const topbar = host.querySelector(".topbar");
+  const topbar = queryHostElement(host, ".topbar");
   if (!topbar) {
     return;
   }


### PR DESCRIPTION
Supersedes #45237.

The original PR branch was not writable from this environment, so this replacement PR carries the same base fix on a fork branch that can be updated.

Summary:
- classify raw OpenAI Codex `server_error` JSON payloads as retryable timeouts so configured fallback models engage instead of surfacing hard-stop errors
- preserve retryable handling when providers send `error.code = "server_error"` alongside a different `error.type`
- preserve the legacy case-insensitive `api_error` check for internal-server-error payloads
- guard deferred dashboard chat scroll callbacks so the node test lane no longer fails with `host.querySelector is not a function`

Why this replacement exists:
- #45237 had one unresolved CI failure in `checks (node, test, pnpm canvas:a2ui:bundle && pnpm test)` caused by the deferred chat-scroll host assumption in `ui/src/ui/app-scroll.ts`
- #45237 also had two unresolved review follow-ups around retryable failover classification

Validation run locally:
- `pnpm test ui/src/ui/app-chat.test.ts`
- `pnpm test src/ui/app-scroll.test.ts` (from `ui/`)
- `pnpm test src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- `pnpm test src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/agents/pi-embedded-error-observation.test.ts`

Closes #45234.
