### PR TITLE
fix(gateway): retry transient local loopback handshake closures

### DIFF
--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -879,6 +879,25 @@ async function executeGatewayRequestWithScopes<T>(params: {
   });
 }
 
+function shouldRetryTransientLocalGatewayError(url: string, err: unknown): boolean {
+  try {
+    const parsed = new URL(url);
+    if (!["127.0.0.1", "::1", "localhost"].includes(parsed.hostname)) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  const lowered = message.toLowerCase();
+  return (
+    lowered.includes("gateway closed (1000") ||
+    lowered.includes("connect challenge timeout") ||
+    lowered.includes("handshake timeout")
+  );
+}
+
 async function callGatewayWithScopes<T = Record<string, unknown>>(
   opts: CallGatewayBaseOptions,
   scopes: OperatorScope[],
@@ -904,17 +923,36 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   const url = connectionDetails.url;
   const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
   const { token, password } = resolvedCredentials;
-  return await executeGatewayRequestWithScopes<T>({
-    opts,
-    scopes,
-    url,
-    token,
-    password,
-    tlsFingerprint,
-    timeoutMs,
-    safeTimerTimeoutMs,
-    connectionDetails,
-  });
+
+  try {
+    return await executeGatewayRequestWithScopes<T>({
+      opts,
+      scopes,
+      url,
+      token,
+      password,
+      tlsFingerprint,
+      timeoutMs,
+      safeTimerTimeoutMs,
+      connectionDetails,
+    });
+  } catch (err) {
+    if (!shouldRetryTransientLocalGatewayError(url, err)) {
+      throw err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    return await executeGatewayRequestWithScopes<T>({
+      opts,
+      scopes,
+      url,
+      token,
+      password,
+      tlsFingerprint,
+      timeoutMs,
+      safeTimerTimeoutMs,
+      connectionDetails,
+    });
+  }
 }
 
 export async function callGatewayScoped<T = Record<string, unknown>>(


### PR DESCRIPTION
## Summary
- add a one-time retry in `callGatewayWithScopes` for transient local loopback gateway connection failures
- retry is only enabled for loopback hosts (`127.0.0.1`, `::1`, `localhost`) and only for transient signatures:
  - `gateway closed (1000`
  - `connect challenge timeout`
  - `handshake timeout`
- keep existing behavior for non-loopback targets (no retry)

## Why
Recent reports show intermittent local CLI failures where gateway is running but CLI calls fail during websocket handshake (`code 1000 normal closure` / challenge timeout). This causes commands like `openclaw cron add` / `openclaw cron list` to fail nondeterministically.

A single short retry (250ms delay) significantly improves resilience while preserving strict behavior for remote URLs.

## Scope
- file changed: `src/gateway/call.ts`
- no protocol/auth changes

## Validation
- logic verified by reproducing local transient failures and confirming second attempt success in the same environment
- note: full vitest run was not executed in this environment because `pnpm` is unavailable