### PR TITLE
feat(cron): add opaque metadata field to cron jobs

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -331,6 +331,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               "thinking",
               "timeoutSeconds",
               "allowUnsafeExternalContent",
+              "metadata",
             ]);
             const synthetic: Record<string, unknown> = {};
             let found = false;
@@ -474,6 +475,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               "wakeMode",
               "failureAlert",
               "allowUnsafeExternalContent",
+              "metadata",
             ]);
             const synthetic: Record<string, unknown> = {};
             let found = false;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -646,7 +646,7 @@ export function applyJobPatch(
     job.state = { ...job.state, ...patch.state };
   }
   if ("metadata" in patch) {
-    job.metadata = (patch as { metadata?: Record<string, unknown> }).metadata;
+    job.metadata = patch.metadata;
   }
   if ("agentId" in patch) {
     job.agentId = normalizeOptionalAgentId((patch as { agentId?: unknown }).agentId);

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -556,6 +556,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     payload: input.payload,
     delivery: resolveInitialCronDelivery(input),
     failureAlert: input.failureAlert,
+    metadata: input.metadata,
     state: {
       ...input.state,
     },
@@ -643,6 +644,9 @@ export function applyJobPatch(
   }
   if (patch.state) {
     job.state = { ...job.state, ...patch.state };
+  }
+  if ("metadata" in patch) {
+    job.metadata = (patch as { metadata?: Record<string, unknown> }).metadata;
   }
   if ("agentId" in patch) {
     job.agentId = normalizeOptionalAgentId((patch as { agentId?: unknown }).agentId);

--- a/src/cron/types-shared.ts
+++ b/src/cron/types-shared.ts
@@ -15,4 +15,8 @@ export type CronJobBase<TSchedule, TSessionTarget, TWakeMode, TPayload, TDeliver
     payload: TPayload;
     delivery?: TDelivery;
     failureAlert?: TFailureAlert;
+    /** Caller-supplied metadata, persisted with the job and available at execution time.
+     *  Cron internals treat this as opaque; channel plugins and tooling may use it
+     *  to carry creation-time context (e.g. requester identity, originating chat). */
+    metadata?: Record<string, unknown>;
   };

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -76,6 +76,7 @@ const CronCommonOptionalFields = {
   description: Type.Optional(Type.String()),
   enabled: Type.Optional(Type.Boolean()),
   deleteAfterRun: Type.Optional(Type.Boolean()),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
 };
 
 function cronIdOrJobIdParams(extraFields: Record<string, TSchema>) {
@@ -261,6 +262,7 @@ export const CronJobSchema = Type.Object(
     payload: CronPayloadSchema,
     delivery: Type.Optional(CronDeliverySchema),
     failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
+    metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
     state: CronJobStateSchema,
   },
   { additionalProperties: false },


### PR DESCRIPTION
## Summary

- Problem: When a cron job is created from a channel interaction, the creator's identity and channel-specific context are lost. The isolated execution session only has delivery target info (`channel`, `to`, `accountId`), with no way to recover who created the job or any plugin-specific data.
- Why it matters: Channel plugins need creation-time context at execution time — for example, to @mention the creator in the output, add card footers, or route results based on the originating chat type.
- What changed: Added an optional `metadata` field (`Record<string, unknown>`) to `CronJobBase`. The field flows through the gateway schema, job creation, and patch operations. Plugins write namespaced data (e.g. `{ <channel>: { ... } }`) via the existing `before_tool_call` hook and read it back from `job.metadata` at execution time.
- What did NOT change (scope boundary): No auto-injection of system context. No hook context enrichment. No changes to cron execution, delivery, or scheduling logic. Cron internals treat metadata as fully opaque.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A (new feature request, no existing issue)

## User-visible / Behavior Changes

- `cron.add` and `cron.update` now accept an optional `metadata` field (object with string keys).
- `cron.list` and job responses now include `metadata` when present.
- No default value — existing jobs are unaffected.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — metadata is stored alongside existing job data in the same `jobs.json` file with the same access controls.

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime/container: Node 22+, Bun
- Model/provider: N/A
- Integration/channel (if any): Any channel plugin
- Relevant config (redacted): Default cron config

### Steps

Verification via CLI gateway RPC:

1. `cron.add` with metadata:
   ```json
   { "name": "test", "metadata": { "myPlugin": { "creatorId": "user_123" } }, "schedule": { "kind": "every", "everyMs": 60000 }, "sessionTarget": "isolated", "wakeMode": "now", "payload": { "kind": "agentTurn", "message": "hello" } }
   ```
2. `cron.list` → verify `metadata` field is present in the returned job
3. `cron.update` with `patch: { metadata: { "myPlugin": { "creatorId": "user_456" } } }` → verify metadata is replaced
4. Restart gateway → `cron.list` → verify metadata survived persistence

Intended plugin usage flow:

- Plugin registers `before_tool_call` hook, intercepts `cron.add`, injects namespaced metadata from its own session context (e.g. creator identity)
- On job execution, plugin reads `job.metadata.<channel>` to recover creation-time context

### Expected

- Metadata is persisted in `jobs.json` and returned in all job queries

### Actual

- Confirmed via test suite (512 cron tests, 33 cron-tool tests, 9 gateway cron tests all pass)

## Evidence

- [x] All existing tests pass — no regressions (512 cron, 33 cron-tool, 9 gateway cron, 19 before-tool-call)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Note: This PR adds the storage/pass-through layer only. Tests for plugin-side metadata injection belong in the plugin's own test suite (via `before_tool_call` hook).

## Human Verification (required)

- Verified scenarios: TypeScript compilation (`pnpm tsgo`), lint/format (`pnpm check`), all cron tests (65 files / 512 tests), cron-tool tests (33), gateway cron tests (9), before-tool-call tests (19)
- Edge cases checked: Existing jobs without metadata load correctly (field is `undefined`); `applyJobPatch` with `metadata` in patch replaces the value; flat-params recovery includes `metadata` for non-frontier model compatibility
- What you did **not** verify: Manual end-to-end test with a real channel plugin writing metadata via `before_tool_call` hook

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` — the store uses plain JSON serialization; existing jobs without `metadata` load as `undefined`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 4-file commit; metadata fields in existing `jobs.json` will be silently ignored on next load
- Files/config to restore: `src/cron/types-shared.ts`, `src/gateway/protocol/schema/cron.ts`, `src/cron/service/jobs.ts`, `src/agents/tools/cron-tool.ts`
- Known bad symptoms reviewers should watch for: Gateway schema validation rejecting `metadata` field (would indicate schema not updated); `jobs.json` growing unexpectedly large if plugins write excessive metadata

## Risks and Mitigations

- Risk: Plugins writing unbounded data into metadata, inflating `jobs.json`
    - Mitigation: Metadata is optional and plugin-authored; document recommended size limits in plugin SDK guidance. Future: add a byte-size cap if needed.
