### PR TITLE
fix: strip raw tool_call/tool_result XML tags from channel messages

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -214,6 +214,7 @@ export function extractObservedOverflowTokenCount(errorMessage?: string): number
 const ERROR_PAYLOAD_PREFIX_RE =
   /^(?:error|api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error)[:\s-]+/i;
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
+const TOOL_XML_RE = /<tool_call>[\s\S]*?<\/tool_call>|<tool_result>[\s\S]*?<\/tool_result>/gi;
 const ERROR_PREFIX_RE =
   /^(?:error|api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|request failed|failed|exception)[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -447,6 +448,27 @@ function stripFinalTagsFromText(text: string): string {
     return text;
   }
   return text.replace(FINAL_TAG_RE, "");
+}
+
+/**
+ * Strip raw <tool_call> / <tool_result> XML that can leak into user-facing text
+ * when models (especially via OpenRouter) emit tool-use as plain text XML
+ * instead of structured content blocks. Respects code fences to avoid
+ * stripping legitimate XML the user may have written. (#45856)
+ */
+function stripToolXmlFromText(text: string): string {
+  if (!text || !text.includes("tool_")) {
+    return text;
+  }
+  const CODE_FENCE_RE = /(```[\s\S]*?```|`[^`\n]*`)/g;
+  const parts = text.split(CODE_FENCE_RE);
+  return parts
+    .map((part, i) => {
+      // Odd indices are captured code fences — leave them untouched
+      if (i % 2 === 1) return part;
+      return part.replace(TOOL_XML_RE, "");
+    })
+    .join("");
 }
 
 function collapseConsecutiveDuplicateBlocks(text: string): string {
@@ -766,7 +788,8 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     return text;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripFinalTagsFromText(text);
+  let stripped = stripFinalTagsFromText(text);
+  stripped = stripToolXmlFromText(stripped);
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";


### PR DESCRIPTION
Fixes #45856

## Problem

Models (especially via OpenRouter) sometimes emit tool-use blocks as raw XML text (<tool_call>, <tool_result>) instead of structured content blocks. These leak into channel messages because the sanitizer only strips structured tool blocks, not raw XML.

## Solution

Added stripToolXmlFromText() that removes raw tool XML tags from user-facing text while preserving content inside code fences.

The function:
1. Fast-exits if text does not contain "tool_" (no overhead for normal messages)
2. Splits on code fences to protect user-written XML
3. Applies regex removal only to non-code parts

Called in sanitizeUserFacingText() right after stripFinalTagsFromText().

## Testing

The existing test suite covers the sanitization path.