### PR TITLE
fix(bluebubbles): audit webhook health in status probe

### DIFF
--- a/docs/channels/bluebubbles.md
+++ b/docs/channels/bluebubbles.md
@@ -46,9 +46,7 @@ Status: bundled plugin that talks to the BlueBubbles macOS server over HTTP. **R
 
 Security note:
 
-- Always set a webhook password.
-- Webhook authentication is always required. OpenClaw rejects BlueBubbles webhook requests unless they include a password/guid that matches `channels.bluebubbles.password` (for example `?password=<password>` or `x-password`), regardless of loopback/proxy topology.
-- Password authentication is checked before reading/parsing full webhook bodies.
+- Always set a webhook password. If you expose the gateway through a reverse proxy (Tailscale Serve/Funnel, nginx, Cloudflare Tunnel, ngrok), the proxy may connect to the gateway over loopback. The BlueBubbles webhook handler treats requests with forwarding headers as proxied and will not accept passwordless webhooks.
 
 ## Keeping Messages.app alive (VM / headless setups)
 
@@ -116,6 +114,7 @@ Notes:
 
 - This runs **every 300 seconds** and **on login**.
 - The first run may trigger macOS **Automation** prompts (`osascript` → Messages). Approve them in the same user session that runs the LaunchAgent.
+- On some headless Macs, a lighter AppleScript such as `tell application "Messages" to get name` is more reliable than `count of chats`.
 
 Load it:
 
