### PR TITLE
feat(discord): add explicit agentId binding to Discord accounts

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -301,6 +301,11 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       await getDiscordRuntime().channel.discord.sendMessageDiscord(`user:${id}`, message);
     },
   }),
+  config: {
+    describeAccount: (account: ResolvedDiscordAccount) => ({
+      agentId: account.config.agentId,
+    }),
+  },
   allowlist: {
     ...buildLegacyDmAccountAllowlistAdapter({
       channelId: "discord",

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -301,11 +301,6 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       await getDiscordRuntime().channel.discord.sendMessageDiscord(`user:${id}`, message);
     },
   }),
-  config: {
-    describeAccount: (account: ResolvedDiscordAccount) => ({
-      agentId: account.config.agentId,
-    }),
-  },
   allowlist: {
     ...buildLegacyDmAccountAllowlistAdapter({
       channelId: "discord",

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -1,5 +1,6 @@
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { createChannelPluginBase } from "openclaw/plugin-sdk/core";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import {
   listDiscordAccountIds,
@@ -75,6 +76,9 @@ export function createDiscordPluginBase(params: {
       describeAccount: (account) => ({
         accountId: account.accountId,
         name: account.name,
+        agentId: account.config.agentId
+          ? normalizeAgentId(account.config.agentId)
+          : undefined,
         enabled: account.enabled,
         configured: Boolean(account.token?.trim()),
         tokenSource: account.tokenSource,

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -138,6 +138,7 @@ export type ChannelMeta = {
 export type ChannelAccountSnapshot = {
   accountId: string;
   name?: string;
+  agentId?: string;
   enabled?: boolean;
   configured?: boolean;
   linked?: boolean;

--- a/src/config/bindings.test.ts
+++ b/src/config/bindings.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it, vi } from "vitest";
+import { listRouteBindings, synthesizeDiscordAccountBindings } from "./bindings.js";
+import type { OpenClawConfig } from "./config.js";
+import type { AgentRouteBinding } from "./types.agents.js";
+
+vi.mock("../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+function makeConfig(overrides: Partial<OpenClawConfig> = {}): OpenClawConfig {
+  return {
+    agents: { list: [{ id: "main" }] },
+    ...overrides,
+  } as OpenClawConfig;
+}
+
+describe("synthesizeDiscordAccountBindings", () => {
+  it("creates a binding for an account with a valid agentId", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          accounts: {
+            theodore: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toEqual([
+      { agentId: "theodore", match: { channel: "discord", accountId: "theodore" } },
+    ]);
+  });
+
+  it("skips accounts with an agentId not in agents.list (fail-secure)", async () => {
+    const { logWarn } = await import("../logger.js");
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }] },
+      channels: {
+        discord: {
+          accounts: {
+            rogue: { agentId: "nonexistent" },
+          },
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toEqual([]);
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("does not exist in agents.list"));
+  });
+
+  it("skips accounts without agentId (backward compatible)", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          accounts: {
+            default: {},
+            theodore: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].match.accountId).toBe("theodore");
+  });
+
+  it("synthesizes bindings for multiple accounts simultaneously", () => {
+    const cfg = makeConfig({
+      agents: {
+        list: [
+          { id: "main" },
+          { id: "theodore" },
+          { id: "gordon" },
+          { id: "wanda" },
+          { id: "gerald" },
+          { id: "sandy" },
+        ],
+      },
+      channels: {
+        discord: {
+          accounts: {
+            theodore: { agentId: "theodore" },
+            gordon: { agentId: "gordon" },
+            wanda: { agentId: "wanda" },
+            gerald: { agentId: "gerald" },
+            sandy: { agentId: "sandy" },
+          },
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toHaveLength(5);
+    const accountIds = result.map((b) => b.match.accountId);
+    expect(accountIds).toContain("theodore");
+    expect(accountIds).toContain("gordon");
+    expect(accountIds).toContain("wanda");
+    expect(accountIds).toContain("gerald");
+    expect(accountIds).toContain("sandy");
+  });
+
+  it("explicit bindings take precedence over synthesized ones", async () => {
+    const { logWarn } = await import("../logger.js");
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          accounts: {
+            theodore: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const explicitBindings: AgentRouteBinding[] = [
+      { agentId: "main", match: { channel: "discord", accountId: "theodore" } },
+    ];
+    const result = synthesizeDiscordAccountBindings(cfg, explicitBindings);
+    expect(result).toEqual([]);
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("explicit binding takes precedence"),
+    );
+  });
+
+  it("matches agentId case-insensitively via normalizeAgentId", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "Theodore" }] },
+      channels: {
+        discord: {
+          accounts: {
+            theo: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe("theodore");
+  });
+
+  it("returns empty array when no discord accounts exist", () => {
+    const cfg = makeConfig({ agents: { list: [{ id: "main" }] } });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toEqual([]);
+  });
+
+  it("skips accounts with empty agentId after trim", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }] },
+      channels: {
+        discord: {
+          accounts: {
+            blank: { agentId: "   " },
+          },
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toEqual([]);
+  });
+
+  it("rejects all agentIds when agents.list is empty (fail-secure)", async () => {
+    const { logWarn } = await import("../logger.js");
+    const cfg = makeConfig({
+      agents: { list: [] },
+      channels: {
+        discord: {
+          accounts: {
+            rogue: { agentId: "rogue" },
+          },
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toEqual([]);
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("does not exist in agents.list"));
+  });
+
+  it("honors top-level agentId in single-account setups (no accounts map)", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          agentId: "theodore",
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toEqual([
+      { agentId: "theodore", match: { channel: "discord", accountId: "default" } },
+    ]);
+  });
+
+  it("account-level agentId overrides top-level agentId", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }, { id: "gordon" }] },
+      channels: {
+        discord: {
+          agentId: "theodore",
+          accounts: {
+            mybot: { agentId: "gordon" },
+          },
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe("gordon");
+    expect(result[0].match.accountId).toBe("mybot");
+  });
+
+  it("accounts without agentId inherit top-level agentId", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          agentId: "theodore",
+          accounts: {
+            mybot: {},
+          },
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe("theodore");
+    expect(result[0].match.accountId).toBe("mybot");
+  });
+
+  it("explicit empty agentId opts out of top-level agent", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          agentId: "theodore",
+          accounts: {
+            optout: { agentId: "" },
+            inherited: {},
+          },
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe("theodore");
+    expect(result[0].match.accountId).toBe("inherited");
+  });
+
+  it("ignores top-level agentId when no discord config exists", () => {
+    const cfg = makeConfig({ agents: { list: [{ id: "main" }] } });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toEqual([]);
+  });
+
+  it("recognizes explicit bindings with differently-cased channel and accountId", async () => {
+    const { logWarn } = await import("../logger.js");
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          accounts: {
+            theodore: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const explicitBindings: AgentRouteBinding[] = [
+      { agentId: "main", match: { channel: "Discord", accountId: "Theodore" } },
+    ];
+    const result = synthesizeDiscordAccountBindings(cfg, explicitBindings);
+    expect(result).toEqual([]);
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("explicit binding takes precedence"),
+    );
+  });
+
+  it("wildcard explicit binding suppresses all synthesized bindings", async () => {
+    const { logWarn } = await import("../logger.js");
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }, { id: "gordon" }] },
+      channels: {
+        discord: {
+          accounts: {
+            theodore: { agentId: "theodore" },
+            gordon: { agentId: "gordon" },
+          },
+        },
+      },
+    });
+    const explicitBindings: AgentRouteBinding[] = [
+      { agentId: "main", match: { channel: "discord", accountId: "*" } },
+    ];
+    const result = synthesizeDiscordAccountBindings(cfg, explicitBindings);
+    expect(result).toEqual([]);
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("explicit binding takes precedence"),
+    );
+  });
+
+  it("channel-only explicit binding (no accountId) only shadows default account", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          agentId: "theodore",
+          accounts: {
+            theodore: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const explicitBindings: AgentRouteBinding[] = [
+      { agentId: "main", match: { channel: "discord" } },
+    ];
+    const result = synthesizeDiscordAccountBindings(cfg, explicitBindings);
+    // The channel-only binding maps to "default" account in routing,
+    // so theodore's account binding is NOT suppressed.
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe("theodore");
+    expect(result[0].match.accountId).toBe("theodore");
+  });
+
+  it("scoped explicit binding (guildId) does not suppress synthesized bindings", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          accounts: {
+            theodore: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const explicitBindings: AgentRouteBinding[] = [
+      { agentId: "main", match: { channel: "discord", guildId: "12345" } },
+    ];
+    const result = synthesizeDiscordAccountBindings(cfg, explicitBindings);
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe("theodore");
+  });
+
+  it("scoped account binding (accountId + guildId) does not suppress synthesized binding", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          accounts: {
+            theodore: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const explicitBindings: AgentRouteBinding[] = [
+      {
+        agentId: "main",
+        match: { channel: "discord", accountId: "theodore", guildId: "12345" },
+      },
+    ];
+    const result = synthesizeDiscordAccountBindings(cfg, explicitBindings);
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe("theodore");
+  });
+
+  it("treats empty accounts map as implicit default account", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      channels: {
+        discord: {
+          agentId: "theodore",
+          accounts: {},
+        },
+      },
+    });
+    const result = synthesizeDiscordAccountBindings(cfg, []);
+    expect(result).toEqual([
+      { agentId: "theodore", match: { channel: "discord", accountId: "default" } },
+    ]);
+  });
+});
+
+describe("listRouteBindings", () => {
+  it("returns only explicit bindings without synthesized ones", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      bindings: [{ agentId: "main", match: { channel: "discord" } }],
+      channels: {
+        discord: {
+          accounts: {
+            theodore: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const result = listRouteBindings(cfg);
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe("main");
+  });
+});

--- a/src/config/bindings.test.ts
+++ b/src/config/bindings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { listRouteBindings, synthesizeDiscordAccountBindings } from "./bindings.js";
+import { listBindings } from "../routing/bindings.js";
 import type { OpenClawConfig } from "./config.js";
 import type { AgentRouteBinding } from "./types.agents.js";
 
@@ -394,5 +395,63 @@ describe("listRouteBindings", () => {
     const result = listRouteBindings(cfg);
     expect(result).toHaveLength(1);
     expect(result[0].agentId).toBe("main");
+  });
+});
+
+describe("listBindings", () => {
+  it("combines explicit and synthesized discord bindings", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      bindings: [{ agentId: "main", match: { channel: "discord" } }],
+      channels: {
+        discord: {
+          accounts: {
+            theodore: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const result = listBindings(cfg);
+    expect(result).toHaveLength(2);
+    expect(result.some((b) => b.agentId === "main")).toBe(true);
+    expect(
+      result.some((b) => b.agentId === "theodore" && b.match.accountId === "theodore"),
+    ).toBe(true);
+  });
+
+  it("returns only explicit bindings when no discord accounts have agentId", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }] },
+      bindings: [{ agentId: "main", match: { channel: "discord" } }],
+      channels: {
+        discord: {
+          accounts: {
+            default: {},
+          },
+        },
+      },
+    });
+    const result = listBindings(cfg);
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe("main");
+  });
+
+  it("does not duplicate when explicit binding already covers a synthesized account", () => {
+    const cfg = makeConfig({
+      agents: { list: [{ id: "main" }, { id: "theodore" }] },
+      bindings: [{ agentId: "main", match: { channel: "discord", accountId: "theodore" } }],
+      channels: {
+        discord: {
+          accounts: {
+            theodore: { agentId: "theodore" },
+          },
+        },
+      },
+    });
+    const result = listBindings(cfg);
+    // explicit binding wins, synthesized is suppressed
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe("main");
+    expect(result[0].match.accountId).toBe("theodore");
   });
 });

