### PR TITLE
agents: fix image format for OpenAI-compatible providers like OpenRouter (#46255)

### DIFF
--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -186,6 +186,10 @@ export type ContentPart =
   | {
       type: "input_image";
       source: { type: "url"; url: string } | { type: "base64"; media_type: string; data: string };
+    }
+  | {
+      type: "image_url";
+      image_url: { url: string };
     };
 
 export type InputItem =

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -102,7 +102,7 @@ export function hasWsSession(sessionId: string): boolean {
 
 type AnyMessage = Message & { role: string; content: unknown };
 type AssistantMessageWithPhase = AssistantMessage & { phase?: OpenAIResponsesAssistantPhase };
-type ReplayModelInfo = { input?: ReadonlyArray<string> };
+type ReplayModelInfo = { input?: ReadonlyArray<string>; api?: string };
 
 function toNonEmptyString(value: unknown): string | null {
   if (typeof value !== "string") {
@@ -187,6 +187,7 @@ function contentToOpenAIParts(content: unknown, modelOverride?: ReplayModelInfo)
   }
 
   const includeImages = supportsImageInput(modelOverride);
+  const useImageUrl = modelOverride?.api === "openai-completions";
   const parts: ContentPart[] = [];
   for (const part of content as Array<{
     type?: string;
@@ -208,14 +209,23 @@ function contentToOpenAIParts(content: unknown, modelOverride?: ReplayModelInfo)
     }
 
     if (part.type === "image" && typeof part.data === "string") {
-      parts.push({
-        type: "input_image",
-        source: {
-          type: "base64",
-          media_type: part.mimeType ?? "image/jpeg",
-          data: part.data,
-        },
-      });
+      if (useImageUrl) {
+        parts.push({
+          type: "image_url",
+          image_url: {
+            url: `data:${part.mimeType ?? "image/jpeg"};base64,${part.data}`,
+          },
+        });
+      } else {
+        parts.push({
+          type: "input_image",
+          source: {
+            type: "base64",
+            media_type: part.mimeType ?? "image/jpeg",
+            data: part.data,
+          },
+        });
+      }
       continue;
     }
 
@@ -225,12 +235,27 @@ function contentToOpenAIParts(content: unknown, modelOverride?: ReplayModelInfo)
       typeof part.source === "object" &&
       typeof (part.source as { type?: unknown }).type === "string"
     ) {
-      parts.push({
-        type: "input_image",
-        source: part.source as
+      if (useImageUrl) {
+        const source = part.source as
           | { type: "url"; url: string }
-          | { type: "base64"; media_type: string; data: string },
-      });
+          | { type: "base64"; media_type: string; data: string };
+        parts.push({
+          type: "image_url",
+          image_url: {
+            url:
+              source.type === "url"
+                ? source.url
+                : `data:${source.media_type};base64,${source.data}`,
+          },
+        });
+      } else {
+        parts.push({
+          type: "input_image",
+          source: part.source as
+            | { type: "url"; url: string }
+            | { type: "base64"; media_type: string; data: string },
+        });
+      }
     }
   }
   return parts;

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -216,7 +216,7 @@ export function resolveModelWithRegistry(params: {
         provider,
         baseUrl: "https://openrouter.ai/api/v1",
         reasoning: false,
-        input: ["text"],
+        input: ["text", "image"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: DEFAULT_CONTEXT_TOKENS,
         // Align with OPENROUTER_DEFAULT_MAX_TOKENS in models-config.providers.ts


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: OpenClaw hardcoded Anthropic's \input_image\ format for all providers, causing OpenAI-compatible vision models (like OpenRouter) to fail.
- Why it matters: Multimodal capabilities were broken for a significant segment of users using OpenAI-compatible proxies.
- What changed: 
    - Added \image_url\ support to OpenAI WS connection types.
    - Updated \contentToOpenAIParts\ to output \image_url\ when using the \openai-completions\ adapter.
    - Enabled \image\ input support for the OpenRouter default model configuration.
- What did NOT change (scope boundary): Anthropic-native providers still use the \input_image\ format.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46255
- Related #

## User-visible / Behavior Changes

OpenRouter vision models now correctly receive and process image attachments.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: win32 10.0.17763
- Runtime/container: Node.js
- Model/provider: OpenRouter / healer-alpha

### Steps

1. Configure OpenRouter provider with a vision model.
2. Send an image via any channel.
3. Check if the model can see the image.

### Expected

Model sees the image and responds accordingly.

### Actual

Model responds with "I don't see an image attached".

## Evidence

- [x] Trace/log snippets: Unit tests passed for OpenAI WS stream logic.

## Human Verification (required)

- Verified scenarios: Checked the logic branch for \openai-completions\ API.
- Edge cases checked: Verified that data URIs are correctly formatted for OpenAI.
- What you did **not** verify: Live testing with every single OpenRouter vision model.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: git revert.
- Files/config to restore: N/A.
- Known bad symptoms reviewers should watch for: 400 errors from OpenAI-native providers (unlikely due to guard).

## Risks and Mitigations

None.