### PR TITLE
fix(browser): keep screenshots viewport-bounded unless fullPage is explicit

### DIFF
--- a/src/agents/tools/browser-tool.test.ts
+++ b/src/agents/tools/browser-tool.test.ts
@@ -458,6 +458,40 @@ describe("browser tool snapshot maxChars", () => {
   });
 });
 
+describe("browser tool boolean param parsing", () => {
+  registerBrowserToolAfterEachReset();
+
+  it('treats screenshot fullPage="false" as false', async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", {
+      action: "screenshot",
+      fullPage: "false",
+    });
+
+    expect(browserActionsMocks.browserScreenshotAction).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        fullPage: false,
+      }),
+    );
+  });
+
+  it('treats dialog accept="false" as false', async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", {
+      action: "dialog",
+      accept: "false",
+    });
+
+    expect(browserActionsMocks.browserArmDialog).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        accept: false,
+      }),
+    );
+  });
+});
+
 describe("browser tool url alias support", () => {
   registerBrowserToolAfterEachReset();
 

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -25,6 +25,7 @@ import {
   untrackSessionBrowserTab,
 } from "../../browser/session-tab-registry.js";
 import { loadConfig } from "../../config/config.js";
+import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
 import {
   executeActAction,
   executeConsoleAction,
@@ -519,7 +520,7 @@ export function createBrowserTool(opts?: {
           });
         case "screenshot": {
           const targetId = readStringParam(params, "targetId");
-          const fullPage = Boolean(params.fullPage);
+          const fullPage = readBooleanParam(params, "fullPage") ?? false;
           const ref = readStringParam(params, "ref");
           const element = readStringParam(params, "element");
           const type = params.type === "jpeg" ? "jpeg" : "png";
@@ -642,7 +643,7 @@ export function createBrowserTool(opts?: {
           );
         }
         case "dialog": {
-          const accept = Boolean(params.accept);
+          const accept = readBooleanParam(params, "accept") ?? false;
           const promptText = typeof params.promptText === "string" ? params.promptText : undefined;
           const { targetId, timeoutMs } = readOptionalTargetAndTimeout(params);
           if (proxyRequest) {

--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -4,7 +4,13 @@ import { type WebSocket, WebSocketServer } from "ws";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import { rawDataToString } from "../infra/ws.js";
 import { isWebSocketUrl } from "./cdp.helpers.js";
-import { createTargetViaCdp, evaluateJavaScript, normalizeCdpWsUrl, snapshotAria } from "./cdp.js";
+import {
+  captureScreenshot,
+  createTargetViaCdp,
+  evaluateJavaScript,
+  normalizeCdpWsUrl,
+  snapshotAria,
+} from "./cdp.js";
 import { parseHttpUrl } from "./config.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 
@@ -261,6 +267,69 @@ describe("cdp", () => {
         url: "https://example.com",
       }),
     ).rejects.toThrow("CDP /json/version missing webSocketDebuggerUrl");
+  });
+
+  it("keeps viewport screenshot bounded when fullPage is false", async () => {
+    const wsPort = await startWsServerWithMessages((msg, socket) => {
+      if (msg.method === "Page.enable") {
+        socket.send(JSON.stringify({ id: msg.id, result: {} }));
+        return;
+      }
+      if (msg.method === "Page.captureScreenshot") {
+        expect(msg.params?.captureBeyondViewport).toBe(false);
+        expect(msg.params?.clip).toBeUndefined();
+        socket.send(
+          JSON.stringify({
+            id: msg.id,
+            result: { data: Buffer.from("png").toString("base64") },
+          }),
+        );
+      }
+    });
+
+    const image = await captureScreenshot({
+      wsUrl: `ws://127.0.0.1:${wsPort}`,
+      fullPage: false,
+    });
+
+    expect(image.byteLength).toBeGreaterThan(0);
+  });
+
+  it("allows beyond-viewport capture for explicit fullPage screenshots", async () => {
+    const wsPort = await startWsServerWithMessages((msg, socket) => {
+      if (msg.method === "Page.enable") {
+        socket.send(JSON.stringify({ id: msg.id, result: {} }));
+        return;
+      }
+      if (msg.method === "Page.getLayoutMetrics") {
+        socket.send(
+          JSON.stringify({
+            id: msg.id,
+            result: {
+              cssContentSize: { width: 1024, height: 4096 },
+            },
+          }),
+        );
+        return;
+      }
+      if (msg.method === "Page.captureScreenshot") {
+        expect(msg.params?.captureBeyondViewport).toBe(true);
+        expect(msg.params?.clip).toMatchObject({ width: 1024, height: 4096 });
+        socket.send(
+          JSON.stringify({
+            id: msg.id,
+            result: { data: Buffer.from("png").toString("base64") },
+          }),
+        );
+      }
+    });
+
+    const image = await captureScreenshot({
+      wsUrl: `ws://127.0.0.1:${wsPort}`,
+      fullPage: true,
+    });
+
+    expect(image.byteLength).toBeGreaterThan(0);
   });
 
   it("captures an aria snapshot via CDP", async () => {

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -88,7 +88,8 @@ export async function captureScreenshot(opts: {
       format,
       ...(quality !== undefined ? { quality } : {}),
       fromSurface: true,
-      captureBeyondViewport: true,
+      // Keep viewport captures bounded. Allow beyond-viewport only for explicit full-page requests.
+      captureBeyondViewport: Boolean(opts.fullPage),
       ...(clip ? { clip } : {}),
     })) as { data?: string };
 


### PR DESCRIPTION
## Summary
This PR fixes two browser screenshot regressions that caused unreadable tall images in Telegram flows:

1. String boolean coercion in browser tool args could treat `"false"` as truthy.
2. CDP screenshot capture always used `captureBeyondViewport: true`, which can produce full-page-like captures even when `fullPage` is not requested.

## Why It Matters
Agents and operators rely on screenshots for step verification. Tall captures are frequently unreadable on mobile and break operator handoff quality.

## Root Cause
- `src/agents/tools/browser-tool.ts` used `Boolean(params.fullPage)` / `Boolean(params.accept)`, so string inputs (for example `"false"`) could be misparsed.
- `src/browser/cdp.ts` always set `captureBeyondViewport: true`, regardless of `fullPage` intent.

## What Changed
- Parse booleans with `readBooleanParam` in browser tool:
  - screenshot `fullPage`
  - dialog `accept`
- Gate CDP `captureBeyondViewport` behind explicit `fullPage`:
  - `captureBeyondViewport: Boolean(opts.fullPage)`
- Added regression tests for both fixes.

## Behavior After Fix
- Default screenshots are viewport-bounded and readable.
- Full-page screenshots are still supported when explicitly requested (`fullPage: true`).

## Validation
Per CONTRIBUTING baseline:

- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm test` ✅

Targeted tests also passed:
- `pnpm exec vitest run src/agents/tools/browser-tool.test.ts src/browser/cdp.test.ts` ✅

Manual runtime verification (Telegram + booking.com) confirmed:
- no forced tall capture when `fullPage` omitted
- no forced tall capture when `fullPage: false`
- readable viewport screenshot delivery

## AI Assistance
- [x] AI-assisted PR
- [x] Fully tested
- [x] I understand what the code does
- [x] `codex review --base upstream/main` run locally

(Review run reported one unrelated dirty-worktree finding outside this PR diff.)
