### PR TITLE
fix(control-ui): use actual context size instead of cumulative input …

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -205,6 +205,9 @@ function extractGroupMeta(group: MessageGroup, contextWindow: number | null): Gr
   let cost = 0;
   let model: string | null = null;
   let hasUsage = false;
+  // Track the last assistant message's input tokens (= actual context size
+  // for that turn), rather than the cumulative sum across all turns.
+  let lastInput = 0;
 
   for (const { message } of group.messages) {
     const m = message as Record<string, unknown>;
@@ -218,6 +221,10 @@ function extractGroupMeta(group: MessageGroup, contextWindow: number | null): Gr
       output += usage.output ?? usage.outputTokens ?? 0;
       cacheRead += usage.cacheRead ?? usage.cache_read_input_tokens ?? 0;
       cacheWrite += usage.cacheWrite ?? usage.cache_creation_input_tokens ?? 0;
+      const turnInput = usage.input ?? usage.inputTokens ?? 0;
+      if (turnInput > 0) {
+        lastInput = turnInput;
+      }
     }
     const c = m.cost as Record<string, number> | undefined;
     if (c?.total) {
@@ -232,8 +239,13 @@ function extractGroupMeta(group: MessageGroup, contextWindow: number | null): Gr
     return null;
   }
 
+  // Use lastInput (single-turn context size) instead of cumulative input
+  // for the context percentage, so the displayed % reflects actual window
+  // utilization rather than the ever-growing sum of all turns.
   const contextPercent =
-    contextWindow && input > 0 ? Math.min(Math.round((input / contextWindow) * 100), 100) : null;
+    contextWindow && lastInput > 0
+      ? Math.min(Math.round((lastInput / contextWindow) * 100), 100)
+      : null;
 
   return { input, output, cacheRead, cacheWrite, cost, model, contextPercent };
 }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -247,35 +247,87 @@ function renderFallbackIndicator(status: FallbackIndicatorStatus | null | undefi
 }
 
 /**
- * Compact notice when context usage reaches 85%+.
- * Progressively shifts from amber (85%) to red (90%+).
+ * Always-visible context usage notice with progressive color coding.
+ *
+ * Bug fix: `session.inputTokens` is the **cumulative** input across all turns
+ * (each turn includes the full context, so the sum grows much larger than the
+ * actual window). When chat messages are available we walk backwards to find
+ * the last assistant message with usage data and use its `input`/`inputTokens`
+ * value, which represents the true current context size.
+ *
+ * Color tiers:
+ *   <50%  green    – plenty of room
+ *   50-75% blue    – moderate
+ *   75-85% amber   – getting full
+ *   ≥85%  red      – danger zone (warning icon)
  */
 function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
+  messages?: Array<{ message: Record<string, unknown> }>,
 ) {
-  const used = session?.inputTokens ?? 0;
+  // Prefer the last assistant message's input tokens (= actual context size)
+  // over the session-level cumulative inputTokens.
+  let used = 0;
+  if (messages?.length) {
+    for (let idx = messages.length - 1; idx >= 0; idx--) {
+      // Messages may be raw objects or {message: ...} wrappers depending on
+      // whether they come from ChatProps.messages or a grouped render array.
+      const raw = messages[idx] as Record<string, unknown>;
+      const m = (raw?.message ?? raw) as Record<string, unknown>;
+      if (m?.role === "assistant") {
+        const usage = m.usage as Record<string, number> | undefined;
+        const t = usage?.input ?? usage?.inputTokens ?? 0;
+        if (t > 0) {
+          used = t;
+          break;
+        }
+      }
+    }
+  }
+  // Fallback to session-level value when no per-message usage is available
+  if (!used) {
+    used = session?.inputTokens ?? 0;
+  }
+
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;
   }
+
   const ratio = used / limit;
-  if (ratio < 0.85) {
-    return nothing;
-  }
   const pct = Math.min(Math.round(ratio * 100), 100);
-  // Lerp from amber (#d97706) at 85% to red (#dc2626) at 95%+
-  const t = Math.min(Math.max((ratio - 0.85) / 0.1, 0), 1);
-  // RGB: amber(217,119,6) → red(220,38,38)
-  const r = Math.round(217 + (220 - 217) * t);
-  const g = Math.round(119 + (38 - 119) * t);
-  const b = Math.round(6 + (38 - 6) * t);
+
+  let r: number, g: number, b: number;
+  if (ratio < 0.5) {
+    // Green
+    r = 76; g = 175; b = 80;
+  } else if (ratio < 0.75) {
+    // Blue
+    r = 59; g = 130; b = 246;
+  } else if (ratio < 0.85) {
+    // Amber
+    r = 245; g = 166; b = 35;
+  } else {
+    // Red (lerp 85% → 100%)
+    const t = Math.min(Math.max((ratio - 0.85) / 0.15, 0), 1);
+    r = Math.round(220 + 35 * t);
+    g = Math.round(120 - 82 * t);
+    b = Math.round(30 + 8 * t);
+  }
+
   const color = `rgb(${r}, ${g}, ${b})`;
-  const bgOpacity = 0.08 + 0.08 * t;
+  const bgOpacity = ratio < 0.75 ? 0.06 : 0.08 + 0.08 * Math.min(ratio, 1);
   const bg = `rgba(${r}, ${g}, ${b}, ${bgOpacity})`;
+
+  // Warning triangle for ≥85%, info circle otherwise
+  const icon = ratio >= 0.85
+    ? html`<svg class="context-notice__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>`
+    : html`<svg class="context-notice__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>`;
+
   return html`
     <div class="context-notice" role="status" style="--ctx-color:${color};--ctx-bg:${bg}">
-      <svg class="context-notice__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+      ${icon}
       <span>${pct}% context used</span>
       <span class="context-notice__detail">${formatTokensCompact(used)} / ${formatTokensCompact(limit)}</span>
     </div>
@@ -1163,7 +1215,7 @@ export function renderChat(props: ChatProps) {
 
       ${renderFallbackIndicator(props.fallbackStatus)}
       ${renderCompactionIndicator(props.compactionStatus)}
-      ${renderContextNotice(activeSession, props.sessions?.defaults?.contextTokens ?? null)}
+      ${renderContextNotice(activeSession, props.sessions?.defaults?.contextTokens ?? null, props.messages as Array<{ message: Record<string, unknown> }>)}
 
       ${
         props.showNewMessages


### PR DESCRIPTION
…tokens for context% display

The context usage banner and per-message context% indicators both used cumulative input tokens (sum of all turns) divided by the context window size, which produced wildly inflated percentages (e.g. 89% when actual usage was 15%). This happened because each LLM turn includes the full context as input, so summing across turns double/triple/N-counts the context.

**Bug fix (chat.ts):** `renderContextNotice` now walks the message list backwards to find the last assistant message with usage data and uses its `input`/`inputTokens` value — which represents the true current context size — instead of the session-level cumulative `inputTokens`.

**Bug fix (grouped-render.ts):** `extractGroupMeta` now tracks `lastInput` (the most recent turn's input tokens) separately from the cumulative `input` sum, and uses it for `contextPercent`.

**Enhancement:** The context banner is now always visible with four color tiers instead of only appearing at ≥85%:
- <50%: green (info icon) — plenty of room
- 50–75%: blue (info icon) — moderate
- 75–85%: amber (info icon) — getting full
- ≥85%: red gradient (warning icon) — danger zone

Fixes #41503

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
