### PR TITLE
fix: multiple channel fixes - thinking tags, model switching, discord replies

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -16,6 +16,7 @@ import {
   extractThinkingFromTaggedText,
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
+  stripThinkingTagsFromText,
 } from "./pi-embedded-utils.js";
 
 const stripTrailingDirective = (text: string): string => {
@@ -298,9 +299,13 @@ export function handleMessageEnd(
     const rawTrimmed = rawText.trim();
     const rawStrippedFinal = rawTrimmed.replace(/<\s*\/?\s*final\s*>/gi, "").trim();
     const rawCandidate = rawStrippedFinal || rawTrimmed;
-    if (rawCandidate) {
-      const parsedFallback = parseReplyDirectives(stripTrailingDirective(rawCandidate));
-      cleanedText = parsedFallback.text ?? rawCandidate;
+    // Strip thinking tags from fallback content to prevent reasoning tokens
+    // from being used as response content. This mirrors the Ollama fix (#45330)
+    // which ensures reasoning visibility is controlled elsewhere, not as fallback.
+    const rawCandidateWithoutThinking = stripThinkingTagsFromText(rawCandidate);
+    if (rawCandidateWithoutThinking) {
+      const parsedFallback = parseReplyDirectives(stripTrailingDirective(rawCandidateWithoutThinking));
+      cleanedText = parsedFallback.text ?? rawCandidateWithoutThinking;
       mediaUrls = parsedFallback.mediaUrls;
       hasMedia = Boolean(mediaUrls && mediaUrls.length > 0);
     }

--- a/src/auto-reply/reply/reply-reference.ts
+++ b/src/auto-reply/reply/reply-reference.ts
@@ -36,8 +36,8 @@ export function createReplyReferencePlanner(options: {
     if (!id) {
       return undefined;
     }
+    // "all": every reply gets a reference - never mark as replied.
     if (options.replyToMode === "all") {
-      hasReplied = true;
       return id;
     }
     // "first": only the first reply gets a reference.

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -431,8 +431,40 @@ export const configHandlers: GatewayRequestHandlers = {
     );
     await writeConfigFile(validated.config, writeOptions);
 
+    // Clear the session's runtime model so it picks up the new config defaults.
+    // This fixes the issue where model changes via Control UI don't take effect
+    // until a full restart because the session entry's stored model takes
+    // precedence over config defaults.
     const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
       resolveConfigRestartRequest(params);
+    if (sessionKey) {
+      try {
+        // Use loadSessionEntry to resolve the store path and get the entry
+        const { storePath, store, entry } = loadSessionEntry(sessionKey);
+        if (storePath && entry) {
+          // Only clear runtime model fields, preserve explicit overrides
+          if (entry.model !== undefined) {
+            delete entry.model;
+          }
+          if (entry.modelProvider !== undefined) {
+            delete entry.modelProvider;
+          }
+          // Also clear context tokens as they're model-specific
+          if (entry.contextTokens !== undefined) {
+            delete entry.contextTokens;
+          }
+          await saveSessionStore(storePath, store);
+          context?.logGateway?.debug(
+            `config.patch cleared runtime model for session ${sessionKey}`,
+          );
+        }
+      } catch (err) {
+        // Non-fatal: don't fail the config.patch if session clearing fails
+        context?.logGateway?.warn(
+          `config.patch failed to clear session runtime model: ${String(err)}`,
+        );
+      }
+    }
     const payload = buildConfigRestartSentinelPayload({
       kind: "config-patch",
       mode: "config.patch",

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -11,6 +11,8 @@ import {
   validateConfigObjectWithPlugins,
   writeConfigFile,
 } from "../../config/config.js";
+import { loadSessionEntry } from "../session-utils.js";
+import { loadSessionStore, saveSessionStore } from "../../config/sessions/store.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { applyLegacyMigrations } from "../../config/legacy.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
@@ -489,8 +491,40 @@ export const configHandlers: GatewayRequestHandlers = {
     );
     await writeConfigFile(parsed.config, writeOptions);
 
+    // Clear the session's runtime model so it picks up the new config defaults.
+    // This fixes the issue where model changes via Control UI don't take effect
+    // until a full restart because the session entry's stored model takes
+    // precedence over config defaults.
     const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
       resolveConfigRestartRequest(params);
+    if (sessionKey) {
+      try {
+        // Use loadSessionEntry to resolve the store path and get the entry
+        const { storePath, store, entry } = loadSessionEntry(sessionKey);
+        if (storePath && entry) {
+          // Only clear runtime model fields, preserve explicit overrides
+          if (entry.model !== undefined) {
+            delete entry.model;
+          }
+          if (entry.modelProvider !== undefined) {
+            delete entry.modelProvider;
+          }
+          // Also clear context tokens as they're model-specific
+          if (entry.contextTokens !== undefined) {
+            delete entry.contextTokens;
+          }
+          await saveSessionStore(storePath, store);
+          context?.logGateway?.debug(
+            `config.apply cleared runtime model for session ${sessionKey}`,
+          );
+        }
+      } catch (err) {
+        // Non-fatal: don't fail the config.apply if session clearing fails
+        context?.logGateway?.warn(
+          `config.apply failed to clear session runtime model: ${String(err)}`,
+        );
+      }
+    }
     const payload = buildConfigRestartSentinelPayload({
       kind: "config-apply",
       mode: "config.apply",

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -215,6 +215,30 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
   });
 
+  it("suppresses duplicate warning when candidates have identical rootDir AND source (exact duplicates)", () => {
+    const dir = makeTempDir();
+    const manifest = { id: "exact-duplicate-plugin", configSchema: { type: "object" } };
+    writeManifest(dir, manifest);
+
+    // Both candidates are exactly the same - same rootDir AND same source
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "exact-duplicate-plugin",
+        rootDir: dir,
+        sourceName: "index.ts",
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "exact-duplicate-plugin",
+        rootDir: dir,
+        sourceName: "index.ts",
+        origin: "global",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
+  });
+
   it("prefers higher-precedence origins for the same physical directory (config > workspace > global > bundled)", () => {
     const dir = makeTempDir();
     mkdirSafe(path.join(dir, "sub"));

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -209,11 +209,19 @@ export function loadPluginManifestRegistry(params: {
       // Check whether both candidates point to the same physical directory
       // (e.g. via symlinks or different path representations). If so, this
       // is a false-positive duplicate and can be silently skipped.
-      const samePath = existing.candidate.rootDir === candidate.rootDir;
+      const sameRootDir = existing.candidate.rootDir === candidate.rootDir;
+      const sameSource = existing.candidate.source === candidate.source;
       const samePlugin = (() => {
-        if (samePath) {
+        // If both rootDir and source are identical, it's definitely the same plugin
+        if (sameRootDir && sameSource) {
           return true;
         }
+        // If rootDir matches exactly (even if source differs), treat as same plugin
+        // This handles cases where the same plugin is specified multiple ways
+        if (sameRootDir) {
+          return true;
+        }
+        // Check realpath for symlink resolution
         const existingReal = safeRealpathSync(existing.candidate.rootDir, realpathCache);
         const candidateReal = safeRealpathSync(candidate.rootDir, realpathCache);
         return Boolean(existingReal && candidateReal && existingReal === candidateReal);


### PR DESCRIPTION
## Description

This PR includes three fixes:

### 1. Telegram duplicate messages fix (#45965)
When using reasoning models (KiloCode, NVIDIA Nemotron, etc.), Telegram was sending duplicate messages. Fixed by stripping thinking tags from fallback content.

### 2. UI Model switching fix (#45955)
Model switch via Control UI now takes effect immediately. Fixed by clearing session runtime model on config changes.

### 3. Discord first reply swallowed fix (#45924)
When replyToMode is set to "all", the use() function was incorrectly setting hasReplied = true on every call. Fixed by removing the unnecessary state mutation.

## Changes

- `src/agents/pi-embedded-subscribe.handlers.messages.ts` - Strip thinking tags
- `src/gateway/server-methods/config.ts` - Clear session model on config change
- `src/auto-reply/reply/reply-reference.ts` - Remove incorrect state mutation

## Related Issues

Fixes: #45965
Fixes: #45955
Fixes: #45924