--- a/src/config/bindings.ts
+++ b/src/config/bindings.ts
@@ -1,3 +1,5 @@
+import { logWarn } from "../logger.js";
+import { normalizeAccountId, normalizeAgentId } from "../routing/session-key.js";
 import type { OpenClawConfig } from "./config.js";
 import type { AgentAcpBinding, AgentBinding, AgentRouteBinding } from "./types.agents.js";
 
@@ -17,6 +19,99 @@ export function isAcpBinding(binding: AgentBinding): binding is AgentAcpBinding 
 
 export function listConfiguredBindings(cfg: OpenClawConfig): AgentBinding[] {
   return Array.isArray(cfg.bindings) ? cfg.bindings : [];
+}
+
+/**
+ * Synthesize route bindings from Discord accounts that have an effective `agentId`.
+ * Each account with a valid `agentId` produces a route binding:
+ *   { match: { channel: "discord", accountId }, agentId }
+ *
+ * The effective `agentId` for an account is resolved as:
+ *   account-level `agentId` > top-level `channels.discord.agentId`
+ * This mirrors how `mergeDiscordAccountConfig` applies top-level Discord
+ * config as defaults for all accounts.
+ *
+ * In single-account setups (no `accounts` map), the implicit "default"
+ * account inherits the top-level `agentId`.
+ *
+ * Accounts referencing an `agentId` not present in `agents.list` are skipped
+ * with a warning (fail-secure: no binding created, default routing applies).
+ *
+ * Explicit bindings in `cfg.bindings` take precedence over synthesized ones.
+ * A warning is logged when a synthesized binding is shadowed by an explicit one.
+ */
+export function synthesizeDiscordAccountBindings(
+  cfg: OpenClawConfig,
+  explicitBindings: AgentRouteBinding[],
+): AgentRouteBinding[] {
+  const discordConfig = cfg.channels?.discord;
+  if (!discordConfig) {
+    return [];
+  }
+  const topLevelAgentId = discordConfig.agentId?.trim() || "";
+  const accounts = discordConfig.accounts;
+  // When no accounts map exists (or it's empty), the implicit "default" account
+  // inherits top-level config (including agentId). Build a synthetic entries list
+  // so the loop below handles both cases uniformly.
+  const hasAccounts = accounts && Object.keys(accounts).length > 0;
+  const accountEntries: [string, { agentId?: string } | undefined][] = hasAccounts
+    ? Object.entries(accounts)
+    : topLevelAgentId
+      ? [["default", undefined]]
+      : [];
+  if (accountEntries.length === 0) {
+    return [];
+  }
+  const agentIds = new Set(
+    (cfg.agents?.list ?? []).filter((a) => a.id?.trim()).map((a) => normalizeAgentId(a.id)),
+  );
+  const explicitDiscordBindings = explicitBindings.filter(
+    (b) => (b.match.channel ?? "").trim().toLowerCase() === "discord",
+  );
+  // Only accountId: "*" is a true wildcard covering all accounts.
+  // A missing accountId maps to DEFAULT_ACCOUNT_ID ("default") in routing,
+  // so it only shadows the default account — not all accounts.
+  const isUnscoped = (b: AgentRouteBinding): boolean => {
+    const m = b.match;
+    return !m.peer && !m.guildId && !m.teamId && (!m.roles || m.roles.length === 0);
+  };
+  const hasWildcardExplicit = explicitDiscordBindings.some(
+    (b) => b.match.accountId?.trim() === "*" && isUnscoped(b),
+  );
+  // Build the set of account IDs covered by unscoped explicit bindings.
+  // Bindings with no accountId target "default"; scoped bindings are excluded.
+  const explicitDiscordAccountIds = new Set(
+    explicitDiscordBindings
+      .filter((b) => b.match.accountId?.trim() !== "*" && isUnscoped(b))
+      .map((b) => normalizeAccountId(b.match.accountId)),
+  );
+  const bindings: AgentRouteBinding[] = [];
+  for (const [accountId, account] of accountEntries) {
+    // Effective agentId: account-level overrides top-level.
+    // An explicit empty agentId ("") opts out of the top-level agent.
+    const rawAgentId = account?.agentId !== undefined ? account.agentId.trim() : topLevelAgentId;
+    if (!rawAgentId) {
+      continue;
+    }
+    const agentId = normalizeAgentId(rawAgentId);
+    if (!agentIds.has(agentId)) {
+      logWarn(
+        `[bindings] Discord account "${accountId}" references agentId "${rawAgentId}" which does not exist in agents.list — skipping binding`,
+      );
+      continue;
+    }
+    if (hasWildcardExplicit || explicitDiscordAccountIds.has(normalizeAccountId(accountId))) {
+      logWarn(
+        `[bindings] Discord account "${accountId}" has agentId "${rawAgentId}" but is already covered by an explicit binding — explicit binding takes precedence`,
+      );
+      continue;
+    }
+    bindings.push({
+      agentId,
+      match: { channel: "discord", accountId },
+    });
+  }
+  return bindings;
 }
 
 export function listRouteBindings(cfg: OpenClawConfig): AgentRouteBinding[] {

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -218,6 +218,8 @@ export type DiscordAutoPresenceConfig = {
 export type DiscordAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
+  /** Explicit agent binding. Routes inbound messages from this account to the specified agent. */
+  agentId?: string;
   /** Optional provider capability tags used for agent/runtime guidance. */
   capabilities?: string[];
   /** Markdown formatting overrides (tables). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -460,6 +460,7 @@ const DiscordVoiceSchema = z
 export const DiscordAccountSchema = z
   .object({
     name: z.string().optional(),
+    agentId: z.string().optional(),
     capabilities: z.array(z.string()).optional(),
     markdown: MarkdownConfigSchema,
     enabled: z.boolean().optional(),

--- a/src/plugin-sdk/discord.ts
+++ b/src/plugin-sdk/discord.ts
@@ -150,3 +150,4 @@ export {
   uploadStickerDiscord,
 } from "../../extensions/discord/runtime-api.js";
 export { discordMessageActions } from "../../extensions/discord/runtime-api.js";
+export { normalizeAgentId } from "../routing/session-key.js";

--- a/src/routing/bindings.ts
+++ b/src/routing/bindings.ts
@@ -1,6 +1,6 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { normalizeChatChannelId } from "../channels/registry.js";
-import { listRouteBindings } from "../config/bindings.js";
+import { listRouteBindings, synthesizeDiscordAccountBindings } from "../config/bindings.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AgentRouteBinding } from "../config/types.agents.js";
 import { normalizeAccountId, normalizeAgentId } from "./session-key.js";
@@ -15,7 +15,9 @@ function normalizeBindingChannelId(raw?: string | null): string | null {
 }
 
 export function listBindings(cfg: OpenClawConfig): AgentRouteBinding[] {
-  return listRouteBindings(cfg);
+  const explicit = listRouteBindings(cfg);
+  const synthesized = synthesizeDiscordAccountBindings(cfg, explicit);
+  return [...explicit, ...synthesized];
 }
 
 function resolveNormalizedBindingMatch(binding: AgentRouteBinding): {

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -193,6 +193,8 @@ type BindingScope = {
 
 type EvaluatedBindingsCache = {
   bindingsRef: OpenClawConfig["bindings"];
+  channelsRef: OpenClawConfig["channels"];
+  agentsRef: OpenClawConfig["agents"];
   byChannel: Map<string, EvaluatedBindingsByChannel>;
   byChannelAccount: Map<string, EvaluatedBinding[]>;
   byChannelAccountIndex: Map<string, EvaluatedBindingsIndex>;
@@ -204,6 +206,7 @@ const resolvedRouteCacheByCfg = new WeakMap<
   OpenClawConfig,
   {
     bindingsRef: OpenClawConfig["bindings"];
+    channelsRef: OpenClawConfig["channels"];
     agentsRef: OpenClawConfig["agents"];
     sessionRef: OpenClawConfig["session"];
     byKey: Map<string, ResolvedAgentRoute>;
@@ -416,12 +419,19 @@ function getEvaluatedBindingsForChannelAccount(
   accountId: string,
 ): EvaluatedBinding[] {
   const bindingsRef = cfg.bindings;
+  const channelsRef = cfg.channels;
+  const agentsRef = cfg.agents;
   const existing = evaluatedBindingsCacheByCfg.get(cfg);
   const cache =
-    existing && existing.bindingsRef === bindingsRef
+    existing &&
+    existing.bindingsRef === bindingsRef &&
+    existing.channelsRef === channelsRef &&
+    existing.agentsRef === agentsRef
       ? existing
       : {
           bindingsRef,
+          channelsRef,
+          agentsRef,
           byChannel: buildEvaluatedBindingsByChannel(cfg),
           byChannelAccount: new Map<string, EvaluatedBinding[]>(),
           byChannelAccountIndex: new Map<string, EvaluatedBindingsIndex>(),
@@ -510,6 +520,7 @@ function resolveRouteCacheForConfig(cfg: OpenClawConfig): Map<string, ResolvedAg
   if (
     existing &&
     existing.bindingsRef === cfg.bindings &&
+    existing.channelsRef === cfg.channels &&
     existing.agentsRef === cfg.agents &&
     existing.sessionRef === cfg.session
   ) {
@@ -518,6 +529,7 @@ function resolveRouteCacheForConfig(cfg: OpenClawConfig): Map<string, ResolvedAg
   const byKey = new Map<string, ResolvedAgentRoute>();
   resolvedRouteCacheByCfg.set(cfg, {
     bindingsRef: cfg.bindings,
+    channelsRef: cfg.channels,
     agentsRef: cfg.agents,
     sessionRef: cfg.session,
     byKey,


### PR DESCRIPTION
## Summary

Add explicit `agentId` binding to Discord account configuration, enabling per-bot-account agent routing without manually writing `bindings:` entries. Each Discord account can declare which agent it belongs to, and the system synthesizes the corresponding route binding automatically.

**Status: REVIEW**

## Motivation

Multi-agent setups with multiple Discord bot accounts currently require users to manually write explicit route bindings mapping each `accountId` to an `agentId`. This is error-prone and duplicative when the account already "knows" which agent it belongs to. Worse, without per-account binding, routing can silently fall through to the default agent — widening permissions in multi-account setups.

This PR lets users declare `agentId` directly on the Discord account config, and the routing layer synthesizes the corresponding binding automatically.

## Threat Model / Invariants

| # | Invariant | Enforcement |
|---|-----------|-------------|
| 1 | **Routing must be deterministic** | Synthesized bindings have stable order (config key order); cache invalidates on `channels`/`agents` ref change |
| 2 | **Failover must be fail-secure** | Unknown `agentId` references are **skipped** (warning logged), never silently routed to default agent |
| 3 | **Explicit bindings always win** | `synthesizeDiscordAccountBindings` receives explicit bindings as input and skips any account already covered |
| 4 | **Invalid references must not route** | `agentId` values not in `agents.list` produce zero bindings; empty string after trim produces zero bindings |
| 5 | **Opt-out must be explicit** | `agentId: ""` on an account opts out of inherited top-level `agentId`; absence inherits |

## Commit Structure

| Commit | Scope | Description |
|--------|-------|-------------|
| **A** | `fix(routing)` | Track `channelsRef`/`agentsRef` in cache invalidation — independently mergeable fail-secure fix |
| **B** | `feat(discord)` | Per-account `agentId` field + `synthesizeDiscordAccountBindings()` + 21 unit tests |
| **C** | `feat(discord)` | Surface `agentId` in `ChannelAccountSnapshot` / `describeAccount` for Mission Control visibility |

Commit A can be merged independently as a correctness fix.

## Config Examples + Expected Routing

### Example 1: Multi-agent, per-account binding

```yaml
agents:
  list:
    - id: main
    - id: theodore
    - id: gordon
channels:
  discord:
    accounts:
      theodore:
        agentId: theodore
        token: $THEODORE_TOKEN
      gordon:
        agentId: gordon
        token: $GORDON_TOKEN
```

| Inbound from account | Routed to agent | Matched by |
|---------------------|-----------------|------------|
| `theodore` | `theodore` | synthesized binding |
| `gordon` | `gordon` | synthesized binding |

### Example 2: Single-account setup with top-level agentId

```yaml
agents:
  list: [{ id: main }, { id: theodore }]
channels:
  discord:
    agentId: theodore
    token: $BOT_TOKEN
```

| Inbound from account | Routed to agent | Matched by |
|---------------------|-----------------|------------|
| `default` | `theodore` | synthesized binding (inherited from top-level) |

### Example 3: Inheritance + opt-out

```yaml
channels:
  discord:
    agentId: theodore
    accounts:
      inherited: {}
      optout:
        agentId: ""
```

| Inbound from account | Routed to agent | Matched by |
|---------------------|-----------------|------------|
| `inherited` | `theodore` | synthesized (inherited from top-level `agentId`) |
| `optout` | `main` | default routing (opted out via empty string) |

### Example 4: Explicit binding takes precedence

```yaml
channels:
  discord:
    accounts:
      theodore:
        agentId: theodore
bindings:
  - agentId: main
    match: { channel: discord, accountId: theodore }
```

| Inbound from account | Routed to agent | Matched by | Note |
|---------------------|-----------------|------------|------|
| `theodore` | `main` | explicit binding | Warning logged; explicit wins over synthesized |

## Files Changed

| File | Commit | Change |
|------|--------|--------|
| `src/routing/resolve-route.ts` | A | Track `channelsRef` + `agentsRef` in evaluated-bindings cache staleness checks |
| `src/config/zod-schema.providers-core.ts` | B | Add `agentId: z.string().optional()` to `DiscordAccountSchema` |
| `src/config/types.discord.ts` | B | Add `agentId?: string` to `DiscordAccountConfig` |
| `src/config/bindings.ts` | B | Add `synthesizeDiscordAccountBindings()` with shadow/wildcard/scoping logic |
| `src/routing/bindings.ts` | B | Update `listBindings()` to combine explicit + synthesized bindings |
| `src/config/bindings.test.ts` | B | 21 unit tests organized by concern |
| `src/channels/plugins/types.core.ts` | C | Add `agentId?: string` to `ChannelAccountSnapshot` |
| `extensions/discord/src/channel.ts` | C | Surface `agentId` in `describeAccount` output |

## Test Coverage (21 tests)

**Precedence:** explicit vs synthesized, wildcard (`*`) suppression, channel-only binding only shadows default account

**Fail-secure:** unknown agentId skipped with warning, empty `agents.list` rejects all, empty/whitespace agentId skipped

**Inheritance:** top-level `agentId` flows to accounts, account-level overrides top-level, empty string `""` opts out

**Normalization:** case-insensitive `agentId` matching via `normalizeAgentId`, case-insensitive channel/accountId in explicit binding shadow checks

**Scoping:** scoped bindings (`guildId`, `accountId+guildId`, `peer`, `roles`) do not shadow synthesized bindings

**Edge cases:** empty `accounts: {}` as implicit default, 5 simultaneous accounts, no discord config returns empty

**Multi-Account Caveat: Shared Guild ConfigWhen multiple Discord accounts share the same `guilds` config (inherited from the top-level `channels.discord.guilds`), all connected bots independently receive messages in those channels. The `agentId` binding correctly routes each account's messages to its assigned agent, but it does **not** prevent multiple accounts from all picking up the same message.**Recommendation for multi-account setups:** Set `requireMention: true` on shared guilds so each bot only responds when explicitly @mentioned. Alternatively, configure per-account `guilds` entries to isolate which channels each bot listens on.```yamlchannels:  discord:    guilds:      "your-guild-id":        requireMention: true   # Each bot only responds when @mentioned    accounts:      default:        token: $DEFAULT_TOKEN      theodore:        agentId: theodore        token: $THEODORE_TOKEN```**
## Open Questions for Reviewers

1. **Empty string as opt-out sentinel:** Is `agentId: ""` acceptable as the way an account opts out of an inherited top-level `channels.discord.agentId`? Alternatives: `agentId: false`, `agentId: null`, or a dedicated `inheritAgentId: false` field.

2. **Synthesis scope:** This PR only synthesizes bindings for Discord. Should the `synthesize*AccountBindings` pattern be generalized to other channels (Telegram, Slack) in a follow-up, or should each channel opt in independently?

3. **Wildcard semantics:** An explicit binding with `accountId: "*"` suppresses all synthesized bindings, but only when unscoped. A binding with no `accountId` maps to `"default"` and only shadows the default account. Is this distinction clear enough, or should we add validation/warnings?

4. **Cache invalidation breadth:** Commit A adds `channelsRef` + `agentsRef` tracking to the evaluated-bindings cache. Should `agentsRef` also be tracked in `resolvedRouteCacheByCfg` for completeness?

## AI Disclosure

🤖 Built with Claude Opus 4.6 (AI-assisted)
- [x] Marked as AI-assisted
- [x] Fully tested (21 unit tests, all passing locally)
- [x] Author (Noopy420) understands and can explain all code
- [x] Codex review addressed — all comments resolved with code fixes and replies
- [x] Bot review conversations resolved after addressing

## Test Plan

- [x] `npx vitest run src/config/bindings.test.ts` — 21 tests pass
- [x] Lint clean locally (`pnpm check`)
- [ ] CI checks pass (currently blocked by upstream type errors on `main` in telegram/whatsapp/discord outbound-adapter — unrelated to this PR)
- [x] Live integration test with multi-account Discord setup