### PR TITLE
fix(acp): sweep stale runId mappings on session removal

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -37,13 +37,11 @@ export function createInMemorySessionStore(options: AcpSessionStoreOptions = {})
     if (!session) {
       return false;
     }
-    if (session.activeRunId) {
-      runIdToSessionId.delete(session.activeRunId);
-    }
-    // Sweep any stale runId mappings that still reference this session.
-    // This can happen when a run is cleared (clearActiveRun) but the
-    // runIdToSessionId entry is not removed due to a timing edge case,
-    // or when the session is reaped while no activeRunId is set.
+    // Sweep all runId → sessionId entries that still reference this session.
+    // Stale entries can accumulate when setActiveRun is called multiple times
+    // for the same session without an intervening clearActiveRun: the previous
+    // runId is silently overwritten in session.activeRunId, leaving its map
+    // entry orphaned.
     for (const [runId, sid] of runIdToSessionId) {
       if (sid === sessionId) {
         runIdToSessionId.delete(runId);

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -40,6 +40,15 @@ export function createInMemorySessionStore(options: AcpSessionStoreOptions = {})
     if (session.activeRunId) {
       runIdToSessionId.delete(session.activeRunId);
     }
+    // Sweep any stale runId mappings that still reference this session.
+    // This can happen when a run is cleared (clearActiveRun) but the
+    // runIdToSessionId entry is not removed due to a timing edge case,
+    // or when the session is reaped while no activeRunId is set.
+    for (const [runId, sid] of runIdToSessionId) {
+      if (sid === sessionId) {
+        runIdToSessionId.delete(runId);
+      }
+    }
     session.abortController?.abort();
     sessions.delete(sessionId);
     return true;


### PR DESCRIPTION
## Problem

When an ACP session is removed (via idle reap or eviction), `removeSession()` in `src/acp/session.ts` only deletes the current `activeRunId` from the `runIdToSessionId` map.

However, if a previous run was cleared via `clearActiveRun()` (which correctly removes the mapping), and then a new run is set and also cleared before the session is reaped, there is a theoretical window where orphaned `runId → sessionId` entries can persist in the map.

Over time in a long-running gateway instance, these orphaned entries accumulate, causing gradual memory growth in the `runIdToSessionId` Map.

## Fix

Add a sweep loop in `removeSession()` that iterates over `runIdToSessionId` and removes all entries referencing the departing `sessionId`. This ensures complete cleanup regardless of the session's active run state at removal time.

The sweep runs only during session removal (idle reap / eviction / explicit delete), so it does not impact hot-path performance.

## Impact

- **Severity**: Low — each leaked entry is a small string→string mapping
- **Affected users**: Long-running gateway instances with high ACP session throughput
- **Risk of fix**: Minimal — only adds cleanup during an already-destructive operation