### PR TITLE
Docker: harden release overlay rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,8 +137,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       procps hostname curl git openssl ffmpeg python3-pip
 
-RUN python3 -m pip install --break-system-packages --no-cache-dir openai-whisper && \
-    npm install -g @google/gemini-cli
+RUN python3 -m pip install --break-system-packages --no-cache-dir openai-whisper
 
 RUN chown node:node /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,12 +129,16 @@ WORKDIR /app
 
 # Install system utilities present in bookworm but missing in bookworm-slim.
 # On the full bookworm image these are already installed (apt-get is a no-op).
+# Keep local audio transcription dependencies available in the runtime image.
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      procps hostname curl git openssl
+      procps hostname curl git openssl ffmpeg python3-pip
+
+RUN python3 -m pip install --break-system-packages --no-cache-dir openai-whisper && \
+    npm install -g @google/gemini-cli
 
 RUN chown node:node /app
 

--- a/scripts/update-openclaw-release.overlays.txt
+++ b/scripts/update-openclaw-release.overlays.txt
@@ -1,0 +1,9 @@
+# Files copied from your current local repo into the fresh release source
+# before docker build. Keep this list focused on local custom fixes.
+
+Dockerfile
+extensions/signal/src/channel.ts
+src/signal/client.ts
+src/signal/monitor.ts
+src/signal/probe.ts
+src/signal/sse-reconnect.ts


### PR DESCRIPTION
## Summary
- keep the custom release overlay list explicit via `scripts/update-openclaw-release.overlays.txt`
- stop carrying `src/gateway/server-constants.ts` in custom release rebuilds so future tags do not reintroduce stale gateway constants
- preserve the local runtime Docker additions needed on this server in the overlay Dockerfile (`ffmpeg`, `python3-pip`, `openai-whisper`, `@google/gemini-cli`)

## Testing
- not run (overlay hardening only)
