### PR TITLE
fix(plugins): suppress false-positive duplicate id warning for channel registration pattern

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -451,4 +451,63 @@ describe("loadPluginManifestRegistry", () => {
     // Should emit a duplicate warning because the channels array does NOT contain "alpha"
     expect(countDuplicateWarnings(registry)).toBe(1);
   });
+
+  it("suppresses duplicate warning when candidates have identical source file path", () => {
+    // This tests the fix for issue #45951:
+    // Same source file discovered multiple times should not trigger duplicate warning,
+    // even if rootDir representations differ.
+    const dir = makeTempDir();
+    const manifest = { id: "same-source-plugin", configSchema: { type: "object" } };
+    writeManifest(dir, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "same-source-plugin",
+        rootDir: dir,
+        origin: "bundled",
+      }),
+      // Same source file, same rootDir - should be detected as duplicate and skipped
+      createPluginCandidate({
+        idHint: "same-source-plugin",
+        rootDir: dir,
+        origin: "global",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    // Should NOT emit a duplicate warning because both point to the same source file
+    expect(countDuplicateWarnings(registry)).toBe(0);
+    // Should only have one plugin entry
+    expect(registry.plugins.length).toBe(1);
+  });
+
+  it("suppresses duplicate warning when source paths are identical but rootDir differs", () => {
+    // Edge case: same source file with different rootDir representations
+    // (e.g., one with trailing slash, one without, or different case on Windows)
+    const dir = makeTempDir();
+    const manifest = { id: "path-variant-plugin", configSchema: { type: "object" } };
+    writeManifest(dir, manifest);
+
+    // Create two candidates with same source but different rootDir string representations
+    // Note: On most systems, path.resolve normalizes these, but we want to be safe
+    const sourcePath = path.join(dir, "index.ts");
+    const candidates: PluginCandidate[] = [
+      {
+        idHint: "path-variant-plugin",
+        source: sourcePath,
+        rootDir: dir,
+        origin: "bundled",
+      },
+      {
+        idHint: "path-variant-plugin",
+        source: sourcePath, // Same source
+        rootDir: path.resolve(dir), // Different string representation but resolves to same
+        origin: "global",
+      },
+    ];
+
+    const registry = loadRegistry(candidates);
+    // Should NOT emit a duplicate warning
+    expect(countDuplicateWarnings(registry)).toBe(0);
+  });
 });

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -371,4 +371,84 @@ describe("loadPluginManifestRegistry", () => {
       fs.realpathSync(second.plugins.find((plugin) => plugin.id === "demo")?.rootDir ?? ""),
     ).toBe(fs.realpathSync(demoB));
   });
+
+  it("suppresses duplicate warning when plugin id matches a declared channel (channel registration pattern)", () => {
+    // This tests the fix for issue #45805:
+    // A plugin with id="X" that declares channels=["X"] is the expected pattern
+    // for channel plugins - the main plugin and its channel share the same id.
+    // This should not trigger a duplicate warning.
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+
+    // First plugin declares id="feishu" and channels=["feishu"]
+    writeManifest(dirA, {
+      id: "feishu",
+      channels: ["feishu"],
+      configSchema: { type: "object" },
+    });
+    fs.writeFileSync(path.join(dirA, "index.ts"), "export default {}", "utf-8");
+
+    // Second plugin has the same id but from a different directory
+    writeManifest(dirB, {
+      id: "feishu",
+      configSchema: { type: "object" },
+    });
+    fs.writeFileSync(path.join(dirB, "index.ts"), "export default {}", "utf-8");
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirA,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirB,
+        origin: "global",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    // Should NOT emit a duplicate warning because the first plugin declares
+    // channels=["feishu"], indicating this is a channel registration pattern.
+    expect(countDuplicateWarnings(registry)).toBe(0);
+  });
+
+  it("still emits duplicate warning when channels do not match the plugin id", () => {
+    // Ensure we still warn when the channel registration pattern does NOT apply
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+
+    // First plugin declares id="alpha" and channels=["beta"] (different from id)
+    writeManifest(dirA, {
+      id: "alpha",
+      channels: ["beta"],
+      configSchema: { type: "object" },
+    });
+    fs.writeFileSync(path.join(dirA, "index.ts"), "export default {}", "utf-8");
+
+    // Second plugin has the same id
+    writeManifest(dirB, {
+      id: "alpha",
+      configSchema: { type: "object" },
+    });
+    fs.writeFileSync(path.join(dirB, "index.ts"), "export default {}", "utf-8");
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "alpha",
+        rootDir: dirA,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "alpha",
+        rootDir: dirB,
+        origin: "global",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    // Should emit a duplicate warning because the channels array does NOT contain "alpha"
+    expect(countDuplicateWarnings(registry)).toBe(1);
+  });
 });

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -12,6 +12,7 @@ type SeenIdEntry = {
   candidate: PluginCandidate;
   recordIndex: number;
   declaredChannels: string[];
+  sourcePath: string;
 };
 
 // Precedence: config > workspace > global > bundled
