### PR TITLE
fix: show provider/model format in /model command suggestions

### DIFF
--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -127,7 +127,8 @@ async function executeModel(
       ]);
       const session = resolveCurrentSession(sessions, sessionKey);
       const model = session?.model || sessions?.defaults?.model || "default";
-      const available = models?.models?.map((m: ModelCatalogEntry) => m.id) ?? [];
+      const available =
+        models?.models?.map((m: ModelCatalogEntry) => `${m.provider}/${m.id}`) ?? [];
       const lines = [`**Current model:** \`${model}\``];
       if (available.length > 0) {
         lines.push(
@@ -137,6 +138,7 @@ async function executeModel(
             .join(", ")}${available.length > 10 ? ` +${available.length - 10} more` : ""}`,
         );
       }
+      lines.push("_Enter `provider/model` to switch (e.g. `anthropic/claude-opus-4.6)`_");
       return { content: lines.join("\n") };
     } catch (err) {
       return { content: `Failed to get model info: ${String(err)}` };


### PR DESCRIPTION
Fixes #46091

## Problem

The /model command in Control UI displayed short model IDs (e.g. `claude-opus-4.6`) but required the full `provider/model` format (e.g. `anthropic/claude-opus-4.6`) to actually switch. This caused user confusion as the suggested names did not work.

## Solution

1. Changed model display from `m.id` to `${m.provider}/${m.id}` format
2. Added hint text: "Enter provider/model to switch (e.g. anthropic/claude-opus-4.6)"

## Changes

- `ui/src/ui/chat/slash-command-executor.ts`: Updated model display format and added usage hint