### PR TITLE
Prevent multiple registrations of Feishu tools on reconnect

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -45,6 +45,8 @@ export {
 } from "./src/mention.js";
 export { feishuPlugin } from "./src/channel.js";
 
+let areToolsRegistered = false; 
+
 const plugin = {
   id: "feishu",
   name: "Feishu",
@@ -53,12 +55,17 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setFeishuRuntime(api.runtime);
     api.registerChannel({ plugin: feishuPlugin });
+    
+    if (!areToolsRegistered) {
     registerFeishuDocTools(api);
     registerFeishuChatTools(api);
     registerFeishuWikiTools(api);
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    areToolsRegistered = true;
+    }
+    
   },
 };
 


### PR DESCRIPTION

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:  The Feishu plugin re-registers all its tools (feishu_doc, feishu_chat, etc.) under certain conditions, such as after a service restart.

- Why it matters:  This redundant process was discovered when listing plugins and skills, where it caused significant memory consumption and led to out-of-memory errors in resource-constrained environments.

- What changed:  A guard variable (areToolsRegistered) was added to the plugin's register function. This ensures the block of tool registration calls is executed only once during the application's lifecycle.

- What did NOT change (scope boundary):  The core channel registration (api.registerChannel) is still allowed to run on every call. Our testing showed this is necessary to maintain a stable communication channel.

## Change Type (select all)

- [x]  Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ]  Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x]  Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes
List user-visible changes (including defaults/config).  
If none, write `None`.

The primary user-visible change is the reduction of log spam and improved memory stability. System logs will be significantly cleaner, and the risk of memory-related errors caused by this plugin will be mitigated. There are no changes to the agent's functional behavior or configuration.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:  N/A

## Repro + Verification

### Environment

- OS: Linux (likely OS-agnostic)
- Runtime/container: Standard Node.js runtime for OpenClaw
- Model/provider: N/A
- Integration/channel (if any):  Feishu
- Relevant config (redacted):  Standard openclaw.config.yaml with the feishu plugin enabled.

### Steps

1. Start the OpenClaw service with the original extensions/feishu/index.ts file (openclaw gateway start).
2. Run a command that lists plugins or skills (e.g., openclaw plugins list).
3. Observe the output, noting the repeated "Registered feishu_doc tool..." messages. In some cases, this command may fail with an out-of-memory error due to the repeated registrations.
4. Apply the patch from this PR to extensions/feishu/index.ts.
5. Restart the OpenClaw service (openclaw gateway restart).
6. Run the same listing command again and confirm the registration messages appear only once.
7. Send a message to the agent via the Feishu channel to confirm that communication is still working correctly.


### Expected

- After the fix, the registration messages appear only once in the command output, memory consumption is stable, and the agent remains responsive in Feishu.

### Actual

- Before the fix, the registration messages appeared multiple times in the output of openclaw plugins list, and this was correlated with out-of-memory errors on the system.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after

- Failing test/log before
19:30:42 [plugins] feishu_doc: Registered feishu_doc, feishu_app_scopes
19:30:42 [plugins] feishu_chat: Registered feishu_chat tool
19:30:42 [plugins] feishu_wiki: Registered feishu_wiki tool
19:30:42 [plugins] feishu_drive: Registered feishu_drive tool
19:30:42 [plugins] feishu_bitable: Registered bitable tools
19:31:26 [plugins] feishu_doc: Registered feishu_doc, feishu_app_scopes
19:31:26 [plugins] feishu_chat: Registered feishu_chat tool
19:31:26 [plugins] feishu_wiki: Registered feishu_wiki tool
19:31:26 [plugins] feishu_drive: Registered feishu_drive tool
19:31:26 [plugins] feishu_bitable: Registered bitable tools
19:31:26 [plugins] feishu_doc: Registered feishu_doc, feishu_app_scopes
19:31:26 [plugins] feishu_chat: Registered feishu_chat tool
19:31:26 [plugins] feishu_wiki: Registered feishu_wiki tool
19:31:26 [plugins] feishu_drive: Registered feishu_drive tool
19:31:26 [plugins] feishu_bitable: Registered bitable tools
19:31:28 [plugins] feishu_doc: Registered feishu_doc, feishu_app_scopes
19:31:28 [plugins] feishu_chat: Registered feishu_chat tool
19:31:28 [plugins] feishu_wiki: Registered feishu_wiki tool
19:31:28 [plugins] feishu_drive: Registered feishu_drive tool
19:31:28 [plugins] feishu_bitable: Registered bitable tools
19:31:28 [plugins] feishu_doc: Registered feishu_doc, feishu_app_scopes
19:31:28 [plugins] feishu_chat: Registered feishu_chat tool
19:31:28 [plugins] feishu_wiki: Registered feishu_wiki tool
19:31:28 [plugins] feishu_drive: Registered feishu_drive tool
19:31:28 [plugins] feishu_bitable: Registered bitable tools

- passing after
21:30:13 [plugins] feishu_doc: Registered feishu_doc, feishu_app_scopes
21:30:13 [plugins] feishu_chat: Registered feishu_chat tool
21:30:13 [plugins] feishu_wiki: Registered feishu_wiki tool
21:30:13 [plugins] feishu_drive: Registered feishu_drive tool
21:30:13 [plugins] feishu_bitable: Registered bitable tools

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: 
 I personally applied the patch to my running OpenClaw instance and restarted the service. I verified two key outcomes:
1. When listing plugins, the registration messages now appear only a single time.
2. I am able to communicate with the agent through the Feishu channel without any issues, confirming the fix did not break the channel connection.

- Additional Context: 
This investigation was prompted by observing out-of-memory errors when listing skills and plugins. While increasing memory resolved the immediate crash, the repeated registration logs were identified as the likely root cause of the high memory usage. This fix is intended to address that underlying resource consumption issue.

- Edge cases checked:
The primary edge case—where preventing the entire register function from running breaks communication—was identified and addressed by this more precise fix.

- What you did **not** verify:
 I did not verify this fix under forced, rapid network flapping conditions or with other channel plugins enabled simultaneously.


## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (YES)
- Config/env changes? (NO)
- Migration needed? (NO)
- If yes, exact upgrade steps:  N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
Revert the changes to the extensions/feishu/index.ts file and restart the OpenClaw service.

- Files/config to restore:
/root/.local/share/pnpm/global/5/.pnpm/openclaw@<version>/node_modules/openclaw/extensions/feishu/index.ts

- Known bad symptoms reviewers should watch for:
The primary symptom of a bad fix would be the agent becoming unresponsive on the Feishu channel.

## Risks and Mitigations
List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

None. This is a low-risk, targeted fix that isolates a non-critical initialization procedure without affecting core communication logic, while improving system stability.

 