### PR TITLE
fix(build): prefer usable POSIX shells for Windows bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "build:docker": "node scripts/tsdown-build.mjs && node scripts/copy-plugin-sdk-root-alias.mjs && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",
     "build:strict-smoke": "pnpm canvas:a2ui:bundle && node scripts/tsdown-build.mjs && node scripts/copy-plugin-sdk-root-alias.mjs && pnpm build:plugin-sdk:dts",
-    "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
+    "canvas:a2ui:bundle": "node scripts/run-bash.mjs scripts/bundle-a2ui.sh",
     "check": "pnpm check:host-env-policy:swift && pnpm format:check && pnpm tsgo && pnpm lint && pnpm lint:tmp:no-random-messaging && pnpm lint:tmp:channel-agnostic-boundaries && pnpm lint:tmp:no-raw-channel-fetch && pnpm lint:agent:ingress-owner && pnpm lint:plugins:no-register-http-handler && pnpm lint:plugins:no-monolithic-plugin-sdk-entry-imports && pnpm lint:webhook:no-low-level-body-read && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope",
     "check:docs": "pnpm format:docs:check && pnpm lint:docs && pnpm docs:check-links",
     "check:host-env-policy:swift": "node scripts/generate-host-env-security-policy-swift.mjs --check",

