### PR TITLE
fix(feishu): widen topic/thread ID regex to accept alphanumeric IDs

### DIFF
--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
+
+describe("resolveAnnounceTargetFromKey", () => {
+  it("extracts numeric Telegram topic ID", () => {
+    const result = resolveAnnounceTargetFromKey(
+      "agent:main:telegram:group:-1001234567890:topic:12345",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.threadId).toBe("12345");
+    expect(result!.channel).toBe("telegram");
+  });
+
+  it("extracts alphanumeric Feishu topic ID", () => {
+    const result = resolveAnnounceTargetFromKey(
+      "agent:main:feishu:group:oc_abc123:topic:om_x100b5460aa5ef4a4b3d98b7bd85fbc0",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.threadId).toBe("om_x100b5460aa5ef4a4b3d98b7bd85fbc0");
+    expect(result!.channel).toBe("feishu");
+  });
+
+  it("extracts Discord thread ID", () => {
+    const result = resolveAnnounceTargetFromKey(
+      "agent:main:discord:channel:9876543210:thread:1122334455",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.threadId).toBe("1122334455");
+    expect(result!.channel).toBe("discord");
+  });
+
+  it("strips topic suffix from target ID", () => {
+    const result = resolveAnnounceTargetFromKey("agent:main:feishu:group:oc_abc123:topic:om_xyz");
+    expect(result).not.toBeNull();
+    expect(result!.to).toContain("oc_abc123");
+    expect(result!.to).not.toContain("om_xyz");
+  });
+
+  it("returns null for short session keys", () => {
+    expect(resolveAnnounceTargetFromKey("agent:main")).toBeNull();
+  });
+
+  it("returns null for non-group/channel keys", () => {
+    expect(resolveAnnounceTargetFromKey("agent:main:telegram:direct:123")).toBeNull();
+  });
+});

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -36,6 +36,22 @@ describe("resolveAnnounceTargetFromKey", () => {
     expect(result!.to).not.toContain("om_xyz");
   });
 
+  it("extracts Slack thread ID with dot separator", () => {
+    const result = resolveAnnounceTargetFromKey(
+      "agent:main:slack:channel:C0123ABC:thread:1234567890.123456",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.threadId).toBe("1234567890.123456");
+    expect(result!.channel).toBe("slack");
+  });
+
+  it("returns no threadId when topic/thread suffix is absent", () => {
+    const result = resolveAnnounceTargetFromKey("agent:main:telegram:group:-1001234567890");
+    expect(result).not.toBeNull();
+    expect(result!.threadId).toBeUndefined();
+    expect(result!.channel).toBe("telegram");
+  });
+
   it("returns null for short session keys", () => {
     expect(resolveAnnounceTargetFromKey("agent:main")).toBeNull();
   });

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -32,8 +32,8 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
   // Telegram uses :topic:, other platforms use :thread:
   let threadId: string | undefined;
   const restJoined = rest.join(":");
-  const topicMatch = restJoined.match(/:topic:(\d+)$/);
-  const threadMatch = restJoined.match(/:thread:(\d+)$/);
+  const topicMatch = restJoined.match(/:topic:([^:]+)$/);
+  const threadMatch = restJoined.match(/:thread:([^:]+)$/);
   const match = topicMatch || threadMatch;
 
   if (match) {
@@ -41,7 +41,7 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
   }
 
   // Remove :topic:N or :thread:N suffix from ID for target
-  const id = match ? restJoined.replace(/:(topic|thread):\d+$/, "") : restJoined.trim();
+  const id = match ? restJoined.replace(/:(topic|thread):[^:]+$/, "") : restJoined.trim();
 
   if (!id) {
     return null;


### PR DESCRIPTION
## Summary

`resolveAnnounceTargetFromKey()` uses `/:topic:(\d+)$/` and `/:thread:(\d+)$/` to extract topic/thread IDs from session keys. The `\d+` pattern only matches numeric IDs (Telegram-style), but Feishu uses alphanumeric topic IDs like `om_x100b5460aa5ef4a4b3d98b7bd85fbc0`.

When a sub-agent completes inside a Feishu topic thread, announce delivery silently loses the topic context and posts to the wrong place.

## Fix

Widen the capture group from `\d+` to `[^:]+` so both numeric (Telegram) and alphanumeric (Feishu) IDs are extracted correctly. The same change is applied to the `replace()` cleanup pattern.

## Tests

Added 6 tests covering:
- Numeric Telegram topic ID extraction
- Alphanumeric Feishu topic ID extraction  
- Discord thread ID extraction
- Topic suffix stripping from target ID
- Null return for short/invalid session keys

Fixes #46113