### PR TITLE
fix(ui): reload control UI after successful updates

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -129,6 +129,7 @@ function createHost() {
     execApprovalQueue: [],
     execApprovalError: null,
     updateAvailable: null,
+    updateRunning: false,
   } as unknown as Parameters<typeof connectGateway>[0];
 }
 
@@ -227,6 +228,61 @@ describe("connectGateway", () => {
     secondClient.emitClose({ code: 1005 });
     expect(host.lastError).toBe("disconnected (1005): no reason");
     expect(host.lastErrorCode).toBeNull();
+  });
+
+  it("reloads the page after service-restart close while update is running", () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { reload },
+    });
+
+    const host = createHost();
+    host.updateRunning = true;
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitClose({ code: 1012, reason: "service restart" });
+    vi.advanceTimersByTime(1500);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.useRealTimers();
+  });
+
+  it("does not reload the page for service-restart close when update is idle", () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { reload },
+    });
+
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitClose({ code: 1012, reason: "service restart" });
+    vi.advanceTimersByTime(1500);
+
+    expect(reload).not.toHaveBeenCalled();
+
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.useRealTimers();
   });
 
   it("maps generic fetch-failed auth errors to actionable token mismatch message", () => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -28,6 +28,7 @@ import {
 } from "./controllers/exec-approval.ts";
 import { loadHealthState } from "./controllers/health.ts";
 import { loadNodes } from "./controllers/nodes.ts";
+import { scheduleLocationReload } from "./controllers/reload.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import {
   resolveGatewayErrorDetailCode,
@@ -82,6 +83,7 @@ type GatewayHost = {
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalError: string | null;
   updateAvailable: UpdateAvailable | null;
+  updateRunning?: boolean;
 };
 
 type SessionDefaultsSnapshot = {
@@ -238,6 +240,10 @@ export function connectGateway(host: GatewayHost) {
       } else {
         host.lastError = null;
         host.lastErrorCode = null;
+        if (host.updateRunning) {
+          host.updateRunning = false;
+          scheduleLocationReload({ delayMs: 1500 });
+        }
       }
     },
     onEvent: (evt) => {

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -371,4 +371,83 @@ describe("runUpdate", () => {
       sessionKey: "agent:main:whatsapp:dm:+15555550123",
     });
   });
+
+  it("reloads the page after a successful update request", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn().mockResolvedValue({ ok: true, result: { status: "ok" } });
+    const reload = vi.fn();
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { reload },
+    });
+
+    await runUpdate(state);
+    vi.advanceTimersByTime(2500);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.useRealTimers();
+  });
+
+  it("does not reload the page when update.run reports failure", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      result: { status: "error", reason: "build-failed" },
+    });
+    const reload = vi.fn();
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { reload },
+    });
+
+    await runUpdate(state);
+    vi.advanceTimersByTime(2500);
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(state.lastError).toBe("Update error: build-failed");
+
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.useRealTimers();
+  });
+
+  it("does not reload the page when update is skipped", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn().mockResolvedValue({ ok: true, result: { status: "skipped" } });
+    const reload = vi.fn();
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { reload },
+    });
+
+    await runUpdate(state);
+    vi.advanceTimersByTime(2500);
+
+    expect(reload).not.toHaveBeenCalled();
+
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.useRealTimers();
+  });
 });

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -8,6 +8,7 @@ import {
   serializeConfigForm,
   setPathValue,
 } from "./config/form-utils.ts";
+import { scheduleLocationReload } from "./reload.ts";
 
 export type ConfigState = {
   client: GatewayBrowserClient | null;
@@ -194,6 +195,9 @@ export async function runUpdate(state: ConfigState) {
       const status = res.result?.status ?? "error";
       const reason = res.result?.reason ?? "Update failed.";
       state.lastError = `Update ${status}: ${reason}`;
+    } else if (res?.result?.status === "ok") {
+      // Only reload on actual success, not skipped updates.
+      scheduleLocationReload({ delayMs: 2500 });
     }
   } catch (err) {
     state.lastError = String(err);

--- a/ui/src/ui/controllers/reload.ts
+++ b/ui/src/ui/controllers/reload.ts
@@ -1,0 +1,23 @@
+export type ScheduleReloadOptions = {
+  delayMs: number;
+  globalRef?: Pick<typeof globalThis, "setTimeout"> & {
+    location?: {
+      reload?: () => void;
+    };
+  };
+};
+
+export function scheduleLocationReload(opts: ScheduleReloadOptions): void {
+  const { delayMs, globalRef = globalThis } = opts;
+  const reload = globalRef.location?.reload;
+  if (typeof reload !== "function") {
+    return;
+  }
+  globalRef.setTimeout(() => {
+    try {
+      reload.call(globalRef.location);
+    } catch {
+      // Ignore reload failures (e.g., test environments or navigation restrictions).
+    }
+  }, delayMs);
+}


### PR DESCRIPTION
## Summary

Fixes an issue where the Control UI would continue showing the old version after a successful update. The problem occurred because:

1. After `update.run` completes successfully, the gateway restarts but the browser page wasn't reloading
2. This caused users to see stale version information even though the backend had already upgraded

## Changes

- **ui/src/ui/controllers/config.ts**: Added automatic page reload after successful `update.run` (2.5s delay)
- **ui/src/ui/app-gateway.ts**: Added fallback page reload when receiving WebSocket close code 1012 (service restart) during an active update
- **ui/src/ui/controllers/config.test.ts**: Added regression tests for successful update reload behavior
- **ui/src/ui/app-gateway.node.test.ts**: Added tests for service-restart triggered reload

## Testing

- `vitest run` tests pass for both modified test files
- Manual testing confirms page reloads after clicking "Update now" and successfully completing the update

## Related

- Issue: Users reporting "already upgraded but page shows old version"