### PR TITLE
fix(agents): recover sandbox edit after post-write failure

### DIFF
--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -30,9 +30,7 @@ export function wrapHostEditToolWithPostWriteRecovery(
   options?: PostWriteRecoveryOptions,
 ): AnyAgentTool {
   const resolvePath = options?.resolvePath ?? resolveHostEditPath;
-  const readFile =
-    options?.readFile ??
-    ((filePath: string) => fs.readFile(filePath, "utf-8"));
+  const readFile = options?.readFile ?? ((filePath: string) => fs.readFile(filePath, "utf-8"));
 
   return {
     ...base,

--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import type { AgentToolResult, AgentToolUpdateCallback } from "@mariozechner/pi-agent-core";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 
+type PostWriteRecoveryOptions = {
+  readFile?: (filePath: string, signal?: AbortSignal) => Promise<string | Buffer>;
+  resolvePath?: (root: string, pathParam: string) => string;
+};
+
 /** Resolve path for host edit: expand ~ and resolve relative paths against root. */
 function resolveHostEditPath(root: string, pathParam: string): string {
   const expanded =
@@ -22,7 +27,13 @@ function resolveHostEditPath(root: string, pathParam: string): string {
 export function wrapHostEditToolWithPostWriteRecovery(
   base: AnyAgentTool,
   root: string,
+  options?: PostWriteRecoveryOptions,
 ): AnyAgentTool {
+  const resolvePath = options?.resolvePath ?? resolveHostEditPath;
+  const readFile =
+    options?.readFile ??
+    ((filePath: string) => fs.readFile(filePath, "utf-8"));
+
   return {
     ...base,
     execute: async (
@@ -53,8 +64,10 @@ export function wrapHostEditToolWithPostWriteRecovery(
           throw err;
         }
         try {
-          const absolutePath = resolveHostEditPath(root, pathParam);
-          const content = await fs.readFile(absolutePath, "utf-8");
+          const absolutePath = resolvePath(root, pathParam);
+          const rawContent = await readFile(absolutePath, signal);
+          const content =
+            typeof rawContent === "string" ? rawContent : rawContent.toString("utf-8");
           // Only recover when the replacement likely occurred: newText is present and oldText
           // is no longer present. This avoids false success when upstream threw before writing
           // (e.g. oldText not found) but the file already contained newText (review feedback).

--- a/src/agents/pi-tools.read.host-edit-recovery.test.ts
+++ b/src/agents/pi-tools.read.host-edit-recovery.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import type { EditToolOptions } from "@mariozechner/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 const mocks = vi.hoisted(() => ({
   executeThrows: true,
@@ -32,7 +33,7 @@ vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
   };
 });
 
-const { createHostWorkspaceEditTool } = await import("./pi-tools.read.js");
+const { createHostWorkspaceEditTool, createSandboxedEditTool } = await import("./pi-tools.read.js");
 
 describe("createHostWorkspaceEditTool post-write recovery", () => {
   let tmpDir = "";
@@ -85,5 +86,39 @@ describe("createHostWorkspaceEditTool post-write recovery", () => {
     await expect(
       tool.execute("call-1", { path: filePath, oldText, newText }, undefined),
     ).rejects.toThrow("Simulated post-write failure");
+  });
+
+  it("returns success for sandbox edit when upstream throws after writing", async () => {
+    const filePath = "/workspace/MEMORY.md";
+    const oldText = "# Memory";
+    const newText = "Blog Writing";
+    const bridge: SandboxFsBridge = {
+      resolvePath: () => ({
+        hostPath: "/tmp/MEMORY.md",
+        relativePath: "MEMORY.md",
+        containerPath: filePath,
+      }),
+      readFile: vi.fn(async () => Buffer.from(`\n\n${newText}\n`, "utf-8")),
+      writeFile: vi.fn(async () => {}),
+      mkdirp: vi.fn(async () => {}),
+      remove: vi.fn(async () => {}),
+      rename: vi.fn(async () => {}),
+      stat: vi.fn(async () => ({ type: "file", size: newText.length, mtimeMs: Date.now() })),
+    };
+
+    const tool = createSandboxedEditTool({ root: "/workspace", bridge });
+    const result = await tool.execute("call-1", { path: filePath, oldText, newText }, undefined);
+
+    expect(result).toBeDefined();
+    const content = Array.isArray((result as { content?: unknown }).content)
+      ? (result as { content: Array<{ type?: string; text?: string }> }).content
+      : [];
+    const textBlock = content.find((b) => b?.type === "text" && typeof b.text === "string");
+    expect(textBlock?.text).toContain("Successfully replaced text");
+    expect(bridge.readFile).toHaveBeenCalledWith({
+      filePath,
+      cwd: "/workspace",
+      signal: undefined,
+    });
   });
 });

--- a/src/agents/pi-tools.read.host-edit-recovery.test.ts
+++ b/src/agents/pi-tools.read.host-edit-recovery.test.ts
@@ -8,7 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import type { EditToolOptions } from "@mariozechner/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+import type { SandboxFsBridge, SandboxFsStat } from "./sandbox/fs-bridge.js";
 
 const mocks = vi.hoisted(() => ({
   executeThrows: true,
@@ -92,6 +92,11 @@ describe("createHostWorkspaceEditTool post-write recovery", () => {
     const filePath = "/workspace/MEMORY.md";
     const oldText = "# Memory";
     const newText = "Blog Writing";
+    const statResult: SandboxFsStat = {
+      type: "file",
+      size: newText.length,
+      mtimeMs: Date.now(),
+    };
     const bridge: SandboxFsBridge = {
       resolvePath: () => ({
         hostPath: "/tmp/MEMORY.md",
@@ -103,7 +108,7 @@ describe("createHostWorkspaceEditTool post-write recovery", () => {
       mkdirp: vi.fn(async () => {}),
       remove: vi.fn(async () => {}),
       rename: vi.fn(async () => {}),
-      stat: vi.fn(async () => ({ type: "file", size: newText.length, mtimeMs: Date.now() })),
+      stat: vi.fn(async () => statResult),
     };
 
     const tool = createSandboxedEditTool({ root: "/workspace", bridge });

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -620,8 +620,7 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
   }) as unknown as AnyAgentTool;
   const withRecovery = wrapHostEditToolWithPostWriteRecovery(base, params.root, {
     resolvePath: (_root, pathParam) => pathParam,
-    readFile: (filePath, signal) =>
-      params.bridge.readFile({ filePath, cwd: params.root, signal }),
+    readFile: (filePath, signal) => params.bridge.readFile({ filePath, cwd: params.root, signal }),
   });
   return wrapToolParamNormalization(withRecovery, CLAUDE_PARAM_GROUPS.edit);
 }

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -618,7 +618,12 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
   const base = createEditTool(params.root, {
     operations: createSandboxEditOperations(params),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+  const withRecovery = wrapHostEditToolWithPostWriteRecovery(base, params.root, {
+    resolvePath: (_root, pathParam) => pathParam,
+    readFile: (filePath, signal) =>
+      params.bridge.readFile({ filePath, cwd: params.root, signal }),
+  });
+  return wrapToolParamNormalization(withRecovery, CLAUDE_PARAM_GROUPS.edit);
 }
 
 export function createHostWorkspaceWriteTool(root: string, options?: { workspaceOnly?: boolean }) {


### PR DESCRIPTION
## Summary

- Problem: sandboxed edit could report a false "failed" result even when the file write had already succeeded, because sandboxed edit did not use the same post-write recovery path that host edit already had.
- Why it matters: mutating tool failures are surfaced to users, so a false failure is misleading and can make a successful edit look unsafe or incomplete.
- What changed: generalized `wrapHostEditToolWithPostWriteRecovery(...)` to accept injected path resolution and read-back behavior, then wired sandbox edit to verify through the sandbox fs bridge and return success when `newText` is present and `oldText` is no longer present after an upstream post-write throw.
- What did NOT change (scope boundary): this does not change generic tool-runner error classification, does not change host edit behavior beyond keeping its existing default recovery path, and does not add any new permissions, config, or network behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45770 
- Related #

## User-visible / Behavior Changes

For sandboxed agent runs, a successful edit no longer emits a false failure when the upstream edit tool throws after the write has already landed (for example, during post-write diff/result formatting).

No config or default behavior changes outside this recovery path.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.16.0, Vitest; sandbox path covered through a bridge-backed unit test
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): None

### Steps

1. Create a sandboxed edit tool using a sandbox fs bridge.
2. Simulate an upstream post-write throw while bridge read-back shows `newText` present and `oldText` absent.
3. Execute the edit tool and observe whether it returns success or surfaces a failure.

### Expected

- If the write already landed, the edit should return success instead of surfacing a false failure.
- Pre-write failures should still be reported as failures.

### Actual

- Before this change, sandboxed edit could surface failure because it did not use post-write recovery.
- After this change, sandboxed edit recovers in the same class of post-write failure that host edit already handled.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```bash
$ volta run --node 22.16.0 pnpm test -- src/agents/pi-tools.read.host-edit-recovery.test.ts

RUN  v4.1.0 /Users/a1-6/openclaw

Test Files  1 passed (1)
Tests       4 passed (4)
