### PR TITLE
feat(browser): add headless existing-session MCP support esp for Linux/Docker/VPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Commands/btw: add `/btw` side questions for quick tool-less answers about the current session without changing future session context, with dismissible in-session TUI answers and explicit BTW replies on external channels. (#45444) Thanks @ngutman.
 - Refactor/channels: remove the legacy channel shim directories and point channel-specific imports directly at the extension-owned implementations. (#45967) thanks @scoootscooob.
+- Browser/existing-session: add headless Chrome DevTools MCP support for Linux, Docker, and VPS setups, including explicit browser URL and WebSocket endpoint attach modes for `existing-session`. Thanks @vincentkoc.
 
 ### Fixes
 

--- a/docs/tools/browser-linux-troubleshooting.md
+++ b/docs/tools/browser-linux-troubleshooting.md
@@ -110,6 +110,48 @@ curl -s -X POST http://127.0.0.1:18791/start
 curl -s http://127.0.0.1:18791/tabs
 ```
 
+## Existing-session MCP on Linux / VPS
+
+If you want Chrome DevTools MCP instead of the managed `openclaw` CDP profile,
+you now have two Linux-safe options:
+
+1. Let MCP launch headless Chrome for an `existing-session` profile:
+
+```json
+{
+  "browser": {
+    "headless": true,
+    "noSandbox": true,
+    "executablePath": "/usr/bin/google-chrome-stable",
+    "defaultProfile": "user"
+  }
+}
+```
+
+2. Attach MCP to a running debuggable Chrome instance:
+
+```json
+{
+  "browser": {
+    "headless": true,
+    "defaultProfile": "user",
+    "profiles": {
+      "user": {
+        "driver": "existing-session",
+        "cdpUrl": "http://127.0.0.1:9222",
+        "color": "#00AA00"
+      }
+    }
+  }
+}
+```
+
+Notes:
+
+- `driver: "existing-session"` still uses Chrome MCP transport, not the extension relay.
+- `cdpUrl` on an `existing-session` profile is interpreted as the MCP browser target (`browserUrl` or `wsEndpoint`), not the normal OpenClaw CDP driver.
+- If you omit `cdpUrl`, headless MCP launches Chrome itself.
+
 ### Config Reference
 
 | Option                   | Description                                                          | Default                                                     |

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -359,9 +359,13 @@ Notes:
 
 ## Chrome existing-session via MCP
 
-OpenClaw can also attach to a running Chrome profile through the official
-Chrome DevTools MCP server. This reuses the tabs and login state already open in
-that Chrome profile.
+OpenClaw can also use the official Chrome DevTools MCP server for two different
+flows:
+
+- desktop attach via `--autoConnect`, which reuses a running Chrome profile and
+  its existing tabs/login state
+- headless or remote attach, where MCP either launches headless Chrome itself
+  or connects to a running debuggable browser URL/WS endpoint
 
 Official background and setup references:
 
@@ -375,7 +379,7 @@ Built-in profile:
 Optional: create your own custom existing-session profile if you want a
 different name or color.
 
-Then in Chrome:
+Desktop attach flow:
 
 1. Open `chrome://inspect/#remote-debugging`
 2. Enable remote debugging
@@ -398,11 +402,46 @@ What success looks like:
 - `tabs` lists your already-open Chrome tabs
 - `snapshot` returns refs from the selected live tab
 
-What to check if attach does not work:
+What to check if desktop attach does not work:
 
 - Chrome is version `144+`
 - remote debugging is enabled at `chrome://inspect/#remote-debugging`
 - Chrome showed and you accepted the attach consent prompt
+
+Headless / Linux / VPS flow:
+
+- Set `browser.headless: true`
+- Set `browser.noSandbox: true` when running as root or in common container/VPS setups
+- Optional: set `browser.executablePath` to a stable Chrome/Chromium binary path
+- Optional: set `browser.profiles.<name>.cdpUrl` on an `existing-session` profile to an
+  MCP target like `http://127.0.0.1:9222` or
+  `ws://127.0.0.1:9222/devtools/browser/<id>`
+
+Example:
+
+```json5
+{
+  browser: {
+    headless: true,
+    noSandbox: true,
+    executablePath: "/usr/bin/google-chrome-stable",
+    defaultProfile: "user",
+    profiles: {
+      user: {
+        driver: "existing-session",
+        cdpUrl: "http://127.0.0.1:9222",
+        color: "#00AA00",
+      },
+    },
+  },
+}
+```
+
+Behavior:
+
+- without `browser.profiles.<name>.cdpUrl`, headless `existing-session` launches Chrome through MCP
+- with `browser.profiles.<name>.cdpUrl`, MCP connects to that running browser URL
+- non-headless `existing-session` keeps using the interactive `--autoConnect` flow
 
 Agent use:
 
@@ -410,18 +449,19 @@ Agent use:
 - If you use a custom existing-session profile, pass that explicit profile name.
 - Prefer `profile="user"` over `profile="chrome-relay"` unless the user
   explicitly wants the extension / attach-tab flow.
-- Only choose this mode when the user is at the computer to approve the attach
-  prompt.
-- the Gateway or node host can spawn `npx chrome-devtools-mcp@latest --autoConnect`
+- On desktop `--autoConnect`, only choose this mode when the user is at the
+  computer to approve the attach prompt.
+- The Gateway or node host can spawn `npx chrome-devtools-mcp@latest --autoConnect`
+  for desktop attach, or use MCP headless/browserUrl/wsEndpoint modes for Linux/VPS paths.
 
 Notes:
 
 - This path is higher-risk than the isolated `openclaw` profile because it can
   act inside your signed-in browser session.
-- OpenClaw does not launch Chrome for this driver; it attaches to an existing
-  session only.
-- OpenClaw uses the official Chrome DevTools MCP `--autoConnect` flow here, not
-  the legacy default-profile remote debugging port workflow.
+- OpenClaw uses the official Chrome DevTools MCP server for this driver.
+- On desktop, OpenClaw uses MCP `--autoConnect`.
+- In headless mode, OpenClaw can launch Chrome through MCP or connect MCP to a
+  configured browser URL/WS endpoint.
 - Existing-session screenshots support page captures and `--ref` element
   captures from snapshots, but not CSS `--element` selectors.
 - Existing-session `wait --url` supports exact, substring, and glob patterns

--- a/src/browser/chrome-mcp.test.ts
+++ b/src/browser/chrome-mcp.test.ts
@@ -1,11 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../config/config.js";
 import {
+  buildChromeMcpLaunchPlanForTest,
   evaluateChromeMcpScript,
   listChromeMcpTabs,
   openChromeMcpTab,
   resetChromeMcpSessionsForTest,
   setChromeMcpSessionFactoryForTest,
 } from "./chrome-mcp.js";
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(),
+}));
 
 type ToolCall = {
   name: string;
@@ -79,6 +85,99 @@ function createFakeSession(): ChromeMcpSession {
 describe("chrome MCP page parsing", () => {
   beforeEach(async () => {
     await resetChromeMcpSessionsForTest();
+    vi.mocked(loadConfig).mockReturnValue({
+      browser: {
+        profiles: {
+          "chrome-live": {
+            driver: "existing-session",
+            attachOnly: true,
+            color: "#00AA00",
+          },
+        },
+      },
+    });
+  });
+
+  it("uses autoConnect for desktop existing-session profiles", () => {
+    const plan = buildChromeMcpLaunchPlanForTest("chrome-live");
+    expect(plan.mode).toBe("autoConnect");
+    expect(plan.args).toContain("--autoConnect");
+  });
+
+  it("uses headless launch flags for headless existing-session profiles", () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      browser: {
+        headless: true,
+        noSandbox: true,
+        executablePath: "/usr/bin/google-chrome-stable",
+        extraArgs: ["--disable-dev-shm-usage"],
+        profiles: {
+          "chrome-live": {
+            driver: "existing-session",
+            attachOnly: true,
+            color: "#00AA00",
+          },
+        },
+      },
+    });
+
+    const plan = buildChromeMcpLaunchPlanForTest("chrome-live");
+    expect(plan.mode).toBe("headless");
+    expect(plan.args).toEqual(
+      expect.arrayContaining([
+        "--headless",
+        "--userDataDir",
+        expect.stringContaining("/browser/chrome-live/user-data"),
+        "--executablePath",
+        "/usr/bin/google-chrome-stable",
+        "--chromeArg",
+        "--no-sandbox",
+        "--chromeArg",
+        "--disable-setuid-sandbox",
+        "--chromeArg",
+        "--disable-dev-shm-usage",
+      ]),
+    );
+  });
+
+  it("uses browserUrl for MCP profiles configured with an HTTP target", () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      browser: {
+        profiles: {
+          "chrome-live": {
+            driver: "existing-session",
+            attachOnly: true,
+            cdpUrl: "http://127.0.0.1:9222",
+            color: "#00AA00",
+          },
+        },
+      },
+    });
+
+    const plan = buildChromeMcpLaunchPlanForTest("chrome-live");
+    expect(plan.mode).toBe("browserUrl");
+    expect(plan.args).toEqual(expect.arrayContaining(["--browserUrl", "http://127.0.0.1:9222"]));
+  });
+
+  it("uses wsEndpoint for MCP profiles configured with a WebSocket target", () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      browser: {
+        profiles: {
+          "chrome-live": {
+            driver: "existing-session",
+            attachOnly: true,
+            cdpUrl: "ws://127.0.0.1:9222/devtools/browser/abc",
+            color: "#00AA00",
+          },
+        },
+      },
+    });
+
+    const plan = buildChromeMcpLaunchPlanForTest("chrome-live");
+    expect(plan.mode).toBe("browserUrl");
+    expect(plan.args).toEqual(
+      expect.arrayContaining(["--wsEndpoint", "ws://127.0.0.1:9222/devtools/browser/abc"]),
+    );
   });
 
   it("parses list_pages text responses when structuredContent is missing", async () => {

--- a/src/browser/chrome-mcp.test.ts
+++ b/src/browser/chrome-mcp.test.ts
@@ -174,7 +174,7 @@ describe("chrome MCP page parsing", () => {
     });
 
     const plan = buildChromeMcpLaunchPlanForTest("chrome-live");
-    expect(plan.mode).toBe("browserUrl");
+    expect(plan.mode).toBe("wsEndpoint");
     expect(plan.args).toEqual(
       expect.arrayContaining(["--wsEndpoint", "ws://127.0.0.1:9222/devtools/browser/abc"]),
     );

--- a/src/browser/chrome-mcp.ts
+++ b/src/browser/chrome-mcp.ts
@@ -4,8 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { loadConfig } from "../config/config.js";
 import type { ChromeMcpSnapshotNode } from "./chrome-mcp.snapshot.js";
+import { resolveOpenClawUserDataDir } from "./chrome.js";
 import type { BrowserTab } from "./client.js";
+import { resolveBrowserConfig, resolveProfile } from "./config.js";
 import { BrowserProfileUnavailableError, BrowserTabNotFoundError } from "./errors.js";
 
 type ChromeMcpStructuredPage = {
@@ -32,7 +35,6 @@ const DEFAULT_CHROME_MCP_COMMAND = "npx";
 const DEFAULT_CHROME_MCP_ARGS = [
   "-y",
   "chrome-devtools-mcp@latest",
-  "--autoConnect",
   // Direct chrome-devtools-mcp launches do not enable structuredContent by default.
   "--experimentalStructuredContent",
   "--experimental-page-id-routing",
@@ -41,6 +43,50 @@ const DEFAULT_CHROME_MCP_ARGS = [
 const sessions = new Map<string, ChromeMcpSession>();
 const pendingSessions = new Map<string, Promise<ChromeMcpSession>>();
 let sessionFactory: ChromeMcpSessionFactory | null = null;
+
+type ChromeMcpLaunchPlan = {
+  args: string[];
+  mode: "autoConnect" | "browserUrl" | "headless";
+};
+
+function buildChromeMcpLaunchPlan(profileName: string): ChromeMcpLaunchPlan {
+  const cfg = loadConfig();
+  const resolved = resolveBrowserConfig(cfg.browser, cfg);
+  const profile = resolveProfile(resolved, profileName);
+  if (!profile || profile.driver !== "existing-session") {
+    throw new BrowserProfileUnavailableError(
+      `Chrome MCP profile "${profileName}" is missing or is not driver=existing-session.`,
+    );
+  }
+
+  const args = [...DEFAULT_CHROME_MCP_ARGS];
+  if (profile.mcpTargetUrl) {
+    const parsed = new URL(profile.mcpTargetUrl);
+    args.push(
+      parsed.protocol === "ws:" || parsed.protocol === "wss:" ? "--wsEndpoint" : "--browserUrl",
+      profile.mcpTargetUrl,
+    );
+    return { args, mode: "browserUrl" };
+  }
+
+  if (!resolved.headless) {
+    args.push("--autoConnect");
+    return { args, mode: "autoConnect" };
+  }
+
+  args.push("--headless");
+  args.push("--userDataDir", resolveOpenClawUserDataDir(profile.name));
+  if (resolved.executablePath) {
+    args.push("--executablePath", resolved.executablePath);
+  }
+  if (resolved.noSandbox) {
+    args.push("--chromeArg", "--no-sandbox", "--chromeArg", "--disable-setuid-sandbox");
+  }
+  for (const arg of resolved.extraArgs) {
+    args.push("--chromeArg", arg);
+  }
+  return { args, mode: "headless" };
+}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -169,9 +215,10 @@ function extractJsonMessage(result: ChromeMcpToolResult): unknown {
 }
 
 async function createRealSession(profileName: string): Promise<ChromeMcpSession> {
+  const launchPlan = buildChromeMcpLaunchPlan(profileName);
   const transport = new StdioClientTransport({
     command: DEFAULT_CHROME_MCP_COMMAND,
-    args: DEFAULT_CHROME_MCP_ARGS,
+    args: launchPlan.args,
     stderr: "pipe",
   });
   const client = new Client(
@@ -191,9 +238,15 @@ async function createRealSession(profileName: string): Promise<ChromeMcpSession>
       }
     } catch (err) {
       await client.close().catch(() => {});
+      const hint =
+        launchPlan.mode === "autoConnect"
+          ? "Make sure Chrome is running, enable chrome://inspect/#remote-debugging, and approve the connection."
+          : launchPlan.mode === "browserUrl"
+            ? "Make sure the configured browserUrl/wsEndpoint is reachable and Chrome is running with remote debugging enabled."
+            : "Make sure a Chrome executable is available, and use browser.noSandbox=true on Linux containers/root setups when needed.";
       throw new BrowserProfileUnavailableError(
         `Chrome MCP existing-session attach failed for profile "${profileName}". ` +
-          `Make sure Chrome is running, enable chrome://inspect/#remote-debugging, and approve the connection. ` +
+          `${hint} ` +
           `Details: ${String(err)}`,
       );
     }
@@ -529,6 +582,10 @@ export async function waitForChromeMcpText(params: {
     text: params.text,
     ...(typeof params.timeoutMs === "number" ? { timeout: params.timeoutMs } : {}),
   });
+}
+
+export function buildChromeMcpLaunchPlanForTest(profileName: string): ChromeMcpLaunchPlan {
+  return buildChromeMcpLaunchPlan(profileName);
 }
 
 export function setChromeMcpSessionFactoryForTest(factory: ChromeMcpSessionFactory | null): void {

--- a/src/browser/chrome-mcp.ts
+++ b/src/browser/chrome-mcp.ts
@@ -46,7 +46,7 @@ let sessionFactory: ChromeMcpSessionFactory | null = null;
 
 type ChromeMcpLaunchPlan = {
   args: string[];
-  mode: "autoConnect" | "browserUrl" | "headless";
+  mode: "autoConnect" | "browserUrl" | "wsEndpoint" | "headless";
 };
 
 function buildChromeMcpLaunchPlan(profileName: string): ChromeMcpLaunchPlan {
@@ -62,10 +62,11 @@ function buildChromeMcpLaunchPlan(profileName: string): ChromeMcpLaunchPlan {
   const args = [...DEFAULT_CHROME_MCP_ARGS];
   if (profile.mcpTargetUrl) {
     const parsed = new URL(profile.mcpTargetUrl);
-    args.push(
-      parsed.protocol === "ws:" || parsed.protocol === "wss:" ? "--wsEndpoint" : "--browserUrl",
-      profile.mcpTargetUrl,
-    );
+    if (parsed.protocol === "ws:" || parsed.protocol === "wss:") {
+      args.push("--wsEndpoint", profile.mcpTargetUrl);
+      return { args, mode: "wsEndpoint" };
+    }
+    args.push("--browserUrl", profile.mcpTargetUrl);
     return { args, mode: "browserUrl" };
   }
 
@@ -241,7 +242,7 @@ async function createRealSession(profileName: string): Promise<ChromeMcpSession>
       const hint =
         launchPlan.mode === "autoConnect"
           ? "Make sure Chrome is running, enable chrome://inspect/#remote-debugging, and approve the connection."
-          : launchPlan.mode === "browserUrl"
+          : launchPlan.mode === "browserUrl" || launchPlan.mode === "wsEndpoint"
             ? "Make sure the configured browserUrl/wsEndpoint is reachable and Chrome is running with remote debugging enabled."
             : "Make sure a Chrome executable is available, and use browser.noSandbox=true on Linux containers/root setups when needed.";
       throw new BrowserProfileUnavailableError(

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -26,6 +26,7 @@ describe("browser config", () => {
     expect(user?.driver).toBe("existing-session");
     expect(user?.cdpPort).toBe(0);
     expect(user?.cdpUrl).toBe("");
+    expect(user?.mcpTargetUrl).toBeUndefined();
     const chromeRelay = resolveProfile(resolved, "chrome-relay");
     expect(chromeRelay?.driver).toBe("extension");
     expect(chromeRelay?.cdpPort).toBe(18792);
@@ -119,6 +120,24 @@ describe("browser config", () => {
     expect(profile?.cdpPort).toBe(9222);
     expect(profile?.cdpUrl).toBe("http://example.com:9222");
     expect(profile?.cdpIsLoopback).toBe(false);
+  });
+
+  it("supports MCP browser URLs for existing-session profiles", () => {
+    const resolved = resolveBrowserConfig({
+      profiles: {
+        user: {
+          driver: "existing-session",
+          cdpUrl: "http://127.0.0.1:9222",
+          color: "#00AA00",
+        },
+      },
+    });
+
+    const profile = resolveProfile(resolved, "user");
+    expect(profile?.driver).toBe("existing-session");
+    expect(profile?.cdpUrl).toBe("");
+    expect(profile?.mcpTargetUrl).toBe("http://127.0.0.1:9222");
+    expect(profile?.cdpIsLoopback).toBe(true);
   });
 
   it("uses profile cdpUrl when provided", () => {

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -45,6 +45,7 @@ export type ResolvedBrowserProfile = {
   cdpUrl: string;
   cdpHost: string;
   cdpIsLoopback: boolean;
+  mcpTargetUrl?: string;
   color: string;
   driver: "openclaw" | "extension" | "existing-session";
   attachOnly: boolean;
@@ -363,13 +364,18 @@ export function resolveProfile(
         : "openclaw";
 
   if (driver === "existing-session") {
-    // existing-session uses Chrome MCP auto-connect; no CDP port/URL needed
+    const parsed = rawProfileUrl
+      ? parseHttpUrl(rawProfileUrl, `browser.profiles.${profileName}.cdpUrl`)
+      : null;
+    // existing-session uses Chrome MCP. It can either auto-connect to a local desktop
+    // session or connect to a debuggable browser URL/WS endpoint when explicitly configured.
     return {
       name: profileName,
       cdpPort: 0,
       cdpUrl: "",
-      cdpHost: "",
-      cdpIsLoopback: true,
+      cdpHost: parsed?.parsed.hostname ?? "",
+      cdpIsLoopback: parsed ? isLoopbackHost(parsed.parsed.hostname) : true,
+      ...(parsed ? { mcpTargetUrl: parsed.normalized } : {}),
       color: profile.color,
       driver,
       attachOnly: true,

--- a/src/browser/profile-capabilities.ts
+++ b/src/browser/profile-capabilities.ts
@@ -41,7 +41,7 @@ export function getBrowserProfileCapabilities(
   if (profile.driver === "existing-session") {
     return {
       mode: "local-existing-session",
-      isRemote: false,
+      isRemote: !profile.cdpIsLoopback,
       usesChromeMcp: true,
       requiresRelay: false,
       requiresAttachedTab: false,

--- a/src/browser/profiles-service.test.ts
+++ b/src/browser/profiles-service.test.ts
@@ -201,20 +201,27 @@ describe("BrowserProfilesService", () => {
     );
   });
 
-  it("rejects driver=existing-session when cdpUrl is provided", async () => {
+  it("allows driver=existing-session when cdpUrl is provided as an MCP target", async () => {
     const resolved = resolveBrowserConfig({});
-    const { ctx } = createCtx(resolved);
+    const { ctx, state } = createCtx(resolved);
     vi.mocked(loadConfig).mockReturnValue({ browser: { profiles: {} } });
 
     const service = createBrowserProfilesService(ctx);
+    const result = await service.createProfile({
+      name: "chrome-live",
+      driver: "existing-session",
+      cdpUrl: "http://127.0.0.1:9222",
+    });
 
-    await expect(
-      service.createProfile({
-        name: "chrome-live",
-        driver: "existing-session",
-        cdpUrl: "http://127.0.0.1:9222",
-      }),
-    ).rejects.toThrow(/does not accept cdpUrl/i);
+    expect(result.transport).toBe("chrome-mcp");
+    expect(result.cdpUrl).toBeNull();
+    expect(result.isRemote).toBe(false);
+    expect(state.resolved.profiles["chrome-live"]).toEqual({
+      cdpUrl: "http://127.0.0.1:9222",
+      driver: "existing-session",
+      attachOnly: true,
+      color: expect.any(String),
+    });
   });
 
   it("deletes remote profiles without stopping or removing local data", async () => {

--- a/src/browser/profiles-service.ts
+++ b/src/browser/profiles-service.ts
@@ -130,15 +130,19 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
         }
       }
       if (driver === "existing-session") {
-        throw new BrowserValidationError(
-          "driver=existing-session does not accept cdpUrl; it attaches via the Chrome MCP auto-connect flow",
-        );
+        profileConfig = {
+          cdpUrl: parsed.normalized,
+          driver,
+          attachOnly: true,
+          color: profileColor,
+        };
+      } else {
+        profileConfig = {
+          cdpUrl: parsed.normalized,
+          ...(driver ? { driver } : {}),
+          color: profileColor,
+        };
       }
-      profileConfig = {
-        cdpUrl: parsed.normalized,
-        ...(driver ? { driver } : {}),
-        color: profileColor,
-      };
     } else {
       if (driver === "extension") {
         throw new BrowserValidationError("driver=extension requires an explicit loopback cdpUrl");

--- a/src/browser/pw-tools-core.clamps-timeoutms-scrollintoview.test.ts
+++ b/src/browser/pw-tools-core.clamps-timeoutms-scrollintoview.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   installPwToolsCoreTestHooks,
+  getPwToolsCoreSessionMocks,
   setPwToolsCoreCurrentPage,
   setPwToolsCoreCurrentRefLocator,
 } from "./pw-tools-core.test-harness.js";
@@ -91,5 +92,25 @@ describe("pw-tools-core", () => {
         ref: "1",
       }),
     ).rejects.toThrow(/not interactable/i);
+  });
+
+  it("keeps Playwright strictness for selector-based actions", async () => {
+    const click = vi.fn(async () => {});
+    const first = vi.fn(() => {
+      throw new Error("selector actions should not call locator.first()");
+    });
+    const locator = vi.fn(() => ({ click, first }));
+    setPwToolsCoreCurrentPage({ locator });
+
+    await mod.clickViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      selector: "button.submit",
+    });
+
+    expect(locator).toHaveBeenCalledWith("button.submit");
+    expect(first).not.toHaveBeenCalled();
+    expect(getPwToolsCoreSessionMocks().refLocator).not.toHaveBeenCalled();
+    expect(click).toHaveBeenCalled();
   });
 });

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -43,6 +43,24 @@ async function getRestoredPageForTarget(opts: TargetOpts) {
   return page;
 }
 
+function resolveLocatorForInteraction(
+  page: Awaited<ReturnType<typeof getRestoredPageForTarget>>,
+  params: { ref?: string; selector?: string },
+) {
+  const resolved = requireRefOrSelector(params.ref, params.selector);
+  if (resolved.ref) {
+    return {
+      locator: refLocator(page, resolved.ref),
+      label: resolved.ref,
+    };
+  }
+  const selector = resolved.selector!;
+  return {
+    locator: page.locator(selector).first(),
+    label: selector,
+  };
+}
+
 function resolveInteractionTimeoutMs(timeoutMs?: number): number {
   return Math.max(500, Math.min(60_000, Math.floor(timeoutMs ?? 8000)));
 }
@@ -88,12 +106,8 @@ export async function clickViaPlaywright(opts: {
   delayMs?: number;
   timeoutMs?: number;
 }): Promise<void> {
-  const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
+  const { locator, label } = resolveLocatorForInteraction(page, opts);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   try {
     const delayMs = resolveBoundedDelayMs(opts.delayMs, "click delayMs", MAX_CLICK_DELAY_MS);
@@ -106,12 +120,14 @@ export async function clickViaPlaywright(opts: {
         timeout,
         button: opts.button,
         modifiers: opts.modifiers,
+        delay: opts.delayMs,
       });
     } else {
       await locator.click({
         timeout,
         button: opts.button,
         modifiers: opts.modifiers,
+        delay: opts.delayMs,
       });
     }
   } catch (err) {
@@ -126,12 +142,8 @@ export async function hoverViaPlaywright(opts: {
   selector?: string;
   timeoutMs?: number;
 }): Promise<void> {
-  const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
+  const { locator, label } = resolveLocatorForInteraction(page, opts);
   try {
     await locator.hover({
       timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
@@ -150,23 +162,21 @@ export async function dragViaPlaywright(opts: {
   endSelector?: string;
   timeoutMs?: number;
 }): Promise<void> {
-  const resolvedStart = requireRefOrSelector(opts.startRef, opts.startSelector);
-  const resolvedEnd = requireRefOrSelector(opts.endRef, opts.endSelector);
   const page = await getRestoredPageForTarget(opts);
-  const startLocator = resolvedStart.ref
-    ? refLocator(page, requireRef(resolvedStart.ref))
-    : page.locator(resolvedStart.selector!);
-  const endLocator = resolvedEnd.ref
-    ? refLocator(page, requireRef(resolvedEnd.ref))
-    : page.locator(resolvedEnd.selector!);
-  const startLabel = resolvedStart.ref ?? resolvedStart.selector!;
-  const endLabel = resolvedEnd.ref ?? resolvedEnd.selector!;
+  const from = resolveLocatorForInteraction(page, {
+    ref: opts.startRef,
+    selector: opts.startSelector,
+  });
+  const to = resolveLocatorForInteraction(page, {
+    ref: opts.endRef,
+    selector: opts.endSelector,
+  });
   try {
-    await startLocator.dragTo(endLocator, {
+    await from.locator.dragTo(to.locator, {
       timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
     });
   } catch (err) {
-    throw toAIFriendlyError(err, `${startLabel} -> ${endLabel}`);
+    throw toAIFriendlyError(err, `${from.label} -> ${to.label}`);
   }
 }
 
@@ -178,15 +188,11 @@ export async function selectOptionViaPlaywright(opts: {
   values: string[];
   timeoutMs?: number;
 }): Promise<void> {
-  const resolved = requireRefOrSelector(opts.ref, opts.selector);
   if (!opts.values?.length) {
     throw new Error("values are required");
   }
   const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
+  const { locator, label } = resolveLocatorForInteraction(page, opts);
   try {
     await locator.selectOption(opts.values, {
       timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
@@ -223,13 +229,9 @@ export async function typeViaPlaywright(opts: {
   slowly?: boolean;
   timeoutMs?: number;
 }): Promise<void> {
-  const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const text = String(opts.text ?? "");
   const page = await getRestoredPageForTarget(opts);
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
+  const { locator, label } = resolveLocatorForInteraction(page, opts);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   try {
     if (opts.slowly) {
@@ -423,14 +425,9 @@ export async function scrollIntoViewViaPlaywright(opts: {
   selector?: string;
   timeoutMs?: number;
 }): Promise<void> {
-  const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
-
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
+  const { locator, label } = resolveLocatorForInteraction(page, opts);
   try {
     await locator.scrollIntoViewIfNeeded({ timeout });
   } catch (err) {

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -56,7 +56,7 @@ function resolveLocatorForInteraction(
   }
   const selector = resolved.selector!;
   return {
-    locator: page.locator(selector).first(),
+    locator: page.locator(selector),
     label: selector,
   };
 }

--- a/src/browser/resolved-config-refresh.ts
+++ b/src/browser/resolved-config-refresh.ts
@@ -7,6 +7,9 @@ function changedProfileInvariants(
   next: ResolvedBrowserProfile,
 ): string[] {
   const changed: string[] = [];
+  if (current.mcpTargetUrl !== next.mcpTargetUrl) {
+    changed.push("mcpTargetUrl");
+  }
   if (current.cdpUrl !== next.cdpUrl) {
     changed.push("cdpUrl");
   }

--- a/src/browser/server-context.headless-default-profile.test.ts
+++ b/src/browser/server-context.headless-default-profile.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { createBrowserRouteContext } from "./server-context.js";
+import type { BrowserServerState } from "./server-context.js";
+
+function makeState(defaultProfile: string): BrowserServerState {
+  return {
+    server: null,
+    port: 0,
+    resolved: {
+      enabled: true,
+      evaluateEnabled: true,
+      controlPort: 18791,
+      cdpPortRangeStart: 18800,
+      cdpPortRangeEnd: 18899,
+      cdpProtocol: "http",
+      cdpHost: "127.0.0.1",
+      cdpIsLoopback: true,
+      remoteCdpTimeoutMs: 1500,
+      remoteCdpHandshakeTimeoutMs: 3000,
+      color: "#FF4500",
+      headless: true,
+      noSandbox: true,
+      attachOnly: false,
+      defaultProfile,
+      profiles: {
+        openclaw: {
+          cdpPort: 18800,
+          color: "#FF4500",
+        },
+        user: {
+          driver: "existing-session",
+          attachOnly: true,
+          color: "#00AA00",
+        },
+        "chrome-relay": {
+          driver: "extension",
+          cdpUrl: "http://127.0.0.1:18792",
+          color: "#00AA00",
+        },
+      },
+      extraArgs: [],
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
+    },
+    profiles: new Map(),
+  };
+}
+
+describe("browser server-context headless implicit default profile", () => {
+  it("falls back from extension relay to openclaw when no profile is specified", () => {
+    const ctx = createBrowserRouteContext({
+      getState: () => makeState("chrome-relay"),
+    });
+
+    expect(ctx.forProfile().profile.name).toBe("openclaw");
+  });
+
+  it("falls back from existing-session to openclaw when no profile is specified", () => {
+    const ctx = createBrowserRouteContext({
+      getState: () => makeState("user"),
+    });
+
+    expect(ctx.forProfile().profile.name).toBe("openclaw");
+  });
+
+  it("keeps explicit interactive profile requests unchanged in headless mode", () => {
+    const ctx = createBrowserRouteContext({
+      getState: () => makeState("chrome-relay"),
+    });
+
+    expect(ctx.forProfile("chrome-relay").profile.name).toBe("chrome-relay");
+    expect(ctx.forProfile("user").profile.name).toBe("user");
+  });
+});

--- a/src/browser/server-context.headless-default-profile.test.ts
+++ b/src/browser/server-context.headless-default-profile.test.ts
@@ -54,12 +54,12 @@ describe("browser server-context headless implicit default profile", () => {
     expect(ctx.forProfile().profile.name).toBe("openclaw");
   });
 
-  it("falls back from existing-session to openclaw when no profile is specified", () => {
+  it("keeps existing-session as the implicit default in headless mode", () => {
     const ctx = createBrowserRouteContext({
       getState: () => makeState("user"),
     });
 
-    expect(ctx.forProfile().profile.name).toBe("openclaw");
+    expect(ctx.forProfile().profile.name).toBe("user");
   });
 
   it("keeps explicit interactive profile requests unchanged in headless mode", () => {

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -6,7 +6,16 @@ import {
 } from "./resolved-config-refresh.js";
 import type { BrowserServerState } from "./server-context.types.js";
 
-let cfgProfiles: Record<string, { cdpPort?: number; cdpUrl?: string; color?: string }> = {};
+let cfgProfiles: Record<
+  string,
+  {
+    cdpPort?: number;
+    cdpUrl?: string;
+    color?: string;
+    driver?: "openclaw" | "existing-session";
+    attachOnly?: boolean;
+  }
+> = {};
 
 // Simulate module-level cache behavior
 let cachedConfig: ReturnType<typeof buildConfig> | null = null;
@@ -205,5 +214,60 @@ describe("server-context hot-reload profiles", () => {
     expect(runtime?.profile.cdpPort).toBe(19999);
     expect(runtime?.lastTargetId).toBeNull();
     expect(runtime?.reconcile?.reason).toContain("cdpPort");
+  });
+
+  it("marks existing-session runtime state for reconcile when MCP target URL changes", async () => {
+    cfgProfiles = {
+      user: {
+        cdpUrl: "http://127.0.0.1:9222",
+        color: "#00AA00",
+        driver: "existing-session",
+        attachOnly: true,
+      },
+    };
+    cachedConfig = null;
+
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig({ ...cfg.browser, defaultProfile: "user" }, cfg);
+    const userProfile = resolveProfile(resolved, "user");
+    expect(userProfile).toBeTruthy();
+    expect(userProfile?.mcpTargetUrl).toBe("http://127.0.0.1:9222");
+
+    const state: BrowserServerState = {
+      server: null,
+      port: 18791,
+      resolved,
+      profiles: new Map([
+        [
+          "user",
+          {
+            profile: userProfile!,
+            running: { pid: 123 } as never,
+            lastTargetId: "tab-1",
+            reconcile: null,
+          },
+        ],
+      ]),
+    };
+
+    cfgProfiles.user = {
+      cdpUrl: "http://127.0.0.1:9333",
+      color: "#00AA00",
+      driver: "existing-session",
+      attachOnly: true,
+    };
+    cachedConfig = null;
+
+    refreshResolvedBrowserConfigFromDisk({
+      current: state,
+      refreshConfigFromDisk: true,
+      mode: "cached",
+    });
+
+    const runtime = state.profiles.get("user");
+    expect(runtime).toBeTruthy();
+    expect(runtime?.profile.mcpTargetUrl).toBe("http://127.0.0.1:9333");
+    expect(runtime?.lastTargetId).toBeNull();
+    expect(runtime?.reconcile?.reason).toContain("mcpTargetUrl");
   });
 });

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -2,6 +2,7 @@ import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import { isChromeReachable, resolveOpenClawUserDataDir } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { resolveProfile } from "./config.js";
+import { DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME } from "./constants.js";
 import { BrowserProfileNotFoundError, toBrowserErrorResponse } from "./errors.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import { getBrowserProfileCapabilities } from "./profile-capabilities.js";
@@ -38,6 +39,35 @@ export function listKnownProfileNames(state: BrowserServerState): string[] {
     names.add(name);
   }
   return [...names];
+}
+
+function resolveImplicitProfileName(state: BrowserServerState): string {
+  const defaultProfileName = state.resolved.defaultProfile;
+  if (!state.resolved.headless) {
+    return defaultProfileName;
+  }
+
+  const defaultProfile = resolveProfile(state.resolved, defaultProfileName);
+  if (!defaultProfile) {
+    return defaultProfileName;
+  }
+
+  const capabilities = getBrowserProfileCapabilities(defaultProfile);
+  if (!capabilities.requiresRelay && !capabilities.usesChromeMcp) {
+    return defaultProfileName;
+  }
+
+  const managedProfile = resolveProfile(state.resolved, DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME);
+  if (!managedProfile) {
+    return defaultProfileName;
+  }
+
+  const managedCapabilities = getBrowserProfileCapabilities(managedProfile);
+  if (managedCapabilities.requiresRelay || managedCapabilities.usesChromeMcp) {
+    return defaultProfileName;
+  }
+
+  return managedProfile.name;
 }
 
 /**
@@ -129,7 +159,7 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
 
   const forProfile = (profileName?: string): ProfileContext => {
     const current = state();
-    const name = profileName ?? current.resolved.defaultProfile;
+    const name = profileName ?? resolveImplicitProfileName(current);
     const profile = resolveBrowserProfileWithHotReload({
       current,
       refreshConfigFromDisk,

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -53,7 +53,7 @@ function resolveImplicitProfileName(state: BrowserServerState): string {
   }
 
   const capabilities = getBrowserProfileCapabilities(defaultProfile);
-  if (!capabilities.requiresRelay && !capabilities.usesChromeMcp) {
+  if (!capabilities.requiresRelay) {
     return defaultProfileName;
   }
 
@@ -63,7 +63,7 @@ function resolveImplicitProfileName(state: BrowserServerState): string {
   }
 
   const managedCapabilities = getBrowserProfileCapabilities(managedProfile);
-  if (managedCapabilities.requiresRelay || managedCapabilities.usesChromeMcp) {
+  if (managedCapabilities.requiresRelay) {
     return defaultProfileName;
   }
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -257,7 +257,7 @@ export const FIELD_HELP: Record<string, string> = {
   "browser.profiles.*.cdpPort":
     "Per-profile local CDP port used when connecting to browser instances by port instead of URL. Use unique ports per profile to avoid connection collisions.",
   "browser.profiles.*.cdpUrl":
-    "Per-profile CDP websocket URL used for explicit remote browser routing by profile name. Use this when profile connections terminate on remote hosts or tunnels.",
+    "Per-profile browser endpoint URL. For openclaw/extension drivers this is the CDP URL; for existing-session it is passed to Chrome DevTools MCP as browserUrl/wsEndpoint so headless or remote MCP attach can target a running debuggable browser.",
   "browser.profiles.*.driver":
     'Per-profile browser driver mode: "openclaw" (or legacy "clawd") or "extension" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.',
   "browser.profiles.*.attachOnly":

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -1,7 +1,7 @@
 export type BrowserProfileConfig = {
   /** CDP port for this profile. Allocated once at creation, persisted permanently. */
   cdpPort?: number;
-  /** CDP URL for this profile (use for remote Chrome). */
+  /** CDP URL for this profile (use for remote Chrome, or as browserUrl/wsEndpoint for existing-session MCP attach). */
   cdpUrl?: string;
   /** Profile driver (default: openclaw). */
   driver?: "openclaw" | "clawd" | "extension" | "existing-session";


### PR DESCRIPTION
## Summary

- Problem: OpenClaw's `existing-session` browser driver was hardwired to Chrome DevTools MCP `--autoConnect`, which requires a live desktop Chrome session and user approval.
- Why it matters: Linux/VPS deployments could not use MCP-backed browser control, even though upstream `chrome-devtools-mcp` supports headless launch plus `--browserUrl` / `--wsEndpoint` attach.
- What changed: `existing-session` now supports three MCP modes: desktop `--autoConnect`, headless MCP-managed Chrome launch, and explicit MCP attach to `browserUrl` / `wsEndpoint` via profile `cdpUrl`.
- What did NOT change (scope boundary): the extension relay is still desktop/interactive; existing-session still does not have full feature parity for every browser action route.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `driver="existing-session"` can now work on Linux/VPS in headless mode.
- In headless mode, existing-session no longer falls back away from MCP; only extension-relay defaults are redirected to `openclaw`.
- `browser.profiles.<name>.cdpUrl` is now accepted for existing-session profiles and is interpreted as an MCP `browserUrl` or `wsEndpoint` target.
- Docs now describe both desktop auto-connect and headless/Linux MCP flows.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - Existing-session can now launch Chrome through MCP in headless environments or attach MCP to explicit browser URLs. This is still the same browser tool trust boundary; mitigation is explicit profile selection, existing browser config, and keeping headless server profiles isolated from personal browser state.

## Repro + Verification

### Environment

- OS: macOS host for development; implementation targets Linux/VPS/headless MCP paths
- Runtime/container: Node 22 workspace
- Model/provider: N/A
- Integration/channel (if any): browser tool / browser control server / Chrome DevTools MCP
- Relevant config (redacted): `browser.headless=true`, `browser.noSandbox=true`, optional existing-session `cdpUrl`

### Steps

1. Configure an `existing-session` profile and enable `browser.headless=true`.
2. Either omit profile `cdpUrl` to let MCP launch headless Chrome, or set `browser.profiles.<name>.cdpUrl` to `http://127.0.0.1:9222` or a devtools browser WS endpoint.
3. Start/status/tabs against that profile.

### Expected

- Existing-session uses MCP in headless mode instead of requiring desktop `--autoConnect`.
- HTTP target URLs map to MCP `--browserUrl` and WS targets map to `--wsEndpoint`.

### Actual

- Before this change, existing-session always used `--autoConnect` and therefore required a local interactive Chrome session.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused Vitest coverage for headless MCP launch plans, browserUrl/wsEndpoint attach plans, existing-session profile resolution, profile creation, and headless default-profile routing.
- Edge cases checked: extension-relay still falls back away from headless implicit default, existing-session no longer does; loopback MCP targets; desktop autoConnect behavior remains available.
- What you did **not** verify: full repo `pnpm check` is still blocked by pre-existing unrelated TypeScript errors in `src/browser/pw-ai.ts` and `src/browser/routes/agent.act.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: keep using `profile="openclaw"` or revert this PR.
- Files/config to restore: `src/browser/chrome-mcp.ts`, `src/browser/config.ts`, `src/browser/profiles-service.ts`
- Known bad symptoms reviewers should watch for: headless existing-session profiles unexpectedly trying desktop `--autoConnect`, or MCP target URLs not mapping to browserUrl/wsEndpoint.

## Risks and Mitigations

- Risk: existing-session semantics are broader now, since they can launch headless Chrome via MCP as well as attach to a running browser URL.
  - Mitigation: desktop autoConnect behavior remains the default when not headless and no explicit target URL is configured; docs/help were updated to make the distinction explicit.
- Risk: reviewers may assume existing-session now has total feature parity with the managed browser.
  - Mitigation: PR scope and docs explicitly call out that some action routes still remain unsupported for existing-session.
