### PR TITLE
fix: add allowed_mentions to enable Discord bot mentions

### DIFF
--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -318,6 +318,11 @@ export function buildDiscordMessagePayload(params: {
   embeds?: Embed[];
   flags?: number;
   files?: MessagePayloadFile[];
+  allowed_mentions?: {
+    parse?: ("users" | "roles" | "everyone")[];
+    roles?: string[];
+    users?: string[];
+  };
 }): MessagePayloadObject {
   const payload: MessagePayloadObject = {};
   const hasV2 = hasV2Components(params.components);
@@ -336,6 +341,9 @@ export function buildDiscordMessagePayload(params: {
   }
   if (params.files?.length) {
     payload.files = params.files;
+  }
+  if (params.allowed_mentions) {
+    payload.allowed_mentions = params.allowed_mentions;
   }
   return payload;
 }
@@ -378,11 +386,14 @@ async function sendDiscordText(
       isFirst,
     });
     const chunkEmbeds = resolveDiscordSendEmbeds({ embeds, isFirst });
+    // Enable user mentions to trigger notifications
+    const allowedMentions = { parse: ["users"] as const };
     const payload = buildDiscordMessagePayload({
       text: chunk,
       components: chunkComponents,
       embeds: chunkEmbeds,
       flags,
+      allowed_mentions: allowedMentions,
     });
     const body = stripUndefinedFields({
       ...serializePayload(payload),
@@ -439,11 +450,14 @@ async function sendDiscordMedia(
     isFirst: true,
   });
   const captionEmbeds = resolveDiscordSendEmbeds({ embeds, isFirst: true });
+  // Enable user mentions to trigger notifications
+  const allowedMentions = { parse: ["users"] as const };
   const payload = buildDiscordMessagePayload({
     text: caption,
     components: captionComponents,
     embeds: captionEmbeds,
     flags,
+    allowed_mentions: allowedMentions,
     files: [
       {
         data: fileData,


### PR DESCRIPTION
I was debugging why our Discord bot mentions weren't triggering notifications. Looks like the Discord API requires explicitly specifying `allowed_mentions` in the message payload - without it, mentions just render as plain text.

What changed:
- Modified `buildDiscordMessagePayload` to accept optional `allowed_mentions` parameter
- Added `allowed_mentions` to payload construction
- Updated `sendDiscordText` to pass `allowed_mentions: { parse: ['users'] }` by default
- Updated `sendDiscordMedia` to pass `allowed_mentions: { parse: ['users'] }` by default

Tested by sending a message with @mention to a user via Discord - notifications now work as expected.

Not sure if there's a reason we weren't including this before, or if other mention types (roles, everyone) should also be enabled by default?

Fixes #45803