### PR TITLE
feat(agents): auto-retry with exponential backoff on 429 rate limits

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -39,6 +39,7 @@ export {
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,
+  extractRetryAfterMs,
   isTransientHttpError,
   isTimeoutErrorMessage,
   parseImageDimensionError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -834,6 +834,37 @@ const IMAGE_DIMENSION_ERROR_RE =
 const IMAGE_DIMENSION_PATH_RE = /messages\.(\d+)\.content\.(\d+)\.image/i;
 const IMAGE_SIZE_ERROR_RE = /image exceeds\s*(\d+(?:\.\d+)?)\s*mb/i;
 
+/**
+ * Extract a retry-after delay (in ms) from a rate-limit error message.
+ *
+ * Providers embed retry hints in different formats:
+ *   - Anthropic: "retry after 30 seconds", "try again in 30s"
+ *   - OpenAI:    "Please retry after 30s", "Rate limit ... try again in 30.000s"
+ *   - NIM/Kimi:  "retry after 5 seconds"
+ *
+ * Returns a clamped value between 1_000 ms and 120_000 ms, or `undefined`
+ * if no parseable hint is found.
+ */
+export function extractRetryAfterMs(raw: string | undefined | null): number | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const m = raw.match(
+    /(?:retry[_ ]?after|try again in)[:\s]*(\d+(?:\.\d+)?)\s*(?:s(?:ec(?:ond)?s?)?|ms)?/i,
+  );
+  if (!m) {
+    return undefined;
+  }
+  const value = parseFloat(m[1]);
+  if (!Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  // If the value looks like milliseconds (> 500), use as-is; otherwise treat as seconds
+  const ms = value > 500 ? value : value * 1000;
+  // Clamp between 1s and 120s
+  return Math.min(Math.max(ms, 1_000), 120_000);
+}
+
 export function isMissingToolCallInputError(raw: string): boolean {
   if (!raw) {
     return false;

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -850,7 +850,7 @@ export function extractRetryAfterMs(raw: string | undefined | null): number | un
     return undefined;
   }
   const m = raw.match(
-    /(?:retry[_ ]?after|try again in)[:\s]*(\d+(?:\.\d+)?)\s*(?:s(?:ec(?:ond)?s?)?|ms)?/i,
+    /(?:retry[_ ]?after|try again in)[:\s]*(\d+(?:\.\d+)?)\s*(ms|s(?:ec(?:ond)?s?)?)?/i,
   );
   if (!m) {
     return undefined;
@@ -859,8 +859,9 @@ export function extractRetryAfterMs(raw: string | undefined | null): number | un
   if (!Number.isFinite(value) || value <= 0) {
     return undefined;
   }
-  // If the value looks like milliseconds (> 500), use as-is; otherwise treat as seconds
-  const ms = value > 500 ? value : value * 1000;
+  // Dispatch on the captured unit group — default to seconds when no unit is present
+  const unit = (m[2] ?? "s").toLowerCase();
+  const ms = unit === "ms" ? value : value * 1_000;
   // Clamp between 1s and 120s
   return Math.min(Math.max(ms, 1_000), 120_000);
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -58,6 +58,7 @@ import {
   parseImageSizeError,
   parseImageDimensionError,
   isRateLimitAssistantError,
+  extractRetryAfterMs,
   isTimeoutErrorMessage,
   pickFallbackThinkingLevel,
   type FailoverReason,
@@ -818,6 +819,9 @@ export async function runEmbeddedPiAgent(
       const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
       const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
       let overflowCompactionAttempts = 0;
+      let rateLimitRetryCount = 0;
+      const MAX_RATE_LIMIT_RETRIES = 2;
+      const MAX_RATE_LIMIT_WAIT_MS = 60_000;
       let toolResultTruncationAttempted = false;
       let bootstrapPromptWarningSignaturesSeen =
         params.bootstrapPromptWarningSignaturesSeen ??
@@ -1508,6 +1512,28 @@ export async function runEmbeddedPiAgent(
               `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
             );
           }
+
+          // Auto-retry with exponential backoff on 429 rate limits.
+          // Before rotating to another profile/model, wait and retry on the same
+          // profile if the provider signals a short retry window. This avoids
+          // burning through all profiles/fallbacks on transient rate limits.
+          if (rateLimitFailure && !aborted && rateLimitRetryCount < MAX_RATE_LIMIT_RETRIES) {
+            const retryMs = extractRetryAfterMs(lastAssistant?.errorMessage ?? "");
+            const backoffMs =
+              retryMs ?? Math.min(1_000 * 2 ** rateLimitRetryCount, MAX_RATE_LIMIT_WAIT_MS);
+            if (backoffMs <= MAX_RATE_LIMIT_WAIT_MS) {
+              rateLimitRetryCount += 1;
+              log.info(
+                `[rate-limit-retry] Profile ${lastProfileId ?? "?"} rate limited. ` +
+                  `Retry ${rateLimitRetryCount}/${MAX_RATE_LIMIT_RETRIES} in ${backoffMs}ms` +
+                  (retryMs ? ` (server Retry-After)` : ` (exponential backoff)`),
+              );
+              await sleepWithAbort(backoffMs, params.signal);
+              continue;
+            }
+          }
+          // Reset retry counter when moving past rate-limit retry (rotating or succeeding).
+          rateLimitRetryCount = 0;
 
           // Rotate on timeout to try another account/model path in this turn,
           // but exclude post-prompt compaction timeouts (model succeeded; no profile issue).

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1533,7 +1533,7 @@ export async function runEmbeddedPiAgent(
                   `Retry ${rateLimitRetryCount}/${MAX_RATE_LIMIT_RETRIES} in ${backoffMs}ms` +
                   (retryMs ? ` (server Retry-After)` : ` (exponential backoff)`),
               );
-              await sleepWithAbort(backoffMs, params.signal);
+              await sleepWithAbort(backoffMs, params.abortSignal);
               continue;
             }
           }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1461,6 +1461,11 @@ export async function runEmbeddedPiAgent(
 
           const authFailure = isAuthAssistantError(lastAssistant);
           const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
+          // Reset rate-limit retry budget on any non-rate-limit iteration so each
+          // new rate-limit event gets a fresh set of retries.
+          if (!rateLimitFailure) {
+            rateLimitRetryCount = 0;
+          }
           const billingFailure = isBillingAssistantError(lastAssistant);
           const failoverFailure = isFailoverAssistantError(lastAssistant);
           const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");


### PR DESCRIPTION
## Problem
When a model returns a 429 rate limit, the agent immediately rotates to the next profile or fallback model. For transient rate limits with short retry windows (e.g., 30 seconds), this burns through all available profiles/models unnecessarily — often exhausting the entire fallback chain when simply waiting would have worked.

## Solution
Before rotating to the next profile/model, the agent now:
1. Parses the provider's retry-after hint from the error message (supports Anthropic, OpenAI, NIM, Kimi formats)
2. Waits with exponential backoff (1s, 2s) or the server's suggested delay
3. Retries up to 2 times on the **same** profile, capped at 60s max wait
4. Only then rotates to the next fallback candidate

### New utility: `extractRetryAfterMs()`
Parses retry-after hints from various provider error message formats:
- Anthropic: `retry after 30 seconds`, `try again in 30s`
- OpenAI: `Please retry after 30s`, `Rate limit ... try again in 30.000s`
- NIM/Kimi: `retry after 5 seconds`

Returns a clamped value between 1s and 120s.

## Impact
- Changes in `errors.ts`, `pi-embedded-helpers.ts`, `run.ts`
- No breaking changes
- Uses existing `sleepWithAbort` to respect cancellation signals during wait
- Significantly reduces unnecessary profile/model rotation on transient rate limits