### PR TITLE
fix(gateway): increase local loopback probe budget to prevent false negative timeouts

### DIFF
--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -117,8 +117,11 @@ export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): Gatew
 }
 
 export function resolveProbeBudgetMs(overallMs: number, kind: TargetKind): number {
+  // Local loopback needs at least 4000ms to account for the gateway client's
+  // default connectChallengeTimeoutMs of 4000ms. The previous 800ms limit was
+  // too short and caused false negative timeouts on Windows.
   if (kind === "localLoopback") {
-    return Math.min(800, overallMs);
+    return Math.max(4000, Math.min(overallMs, 8000));
   }
   if (kind === "sshTunnel") {
     return Math.min(2000, overallMs);


### PR DESCRIPTION
## Description

The gateway probe was giving local loopback connections only 800ms to connect and authenticate, but the gateway client has a default `connectChallengeTimeoutMs` of 4000ms. This caused false negative timeouts on Windows where the WebSocket handshake can take longer than expected.

## Changes

Changed the local loopback probe budget from `Math.min(800, overallMs)` to `Math.max(4000, Math.min(overallMs, 8000))` to ensure enough time for the client's internal authentication to complete.

## Related Issue

Fixes: #45940

## Testing

This fix ensures that local loopback probe connections have at least 4 seconds to complete the WebSocket handshake, matching the gateway client's internal timeout.