### PR TITLE
fix: keep heartbeat wakes out of cron run sessions

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -830,6 +830,77 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("falls back to the main session when runHeartbeatOnce is forced to a cron session", async () => {
+    const tmpDir = await createCaseDir("hb-forced-cron-session-ignored");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const mainSessionKey = resolveMainSessionKey(cfg);
+      const agentId = resolveAgentIdFromSessionKey(mainSessionKey);
+      const cronSessionKey = `agent:${agentId}:cron:job-1:run:run-1`;
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [mainSessionKey]: {
+            sessionId: "sid-main",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+          [cronSessionKey]: {
+            sessionId: "sid-cron-run",
+            updatedAt: Date.now() + 10_000,
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567891@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: "Main session alert" }]);
+      const sendWhatsApp = vi
+        .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: cronSessionKey,
+        deps: createHeartbeatDeps(sendWhatsApp),
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledWith(
+        "120363401234567890@g.us",
+        "Main session alert",
+        expect.any(Object),
+      );
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          SessionKey: mainSessionKey,
+          From: "120363401234567890@g.us",
+          To: "120363401234567890@g.us",
+          Provider: "heartbeat",
+        }),
+        expect.objectContaining({ isHeartbeat: true, suppressToolErrorWarnings: false }),
+        cfg,
+      );
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
   it("suppresses duplicate heartbeat payloads within 24h", async () => {
     const tmpDir = await createCaseDir("hb-dup-suppress");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -871,9 +871,10 @@ describe("runHeartbeatOnce", () => {
       );
 
       replySpy.mockResolvedValue([{ text: "Main session alert" }]);
-      const sendWhatsApp = vi
-        .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
-        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+      const sendWhatsApp = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        toJid: "jid",
+      });
 
       await runHeartbeatOnce({
         cfg,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -287,7 +287,8 @@ function resolveHeartbeatSession(
       agentId: resolvedAgentId,
       sessionKey: forcedCandidate,
     });
-    if (forcedCanonical !== "global") {
+    const forcedIsCronSession = forcedCanonical !== "global" && forcedCanonical.includes(":cron:");
+    if (forcedCanonical !== "global" && !forcedIsCronSession) {
       const sessionAgentId = resolveAgentIdFromSessionKey(forcedCanonical);
       if (sessionAgentId === normalizeAgentId(resolvedAgentId)) {
         return {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -39,6 +39,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import {
+  isCronSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
   toAgentStoreSessionKey,
@@ -287,7 +288,7 @@ function resolveHeartbeatSession(
       agentId: resolvedAgentId,
       sessionKey: forcedCandidate,
     });
-    const forcedIsCronSession = forcedCanonical !== "global" && forcedCanonical.includes(":cron:");
+    const forcedIsCronSession = isCronSessionKey(forcedCanonical);
     if (forcedCanonical !== "global" && !forcedIsCronSession) {
       const sessionAgentId = resolveAgentIdFromSessionKey(forcedCanonical);
       if (sessionAgentId === normalizeAgentId(resolvedAgentId)) {

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -8,6 +8,7 @@ import {
   classifySessionKeyShape,
   isValidAgentId,
   parseAgentSessionKey,
+  scopedHeartbeatWakeOptions,
   toAgentStoreSessionKey,
 } from "./session-key.js";
 
@@ -114,6 +115,23 @@ describe("session key canonicalization", () => {
         requestKey: "agent:main:main",
       }),
     ).toBe("agent:main:main");
+  });
+});
+
+describe("scopedHeartbeatWakeOptions", () => {
+  it("preserves non-cron agent session keys", () => {
+    expect(
+      scopedHeartbeatWakeOptions("agent:main:telegram:direct:123", { reason: "exec:1:exit" }),
+    ).toEqual({
+      reason: "exec:1:exit",
+      sessionKey: "agent:main:telegram:direct:123",
+    });
+  });
+
+  it("does not preserve cron session keys", () => {
+    expect(
+      scopedHeartbeatWakeOptions("agent:main:cron:job-1:run:run-1", { reason: "exec:1:exit" }),
+    ).toEqual({ reason: "exec:1:exit" });
   });
 });
 

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -1,5 +1,9 @@
 import type { ChatType } from "../channels/chat-type.js";
-import { parseAgentSessionKey, type ParsedAgentSessionKey } from "../sessions/session-key-utils.js";
+import {
+  isCronSessionKey,
+  parseAgentSessionKey,
+  type ParsedAgentSessionKey,
+} from "../sessions/session-key-utils.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "./account-id.js";
 
 export {
@@ -34,7 +38,14 @@ export function scopedHeartbeatWakeOptions<T extends object>(
   sessionKey: string,
   wakeOptions: T,
 ): T | (T & { sessionKey: string }) {
-  return parseAgentSessionKey(sessionKey) ? { ...wakeOptions, sessionKey } : wakeOptions;
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return wakeOptions;
+  }
+  if (isCronSessionKey(sessionKey)) {
+    return wakeOptions;
+  }
+  return { ...wakeOptions, sessionKey };
 }
 
 export function normalizeMainKey(value: string | undefined | null): string {


### PR DESCRIPTION
# Prevent heartbeat wake targeting isolated cron run sessions

## Summary

Fix a runtime correctness bug where background `exec` completion inside an isolated cron run can wake heartbeat into the same cron run session. In practice, that lets a heartbeat prompt land inside `agent:<id>:cron:<job>:run:<session>` and potentially overwrite the run's final summary with `HEARTBEAT_OK`, suppressing delivery of the real cron failure.

## Root cause

Two runtime behaviors combine here:

1. Background exec completion triggers `requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, ...))`.
2. Heartbeat session resolution accepts forced session keys and uses them directly.

When the originating session key is a cron run session, the wake path incorrectly preserves that cron session key, so the next heartbeat run is injected into the isolated cron run instead of the agent's main session.

## Changes

- `src/routing/session-key.ts`
  - `scopedHeartbeatWakeOptions(...)` now refuses to preserve cron session keys.
- `src/infra/heartbeat-runner.ts`
  - `resolveHeartbeatSession(...)` now ignores forced cron session keys and falls back to normal heartbeat session resolution.
- Tests:
  - `src/routing/session-key.test.ts`
  - `src/infra/heartbeat-runner.returns-default-unset.test.ts`

## Why this is safe

- It only changes heartbeat targeting for cron sessions.
- Non-cron agent sessions still preserve explicit wake scoping.
- Heartbeat still runs; it just no longer targets isolated cron run sessions.

## Reproduction

1. Run an isolated cron job that uses background `exec/process` work.
2. Let the background exec finish near the end of the cron run.
3. Observe that exec exit can wake heartbeat with the cron run's session key.
4. The isolated run may receive the heartbeat prompt directly and reply `HEARTBEAT_OK`.
5. The run summary can end up as `HEARTBEAT_OK`, suppressing delivery of the actual failure/summary.

## Verification

```bash
corepack pnpm exec vitest run --config vitest.unit.config.ts \
  src/routing/session-key.test.ts \
  src/infra/heartbeat-runner.returns-default-unset.test.ts
```

Passing locally:
- 2 test files
- 46 tests passed

## Follow-up (not included in this PR)

A separate hardening follow-up could prevent heartbeat-only acknowledgements from overwriting an already-established cron failure summary, even if some future path reintroduces cross-session prompt injection.
