### PR TITLE
fix(whatsapp): improve @mention detection in group chats

### DIFF
--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -64,18 +64,26 @@ export function extractMentionedJids(rawMessage: proto.IMessage | undefined): st
     return undefined;
   }
 
-  const candidates: Array<string[] | null | undefined> = [
-    message.extendedTextMessage?.contextInfo?.mentionedJid,
-    message.extendedTextMessage?.contextInfo?.quotedMessage?.extendedTextMessage?.contextInfo
-      ?.mentionedJid,
-    message.imageMessage?.contextInfo?.mentionedJid,
-    message.videoMessage?.contextInfo?.mentionedJid,
-    message.documentMessage?.contextInfo?.mentionedJid,
-    message.audioMessage?.contextInfo?.mentionedJid,
-    message.stickerMessage?.contextInfo?.mentionedJid,
-    message.buttonsResponseMessage?.contextInfo?.mentionedJid,
-    message.listResponseMessage?.contextInfo?.mentionedJid,
-  ];
+  // Use extractMessageContent to handle wrapped messages (e.g., viewOnceMessageV2Extension)
+  const extracted = extractMessageContent(message);
+  const candidatesToCheck = [message, extracted && extracted !== message ? extracted : undefined];
+
+  const candidates: Array<string[] | null | undefined> = [];
+  for (const msg of candidatesToCheck) {
+    if (!msg) continue;
+    candidates.push(
+      msg.extendedTextMessage?.contextInfo?.mentionedJid,
+      msg.extendedTextMessage?.contextInfo?.quotedMessage?.extendedTextMessage?.contextInfo
+        ?.mentionedJid,
+      msg.imageMessage?.contextInfo?.mentionedJid,
+      msg.videoMessage?.contextInfo?.mentionedJid,
+      msg.documentMessage?.contextInfo?.mentionedJid,
+      msg.audioMessage?.contextInfo?.mentionedJid,
+      msg.stickerMessage?.contextInfo?.mentionedJid,
+      msg.buttonsResponseMessage?.contextInfo?.mentionedJid,
+      msg.listResponseMessage?.contextInfo?.mentionedJid,
+    );
+  }
 
   const flattened = candidates.flatMap((arr) => arr ?? []).filter(Boolean);
   if (flattened.length === 0) {


### PR DESCRIPTION
## Description

When a user sends a message with @mention in a WhatsApp group chat, the mention was not being detected. The system logs showed:
- wasMentioned: false
- mentionedJids: null

This happened because the `extractMentionedJids` function was not properly handling wrapped messages (like `viewOnceMessageV2Extension`).

## Root Cause

Unlike `extractText` which uses `extractMessageContent` to handle wrapped messages, `extractMentionedJids` was only checking the raw message object directly. This caused @mentions in WhatsApp group chats to not be detected when the message was wrapped in a container.

## Changes

Modified `extensions/whatsapp/src/inbound/extract.ts` to use `extractMessageContent` for finding mentions in wrapped messages, similar to how `extractText` works.

## Testing

All existing tests pass:
- `inbound.test.ts` - 14 tests passed
- `web-auto-reply-utils.test.ts` - 25 tests passed  
- `inbound.media.test.ts` - 2 tests passed
- `monitor-inbox.captures-media-path-image-messages.test.ts` - 8 tests passed

## Related Issue

Fixes: #46010