### PR TITLE
fix: report not-requested when delivery.mode=none (#44533)

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -165,10 +165,11 @@ function resolveDeliveryStatus(params: { job: CronJob; delivered?: boolean }): C
   if (params.delivered === true) {
     return "delivered";
   }
+  const deliveryRequested = resolveCronDeliveryPlan(params.job).requested;
   if (params.delivered === false) {
-    return "not-delivered";
+    return deliveryRequested ? "not-delivered" : "not-requested";
   }
-  return resolveCronDeliveryPlan(params.job).requested ? "unknown" : "not-requested";
+  return deliveryRequested ? "unknown" : "not-requested";
 }
 
 function normalizeCronMessageChannel(input: unknown): CronMessageChannel | undefined {


### PR DESCRIPTION
Fixes #44533

## Problem

When `delivery.mode = "none"` is set in a cron job, the system incorrectly reports `lastDeliveryStatus: "not-delivered"` instead of `"not-requested"`. This is misleading because delivery was never requested.

## Solution

Updated `resolveDeliveryStatus()` to check if delivery was requested before deciding between "not-delivered" and "not-requested". When `delivered === false` but delivery was not requested (mode=none), it now returns "not-requested".

## Changes

- `src/cron/service/timer.ts`: Fixed `resolveDeliveryStatus()` to properly handle delivery.mode=none