### PR TITLE
fix(failover): widen raw 402 detection for third-party proxy messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engines: keep loop-hook and final `afterTurn` prompt-cache touch metadata aligned with the current assistant turn so cache-aware context engines retain accurate cache TTL state during tool loops. (#67767) thanks @jalehman.
 - Memory/dreaming: strip AI-facing inbound metadata envelopes from session-corpus user turns before normalization so REM topic extraction sees the user's actual message text, including array-shaped split envelopes. (#66548) Thanks @zqchris.
 - Agents/errors: detect standalone Cloudflare/CDN HTML challenge pages before transport DNS classification so provider block pages no longer appear as local DNS lookup failures. (#67704) Thanks @chris-yyau.
+- Agents/failover: avoid treating bare leading `402 ...` prose as billing errors while still recognizing proxy subscription failures. (#45827) Thanks @junyuc25.
 - Security/approvals: redact secrets in exec approval prompts so inline approval review can no longer leak credential material in rendered prompt content. (#61077, #64790)
 - CLI/configure: re-read the persisted config hash after writes so config updates stop failing with stale-hash races. (#64188, #66528)
 - CLI/update: prune stale packaged `dist` chunks after npm upgrades and keep downgrade/verify inventory checks compat-safe so global upgrades stop failing on stale chunk imports. (#66959) Thanks @obviyus.
@@ -2014,10 +2015,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/edit tool: accept common path/text alias spellings, show current file contents on exact-match failures, and avoid false edit failures after successful writes. (#52516) thanks @mbelinky.
-
-### Fixes
-
-- Agents/failover: avoid treating bare leading `402 ...` prose as billing errors while still recognizing proxy subscription failures. (#45827) Thanks @junyuc25.
 
 ## 2026.3.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/wake: allow unknown properties on wake payloads so external senders like Paperclip can attach opaque metadata without failing schema validation. (#68355) Thanks @kagura-agent.
 - Matrix: honor `channels.matrix.network.dangerouslyAllowPrivateNetwork` when creating clients for private-network homeservers. (#68332) Thanks @kagura-agent.
 - Cron/message tool: keep cron-owned runs with `delivery.mode: "none"` on the normal message-tool path so they can still send explicit messages, create threads, and route conditionally when no runner-owned delivery target is active. (#68482) Thanks @obviyus.
+- Agents/failover: avoid treating bare leading `402 ...` prose as billing errors while still recognizing proxy subscription failures. (#45827) Thanks @junyuc25.
 
 ## 2026.4.15
 
@@ -110,7 +111,6 @@ Docs: https://docs.openclaw.ai
 - Agents/context engines: keep loop-hook and final `afterTurn` prompt-cache touch metadata aligned with the current assistant turn so cache-aware context engines retain accurate cache TTL state during tool loops. (#67767) thanks @jalehman.
 - Memory/dreaming: strip AI-facing inbound metadata envelopes from session-corpus user turns before normalization so REM topic extraction sees the user's actual message text, including array-shaped split envelopes. (#66548) Thanks @zqchris.
 - Agents/errors: detect standalone Cloudflare/CDN HTML challenge pages before transport DNS classification so provider block pages no longer appear as local DNS lookup failures. (#67704) Thanks @chris-yyau.
-- Agents/failover: avoid treating bare leading `402 ...` prose as billing errors while still recognizing proxy subscription failures. (#45827) Thanks @junyuc25.
 - Security/approvals: redact secrets in exec approval prompts so inline approval review can no longer leak credential material in rendered prompt content. (#61077, #64790)
 - CLI/configure: re-read the persisted config hash after writes so config updates stop failing with stale-hash races. (#64188, #66528)
 - CLI/update: prune stale packaged `dist` chunks after npm upgrades and keep downgrade/verify inventory checks compat-safe so global upgrades stop failing on stale chunk imports. (#66959) Thanks @obviyus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2015,6 +2015,10 @@ Docs: https://docs.openclaw.ai
 
 - Agents/edit tool: accept common path/text alias spellings, show current file contents on exact-match failures, and avoid false edit failures after successful writes. (#52516) thanks @mbelinky.
 
+### Fixes
+
+- Agents/failover: avoid treating bare leading `402 ...` prose as billing errors while still recognizing proxy subscription failures. (#45827) Thanks @junyuc25.
+
 ## 2026.3.13
 
 ### Changes

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1014,6 +1014,12 @@ describe("classifyFailoverReason", () => {
         "402 You've used up your points! Visit https://poe.com/api/keys to get more.",
       ),
     ).toBe("billing");
+    // Third-party proxy 402 with non-standard wording (#45774)
+    expect(
+      classifyFailoverReason(
+        "402 No available asset for API access, please purchase a subscription",
+      ),
+    ).toBe("billing");
     expect(classifyFailoverReason(INSUFFICIENT_QUOTA_PAYLOAD)).toBe("billing");
     expect(classifyFailoverReason("deadline exceeded")).toBe("timeout");
     expect(classifyFailoverReason("request ended without sending any chunks")).toBe("timeout");

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -923,6 +923,9 @@ describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => 
     expect(classifyFailoverReasonFromHttpStatus(402, undefined)).toBe("billing");
     expect(classifyFailoverReasonFromHttpStatus(402, "")).toBe("billing");
     expect(classifyFailoverReasonFromHttpStatus(402, "Payment required")).toBe("billing");
+    expect(classifyFailoverReasonFromHttpStatus(402, "402 custom proxy billing failure")).toBe(
+      "billing",
+    );
   });
 
   it("matches raw 402 wrappers and status-split payloads for the same message", () => {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -941,6 +941,9 @@ describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => 
 
   it("keeps explicit 402 rate-limit messages in the rate_limit lane", () => {
     const transientMessage = "rate limit exceeded";
+    expect(classifyFailoverReasonFromHttpStatus(402, `402: ${transientMessage}`)).toBe(
+      "rate_limit",
+    );
     expect(classifyFailoverReason(`HTTP 402 Payment Required: ${transientMessage}`)).toBe(
       "rate_limit",
     );

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1020,6 +1020,8 @@ describe("classifyFailoverReason", () => {
         "402 No available asset for API access, please purchase a subscription",
       ),
     ).toBe("billing");
+    expect(classifyFailoverReason("402 items found in the database")).toBeNull();
+    expect(classifyFailoverReason("402 room is available")).toBeNull();
     expect(classifyFailoverReason(INSUFFICIENT_QUOTA_PAYLOAD)).toBe("billing");
     expect(classifyFailoverReason("deadline exceeded")).toBe("timeout");
     expect(classifyFailoverReason("request ended without sending any chunks")).toBe("timeout");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -609,7 +609,7 @@ function classifyFailoverClassificationFromHttpStatus(
         return toReasonClassification(reasonFrom402Text);
       }
       return typeof explicitStatus === "number"
-        ? toReasonClassification("billing")
+        ? toReasonClassification(classify402Message(message))
         : messageClassification;
     }
     return toReasonClassification(classify402Message(message));

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -298,12 +298,10 @@ const RETRYABLE_402_SCOPED_RESULT_HINTS = [
   "exhausted",
 ] as const;
 const RAW_402_MARKER_RE =
-  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment required\b|^\s*402\s+.*used up your points\b/i;
+  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+(?:payment required\b|.*used up your points\b|no available asset for api access\b)/i;
 const BARE_LEADING_402_RE = /^\s*402\b/i;
 const LEADING_402_WRAPPER_RE =
   /^(?:error[:\s-]+)?(?:(?:http\s*)?402(?:\s+payment required)?|payment required)(?:[:\s-]+|$)/i;
-const LEADING_BARE_402_RE = /^\s*402\s+\S/i;
-const LEADING_402_PAYMENT_REQUIRED_RE = /^\s*402\s+payment required\b/i;
 const TIMEOUT_ERROR_CODES = new Set([
   "ETIMEDOUT",
   "ESOCKETTIMEDOUT",
@@ -540,18 +538,6 @@ function classify402Message(message: string): PaymentRequiredFailoverReason {
   return "billing";
 }
 
-function hasBareLeading402Signal(text: string): boolean {
-  return (
-    hasQuotaRefreshWindowSignal(text) ||
-    hasExplicit402BillingSignal(text) ||
-    isRateLimitErrorMessage(text) ||
-    hasRetryable402TransientSignal(text) ||
-    text.includes("used up your points") ||
-    text.includes("no available asset for api access") ||
-    (text.includes("purchase") && text.includes("subscription"))
-  );
-}
-
 function classifyFailoverReasonFrom402Text(raw: string): PaymentRequiredFailoverReason | null {
   if (RAW_402_MARKER_RE.test(raw)) {
     return classify402Message(raw);
@@ -561,15 +547,6 @@ function classifyFailoverReasonFrom402Text(raw: string): PaymentRequiredFailover
   }
   const normalized = normalize402Message(raw);
   if (!normalized || !hasKnownBareLeading402Signal(normalized)) {
-    return null;
-  }
-  const normalized = normalize402Message(raw);
-  if (
-    normalized &&
-    LEADING_BARE_402_RE.test(raw) &&
-    !LEADING_402_PAYMENT_REQUIRED_RE.test(raw) &&
-    !hasBareLeading402Signal(normalized)
-  ) {
     return null;
   }
   return classify402Message(raw);
@@ -621,7 +598,15 @@ function classifyFailoverClassificationFromHttpStatus(
   }
 
   if (status === 402) {
-    return toReasonClassification(message ? classify402Message(message) : "billing");
+    if (!message) {
+      return toReasonClassification("billing");
+    }
+    const leadingStatus = extractLeadingHttpStatus(message.trim());
+    if (leadingStatus?.code === 402) {
+      const reasonFrom402Text = classifyFailoverReasonFrom402Text(message);
+      return reasonFrom402Text ? toReasonClassification(reasonFrom402Text) : messageClassification;
+    }
+    return toReasonClassification(classify402Message(message));
   }
   if (status === 429) {
     return toReasonClassification("rate_limit");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -583,7 +583,7 @@ export function classifyFailoverReasonFromHttpStatus(
     ? classifyFailoverClassificationFromMessage(message, opts?.provider)
     : null;
   return failoverReasonFromClassification(
-    classifyFailoverClassificationFromHttpStatus(status, message, messageClassification),
+    classifyFailoverClassificationFromHttpStatus(status, message, messageClassification, status),
   );
 }
 
@@ -591,6 +591,7 @@ function classifyFailoverClassificationFromHttpStatus(
   status: number | undefined,
   message: string | undefined,
   messageClassification: FailoverClassification | null,
+  explicitStatus: number | undefined,
 ): FailoverClassification | null {
   const messageReason = failoverReasonFromClassification(messageClassification);
   if (typeof status !== "number" || !Number.isFinite(status)) {
@@ -604,7 +605,12 @@ function classifyFailoverClassificationFromHttpStatus(
     const leadingStatus = extractLeadingHttpStatus(message.trim());
     if (leadingStatus?.code === 402) {
       const reasonFrom402Text = classifyFailoverReasonFrom402Text(message);
-      return reasonFrom402Text ? toReasonClassification(reasonFrom402Text) : messageClassification;
+      if (reasonFrom402Text) {
+        return toReasonClassification(reasonFrom402Text);
+      }
+      return typeof explicitStatus === "number"
+        ? toReasonClassification("billing")
+        : messageClassification;
     }
     return toReasonClassification(classify402Message(message));
   }
@@ -835,6 +841,7 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
     inferredStatus,
     signal.message,
     messageClassification,
+    signal.status,
   );
   if (statusClassification) {
     return statusClassification;
@@ -1246,20 +1253,8 @@ export function classifyFailoverReason(
   raw: string,
   opts?: { provider?: string },
 ): FailoverReason | null {
-  const trimmed = raw.trim();
-  const leadingStatus = extractLeadingHttpStatus(trimmed);
-  const reasonFrom402Text =
-    leadingStatus?.code === 402 ? classifyFailoverReasonFrom402Text(trimmed) : null;
-  if (
-    leadingStatus?.code === 402 &&
-    !reasonFrom402Text &&
-    !isHtmlErrorResponse(trimmed, leadingStatus.code)
-  ) {
-    return null;
-  }
   return failoverReasonFromClassification(
     classifyFailoverSignal({
-      status: leadingStatus?.code,
       message: raw,
       provider: opts?.provider,
     }),

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -302,6 +302,8 @@ const RAW_402_MARKER_RE =
 const BARE_LEADING_402_RE = /^\s*402\b/i;
 const LEADING_402_WRAPPER_RE =
   /^(?:error[:\s-]+)?(?:(?:http\s*)?402(?:\s+payment required)?|payment required)(?:[:\s-]+|$)/i;
+const LEADING_BARE_402_RE = /^\s*402\s+\S/i;
+const LEADING_402_PAYMENT_REQUIRED_RE = /^\s*402\s+payment required\b/i;
 const TIMEOUT_ERROR_CODES = new Set([
   "ETIMEDOUT",
   "ESOCKETTIMEDOUT",
@@ -464,7 +466,6 @@ function isOAuthCallbackTimeoutMessage(raw: string): boolean {
 function isOAuthCallbackValidationMessage(raw: string): boolean {
   return /\bcallback_validation_failed\b/i.test(raw);
 }
-
 function includesAnyHint(text: string, hints: readonly string[]): boolean {
   return hints.some((hint) => text.includes(hint));
 }
@@ -539,6 +540,18 @@ function classify402Message(message: string): PaymentRequiredFailoverReason {
   return "billing";
 }
 
+function hasBareLeading402Signal(text: string): boolean {
+  return (
+    hasQuotaRefreshWindowSignal(text) ||
+    hasExplicit402BillingSignal(text) ||
+    isRateLimitErrorMessage(text) ||
+    hasRetryable402TransientSignal(text) ||
+    text.includes("used up your points") ||
+    text.includes("no available asset for api access") ||
+    (text.includes("purchase") && text.includes("subscription"))
+  );
+}
+
 function classifyFailoverReasonFrom402Text(raw: string): PaymentRequiredFailoverReason | null {
   if (RAW_402_MARKER_RE.test(raw)) {
     return classify402Message(raw);
@@ -548,6 +561,15 @@ function classifyFailoverReasonFrom402Text(raw: string): PaymentRequiredFailover
   }
   const normalized = normalize402Message(raw);
   if (!normalized || !hasKnownBareLeading402Signal(normalized)) {
+    return null;
+  }
+  const normalized = normalize402Message(raw);
+  if (
+    normalized &&
+    LEADING_BARE_402_RE.test(raw) &&
+    !LEADING_402_PAYMENT_REQUIRED_RE.test(raw) &&
+    !hasBareLeading402Signal(normalized)
+  ) {
     return null;
   }
   return classify402Message(raw);

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -217,6 +217,8 @@ export function isBillingErrorMessage(raw: string): boolean {
     value.includes("upgrade") ||
     value.includes("credits") ||
     value.includes("payment") ||
+    value.includes("purchase") ||
+    value.includes("subscription") ||
     value.includes("plan")
   );
 }


### PR DESCRIPTION
## Summary

- Problem: Third-party proxy 402 responses with non-standard wording (e.g. `402 No available asset for API access, please purchase a subscription`) are not recognized as billing errors, so `failoverReason` stays `null` and no auth profile rotation or model fallback occurs.
- Why it matters: Users behind proxies lose automatic failover on payment errors, causing silent failures instead of graceful degradation.
- What changed: Broadened `RAW_402_MARKER_RE` to accept any `^\s*402\s+\S` prefix (was limited to `payment required` and `used up your points`). Added `purchase` and `subscription` to `isBillingErrorMessage` keyword list.
- What did NOT change: The status-aware classifier (`classifyFailoverReasonFromHttpStatus`) is untouched — it already handles 402 correctly. The `classify402Message` billing-vs-rate_limit refinement logic is unchanged. `ERROR_PATTERNS.billing` regex is unchanged (avoids false positives on strings like "402 items found").

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45774

## User-visible / Behavior Changes

Third-party proxy 402 errors with non-standard messages now correctly trigger billing failover instead of being silently dropped.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / Bun
- Model/provider: Any provider behind a third-party Anthropic-compatible proxy
- Integration/channel: Any
- Relevant config: auth profiles with proxy endpoint

### Steps

1. Configure a third-party proxy that returns `402 No available asset for API access, please purchase a subscription`
2. Send a message that triggers the proxy error
3. Check `failoverReason` in logs

### Expected

- `failoverReason: "billing"`, triggering auth profile rotation or model fallback

### Actual (before fix)

- `failoverReason: null`, no failover

## Evidence

- [x] Failing test/log before + passing after

Added regression test for the exact proxy message from the issue. All 103 failover-related tests pass, including existing false-positive guards ("402 items found in the database", etc.).

## Human Verification (required)

- Verified scenarios: Ran `pnpm test -- src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` (71 tests), `src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts` (5 tests), `src/agents/failover-error.test.ts` (32 tests) — all pass
- Edge cases checked: Existing false-positive test cases ("402 items found in the database", "processed 402 records", etc.) still correctly return false
- What I did **not** verify: Live proxy end-to-end test with actual third-party proxy

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`, `src/agents/pi-embedded-helpers/failover-matches.ts`
- Known bad symptoms reviewers should watch for: Unexpected billing failover on non-billing 402-prefixed messages (unlikely since `classify402Message` defaults to billing which is the correct behavior for any real 402)

## Risks and Mitigations

- Risk: `^\s*402\s+\S` is broader than the previous specific patterns, could match edge-case error strings that start with "402 " but aren't actual HTTP 402 errors.
  - Mitigation: This regex is only used in `classifyFailoverReasonFrom402Text`, which feeds into `classify402Message` — defaulting to `"billing"` is correct for any genuine 402. The separate `isBillingErrorMessage` (used for arbitrary text) keeps the narrower `ERROR_PATTERNS.billing` regex unchanged, so false positives on strings like "402 items found" are not affected.