### PR TITLE
fix(gateway): skip eager context warmup for probe

### DIFF
--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -90,6 +90,20 @@ describe("lookupContextTokens", () => {
     }
   });
 
+  it("skips eager warmup for gateway probe", async () => {
+    const loadConfigMock = vi.fn(() => ({ models: {} }));
+    mockContextModuleDeps(loadConfigMock);
+
+    const argvSnapshot = process.argv;
+    process.argv = ["node", "openclaw", "gateway", "probe", "--timeout", "3000", "--json"];
+    try {
+      await import("./context.js");
+      expect(loadConfigMock).not.toHaveBeenCalled();
+    } finally {
+      process.argv = argvSnapshot;
+    }
+  });
+
   it("retries config loading after backoff when an initial load fails", async () => {
     vi.useFakeTimers();
     const loadConfigMock = vi

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -110,7 +110,13 @@ function getCommandPathFromArgv(argv: string[]): string[] {
 
 function shouldSkipEagerContextWindowWarmup(argv: string[] = process.argv): boolean {
   const [primary, secondary] = getCommandPathFromArgv(argv);
-  return primary === "config" && secondary === "validate";
+  if (primary === "config" && secondary === "validate") {
+    return true;
+  }
+  if (primary === "gateway" && secondary === "probe") {
+    return true;
+  }
+  return false;
 }
 
 function primeConfiguredContextWindows(): OpenClawConfig | undefined {


### PR DESCRIPTION
## Summary
- skip eager context-window warmup when running \openclaw gateway probe\
- avoid loading config/models discovery on the probe fast path
- keep all other CLI startup behavior unchanged

## Testing
- pnpm exec vitest run src/agents/context.lookup.test.ts
- pnpm exec vitest run src/cli/gateway-cli.coverage.test.ts src/cli/run-main.test.ts src/cli/program/routes.test.ts src/gateway/probe.test.ts