### PR TITLE
fix(whatsapp): handle SIGUSR1 restarts cleanly

### DIFF
--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../src/config/config.js";
+import { setGatewaySigusr1RestartPolicy } from "../../../src/infra/restart.js";
 import { setLoggerOverride } from "../../../src/logging.js";
 import { withEnvAsync } from "../../../src/test-utils/env.js";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../../test/helpers/envelope-timestamp.js";
@@ -199,6 +200,164 @@ describe("web auto-reply connection", () => {
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("status 440"));
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("session conflict"));
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Stopping web monitoring"));
+  });
+
+  it("gracefully closes the active listener on SIGUSR1 restart without reconnecting", async () => {
+    const sleep = vi.fn(async () => {});
+    let resolveClose: (reason?: unknown) => void = () => {};
+    const close = vi.fn(async () => undefined);
+    const signalClose = vi.fn((reason?: unknown) => resolveClose(reason));
+    const listenerFactory = vi.fn(async () => {
+      const onClose = new Promise<unknown>((res) => {
+        resolveClose = res;
+      });
+      return { close, onClose, signalClose };
+    });
+    const { run } = startMonitorWebChannel({
+      monitorWebChannelFn: monitorWebChannel as never,
+      listenerFactory,
+      sleep,
+      heartbeatSeconds: 60,
+    });
+
+    await Promise.resolve();
+    expect(listenerFactory).toHaveBeenCalledTimes(1);
+
+    setGatewaySigusr1RestartPolicy({ allowExternal: true });
+    try {
+      process.emit("SIGUSR1");
+      await run;
+
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(signalClose).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 499,
+          isLoggedOut: false,
+          error: "restart",
+        }),
+      );
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+      expect(sleep).not.toHaveBeenCalled();
+    } finally {
+      setGatewaySigusr1RestartPolicy({ allowExternal: false });
+    }
+  });
+
+  it("exits reconnect backoff immediately when SIGUSR1 requests a restart", async () => {
+    let resolveClose: (reason?: unknown) => void = () => {};
+    const close = vi.fn(async () => undefined);
+    const sleep = vi.fn(
+      async () =>
+        await new Promise<void>(() => {
+          // The restart signal should short-circuit this wait.
+        }),
+    );
+    const listenerFactory = vi.fn(async () => {
+      const onClose = new Promise<unknown>((res) => {
+        resolveClose = res;
+      });
+      return { close, onClose, signalClose: vi.fn() };
+    });
+    const { run, runtime } = startMonitorWebChannel({
+      monitorWebChannelFn: monitorWebChannel as never,
+      listenerFactory,
+      sleep,
+      reconnect: { initialMs: 10_000, maxMs: 10_000, maxAttempts: 3, factor: 1.1 },
+    });
+
+    await Promise.resolve();
+    expect(listenerFactory).toHaveBeenCalledTimes(1);
+
+    resolveClose({ status: 500, isLoggedOut: false, error: "socket closed" });
+    await vi.waitFor(
+      () => {
+        expect(sleep).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 250, interval: 2 },
+    );
+
+    setGatewaySigusr1RestartPolicy({ allowExternal: true });
+    try {
+      process.emit("SIGUSR1");
+      await run;
+
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("status 500"));
+    } finally {
+      setGatewaySigusr1RestartPolicy({ allowExternal: false });
+    }
+  });
+
+  it("exits listener startup immediately when SIGUSR1 requests a restart", async () => {
+    const sleep = vi.fn(async () => {});
+    let resolveListener:
+      | ((listener: {
+          close: () => Promise<void>;
+          signalClose: (reason?: unknown) => void;
+        }) => void)
+      | null = null;
+    const close = vi.fn(async () => undefined);
+    const signalClose = vi.fn();
+    const listenerFactory = vi.fn(
+      async () =>
+        await new Promise<{ close: () => Promise<void>; signalClose: (reason?: unknown) => void }>(
+          (resolve) => {
+            resolveListener = resolve;
+          },
+        ),
+    );
+    const { run } = startMonitorWebChannel({
+      monitorWebChannelFn: monitorWebChannel as never,
+      listenerFactory,
+      sleep,
+    });
+
+    await Promise.resolve();
+    expect(listenerFactory).toHaveBeenCalledTimes(1);
+
+    setGatewaySigusr1RestartPolicy({ allowExternal: true });
+    try {
+      process.emit("SIGUSR1");
+      resolveListener?.({ close, signalClose });
+      await run;
+
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+      expect(sleep).not.toHaveBeenCalled();
+      await vi.waitFor(
+        () => {
+          expect(close).toHaveBeenCalledTimes(1);
+          expect(signalClose).toHaveBeenCalledWith(
+            expect.objectContaining({
+              status: 499,
+              isLoggedOut: false,
+              error: "restart",
+            }),
+          );
+        },
+        { timeout: 250, interval: 2 },
+      );
+    } finally {
+      setGatewaySigusr1RestartPolicy({ allowExternal: false });
+    }
+  });
+
+  it("removes the SIGUSR1 handler when listener startup throws", async () => {
+    const sleep = vi.fn(async () => {});
+    const listenerFactory = vi.fn(async () => {
+      throw new Error("startup failed");
+    });
+    const sigusr1Before = process.listenerCount("SIGUSR1");
+
+    await expect(
+      startMonitorWebChannel({
+        monitorWebChannelFn: monitorWebChannel as never,
+        listenerFactory,
+        sleep,
+      }).run,
+    ).rejects.toThrow("startup failed");
+
+    expect(process.listenerCount("SIGUSR1")).toBe(sigusr1Before);
   });
 
   it("forces reconnect when watchdog closes without onClose", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -8,6 +8,11 @@ import { loadConfig } from "../../../../src/config/config.js";
 import { createConnectedChannelStatusPatch } from "../../../../src/gateway/channel-status-patches.js";
 import { logVerbose } from "../../../../src/globals.js";
 import { formatDurationPrecise } from "../../../../src/infra/format-time/format-duration.ts";
+import {
+  hasGatewaySigusr1RestartAuthorization,
+  isGatewaySigusr1RestartHandling,
+  isGatewaySigusr1RestartExternallyAllowed,
+} from "../../../../src/infra/restart.js";
 import { enqueueSystemEvent } from "../../../../src/infra/system-events.js";
 import { registerUnhandledRejectionHandler } from "../../../../src/infra/unhandled-rejections.js";
 import { getChildLogger } from "../../../../src/logging.js";
@@ -118,6 +123,7 @@ export async function monitorWebChannel(
   const sleep =
     tuning.sleep ??
     ((ms: number, signal?: AbortSignal) => sleepWithAbort(ms, signal ?? abortSignal));
+  const lateStartupCloseTimeoutMs = 3000;
   const stopRequested = () => abortSignal?.aborted === true;
   const abortPromise =
     abortSignal &&
@@ -126,6 +132,10 @@ export async function monitorWebChannel(
         once: true,
       }),
     );
