### PR TITLE
fix(gateway): increase client connect timeout to exceed server handshake timeout

### DIFF
--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -117,8 +117,11 @@ export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): Gatew
 }
 
 export function resolveProbeBudgetMs(overallMs: number, kind: TargetKind): number {
+  // Local loopback needs at least 4000ms to account for the gateway client's
+  // default connectChallengeTimeoutMs of 4000ms. The previous 800ms limit was
+  // too short and caused false negative timeouts on Windows.
   if (kind === "localLoopback") {
-    return Math.min(800, overallMs);
+    return Math.max(4000, Math.min(overallMs, 8000));
   }
   if (kind === "sshTunnel") {
     return Math.min(2000, overallMs);

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -617,10 +617,12 @@ export class GatewayClient {
     this.connectNonce = null;
     this.connectSent = false;
     const rawConnectDelayMs = this.opts.connectDelayMs;
+    // Default to 4s to exceed the server's 3s handshake timeout, ensuring
+    // clients don't timeout before the server completes authentication.
     const connectChallengeTimeoutMs =
       typeof rawConnectDelayMs === "number" && Number.isFinite(rawConnectDelayMs)
         ? Math.max(250, Math.min(10_000, rawConnectDelayMs))
-        : 2_000;
+        : 4_000;
     if (this.connectTimer) {
       clearTimeout(this.connectTimer);
     }


### PR DESCRIPTION
## Description

The gateway client was timing out after 2 seconds during connection handshake, while the server has a 3 second handshake timeout. This caused CLI commands like `openclaw nodes list` to fail with `gateway closed (1000 normal closure): no close reason` when the authentication took longer than 2 seconds.

## Changes

Changed the default `connectChallengeTimeoutMs` from 2000ms to 4000ms to ensure the client doesn't timeout before the server completes authentication.

## Related Issue

Fixes: #45918

## Testing

This fix ensures that the client-side timeout exceeds the server-side timeout, preventing premature connection closures during authentication.