### PR TITLE
memory: fix FTS-only indexing gap and sync N+1 queries

### DIFF
--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -767,11 +767,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           .run(pathname, source);
       } catch {}
     }
-    if (this.fts.enabled && this.fts.available && this.provider) {
+    if (this.fts.enabled && this.fts.available) {
       try {
+        // Delete all FTS rows for this path+source regardless of model so that
+        // stale entries from a previous provider or FTS-only mode are cleaned up.
         this.db
-          .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-          .run(pathname, source, this.provider.model);
+          .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+          .run(pathname, source);
       } catch {}
     }
     this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(pathname, source);
@@ -804,12 +806,60 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     entry: MemoryFileEntry | SessionFileEntry,
     options: { source: MemorySource; content?: string },
   ) {
-    // FTS-only mode: skip indexing if no provider
+    // FTS-only mode: index text chunks for keyword search without embeddings.
     if (!this.provider) {
-      log.debug("Skipping embedding indexing in FTS-only mode", {
-        path: entry.path,
-        source: options.source,
-      });
+      if (!(this.fts.enabled && this.fts.available)) {
+        return;
+      }
+      // Skip multimodal files — they need an embedding provider.
+      if ("kind" in entry && entry.kind === "multimodal") {
+        return;
+      }
+      const content = options.content ?? (await fs.readFile(entry.absPath, "utf-8"));
+      const chunks = chunkMarkdown(content, this.settings.chunking).filter(
+        (chunk) => chunk.text.trim().length > 0,
+      );
+      if (options.source === "sessions" && "lineMap" in entry) {
+        remapChunkLines(chunks, entry.lineMap);
+      }
+      const model = "fts-only";
+      const now = Date.now();
+      this.clearIndexedFileData(entry.path, options.source);
+      for (const chunk of chunks) {
+        const id = hashText(
+          `${options.source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${model}`,
+        );
+        this.db
+          .prepare(
+            `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+               hash=excluded.hash,
+               model=excluded.model,
+               text=excluded.text,
+               embedding=excluded.embedding,
+               updated_at=excluded.updated_at`,
+          )
+          .run(
+            id,
+            entry.path,
+            options.source,
+            chunk.startLine,
+            chunk.endLine,
+            chunk.hash,
+            model,
+            chunk.text,
+            "[]",
+            now,
+          );
+        this.db
+          .prepare(
+            `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
+              ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          )
+          .run(chunk.text, id, entry.path, options.source, model, chunk.startLine, chunk.endLine);
+      }
+      this.upsertFileRecord(entry, options.source);
       return;
     }
 

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -833,8 +833,10 @@ export abstract class MemoryManagerSyncOps {
     }
 
     // Bulk-load existing session file hashes to avoid per-file queries (N+1 → 1).
+    // Skip bulk preload for targeted syncs (small file sets) where per-file lookup is cheaper.
+    const usePerFileLookup = !params.needsFullReindex && targetSessionFiles !== null;
     const existingRecords = new Map<string, string>();
-    if (!params.needsFullReindex) {
+    if (!params.needsFullReindex && !usePerFileLookup) {
       const rows = this.db
         .prepare(`SELECT path, hash FROM files WHERE source = ?`)
         .all("sessions") as Array<{ path: string; hash: string }>;
@@ -865,7 +867,14 @@ export abstract class MemoryManagerSyncOps {
         }
         return;
       }
-      if (!params.needsFullReindex && existingRecords.get(entry.path) === entry.hash) {
+      const existingHash = usePerFileLookup
+        ? (
+            this.db
+              .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
+              .get(entry.path, "sessions") as { hash: string } | undefined
+          )?.hash
+        : existingRecords.get(entry.path);
+      if (!params.needsFullReindex && existingHash === entry.hash) {
         if (params.progress) {
           params.progress.completed += 1;
           params.progress.report({

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -697,9 +697,9 @@ export abstract class MemoryManagerSyncOps {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
   }) {
-    // FTS-only mode: skip embedding sync (no provider)
-    if (!this.provider) {
-      log.debug("Skipping memory file sync in FTS-only mode (no embedding provider)");
+    // No provider and no FTS: nothing we can index.
+    if (!this.provider && !(this.fts.enabled && this.fts.available)) {
+      log.debug("Skipping memory file sync (no embedding provider and FTS unavailable)");
       return;
     }
 
@@ -733,11 +733,19 @@ export abstract class MemoryManagerSyncOps {
       });
     }
 
+    // Bulk-load existing file hashes to avoid per-file queries (N+1 → 1).
+    const existingRecords = new Map<string, string>();
+    if (!params.needsFullReindex) {
+      const rows = this.db
+        .prepare(`SELECT path, hash FROM files WHERE source = ?`)
+        .all("memory") as Array<{ path: string; hash: string }>;
+      for (const row of rows) {
+        existingRecords.set(row.path, row.hash);
+      }
+    }
+
     const tasks = fileEntries.map((entry) => async () => {
-      const record = this.db
-        .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
-        .get(entry.path, "memory") as { hash: string } | undefined;
-      if (!params.needsFullReindex && record?.hash === entry.hash) {
+      if (!params.needsFullReindex && existingRecords.get(entry.path) === entry.hash) {
         if (params.progress) {
           params.progress.completed += 1;
           params.progress.report({
@@ -758,27 +766,34 @@ export abstract class MemoryManagerSyncOps {
     });
     await runWithConcurrency(tasks, this.getIndexConcurrency());
 
-    const staleRows = this.db
-      .prepare(`SELECT path FROM files WHERE source = ?`)
-      .all("memory") as Array<{ path: string }>;
-    for (const stale of staleRows) {
-      if (activePaths.has(stale.path)) {
+    // Bulk-load stale paths to avoid per-file queries during cleanup.
+    const allIndexedPaths = params.needsFullReindex
+      ? existingRecords
+      : new Map(
+          (
+            this.db.prepare(`SELECT path FROM files WHERE source = ?`).all("memory") as Array<{
+              path: string;
+            }>
+          ).map((row) => [row.path, ""]),
+        );
+    for (const [stalePath] of allIndexedPaths) {
+      if (activePaths.has(stalePath)) {
         continue;
       }
-      this.db.prepare(`DELETE FROM files WHERE path = ? AND source = ?`).run(stale.path, "memory");
+      this.db.prepare(`DELETE FROM files WHERE path = ? AND source = ?`).run(stalePath, "memory");
       try {
         this.db
           .prepare(
             `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE path = ? AND source = ?)`,
           )
-          .run(stale.path, "memory");
+          .run(stalePath, "memory");
       } catch {}
-      this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(stale.path, "memory");
+      this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(stalePath, "memory");
       if (this.fts.enabled && this.fts.available) {
         try {
           this.db
-            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-            .run(stale.path, "memory", this.provider.model);
+            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+            .run(stalePath, "memory");
         } catch {}
       }
     }
@@ -789,9 +804,9 @@ export abstract class MemoryManagerSyncOps {
     targetSessionFiles?: string[];
     progress?: MemorySyncProgressState;
   }) {
-    // FTS-only mode: skip embedding sync (no provider)
-    if (!this.provider) {
-      log.debug("Skipping session file sync in FTS-only mode (no embedding provider)");
+    // No provider and no FTS: nothing we can index.
+    if (!this.provider && !(this.fts.enabled && this.fts.available)) {
+      log.debug("Skipping session file sync (no embedding provider and FTS unavailable)");
       return;
     }
 
@@ -823,6 +838,17 @@ export abstract class MemoryManagerSyncOps {
       });
     }
 
+    // Bulk-load existing session file hashes to avoid per-file queries (N+1 → 1).
+    const existingRecords = new Map<string, string>();
+    if (!params.needsFullReindex) {
+      const rows = this.db
+        .prepare(`SELECT path, hash FROM files WHERE source = ?`)
+        .all("sessions") as Array<{ path: string; hash: string }>;
+      for (const row of rows) {
+        existingRecords.set(row.path, row.hash);
+      }
+    }
+
     const tasks = files.map((absPath) => async () => {
       if (!indexAll && !this.sessionsDirtyFiles.has(absPath)) {
         if (params.progress) {
@@ -845,10 +871,7 @@ export abstract class MemoryManagerSyncOps {
         }
         return;
       }
-      const record = this.db
-        .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
-        .get(entry.path, "sessions") as { hash: string } | undefined;
-      if (!params.needsFullReindex && record?.hash === entry.hash) {
+      if (!params.needsFullReindex && existingRecords.get(entry.path) === entry.hash) {
         if (params.progress) {
           params.progress.completed += 1;
           params.progress.report({
@@ -877,6 +900,7 @@ export abstract class MemoryManagerSyncOps {
       return;
     }
 
+    // Bulk-load stale paths to avoid per-file queries during cleanup.
     const staleRows = this.db
       .prepare(`SELECT path FROM files WHERE source = ?`)
       .all("sessions") as Array<{ path: string }>;
@@ -900,8 +924,8 @@ export abstract class MemoryManagerSyncOps {
       if (this.fts.enabled && this.fts.available) {
         try {
           this.db
-            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
-            .run(stale.path, "sessions", this.provider.model);
+            .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+            .run(stale.path, "sessions");
         } catch {}
       }
     }

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -766,17 +766,11 @@ export abstract class MemoryManagerSyncOps {
     });
     await runWithConcurrency(tasks, this.getIndexConcurrency());
 
-    // Bulk-load stale paths to avoid per-file queries during cleanup.
-    const allIndexedPaths = params.needsFullReindex
-      ? existingRecords
-      : new Map(
-          (
-            this.db.prepare(`SELECT path FROM files WHERE source = ?`).all("memory") as Array<{
-              path: string;
-            }>
-          ).map((row) => [row.path, ""]),
-        );
-    for (const [stalePath] of allIndexedPaths) {
+    // Fresh query for stale paths after indexing (consistent with syncSessionFiles).
+    const indexedRows = this.db
+      .prepare(`SELECT path FROM files WHERE source = ?`)
+      .all("memory") as Array<{ path: string }>;
+    for (const { path: stalePath } of indexedRows) {
       if (activePaths.has(stalePath)) {
         continue;
       }

--- a/src/memory/manager.fts-only.test.ts
+++ b/src/memory/manager.fts-only.test.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMemorySearchManager, type MemoryIndexManager } from "./index.js";
+import "./test-runtime-mocks.js";
+
+// Mock createEmbeddingProvider to return null provider (no embedding available).
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: async () => ({
+    requestedProvider: "auto",
+    provider: null,
+    providerUnavailableReason: "no API keys configured",
+  }),
+}));
+
+describe("memory FTS-only indexing (no embedding provider)", () => {
+  let fixtureRoot = "";
+  let workspaceDir = "";
+  let memoryDir = "";
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-fts-only-"));
+    workspaceDir = path.join(fixtureRoot, "workspace");
+    memoryDir = path.join(workspaceDir, "memory");
+    await fs.mkdir(memoryDir, { recursive: true });
+    await fs.writeFile(
+      path.join(memoryDir, "2026-01-15.md"),
+      "# Notes\nAlpha memory line.\nZebra memory line.\nBeta detail here.",
+    );
+  });
+
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "1");
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+  });
+
+  type TestCfg = Parameters<typeof getMemorySearchManager>[0]["cfg"];
+
+  function createCfg(storePath: string): TestCfg {
+    return {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "",
+            store: { path: storePath, vector: { enabled: false } },
+            chunking: { tokens: 4000, overlap: 0 },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+            query: {
+              minScore: 0,
+              hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
+            },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    };
+  }
+
+  it("indexes memory files and finds them via FTS search without an embedding provider", async () => {
+    const storePath = path.join(workspaceDir, `fts-only-${randomUUID()}.sqlite`);
+    const cfg = createCfg(storePath);
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    expect(result.manager).not.toBeNull();
+    const manager = result.manager as MemoryIndexManager;
+
+    await manager.sync({ reason: "test" });
+
+    const status = manager.status();
+    expect(status.files).toBeGreaterThan(0);
+    expect(status.chunks).toBeGreaterThan(0);
+
+    const results = await manager.search("zebra");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.path).toContain("memory/2026-01-15.md");
+
+    await manager.close();
+  });
+
+  it("cleans up stale FTS entries when a memory file is removed", async () => {
+    const storePath = path.join(workspaceDir, `fts-stale-${randomUUID()}.sqlite`);
+    const tempFile = path.join(memoryDir, `temp-${randomUUID()}.md`);
+    await fs.writeFile(tempFile, "Temporary gamma content for stale test.");
+
+    const cfg = createCfg(storePath);
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    const manager = result.manager as MemoryIndexManager;
+
+    await manager.sync({ reason: "test" });
+
+    // Verify the temp file was indexed.
+    const beforeResults = await manager.search("gamma");
+    expect(beforeResults.length).toBeGreaterThan(0);
+
+    // Remove the temp file and re-sync.
+    await fs.rm(tempFile);
+    (manager as unknown as { dirty: boolean }).dirty = true;
+    await manager.sync({ reason: "test" });
+
+    // Stale FTS entries should be gone.
+    const afterResults = await manager.search("gamma");
+    expect(afterResults.length).toBe(0);
+
+    await manager.close();
+  });
+
+  it("reindexes correctly when file content changes", async () => {
+    const storePath = path.join(workspaceDir, `fts-reindex-${randomUUID()}.sqlite`);
+    const mutableFile = path.join(memoryDir, `mutable-${randomUUID()}.md`);
+    await fs.writeFile(mutableFile, "Original delta content.");
+
+    const cfg = createCfg(storePath);
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    const manager = result.manager as MemoryIndexManager;
+
+    await manager.sync({ reason: "test" });
+    const firstResults = await manager.search("delta");
+    expect(firstResults.length).toBeGreaterThan(0);
+
+    // Update content, close manager, and create a fresh one to force full reindex.
+    await fs.writeFile(mutableFile, "Updated epsilon content only.");
+    await manager.close();
+
+    const result2 = await getMemorySearchManager({ cfg, agentId: "main" });
+    const manager2 = result2.manager as MemoryIndexManager;
+    await manager2.sync({ force: true });
+
+    const deltaResults = await manager2.search("delta");
+    expect(deltaResults.length).toBe(0);
+
+    const epsilonResults = await manager2.search("epsilon");
+    expect(epsilonResults.length).toBeGreaterThan(0);
+
+    await fs.rm(mutableFile);
+    await manager2.close();
+  });
+});

--- a/src/memory/manager.fts-provider-transition.test.ts
+++ b/src/memory/manager.fts-provider-transition.test.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MemoryIndexManager } from "./index.js";
+import "./test-runtime-mocks.js";
+
+// Switchable provider mock: starts with a real provider, can be toggled to null.
+let providerEnabled = true;
+
+const embedText = (text: string) => {
+  const lower = text.toLowerCase();
+  return [lower.split("alpha").length - 1, lower.split("beta").length - 1];
+};
+
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: async () => {
+    if (!providerEnabled) {
+      return {
+        requestedProvider: "auto",
+        provider: null,
+        providerUnavailableReason: "no API keys configured",
+      };
+    }
+    return {
+      requestedProvider: "openai",
+      provider: {
+        id: "openai",
+        model: "text-embedding-3-small",
+        embedQuery: async (text: string) => embedText(text),
+        embedBatch: async (texts: string[]) => texts.map(embedText),
+      },
+      openAi: {
+        baseUrl: "https://api.openai.com/v1",
+        headers: { Authorization: "Bearer test", "Content-Type": "application/json" },
+        model: "text-embedding-3-small",
+      },
+    };
+  },
+}));
+
+describe("provider → no-provider FTS transition", () => {
+  let fixtureRoot = "";
+  let workspaceDir = "";
+  let memoryDir = "";
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-transition-"));
+    workspaceDir = path.join(fixtureRoot, "workspace");
+    memoryDir = path.join(workspaceDir, "memory");
+    await fs.mkdir(memoryDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "1");
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    providerEnabled = true;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  type TestCfg = Parameters<typeof import("./index.js").getMemorySearchManager>[0]["cfg"];
+
+  function createCfg(storePath: string): TestCfg {
+    return {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "text-embedding-3-small",
+            store: { path: storePath, vector: { enabled: false } },
+            chunking: { tokens: 4000, overlap: 0 },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+            query: {
+              minScore: 0,
+              hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+            },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    };
+  }
+
+  it("does not leak old provider FTS rows when switching to no-provider mode", async () => {
+    const { getMemorySearchManager } = await import("./index.js");
+    const storePath = path.join(workspaceDir, `transition-${randomUUID()}.sqlite`);
+    const memFile = path.join(memoryDir, `transition-${randomUUID()}.md`);
+    await fs.writeFile(memFile, "Alpha transition content with unique kappa keyword.");
+
+    // Phase 1: index with a provider.
+    providerEnabled = true;
+    const cfg = createCfg(storePath);
+    const result1 = await getMemorySearchManager({ cfg, agentId: "main" });
+    const manager1 = result1.manager as MemoryIndexManager;
+    await manager1.sync({ reason: "test" });
+
+    const withProvider = await manager1.search("kappa");
+    expect(withProvider.length).toBeGreaterThan(0);
+    await manager1.close();
+
+    // Remove the file so that it becomes stale.
+    await fs.rm(memFile);
+
+    // Phase 2: switch to no-provider and force reindex on the same DB.
+    providerEnabled = false;
+    const result2 = await getMemorySearchManager({ cfg, agentId: "main" });
+    const manager2 = result2.manager as MemoryIndexManager;
+    await manager2.sync({ force: true });
+
+    // Old provider's FTS rows for the removed file should not leak.
+    const afterTransition = await manager2.search("kappa");
+    expect(afterTransition.length).toBe(0);
+
+    await manager2.close();
+  });
+});


### PR DESCRIPTION


## Summary

Describe the problem and fix in 2–5 bullets:

  - Fix sync N+1 queries: bulk-load file hashes before loop instead of per-file SELECT in syncMemoryFiles and syncSessionFiles
  - Enable FTS-only first-round indexing: no longer skip sync entirely when embedding provider is unavailable but FTS is available
  - Add FTS-only indexFile path: chunk text and write to chunks + chunks_fts with "fts-only" sentinel model, skipping embeddings and multimodal files
  - Align FTS cleanup lifecycle: delete chunks_fts by path + source (not model-filtered) so stale rows from a previous provider cannot leak into FTS-only search results
  - Add regression tests for FTS-only sync, search, stale cleanup, content reindex, and provider-to-no-provider transition

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra



## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