+  let resolveRestartSignal: (() => void) | null = null;
+  const restartPromise = new Promise<"restart">((resolve) => {
+    resolveRestartSignal = () => resolve("restart");
+  });
 
   // Avoid noisy MaxListenersExceeded warnings in test environments where
   // multiple gateway instances may be constructed.
@@ -135,14 +145,54 @@ export async function monitorWebChannel(
   }
 
   let sigintStop = false;
+  let restartRequested = false;
+  let currentListener: Awaited<ReturnType<typeof monitorWebInbox>> | null = null;
+  let restartCloseStarted = false;
+  let restartClosePromise: Promise<void> | null = null;
+  let reconnectSleepController: AbortController | null = null;
   const handleSigint = () => {
     sigintStop = true;
   };
+  const startRestartClose = (
+    active: Awaited<ReturnType<typeof monitorWebInbox>> | null,
+  ): Promise<void> | null => {
+    if (!active || restartCloseStarted) {
+      return restartClosePromise;
+    }
+    restartCloseStarted = true;
+    restartClosePromise = (async () => {
+      try {
+        await active.close?.();
+      } catch (err) {
+        logVerbose(`SIGUSR1 close failed: ${formatError(err)}`);
+      }
+      active.signalClose?.({
+        status: 499,
+        isLoggedOut: false,
+        error: "restart",
+      });
+    })();
+    return restartClosePromise;
+  };
+  const handleSigusr1 = () => {
+    if (
+      !hasGatewaySigusr1RestartAuthorization() &&
+      !isGatewaySigusr1RestartExternallyAllowed() &&
+      !isGatewaySigusr1RestartHandling()
+    ) {
+      return;
+    }
+    restartRequested = true;
+    resolveRestartSignal?.();
+    reconnectSleepController?.abort();
+    void startRestartClose(currentListener);
+  };
   process.once("SIGINT", handleSigint);
+  process.on("SIGUSR1", handleSigusr1);
 
   let reconnectAttempts = 0;
