### PR TITLE
fix(gateway): increase client connect timeout to exceed server handshake timeout

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -620,7 +620,7 @@ export class GatewayClient {
     const connectChallengeTimeoutMs =
       typeof rawConnectDelayMs === "number" && Number.isFinite(rawConnectDelayMs)
         ? Math.max(250, Math.min(10_000, rawConnectDelayMs))
-        : 2_000;
+        : 4_000;
     if (this.connectTimer) {
       clearTimeout(this.connectTimer);
     }


### PR DESCRIPTION
## Description

When running `openclaw devices list`, it fails with error: "gateway closed (1006 abnormal closure (no close frame)): no close reason".

This is the same issue as #45918 - the gateway client's default connection timeout was too short. Changed the default `connectChallengeTimeoutMs` from 2000ms to 4000ms to ensure the client doesn't timeout before the server completes authentication.

## Root Cause

- Client default timeout: 2 seconds
- Server handshake timeout: 3 seconds
- When authentication takes longer than 2 seconds, the client times out

## Changes

Changed the default `connectChallengeTimeoutMs` in `src/gateway/client.ts` from 2000 to 4000 milliseconds.

## Related Issue

Fixes: #46008