### PR TITLE
fix(ui): use full provider/model path in model select dropdown

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import { modelKey } from "../../../src/agents/model-selection.js";
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { t } from "../i18n/index.ts";
 import { refreshChat } from "./app-chat.ts";
@@ -372,7 +373,8 @@ function buildChatModelOptions(
 
   for (const entry of catalog) {
     const provider = entry.provider?.trim();
-    addOption(entry.id, provider ? `${entry.id} · ${provider}` : entry.id);
+    const fullKey = modelKey(provider ?? "", entry.id);
+    addOption(fullKey, provider ? `${fullKey} · ${provider}` : fullKey);
   }
 
   if (currentOverride) {


### PR DESCRIPTION
Fix: The model select dropdown was using only the model ID without the provider prefix, leading to invalid requests when switching models. This change constructs the full 'provider/model' path for each option.