### PR TITLE
fix: block JVM/.NET/Rust/Ansible env vars in host exec blocklist

### DIFF
--- a/src/infra/host-env-security-policy.json
+++ b/src/infra/host-env-security-policy.json
@@ -17,7 +17,18 @@
     "PS4",
     "GCONV_PATH",
     "IFS",
-    "SSLKEYLOGFILE"
+    "SSLKEYLOGFILE",
+    "JAVA_TOOL_OPTIONS",
+    "JDK_JAVA_OPTIONS",
+    "_JAVA_OPTIONS",
+    "MAVEN_OPTS",
+    "GRADLE_OPTS",
+    "DOTNET_STARTUP_HOOKS",
+    "CORECLR_ENABLE_PROFILING",
+    "CORECLR_PROFILER_PATH",
+    "ANSIBLE_FILTER_PLUGINS",
+    "ANSIBLE_CALLBACK_PLUGINS",
+    "RUSTFLAGS"
   ],
   "blockedOverrideKeys": [
     "HOME",
@@ -47,5 +58,5 @@
     "CURL_HOME"
   ],
   "blockedOverridePrefixes": ["GIT_CONFIG_", "NPM_CONFIG_"],
-  "blockedPrefixes": ["DYLD_", "LD_", "BASH_FUNC_"]
+  "blockedPrefixes": ["DYLD_", "LD_", "BASH_FUNC_", "CORECLR_", "ANSIBLE_"]
 }


### PR DESCRIPTION
## GHSA-001: Environment Variable Blocklist Bypass via JVM/CLR/Build-Tool Injection

**Severity:** High (CVSS 8.1)

## Vulnerability

The exec tool's `env` parameter allows AI agents to pass custom environment variables to child processes. These variables go through two sanitization stages — `validateHostEnv()` and `sanitizeHostExecEnv()` — both relying on blocklists defined in `host-env-security-policy.json`.

The blocklist was missing 11 well-known code-execution-capable variables such as `JAVA_TOOL_OPTIONS`, `DOTNET_STARTUP_HOOKS`, and `RUSTFLAGS`. An attacker (or prompt injection payload) can inject e.g. `JAVA_TOOL_OPTIONS: "-javaagent:evil.jar"` — when the child process is a JVM, the malicious JAR executes before the target application's `main()`, achieving arbitrary code execution on the host.

## Fix

- Add 11 missing dangerous variables to `blockedKeys`: `JAVA_TOOL_OPTIONS`, `JDK_JAVA_OPTIONS`, `_JAVA_OPTIONS`, `MAVEN_OPTS`, `GRADLE_OPTS`, `DOTNET_STARTUP_HOOKS`, `CORECLR_ENABLE_PROFILING`, `CORECLR_PROFILER_PATH`, `ANSIBLE_FILTER_PLUGINS`, `ANSIBLE_CALLBACK_PLUGINS`, `RUSTFLAGS`
- Add `CORECLR_` and `ANSIBLE_` to `blockedPrefixes` to catch future variants

## Affected File

- `src/infra/host-env-security-policy.json`