### PR TITLE
fix(bluebubbles): preserve intra-word underscores in stripMarkdown

### DIFF
--- a/src/line/markdown-to-line.ts
+++ b/src/line/markdown-to-line.ts
@@ -350,7 +350,8 @@ export function stripMarkdown(text: string): string {
 
   // Remove italic: *text* or _text_ (but not already processed)
   result = result.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "$1");
-  result = result.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "$1");
+  // Only match _text_ when underscores are at word boundaries (CommonMark-compliant)
+  result = result.replace(/(?<=\s|^)_(?!_)(.+?)(?<!_)_(?=\s|$|[.,;:!?)/\]])/g, "$1");
 
   // Remove strikethrough: ~~text~~
   result = result.replace(/~~(.+?)~~/g, "$1");


### PR DESCRIPTION
## Summary

Fixes #46185

The `stripMarkdown` function used in BlueBubbles outbound text processing strips single underscores inside words (e.g., `here_is_a_message_with_underscores` → `hereisamessagewithunderscores`).

## Root Cause

The underscore-based italic regex `(?<!_)_(?!_)(.+?)(?<!_)_(?!_)` matches `_text_` anywhere, even when underscores are clearly word-internal separators rather than markdown italic delimiters.

## Fix

Updated the regex to require whitespace or start/end position around underscore delimiters:

```js
// Before
result.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "$1");

// After (CommonMark-compliant)
result.replace(/(?<=\s|^)_(?!_)(.+?)(?<!_)_(?=\s|$|[.,;:!?)/\]])/g, "$1");
```

This matches CommonMark spec for flanking delimiter runs — only `_text_` with proper word boundaries is treated as italic formatting. Underscores inside words (like snake_case identifiers) are preserved.

## Test Cases

| Input | Before | After |
|---|---|---|
| `here_is_a_message` | `hereisamessage` | `here_is_a_message` ✅ |
| `hello _world_ there` | `hello world there` | `hello world there` ✅ |
| `_italic text_` | `italic text` | `italic text` ✅ |
| `snake_case_var` | `snakecasevar` | `snake_case_var` ✅ |