### PR TITLE
fix(gateway): pre-compute dedupe cache excess before cleanup loop

### DIFF
--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -85,7 +85,8 @@ export function startGatewayMaintenanceTimers(params: {
     }
     if (params.dedupe.size > DEDUPE_MAX) {
       const entries = [...params.dedupe.entries()].toSorted((a, b) => a[1].ts - b[1].ts);
-      for (let i = 0; i < params.dedupe.size - DEDUPE_MAX; i++) {
+      const excess = params.dedupe.size - DEDUPE_MAX;
+      for (let i = 0; i < excess; i++) {
         params.dedupe.delete(entries[i][0]);
       }
     }


### PR DESCRIPTION
## Summary

- Fix shrinking loop bound bug in dedupe cache overflow cleanup in `server-maintenance.ts`
- The `for` loop condition `i < params.dedupe.size - DEDUPE_MAX` references `params.dedupe.size` which decreases on every iteration as entries are deleted, causing the loop to terminate early and only remove ~N/2 excess entries instead of N
- Pre-compute the excess count before the loop starts, matching the correct pattern already used for `agentRunSeq` cleanup at line 94

### Bug details

When the dedupe cache exceeds `DEDUPE_MAX` (1000), the cleanup loop is supposed to remove the oldest excess entries. However, because `params.dedupe.delete()` shrinks `params.dedupe.size` on each iteration while `i` increments, the two values converge at roughly the midpoint:

| Iteration | `i` | `size` | `i < size - 1000` |
|-----------|-----|--------|--------------------|
| 0 | 0 | 1010 | 0 < 10 ✓ |
| 1 | 1 | 1009 | 1 < 9 ✓ |
| ... | ... | ... | ... |
| 5 | 5 | 1005 | 5 < 5 ✗ STOP |

Only 5 of 10 excess entries are removed. Over many cycles with new entries being added, this causes gradual unbounded memory growth.

### Fix

```typescript
// Before (buggy): loop bound shrinks as entries are deleted
for (let i = 0; i < params.dedupe.size - DEDUPE_MAX; i++) {

// After (fixed): pre-compute excess count
const excess = params.dedupe.size - DEDUPE_MAX;
for (let i = 0; i < excess; i++) {
```

## Test plan

- [ ] Verify existing tests pass (`vitest`)
- [ ] Verify dedupe cache is correctly trimmed to `DEDUPE_MAX` when overflow occurs
- [ ] Compare with the correct `while` loop pattern in `server-http.ts:407` and the `agentRunSeq` cleanup at line 94 of the same file