### PR TITLE
fix(ui): avoid empty-state lockout when chat has hidden activity

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -9,6 +9,7 @@
 
 .chat-main {
   min-width: 400px;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -268,6 +268,28 @@ describe("chat view", () => {
     expect(indicator?.textContent).toContain("Compacting context...");
   });
 
+  it("does not show the welcome state when hidden tool-result activity exists", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: false,
+          messages: [
+            {
+              role: "toolResult",
+              content: "background tool output",
+              timestamp: 1_000,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".agent-chat__welcome")).toBeNull();
+    expect(container.querySelector(".agent-chat__input")).not.toBeNull();
+  });
+
   it("renders completion indicator shortly after compaction", () => {
     const container = document.createElement("div");
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -850,7 +850,14 @@ export function renderChat(props: ChatProps) {
   };
 
   const chatItems = buildChatItems(props);
-  const isEmpty = chatItems.length === 0 && !props.loading;
+  const hasSessionActivity =
+    (Array.isArray(props.messages) && props.messages.length > 0) ||
+    (Array.isArray(props.toolMessages) && props.toolMessages.length > 0) ||
+    (Array.isArray(props.streamSegments) &&
+      props.streamSegments.some((segment) => segment.text.trim())) ||
+    props.stream !== null;
+  const showWelcomeState = !hasSessionActivity && !props.loading && !vs.searchOpen;
+  const showEmptySearch = chatItems.length === 0 && !props.loading && vs.searchOpen;
 
   const thread = html`
     <div
@@ -893,9 +900,9 @@ export function renderChat(props: ChatProps) {
             `
           : nothing
       }
-      ${isEmpty && !vs.searchOpen ? renderWelcomeState(props) : nothing}
+      ${showWelcomeState ? renderWelcomeState(props) : nothing}
       ${
-        isEmpty && vs.searchOpen
+        showEmptySearch
           ? html`
               <div class="agent-chat__empty">No matching messages</div>
             `


### PR DESCRIPTION
## Summary
- only show the chat welcome empty state when a session truly has no history, tool activity, or stream state
- keep the split chat pane shrinkable so transient empty renders do not push the compose box out of reach
- add a regression test covering hidden `toolResult` activity so the input stays available even when those messages are not rendered

## Test plan
- [x] `codex review --base origin/main`
- [ ] `pnpm exec vitest run --config vitest.config.ts ui/src/ui/views/chat.test.ts ui/src/ui/views/chat.browser.test.ts` (current checkout is missing `jsdom`, so the jsdom suite cannot start)
- [ ] `pnpm build` (fails on current `origin/main` checkout with unrelated TypeScript/module errors in `src/agents/**`, `src/browser/chrome-mcp.ts`, and `src/commands/openai-codex-oauth.ts`)

## Notes
- AI-assisted
- This is a defense-in-depth UI fix for sessions that have activity but temporarily render with no visible chat items.

Fixes #45707

Made with [Cursor](https://cursor.com)