### PR TITLE
fix: remove query parameter token support from extension relay auth

### DIFF
--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -99,16 +99,8 @@ function getHeader(req: IncomingMessage, name: string): string | undefined {
   return headerValue(req.headers[name.toLowerCase()]);
 }
 
-function getRelayAuthTokenFromRequest(req: IncomingMessage, url?: URL): string | undefined {
-  const headerToken = getHeader(req, RELAY_AUTH_HEADER)?.trim();
-  if (headerToken) {
-    return headerToken;
-  }
-  const queryToken = url?.searchParams.get("token")?.trim();
-  if (queryToken) {
-    return queryToken;
-  }
-  return undefined;
+function getRelayAuthTokenFromRequest(req: IncomingMessage, _url?: URL): string | undefined {
+  return getHeader(req, RELAY_AUTH_HEADER)?.trim();
 }
 
 export type ChromeExtensionRelayServer = {


### PR DESCRIPTION
## Vulnerability: Relay Authentication Token Exposure via URL Query Parameters

**Severity:** Medium (CVSS 7.5)

## Root Cause

`getRelayAuthTokenFromRequest()` in `extension-relay.ts` accepts tokens via both HTTP headers (secure) and URL query parameters (`?token=...`). Tokens in query parameters are recorded in HTTP access logs, browser history, reverse proxy logs, and leaked via `Referer` headers to third parties.

The relay token grants full Chrome DevTools Protocol access — an attacker who harvests the token from logs can execute arbitrary JavaScript, steal cookies (including HttpOnly), capture screenshots, intercept network requests, and navigate pages.

## Fix

Remove the URL query parameter fallback entirely. Tokens must now be sent exclusively via the `x-openclaw-relay-auth` HTTP header, which is not logged by default in web server access logs.

## Affected File

- `src/browser/extension-relay.ts`