### PR TITLE
fix(agents): recognize OpenAI/Codex server_error as retryable for model fallback

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -860,4 +860,11 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+  it("classifies JSON server_error internal server failures as timeout", () => {
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred..."}}',
+      ),
+    ).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -859,9 +859,20 @@ function isJsonApiInternalServerError(raw: string): boolean {
     return true;
   }
   // OpenAI/Codex wraps transient 500s as:
-  // {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred..."}}
-  if (value.includes('"type":"server_error"') && value.includes('"code":"server_error"')) {
-    return true;
+  // {"type":"error","error":{"type":"server_error","code":"server_error","message":"..."}}
+  // Use JSON.parse to safely handle pretty-printed or spaced JSON.
+  try {
+    const parsed = JSON.parse(raw);
+    const errType = parsed?.error?.type;
+    const errCode = parsed?.error?.code;
+    if (errType === "server_error" && errCode === "server_error") {
+      return true;
+    }
+  } catch {
+    // Not valid JSON — fall through to substring check for compact format
+    if (value.includes('"type":"server_error"') && value.includes('"code":"server_error"')) {
+      return true;
+    }
   }
   return false;
 }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -855,7 +855,15 @@ function isJsonApiInternalServerError(raw: string): boolean {
   const value = raw.toLowerCase();
   // Anthropic often wraps transient 500s in JSON payloads like:
   // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  if (value.includes('"type":"api_error"') && value.includes("internal server error")) {
+    return true;
+  }
+  // OpenAI/Codex wraps transient 500s as:
+  // {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred..."}}
+  if (value.includes('"type":"server_error"') && value.includes('"code":"server_error"')) {
+    return true;
+  }
+  return false;
 }
 
 export function parseImageDimensionError(raw: string): {


### PR DESCRIPTION
## Problem
The transient HTTP error detector (`isJsonApiInternalServerError`) only recognized Anthropic's `api_error` JSON format. OpenAI and Codex use a different envelope:
```json
{"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred..."}}
```
These transient 500s were treated as fatal errors, causing the model fallback chain to skip retrying — resulting in unnecessary failures.

## Fix
Extend `isJsonApiInternalServerError()` to also match the OpenAI/Codex `server_error` pattern, so these transient errors trigger proper fallback behavior.

## Impact
- 7-line change in `src/agents/pi-embedded-helpers/errors.ts`
- No breaking changes
- OpenAI/Codex transient 500s now correctly trigger model fallback instead of hard-failing