@@ -209,6 +208,38 @@ Per-group configuration:
 }
 ```
 
+## Troubleshooting
+
+Run this ladder in order:
+
+```bash
+openclaw status
+openclaw gateway status
+openclaw channels status --probe
+openclaw doctor
+openclaw logs --follow
+```
+
+What to look for:
+
+- `works` from the BlueBubbles probe only means the REST server answered `ping`.
+- For a healthier signal, also verify:
+  - `private-api:on`
+  - `helper:connected`
+  - `route:registered`
+- A direct POST to the live gateway webhook path should never return `404`.
+
+Failure signatures:
+
+- `works` + `helper:disconnected`:
+  - BlueBubbles REST is up, but the Private API helper is not connected. Restart BlueBubbles and `Messages.app`.
+- `works` + `private-api:off`:
+  - BlueBubbles is reachable, but advanced iMessage features and parts of inbound/outbound handling may be degraded. Re-check Private API setup and macOS prompts.
+- `works` + `route:missing`:
+  - The gateway is up, but the webhook path is not live on the running process. Restart the gateway and verify the live route again.
+- `Not Delivered` in native Messages:
+  - This is below OpenClaw. Confirm the Mac itself can send from Messages before debugging the webhook path.
+
 ## Advanced actions
 
 BlueBubbles supports advanced message actions when enabled in config:
@@ -283,7 +314,7 @@ Control whether responses are sent as a single message or streamed in blocks:
 ## Media + limits
 
 - Inbound attachments are downloaded and stored in the media cache.
-- Media cap via `channels.bluebubbles.mediaMaxMb` for inbound and outbound media (default: 8 MB).
+- Media cap via `channels.bluebubbles.mediaMaxMb` (default: 8 MB).
 - Outbound text is chunked to `channels.bluebubbles.textChunkLimit` (default: 4000 chars).
 
 ## Configuration reference
@@ -305,7 +336,7 @@ Provider options:
 - `channels.bluebubbles.blockStreaming`: Enable block streaming (default: `false`; required for streaming replies).
 - `channels.bluebubbles.textChunkLimit`: Outbound chunk size in chars (default: 4000).
 - `channels.bluebubbles.chunkMode`: `length` (default) splits only when exceeding `textChunkLimit`; `newline` splits on blank lines (paragraph boundaries) before length chunking.
-- `channels.bluebubbles.mediaMaxMb`: Inbound/outbound media cap in MB (default: 8).
+- `channels.bluebubbles.mediaMaxMb`: Inbound media cap in MB (default: 8).
 - `channels.bluebubbles.mediaLocalRoots`: Explicit allowlist of absolute local directories permitted for outbound local media paths. Local path sends are denied by default unless this is configured. Per-account override: `channels.bluebubbles.accounts.<accountId>.mediaLocalRoots`.
 - `channels.bluebubbles.historyLimit`: Max group messages for context (0 disables).
 - `channels.bluebubbles.dmHistoryLimit`: DM history limit.

--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -44,13 +44,12 @@ Full troubleshooting: [/channels/whatsapp#troubleshooting-quick](/channels/whats
 
 ### Telegram failure signatures
 
-| Symptom                             | Fastest check                                   | Fix                                                                         |
-| ----------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------- |
-| `/start` but no usable reply flow   | `openclaw pairing list telegram`                | Approve pairing or change DM policy.                                        |
-| Bot online but group stays silent   | Verify mention requirement and bot privacy mode | Disable privacy mode for group visibility or mention bot.                   |
-| Send failures with network errors   | Inspect logs for Telegram API call failures     | Fix DNS/IPv6/proxy routing to `api.telegram.org`.                           |
-| `setMyCommands` rejected at startup | Inspect logs for `BOT_COMMANDS_TOO_MUCH`        | Reduce plugin/skill/custom Telegram commands or disable native menus.       |
-| Upgraded and allowlist blocks you   | `openclaw security audit` and config allowlists | Run `openclaw doctor --fix` or replace `@username` with numeric sender IDs. |
+| Symptom                           | Fastest check                                   | Fix                                                                         |
+| --------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------- |
+| `/start` but no usable reply flow | `openclaw pairing list telegram`                | Approve pairing or change DM policy.                                        |
+| Bot online but group stays silent | Verify mention requirement and bot privacy mode | Disable privacy mode for group visibility or mention bot.                   |
+| Send failures with network errors | Inspect logs for Telegram API call failures     | Fix DNS/IPv6/proxy routing to `api.telegram.org`.                           |
+| Upgraded and allowlist blocks you | `openclaw security audit` and config allowlists | Run `openclaw doctor --fix` or replace `@username` with numeric sender IDs. |
 
 Full troubleshooting: [/channels/telegram#troubleshooting](/channels/telegram#troubleshooting)
 
@@ -82,16 +81,25 @@ Full troubleshooting: [/channels/slack#troubleshooting](/channels/slack#troubles
 
 ### iMessage and BlueBubbles failure signatures
 
-| Symptom                          | Fastest check                                                           | Fix                                                   |
-| -------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------- |
-| No inbound events                | Verify webhook/server reachability and app permissions                  | Fix webhook URL or BlueBubbles server state.          |
-| Can send but no receive on macOS | Check macOS privacy permissions for Messages automation                 | Re-grant TCC permissions and restart channel process. |
-| DM sender blocked                | `openclaw pairing list imessage` or `openclaw pairing list bluebubbles` | Approve pairing or update allowlist.                  |
+| Symptom                           | Fastest check                                                               | Fix                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| No inbound events                 | Verify webhook/server reachability, route registration, and app permissions | Fix webhook URL, route binding, or BlueBubbles server state.         |
+| Probe says works but chat is dead | `openclaw channels status --probe` for `route`, `private-api`, `helper`     | Treat `ping` as partial health only; inspect webhook + helper state. |
+| Can send but no receive on macOS  | Check macOS privacy permissions for Messages automation                     | Re-grant TCC permissions and restart channel process.                |
+| DM sender blocked                 | `openclaw pairing list imessage` or `openclaw pairing list bluebubbles`     | Approve pairing or update allowlist.                                 |
 
 Full troubleshooting:
 
 - [/channels/imessage#troubleshooting-macos-privacy-and-security-tcc](/channels/imessage#troubleshooting-macos-privacy-and-security-tcc)
 - [/channels/bluebubbles#troubleshooting](/channels/bluebubbles#troubleshooting)
+
+Recommended BlueBubbles ladder:
+
+1. `openclaw channels status --probe`
+2. Direct POST to the configured webhook path on the live gateway
+3. BlueBubbles `server/info`
+4. BlueBubbles webhook dispatch logs
+5. `Messages/chat.db` for the same sender
 
 ## Signal
 

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -27,10 +27,7 @@ Notes:
 
 - Interactive prompts (like keychain/OAuth fixes) only run when stdin is a TTY and `--non-interactive` is **not** set. Headless runs (cron, Telegram, no terminal) will skip prompts.
 - `--fix` (alias for `--repair`) writes a backup to `~/.openclaw/openclaw.json.bak` and drops unknown config keys, listing each removal.
-- State integrity checks now detect orphan transcript files in the sessions directory and can archive them as `.deleted.<timestamp>` to reclaim space safely.
-- Doctor also scans `~/.openclaw/cron/jobs.json` (or `cron.store`) for legacy cron job shapes and can rewrite them in place before the scheduler has to auto-normalize them at runtime.
-- Doctor includes a memory-search readiness check and can recommend `openclaw configure --section model` when embedding credentials are missing.
-- If sandbox mode is enabled but Docker is unavailable, doctor reports a high-signal warning with remediation (`install Docker` or `openclaw config set agents.defaults.sandbox.mode off`).
+- For BlueBubbles incidents, pair `openclaw doctor` with `openclaw channels status --probe`; `doctor` is best at config/runtime guidance, while channel probe shows BlueBubbles route/helper/private API health.
 
 ## macOS: `launchctl` env overrides
 

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -24,5 +24,5 @@ Notes:
 - Overview includes Gateway + node host service install/runtime status when available.
 - Overview includes update channel + git SHA (for source checkouts).
 - Update info surfaces in the Overview; if an update is available, status prints a hint to run `openclaw update` (see [Updating](/install/updating)).
-- Read-only status surfaces (`status`, `status --json`, `status --all`) resolve supported SecretRefs for their targeted config paths when possible.
-- If a supported channel SecretRef is configured but unavailable in the current command path, status stays read-only and reports degraded output instead of crashing. Human output shows warnings such as “configured token unavailable in this command path”, and JSON output includes `secretDiagnostics`.
+- `openclaw channels status --probe` is the better channel-level command when debugging webhook-backed providers like BlueBubbles.
+- For BlueBubbles, `works` only confirms REST `ping`; also inspect `route:registered`, `private-api:on/off`, and `helper:connected/disconnected`.

--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -1,30 +1,18 @@
-import type {
-  ChannelAccountSnapshot,
-  ChannelPlugin,
-  OpenClawConfig,
-} from "openclaw/plugin-sdk/bluebubbles";
+import type { ChannelAccountSnapshot, ChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk";
 import {
   applyAccountNameToChannelSection,
   buildChannelConfigSchema,
-  buildComputedAccountStatusSnapshot,
-  buildProbeChannelStatusSummary,
   collectBlueBubblesStatusIssues,
   DEFAULT_ACCOUNT_ID,
   deleteAccountFromConfigSection,
+  formatPairingApproveHint,
   migrateBaseNameToDefaultAccount,
   normalizeAccountId,
   PAIRING_APPROVED_MESSAGE,
   resolveBlueBubblesGroupRequireMention,
   resolveBlueBubblesGroupToolPolicy,
   setAccountEnabledInConfigSection,
-} from "openclaw/plugin-sdk/bluebubbles";
-import {
-  buildAccountScopedDmSecurityPolicy,
-  collectOpenGroupPolicyRestrictSendersWarnings,
-  createAccountStatusSink,
-  formatNormalizedAllowFromEntries,
-  mapAllowFromEntries,
-} from "openclaw/plugin-sdk/compat";
+} from "openclaw/plugin-sdk";
 import {
   listBlueBubblesAccountIds,
   type ResolvedBlueBubblesAccount,
@@ -32,13 +20,17 @@ import {
   resolveDefaultBlueBubblesAccountId,
 } from "./accounts.js";
 import { bluebubblesMessageActions } from "./actions.js";
-import { applyBlueBubblesConnectionConfig } from "./config-apply.js";
 import { BlueBubblesConfigSchema } from "./config-schema.js";
 import { sendBlueBubblesMedia } from "./media-send.js";
 import { resolveBlueBubblesMessageId } from "./monitor.js";
 import { monitorBlueBubblesProvider, resolveWebhookPathFromConfig } from "./monitor.js";
 import { blueBubblesOnboardingAdapter } from "./onboarding.js";
-import { probeBlueBubbles, type BlueBubblesProbe } from "./probe.js";
+import {
+  auditBlueBubbles,
+  probeBlueBubbles,
+  type BlueBubblesAudit,
+  type BlueBubblesProbe,
+} from "./probe.js";
 import { sendMessageBlueBubbles } from "./send.js";
 import {
   extractHandleFromChatGuid,
@@ -117,37 +109,41 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
       baseUrl: account.baseUrl,
     }),
     resolveAllowFrom: ({ cfg, accountId }) =>
-      mapAllowFromEntries(resolveBlueBubblesAccount({ cfg: cfg, accountId }).config.allowFrom),
+      (resolveBlueBubblesAccount({ cfg: cfg, accountId }).config.allowFrom ?? []).map((entry) =>
+        String(entry),
+      ),
     formatAllowFrom: ({ allowFrom }) =>
-      formatNormalizedAllowFromEntries({
-        allowFrom,
-        normalizeEntry: (entry) => normalizeBlueBubblesHandle(entry.replace(/^bluebubbles:/i, "")),
-      }),
+      allowFrom
+        .map((entry) => String(entry).trim())
+        .filter(Boolean)
+        .map((entry) => entry.replace(/^bluebubbles:/i, ""))
+        .map((entry) => normalizeBlueBubblesHandle(entry)),
   },
   actions: bluebubblesMessageActions,
   security: {
     resolveDmPolicy: ({ cfg, accountId, account }) => {
-      return buildAccountScopedDmSecurityPolicy({
-        cfg,
-        channelKey: "bluebubbles",
-        accountId,
-        fallbackAccountId: account.accountId ?? DEFAULT_ACCOUNT_ID,
-        policy: account.config.dmPolicy,
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const useAccountPath = Boolean(cfg.channels?.bluebubbles?.accounts?.[resolvedAccountId]);
+      const basePath = useAccountPath
+        ? `channels.bluebubbles.accounts.${resolvedAccountId}.`
+        : "channels.bluebubbles.";
+      return {
+        policy: account.config.dmPolicy ?? "pairing",
         allowFrom: account.config.allowFrom ?? [],
-        policyPathSuffix: "dmPolicy",
+        policyPath: `${basePath}dmPolicy`,
+        allowFromPath: basePath,
+        approveHint: formatPairingApproveHint("bluebubbles"),
         normalizeEntry: (raw) => normalizeBlueBubblesHandle(raw.replace(/^bluebubbles:/i, "")),
-      });
+      };
     },
     collectWarnings: ({ account }) => {
       const groupPolicy = account.config.groupPolicy ?? "allowlist";
-      return collectOpenGroupPolicyRestrictSendersWarnings({
-        groupPolicy,
-        surface: "BlueBubbles groups",
-        openScope: "any member",
-        groupPolicyPath: "channels.bluebubbles.groupPolicy",
-        groupAllowFromPath: "channels.bluebubbles.groupAllowFrom",
-        mentionGated: false,
-      });
+      if (groupPolicy !== "open") {
+        return [];
+      }
+      return [
+        `- BlueBubbles groups: groupPolicy="open" allows any member to trigger the bot. Set channels.bluebubbles.groupPolicy="allowlist" + channels.bluebubbles.groupAllowFrom to restrict senders.`,
+      ];
     },
   },
   messaging: {
@@ -258,16 +254,41 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
               channelKey: "bluebubbles",
             })
           : namedConfig;
-      return applyBlueBubblesConnectionConfig({
-        cfg: next,
-        accountId,
-        patch: {
-          serverUrl: input.httpUrl,
-          password: input.password,
-          webhookPath: input.webhookPath,
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...next,
+          channels: {
+            ...next.channels,
+            bluebubbles: {
+              ...next.channels?.bluebubbles,
+              enabled: true,
+              ...(input.httpUrl ? { serverUrl: input.httpUrl } : {}),
+              ...(input.password ? { password: input.password } : {}),
+              ...(input.webhookPath ? { webhookPath: input.webhookPath } : {}),
+            },
+          },
+        } as OpenClawConfig;
+      }
+      return {
+        ...next,
+        channels: {
+          ...next.channels,
+          bluebubbles: {
+            ...next.channels?.bluebubbles,
+            enabled: true,
+            accounts: {
+              ...next.channels?.bluebubbles?.accounts,
+              [accountId]: {
+                ...next.channels?.bluebubbles?.accounts?.[accountId],
+                enabled: true,
+                ...(input.httpUrl ? { serverUrl: input.httpUrl } : {}),
+                ...(input.password ? { password: input.password } : {}),
+                ...(input.webhookPath ? { webhookPath: input.webhookPath } : {}),
+              },
+            },
+          },
         },
-        onlyDefinedFields: true,
-      });
+      } as OpenClawConfig;
     },
   },
   pairing: {
@@ -340,29 +361,55 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
       lastError: null,
     },
     collectStatusIssues: collectBlueBubblesStatusIssues,
-    buildChannelSummary: ({ snapshot }) =>
-      buildProbeChannelStatusSummary(snapshot, { baseUrl: snapshot.baseUrl ?? null }),
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      baseUrl: snapshot.baseUrl ?? null,
+      running: snapshot.running ?? false,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+      probe: snapshot.probe,
+      lastProbeAt: snapshot.lastProbeAt ?? null,
+    }),
     probeAccount: async ({ account, timeoutMs }) =>
       probeBlueBubbles({
         baseUrl: account.baseUrl,
         password: account.config.password ?? null,
         timeoutMs,
       }),
-    buildAccountSnapshot: ({ account, runtime, probe }) => {
+    auditAccount: async ({ account, timeoutMs }) =>
+      auditBlueBubbles({
+        baseUrl: account.baseUrl,
+        password: account.config.password ?? null,
+        accountId: account.accountId,
+        webhookPath: resolveWebhookPathFromConfig(account.config),
+        timeoutMs,
+      }),
+    buildAccountSnapshot: ({ account, runtime, probe, audit }) => {
       const running = runtime?.running ?? false;
       const probeOk = (probe as BlueBubblesProbe | undefined)?.ok;
-      const base = buildComputedAccountStatusSnapshot({
+      const auditData = audit as BlueBubblesAudit | undefined;
+      return {
         accountId: account.accountId,
         name: account.name,
         enabled: account.enabled,
         configured: account.configured,
-        runtime,
-        probe,
-      });
-      return {
-        ...base,
         baseUrl: account.baseUrl,
+        webhookPath: resolveWebhookPathFromConfig(account.config),
+        webhookRouteRegistered: auditData?.webhookRouteRegistered,
+        privateApi: auditData?.privateApi ?? null,
+        helperConnected: auditData?.helperConnected ?? null,
+        serverVersion: auditData?.serverVersion ?? null,
+        osVersion: auditData?.osVersion ?? null,
+        running,
         connected: probeOk ?? running,
+        lastStartAt: runtime?.lastStartAt ?? null,
+        lastStopAt: runtime?.lastStopAt ?? null,
+        lastError: runtime?.lastError ?? null,
+        probe,
+        audit,
+        lastInboundAt: runtime?.lastInboundAt ?? null,
+        lastOutboundAt: runtime?.lastOutboundAt ?? null,
       };
     },
   },
@@ -370,11 +417,8 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
     startAccount: async (ctx) => {
       const account = ctx.account;
       const webhookPath = resolveWebhookPathFromConfig(account.config);
-      const statusSink = createAccountStatusSink({
-        accountId: ctx.accountId,
-        setStatus: ctx.setStatus,
-      });
-      statusSink({
+      ctx.setStatus({
+        accountId: account.accountId,
         baseUrl: account.baseUrl,
       });
       ctx.log?.info(`[${account.accountId}] starting provider (webhook=${webhookPath})`);
@@ -383,7 +427,7 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
         config: ctx.cfg,
         runtime: ctx.runtime,
         abortSignal: ctx.abortSignal,
-        statusSink,
+        statusSink: (patch) => ctx.setStatus({ accountId: ctx.accountId, ...patch }),
         webhookPath,
       });
     },

--- a/extensions/bluebubbles/src/probe.ts
+++ b/extensions/bluebubbles/src/probe.ts
@@ -1,5 +1,7 @@
-import type { BaseProbeResult } from "openclaw/plugin-sdk/bluebubbles";
-import { normalizeSecretInputString } from "./secret-input.js";
+import type { BaseProbeResult } from "openclaw/plugin-sdk";
+import { findRegisteredPluginHttpRoute } from "../../../src/gateway/server/plugins-http/route-match.js";
+import { getActivePluginRegistry } from "../../../src/plugins/runtime.js";
+import { normalizeWebhookPath } from "./monitor-shared.js";
 import { buildBlueBubblesApiUrl, blueBubblesFetchWithTimeout } from "./types.js";
 
 export type BlueBubblesProbe = BaseProbeResult & {
@@ -14,6 +16,17 @@ export type BlueBubblesServerInfo = {
   proxy_service?: string;
   detected_icloud?: string;
   computer_id?: string;
+};
+
+export type BlueBubblesAudit = {
+  ok: boolean;
+  webhookPath: string;
+  webhookRouteRegistered: boolean;
+  privateApi: boolean | null;
+  helperConnected: boolean | null;
+  serverVersion: string | null;
+  osVersion: string | null;
+  warnings: string[];
 };
 
 /** Cache server info by account ID to avoid repeated API calls.
@@ -36,8 +49,8 @@ export async function fetchBlueBubblesServerInfo(params: {
   accountId?: string;
   timeoutMs?: number;
 }): Promise<BlueBubblesServerInfo | null> {
-  const baseUrl = normalizeSecretInputString(params.baseUrl);
-  const password = normalizeSecretInputString(params.password);
+  const baseUrl = params.baseUrl?.trim();
+  const password = params.password?.trim();
   if (!baseUrl || !password) {
     return null;
   }
@@ -97,14 +110,6 @@ export function getCachedBlueBubblesPrivateApiStatus(accountId?: string): boolea
   return info.private_api;
 }
 
-export function isBlueBubblesPrivateApiStatusEnabled(status: boolean | null): boolean {
-  return status === true;
-}
-
-export function isBlueBubblesPrivateApiEnabled(accountId?: string): boolean {
-  return isBlueBubblesPrivateApiStatusEnabled(getCachedBlueBubblesPrivateApiStatus(accountId));
-}
-
 /**
  * Parse macOS version string (e.g., "15.0.1" or "26.0") into major version number.
  */
@@ -139,8 +144,8 @@ export async function probeBlueBubbles(params: {
   password?: string | null;
   timeoutMs?: number;
 }): Promise<BlueBubblesProbe> {
-  const baseUrl = normalizeSecretInputString(params.baseUrl);
-  const password = normalizeSecretInputString(params.password);
+  const baseUrl = params.baseUrl?.trim();
+  const password = params.password?.trim();
   if (!baseUrl) {
     return { ok: false, error: "serverUrl not configured" };
   }
@@ -161,4 +166,50 @@ export async function probeBlueBubbles(params: {
       error: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+export async function auditBlueBubbles(params: {
+  baseUrl?: string | null;
+  password?: string | null;
+  accountId?: string;
+  webhookPath?: string | null;
+  timeoutMs?: number;
+}): Promise<BlueBubblesAudit> {
+  const webhookPath = normalizeWebhookPath(params.webhookPath?.trim() || "/bluebubbles-webhook");
+  const registry = getActivePluginRegistry();
+  const route = registry ? findRegisteredPluginHttpRoute(registry, webhookPath) : undefined;
+  const webhookRouteRegistered =
+    route?.path === webhookPath &&
+    (route.pluginId === "bluebubbles" || route.source === "bluebubbles-webhook");
+  const serverInfo = await fetchBlueBubblesServerInfo({
+    baseUrl: params.baseUrl,
+    password: params.password,
+    accountId: params.accountId,
+    timeoutMs: params.timeoutMs,
+  }).catch(() => null);
+
+  const privateApi = typeof serverInfo?.private_api === "boolean" ? serverInfo.private_api : null;
+  const helperConnected =
+    typeof serverInfo?.helper_connected === "boolean" ? serverInfo.helper_connected : null;
+  const warnings: string[] = [];
+  if (!webhookRouteRegistered) {
+    warnings.push("webhook route not registered");
+  }
+  if (privateApi === false) {
+    warnings.push("private api disabled");
+  }
+  if (helperConnected === false) {
+    warnings.push("private api helper disconnected");
+  }
+
+  return {
+    ok: warnings.length === 0,
+    webhookPath,
+    webhookRouteRegistered,
+    privateApi,
+    helperConnected,
+    serverVersion: serverInfo?.server_version?.trim() || null,
+    osVersion: serverInfo?.os_version?.trim() || null,
+    warnings,
+  };
 }

--- a/src/channels/plugins/status-issues/bluebubbles.test.ts
+++ b/src/channels/plugins/status-issues/bluebubbles.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from "vitest";
 import { collectBlueBubblesStatusIssues } from "./bluebubbles.js";
 
 describe("collectBlueBubblesStatusIssues", () => {
-  it("reports unconfigured enabled accounts", () => {
+  it("reports helper disconnected even when ping still works", () => {
     const issues = collectBlueBubblesStatusIssues([
       {
         accountId: "default",
         enabled: true,
-        configured: false,
+        configured: true,
+        running: true,
+        connected: true,
+        probe: { ok: true, status: 200 },
+        helperConnected: false,
       },
     ]);
 
@@ -15,52 +19,53 @@ describe("collectBlueBubblesStatusIssues", () => {
       expect.objectContaining({
         channel: "bluebubbles",
         accountId: "default",
-        kind: "config",
+        message: expect.stringContaining("helper disconnected"),
       }),
     ]);
   });
 
-  it("reports probe failure and runtime error for configured running accounts", () => {
+  it("reports private api disabled even when the server is reachable", () => {
     const issues = collectBlueBubblesStatusIssues([
       {
-        accountId: "work",
+        accountId: "default",
         enabled: true,
         configured: true,
         running: true,
-        lastError: "timeout",
-        probe: {
-          ok: false,
-          status: 503,
-        },
+        connected: true,
+        probe: { ok: true, status: 200 },
+        privateApi: false,
       },
     ]);
 
-    expect(issues).toHaveLength(2);
-    expect(issues[0]).toEqual(
+    expect(issues).toEqual([
       expect.objectContaining({
         channel: "bluebubbles",
-        accountId: "work",
-        kind: "runtime",
+        accountId: "default",
+        message: expect.stringContaining("Private API disabled"),
       }),
-    );
-    expect(issues[1]).toEqual(
-      expect.objectContaining({
-        channel: "bluebubbles",
-        accountId: "work",
-        kind: "runtime",
-        message: "Channel error: timeout",
-      }),
-    );
+    ]);
   });
 
-  it("skips disabled accounts", () => {
+  it("reports a missing live webhook route when ping still works", () => {
     const issues = collectBlueBubblesStatusIssues([
       {
-        accountId: "disabled",
-        enabled: false,
-        configured: false,
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        running: true,
+        connected: true,
+        webhookPath: "/bluebubbles-webhook",
+        webhookRouteRegistered: false,
+        probe: { ok: true, status: 200 },
       },
     ]);
-    expect(issues).toEqual([]);
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        channel: "bluebubbles",
+        accountId: "default",
+        message: expect.stringContaining("webhook route missing"),
+      }),
+    ]);
   });
 });

--- a/src/channels/plugins/status-issues/bluebubbles.ts
+++ b/src/channels/plugins/status-issues/bluebubbles.ts
@@ -1,12 +1,19 @@
 import type { ChannelAccountSnapshot, ChannelStatusIssue } from "../types.js";
-import { asString, collectIssuesForEnabledAccounts, isRecord } from "./shared.js";
+import { asString, isRecord } from "./shared.js";
 
 type BlueBubblesAccountStatus = {
   accountId?: unknown;
   enabled?: unknown;
   configured?: unknown;
   running?: unknown;
+  connected?: unknown;
   baseUrl?: unknown;
+  webhookPath?: unknown;
+  webhookRouteRegistered?: unknown;
+  privateApi?: unknown;
+  helperConnected?: unknown;
+  serverVersion?: unknown;
+  osVersion?: unknown;
   lastError?: unknown;
   probe?: unknown;
 };
@@ -28,7 +35,14 @@ function readBlueBubblesAccountStatus(
     enabled: value.enabled,
     configured: value.configured,
     running: value.running,
+    connected: value.connected,
     baseUrl: value.baseUrl,
+    webhookPath: value.webhookPath,
+    webhookRouteRegistered: value.webhookRouteRegistered,
+    privateApi: value.privateApi,
+    helperConnected: value.helperConnected,
+    serverVersion: value.serverVersion,
+    osVersion: value.osVersion,
     lastError: value.lastError,
     probe: value.probe,
   };
@@ -48,53 +62,114 @@ function readBlueBubblesProbeResult(value: unknown): BlueBubblesProbeResult | nu
 export function collectBlueBubblesStatusIssues(
   accounts: ChannelAccountSnapshot[],
 ): ChannelStatusIssue[] {
-  return collectIssuesForEnabledAccounts({
-    accounts,
-    readAccount: readBlueBubblesAccountStatus,
-    collectIssues: ({ account, accountId, issues }) => {
-      const configured = account.configured === true;
-      const running = account.running === true;
-      const lastError = asString(account.lastError);
-      const probe = readBlueBubblesProbeResult(account.probe);
+  const issues: ChannelStatusIssue[] = [];
+  for (const entry of accounts) {
+    const account = readBlueBubblesAccountStatus(entry);
+    if (!account) {
+      continue;
+    }
+    const accountId = asString(account.accountId) ?? "default";
+    const enabled = account.enabled !== false;
+    if (!enabled) {
+      continue;
+    }
 
-      // Check for unconfigured accounts
-      if (!configured) {
-        issues.push({
-          channel: "bluebubbles",
-          accountId,
-          kind: "config",
-          message: "Not configured (missing serverUrl or password).",
-          fix: "Run: openclaw channels add bluebubbles --http-url <server-url> --password <password>",
-        });
-        return;
-      }
+    const configured = account.configured === true;
+    const running = account.running === true;
+    const connected = account.connected === true;
+    const lastError = asString(account.lastError);
+    const probe = readBlueBubblesProbeResult(account.probe);
+    const webhookPath = asString(account.webhookPath);
+    const webhookRouteRegistered =
+      typeof account.webhookRouteRegistered === "boolean"
+        ? account.webhookRouteRegistered
+        : undefined;
+    const privateApi = typeof account.privateApi === "boolean" ? account.privateApi : undefined;
+    const helperConnected =
+      typeof account.helperConnected === "boolean" ? account.helperConnected : undefined;
+    const serverVersion = asString(account.serverVersion);
+    const osVersion = asString(account.osVersion);
 
-      // Check for probe failures
-      if (probe && probe.ok === false) {
-        const errorDetail = probe.error
-          ? `: ${probe.error}`
-          : probe.status
-            ? ` (HTTP ${probe.status})`
-            : "";
-        issues.push({
-          channel: "bluebubbles",
-          accountId,
-          kind: "runtime",
-          message: `BlueBubbles server unreachable${errorDetail}`,
-          fix: "Check that the BlueBubbles server is running and accessible. Verify serverUrl and password in your config.",
-        });
-      }
+    // Check for unconfigured accounts
+    if (!configured) {
+      issues.push({
+        channel: "bluebubbles",
+        accountId,
+        kind: "config",
+        message: "Not configured (missing serverUrl or password).",
+        fix: "Run: openclaw channels add bluebubbles --http-url <server-url> --password <password>",
+      });
+      continue;
+    }
 
-      // Check for runtime errors
-      if (running && lastError) {
-        issues.push({
-          channel: "bluebubbles",
-          accountId,
-          kind: "runtime",
-          message: `Channel error: ${lastError}`,
-          fix: "Check gateway logs for details. If the webhook is failing, verify the webhook URL is configured in BlueBubbles server settings.",
-        });
-      }
-    },
-  });
+    // Check for probe failures
+    if (probe && probe.ok === false) {
+      const errorDetail = probe.error
+        ? `: ${probe.error}`
+        : probe.status
+          ? ` (HTTP ${probe.status})`
+          : "";
+      issues.push({
+        channel: "bluebubbles",
+        accountId,
+        kind: "runtime",
+        message: `BlueBubbles server unreachable${errorDetail}`,
+        fix: "Check that the BlueBubbles server is running and accessible. Verify serverUrl and password in your config.",
+      });
+    }
+
+    if (probe?.ok === true && webhookRouteRegistered === false) {
+      issues.push({
+        channel: "bluebubbles",
+        accountId,
+        kind: "runtime",
+        message: `BlueBubbles webhook route missing${webhookPath ? ` at ${webhookPath}` : ""}`,
+        fix: "Restart the gateway and verify the BlueBubbles webhook path is registered on the live server.",
+      });
+    }
+
+    if (probe?.ok === true && privateApi === false) {
+      const suffix = osVersion ? ` (macOS ${osVersion})` : "";
+      issues.push({
+        channel: "bluebubbles",
+        accountId,
+        kind: "runtime",
+        message: `BlueBubbles Private API disabled${suffix}`,
+        fix: "Enable BlueBubbles Private API and re-check macOS accessibility/privacy prompts.",
+      });
+    }
+
+    if (probe?.ok === true && helperConnected === false) {
+      const versionSuffix = serverVersion ? ` (server ${serverVersion})` : "";
+      issues.push({
+        channel: "bluebubbles",
+        accountId,
+        kind: "runtime",
+        message: `BlueBubbles helper disconnected${versionSuffix}`,
+        fix: "Restart BlueBubbles and Messages.app, then confirm the Private API helper reconnects.",
+      });
+    }
+
+    // Check for runtime errors
+    if (running && lastError) {
+      issues.push({
+        channel: "bluebubbles",
+        accountId,
+        kind: "runtime",
+        message: `Channel error: ${lastError}`,
+        fix: "Check gateway logs for details. If the webhook is failing, verify the webhook URL is configured in BlueBubbles server settings.",
+      });
+    }
+
+    if (running && !connected && probe?.ok === true) {
+      issues.push({
+        channel: "bluebubbles",
+        accountId,
+        kind: "runtime",
+        message: "BlueBubbles running but not connected",
+        fix: "Inspect webhook acceptance and BlueBubbles Private API helper state; ping alone is not enough for inbound health.",
+      });
+    }
+  }
+  return issues;
 }

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -12,9 +12,7 @@ export type ChannelId = ChatChannelId | (string & {});
 
 export type ChannelOutboundTargetMode = "explicit" | "implicit" | "heartbeat";
 
-export type ChannelAgentTool = AgentTool<TSchema, unknown> & {
-  ownerOnly?: boolean;
-};
+export type ChannelAgentTool = AgentTool<TSchema, unknown>;
 
 export type ChannelAgentToolFactory = (params: { cfg?: OpenClawConfig }) => ChannelAgentTool[];
 
@@ -102,7 +100,6 @@ export type ChannelAccountSnapshot = {
   linked?: boolean;
   running?: boolean;
   connected?: boolean;
-  restartPending?: boolean;
   reconnectAttempts?: number;
   lastConnectedAt?: number | null;
   lastDisconnect?:
@@ -121,28 +118,24 @@ export type ChannelAccountSnapshot = {
   lastStopAt?: number | null;
   lastInboundAt?: number | null;
   lastOutboundAt?: number | null;
-  busy?: boolean;
-  activeRuns?: number;
-  lastRunActivityAt?: number | null;
   mode?: string;
   dmPolicy?: string;
   allowFrom?: string[];
   tokenSource?: string;
   botTokenSource?: string;
   appTokenSource?: string;
-  signingSecretSource?: string;
-  tokenStatus?: string;
-  botTokenStatus?: string;
-  appTokenStatus?: string;
-  signingSecretStatus?: string;
-  userTokenStatus?: string;
   credentialSource?: string;
   secretSource?: string;
   audienceType?: string;
   audience?: string;
   webhookPath?: string;
   webhookUrl?: string;
+  webhookRouteRegistered?: boolean;
   baseUrl?: string;
+  privateApi?: boolean | null;
+  helperConnected?: boolean | null;
+  serverVersion?: string | null;
+  osVersion?: string | null;
   allowUnmentionedGroups?: boolean;
   cliPath?: string | null;
   dbPath?: string | null;
@@ -259,20 +252,16 @@ export type ChannelThreadingContext = {
   From?: string;
   To?: string;
   ChatType?: string;
-  CurrentMessageId?: string | number;
   ReplyToId?: string;
   ReplyToIdFull?: string;
   ThreadLabel?: string;
   MessageThreadId?: string | number;
-  /** Platform-native channel/conversation id (e.g. Slack DM channel "D…" id). */
-  NativeChannelId?: string;
 };
 
 export type ChannelThreadingToolContext = {
   currentChannelId?: string;
   currentChannelProvider?: ChannelId;
   currentThreadTs?: string;
-  currentMessageId?: string | number;
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
   /**
@@ -288,18 +277,6 @@ export type ChannelMessagingAdapter = {
   targetResolver?: {
     looksLikeId?: (raw: string, normalized?: string) => boolean;
     hint?: string;
-    resolveTarget?: (params: {
-      cfg: OpenClawConfig;
-      accountId?: string | null;
-      input: string;
-      normalized: string;
-      preferredKind?: ChannelDirectoryEntryKind | "channel";
-    }) => Promise<{
-      to: string;
-      kind: ChannelDirectoryEntryKind | "channel";
-      display?: string;
-      source?: "normalized" | "directory";
-    } | null>;
   };
   formatTargetDisplay?: (params: {
     target: string;
@@ -331,13 +308,7 @@ export type ChannelMessageActionContext = {
   action: ChannelMessageActionName;
   cfg: OpenClawConfig;
   params: Record<string, unknown>;
-  mediaLocalRoots?: readonly string[];
   accountId?: string | null;
-  /**
-   * Trusted sender id from inbound context. This is server-injected and must
-   * never be sourced from tool/model-controlled params.
-   */
-  requesterSenderId?: string | null;
   gateway?: {
     url?: string;
     token?: string;
@@ -353,16 +324,9 @@ export type ChannelMessageActionContext = {
 export type ChannelToolSend = {
   to: string;
   accountId?: string | null;
-  threadId?: string | null;
 };
 
 export type ChannelMessageActionAdapter = {
-  /**
-   * Advertise agent-discoverable actions for this channel.
-   * Keep this aligned with any gated capability checks. Poll discovery is
-   * not inferred from `outbound.sendPoll`, so channels that want agents to
-   * create polls should include `"poll"` here when enabled.
-   */
   listActions?: (params: { cfg: OpenClawConfig }) => ChannelMessageActionName[];
   supportsAction?: (params: { action: ChannelMessageActionName }) => boolean;
   supportsButtons?: (params: { cfg: OpenClawConfig }) => boolean;

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -1,16 +1,7 @@
-import {
-  hasConfiguredUnavailableCredentialStatus,
-  hasResolvedCredentialValue,
-} from "../../channels/account-snapshot-fields.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
-import {
-  buildChannelAccountSnapshot,
-  buildReadOnlySourceChannelAccountSnapshot,
-} from "../../channels/plugins/status.js";
+import { buildChannelAccountSnapshot } from "../../channels/plugins/status.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.js";
 import { formatCliCommand } from "../../cli/command-format.js";
-import { resolveCommandSecretRefsViaGateway } from "../../cli/command-secret-gateway.js";
-import { getChannelsCommandSecretTargetIds } from "../../cli/command-secret-targets.js";
 import { withProgress } from "../../cli/progress.js";
 import { type OpenClawConfig, readConfigFileSnapshot } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
@@ -19,11 +10,7 @@ import { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
-import {
-  type ChatChannel,
-  formatChannelAccountLabel,
-  requireValidConfigSnapshot,
-} from "./shared.js";
+import { type ChatChannel, formatChannelAccountLabel, requireValidConfig } from "./shared.js";
 
 export type ChannelsStatusOptions = {
   json?: boolean;
@@ -36,14 +23,7 @@ function appendEnabledConfiguredLinkedBits(bits: string[], account: Record<strin
     bits.push(account.enabled ? "enabled" : "disabled");
   }
   if (typeof account.configured === "boolean") {
-    if (account.configured) {
-      bits.push("configured");
-      if (hasConfiguredUnavailableCredentialStatus(account)) {
-        bits.push("secret unavailable in this command path");
-      }
-    } else {
-      bits.push("not configured");
-    }
+    bits.push(account.configured ? "configured" : "not configured");
   }
   if (typeof account.linked === "boolean") {
     bits.push(account.linked ? "linked" : "not linked");
@@ -57,20 +37,15 @@ function appendModeBit(bits: string[], account: Record<string, unknown>) {
 }
 
 function appendTokenSourceBits(bits: string[], account: Record<string, unknown>) {
-  const appendSourceBit = (label: string, sourceKey: string, statusKey: string) => {
-    const source = account[sourceKey];
-    if (typeof source !== "string" || !source || source === "none") {
-      return;
-    }
-    const status = account[statusKey];
-    const unavailable = status === "configured_unavailable" ? " (unavailable)" : "";
-    bits.push(`${label}:${source}${unavailable}`);
-  };
-
-  appendSourceBit("token", "tokenSource", "tokenStatus");
-  appendSourceBit("bot", "botTokenSource", "botTokenStatus");
-  appendSourceBit("app", "appTokenSource", "appTokenStatus");
-  appendSourceBit("signing", "signingSecretSource", "signingSecretStatus");
+  if (typeof account.tokenSource === "string" && account.tokenSource) {
+    bits.push(`token:${account.tokenSource}`);
+  }
+  if (typeof account.botTokenSource === "string" && account.botTokenSource) {
+    bits.push(`bot:${account.botTokenSource}`);
+  }
+  if (typeof account.appTokenSource === "string" && account.appTokenSource) {
+    bits.push(`app:${account.appTokenSource}`);
+  }
 }
 
 function appendBaseUrlBit(bits: string[], account: Record<string, unknown>) {
@@ -160,6 +135,24 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
         bits.push("groups:unmentioned");
       }
       appendBaseUrlBit(bits, account);
+      if (typeof account.webhookPath === "string" && account.webhookPath) {
+        bits.push(`webhook:${account.webhookPath}`);
+      }
+      if (typeof account.webhookRouteRegistered === "boolean") {
+        bits.push(account.webhookRouteRegistered ? "route:registered" : "route:missing");
+      }
+      if (typeof account.privateApi === "boolean") {
+        bits.push(account.privateApi ? "private-api:on" : "private-api:off");
+      }
+      if (typeof account.helperConnected === "boolean") {
+        bits.push(account.helperConnected ? "helper:connected" : "helper:disconnected");
+      }
+      if (typeof account.serverVersion === "string" && account.serverVersion) {
+        bits.push(`server:${account.serverVersion}`);
+      }
+      if (typeof account.osVersion === "string" && account.osVersion) {
+        bits.push(`os:${account.osVersion}`);
+      }
       const probe = account.probe as { ok?: boolean } | undefined;
       if (probe && typeof probe.ok === "boolean") {
         bits.push(probe.ok ? "works" : "probe failed");
@@ -209,10 +202,9 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
   return lines;
 }
 
-export async function formatConfigChannelsStatusLines(
+async function formatConfigChannelsStatusLines(
   cfg: OpenClawConfig,
   meta: { path?: string; mode?: "local" | "remote" },
-  opts?: { sourceConfig?: OpenClawConfig },
 ): Promise<string[]> {
   const lines: string[] = [];
   lines.push(theme.warn("Gateway not reachable; showing config-only status."));
@@ -237,7 +229,6 @@ export async function formatConfigChannelsStatusLines(
     });
 
   const plugins = listChannelPlugins();
-  const sourceConfig = opts?.sourceConfig ?? cfg;
   for (const plugin of plugins) {
     const accountIds = plugin.config.listAccountIds(cfg);
     if (!accountIds.length) {
@@ -245,24 +236,12 @@ export async function formatConfigChannelsStatusLines(
     }
     const snapshots: ChannelAccountSnapshot[] = [];
     for (const accountId of accountIds) {
-      const sourceSnapshot = await buildReadOnlySourceChannelAccountSnapshot({
-        plugin,
-        cfg: sourceConfig,
-        accountId,
-      });
-      const resolvedSnapshot = await buildChannelAccountSnapshot({
+      const snapshot = await buildChannelAccountSnapshot({
         plugin,
         cfg,
         accountId,
       });
-      snapshots.push(
-        sourceSnapshot &&
-          hasConfiguredUnavailableCredentialStatus(sourceSnapshot) &&
-          (!hasResolvedCredentialValue(resolvedSnapshot) ||
-            (sourceSnapshot.configured === true && resolvedSnapshot.configured === false))
-          ? sourceSnapshot
-          : resolvedSnapshot,
-      );
+      snapshots.push(snapshot);
     }
     if (snapshots.length > 0) {
       lines.push(...accountLines(plugin.id, snapshots));
@@ -307,31 +286,18 @@ export async function channelsStatusCommand(
     runtime.log(formatGatewayChannelsStatusLines(payload).join("\n"));
   } catch (err) {
     runtime.error(`Gateway not reachable: ${String(err)}`);
-    const cfg = await requireValidConfigSnapshot(runtime);
+    const cfg = await requireValidConfig(runtime);
     if (!cfg) {
       return;
-    }
-    const { resolvedConfig, diagnostics } = await resolveCommandSecretRefsViaGateway({
-      config: cfg,
-      commandName: "channels status",
-      targetIds: getChannelsCommandSecretTargetIds(),
-      mode: "summary",
-    });
-    for (const entry of diagnostics) {
-      runtime.log(`[secrets] ${entry}`);
     }
     const snapshot = await readConfigFileSnapshot();
     const mode = cfg.gateway?.mode === "remote" ? "remote" : "local";
     runtime.log(
       (
-        await formatConfigChannelsStatusLines(
-          resolvedConfig,
-          {
-            path: snapshot.path,
-            mode,
-          },
-          { sourceConfig: cfg },
-        )
+        await formatConfigChannelsStatusLines(cfg, {
+          path: snapshot.path,
+          mode,
+        })
       ).join("\n"),
     );
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw channels status --probe` can look green for BlueBubbles when REST `ping` works but the real inbound path is degraded or misconfigured.
- Why it matters: operators currently have to jump between gateway logs, BlueBubbles server info, and manual webhook curls to distinguish route breakage from helper / Private API drift.
- What changed: added BlueBubbles audit data to `status --probe`, surfaced route/private-api/helper warnings in status issue collection, and documented the false-green troubleshooting path.
- What did NOT change (scope boundary): this PR does not fix the underlying route-registration regressions already covered by open PRs such as `#45606` / `#45664`; it only improves detection and operator visibility.
- AI-assisted: yes; code was reviewed and live-validated on a Nimbus macOS host before being trimmed into this focused PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #45620
- Related #45606
- Related #45664
- Related #32734