@@ -208,14 +209,22 @@ export function loadPluginManifestRegistry(params: {
 
     const existing = seenIds.get(manifest.id);
     if (existing) {
-      // Check whether both candidates point to the same physical directory
-      // (e.g. via symlinks or different path representations). If so, this
-      // is a false-positive duplicate and can be silently skipped.
+      // Check whether both candidates point to the same physical directory or source file.
+      // This can happen when:
+      // 1. Same plugin discovered via different paths (e.g., symlinks)
+      // 2. Same source file with different rootDir representations
+      // 3. realpath resolution issues on some platforms
+      const sameSource = existing.sourcePath === candidate.source;
       const samePath = existing.candidate.rootDir === candidate.rootDir;
       const samePlugin = (() => {
+        // If source files are identical, it's definitely the same plugin
+        if (sameSource) {
+          return true;
+        }
         if (samePath) {
           return true;
         }
+        // Check if rootDirs resolve to the same physical location
         const existingReal = safeRealpathSync(existing.candidate.rootDir, realpathCache);
         const candidateReal = safeRealpathSync(candidate.rootDir, realpathCache);
         // If either realpath fails, fall back to path comparison for Windows compatibility
@@ -242,6 +251,7 @@ export function loadPluginManifestRegistry(params: {
             candidate,
             recordIndex: existing.recordIndex,
             declaredChannels: manifest.channels ?? [],
+            sourcePath: candidate.source,
           });
         }
         continue;
@@ -268,6 +278,7 @@ export function loadPluginManifestRegistry(params: {
         candidate,
         recordIndex: records.length,
         declaredChannels: manifest.channels ?? [],
+        sourcePath: candidate.source,
       });
     }
 

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
 import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
@@ -10,6 +11,7 @@ import type { PluginConfigUiHint, PluginDiagnostic, PluginKind, PluginOrigin } f
 type SeenIdEntry = {
   candidate: PluginCandidate;
   recordIndex: number;
+  declaredChannels: string[];
 };
 
 // Precedence: config > workspace > global > bundled
@@ -216,7 +218,14 @@ export function loadPluginManifestRegistry(params: {
         }
         const existingReal = safeRealpathSync(existing.candidate.rootDir, realpathCache);
         const candidateReal = safeRealpathSync(candidate.rootDir, realpathCache);
-        return Boolean(existingReal && candidateReal && existingReal === candidateReal);
+        // If either realpath fails, fall back to path comparison for Windows compatibility
+        if (!existingReal || !candidateReal) {
+          // Normalize and compare paths as a fallback when realpath is unavailable
+          const normalizedExisting = path.resolve(existing.candidate.rootDir).toLowerCase();
+          const normalizedCandidate = path.resolve(candidate.rootDir).toLowerCase();
+          return normalizedExisting === normalizedCandidate;
+        }
+        return existingReal === candidateReal;
       })();
       if (samePlugin) {
         // Prefer higher-precedence origins even if candidates are passed in
@@ -229,10 +238,25 @@ export function loadPluginManifestRegistry(params: {
             schemaCacheKey,
             configSchema,
           });
-          seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+          seenIds.set(manifest.id, {
+            candidate,
+            recordIndex: existing.recordIndex,
+            declaredChannels: manifest.channels ?? [],
+          });
         }
         continue;
       }
+
+      // Check if this is a channel being registered by its parent plugin.
+      // A plugin with id="X" that declares channels=["X"] is the expected pattern
+      // for channel plugins - the main plugin and its channel share the same id.
+      // This should not trigger a duplicate warning.
+      const isChannelRegistration = existing.declaredChannels.includes(manifest.id);
+      if (isChannelRegistration) {
+        // Same plugin registering a channel with matching id - skip warning.
+        continue;
+      }
+
       diagnostics.push({
         level: "warn",
         pluginId: manifest.id,
@@ -240,7 +264,11 @@ export function loadPluginManifestRegistry(params: {
         message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
       });
     } else {
-      seenIds.set(manifest.id, { candidate, recordIndex: records.length });
+      seenIds.set(manifest.id, {
+        candidate,
+        recordIndex: records.length,
+        declaredChannels: manifest.channels ?? [],
+      });
     }
 
     records.push(


### PR DESCRIPTION
Fixes #45805 - When a plugin id matches a declared channel, skip the duplicate warning as this is the expected channel registration pattern.