### PR TITLE
fix(ui): constrain context notice icon size to prevent viewport overflow

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -168,6 +168,8 @@
 .context-notice__icon {
   width: 16px;
   height: 16px;
+  max-width: 16px;
+  max-height: 16px;
   flex-shrink: 0;
   stroke: currentColor;
 }


### PR DESCRIPTION
The context notice warning icon (shown when context usage > 85%) could overflow and cover the entire chat area due to missing max-width/max-height CSS constraints. This fix adds explicit size bounds to ensure the icon stays at 16x16px.

Fixes #45617

## Summary

- Problem: The context notice warning icon (SVG) could grow unbounded and cover the entire chat viewport when context usage exceeded 85%.
- Why it matters: Users could not see or interact with the chat interface, making the Control UI unusable until manually deleting the DOM element via dev tools.
- What changed: Added explicit `max-width: 16px` and `max-height: 16px` CSS constraints to `.context-notice__icon` in `ui/src/styles/chat/layout.css`.
- What did NOT change: No logic changes, no other UI components affected, no breaking changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #45617
- Related #45442, #45260, #45251

## User-visible / Behavior Changes

- The context notice warning icon (shown when context usage > 85%) now correctly stays at 16x16px instead of potentially expanding to fill the viewport.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS (Darwin 24.1.0 arm64)
- Runtime/container: Node.js v22.22.1, OpenClaw 2026.3.12
- Model/provider: N/A
- Integration/channel: Control UI (web)
- Relevant config: Default

### Steps

1. Start OpenClaw gateway: `openclaw gateway run`
2. Open Control UI in browser
3. Use the chat until context usage exceeds 85%
4. Observe the warning icon near the compose area

### Expected

- A small warning icon (16x16px) appears alongside the "X% context used" notice

### Actual (before fix)

- The warning icon expands to fill the entire viewport, blocking all chat content

### Actual (after fix)

- The warning icon stays at 16x16px as intended

## Evidence

- [x] Failing test/log before + passing after
  - Existing test in `ui/src/ui/views/chat.browser.test.ts` validates icon size
  - Test: "keeps the warning icon badge-sized" checks `getBoundingClientRect().width < 24`

## Human Verification (required)

- Verified scenarios:
  - Triggered context > 85% usage in Control UI
  - Confirmed icon no longer overflows
  - Confirmed the notice still displays correctly with proper styling
- Edge cases checked:
  - Context at exactly 85%, 90%, 95%, 100%
  - Different browser window sizes
- What you did **not** verify:
  - Mobile/responsive layouts (desktop only)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 2-line CSS addition
- Files/config to restore: `ui/src/styles/chat/layout.css`
- Known bad symptoms reviewers should watch for: Icon appearing too small or