### PR TITLE
fix: clear model/provider overrides on bare /new and /reset

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1526,6 +1526,66 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     expect(result.sessionEntry.providerOverride).toBe("github-copilot");
   });
 
+  it("does not carry fallbackNotice fields across bare /new and /reset", async () => {
+    // Addresses reviewer question: fallbackNotice fields should not bleed into
+    // a new session after a reset.  They are not persisted by initSessionState
+    // at all (agent-runner clears them at run start), but this test documents
+    // the contract explicitly so it is visible in the test suite.
+    const storePath = await createStorePath("openclaw-reset-fallback-notice-");
+    const sessionKey = "agent:main:telegram:dm:user-fallback-notice";
+    const existingSessionId = "existing-session-fallback-notice";
+    const overrides = {
+      verboseLevel: "on",
+      fallbackNoticeSelectedModel: "github-copilot/claude-opus-4.6",
+      fallbackNoticeActiveModel: "deepinfra/zai-org/GLM-5",
+      fallbackNoticeReason: "rate limit",
+    };
+    const cases = [
+      { name: "bare /new does not carry fallbackNotice", body: "/new" },
+      { name: "bare /reset does not carry fallbackNotice", body: "/reset" },
+    ] as const;
+
+    for (const testCase of cases) {
+      await seedSessionStoreWithOverrides({
+        storePath,
+        sessionKey,
+        sessionId: existingSessionId,
+        overrides: { ...overrides },
+      });
+
+      const cfg = {
+        session: { store: storePath, idleMinutes: 999 },
+      } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: {
+          Body: testCase.body,
+          RawBody: testCase.body,
+          CommandBody: testCase.body,
+          From: "user-fallback-notice",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession, testCase.name).toBe(true);
+      expect(result.resetTriggered, testCase.name).toBe(true);
+      // Behavior overrides are preserved.
+      expect(result.sessionEntry.verboseLevel, testCase.name).toBe("on");
+      // fallbackNotice fields are NOT carried over — they belong to the old
+      // session's runtime state and must not pin a fallback provider into the
+      // new session.
+      expect(result.sessionEntry.fallbackNoticeSelectedModel, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeActiveModel, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeReason, testCase.name).toBeUndefined();
+    }
+  });
+
   it("archives the old session store entry on /new", async () => {
     const storePath = await createStorePath("openclaw-archive-old-");
     const sessionKey = "agent:main:telegram:dm:user-archive";

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1428,6 +1428,104 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("clears model/provider overrides on bare /new and /reset", async () => {
+    const storePath = await createStorePath("openclaw-reset-model-clear-");
+    const sessionKey = "agent:main:telegram:dm:user-model-clear";
+    const existingSessionId = "existing-session-model-clear";
+    const overrides = {
+      verboseLevel: "on",
+      thinkingLevel: "high",
+      modelOverride: "claude-opus-4.6",
+      providerOverride: "github-copilot",
+    };
+    const cases = [
+      { name: "bare /new clears model overrides", body: "/new" },
+      { name: "bare /reset clears model overrides", body: "/reset" },
+    ] as const;
+
+    for (const testCase of cases) {
+      await seedSessionStoreWithOverrides({
+        storePath,
+        sessionKey,
+        sessionId: existingSessionId,
+        overrides: { ...overrides },
+      });
+
+      const cfg = {
+        session: { store: storePath, idleMinutes: 999 },
+      } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: {
+          Body: testCase.body,
+          RawBody: testCase.body,
+          CommandBody: testCase.body,
+          From: "user-model-clear",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession, testCase.name).toBe(true);
+      expect(result.resetTriggered, testCase.name).toBe(true);
+      // Behavior overrides are preserved.
+      expect(result.sessionEntry.verboseLevel, testCase.name).toBe("on");
+      expect(result.sessionEntry.thinkingLevel, testCase.name).toBe("high");
+      // Model/provider overrides are cleared.
+      expect(result.sessionEntry.modelOverride, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.providerOverride, testCase.name).toBeUndefined();
+    }
+  });
+
+  it("/new with model argument preserves model override from argument", async () => {
+    const storePath = await createStorePath("openclaw-reset-model-keep-");
+    const sessionKey = "agent:main:telegram:dm:user-model-keep";
+    const existingSessionId = "existing-session-model-keep";
+    const overrides = {
+      modelOverride: "claude-opus-4.6",
+      providerOverride: "github-copilot",
+    };
+    await seedSessionStoreWithOverrides({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      overrides: { ...overrides },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new minimax",
+        RawBody: "/new minimax",
+        CommandBody: "/new minimax",
+        From: "user-model-keep",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.bodyStripped).toBe("minimax");
+    // Model/provider overrides are carried over (applyResetModelOverride will
+    // replace them with the resolved model from "minimax" in get-reply.ts).
+    expect(result.sessionEntry.modelOverride).toBe("claude-opus-4.6");
+    expect(result.sessionEntry.providerOverride).toBe("github-copilot");
+  });
+
   it("archives the old session store entry on /new", async () => {
     const storePath = await createStorePath("openclaw-archive-old-");
     const sessionKey = "agent:main:telegram:dm:user-archive";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -367,8 +367,18 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
+      // Model/provider overrides are only carried over when the reset trigger
+      // includes a model argument (e.g. "/new sonnet46").  A bare "/new" or
+      // "/reset" clears the override so the session falls back to the agent's
+      // configured default model chain.  Without this, a previous "/new <model>"
+      // pins the provider across session resets, which can cause prolonged
+      // unavailability when the pinned provider is rate-limited.  See #2d.
+      // When bodyStripped has content, applyResetModelOverride() (called after
+      // initSessionState) will set the correct overrides from the model argument.
+      if (bodyStripped) {
+        persistedModelOverride = entry.modelOverride;
+        persistedProviderOverride = entry.providerOverride;
+      }
       persistedLabel = entry.label;
     }
   }


### PR DESCRIPTION
## Summary

A bare `/new` or `/reset` command carries over `modelOverride` and `providerOverride` from the previous session entry. This pins the session to a specific provider across session resets, causing **8–10 minute unresponsiveness** when that provider is rate-limited — because the normal model fallback chain is entirely bypassed.

## Root cause

In `initSessionState()` (`src/auto-reply/reply/session.ts`), when a reset trigger fires and a previous session entry exists, the code unconditionally copies `modelOverride` and `providerOverride` from the old entry:

```typescript
if (resetTriggered && entry) {
  persistedModelOverride = entry.modelOverride;      // ← always carried over
  persistedProviderOverride = entry.providerOverride; // ← always carried over
}
```

For **bare** `/new` (no model argument), `bodyStripped` is empty, so `applyResetModelOverride()` (called afterward in `get-reply.ts`) returns early without clearing these overrides. The old provider pin persists into the new session.

For `/new <model>`, `applyResetModelOverride()` replaces the overrides with the resolved model — so this path already works correctly.

## Fix

Only carry over `modelOverride`/`providerOverride` when `bodyStripped` has content (i.e., the user specified a model argument). A bare `/new` or `/reset` now starts with a clean slate for model routing, falling back to the agent's configured default model chain.

Behavior overrides (`thinkingLevel`, `verboseLevel`, `reasoningLevel`, `ttsAuto`, `label`) are still preserved across all resets — only the provider-pinning fields are affected.

## Tests

Two new test cases added to the existing `"initSessionState preserves behavior overrides across /new and /reset"` describe block:

1. **`clears model/provider overrides on bare /new and /reset`** — verifies that bare `/new` and `/reset` clear `modelOverride`/`providerOverride` while preserving behavior overrides
2. **`/new with model argument preserves model override from argument`** — verifies that `/new minimax` still carries over the old overrides (which `applyResetModelOverride` will then replace)

All 1041 test files pass (8589 tests, 3 pre-existing skips). `pnpm build && pnpm check && pnpm test` all green.

## Reproduction scenario

1. User sends `/new opus46` → session pinned to `github-copilot` provider
2. Provider gets rate-limited (429)
3. User sends `/new` (bare) to start fresh → expects default fallback chain
4. **Before fix:** `providerOverride: "github-copilot"` persists → all requests retry the rate-limited provider → 8–10 min wait
5. **After fix:** overrides cleared → fallback chain proceeds normally → response in seconds

---

*AI-assisted: investigation and implementation aided by Claude.*