### PR TITLE
fix(channels): add circuit breaker to typing keepalive loop

### DIFF
--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -965,10 +965,12 @@ export async function sendTypingTelegram(
     persistTarget: to,
     verbose: opts.verbose,
   });
+  // Typing indicators are cosmetic — use a lightweight retry policy to avoid
+  // blocking the event loop for up to 90s on network failures (#45759).
   const requestWithDiag = createTelegramRequestWithDiag({
     cfg,
     account,
-    retry: opts.retry,
+    retry: opts.retry ?? { attempts: 1, maxDelayMs: 5_000 },
     verbose: opts.verbose,
     shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
   });

--- a/src/channels/typing-lifecycle.test.ts
+++ b/src/channels/typing-lifecycle.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTypingKeepaliveLoop } from "./typing-lifecycle.js";
+
+describe("createTypingKeepaliveLoop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resets error count on successful tick", async () => {
+    let calls = 0;
+    const loop = createTypingKeepaliveLoop({
+      intervalMs: 100,
+      onTick: () => {
+        calls += 1;
+        if (calls <= 2) {
+          throw new Error("network error");
+        }
+      },
+      maxConsecutiveErrors: 3,
+    });
+
+    loop.start();
+    // Tick 1: error (consecutiveErrors=1)
+    await vi.advanceTimersByTimeAsync(100);
+    expect(loop.isRunning()).toBe(true);
+    // Tick 2: error (consecutiveErrors=2)
+    await vi.advanceTimersByTimeAsync(100);
+    expect(loop.isRunning()).toBe(true);
+    // Tick 3: success (consecutiveErrors reset to 0)
+    await vi.advanceTimersByTimeAsync(100);
+    expect(loop.isRunning()).toBe(true);
+    expect(calls).toBe(3);
+    loop.stop();
+  });
+
+  it("stops after maxConsecutiveErrors consecutive failures", async () => {
+    const loop = createTypingKeepaliveLoop({
+      intervalMs: 100,
+      onTick: () => {
+        throw new Error("network error");
+      },
+      maxConsecutiveErrors: 3,
+    });
+
+    loop.start();
+    expect(loop.isRunning()).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(loop.isRunning()).toBe(true);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(loop.isRunning()).toBe(true);
+    // Third error triggers circuit breaker
+    await vi.advanceTimersByTimeAsync(100);
+    expect(loop.isRunning()).toBe(false);
+  });
+
+  it("defaults to 3 max consecutive errors", async () => {
+    const loop = createTypingKeepaliveLoop({
+      intervalMs: 50,
+      onTick: () => {
+        throw new Error("fail");
+      },
+    });
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(loop.isRunning()).toBe(true);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(loop.isRunning()).toBe(false);
+  });
+
+  it("can restart after circuit breaker trips", async () => {
+    let shouldFail = true;
+    const loop = createTypingKeepaliveLoop({
+      intervalMs: 100,
+      onTick: () => {
+        if (shouldFail) {
+          throw new Error("fail");
+        }
+      },
+      maxConsecutiveErrors: 1,
+    });
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(loop.isRunning()).toBe(false);
+
+    shouldFail = false;
+    loop.start();
+    expect(loop.isRunning()).toBe(true);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(loop.isRunning()).toBe(true);
+    loop.stop();
+  });
+});

--- a/src/channels/typing-lifecycle.ts
+++ b/src/channels/typing-lifecycle.ts
@@ -7,12 +7,18 @@ export type TypingKeepaliveLoop = {
   isRunning: () => boolean;
 };
 
+const DEFAULT_MAX_CONSECUTIVE_ERRORS = 3;
+
 export function createTypingKeepaliveLoop(params: {
   intervalMs: number;
   onTick: AsyncTick;
+  /** Stop the loop after this many consecutive tick errors (default: 3). */
+  maxConsecutiveErrors?: number;
 }): TypingKeepaliveLoop {
   let timer: ReturnType<typeof setInterval> | undefined;
   let tickInFlight = false;
+  let consecutiveErrors = 0;
+  const maxErrors = params.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS;
 
   const tick = async () => {
     if (tickInFlight) {
@@ -21,6 +27,12 @@ export function createTypingKeepaliveLoop(params: {
     tickInFlight = true;
     try {
       await params.onTick();
+      consecutiveErrors = 0;
+    } catch {
+      consecutiveErrors += 1;
+      if (consecutiveErrors >= maxErrors) {
+        stop();
+      }
     } finally {
       tickInFlight = false;
     }
@@ -30,6 +42,7 @@ export function createTypingKeepaliveLoop(params: {
     if (params.intervalMs <= 0 || timer) {
       return;
     }
+    consecutiveErrors = 0;
     timer = setInterval(() => {
       void tick();
     }, params.intervalMs);


### PR DESCRIPTION
## Summary

`createTypingKeepaliveLoop` uses a bare `setInterval` with no error handling — when the network drops or the API errors, `onTick` throws every interval tick, flooding the process with unhandled rejections and potentially crashing the gateway.

This adds a try/catch inside the tick with a consecutive error counter. After `maxConsecutiveErrors` (default 3) consecutive failures, the loop auto-stops via `clearInterval`. A successful tick resets the counter so transient blips don't kill the loop.

- `src/channels/typing-lifecycle.ts` — wrap tick in try/catch, add `consecutiveErrors` counter + `maxConsecutiveErrors` option
- `src/channels/typing-lifecycle.test.ts` — 4 new tests covering reset-on-success, circuit breaker trip, default threshold, and restart after trip

Fixes #45759

## Test plan

- [x] New unit tests pass (`pnpm test -- --run src/channels/typing-lifecycle.test.ts` — 4/4)
- [x] All existing channel tests pass (`pnpm test -- --run src/channels/` — 530/530)
- [ ] CI green