-
-  while (true) {
+  try {
+    while (true) {
     if (stopRequested()) {
       break;
     }
@@ -192,7 +242,7 @@ export async function monitorWebChannel(
       return !hasControlCommand(msg.body, cfg);
     };
 
-    const listener = await (listenerFactory ?? monitorWebInbox)({
+    const listenerPromise = (listenerFactory ?? monitorWebInbox)({
       verbose,
       accountId: account.accountId,
       authDir: account.authDir,
@@ -210,22 +260,37 @@ export async function monitorWebChannel(
         await onMessage(msg);
       },
     });
-
-    Object.assign(status, createConnectedChannelStatusPatch());
-    status.lastError = null;
-    emitStatus();
-
-    // Surface a concise connection event for the next main-session turn/heartbeat.
-    const { e164: selfE164 } = readWebSelfId(account.authDir);
-    const connectRoute = resolveAgentRoute({
-      cfg,
-      channel: "whatsapp",
-      accountId: account.accountId,
-    });
-    enqueueSystemEvent(`WhatsApp gateway connected${selfE164 ? ` as ${selfE164}` : ""}.`, {
-      sessionKey: connectRoute.sessionKey,
-    });
-
+    const listenerResult = await Promise.race([
+      listenerPromise.then((listener) => ({ kind: "listener" as const, listener })),
+      restartPromise.then(() => ({ kind: "restart" as const })),
+    ]);
+    if (listenerResult.kind === "restart") {
+      const lateStartupShutdown = listenerPromise
+        .then(async (listener) => {
+          try {
+            await listener.close?.();
+          } catch (err) {
+            logVerbose(`Late startup close failed: ${formatError(err)}`);
+          }
+          listener.signalClose?.({
+            status: 499,
+            isLoggedOut: false,
+            error: "restart",
+          });
+        })
+        .catch((err) => {
+          logVerbose(`Late startup listener failed after restart: ${formatError(err)}`);
+        });
+      await Promise.race([
+        lateStartupShutdown,
+        new Promise<void>((resolve) => setTimeout(resolve, lateStartupCloseTimeoutMs)),
+      ]);
+      break;
+    }
+    const listener = listenerResult.listener;
+    currentListener = listener;
+    restartCloseStarted = false;
+    restartClosePromise = null;
     setActiveWebListener(account.accountId, listener);
     unregisterUnhandled = registerUnhandledRejectionHandler((reason) => {
       if (!isLikelyWhatsAppCryptoError(reason)) {
@@ -244,7 +309,8 @@ export async function monitorWebChannel(
       return true;
     });
 
-    const closeListener = async () => {
+    const closeListener = async (opts?: { skipSocketClose?: boolean }) => {
+      currentListener = null;
       setActiveWebListener(account.accountId, null);
       if (unregisterUnhandled) {
         unregisterUnhandled();
@@ -260,12 +326,38 @@ export async function monitorWebChannel(
         await Promise.allSettled(backgroundTasks);
         backgroundTasks.clear();
       }
-      try {
-        await listener.close();
-      } catch (err) {
-        logVerbose(`Socket close failed: ${formatError(err)}`);
+      if (!opts?.skipSocketClose) {
+        try {
+          await listener.close();
+        } catch (err) {
+          logVerbose(`Socket close failed: ${formatError(err)}`);
+        }
       }
     };
+
+    if (restartRequested) {
+      const pendingRestartClose = startRestartClose(listener);
+      if (pendingRestartClose) {
+        await Promise.resolve(pendingRestartClose);
+      }
+      await closeListener({ skipSocketClose: Boolean(pendingRestartClose) });
+      break;
+    }
+
+    Object.assign(status, createConnectedChannelStatusPatch());
+    status.lastError = null;
+    emitStatus();
+
+    // Surface a concise connection event for the next main-session turn/heartbeat.
+    const { e164: selfE164 } = readWebSelfId(account.authDir);
+    const connectRoute = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: account.accountId,
+    });
+    enqueueSystemEvent(`WhatsApp gateway connected${selfE164 ? ` as ${selfE164}` : ""}.`, {
+      sessionKey: connectRoute.sessionKey,
+    });
 
     if (keepAlive) {
       heartbeat = setInterval(() => {
@@ -332,7 +424,6 @@ export async function monitorWebChannel(
 
     if (!keepAlive) {
       await closeListener();
-      process.removeListener("SIGINT", handleSigint);
       return;
     }
 
@@ -342,6 +433,7 @@ export async function monitorWebChannel(
         return { status: 500, isLoggedOut: false, error: err };
       }) ?? waitForever(),
       abortPromise ?? waitForever(),
+      restartPromise,
     ]);
 
     const uptimeMs = Date.now() - startedAt;
@@ -350,6 +442,15 @@ export async function monitorWebChannel(
     }
     status.reconnectAttempts = reconnectAttempts;
     emitStatus();
+
+    if (restartRequested || reason === "restart") {
+      const pendingRestartClose = restartClosePromise;
+      if (pendingRestartClose) {
+        await Promise.resolve(pendingRestartClose);
+      }
+      await closeListener({ skipSocketClose: restartCloseStarted });
+      break;
+    }
 
     if (stopRequested() || sigintStop || reason === "aborted") {
       await closeListener();
@@ -453,17 +554,30 @@ export async function monitorWebChannel(
       `WhatsApp Web connection closed (status ${statusCode}). Retry ${reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationPrecise(delay)}… (${errorStr})`,
     );
     await closeListener();
+    reconnectSleepController = new AbortController();
     try {
-      await sleep(delay, abortSignal);
+      const sleepSignal = abortSignal
+        ? AbortSignal.any([abortSignal, reconnectSleepController.signal])
+        : reconnectSleepController.signal;
+      const nextStep = await Promise.race([
+        sleep(delay, sleepSignal).then(() => "slept" as const),
+        restartPromise,
+      ]);
+      reconnectSleepController = null;
+      if (nextStep === "restart") {
+        break;
+      }
     } catch {
+      reconnectSleepController = null;
       break;
     }
+    }
+  } finally {
+    status.running = false;
+    status.connected = false;
+    status.lastEventAt = Date.now();
+    emitStatus();
+    process.removeListener("SIGINT", handleSigint);
+    process.removeListener("SIGUSR1", handleSigusr1);
   }
-
-  status.running = false;
-  status.connected = false;
-  status.lastEventAt = Date.now();
-  emitStatus();
-
-  process.removeListener("SIGINT", handleSigint);
 }

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -193,384 +193,384 @@ export async function monitorWebChannel(
   let reconnectAttempts = 0;
   try {
     while (true) {
-    if (stopRequested()) {
-      break;
-    }
-
-    const connectionId = newConnectionId();
-    const startedAt = Date.now();
-    let heartbeat: NodeJS.Timeout | null = null;
-    let watchdogTimer: NodeJS.Timeout | null = null;
-    let lastMessageAt: number | null = null;
-    let handledMessages = 0;
-    let _lastInboundMsg: WebInboundMsg | null = null;
-    let unregisterUnhandled: (() => void) | null = null;
-
-    // Watchdog to detect stuck message processing (e.g., event emitter died).
-    // Tuning overrides are test-oriented; production defaults remain unchanged.
-    const MESSAGE_TIMEOUT_MS = tuning.messageTimeoutMs ?? 30 * 60 * 1000; // 30m default
-    const WATCHDOG_CHECK_MS = tuning.watchdogCheckMs ?? 60 * 1000; // 1m default
-
-    const backgroundTasks = new Set<Promise<unknown>>();
-    const onMessage = createWebOnMessageHandler({
-      cfg,
-      verbose,
-      connectionId,
-      maxMediaBytes,
-      groupHistoryLimit,
-      groupHistories,
-      groupMemberNames,
-      echoTracker,
-      backgroundTasks,
-      replyResolver: replyResolver ?? getReplyFromConfig,
-      replyLogger,
-      baseMentionConfig,
-      account,
-    });
-
-    const inboundDebounceMs = resolveInboundDebounceMs({ cfg, channel: "whatsapp" });
-    const shouldDebounce = (msg: WebInboundMsg) => {
-      if (msg.mediaPath || msg.mediaType) {
-        return false;
+      if (stopRequested()) {
+        break;
       }
-      if (msg.location) {
-        return false;
-      }
-      if (msg.replyToId || msg.replyToBody) {
-        return false;
-      }
-      return !hasControlCommand(msg.body, cfg);
-    };
 
-    const listenerPromise = (listenerFactory ?? monitorWebInbox)({
-      verbose,
-      accountId: account.accountId,
-      authDir: account.authDir,
-      mediaMaxMb: account.mediaMaxMb,
-      sendReadReceipts: account.sendReadReceipts,
-      debounceMs: inboundDebounceMs,
-      shouldDebounce,
-      onMessage: async (msg: WebInboundMsg) => {
-        handledMessages += 1;
-        lastMessageAt = Date.now();
-        status.lastMessageAt = lastMessageAt;
-        status.lastEventAt = lastMessageAt;
-        emitStatus();
-        _lastInboundMsg = msg;
-        await onMessage(msg);
-      },
-    });
-    const listenerResult = await Promise.race([
-      listenerPromise.then((listener) => ({ kind: "listener" as const, listener })),
-      restartPromise.then(() => ({ kind: "restart" as const })),
-    ]);
-    if (listenerResult.kind === "restart") {
-      const lateStartupShutdown = listenerPromise
-        .then(async (listener) => {
-          try {
-            await listener.close?.();
-          } catch (err) {
-            logVerbose(`Late startup close failed: ${formatError(err)}`);
-          }
-          listener.signalClose?.({
-            status: 499,
-            isLoggedOut: false,
-            error: "restart",
-          });
-        })
-        .catch((err) => {
-          logVerbose(`Late startup listener failed after restart: ${formatError(err)}`);
-        });
-      await Promise.race([
-        lateStartupShutdown,
-        new Promise<void>((resolve) => setTimeout(resolve, lateStartupCloseTimeoutMs)),
-      ]);
-      break;
-    }
-    const listener = listenerResult.listener;
-    currentListener = listener;
-    restartCloseStarted = false;
-    restartClosePromise = null;
-    setActiveWebListener(account.accountId, listener);
-    unregisterUnhandled = registerUnhandledRejectionHandler((reason) => {
-      if (!isLikelyWhatsAppCryptoError(reason)) {
-        return false;
-      }
-      const errorStr = formatError(reason);
-      reconnectLogger.warn(
-        { connectionId, error: errorStr },
-        "web reconnect: unhandled rejection from WhatsApp socket; forcing reconnect",
-      );
-      listener.signalClose?.({
-        status: 499,
-        isLoggedOut: false,
-        error: reason,
+      const connectionId = newConnectionId();
+      const startedAt = Date.now();
+      let heartbeat: NodeJS.Timeout | null = null;
+      let watchdogTimer: NodeJS.Timeout | null = null;
+      let lastMessageAt: number | null = null;
+      let handledMessages = 0;
+      let _lastInboundMsg: WebInboundMsg | null = null;
+      let unregisterUnhandled: (() => void) | null = null;
+
+      // Watchdog to detect stuck message processing (e.g., event emitter died).
+      // Tuning overrides are test-oriented; production defaults remain unchanged.
+      const MESSAGE_TIMEOUT_MS = tuning.messageTimeoutMs ?? 30 * 60 * 1000; // 30m default
+      const WATCHDOG_CHECK_MS = tuning.watchdogCheckMs ?? 60 * 1000; // 1m default
+
+      const backgroundTasks = new Set<Promise<unknown>>();
+      const onMessage = createWebOnMessageHandler({
+        cfg,
+        verbose,
+        connectionId,
+        maxMediaBytes,
+        groupHistoryLimit,
+        groupHistories,
+        groupMemberNames,
+        echoTracker,
+        backgroundTasks,
+        replyResolver: replyResolver ?? getReplyFromConfig,
+        replyLogger,
+        baseMentionConfig,
+        account,
       });
-      return true;
-    });
 
-    const closeListener = async (opts?: { skipSocketClose?: boolean }) => {
-      currentListener = null;
-      setActiveWebListener(account.accountId, null);
-      if (unregisterUnhandled) {
-        unregisterUnhandled();
-        unregisterUnhandled = null;
-      }
-      if (heartbeat) {
-        clearInterval(heartbeat);
-      }
-      if (watchdogTimer) {
-        clearInterval(watchdogTimer);
-      }
-      if (backgroundTasks.size > 0) {
-        await Promise.allSettled(backgroundTasks);
-        backgroundTasks.clear();
-      }
-      if (!opts?.skipSocketClose) {
-        try {
-          await listener.close();
-        } catch (err) {
-          logVerbose(`Socket close failed: ${formatError(err)}`);
+      const inboundDebounceMs = resolveInboundDebounceMs({ cfg, channel: "whatsapp" });
+      const shouldDebounce = (msg: WebInboundMsg) => {
+        if (msg.mediaPath || msg.mediaType) {
+          return false;
         }
+        if (msg.location) {
+          return false;
+        }
+        if (msg.replyToId || msg.replyToBody) {
+          return false;
+        }
+        return !hasControlCommand(msg.body, cfg);
+      };
+
+      const listenerPromise = (listenerFactory ?? monitorWebInbox)({
+        verbose,
+        accountId: account.accountId,
+        authDir: account.authDir,
+        mediaMaxMb: account.mediaMaxMb,
+        sendReadReceipts: account.sendReadReceipts,
+        debounceMs: inboundDebounceMs,
+        shouldDebounce,
+        onMessage: async (msg: WebInboundMsg) => {
+          handledMessages += 1;
+          lastMessageAt = Date.now();
+          status.lastMessageAt = lastMessageAt;
+          status.lastEventAt = lastMessageAt;
+          emitStatus();
+          _lastInboundMsg = msg;
+          await onMessage(msg);
+        },
+      });
+      const listenerResult = await Promise.race([
+        listenerPromise.then((listener) => ({ kind: "listener" as const, listener })),
+        restartPromise.then(() => ({ kind: "restart" as const })),
+      ]);
+      if (listenerResult.kind === "restart") {
+        const lateStartupShutdown = listenerPromise
+          .then(async (listener) => {
+            try {
+              await listener.close?.();
+            } catch (err) {
+              logVerbose(`Late startup close failed: ${formatError(err)}`);
+            }
+            listener.signalClose?.({
+              status: 499,
+              isLoggedOut: false,
+              error: "restart",
+            });
+          })
+          .catch((err) => {
+            logVerbose(`Late startup listener failed after restart: ${formatError(err)}`);
+          });
+        await Promise.race([
+          lateStartupShutdown,
+          new Promise<void>((resolve) => setTimeout(resolve, lateStartupCloseTimeoutMs)),
+        ]);
+        break;
       }
-    };
-
-    if (restartRequested) {
-      const pendingRestartClose = startRestartClose(listener);
-      if (pendingRestartClose) {
-        await Promise.resolve(pendingRestartClose);
-      }
-      await closeListener({ skipSocketClose: Boolean(pendingRestartClose) });
-      break;
-    }
-
-    Object.assign(status, createConnectedChannelStatusPatch());
-    status.lastError = null;
-    emitStatus();
-
-    // Surface a concise connection event for the next main-session turn/heartbeat.
-    const { e164: selfE164 } = readWebSelfId(account.authDir);
-    const connectRoute = resolveAgentRoute({
-      cfg,
-      channel: "whatsapp",
-      accountId: account.accountId,
-    });
-    enqueueSystemEvent(`WhatsApp gateway connected${selfE164 ? ` as ${selfE164}` : ""}.`, {
-      sessionKey: connectRoute.sessionKey,
-    });
-
-    if (keepAlive) {
-      heartbeat = setInterval(() => {
-        const authAgeMs = getWebAuthAgeMs(account.authDir);
-        const minutesSinceLastMessage = lastMessageAt
-          ? Math.floor((Date.now() - lastMessageAt) / 60000)
-          : null;
-
-        const logData = {
-          connectionId,
-          reconnectAttempts,
-          messagesHandled: handledMessages,
-          lastMessageAt,
-          authAgeMs,
-          uptimeMs: Date.now() - startedAt,
-          ...(minutesSinceLastMessage !== null && minutesSinceLastMessage > 30
-            ? { minutesSinceLastMessage }
-            : {}),
-        };
-
-        if (minutesSinceLastMessage && minutesSinceLastMessage > 30) {
-          heartbeatLogger.warn(logData, "⚠️ web gateway heartbeat - no messages in 30+ minutes");
-        } else {
-          heartbeatLogger.info(logData, "web gateway heartbeat");
+      const listener = listenerResult.listener;
+      currentListener = listener;
+      restartCloseStarted = false;
+      restartClosePromise = null;
+      setActiveWebListener(account.accountId, listener);
+      unregisterUnhandled = registerUnhandledRejectionHandler((reason) => {
+        if (!isLikelyWhatsAppCryptoError(reason)) {
+          return false;
         }
-      }, heartbeatSeconds * 1000);
-
-      watchdogTimer = setInterval(() => {
-        if (!lastMessageAt) {
-          return;
-        }
-        const timeSinceLastMessage = Date.now() - lastMessageAt;
-        if (timeSinceLastMessage <= MESSAGE_TIMEOUT_MS) {
-          return;
-        }
-        const minutesSinceLastMessage = Math.floor(timeSinceLastMessage / 60000);
-        heartbeatLogger.warn(
-          {
-            connectionId,
-            minutesSinceLastMessage,
-            lastMessageAt: new Date(lastMessageAt),
-            messagesHandled: handledMessages,
-          },
-          "Message timeout detected - forcing reconnect",
+        const errorStr = formatError(reason);
+        reconnectLogger.warn(
+          { connectionId, error: errorStr },
+          "web reconnect: unhandled rejection from WhatsApp socket; forcing reconnect",
         );
-        whatsappHeartbeatLog.warn(
-          `No messages received in ${minutesSinceLastMessage}m - restarting connection`,
-        );
-        void closeListener().catch((err) => {
-          logVerbose(`Close listener failed: ${formatError(err)}`);
-        });
         listener.signalClose?.({
           status: 499,
           isLoggedOut: false,
-          error: "watchdog-timeout",
+          error: reason,
         });
-      }, WATCHDOG_CHECK_MS);
-    }
+        return true;
+      });
 
-    whatsappLog.info("Listening for personal WhatsApp inbound messages.");
-    if (process.stdout.isTTY || process.stderr.isTTY) {
-      whatsappLog.raw("Ctrl+C to stop.");
-    }
+      const closeListener = async (opts?: { skipSocketClose?: boolean }) => {
+        currentListener = null;
+        setActiveWebListener(account.accountId, null);
+        if (unregisterUnhandled) {
+          unregisterUnhandled();
+          unregisterUnhandled = null;
+        }
+        if (heartbeat) {
+          clearInterval(heartbeat);
+        }
+        if (watchdogTimer) {
+          clearInterval(watchdogTimer);
+        }
+        if (backgroundTasks.size > 0) {
+          await Promise.allSettled(backgroundTasks);
+          backgroundTasks.clear();
+        }
+        if (!opts?.skipSocketClose) {
+          try {
+            await listener.close();
+          } catch (err) {
+            logVerbose(`Socket close failed: ${formatError(err)}`);
+          }
+        }
+      };
 
-    if (!keepAlive) {
-      await closeListener();
-      return;
-    }
-
-    const reason = await Promise.race([
-      listener.onClose?.catch((err) => {
-        reconnectLogger.error({ error: formatError(err) }, "listener.onClose rejected");
-        return { status: 500, isLoggedOut: false, error: err };
-      }) ?? waitForever(),
-      abortPromise ?? waitForever(),
-      restartPromise,
-    ]);
-
-    const uptimeMs = Date.now() - startedAt;
-    if (uptimeMs > heartbeatSeconds * 1000) {
-      reconnectAttempts = 0; // Healthy stretch; reset the backoff.
-    }
-    status.reconnectAttempts = reconnectAttempts;
-    emitStatus();
-
-    if (restartRequested || reason === "restart") {
-      const pendingRestartClose = restartClosePromise;
-      if (pendingRestartClose) {
-        await Promise.resolve(pendingRestartClose);
+      if (restartRequested) {
+        const pendingRestartClose = startRestartClose(listener);
+        if (pendingRestartClose) {
+          await Promise.resolve(pendingRestartClose);
+        }
+        await closeListener({ skipSocketClose: Boolean(pendingRestartClose) });
+        break;
       }
-      await closeListener({ skipSocketClose: restartCloseStarted });
-      break;
-    }
 
-    if (stopRequested() || sigintStop || reason === "aborted") {
-      await closeListener();
-      break;
-    }
+      Object.assign(status, createConnectedChannelStatusPatch());
+      status.lastError = null;
+      emitStatus();
 
-    const statusCode =
-      (typeof reason === "object" && reason && "status" in reason
-        ? (reason as { status?: number }).status
-        : undefined) ?? "unknown";
-    const loggedOut =
-      typeof reason === "object" &&
-      reason &&
-      "isLoggedOut" in reason &&
-      (reason as { isLoggedOut?: boolean }).isLoggedOut;
+      // Surface a concise connection event for the next main-session turn/heartbeat.
+      const { e164: selfE164 } = readWebSelfId(account.authDir);
+      const connectRoute = resolveAgentRoute({
+        cfg,
+        channel: "whatsapp",
+        accountId: account.accountId,
+      });
+      enqueueSystemEvent(`WhatsApp gateway connected${selfE164 ? ` as ${selfE164}` : ""}.`, {
+        sessionKey: connectRoute.sessionKey,
+      });
 
-    const errorStr = formatError(reason);
-    status.connected = false;
-    status.lastEventAt = Date.now();
-    status.lastDisconnect = {
-      at: status.lastEventAt,
-      status: typeof statusCode === "number" ? statusCode : undefined,
-      error: errorStr,
-      loggedOut: Boolean(loggedOut),
-    };
-    status.lastError = errorStr;
-    status.reconnectAttempts = reconnectAttempts;
-    emitStatus();
+      if (keepAlive) {
+        heartbeat = setInterval(() => {
+          const authAgeMs = getWebAuthAgeMs(account.authDir);
+          const minutesSinceLastMessage = lastMessageAt
+            ? Math.floor((Date.now() - lastMessageAt) / 60000)
+            : null;
 
-    reconnectLogger.info(
-      {
-        connectionId,
-        status: statusCode,
-        loggedOut,
-        reconnectAttempts,
+          const logData = {
+            connectionId,
+            reconnectAttempts,
+            messagesHandled: handledMessages,
+            lastMessageAt,
+            authAgeMs,
+            uptimeMs: Date.now() - startedAt,
+            ...(minutesSinceLastMessage !== null && minutesSinceLastMessage > 30
+              ? { minutesSinceLastMessage }
+              : {}),
+          };
+
+          if (minutesSinceLastMessage && minutesSinceLastMessage > 30) {
+            heartbeatLogger.warn(logData, "⚠️ web gateway heartbeat - no messages in 30+ minutes");
+          } else {
+            heartbeatLogger.info(logData, "web gateway heartbeat");
+          }
+        }, heartbeatSeconds * 1000);
+
+        watchdogTimer = setInterval(() => {
+          if (!lastMessageAt) {
+            return;
+          }
+          const timeSinceLastMessage = Date.now() - lastMessageAt;
+          if (timeSinceLastMessage <= MESSAGE_TIMEOUT_MS) {
+            return;
+          }
+          const minutesSinceLastMessage = Math.floor(timeSinceLastMessage / 60000);
+          heartbeatLogger.warn(
+            {
+              connectionId,
+              minutesSinceLastMessage,
+              lastMessageAt: new Date(lastMessageAt),
+              messagesHandled: handledMessages,
+            },
+            "Message timeout detected - forcing reconnect",
+          );
+          whatsappHeartbeatLog.warn(
+            `No messages received in ${minutesSinceLastMessage}m - restarting connection`,
+          );
+          void closeListener().catch((err) => {
+            logVerbose(`Close listener failed: ${formatError(err)}`);
+          });
+          listener.signalClose?.({
+            status: 499,
+            isLoggedOut: false,
+            error: "watchdog-timeout",
+          });
+        }, WATCHDOG_CHECK_MS);
+      }
+
+      whatsappLog.info("Listening for personal WhatsApp inbound messages.");
+      if (process.stdout.isTTY || process.stderr.isTTY) {
+        whatsappLog.raw("Ctrl+C to stop.");
+      }
+
+      if (!keepAlive) {
+        await closeListener();
+        return;
+      }
+
+      const reason = await Promise.race([
+        listener.onClose?.catch((err) => {
+          reconnectLogger.error({ error: formatError(err) }, "listener.onClose rejected");
+          return { status: 500, isLoggedOut: false, error: err };
+        }) ?? waitForever(),
+        abortPromise ?? waitForever(),
+        restartPromise,
+      ]);
+
+      const uptimeMs = Date.now() - startedAt;
+      if (uptimeMs > heartbeatSeconds * 1000) {
+        reconnectAttempts = 0; // Healthy stretch; reset the backoff.
+      }
+      status.reconnectAttempts = reconnectAttempts;
+      emitStatus();
+
+      if (restartRequested || reason === "restart") {
+        const pendingRestartClose = restartClosePromise;
+        if (pendingRestartClose) {
+          await Promise.resolve(pendingRestartClose);
+        }
+        await closeListener({ skipSocketClose: restartCloseStarted });
+        break;
+      }
+
+      if (stopRequested() || sigintStop || reason === "aborted") {
+        await closeListener();
+        break;
+      }
+
+      const statusCode =
+        (typeof reason === "object" && reason && "status" in reason
+          ? (reason as { status?: number }).status
+          : undefined) ?? "unknown";
+      const loggedOut =
+        typeof reason === "object" &&
+        reason &&
+        "isLoggedOut" in reason &&
+        (reason as { isLoggedOut?: boolean }).isLoggedOut;
+
+      const errorStr = formatError(reason);
+      status.connected = false;
+      status.lastEventAt = Date.now();
+      status.lastDisconnect = {
+        at: status.lastEventAt,
+        status: typeof statusCode === "number" ? statusCode : undefined,
         error: errorStr,
-      },
-      "web reconnect: connection closed",
-    );
+        loggedOut: Boolean(loggedOut),
+      };
+      status.lastError = errorStr;
+      status.reconnectAttempts = reconnectAttempts;
+      emitStatus();
 
-    enqueueSystemEvent(`WhatsApp gateway disconnected (status ${statusCode ?? "unknown"})`, {
-      sessionKey: connectRoute.sessionKey,
-    });
-
-    if (loggedOut) {
-      runtime.error(
-        `WhatsApp session logged out. Run \`${formatCliCommand("openclaw channels login --channel web")}\` to relink.`,
-      );
-      await closeListener();
-      break;
-    }
-
-    if (isNonRetryableWebCloseStatus(statusCode)) {
-      reconnectLogger.warn(
+      reconnectLogger.info(
         {
           connectionId,
           status: statusCode,
+          loggedOut,
+          reconnectAttempts,
           error: errorStr,
         },
-        "web reconnect: non-retryable close status; stopping monitor",
+        "web reconnect: connection closed",
       );
-      runtime.error(
-        `WhatsApp Web connection closed (status ${statusCode}: session conflict). Resolve conflicting WhatsApp Web sessions, then relink with \`${formatCliCommand("openclaw channels login --channel web")}\`. Stopping web monitoring.`,
-      );
-      await closeListener();
-      break;
-    }
 
-    reconnectAttempts += 1;
-    status.reconnectAttempts = reconnectAttempts;
-    emitStatus();
-    if (reconnectPolicy.maxAttempts > 0 && reconnectAttempts >= reconnectPolicy.maxAttempts) {
-      reconnectLogger.warn(
+      enqueueSystemEvent(`WhatsApp gateway disconnected (status ${statusCode ?? "unknown"})`, {
+        sessionKey: connectRoute.sessionKey,
+      });
+
+      if (loggedOut) {
+        runtime.error(
+          `WhatsApp session logged out. Run \`${formatCliCommand("openclaw channels login --channel web")}\` to relink.`,
+        );
+        await closeListener();
+        break;
+      }
+
+      if (isNonRetryableWebCloseStatus(statusCode)) {
+        reconnectLogger.warn(
+          {
+            connectionId,
+            status: statusCode,
+            error: errorStr,
+          },
+          "web reconnect: non-retryable close status; stopping monitor",
+        );
+        runtime.error(
+          `WhatsApp Web connection closed (status ${statusCode}: session conflict). Resolve conflicting WhatsApp Web sessions, then relink with \`${formatCliCommand("openclaw channels login --channel web")}\`. Stopping web monitoring.`,
+        );
+        await closeListener();
+        break;
+      }
+
+      reconnectAttempts += 1;
+      status.reconnectAttempts = reconnectAttempts;
+      emitStatus();
+      if (reconnectPolicy.maxAttempts > 0 && reconnectAttempts >= reconnectPolicy.maxAttempts) {
+        reconnectLogger.warn(
+          {
+            connectionId,
+            status: statusCode,
+            reconnectAttempts,
+            maxAttempts: reconnectPolicy.maxAttempts,
+          },
+          "web reconnect: max attempts reached; continuing in degraded mode",
+        );
+        runtime.error(
+          `WhatsApp Web reconnect: max attempts reached (${reconnectAttempts}/${reconnectPolicy.maxAttempts}). Stopping web monitoring.`,
+        );
+        await closeListener();
+        break;
+      }
+
+      const delay = computeBackoff(reconnectPolicy, reconnectAttempts);
+      reconnectLogger.info(
         {
           connectionId,
           status: statusCode,
           reconnectAttempts,
-          maxAttempts: reconnectPolicy.maxAttempts,
+          maxAttempts: reconnectPolicy.maxAttempts || "unlimited",
+          delayMs: delay,
         },
-        "web reconnect: max attempts reached; continuing in degraded mode",
+        "web reconnect: scheduling retry",
       );
       runtime.error(
-        `WhatsApp Web reconnect: max attempts reached (${reconnectAttempts}/${reconnectPolicy.maxAttempts}). Stopping web monitoring.`,
+        `WhatsApp Web connection closed (status ${statusCode}). Retry ${reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationPrecise(delay)}… (${errorStr})`,
       );
       await closeListener();
-      break;
-    }
-
-    const delay = computeBackoff(reconnectPolicy, reconnectAttempts);
-    reconnectLogger.info(
-      {
-        connectionId,
-        status: statusCode,
-        reconnectAttempts,
-        maxAttempts: reconnectPolicy.maxAttempts || "unlimited",
-        delayMs: delay,
-      },
-      "web reconnect: scheduling retry",
-    );
-    runtime.error(
-      `WhatsApp Web connection closed (status ${statusCode}). Retry ${reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationPrecise(delay)}… (${errorStr})`,
-    );
-    await closeListener();
-    reconnectSleepController = new AbortController();
-    try {
-      const sleepSignal = abortSignal
-        ? AbortSignal.any([abortSignal, reconnectSleepController.signal])
-        : reconnectSleepController.signal;
-      const nextStep = await Promise.race([
-        sleep(delay, sleepSignal).then(() => "slept" as const),
-        restartPromise,
-      ]);
-      reconnectSleepController = null;
-      if (nextStep === "restart") {
+      reconnectSleepController = new AbortController();
+      try {
+        const sleepSignal = abortSignal
+          ? AbortSignal.any([abortSignal, reconnectSleepController.signal])
+          : reconnectSleepController.signal;
+        const nextStep = await Promise.race([
+          sleep(delay, sleepSignal).then(() => "slept" as const),
+          restartPromise,
+        ]);
+        reconnectSleepController = null;
+        if (nextStep === "restart") {
+          break;
+        }
+      } catch {
+        reconnectSleepController = null;
         break;
       }
-    } catch {
-      reconnectSleepController = null;
-      break;
-    }
     }
   } finally {
     status.running = false;

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -510,6 +510,7 @@ export const __testing = {
     sigusr1AuthorizedCount = 0;
     sigusr1AuthorizedUntil = 0;
     sigusr1ExternalAllowed = false;
+    handlingAuthorizedSigusr1Restart = false;
     preRestartCheck = null;
     restartCycleToken = 0;
     emittedRestartToken = 0;

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -35,6 +35,7 @@ let restartCycleToken = 0;
 let emittedRestartToken = 0;
 let consumedRestartToken = 0;
 let lastRestartEmittedAt = 0;
+let handlingAuthorizedSigusr1Restart = false;
 let pendingRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRestartDueAt = 0;
 let pendingRestartReason: string | undefined;
@@ -171,6 +172,11 @@ export function consumeGatewaySigusr1RestartAuthorization(): boolean {
   return true;
 }
 
+export function hasGatewaySigusr1RestartAuthorization(): boolean {
+  resetSigusr1AuthorizationIfExpired();
+  return sigusr1AuthorizedCount > 0;
+}
+
 /**
  * Mark the currently emitted SIGUSR1 restart cycle as consumed by the run loop.
  * This explicitly advances the cycle state instead of resetting emit guards inside
@@ -180,6 +186,14 @@ export function markGatewaySigusr1RestartHandled(): void {
   if (hasUnconsumedRestartSignal()) {
     consumedRestartToken = emittedRestartToken;
   }
+  handlingAuthorizedSigusr1Restart = true;
+  queueMicrotask(() => {
+    handlingAuthorizedSigusr1Restart = false;
+  });
+}
+
+export function isGatewaySigusr1RestartHandling(): boolean {
+  return handlingAuthorizedSigusr1Restart;
 }
 
 export type RestartDeferralHooks = {


### PR DESCRIPTION
## Summary
- make the WhatsApp web channel monitor exit cleanly on authorized `SIGUSR1` restarts instead of hanging or reconnecting
- cover active-listener, startup-race, and reconnect-backoff restart paths with focused e2e tests
- guard `SIGUSR1` handling behind the gateway restart authorization flow so normal signals do not shut the monitor down unexpectedly

Closes #45730

## Test plan
- [x] `pnpm exec vitest run --config vitest.e2e.config.ts src/web/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`
- [x] `codex review --base origin/main`
- [ ] `pnpm build` *(currently blocked by pre-existing TypeScript errors in `src/browser/pw-tools-core.interactions.ts` on this checkout)*

AI-assisted: Cursor (GPT-5.4)

Made with [Cursor](https://cursor.com)