### PR TITLE
fix(cron): suppress NO_REPLY for thread-based and structured content delivery

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -546,6 +546,26 @@ export async function dispatchCronDelivery(
       };
     }
 
+    // Silent reply token suppresses delivery regardless of delivery path
+    // (text-only, thread-based, or structured content).
+    if (synthesizedText?.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
+      return {
+        result: params.withRunSession({
+          status: "ok",
+          summary,
+          outputText,
+          delivered: true,
+          ...params.telemetry,
+        }),
+        delivered: true,
+        deliveryAttempted,
+        summary,
+        outputText,
+        synthesizedText,
+        deliveryPayloads,
+      };
+    }
+
     // Finalize descendant/subagent output first for text-only cron runs, then
     // send through the real outbound adapter so delivered=true always reflects
     // an actual channel send instead of internal announce routing.


### PR DESCRIPTION
## Summary

- Move `SILENT_REPLY_TOKEN` check before the `useDirectDelivery` branch in `delivery-dispatch.ts`
- `NO_REPLY` now suppresses delivery for all paths: text-only, thread-based, and structured content

## Problem

The `NO_REPLY` check was only inside `finalizeTextDelivery`, which is skipped when `useDirectDelivery = true` (thread-based delivery via `--thread` or structured content). This caused the literal string `NO_REPLY` to be sent to the channel.

Fixes #45909, related to #45903.

## Test plan

- [ ] Cron job with `--announce` + text-only: agent replies `NO_REPLY` → delivery skipped (existing behavior, should still work)
- [ ] Cron job with `--announce --thread <id>`: agent replies `NO_REPLY` → delivery skipped (was broken, now fixed)
- [ ] Cron job with structured content response: `NO_REPLY` text → delivery skipped (was broken, now fixed)
- [ ] Normal replies still deliver as expected in all three paths