### PR TITLE
feat(web-search): add configurable baseUrl for Brave Search API

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1623,7 +1623,9 @@ async function runWebSearch(params: {
           ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
           : params.provider === "kimi"
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-            : "";
+            : params.provider === "brave"
+              ? `${params.braveBaseUrl ?? DEFAULT_BRAVE_BASE_URL}:${effectiveBraveMode}`
+              : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
       ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -26,8 +26,9 @@ const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as co
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
-const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
-const BRAVE_LLM_CONTEXT_ENDPOINT = "https://api.search.brave.com/res/v1/llm/context";
+const DEFAULT_BRAVE_BASE_URL = "https://api.search.brave.com";
+const BRAVE_SEARCH_PATH = "/res/v1/web/search";
+const BRAVE_LLM_CONTEXT_PATH = "/res/v1/llm/context";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
@@ -309,6 +310,7 @@ type BraveLlmContextResponse = {
 
 type BraveConfig = {
   mode?: string;
+  baseUrl?: string;
 };
 
 type PerplexityConfig = {
@@ -682,6 +684,11 @@ function resolveBraveConfig(search?: WebSearchConfig): BraveConfig {
 
 function resolveBraveMode(brave: BraveConfig): "web" | "llm-context" {
   return brave.mode === "llm-context" ? "llm-context" : "web";
+}
+
+function resolveBraveBaseUrl(brave: BraveConfig): string {
+  const raw = brave.baseUrl?.trim().replace(/\/$/, "");
+  return raw || DEFAULT_BRAVE_BASE_URL;
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {
@@ -1529,6 +1536,7 @@ async function runBraveLlmContextSearch(params: {
   country?: string;
   search_lang?: string;
   freshness?: string;
+  braveBaseUrl?: string;
 }): Promise<{
   results: Array<{
     url: string;
@@ -1538,7 +1546,7 @@ async function runBraveLlmContextSearch(params: {
   }>;
   sources?: BraveLlmContextResponse["sources"];
 }> {
-  const url = new URL(BRAVE_LLM_CONTEXT_ENDPOINT);
+  const url = new URL(`${params.braveBaseUrl ?? DEFAULT_BRAVE_BASE_URL}${BRAVE_LLM_CONTEXT_PATH}`);
   url.searchParams.set("q", params.query);
   if (params.country) {
     url.searchParams.set("country", params.country);
@@ -1603,6 +1611,7 @@ async function runWebSearch(params: {
   kimiBaseUrl?: string;
   kimiModel?: string;
   braveMode?: "web" | "llm-context";
+  braveBaseUrl?: string;
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
   const providerSpecificKey =
@@ -1781,6 +1790,7 @@ async function runWebSearch(params: {
       country: params.country,
       search_lang: params.search_lang,
       freshness: params.freshness,
+      braveBaseUrl: params.braveBaseUrl,
     });
 
     const mapped = llmResults.map((entry) => ({
@@ -1809,7 +1819,7 @@ async function runWebSearch(params: {
     return payload;
   }
 
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  const url = new URL(`${params.braveBaseUrl ?? DEFAULT_BRAVE_BASE_URL}${BRAVE_SEARCH_PATH}`);
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
   if (params.country) {
@@ -1911,6 +1921,7 @@ export function createWebSearchTool(options?: {
   const kimiConfig = resolveKimiConfig(search);
   const braveConfig = resolveBraveConfig(search);
   const braveMode = resolveBraveMode(braveConfig);
+  const braveBaseUrl = resolveBraveBaseUrl(braveConfig);
 
   const description =
     provider === "perplexity"
@@ -2186,6 +2197,7 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         braveMode,
+        braveBaseUrl,
       });
       return jsonResult(result);
     },
@@ -2218,5 +2230,6 @@ export const __testing = {
   extractKimiCitations,
   resolveRedirectUrl: resolveCitationRedirectUrl,
   resolveBraveMode,
+  resolveBraveBaseUrl,
   mapBraveLlmContextResults,
 } as const;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -668,6 +668,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",
   "tools.web.search.brave.mode":
     'Brave Search mode: "web" (URL results) or "llm-context" (pre-extracted page content for LLM grounding).',
+  "tools.web.search.brave.baseUrl":
+    "Custom base URL for Brave Search API requests. Useful for routing through a proxy when datacenter IPs receive degraded results. Must serve the same API contract as api.search.brave.com. Default: https://api.search.brave.com.",
   "tools.web.search.gemini.apiKey":
     "Gemini API key for Google Search grounding (fallback: GEMINI_API_KEY env var).",
   "tools.web.search.gemini.model": 'Gemini model override (default: "gemini-2.5-flash").',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -219,6 +219,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.search.timeoutSeconds": "Web Search Timeout (sec)",
   "tools.web.search.cacheTtlMinutes": "Web Search Cache TTL (min)",
   "tools.web.search.brave.mode": "Brave Search Mode",
+  "tools.web.search.brave.baseUrl": "Brave Search Base URL",
   "tools.web.search.gemini.apiKey": "Gemini Search API Key", // pragma: allowlist secret
   "tools.web.search.gemini.model": "Gemini Search Model",
   "tools.web.search.grok.apiKey": "Grok Search API Key", // pragma: allowlist secret

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -471,6 +471,8 @@ export type ToolsConfig = {
       brave?: {
         /** Brave Search mode: "web" (standard results) or "llm-context" (pre-extracted page content). Default: "web". */
         mode?: "web" | "llm-context";
+        /** Custom base URL for Brave Search API. Useful for routing through a proxy (e.g. Cloudflare Worker) when datacenter IPs receive degraded results. Must serve the same API contract as api.search.brave.com. Default: "https://api.search.brave.com". */
+        baseUrl?: string;
       };
       /** Gemini-specific configuration (used when provider="gemini"). */
       gemini?: {


### PR DESCRIPTION
## Problem

Cloud-hosted OpenClaw agents (Azure Container Apps, AWS ECS, GCP Cloud Run) receive degraded/stale search results from Brave Search API. Brave appears to serve lower-quality cached results to requests originating from well-known datacenter IP ranges.

Fixes #45729
Fixes #19075

## Solution

Add `tools.web.search.brave.baseUrl` config option to override the default Brave Search API endpoint (`api.search.brave.com`). This allows operators to route search traffic through a proxy (e.g. Cloudflare Worker, residential relay) that re-issues requests from non-datacenter IPs.

The proxy must serve the same API contract as `api.search.brave.com`. Both the `/res/v1/web/search` and `/res/v1/llm/context` endpoints respect the override.

### Example config

```json
{
  "tools": {
    "web": {
      "search": {
        "brave": {
          "baseUrl": "https://search-proxy.example.workers.dev"
        }
      }
    }
  }
}
```

### Security considerations

- Only HTTPS URLs should be used in production
- The base URL is an operator-level config, not user-facing
- The existing SSRF guard (`withTrustedWebSearchEndpoint`) still applies to the constructed URL
- This follows the same pattern as `perplexity.baseUrl` and `kimi.baseUrl` which are already configurable

### Changes

- `src/agents/tools/web-search.ts`: Replace hardcoded endpoint consts with `DEFAULT_BRAVE_BASE_URL` + path consts; add `resolveBraveBaseUrl()`; pipe `braveBaseUrl` through params
- `src/config/types.tools.ts`: Add `baseUrl?` to brave config type
- `src/config/schema.labels.ts`: Add label
- `src/config/schema.help.ts`: Add help text