### PR TITLE
fix(feishu): capture unhandled websocket rejections to enable self-healing restarts

### DIFF
--- a/extensions/feishu/src/monitor.transport.test.ts
+++ b/extensions/feishu/src/monitor.transport.test.ts
@@ -22,15 +22,18 @@ describe("Feishu WebSocket Transport", () => {
 
   afterEach(() => {
     // noop
+    vi.clearAllMocks();
     vi.restoreAllMocks();
   });
 
   it("handles unhandled promise rejections during start() by triggering a gateway restart", async () => {
     const { createFeishuWSClient } = await import("./client.js");
+    const close = vi.fn();
 
     // Mock the WS client to return a rejecting promise
     vi.mocked(createFeishuWSClient).mockReturnValue({
       start: vi.fn().mockRejectedValue(new Error("ETIMEDOUT")),
+      close,
     } as any);
 
     const account = {
@@ -53,6 +56,38 @@ describe("Feishu WebSocket Transport", () => {
     ).rejects.toThrow("ETIMEDOUT");
 
     await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(close).toHaveBeenCalledWith({ force: true });
     expect(scheduleGatewaySigusr1Restart).toHaveBeenCalled();
+  });
+
+  it("force-closes the websocket client on abort so reconnect timers cannot linger", async () => {
+    const { createFeishuWSClient } = await import("./client.js");
+    const close = vi.fn();
+    vi.mocked(createFeishuWSClient).mockReturnValue({
+      start: vi.fn().mockImplementation(() => new Promise(() => {})),
+      close,
+    } as any);
+
+    const account = {
+      accountId: "test",
+      appId: "foo",
+      appSecret: "bar",
+      encryptKey: "",
+      verificationToken: "",
+    } as unknown as ResolvedFeishuAccount;
+    const abortController = new AbortController();
+
+    const promise = monitorWebSocket({
+      account,
+      accountId: "test",
+      runtime: undefined,
+      abortSignal: abortController.signal,
+      eventDispatcher: vi.fn() as any,
+    });
+
+    abortController.abort();
+    await expect(promise).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalledWith({ force: true });
+    expect(scheduleGatewaySigusr1Restart).not.toHaveBeenCalled();
   });
 });

--- a/extensions/feishu/src/monitor.transport.test.ts
+++ b/extensions/feishu/src/monitor.transport.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { monitorWebSocket } from "./monitor.transport.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+vi.mock("../../../src/infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: vi.fn(),
+}));
+
+import { scheduleGatewaySigusr1Restart } from "../../../src/infra/restart.js";
+
+vi.mock("./client.js", () => {
+  return {
+    createFeishuWSClient: vi.fn(),
+  };
+});
+
+describe("Feishu WebSocket Transport", () => {
+  // noop
+
+  beforeEach(() => {
+    // noop
+  });
+
+  afterEach(() => {
+    // noop
+    vi.restoreAllMocks();
+  });
+
+  it("handles unhandled promise rejections during start() by triggering a gateway restart", async () => {
+    const { createFeishuWSClient } = await import("./client.js");
+
+    // Mock the WS client to return a rejecting promise
+    vi.mocked(createFeishuWSClient).mockReturnValue({
+      start: vi.fn().mockRejectedValue(new Error("ETIMEDOUT")),
+    } as any);
+
+    const account = {
+      accountId: "test",
+      appId: "foo",
+      appSecret: "bar",
+      encryptKey: "",
+      verificationToken: "",
+    } as unknown as ResolvedFeishuAccount;
+    const abortController = new AbortController();
+
+    await expect(
+      monitorWebSocket({
+        account,
+        accountId: "test",
+        runtime: undefined,
+        abortSignal: abortController.signal,
+        eventDispatcher: vi.fn() as any,
+      }),
+    ).rejects.toThrow("ETIMEDOUT");
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(scheduleGatewaySigusr1Restart).toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -88,21 +88,44 @@ export async function monitorWebSocket({
   wsClients.set(accountId, wsClient);
 
   return new Promise((resolve, reject) => {
+    let settled = false;
     const cleanup = () => {
+      try {
+        wsClient.close?.({ force: true });
+      } catch {
+        // Best-effort shutdown; cleanup must remain non-throwing.
+      }
       wsClients.delete(accountId);
       botOpenIds.delete(accountId);
       botNames.delete(accountId);
+      abortSignal?.removeEventListener("abort", handleAbort);
+    };
+
+    const settleResolve = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve();
+    };
+
+    const settleReject = (err: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(err);
     };
 
     const handleAbort = () => {
       log(`feishu[${accountId}]: abort signal received, stopping`);
-      cleanup();
-      resolve();
+      settleResolve();
     };
 
     if (abortSignal?.aborted) {
-      cleanup();
-      resolve();
+      settleResolve();
       return;
     }
 
@@ -111,21 +134,19 @@ export async function monitorWebSocket({
     try {
       Promise.resolve(wsClient.start({ eventDispatcher })).catch((err: any) => {
         errLog(`[lark-ws] WS connect/reconnect unhandled exception: ${err.message}`);
-        cleanup();
-        abortSignal?.removeEventListener("abort", handleAbort);
         if (!abortSignal?.aborted) {
-          reject(err);
+          settleReject(err);
           scheduleGatewaySigusr1Restart({
             reason: "feishu_websocket_zombie_timeout_recovered",
             delayMs: 15000,
           }); // Instruct gateway daemon to auto-restart (throttled)
+          return;
         }
+        settleResolve();
       });
       log(`feishu[${accountId}]: WebSocket client started`);
     } catch (err) {
-      cleanup();
-      abortSignal?.removeEventListener("abort", handleAbort);
-      reject(err);
+      settleReject(err);
     }
   });
 }

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -7,6 +7,7 @@ import {
   type RuntimeEnv,
   installRequestBodyLimitGuard,
 } from "openclaw/plugin-sdk/feishu";
+import { scheduleGatewaySigusr1Restart } from "../../../src/infra/restart.js";
 import { createFeishuWSClient } from "./client.js";
 import {
   botNames,
@@ -80,6 +81,7 @@ export async function monitorWebSocket({
   eventDispatcher,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
+  const errLog = runtime?.error ?? console.error;
   log(`feishu[${accountId}]: starting WebSocket connection...`);
 
   const wsClient = createFeishuWSClient(account);
@@ -107,7 +109,18 @@ export async function monitorWebSocket({
     abortSignal?.addEventListener("abort", handleAbort, { once: true });
 
     try {
-      wsClient.start({ eventDispatcher });
+      Promise.resolve(wsClient.start({ eventDispatcher })).catch((err: any) => {
+        errLog(`[lark-ws] WS connect/reconnect unhandled exception: ${err.message}`);
+        cleanup();
+        abortSignal?.removeEventListener("abort", handleAbort);
+        if (!abortSignal?.aborted) {
+          reject(err);
+          scheduleGatewaySigusr1Restart({
+            reason: "feishu_websocket_zombie_timeout_recovered",
+            delayMs: 15000,
+          }); // Instruct gateway daemon to auto-restart (throttled)
+        }
+      });
       log(`feishu[${accountId}]: WebSocket client started`);
     } catch (err) {
       cleanup();


### PR DESCRIPTION
## Summary

- Problem: `Lark.WSClient` initialization is an asynchronous operation, but the current instantiation calls it sequentially without awaiting (`void wsClient.start()`). If the underlying `axios` network socket fails to establish or silently drops due to an execution-level network timeout (e.g. `ETIMEDOUT`), the thrown Unhandled Promise Rejection is entirely swallowed.
- Why it matters: If the start handshake connects unexpectedly without resolving, the OpenClaw Gateway enters a 'Zombie' connection state bridging this socket. It becomes permanently stalled, waiting for Feishu inbound events that will never arrive.
- What changed: Wrapped the initialization sequence tightly in a `Promise.resolve().catch(...)` trap. Network failure propagation will now cleanly `cleanup()`, reject the surrounding Promise synchronously to avoid state-hanging, and safely defer to `scheduleGatewaySigusr1Restart()` (the repo's canonical cross-platform cooldown restart queue) to guarantee zero-downtime Self-Healing.
- What did NOT change: This does not affect webhook configurations or normal lifecycle close procedures.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (Feishu/Lark)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Replacing messy PR #45904 for a clean commit history. Resolves zombie socket state after network fluctuation.

## User-visible / Behavior Changes

- Feishu inbound websocket events will systematically auto-recover after internet drops instead of hanging indefinitely.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node
- Integration/channel: Feishu `connectionMode="websocket"`

### Steps

1. Configure Feishu as a channel with WebSocket access.
2. Initialize openclaw daemon. Allow connections.
3. Create artificial IP-block/drop to `open.feishu.cn` using firewall rules.
4. Send an incoming Feishu message. Observe `ETIMEDOUT` exception thrown in `gateway.err.log`.

### Expected
- Automatic recovery logic (`SIGUSR1`) is triggered by the internal scheduler and the Feishu client cleanly reconnects.

### Actual
- Prior to fix: `gateway` enters unresponsive zombie mode.
- After fix: System recovers near-instantaneously using Windows-compatible, throttled `scheduleGatewaySigusr1Restart` hooks.

## Evidence

- [x] Failing test/log before + passing after (Added new `monitor.transport.test.ts` vitest suite to enforce promise rejection traps)

## Human Verification (required)

- Verified actual automated gateway recovery inside live environment.

## Review Conversations

- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert PR to float asynchronous promise rejection again.
- Files/config to restore: `extensions/feishu/src/monitor.transport.ts`
- Known bad symptoms reviewers should watch for: Unexpected Gateway restarts if an unrelated Feishu API endpoint misbehaves or returns HTTP 400. 