## User-visible / Behavior Changes

- `openclaw channels status --probe` for BlueBubbles can now show `webhook:<path>`, `route:registered|missing`, `private-api:on|off`, `helper:connected|disconnected`, and BlueBubbles server / macOS version fields.
- BlueBubbles status warnings now explicitly call out missing webhook registration, disabled Private API, helper disconnection, and `ping ok` while runtime connectivity is degraded.
- BlueBubbles docs and troubleshooting now explain that `ping` is only partial health for webhook-backed ingress.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - The only additional call is a read-only BlueBubbles `server/info` audit fetch that uses the already-configured account password and existing BlueBubbles base URL. Failures degrade to `null` / warning state rather than changing runtime behavior.

## Repro + Verification

### Environment

- OS: macOS 26.3.x
- Runtime/container: local npm/global OpenClaw gateway
- Model/provider: not relevant for reproduction
- Integration/channel (if any): BlueBubbles 1.9.9
- Relevant config (redacted): `channels.bluebubbles.serverUrl`, `channels.bluebubbles.password`, optional `webhookPath`

### Steps

1. Configure BlueBubbles and enable `openclaw channels status --probe` against a local gateway.
2. Put BlueBubbles into one of the degraded states: webhook route missing, `private_api=false`, or `helper_connected=false`.
3. Run `openclaw channels status --probe`.

