### PR TITLE
fix(cron): clarify default timezone for cron expressions

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -252,9 +252,10 @@ SCHEDULE TYPES (schedule.kind):
 - "every": Recurring interval
   { "kind": "every", "everyMs": <interval-ms>, "anchorMs": <optional-start-ms> }
 - "cron": Cron expression
-  { "kind": "cron", "expr": "<cron-expression>", "tz": "<optional-timezone>" }
+  { "kind": "cron", "expr": "<cron-expression>", "tz": "<optional-IANA-timezone>" }
+  When tz is omitted, cron expressions are evaluated in the Gateway's local system timezone (NOT UTC).
 
-ISO timestamps without an explicit timezone are treated as UTC.
+ISO timestamps (schedule.kind="at") without an explicit timezone offset are treated as UTC.
 
 PAYLOAD TYPES (payload.kind):
 - "systemEvent": Injects text as system event into session

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -76,7 +76,11 @@ export function registerCronAddCommand(cron: Command) {
       .option("--at <when>", "Run once at time (ISO) or +duration (e.g. 20m)")
       .option("--every <duration>", "Run every duration (e.g. 10m, 1h)")
       .option("--cron <expr>", "Cron expression (5-field or 6-field with seconds)")
-      .option("--tz <iana>", "Timezone for cron expressions (IANA)", "")
+      .option(
+        "--tz <iana>",
+        "Timezone for cron expressions (IANA, defaults to system local timezone)",
+        "",
+      )
       .option("--stagger <duration>", "Cron stagger window (e.g. 30s, 5m)")
       .option("--exact", "Disable cron staggering (set stagger to 0)", false)
       .option("--system-event <text>", "System event payload (main session)")

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -44,7 +44,10 @@ export function registerCronEditCommand(cron: Command) {
       .option("--at <when>", "Set one-shot time (ISO) or duration like 20m")
       .option("--every <duration>", "Set interval duration like 10m")
       .option("--cron <expr>", "Set cron expression")
-      .option("--tz <iana>", "Timezone for cron expressions (IANA)")
+      .option(
+        "--tz <iana>",
+        "Timezone for cron expressions (IANA, defaults to system local timezone)",
+      )
       .option("--stagger <duration>", "Cron stagger window (e.g. 30s, 5m)")
       .option("--exact", "Disable cron staggering (set stagger to 0)")
       .option("--system-event <text>", "Set systemEvent payload")


### PR DESCRIPTION
## Summary

Clarify that cron expressions without an explicit `tz` parameter are evaluated
in the Gateway's local system timezone, not UTC. This prevents AI agents (and
humans) from mistakenly writing cron expressions in UTC when no `--tz` is
specified.

## Problem

The cron tool description previously stated:

> ISO timestamps without an explicit timezone are treated as UTC.

This is accurate for `schedule.kind="at"`, but LLMs frequently
misinterpret it as applying to cron expressions as well. In practice,
`resolveCronTimezone()` in `schedule.ts` falls back to
`Intl.DateTimeFormat().resolvedOptions().timeZone` (the local system timezone)
when `tz` is omitted — the opposite of UTC.

This mismatch caused real scheduling errors: agents would write
`--cron "20 0 * * *"` intending UTC 00:20 (= local 08:20 in timezone Asia/Shanghai), but it would
actually run at local 00:20.

## Testing
 all passing, changes can be considered a documentation improvement to the tool description.