### PR TITLE
docs: fix sub-agent bootstrap file list (5 files, not 2)

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -290,6 +290,6 @@ Sub-agents use a dedicated in-process queue lane:
 - Sub-agent announce is **best-effort**. If the gateway restarts, pending "announce back" work is lost.
 - Sub-agents still share the same gateway process resources; treat `maxConcurrent` as a safety valve.
 - `sessions_spawn` is always non-blocking: it returns `{ status: "accepted", runId, childSessionKey }` immediately.
-- Sub-agent context only injects `AGENTS.md` + `TOOLS.md` (no `SOUL.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`).
+- Sub-agent context injects `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, and `USER.md` (no `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`, or `memory/*.md`).
 - Maximum nesting depth is 5 (`maxSpawnDepth` range: 1–5). Depth 2 is recommended for most use cases.
 - `maxChildrenPerAgent` caps active children per session (default: 5, range: 1–20).

--- a/docs/zh-CN/tools/subagents.md
+++ b/docs/zh-CN/tools/subagents.md
@@ -164,4 +164,4 @@ x-i18n:
 - 子智能体通告是**尽力而为**的。如果 Gateway 网关重启，待处理的"通告回复"工作会丢失。
 - 子智能体仍然共享相同的 Gateway 网关进程资源；将 `maxConcurrent` 视为安全阀。
 - `sessions_spawn` 始终是非阻塞的：它立即返回 `{ status: "accepted", runId, childSessionKey }`。
-- 子智能体上下文仅注入 `AGENTS.md` + `TOOLS.md`（无 `SOUL.md`、`IDENTITY.md`、`USER.md`、`HEARTBEAT.md` 或 `BOOTSTRAP.md`）。
+- 子智能体上下文注入 `AGENTS.md`、`TOOLS.md`、`SOUL.md`、`IDENTITY.md` 和 `USER.md`（来自 `MINIMAL_BOOTSTRAP_ALLOWLIST`，不包含 `HEARTBEAT.md` 或 `BOOTSTRAP.md`）。

--- a/docs/zh-CN/tools/subagents.md
+++ b/docs/zh-CN/tools/subagents.md
@@ -164,4 +164,4 @@ x-i18n:
 - 子智能体通告是**尽力而为**的。如果 Gateway 网关重启，待处理的"通告回复"工作会丢失。
 - 子智能体仍然共享相同的 Gateway 网关进程资源；将 `maxConcurrent` 视为安全阀。
 - `sessions_spawn` 始终是非阻塞的：它立即返回 `{ status: "accepted", runId, childSessionKey }`。
-- 子智能体上下文注入 `AGENTS.md`、`TOOLS.md`、`SOUL.md`、`IDENTITY.md` 和 `USER.md`（来自 `MINIMAL_BOOTSTRAP_ALLOWLIST`，不包含 `HEARTBEAT.md` 或 `BOOTSTRAP.md`）。
+- 子智能体上下文注入 `AGENTS.md`、`TOOLS.md`、`SOUL.md`、`IDENTITY.md` 和 `USER.md`（不包含 `HEARTBEAT.md`、`BOOTSTRAP.md`、`MEMORY.md` 或 `memory/*.md`）。


### PR DESCRIPTION
## Summary

The documentation incorrectly stated that sub-agent sessions only inject **2 files** (`AGENTS.md` + `TOOLS.md`). In reality, the `MINIMAL_BOOTSTRAP_ALLOWLIST` in `src/agents/workspace.ts` includes **5 files**:

```ts
const MINIMAL_BOOTSTRAP_ALLOWLIST = new Set([
  "AGENTS.md",
  "TOOLS.md",
  "SOUL.md",
  "IDENTITY.md",
  "USER.md",
]);
```

Verified by inspecting `filterBootstrapFilesForSession()` at line 551 of `src/agents/workspace.ts` — sub-agent and cron sessions both use this allowlist.

## Changes

- **`docs/tools/subagents.md`**: Updated the limitations section to list all 5 injected files
- **`docs/zh-CN/tools/subagents.md`**: Synced the Chinese translation with the same correction

## Impact

This matters because users optimizing sub-agent context may have been removing `SOUL.md`, `IDENTITY.md`, or `USER.md` from their workspace thinking they wouldn't be injected — causing personality/identity loss in sub-agents.

Fixes #30658