### PR TITLE
fix(ui): show session label instead of id in session selector dropdown

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -668,16 +668,24 @@ function resolveSessionScopedOptionLabel(
   key: string,
   row?: SessionsListResult["sessions"][number],
   rest?: string,
-) {
+): string {
+  // 优先使用 label，然后是 displayName，最后才用 rest/key
+  const label = typeof row?.label === "string" ? row.label.trim() : "";
+  const displayName =
+    typeof row?.displayName === "string" && row.displayName.trim().length > 0
+      ? row.displayName.trim()
+      : null;
+
+  // 如果有有效的 label 且不是 key 本身，直接返回 label
+  if (label && label !== key) {
+    return label;
+  }
+
   const base = rest?.trim() || key;
   if (!row) {
     return base;
   }
-  const displayName =
-    typeof row.displayName === "string" && row.displayName.trim().length > 0
-      ? row.displayName.trim()
-      : null;
-  const label = typeof row.label === "string" ? row.label.trim() : "";
+
   const showDisplayName = Boolean(
     displayName && displayName !== key && displayName !== label && displayName !== base,
   );


### PR DESCRIPTION
## Summary

The session selector dropdown was showing session IDs instead of labels when a session had a label set.

## Root Cause

The `resolveSessionScopedOptionLabel` function was using `rest` or `key` as the base label, ignoring the `label` field from the session row.

## Fix

Modified `resolveSessionScopedOptionLabel` to prioritize:
1. `label` field (if set and different from key)
2. `displayName` field (with base prefix)
3. `rest` or `key` as fallback

## Test

- All existing tests pass
- Manual verification: Session dropdown now displays the configured label (e.g., 'openclaw-control-ui') instead of the raw session ID

## Screenshot

Before: Dropdown showed session ID like `agent:main:webchat:direct:openclaw-control-ui`
After: Dropdown shows label `openclaw-control-ui` when label is configured