### PR TITLE
fix(memory-lancedb): add encoding_format float for Ollama compatibility

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -173,9 +173,10 @@ class Embeddings {
   }
 
   async embed(text: string): Promise<number[]> {
-    const params: { model: string; input: string; dimensions?: number } = {
+    const params: { model: string; input: string; dimensions?: number; encoding_format?: "float" | "base64" } = {
       model: this.model,
       input: text,
+      encoding_format: "float",
     };
     if (this.dimensions) {
       params.dimensions = this.dimensions;


### PR DESCRIPTION
## Summary

- Add `encoding_format: "float"` to embeddings API calls for Ollama compatibility

## Problem

When using Ollama as the embedding provider, the OpenAI Node.js client defaults to `encoding_format: 'base64'`. Ollama's OpenAI-compatible endpoint has issues parsing base64 responses, causing 768-dimensional vectors to be incorrectly returned as 192-dimensional (768/4 = 192).

This causes vector search to fail with:
```
Error: No vector column found to match with the query vector dimension: 192
```

## Solution

Explicitly set `encoding_format: "float"` in the embeddings request. This ensures the response contains a plain array of floats, which is correctly parsed by all providers.

## Test plan

- [x] Tested with Ollama `nomic-embed-text` model (768 dimensions)
- [x] Verified `openclaw ltm search` works correctly after fix
- [x] Verified `openclaw ltm stats` shows correct memory count

Fixes #45982
