### PR TITLE
fix: include current time in system prompt to fix wrong greeting

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -94,11 +94,16 @@ function buildOwnerIdentityLine(
   return `Authorized senders: ${displayOwnerNumbers.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const lines = ["## Current Date & Time", `Time zone: ${params.userTimezone}`];
+  if (params.userTime) {
+    lines.push(`Current time: ${params.userTime}`);
+  }
+  lines.push("");
+  return lines;
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -564,6 +569,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",


### PR DESCRIPTION
Fixes #38782

## Problem

The /new and /reset commands often produced wrong time-of-day greetings (e.g. "Good evening" in the morning). This happened because `buildTimeSection()` only included the user timezone in the system prompt, but not the actual current time. Models had to guess the time based on conversation context.

## Solution

1. Updated `buildTimeSection()` to accept an optional `userTime` parameter
2. When `userTime` is provided, it's displayed in the "Current Date & Time" section alongside the timezone
3. Updated the call site to pass `params.userTime` to the function

## Changes

- `src/agents/system-prompt.ts`: Added `userTime` param to `buildTimeSection()` and its call site