### PR TITLE
fix: preserve labeled session titles during heartbeat polls

### DIFF
--- a/src/gateway/session-title.test.ts
+++ b/src/gateway/session-title.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import { deriveSessionTitle } from "./session-title.js";
+
+describe("deriveSessionTitle", () => {
+  test("returns undefined for undefined entry", () => {
+    expect(deriveSessionTitle(undefined)).toBeUndefined();
+  });
+
+  test("prefers displayName when set", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      displayName: "My Custom Session",
+      subject: "Group Chat",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("My Custom Session");
+  });
+
+  test("falls back to subject when displayName is missing", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      subject: "Dev Team Chat",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("Dev Team Chat");
+  });
+
+  test("prefers session label over first user message when present", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      label: "My App - Dashboard",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry, "heartbeat")).toBe("My App - Dashboard");
+  });
+
+  test("falls back to origin label before transcript-derived title", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      origin: { label: "Discord: Engineering" },
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry, "heartbeat")).toBe("Discord: Engineering");
+  });
+
+  test("uses first user message when displayName, subject, and labels are missing", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry, "Hello, how are you?")).toBe("Hello, how are you?");
+  });
+
+  test("truncates long first user message to 60 chars with ellipsis", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+    } as SessionEntry;
+    const longMsg =
+      "This is a very long message that exceeds sixty characters and should be truncated appropriately";
+    const result = deriveSessionTitle(entry, longMsg);
+    expect(result).toBeDefined();
+    expect(result!.length).toBeLessThanOrEqual(60);
+    expect(result!.endsWith("…")).toBe(true);
+  });
+
+  test("falls back to sessionId prefix with date", () => {
+    const entry = {
+      sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
+      updatedAt: new Date("2024-03-15T10:30:00Z").getTime(),
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("abcd1234 (2024-03-15)");
+  });
+});

--- a/src/gateway/session-title.test.ts
+++ b/src/gateway/session-title.test.ts
@@ -35,6 +35,26 @@ describe("deriveSessionTitle", () => {
     expect(deriveSessionTitle(entry, "heartbeat")).toBe("My App - Dashboard");
   });
 
