### PR TITLE
fix: add SSRF hostname validation to Ollama/vLLM model discovery and stream

### DIFF
--- a/src/agents/models-config.providers.discovery.ts
+++ b/src/agents/models-config.providers.discovery.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isBlockedHostnameOrIp } from "../infra/net/ssrf.js";
 import { KILOCODE_BASE_URL } from "../providers/kilocode-shared.js";
 import {
   discoverHuggingfaceModels,
@@ -27,6 +28,20 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
 const log = createSubsystemLogger("agents/model-providers");
+
+function assertBaseUrlNotBlocked(baseUrl: string): void {
+  try {
+    const parsed = new URL(baseUrl);
+    if (isBlockedHostnameOrIp(parsed.hostname)) {
+      throw new Error(`Model provider baseUrl targets a blocked host: ${parsed.hostname}`);
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("blocked host")) {
+      throw err;
+    }
+    // If URL parsing fails, let the fetch() call handle it
+  }
+}
 
 const OLLAMA_SHOW_CONCURRENCY = 8;
 const OLLAMA_SHOW_MAX_MODELS = 200;
@@ -59,6 +74,7 @@ async function discoverOllamaModels(
   }
   try {
     const apiBase = resolveOllamaApiBase(baseUrl);
+    assertBaseUrlNotBlocked(apiBase);
     const response = await fetch(`${apiBase}/api/tags`, {
       signal: AbortSignal.timeout(5000),
     });
@@ -114,6 +130,7 @@ async function discoverOpenAICompatibleLocalModels(params: {
   const url = `${trimmedBaseUrl}/models`;
 
   try {
+    assertBaseUrlNotBlocked(trimmedBaseUrl);
     const trimmedApiKey = params.apiKey?.trim();
     const response = await fetch(url, {
       headers: trimmedApiKey ? { Authorization: `Bearer ${trimmedApiKey}` } : undefined,

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { isBlockedHostnameOrIp } from "../infra/net/ssrf.js";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type {
   AssistantMessage,
@@ -435,6 +436,16 @@ export function createOllamaStreamFn(
   defaultHeaders?: Record<string, string>,
 ): StreamFn {
   const chatUrl = resolveOllamaChatUrl(baseUrl);
+  try {
+    const parsed = new URL(chatUrl);
+    if (isBlockedHostnameOrIp(parsed.hostname)) {
+      throw new Error(`Ollama baseUrl targets a blocked host: ${parsed.hostname}`);
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("blocked host")) {
+      throw err;
+    }
+  }
 
   return (model, context, options) => {
     const stream = createAssistantMessageEventStream();


### PR DESCRIPTION
## Vulnerability: Ollama/vLLM Model Discovery and Stream SSRF

**Severity:** Medium (CVSS 6.8)

## Root Cause

Ollama model discovery, vLLM/sglang model discovery, and the Ollama stream function all use raw `fetch()` with user-controlled `baseUrl` from configuration without SSRF validation. An attacker with `operator.admin` scope can set `baseUrl` to cloud metadata endpoints (169.254.169.254), internal services, or K8s APIs for network reconnaissance.

## Fix

Add `isBlockedHostnameOrIp()` validation to reject requests targeting blocked hosts before the `fetch()` call in `discoverOllamaModels()`, `discoverOpenAICompatibleLocalModels()`, and `createOllamaStreamFn()`.

## Affected Files

- `src/agents/models-config.providers.discovery.ts`
- `src/agents/ollama-stream.ts`