### PR TITLE
fix: clear modelOverride, providerOverride and fallback notice on /new

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1557,6 +1557,100 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     expect(result.sessionEntry.verboseLevel).toBeUndefined();
     expect(result.sessionEntry.thinkingLevel).toBeUndefined();
   });
+
+  it("does not carry modelOverride or providerOverride across /new", async () => {
+    const storePath = await createStorePath("openclaw-no-model-override-");
+    const sessionKey = "agent:main:telegram:dm:user-model-override";
+    const existingSessionId = "existing-session-model-override";
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+        // Simulate a fallback-set model/provider override on the old session.
+        modelOverride: "gemini-2.5-pro",
+        providerOverride: "google",
+        // Behavior overrides should still carry over.
+        verboseLevel: "on",
+        thinkingLevel: "high",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        From: "user-model-override",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    // modelOverride and providerOverride must NOT persist — they may have been
+    // set by automatic fallback and would pin the new session to a fallback model.
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+    // Behavior overrides should still be preserved.
+    expect(result.sessionEntry.verboseLevel).toBe("on");
+    expect(result.sessionEntry.thinkingLevel).toBe("high");
+  });
+
+  it("clears fallback notice fields on /new", async () => {
+    const storePath = await createStorePath("openclaw-clear-fallback-notice-");
+    const sessionKey = "agent:main:telegram:dm:user-fallback-notice";
+    const existingSessionId = "existing-session-fallback-notice";
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+        // Simulate fallback notice fields left over from the previous session.
+        fallbackNoticeActiveModel: "gemini-2.5-pro",
+        fallbackNoticeSelectedModel: "claude-sonnet-4.6",
+        fallbackNoticeReason: "rate_limit",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        From: "user-fallback-notice",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    // Fallback notice fields must be cleared so the new session doesn't show
+    // a stale "using <fallback model> because <reason>" banner.
+    expect(result.sessionEntry.fallbackNoticeActiveModel).toBeUndefined();
+    expect(result.sessionEntry.fallbackNoticeSelectedModel).toBeUndefined();
+    expect(result.sessionEntry.fallbackNoticeReason).toBeUndefined();
+  });
 });
 
 describe("drainFormattedSystemEvents", () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -362,13 +362,16 @@ export async function initSessionState(params: {
     // When a reset trigger (/new, /reset) starts a new session, carry over
     // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
     // so the user doesn't have to re-enable them every time.
+    // NOTE: modelOverride and providerOverride are intentionally NOT carried
+    // over — they may have been set by automatic fallback (not the user) and
+    // would pin the new session to the fallback model.  If the user wants a
+    // specific model they can use `/new <model>` which calls
+    // applyResetModelOverride() after initSessionState().
     if (resetTriggered && entry) {
       persistedThinking = entry.thinkingLevel;
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
       persistedLabel = entry.label;
     }
   }
@@ -518,6 +521,11 @@ export async function initSessionState(params: {
     sessionEntry.inputTokens = undefined;
     sessionEntry.outputTokens = undefined;
     sessionEntry.contextTokens = undefined;
+    // Clear fallback notice fields so the new session doesn't show a stale
+    // "using <fallback model> because <reason>" banner from the old session.
+    sessionEntry.fallbackNoticeActiveModel = undefined;
+    sessionEntry.fallbackNoticeSelectedModel = undefined;
+    sessionEntry.fallbackNoticeReason = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };


### PR DESCRIPTION
## Summary

When automatic model fallback activates (e.g. the primary model returns HTTP 429), `applyModelOverrideToSessionEntry` writes the fallback provider/model into the session entry's `modelOverride` and `providerOverride` fields. Previously, `initSessionState` carried these fields across `/new` and `/reset`, pinning the new session to the fallback model even though the user intended a fresh start.

This PR:

- **Removes** the two lines in `initSessionState` that persist `modelOverride` and `providerOverride` across `/new` and `/reset` resets. `/new <model>` still works because `applyResetModelOverride()` runs after `initSessionState` and sets the override fresh.
- **Clears** `fallbackNoticeActiveModel`, `fallbackNoticeSelectedModel`, and `fallbackNoticeReason` in the `isNewSession` block so the new session does not display a stale "using \<fallback model\> because \<reason\>" banner.

## Test plan

Two new tests added to `session.test.ts`:

1. **"does not carry modelOverride or providerOverride across /new"** — seeds a session with `modelOverride` and `providerOverride`, triggers `/new`, verifies they are `undefined` on the new session while behavior overrides (`verboseLevel`, `thinkingLevel`) are still preserved.
2. **"clears fallback notice fields on /new"** — seeds a session with all three `fallbackNotice*` fields, triggers `/new`, verifies they are all `undefined`.

All 52 tests in `session.test.ts` pass (including the existing "preserves behavior overrides across /new and /reset" test which confirms `verboseLevel`, `thinkingLevel`, `reasoningLevel`, and `label` are still carried over).

Fixes #19730