### PR TITLE
fix(memory-lancedb): use float encoding for Ollama embedding compatibility

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -208,6 +208,7 @@ describe("memory plugin e2e", () => {
       expect(embeddingsCreate).toHaveBeenCalledWith({
         model: "text-embedding-3-small",
         input: "hello dimensions",
+        encoding_format: "float",
         dimensions: 1024,
       });
     } finally {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -173,9 +173,10 @@ class Embeddings {
   }
 
   async embed(text: string): Promise<number[]> {
-    const params: { model: string; input: string; dimensions?: number } = {
+    const params: { model: string; input: string; dimensions?: number; encoding_format: string } = {
       model: this.model,
       input: text,
+      encoding_format: "float",
     };
     if (this.dimensions) {
       params.dimensions = this.dimensions;

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -173,10 +173,10 @@ class Embeddings {
   }
 
   async embed(text: string): Promise<number[]> {
-    const params: { model: string; input: string; dimensions?: number; encoding_format: "float" } = {
+    const params = {
       model: this.model,
       input: text,
-      encoding_format: "float",
+      encoding_format: "float" as const,
     };
     if (this.dimensions) {
       params.dimensions = this.dimensions;

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -173,7 +173,7 @@ class Embeddings {
   }
 
   async embed(text: string): Promise<number[]> {
-    const params: { model: string; input: string; dimensions?: number; encoding_format: string } = {
+    const params: { model: string; input: string; dimensions?: number; encoding_format: "float" } = {
       model: this.model,
       input: text,
       encoding_format: "float",


### PR DESCRIPTION
## Summary

When using Ollama as the embedding provider for `memory-lancedb`, vector search fails with a dimension mismatch error. The expected dimension is 768 (for `nomic-embed-text`), but the client returns 192.

## Root Cause

The OpenAI Node.js client defaults to `encoding_format: 'base64'`. Ollama's OpenAI-compatible endpoint has a bug parsing base64-encoded responses, causing 768 floats to be incorrectly parsed as 192 values (768/4 = 192).

## Fix

Add `encoding_format: "float"` to the embedding request params. This is compatible with all major providers and avoids the Ollama base64 parsing issue.

```ts
const params = {
  model: this.model,
  input: text,
  encoding_format: "float",
};
```

Fixes #45982