### PR TITLE
fix(ui): stabilize agent primary model selection on switch

### DIFF
--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -1,4 +1,6 @@
 import { html, nothing } from "lit";
+import { live } from "lit/directives/live.js";
+import { ref } from "lit/directives/ref.js";
 import type { AgentIdentityResult, AgentsFilesListResult, AgentsListResult } from "../types.ts";
 import {
   buildModelOptions,
@@ -51,17 +53,20 @@ export function renderAgentOverview(params: {
     ? resolveModelLabel(config.entry?.model)
     : resolveModelLabel(config.defaults?.model);
   const defaultModel = resolveModelLabel(config.defaults?.model);
-  const entryPrimary = resolveModelPrimary(config.entry?.model);
+  const modelPrimary = resolveModelPrimary(config.entry?.model);
   const defaultPrimary =
     resolveModelPrimary(config.defaults?.model) ||
     (defaultModel !== "-" ? normalizeModelValue(defaultModel) : null);
-  const effectivePrimary = entryPrimary ?? defaultPrimary ?? null;
   const modelFallbacks = resolveModelFallbacks(config.entry?.model);
   const fallbackChips = modelFallbacks ?? [];
   const skillFilter = Array.isArray(config.entry?.skills) ? config.entry?.skills : null;
   const skillCount = skillFilter?.length ?? null;
   const isDefault = Boolean(params.defaultId && agent.id === params.defaultId);
   const disabled = !configForm || configLoading || configSaving;
+  const optionCurrent = isDefault
+    ? (modelPrimary ?? defaultPrimary ?? undefined)
+    : (modelPrimary ?? undefined);
+  const selectValue = isDefault ? (modelPrimary ?? defaultPrimary ?? "") : (modelPrimary ?? "");
 
   const removeChip = (index: number) => {
     const next = fallbackChips.filter((_, i) => i !== index);
@@ -121,7 +126,20 @@ export function renderAgentOverview(params: {
           <label class="field">
             <span>Primary model${isDefault ? " (default)" : ""}</span>
             <select
-              .value=${isDefault ? (effectivePrimary ?? "") : (entryPrimary ?? "")}
+              .value=${live(selectValue)}
+              ${ref((element) => {
+                if (!(element instanceof HTMLSelectElement)) {
+                  return;
+                }
+                queueMicrotask(() => {
+                  const hasDomMatch = Array.from(element.options).some(
+                    (option) => option.value === selectValue,
+                  );
+                  if (element.value !== selectValue && hasDomMatch) {
+                    element.value = selectValue;
+                  }
+                });
+              })}
               ?disabled=${disabled}
               @change=${(e: Event) =>
                 onModelChange(agent.id, (e.target as HTMLSelectElement).value || null)}
@@ -135,7 +153,7 @@ export function renderAgentOverview(params: {
                       </option>
                     `
               }
-              ${buildModelOptions(configForm, effectivePrimary ?? undefined)}
+              ${buildModelOptions(configForm, optionCurrent)}
             </select>
           </label>
           <div class="field">

--- a/ui/src/ui/views/agents.browser.test.ts
+++ b/ui/src/ui/views/agents.browser.test.ts
@@ -1,0 +1,217 @@
+import { render } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import type { GatewayAgentRow } from "../types.ts";
+import { renderAgents, type AgentsProps } from "./agents.ts";
+
+function createConfigForm(list: Array<Record<string, unknown>> = []) {
+  return {
+    agents: {
+      defaults: {
+        model: "openai/gpt-4.1-mini",
+        models: {
+          "anthropic/claude-opus-4-6": {},
+          "openai/gpt-4.1": {},
+          "openai/gpt-4.1-mini": {},
+        },
+      },
+      list,
+    },
+  };
+}
+
+function createAgent(id: string, name: string): GatewayAgentRow {
+  return { id, name };
+}
+
+function createProps(overrides: Partial<AgentsProps> = {}): AgentsProps {
+  return {
+    basePath: "",
+    loading: false,
+    error: null,
+    agentsList: {
+      defaultId: "dev",
+      mainKey: "main",
+      scope: "workspace",
+      agents: [createAgent("dev", "Dev"), createAgent("qa", "QA"), createAgent("ops", "Ops")],
+    },
+    selectedAgentId: "dev",
+    activePanel: "overview",
+    config: {
+      form: createConfigForm([
+        { id: "qa", model: "anthropic/claude-opus-4-6" },
+        { id: "ops", model: "openai/gpt-4.1" },
+      ]),
+      loading: false,
+      saving: false,
+      dirty: false,
+    },
+    channels: {
+      snapshot: null,
+      loading: false,
+      error: null,
+      lastSuccess: null,
+    },
+    cron: {
+      status: null,
+      jobs: [],
+      loading: false,
+      error: null,
+    },
+    agentFiles: {
+      list: null,
+      loading: false,
+      error: null,
+      active: null,
+      contents: {},
+      drafts: {},
+      saving: false,
+    },
+    agentIdentityLoading: false,
+    agentIdentityError: null,
+    agentIdentityById: {},
+    agentSkills: {
+      report: null,
+      loading: false,
+      error: null,
+      agentId: null,
+      filter: "",
+    },
+    toolsCatalog: {
+      loading: false,
+      error: null,
+      result: null,
+    },
+    onRefresh: () => undefined,
+    onSelectAgent: () => undefined,
+    onSelectPanel: () => undefined,
+    onLoadFiles: () => undefined,
+    onSelectFile: () => undefined,
+    onFileDraftChange: () => undefined,
+    onFileReset: () => undefined,
+    onFileSave: () => undefined,
+    onToolsProfileChange: () => undefined,
+    onToolsOverridesChange: () => undefined,
+    onConfigReload: () => undefined,
+    onConfigSave: () => undefined,
+    onModelChange: () => undefined,
+    onModelFallbacksChange: () => undefined,
+    onChannelsRefresh: () => undefined,
+    onCronRefresh: () => undefined,
+    onCronRunNow: () => undefined,
+    onSkillsFilterChange: () => undefined,
+    onSkillsRefresh: () => undefined,
+    onAgentSkillToggle: () => undefined,
+    onAgentSkillsClear: () => undefined,
+    onAgentSkillsDisableAll: () => undefined,
+    onSetDefault: () => undefined,
+    ...overrides,
+  };
+}
+
+const mountedContainers = new Set<HTMLElement>();
+
+function createContainer() {
+  const container = document.createElement("div");
+  mountedContainers.add(container);
+  return container;
+}
+
+afterEach(() => {
+  for (const container of mountedContainers) {
+    render(null, container);
+    container.remove();
+  }
+  mountedContainers.clear();
+});
+
+function nextFrame() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
+async function flushRender() {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  await nextFrame();
+  await Promise.resolve();
+}
+
+function getPrimaryModelSelect(container: HTMLElement) {
+  const select = container.querySelector<HTMLSelectElement>(".agent-model-select select");
+  expect(select).not.toBeNull();
+  return select!;
+}
+
+describe("agents overview primary model select (browser)", () => {
+  it("prefers an explicit model override on the default agent", async () => {
+    const container = createContainer();
+
+    render(
+      renderAgents(
+        createProps({
+          selectedAgentId: "dev",
+          config: {
+            form: createConfigForm([{ id: "dev", model: "openai/gpt-4.1" }]),
+            loading: false,
+            saving: false,
+            dirty: false,
+          },
+        }),
+      ),
+      container,
+    );
+    await flushRender();
+
+    expect(getPrimaryModelSelect(container).value).toBe("openai/gpt-4.1");
+  });
+
+  it("keeps explicit non-default models selected when switching between agents", async () => {
+    const container = createContainer();
+
+    render(renderAgents(createProps({ selectedAgentId: "dev" })), container);
+    await flushRender();
+
+    render(renderAgents(createProps({ selectedAgentId: "qa" })), container);
+    await flushRender();
+    expect(getPrimaryModelSelect(container).value).toBe("anthropic/claude-opus-4-6");
+
+    render(renderAgents(createProps({ selectedAgentId: "ops" })), container);
+    await flushRender();
+    expect(getPrimaryModelSelect(container).value).toBe("openai/gpt-4.1");
+
+    render(renderAgents(createProps({ selectedAgentId: "qa" })), container);
+    await flushRender();
+    expect(getPrimaryModelSelect(container).value).toBe("anthropic/claude-opus-4-6");
+  });
+
+  it("shows the inherit-default option text instead of going blank", async () => {
+    const container = createContainer();
+
+    render(renderAgents(createProps({ selectedAgentId: "qa" })), container);
+    await flushRender();
+    expect(getPrimaryModelSelect(container).value).toBe("anthropic/claude-opus-4-6");
+
+    render(
+      renderAgents(
+        createProps({
+          selectedAgentId: "qa",
+          config: {
+            form: createConfigForm([{ id: "qa" }]),
+            loading: false,
+            saving: false,
+            dirty: true,
+          },
+        }),
+      ),
+      container,
+    );
+    await flushRender();
+
+    const select = getPrimaryModelSelect(container);
+    expect(select.value).toBe("");
+    expect(select.selectedOptions[0]?.textContent?.trim()).toBe(
+      "Inherit default (openai/gpt-4.1-mini)",
+    );
+  });
+});

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { keyed } from "lit/directives/keyed.js";
 import type {
   AgentIdentityResult,
   AgentsFilesListResult,
@@ -151,10 +152,14 @@ export function renderAgents(props: AgentsProps) {
                       `
                     : agents.map(
                         (agent) => html`
-                        <option value=${agent.id} ?selected=${agent.id === selectedId}>
-                          ${normalizeAgentLabel(agent)}${agentBadgeText(agent.id, defaultId) ? ` (${agentBadgeText(agent.id, defaultId)})` : ""}
-                        </option>
-                      `,
+                          <option value=${agent.id} ?selected=${agent.id === selectedId}>
+                            ${normalizeAgentLabel(agent)}${
+                              agentBadgeText(agent.id, defaultId)
+                                ? ` (${agentBadgeText(agent.id, defaultId)})`
+                                : ""
+                            }
+                          </option>
+                        `,
                       )
                 }
               </select>
@@ -175,10 +180,15 @@ export function renderAgents(props: AgentsProps) {
                           actionsMenuOpen
                             ? html`
                                 <div class="agent-actions-menu">
-                                  <button type="button" @click=${() => {
-                                    void navigator.clipboard.writeText(selectedAgent.id);
-                                    actionsMenuOpen = false;
-                                  }}>Copy agent ID</button>
+                                  <button
+                                    type="button"
+                                    @click=${() => {
+                                      void navigator.clipboard.writeText(selectedAgent.id);
+                                      actionsMenuOpen = false;
+                                    }}
+                                  >
+                                    Copy agent ID
+                                  </button>
                                   <button
                                     type="button"
                                     ?disabled=${Boolean(defaultId && selectedAgent.id === defaultId)}
@@ -187,7 +197,11 @@ export function renderAgents(props: AgentsProps) {
                                       actionsMenuOpen = false;
                                     }}
                                   >
-                                    ${defaultId && selectedAgent.id === defaultId ? "Already default" : "Set as default"}
+                                    ${
+                                      defaultId && selectedAgent.id === defaultId
+                                        ? "Already default"
+                                        : "Set as default"
+                                    }
                                   </button>
                                 </div>
                               `
@@ -197,7 +211,11 @@ export function renderAgents(props: AgentsProps) {
                     `
                   : nothing
               }
-              <button class="btn btn--sm agents-refresh-btn" ?disabled=${props.loading} @click=${props.onRefresh}>
+              <button
+                class="btn btn--sm agents-refresh-btn"
+                ?disabled=${props.loading}
+                @click=${props.onRefresh}
+              >
                 ${props.loading ? "Loading…" : "Refresh"}
               </button>
             </div>
@@ -218,130 +236,137 @@ export function renderAgents(props: AgentsProps) {
                   <div class="card-sub">Pick an agent to inspect its workspace and tools.</div>
                 </div>
               `
-            : html`
-                ${renderAgentTabs(props.activePanel, (panel) => props.onSelectPanel(panel), tabCounts)}
-                ${
-                  props.activePanel === "overview"
-                    ? renderAgentOverview({
-                        agent: selectedAgent,
-                        basePath: props.basePath,
-                        defaultId,
-                        configForm: props.config.form,
-                        agentFilesList: props.agentFiles.list,
-                        agentIdentity: props.agentIdentityById[selectedAgent.id] ?? null,
-                        agentIdentityError: props.agentIdentityError,
-                        agentIdentityLoading: props.agentIdentityLoading,
-                        configLoading: props.config.loading,
-                        configSaving: props.config.saving,
-                        configDirty: props.config.dirty,
-                        onConfigReload: props.onConfigReload,
-                        onConfigSave: props.onConfigSave,
-                        onModelChange: props.onModelChange,
-                        onModelFallbacksChange: props.onModelFallbacksChange,
-                        onSelectPanel: props.onSelectPanel,
-                      })
-                    : nothing
-                }
-                ${
-                  props.activePanel === "files"
-                    ? renderAgentFiles({
-                        agentId: selectedAgent.id,
-                        agentFilesList: props.agentFiles.list,
-                        agentFilesLoading: props.agentFiles.loading,
-                        agentFilesError: props.agentFiles.error,
-                        agentFileActive: props.agentFiles.active,
-                        agentFileContents: props.agentFiles.contents,
-                        agentFileDrafts: props.agentFiles.drafts,
-                        agentFileSaving: props.agentFiles.saving,
-                        onLoadFiles: props.onLoadFiles,
-                        onSelectFile: props.onSelectFile,
-                        onFileDraftChange: props.onFileDraftChange,
-                        onFileReset: props.onFileReset,
-                        onFileSave: props.onFileSave,
-                      })
-                    : nothing
-                }
-                ${
-                  props.activePanel === "tools"
-                    ? renderAgentTools({
-                        agentId: selectedAgent.id,
-                        configForm: props.config.form,
-                        configLoading: props.config.loading,
-                        configSaving: props.config.saving,
-                        configDirty: props.config.dirty,
-                        toolsCatalogLoading: props.toolsCatalog.loading,
-                        toolsCatalogError: props.toolsCatalog.error,
-                        toolsCatalogResult: props.toolsCatalog.result,
-                        onProfileChange: props.onToolsProfileChange,
-                        onOverridesChange: props.onToolsOverridesChange,
-                        onConfigReload: props.onConfigReload,
-                        onConfigSave: props.onConfigSave,
-                      })
-                    : nothing
-                }
-                ${
-                  props.activePanel === "skills"
-                    ? renderAgentSkills({
-                        agentId: selectedAgent.id,
-                        report: props.agentSkills.report,
-                        loading: props.agentSkills.loading,
-                        error: props.agentSkills.error,
-                        activeAgentId: props.agentSkills.agentId,
-                        configForm: props.config.form,
-                        configLoading: props.config.loading,
-                        configSaving: props.config.saving,
-                        configDirty: props.config.dirty,
-                        filter: props.agentSkills.filter,
-                        onFilterChange: props.onSkillsFilterChange,
-                        onRefresh: props.onSkillsRefresh,
-                        onToggle: props.onAgentSkillToggle,
-                        onClear: props.onAgentSkillsClear,
-                        onDisableAll: props.onAgentSkillsDisableAll,
-                        onConfigReload: props.onConfigReload,
-                        onConfigSave: props.onConfigSave,
-                      })
-                    : nothing
-                }
-                ${
-                  props.activePanel === "channels"
-                    ? renderAgentChannels({
-                        context: buildAgentContext(
-                          selectedAgent,
-                          props.config.form,
-                          props.agentFiles.list,
+            : keyed(
+                selectedAgent.id,
+                html`
+                  ${renderAgentTabs(
+                    props.activePanel,
+                    (panel) => props.onSelectPanel(panel),
+                    tabCounts,
+                  )}
+                  ${
+                    props.activePanel === "overview"
+                      ? renderAgentOverview({
+                          agent: selectedAgent,
+                          basePath: props.basePath,
                           defaultId,
-                          props.agentIdentityById[selectedAgent.id] ?? null,
-                        ),
-                        configForm: props.config.form,
-                        snapshot: props.channels.snapshot,
-                        loading: props.channels.loading,
-                        error: props.channels.error,
-                        lastSuccess: props.channels.lastSuccess,
-                        onRefresh: props.onChannelsRefresh,
-                      })
-                    : nothing
-                }
-                ${
-                  props.activePanel === "cron"
-                    ? renderAgentCron({
-                        context: buildAgentContext(
-                          selectedAgent,
-                          props.config.form,
-                          props.agentFiles.list,
-                          defaultId,
-                          props.agentIdentityById[selectedAgent.id] ?? null,
-                        ),
-                        agentId: selectedAgent.id,
-                        jobs: props.cron.jobs,
-                        status: props.cron.status,
-                        loading: props.cron.loading,
-                        error: props.cron.error,
-                        onRefresh: props.onCronRefresh,
-                        onRunNow: props.onCronRunNow,
-                      })
-                    : nothing
-                }
-              `
+                          configForm: props.config.form,
+                          agentFilesList: props.agentFiles.list,
+                          agentIdentity: props.agentIdentityById[selectedAgent.id] ?? null,
+                          agentIdentityError: props.agentIdentityError,
+                          agentIdentityLoading: props.agentIdentityLoading,
+                          configLoading: props.config.loading,
+                          configSaving: props.config.saving,
+                          configDirty: props.config.dirty,
+                          onConfigReload: props.onConfigReload,
+                          onConfigSave: props.onConfigSave,
+                          onModelChange: props.onModelChange,
+                          onModelFallbacksChange: props.onModelFallbacksChange,
+                          onSelectPanel: props.onSelectPanel,
+                        })
+                      : nothing
+                  }
+                  ${
+                    props.activePanel === "files"
+                      ? renderAgentFiles({
+                          agentId: selectedAgent.id,
+                          agentFilesList: props.agentFiles.list,
+                          agentFilesLoading: props.agentFiles.loading,
+                          agentFilesError: props.agentFiles.error,
+                          agentFileActive: props.agentFiles.active,
+                          agentFileContents: props.agentFiles.contents,
+                          agentFileDrafts: props.agentFiles.drafts,
+                          agentFileSaving: props.agentFiles.saving,
+                          onLoadFiles: props.onLoadFiles,
+                          onSelectFile: props.onSelectFile,
+                          onFileDraftChange: props.onFileDraftChange,
+                          onFileReset: props.onFileReset,
+                          onFileSave: props.onFileSave,
+                        })
+                      : nothing
+                  }
+                  ${
+                    props.activePanel === "tools"
+                      ? renderAgentTools({
+                          agentId: selectedAgent.id,
+                          configForm: props.config.form,
+                          configLoading: props.config.loading,
+                          configSaving: props.config.saving,
+                          configDirty: props.config.dirty,
+                          toolsCatalogLoading: props.toolsCatalog.loading,
+                          toolsCatalogError: props.toolsCatalog.error,
+                          toolsCatalogResult: props.toolsCatalog.result,
+                          onProfileChange: props.onToolsProfileChange,
+                          onOverridesChange: props.onToolsOverridesChange,
+                          onConfigReload: props.onConfigReload,
+                          onConfigSave: props.onConfigSave,
+                        })
+                      : nothing
+                  }
+                  ${
+                    props.activePanel === "skills"
+                      ? renderAgentSkills({
+                          agentId: selectedAgent.id,
+                          report: props.agentSkills.report,
+                          loading: props.agentSkills.loading,
+                          error: props.agentSkills.error,
+                          activeAgentId: props.agentSkills.agentId,
+                          configForm: props.config.form,
+                          configLoading: props.config.loading,
+                          configSaving: props.config.saving,
+                          configDirty: props.config.dirty,
+                          filter: props.agentSkills.filter,
+                          onFilterChange: props.onSkillsFilterChange,
+                          onRefresh: props.onSkillsRefresh,
+                          onToggle: props.onAgentSkillToggle,
+                          onClear: props.onAgentSkillsClear,
+                          onDisableAll: props.onAgentSkillsDisableAll,
+                          onConfigReload: props.onConfigReload,
+                          onConfigSave: props.onConfigSave,
+                        })
+                      : nothing
+                  }
+                  ${
+                    props.activePanel === "channels"
+                      ? renderAgentChannels({
+                          context: buildAgentContext(
+                            selectedAgent,
+                            props.config.form,
+                            props.agentFiles.list,
+                            defaultId,
+                            props.agentIdentityById[selectedAgent.id] ?? null,
+                          ),
+                          configForm: props.config.form,
+                          snapshot: props.channels.snapshot,
+                          loading: props.channels.loading,
+                          error: props.channels.error,
+                          lastSuccess: props.channels.lastSuccess,
+                          onRefresh: props.onChannelsRefresh,
+                        })
+                      : nothing
+                  }
+                  ${
+                    props.activePanel === "cron"
+                      ? renderAgentCron({
+                          context: buildAgentContext(
+                            selectedAgent,
+                            props.config.form,
+                            props.agentFiles.list,
+                            defaultId,
+                            props.agentIdentityById[selectedAgent.id] ?? null,
+                          ),
+                          agentId: selectedAgent.id,
+                          jobs: props.cron.jobs,
+                          status: props.cron.status,
+                          loading: props.cron.loading,
+                          error: props.cron.error,
+                          onRefresh: props.onCronRefresh,
+                          onRunNow: props.onCronRunNow,
+                        })
+                      : nothing
+                  }
+                `,
+              )
         }
       </section>
     </div>
@@ -372,7 +397,11 @@ function renderAgentTabs(
             type="button"
             @click=${() => onSelect(tab.id)}
           >
-            ${tab.label}${counts[tab.id] != null ? html`<span class="agent-tab-count">${counts[tab.id]}</span>` : nothing}
+            ${tab.label}${
+              counts[tab.id] != null
+                ? html`<span class="agent-tab-count">${counts[tab.id]}</span>`
+                : nothing
+            }
           </button>
         `,
       )}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In the Agents UI, the Primary Model control for non-default agents could temporarily show the default model, or drift to the wrong selected option, when switching between agents.
- Why it matters: This made the UI inconsistent with the actual saved config and with the Overview panel, which was confusing and made agent model editing unreliable.
- What changed: Remounted selected-agent details on agent switch, stabilized non-default primary-model select binding around the explicit entry model only, and corrected native `<select>` DOM drift when a matching option exists.
- What did NOT change (scope boundary): No backend config persistence, validation, redaction, or gateway save-path behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41344
- Related #

## User-visible / Behavior Changes

- For non-default agents, the Primary Model control now stays aligned with the actual explicit model override when switching between agents.
- The control no longer temporarily shows the default model before correcting itself.
- Switching a non-default agent back to inherit default no longer leaves the control blank.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime/container: Local dev run from source
- Model/provider: OpenAI + Anthropic model identifiers in local config
- Integration/channel (if any): None (channels disabled in local dev)
- Relevant config (redacted):
  - `agents.defaults.model = 'openai/gpt-4.1-mini'`
  - non-default agent `qa.model = 'anthropic/claude-opus-4-6'`
  - non-default agent `ops.model = 'openai/gpt-4.1'`

### Steps

1. Start local gateway and Control UI on latest main-based branch.
2. Configure multiple agents where defaults and non-default explicit models differ.
3. Open Agents and switch between `dev`, `qa`, and `ops`.
4. For a non-default agent, also switch Primary Model back to inherit default.

### Expected

- Non-default agents should immediately show their explicit model override in the Primary Model control.
- The control should remain consistent with the Overview panel and actual config.
- Switching back to inherit default should show the inherit/default state cleanly.

### Actual

- Before this fix, the Primary Model control could initially show the default model for a non-default agent, then correct itself after a delay.
- In some cases the native `<select>` selected state drifted away from the intended bound value.
- Switching back to inherit default could temporarily leave the control blank.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Switched `dev -> qa`
  - Switched `dev -> ops`
  - Switched back and forth repeatedly between agents
  - Switched a non-default agent back to inherit default
- Edge cases checked:
  - Non-default agents with explicit model overrides different from defaults
  - Default agent behavior remained correct
  - Unsaved UI state no longer produced the temporary wrong selected option during agent switching
- What you did **not** verify:
  - Automated UI/browser tests were not added in this PR
  - Other unrelated agent panels beyond the Primary Model control were not revalidated exhaustively

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR or restore the previous UI files from main.
- Files/config to restore:
  - `ui/src/ui/views/agents.ts`
  - `ui/src/ui/views/agents-panels-overview.ts`
- Known bad symptoms reviewers should watch for:
  - Primary Model control shows the wrong selected option after agent switch
  - Non-default agents temporarily display defaults instead of explicit overrides
  - Switching back to inherit default leaves the control blank

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: The fix touches native `<select>` synchronization logic and selected-agent remount behavior in the Agents UI.
  - Mitigation: Kept the patch localized to the relevant UI files, preserved backend/save-path behavior, and manually verified agent switching and inherit-default scenarios on a latest-main-based branch.