### PR TITLE
fix: validate parent dir realpath on Windows before new file creation

### DIFF
--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -413,6 +413,20 @@ export async function openWritableFileWithinRoot(params: {
     if (!isNotFoundPathError(err)) {
       throw err;
     }
+    // File doesn't exist yet (ENOENT). On Windows, O_NOFOLLOW is unavailable,
+    // so open(O_CREAT) would follow directory junctions. Resolve the parent
+    // directory to verify it is inside the workspace root before creating.
+    if (!SUPPORTS_NOFOLLOW) {
+      const parentDir = path.dirname(resolved);
+      const parentReal = await fs.realpath(parentDir);
+      if (!isPathInside(rootWithSep, parentReal) && parentReal !== rootReal) {
+        throw new SafeOpenError(
+          "outside-workspace",
+          "parent directory resolves outside workspace root",
+        );
+      }
+      ioPath = path.join(parentReal, path.basename(resolved));
+    }
   }
 
   const fileMode = params.mode ?? 0o600;


### PR DESCRIPTION
## Vulnerability: Windows New File Creation Escapes Workspace via Directory Junction

**Severity:** Medium (CVSS 5.4) — Windows only

## Root Cause

On Windows, `O_NOFOLLOW` does not exist (`SUPPORTS_NOFOLLOW = false`), so all `open()` calls silently follow symlinks/junctions. The safe file I/O layer in `fs-safe.ts` compensates with `realpath()` checks for existing files, but **new file creation** has a gap:

1. `openWritableFileWithinRoot()` calls `realpath(targetPath)` — throws ENOENT (file doesn't exist yet)
2. Code falls through, keeps the lexical path (which may contain a directory junction)
3. `open(O_CREAT|O_EXCL)` follows the junction, creating the file **outside** the workspace
4. Post-open `resolveOpenedFileRealPathForHandle` would detect this, but on Windows `fdCandidates = []`, so it always fails
5. The file has already been written to disk before the error is thrown

## Fix

When `realpath()` fails with ENOENT and `O_NOFOLLOW` is not supported (Windows), resolve the **parent directory** via `realpath()` and verify it is inside the workspace root before proceeding with file creation. Also rewrite `ioPath` to use the resolved parent, so `open()` targets the real location.

## Affected File

- `src/infra/fs-safe.ts`