--- a/scripts/run-bash.mjs
+++ b/scripts/run-bash.mjs
@@ -1,0 +1,127 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+function isUsableExecutable(candidate) {
+  if (!candidate) {
+    return false;
+  }
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathEntries(pathEnv = process.env.PATH ?? "") {
+  return pathEnv.split(path.delimiter).filter(Boolean);
+}
+
+export function preferredWindowsShells(params = {}) {
+  const platform = params.platform ?? process.platform;
+  const systemDrive = params.systemDrive ?? process.env.SystemDrive;
+  if (platform !== "win32") {
+    return [];
+  }
+
+  const candidates = [];
+  const driveRoots = new Set([systemDrive ? `${systemDrive}\\` : null, "C:\\"]);
+
+  for (const root of driveRoots) {
+    if (!root) {
+      continue;
+    }
+    candidates.push(path.join(root, "msys64", "usr", "bin", "bash.exe"));
+    candidates.push(path.join(root, "msys64", "usr", "bin", "sh.exe"));
+    candidates.push(path.join(root, "Program Files", "Git", "bin", "bash.exe"));
+    candidates.push(path.join(root, "Program Files", "Git", "usr", "bin", "bash.exe"));
+    candidates.push(path.join(root, "Program Files", "Git", "usr", "bin", "sh.exe"));
+  }
+
+  return candidates;
+}
+
+export function buildShellPath(params = {}) {
+  const platform = params.platform ?? process.platform;
+  const execPath = params.execPath ?? process.execPath;
+  const appData = params.appData ?? process.env.APPDATA;
+  const pathEnv = params.pathEnv ?? process.env.PATH ?? "";
+  const nodeBinDir = path.dirname(execPath);
+  const roamingNpmBin = platform === "win32" && appData ? path.join(appData, "npm") : null;
+  return [roamingNpmBin, nodeBinDir, pathEnv].filter(Boolean).join(path.delimiter);
+}
+
+export function resolvePosixShell(params = {}) {
+  const platform = params.platform ?? process.platform;
+  const candidates = [];
+
+  for (const candidate of params.preferredCandidates ?? preferredWindowsShells(params)) {
+    candidates.push(candidate);
+  }
+
+  const entries = pathEntries(params.pathEnv);
+  const seen = new Set();
+  for (const entry of entries) {
+    const normalized = path.normalize(entry).toLowerCase();
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+
+    if (platform === "win32") {
+      if (
+        normalized.includes(`${path.sep}windows${path.sep}system32`) ||
+        normalized.includes(`${path.sep}windowsapps`) ||
+        normalized.includes(`${path.sep}cygwin`)
+      ) {
+        continue;
+      }
+    }
+
+    candidates.push(path.join(entry, "sh.exe"));
+    candidates.push(path.join(entry, "bash.exe"));
+    candidates.push(path.join(entry, "sh"));
+    candidates.push(path.join(entry, "bash"));
+  }
+
+  return candidates.find(isUsableExecutable);
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const shell = resolvePosixShell();
+  if (!shell) {
+    console.error("Unable to find a usable POSIX shell on PATH.");
+    console.error("Install Git Bash, MSYS2, or Cygwin and retry.");
+    return 1;
+  }
+
+  const scriptPath = argv[0];
+  if (!scriptPath) {
+    console.error("Usage: node scripts/run-bash.mjs <script> [args...]");
+    return 1;
+  }
+
+  const args = [scriptPath, ...argv.slice(1)];
+  const result = spawnSync(shell, args, {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      PATH: buildShellPath(),
+    },
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    console.error(result.error.message);
+    return 1;
+  }
+
+  return result.status ?? 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exit(main());
+}

--- a/test/run-bash.test.ts
+++ b/test/run-bash.test.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildShellPath, resolvePosixShell } from "../scripts/run-bash.mjs";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function touchExecutable(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, "");
+  fs.chmodSync(filePath, 0o755);
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolvePosixShell", () => {
+  it("prefers explicit candidates before PATH scanning", () => {
+    const preferred = path.join(makeTempDir("openclaw-run-bash-pref-"), "bash.exe");
+    touchExecutable(preferred);
+
+    const pathShellDir = makeTempDir("openclaw-run-bash-path-");
+    touchExecutable(path.join(pathShellDir, "bash.exe"));
+
+    const resolved = resolvePosixShell({
+      platform: "win32",
+      preferredCandidates: [preferred],
+      pathEnv: pathShellDir,
+    });
+
+    expect(resolved).toBe(preferred);
+  });
+
+  it("skips Windows and Cygwin shim directories when scanning PATH on Windows", () => {
+    const root = makeTempDir("openclaw-run-bash-root-");
+    const system32Dir = path.join(root, "Windows", "System32");
+    const cygwinDir = path.join(root, "cygwin64", "bin");
+    const msysDir = path.join(root, "msys64", "usr", "bin");
+    touchExecutable(path.join(system32Dir, "bash.exe"));
+    touchExecutable(path.join(cygwinDir, "bash.exe"));
+    const msysShell = path.join(msysDir, "sh.exe");
+    touchExecutable(msysShell);
+
+    const resolved = resolvePosixShell({
+      platform: "win32",
+      preferredCandidates: [],
+      pathEnv: [system32Dir, cygwinDir, msysDir].join(path.delimiter),
+    });
+
+    expect(resolved).toBe(msysShell);
+  });
+});
+
+describe("buildShellPath", () => {
+  it("prepends roaming npm and the current node directory on Windows", () => {
+    const built = buildShellPath({
+      platform: "win32",
+      appData: "C:\\Users\\tester\\AppData\\Roaming",
+      execPath: "C:\\Program Files\\nodejs\\node.exe",
+      pathEnv: "C:\\existing\\bin",
+    });
+
+    expect(built).toBe(
+      [
+        "C:\\Users\\tester\\AppData\\Roaming\\npm",
+        "C:\\Program Files\\nodejs",
+        "C:\\existing\\bin",
+      ].join(path.delimiter),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: `pnpm build` on Windows could fail during `canvas:a2ui:bundle` because bare `bash` could resolve to the WSL shim (`C:\Windows\System32\bash.exe`) instead of a usable POSIX shell.
- Why it matters: source builds fail before the actual TypeScript build starts, even on machines that already have a usable shell such as MSYS2 or Git Bash.
- What changed: route the A2UI bundle step through a small Node wrapper that prefers usable Windows POSIX shells and forwards the active `node` / roaming `pnpm` paths.
- What did NOT change (scope boundary): no runtime auth/model behavior, no gateway protocol changes, and no changes to the A2UI bundle contents themselves.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

## User-visible / Behavior Changes

- Windows source builds now avoid resolving `canvas:a2ui:bundle` through the WSL `bash.exe` shim when a usable MSYS2/Git Bash shell is available.
- No config or runtime defaults changed.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11 / Windows 10 shell environment
- Runtime/container: local source checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. On Windows, use a source checkout where `bash` resolves to the WSL shim before a usable POSIX shell.
2. Run `pnpm build`.
3. Observe the build fail in `canvas:a2ui:bundle` before the TypeScript build starts.

### Expected

- `pnpm build` should use a usable POSIX shell on Windows and complete successfully when MSYS2/Git Bash is installed.

### Actual

- `pnpm build` could invoke the WSL shim and fail before bundling/build completion.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran `pnpm vitest run test/run-bash.test.ts`
  - Ran `pnpm build`
  - Confirmed the bundle step used the wrapper and the build completed successfully on Windows
- Edge cases checked:
  - preferred shell candidates win over PATH scanning
  - Windows shim/Cygwin-style paths are skipped during shell resolution
  - wrapper PATH includes roaming `pnpm` and active `node` locations
- What you did **not** verify:
  - did not test on Linux/macOS
  - did not verify behavior on machines without any usable POSIX shell installed

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR
  - or temporarily restore the previous `canvas:a2ui:bundle` script in `package.json`
- Files/config to restore:
  - `package.json`
  - `scripts/run-bash.mjs`
  - `test/run-bash.test.ts`
- Known bad symptoms reviewers should watch for:
  - wrapper fails to find a usable POSIX shell on Windows
  - unexpected shell selection differences on uncommon Windows setups

## Risks and Mitigations

- Risk:
  - shell selection could prefer a different Windows POSIX shell than a contributor expects
  - Mitigation:
    - prefer explicit MSYS2 / Git Bash candidates first
    - add tests for shell selection and PATH construction
