### PR TITLE
fix(sanitize): strip raw tool_call/tool_result XML tags from user-facing text

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -15,6 +15,28 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it("strips raw tool_call/tool_result XML tags (#45856)", () => {
+    // Full tag pairs with content
+    expect(
+      sanitizeUserFacingText('Here is the result: <tool_call>{"name":"bash"}</tool_call> done.'),
+    ).toBe("Here is the result:  done.");
+    expect(sanitizeUserFacingText("Output: <tool_result>Success</tool_result>")).toBe("Output: ");
+
+    // Orphaned/self-closing tags
+    expect(sanitizeUserFacingText("Text <tool_call /> more")).toBe("Text  more");
+    expect(sanitizeUserFacingText("Before </tool_result> after")).toBe("Before  after");
+
+    // Mixed with final tags
+    expect(sanitizeUserFacingText("<final>Result</final><tool_call>data</tool_call>")).toBe(
+      "Result",
+    );
+
+    // Multiline content in tags
+    expect(sanitizeUserFacingText("Start\n<tool_result>\nline1\nline2\n</tool_result>\nEnd")).toBe(
+      "Start\n\nEnd",
+    );
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -35,6 +35,14 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Start\n<tool_result>\nline1\nline2\n</tool_result>\nEnd")).toBe(
       "Start\n\nEnd",
     );
+
+    // Word boundary — should NOT match tags that merely start with tool_call/tool_result
+    expect(sanitizeUserFacingText("<tool_calling>data</tool_calling>")).toBe(
+      "<tool_calling>data</tool_calling>",
+    );
+    expect(sanitizeUserFacingText("<tool_results>data</tool_results>")).toBe(
+      "<tool_results>data</tool_results>",
+    );
   });
 
   it.each(["202 results found", "400 days left"])(

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -43,6 +43,10 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("<tool_results>data</tool_results>")).toBe(
       "<tool_results>data</tool_results>",
     );
+
+    // Unclosed opening tag — strip tag and all content to end of string
+    expect(sanitizeUserFacingText('<tool_call>{"name":"bash"}')).toBe("");
+    expect(sanitizeUserFacingText("Prefix <tool_result>leaked content")).toBe("Prefix ");
   });
 
   it.each(["202 results found", "400 days left"])(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -276,6 +276,12 @@ export function extractObservedOverflowTokenCount(errorMessage?: string): number
 }
 
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
+// Raw tool XML tags that some models (via OpenRouter) may emit in plain text.
+// Strip both the tags and their content since this is internal protocol. See #45856.
+const TOOL_XML_TAG_RE =
+  /<\s*(?:tool_call|tool_result)[^>]*>[\s\S]*?<\s*\/\s*(?:tool_call|tool_result)\s*>/gi;
+// Also catch self-closing or orphaned opening/closing tags
+const TOOL_XML_ORPHAN_TAG_RE = /<\s*\/?\s*(?:tool_call|tool_result)[^>]*\/?>/gi;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -472,7 +478,12 @@ function stripFinalTagsFromText(text: string): string {
   if (!text) {
     return text;
   }
-  return text.replace(FINAL_TAG_RE, "");
+  // Strip <final> tags, then raw <tool_call>/<tool_result> XML that some models emit.
+  // First strip complete tag pairs (with content), then orphaned opening/closing tags.
+  return text
+    .replace(FINAL_TAG_RE, "")
+    .replace(TOOL_XML_TAG_RE, "")
+    .replace(TOOL_XML_ORPHAN_TAG_RE, "");
 }
 
 function collapseConsecutiveDuplicateBlocks(text: string): string {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -280,7 +280,11 @@ const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
 // Strip both the tags and their content since this is internal protocol. See #45856.
 const TOOL_XML_TAG_RE =
   /<\s*(?:tool_call|tool_result)\b[^>]*>[\s\S]*?<\s*\/\s*(?:tool_call|tool_result)\b\s*>/gi;
-// Also catch self-closing or orphaned opening/closing tags
+// Strip unclosed opening tags and their content to end of string (no closing tag found).
+// Applied after TOOL_XML_TAG_RE to catch remaining orphaned openers.
+// Uses negative lookbehind (?<!\/) to exclude self-closing tags like <tool_call />.
+const TOOL_XML_UNCLOSED_TAG_RE = /<\s*(?:tool_call|tool_result)\b[^>]*(?<!\/)>[\s\S]*$/gi;
+// Also catch self-closing or orphaned closing tags (stray </tool_call> etc.)
 const TOOL_XML_ORPHAN_TAG_RE = /<\s*\/?\s*(?:tool_call|tool_result)\b[^>]*\/?>/gi;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
@@ -479,10 +483,11 @@ function stripFinalTagsFromText(text: string): string {
     return text;
   }
   // Strip <final> tags, then raw <tool_call>/<tool_result> XML that some models emit.
-  // First strip complete tag pairs (with content), then orphaned opening/closing tags.
+  // Order: (1) complete tag pairs, (2) unclosed openers to end, (3) stray tags.
   return text
     .replace(FINAL_TAG_RE, "")
     .replace(TOOL_XML_TAG_RE, "")
+    .replace(TOOL_XML_UNCLOSED_TAG_RE, "")
     .replace(TOOL_XML_ORPHAN_TAG_RE, "");
 }
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -279,9 +279,9 @@ const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
 // Raw tool XML tags that some models (via OpenRouter) may emit in plain text.
 // Strip both the tags and their content since this is internal protocol. See #45856.
 const TOOL_XML_TAG_RE =
-  /<\s*(?:tool_call|tool_result)[^>]*>[\s\S]*?<\s*\/\s*(?:tool_call|tool_result)\s*>/gi;
+  /<\s*(?:tool_call|tool_result)\b[^>]*>[\s\S]*?<\s*\/\s*(?:tool_call|tool_result)\b\s*>/gi;
 // Also catch self-closing or orphaned opening/closing tags
-const TOOL_XML_ORPHAN_TAG_RE = /<\s*\/?\s*(?:tool_call|tool_result)[^>]*\/?>/gi;
+const TOOL_XML_ORPHAN_TAG_RE = /<\s*\/?\s*(?:tool_call|tool_result)\b[^>]*\/?>/gi;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =


### PR DESCRIPTION
## Summary
Some models (observed with Anthropic Claude via OpenRouter) occasionally emit raw `<tool_call>` and `<tool_result>` XML tags in their text responses. These internal protocol tags should not leak to end users.

## Changes
This fix adds regex-based stripping in `sanitizeUserFacingText` for:
- Complete `<tool_call>...</tool_call>` tag pairs with content
- Complete `<tool_result>...</tool_result>` tag pairs with content  
- Orphaned opening/closing tags

## Testing
Added test cases covering:
- Full tag pairs with content
- Orphaned/self-closing tags
- Mixed with `<final>` tags
- Multiline content in tags

All 62 tests in `pi-embedded-helpers.sanitizeuserfacingtext.test.ts` pass.

Fixes #45856