### PR TITLE
fix(feishu): preserve read tool image paths for auto-reply media

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -79,6 +79,25 @@ async function emitPngMediaToolResult(
   });
 }
 
+async function emitReadImageToolResultWithoutDetailsPath(ctx: EmbeddedPiSubscribeContext) {
+  await handleToolExecutionStart(ctx, {
+    type: "tool_execution_start",
+    toolName: "read",
+    toolCallId: "tc-1",
+    args: { file_path: "/tmp/from-read.png" },
+  });
+
+  await handleToolExecutionEnd(ctx, {
+    type: "tool_execution_end",
+    toolName: "read",
+    toolCallId: "tc-1",
+    isError: false,
+    result: {
+      content: [{ type: "image", data: "base64", mimeType: "image/png" }],
+    },
+  });
+}
+
 async function emitUntrustedToolMediaResult(
   ctx: EmbeddedPiSubscribeContext,
   mediaPathOrUrl: string,
@@ -126,6 +145,17 @@ describe("handleToolExecutionEnd media emission", () => {
     await emitUntrustedToolMediaResult(ctx, "/tmp/secret.png");
 
     expect(onToolResult).not.toHaveBeenCalled();
+  });
+
+  it("falls back to read start args when image tool result omits details.path", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await emitReadImageToolResultWithoutDetailsPath(ctx);
+
+    expect(onToolResult).toHaveBeenCalledWith({
+      mediaUrls: ["/tmp/from-read.png"],
+    });
   });
 
   it("emits remote media for untrusted tools", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -224,8 +224,9 @@ async function emitToolResultOutput(params: {
   isToolError: boolean;
   result: unknown;
   sanitizedResult: unknown;
+  startArgs?: Record<string, unknown>;
 }) {
-  const { ctx, toolName, meta, isToolError, result, sanitizedResult } = params;
+  const { ctx, toolName, meta, isToolError, result, sanitizedResult, startArgs } = params;
   if (!ctx.params.onToolResult) {
     return;
   }
@@ -284,7 +285,10 @@ async function emitToolResultOutput(params: {
 
   // emitToolOutput() already handles MEDIA: directives when enabled; this path
   // only sends raw media URLs for non-verbose delivery mode.
-  const mediaPaths = filterToolResultMediaUrls(toolName, extractToolResultMediaPaths(result));
+  const mediaPaths = filterToolResultMediaUrls(
+    toolName,
+    extractToolResultMediaPaths(result, startArgs),
+  );
   if (mediaPaths.length === 0) {
     return;
   }
@@ -545,7 +549,15 @@ export async function handleToolExecutionEnd(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
 
-  await emitToolResultOutput({ ctx, toolName, meta, isToolError, result, sanitizedResult });
+  await emitToolResultOutput({
+    ctx,
+    toolName,
+    meta,
+    isToolError,
+    result,
+    sanitizedResult,
+    startArgs,
+  });
 
   // Run after_tool_call plugin hook (fire-and-forget)
   const hookRunnerAfter = ctx.hookRunner ?? getGlobalHookRunner();

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -193,7 +193,10 @@ export function filterToolResultMediaUrls(
  * returns base64 image data but no file path; those need a different delivery
  * path like saving to a temp file).
  */
-export function extractToolResultMediaPaths(result: unknown): string[] {
+export function extractToolResultMediaPaths(
+  result: unknown,
+  startArgs?: Record<string, unknown>,
+): string[] {
   if (!result || typeof result !== "object") {
     return [];
   }
@@ -234,6 +237,15 @@ export function extractToolResultMediaPaths(result: unknown): string[] {
     const p = typeof details?.path === "string" ? details.path.trim() : "";
     if (p) {
       return [p];
+    }
+    const startPath =
+      typeof startArgs?.path === "string"
+        ? startArgs.path.trim()
+        : typeof startArgs?.file_path === "string"
+          ? startArgs.file_path.trim()
+          : "";
+    if (startPath) {
+      return [startPath];
     }
   }
 

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -382,7 +382,7 @@ export async function runPreparedReply(
   const prefixedBody = [threadContextNote, prefixedBodyBase].filter(Boolean).join("\n\n");
   const mediaNote = buildInboundMediaNote(ctx);
   const mediaReplyHint = mediaNote
-    ? "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Avoid absolute paths (MEDIA:/...) and ~ paths — they are blocked for security. Keep caption in the text body."
+    ? "To send an image back, prefer the message tool (media/path/filePath) if it is available in this session. Otherwise inline the attachment with MEDIA:<path-or-url>. HTTP(S) URLs work. Local paths must stay inside allowed roots: workspace-relative paths like MEDIA:./image.jpg are safe, and absolute paths are allowed when they point inside the current agent workspace. Avoid ~ paths and absolute paths outside allowed roots. Keep caption in the text body."
     : undefined;
   let prefixedCommandBody = mediaNote
     ? [mediaNote, mediaReplyHint, prefixedBody ?? ""].filter(Boolean).join("\n").trim()


### PR DESCRIPTION
Closes #41744

## Summary

Fix Feishu auto-reply image delivery when the agent uses `read` on a local image file and the tool result contains inline image content but no `details.path`.

## Root cause

The embedded auto-reply media extraction path accepted:

- `MEDIA:` tokens from text blocks
- `result.details.path` when image content existed

But `read` can return inline image blocks without `details.path`.

In that case, the runtime never populated outbound `mediaUrls`, so Feishu received a text-only final payload even though the image was successfully read.

## Fix

- extend tool-result media extraction to accept the original tool call args
- when image content exists and `details.path` is missing, fall back to:
  - `startArgs.path`
  - `startArgs.file_path`
- pass `startData?.args` into the tool-result reply emission path
- update the media hint so it only prefers `message` when that tool is actually available, and no longer incorrectly says all absolute paths are blocked

## Verification

- `corepack pnpm exec vitest run src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts`
- `corepack pnpm exec vitest run src/agents/pi-embedded-subscribe.tools.test.ts`

Both passed locally.

## Risk

Low. The behavior change only affects trusted tool-result media extraction when image content exists and the explicit `details.path` field is missing.
