### PR TITLE
fix(tlon): enforce media download size limit

### DIFF
--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -1,15 +1,21 @@
 import { randomUUID } from "node:crypto";
 import { createWriteStream } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import * as path from "node:path";
-import { Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/tlon";
 import { getDefaultSsrFPolicy } from "../urbit/context.js";
 
 // Default to OpenClaw workspace media directory
 const DEFAULT_MEDIA_DIR = path.join(homedir(), ".openclaw", "workspace", "media", "inbound");
+
+/** Max download size for inbound media (5 MB, matches core MEDIA_MAX_BYTES). */
+const MAX_DOWNLOAD_BYTES = 5 * 1024 * 1024;
+
+/** Restricted directory mode for media storage. */
+const MEDIA_DIR_MODE = 0o700;
 
 export interface ExtractedImage {
   url: string;
@@ -61,8 +67,8 @@ export async function downloadMedia(
       return null;
     }
 
-    // Ensure media directory exists
-    await mkdir(mediaDir, { recursive: true });
+    // Ensure media directory exists with restricted permissions
+    await mkdir(mediaDir, { recursive: true, mode: MEDIA_DIR_MODE });
 
     // Fetch with SSRF protection
     // Use fetchWithSsrFGuard directly (not urbitFetch) to preserve the full URL path
@@ -79,6 +85,18 @@ export async function downloadMedia(
         return null;
       }
 
+      // Pre-check Content-Length when available
+      const contentLengthHeader = response.headers.get("content-length");
+      if (contentLengthHeader) {
+        const declaredSize = Number(contentLengthHeader);
+        if (Number.isFinite(declaredSize) && declaredSize > MAX_DOWNLOAD_BYTES) {
+          console.warn(
+            `[tlon-media] Rejected oversized media (${declaredSize} bytes > ${MAX_DOWNLOAD_BYTES}): ${url}`,
+          );
+          return null;
+        }
+      }
+
       // Determine content type and extension
       const contentType = response.headers.get("content-type") || "application/octet-stream";
       const ext = getExtensionFromContentType(contentType) || getExtensionFromUrl(url) || "bin";
@@ -87,15 +105,39 @@ export async function downloadMedia(
       const filename = `${randomUUID()}.${ext}`;
       const localPath = path.join(mediaDir, filename);
 
-      // Stream to file
+      // Stream to file with byte-count enforcement
       const body = response.body;
       if (!body) {
         console.error(`[tlon-media] No response body for ${url}`);
         return null;
       }
 
-      const writeStream = createWriteStream(localPath);
-      await pipeline(Readable.fromWeb(body as any), writeStream);
+      let bytesWritten = 0;
+      const limiter = new Transform({
+        transform(chunk: Buffer, _encoding, callback) {
+          bytesWritten += chunk.length;
+          if (bytesWritten > MAX_DOWNLOAD_BYTES) {
+            callback(new Error(`Download exceeded ${MAX_DOWNLOAD_BYTES} bytes`));
+            return;
+          }
+          callback(null, chunk);
+        },
+      });
+
+      const writeStream = createWriteStream(localPath, { mode: 0o644 });
+      try {
+        await pipeline(Readable.fromWeb(body as any), limiter, writeStream);
+      } catch (err: any) {
+        // Clean up partial file on size limit or other pipeline errors
+        await unlink(localPath).catch(() => {});
+        if (bytesWritten > MAX_DOWNLOAD_BYTES) {
+          console.warn(
+            `[tlon-media] Aborted oversized download (${bytesWritten} bytes > ${MAX_DOWNLOAD_BYTES}): ${url}`,
+          );
+          return null;
+        }
+        throw err;
+      }
 
       return {
         localPath,

--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createWriteStream } from "node:fs";
-import { mkdir, unlink } from "node:fs/promises";
+import { chmod, mkdir, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import * as path from "node:path";
 import { Readable, Transform } from "node:stream";
@@ -69,6 +69,8 @@ export async function downloadMedia(
 
     // Ensure media directory exists with restricted permissions
     await mkdir(mediaDir, { recursive: true, mode: MEDIA_DIR_MODE });
+    // chmod to harden directories created by earlier versions (recursive: true won't update existing dirs)
+    await chmod(mediaDir, MEDIA_DIR_MODE).catch(() => {});
 
     // Fetch with SSRF protection
     // Use fetchWithSsrFGuard directly (not urbitFetch) to preserve the full URL path


### PR DESCRIPTION
## Summary

- **Problem:** The Tlon extension's `downloadMedia` function streams remote media to disk without any file size limit. There is no `Content-Length` pre-check and no streaming byte counter. Additionally, the media directory is created without explicit `0o700` mode.
- **Why it matters:** Defense-in-depth — aligns the extension with the core media pipeline's safety guarantees (`src/media/store.ts` enforces `MEDIA_MAX_BYTES` at 5 MB with streaming enforcement).
- **What changed:** Added `Content-Length` pre-check, a streaming `Transform` limiter capped at 5 MB, partial file cleanup on abort, explicit `0o644` file mode on the write stream, and `0o700` on the media directory.
- **What did NOT change:** No changes to the SSRF guard, URL validation, filename generation, or the `extractImageBlocks`/`downloadMessageImages` public API.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A — proactive defense-in-depth hardening for the Tlon extension media pipeline.

## User-visible / Behavior Changes

Media files larger than 5 MB from Tlon messages will be silently skipped instead of downloaded. This matches the behavior of the core media pipeline.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Integration/channel: Tlon/Urbit

### Steps

1. `pnpm tsgo` — no type errors in changed files.
2. Code review: verify the `Transform` limiter correctly aborts and cleans up partial files.

### Expected

- Downloads under 5 MB succeed as before.
- Downloads over 5 MB are aborted, partial file is cleaned up, function returns `null`.

### Actual

- Confirmed via code review and type checking.

## Evidence

- [x] Trace/log snippets

The limiter emits `[tlon-media] Aborted oversized download (N bytes > 5242880)` when the cap is hit, and `[tlon-media] Rejected oversized media (N bytes > 5242880)` when Content-Length pre-check triggers.

## Human Verification (required)

- Verified scenarios: TypeScript compiles cleanly, `Content-Length` pre-check path, streaming byte-count path, cleanup of partial file on abort
- Edge cases checked: no response body, non-ok status, non-http URL rejection (all existing paths unchanged)
- What I did **not** verify: live Tlon integration test with an actual oversized file (no Urbit test environment available)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — previously unbounded downloads are now capped at 5 MB
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore: none
- Known bad symptoms reviewers should watch for: Tlon media attachments silently missing if they exceed 5 MB (expected behavior, logged)

## Risks and Mitigations

- Risk: Legitimate media files larger than 5 MB from Tlon will be silently dropped.
  - Mitigation: 5 MB matches the core `MEDIA_MAX_BYTES` constant. If a higher limit is needed, it can be made configurable later.