### PR TITLE
fix: Windows npm path for Gemini OAuth + feat: WORKING.md bootstrap (#46368, #46367)

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -189,6 +189,53 @@ describe("extractGeminiCliCredentials", () => {
     expectFakeCliCredentials(result);
   });
 
+  it("falls back to APPDATA npm global path on Windows when gemini is not in PATH", async () => {
+    const originalPlatform = process.platform;
+    const originalAppdata = process.env.APPDATA;
+    try {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      process.env.APPDATA = join(rootDir, "fake", "AppData", "Roaming");
+      process.env.PATH = "/nonexistent";
+
+      const appdataOauth2Path = join(
+        process.env.APPDATA,
+        "npm",
+        "node_modules",
+        "@google",
+        "gemini-cli",
+        "node_modules",
+        "@google",
+        "gemini-cli-core",
+        "dist",
+        "src",
+        "code_assist",
+        "oauth2.js",
+      );
+
+      mockExistsSync.mockImplementation((p: string) => {
+        const normalized = normalizePath(p);
+        if (normalized === normalizePath(appdataOauth2Path)) {
+          return true;
+        }
+        return false;
+      });
+      mockReadFileSync.mockReturnValue(FAKE_OAUTH2_CONTENT);
+
+      const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
+      clearCredentialsCache();
+      const result = extractGeminiCliCredentials();
+
+      expectFakeCliCredentials(result);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+      if (originalAppdata !== undefined) {
+        process.env.APPDATA = originalAppdata;
+      } else {
+        delete process.env.APPDATA;
+      }
+    }
+  });
+
   it("returns null when oauth2.js cannot be found", async () => {
     installGeminiLayout({ oauth2Exists: false, readdir: [] });
 

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -74,12 +74,17 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
 
   try {
     const geminiPath = findInPath("gemini");
-    if (!geminiPath) {
+    let geminiCliDirs: string[];
+    if (geminiPath) {
+      const resolvedPath = realpathSync(geminiPath);
+      geminiCliDirs = resolveGeminiCliDirs(geminiPath, resolvedPath);
+    } else if (process.platform === "win32" && process.env.APPDATA) {
+      // Fallback: on Windows the npm global bin may not be in PATH, but
+      // globally-installed packages are still under %APPDATA%\npm\node_modules.
+      geminiCliDirs = [join(process.env.APPDATA, "npm", "node_modules", "@google", "gemini-cli")];
+    } else {
       return null;
     }
-
-    const resolvedPath = realpathSync(geminiPath);
-    const geminiCliDirs = resolveGeminiCliDirs(geminiPath, resolvedPath);
 
     let content: string | null = null;
     for (const geminiCliDir of geminiCliDirs) {
@@ -145,6 +150,12 @@ function resolveGeminiCliDirs(geminiPath: string, resolvedPath: string): string[
     join(dirname(binDir), "node_modules", "@google", "gemini-cli"),
     join(dirname(binDir), "lib", "node_modules", "@google", "gemini-cli"),
   ];
+
+  // On Windows, npm global packages live under %APPDATA%\npm\node_modules
+  // regardless of where the bin shim is located.
+  if (process.platform === "win32" && process.env.APPDATA) {
+    candidates.push(join(process.env.APPDATA, "npm", "node_modules", "@google", "gemini-cli"));
+  }
 
   const deduped: string[] = [];
   const seen = new Set<string>();

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_MEMORY_FILENAME,
   DEFAULT_TOOLS_FILENAME,
   DEFAULT_USER_FILENAME,
+  DEFAULT_WORKING_FILENAME,
   ensureAgentWorkspace,
   filterBootstrapFilesForSession,
   loadWorkspaceBootstrapFiles,
@@ -189,6 +190,29 @@ describe("loadWorkspaceBootstrapFiles", () => {
 
     const files = await loadWorkspaceBootstrapFiles(tempDir);
     expect(getMemoryEntries(files)).toHaveLength(0);
+  });
+
+  it("includes WORKING.md when present", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: "WORKING.md",
+      content: "# Active task\nDoing stuff",
+    });
+
+    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const working = files.find((f) => f.name === DEFAULT_WORKING_FILENAME);
+    expect(working).toBeDefined();
+    expect(working?.missing).toBe(false);
+    expect(working?.content).toBe("# Active task\nDoing stuff");
+  });
+
+  it("omits WORKING.md when not present", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const working = files.find((f) => f.name === DEFAULT_WORKING_FILENAME);
+    expect(working).toBeUndefined();
   });
 
   it("treats hardlinked bootstrap aliases as missing", async () => {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -31,6 +31,7 @@ export const DEFAULT_HEARTBEAT_FILENAME = "HEARTBEAT.md";
 export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 export const DEFAULT_MEMORY_FILENAME = "MEMORY.md";
 export const DEFAULT_MEMORY_ALT_FILENAME = "memory.md";
+export const DEFAULT_WORKING_FILENAME = "WORKING.md";
 const WORKSPACE_STATE_DIRNAME = ".openclaw";
 const WORKSPACE_STATE_FILENAME = "workspace-state.json";
 const WORKSPACE_STATE_VERSION = 1;
@@ -138,7 +139,8 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_HEARTBEAT_FILENAME
   | typeof DEFAULT_BOOTSTRAP_FILENAME
   | typeof DEFAULT_MEMORY_FILENAME
-  | typeof DEFAULT_MEMORY_ALT_FILENAME;
+  | typeof DEFAULT_MEMORY_ALT_FILENAME
+  | typeof DEFAULT_WORKING_FILENAME;
 
 export type WorkspaceBootstrapFile = {
   name: WorkspaceBootstrapFileName;
@@ -176,6 +178,7 @@ const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
   DEFAULT_BOOTSTRAP_FILENAME,
   DEFAULT_MEMORY_FILENAME,
   DEFAULT_MEMORY_ALT_FILENAME,
+  DEFAULT_WORKING_FILENAME,
 ]);
 
 async function writeFileIfMissing(filePath: string, content: string): Promise<boolean> {
@@ -518,6 +521,15 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   const memoryEntry = await resolveMemoryBootstrapEntry(resolvedDir);
   if (memoryEntry) {
     entries.push(memoryEntry);
+  }
+
+  // WORKING.md is opt-in: only loaded when present in the workspace.
+  const workingPath = path.join(resolvedDir, DEFAULT_WORKING_FILENAME);
+  try {
+    await fs.access(workingPath);
+    entries.push({ name: DEFAULT_WORKING_FILENAME, filePath: workingPath });
+  } catch {
+    // WORKING.md not present — skip
   }
 
   const result: WorkspaceBootstrapFile[] = [];


### PR DESCRIPTION
Combines fixes from upstream PRs:
- #46368: fix: add Windows npm global path resolution for Gemini CLI OAuth (closes #30403)
- #46367: feat: add WORKING.md as opt-in bootstrap file for working memory (Fixes #9386)

Merged from openclaw/openclaw PRs.