### PR TITLE
fix(ui): add explicit size constraints to context warning SVG

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -168,6 +168,8 @@
 .context-notice__icon {
   width: 16px;
   height: 16px;
+  max-width: 16px;
+  max-height: 16px;
   flex-shrink: 0;
   stroke: currentColor;
 }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -276,7 +276,7 @@ function renderContextNotice(
   const bg = `rgba(${r}, ${g}, ${b}, ${bgOpacity})`;
   return html`
     <div class="context-notice" role="status" style="--ctx-color:${color};--ctx-bg:${bg}">
-      <svg class="context-notice__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+      <svg class="context-notice__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
       <span>${pct}% context used</span>
       <span class="context-notice__detail">${formatTokensCompact(used)} / ${formatTokensCompact(limit)}</span>
     </div>


### PR DESCRIPTION
## Summary

Fixes #45722, #45780

The context warning icon could expand beyond its intended size because the inline SVG had no explicit width/height attributes. In some flex contexts, SVGs without intrinsic dimensions can expand to fill available space, causing the warning triangle to cover the entire chat area.

## Changes

1. **SVG attributes:** Added `width="16" height="16"` to the inline SVG element
2. **CSS safety:** Added `max-width` and `max-height` constraints as a fallback

## Test plan

1. Open Control UI → Chat
2. Send messages until context is >70% (to trigger warning)
3. Verify warning icon stays at 16x16px and doesn't expand