+  test("keeps displayName ahead of label", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      displayName: "Override",
+      label: "Should Not Appear",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("Override");
+  });
+
+  test("keeps subject ahead of label", () => {
+    const entry = {
+      sessionId: "abc123",
+      updatedAt: Date.now(),
+      subject: "Room Title",
+      label: "Should Not Appear",
+    } as SessionEntry;
+    expect(deriveSessionTitle(entry)).toBe("Room Title");
+  });
+
   test("falls back to origin label before transcript-derived title", () => {
     const entry = {
       sessionId: "abc123",

--- a/src/gateway/session-title.ts
+++ b/src/gateway/session-title.ts
@@ -1,0 +1,61 @@
+import type { SessionEntry } from "../config/sessions.js";
+
+const DERIVED_TITLE_MAX_LEN = 60;
+
+function formatSessionIdPrefix(sessionId: string, updatedAt?: number | null): string {
+  const prefix = sessionId.slice(0, 8);
+  if (updatedAt && updatedAt > 0) {
+    const d = new Date(updatedAt);
+    const date = d.toISOString().slice(0, 10);
+    return `${prefix} (${date})`;
+  }
+  return prefix;
+}
+
+function truncateTitle(text: string, maxLen: number): string {
+  if (text.length <= maxLen) {
+    return text;
+  }
+  const cut = text.slice(0, maxLen - 1);
+  const lastSpace = cut.lastIndexOf(" ");
+  if (lastSpace > maxLen * 0.6) {
+    return cut.slice(0, lastSpace) + "…";
+  }
+  return cut + "…";
+}
+
+export function deriveSessionTitle(
+  entry: SessionEntry | undefined,
+  firstUserMessage?: string | null,
+): string | undefined {
+  if (!entry) {
+    return undefined;
+  }
+
+  if (entry.displayName?.trim()) {
+    return entry.displayName.trim();
+  }
+
+  if (entry.subject?.trim()) {
+    return entry.subject.trim();
+  }
+
+  if (entry.label?.trim()) {
+    return entry.label.trim();
+  }
+
+  if (entry.origin?.label?.trim()) {
+    return entry.origin.label.trim();
+  }
+
+  if (firstUserMessage?.trim()) {
+    const normalized = firstUserMessage.replace(/\s+/g, " ").trim();
+    return truncateTitle(normalized, DERIVED_TITLE_MAX_LEN);
+  }
+
+  if (entry.sessionId) {
+    return formatSessionIdPrefix(entry.sessionId, entry.updatedAt);
+  }
+
+  return undefined;
+}

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -38,6 +38,7 @@ import {
   resolveAvatarMime,
 } from "../shared/avatar-policy.js";
 import { normalizeSessionDeliveryFields } from "../utils/delivery-context.js";
+import { deriveSessionTitle } from "./session-title.js";
 import { readSessionTitleFieldsFromTranscript } from "./session-utils.fs.js";
 import type {
   GatewayAgentRow,
@@ -57,6 +58,7 @@ export {
   readSessionMessages,
   resolveSessionTranscriptCandidates,
 } from "./session-utils.fs.js";
+export { deriveSessionTitle } from "./session-title.js";
 export type {
   GatewayAgentRow,
   GatewaySessionRow,
@@ -66,8 +68,6 @@ export type {
   SessionsPreviewEntry,
   SessionsPreviewResult,
 } from "./session-utils.types.js";
-
-const DERIVED_TITLE_MAX_LEN = 60;
 
 function tryResolveExistingPath(value: string): string | null {
   try {
@@ -123,56 +123,6 @@ function resolveIdentityAvatarUrl(
   } catch {
     return undefined;
   }
-}
-
-function formatSessionIdPrefix(sessionId: string, updatedAt?: number | null): string {
-  const prefix = sessionId.slice(0, 8);
-  if (updatedAt && updatedAt > 0) {
-    const d = new Date(updatedAt);
-    const date = d.toISOString().slice(0, 10);
-    return `${prefix} (${date})`;
-  }
-  return prefix;
-}
-
-function truncateTitle(text: string, maxLen: number): string {
-  if (text.length <= maxLen) {
-    return text;
-  }
-  const cut = text.slice(0, maxLen - 1);
-  const lastSpace = cut.lastIndexOf(" ");
-  if (lastSpace > maxLen * 0.6) {
-    return cut.slice(0, lastSpace) + "…";
-  }
-  return cut + "…";
-}
-
-export function deriveSessionTitle(
-  entry: SessionEntry | undefined,
-  firstUserMessage?: string | null,
-): string | undefined {
-  if (!entry) {
-    return undefined;
-  }
-
-  if (entry.displayName?.trim()) {
-    return entry.displayName.trim();
-  }
-
-  if (entry.subject?.trim()) {
-    return entry.subject.trim();
-  }
-
-  if (firstUserMessage?.trim()) {
-    const normalized = firstUserMessage.replace(/\s+/g, " ").trim();
-    return truncateTitle(normalized, DERIVED_TITLE_MAX_LEN);
-  }
-
-  if (entry.sessionId) {
-    return formatSessionIdPrefix(entry.sessionId, entry.updatedAt);
-  }
-
-  return undefined;
 }
 
 export function loadSessionEntry(sessionKey: string) {


### PR DESCRIPTION
## Summary
- extract session title derivation into a small standalone helper with focused coverage
- prefer persisted session labels before transcript-derived titles so heartbeat turns do not rename labeled sessions to `heartbeat`
- add precedence coverage so `displayName` and `subject` stay ahead of label-based fallbacks

## Testing
- `./node_modules/.bin/vitest run src/gateway/session-title.test.ts`

Closes #42495.