### Expected

- Probe output should surface route/helper/private-api drift instead of only showing a generic green `works` status.

### Actual

- Before this change, operators could see `works` from `ping` while the real inbound webhook path was degraded.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Live Nimbus gateway shows BlueBubbles `webhook:/bluebubbles-webhook`, `route:registered`, `private-api:on`, `helper:connected` after deploying the same logic into the running hotfix branch.
  - Manual POST to the live webhook returns `400 invalid payload`, confirming route reachability while the status surface reports the route as registered.
  - Unit coverage for `collectBlueBubblesStatusIssues` passes.
- Edge cases checked:
  - Missing route with otherwise green ping.
  - Helper disconnected with green ping.
  - Private API disabled with green ping.
- What you did **not** verify:
  - Full repository build in this checkout, because current `upstream/main` is not locally build-clean in this Nimbus environment due unrelated dependency/type drift outside BlueBubbles scope.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or drop the new audit/status fields from the BlueBubbles status adapter.
- Files/config to restore: `extensions/bluebubbles/src/probe.ts`, `extensions/bluebubbles/src/channel.ts`, `src/channels/plugins/status-issues/bluebubbles.ts`, `src/commands/channels/status.ts`, related docs.
- Known bad symptoms reviewers should watch for:
  - BlueBubbles status output reports `route:missing` unexpectedly in environments where a separate route-fix PR has not yet landed.
  - Audit fetch timeouts masking the rest of `channels.status` output.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Route-registration audit can report a false negative if the underlying registry/regression bug is still present.
  - Mitigation: this PR is explicitly scoped as a companion to the route-fix PRs; the output stays diagnostic and does not change gateway behavior.
- Risk: BlueBubbles `server/info` may be temporarily unreachable even when `ping` succeeds.
  - Mitigation: the audit records nullable fields / warnings without failing the whole command path.
