### PR TITLE
fix(gateway): skip config.patch restart for hot-reloadable changes

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -487,7 +487,7 @@ export function buildAgentSystemPrompt(params: {
           "Get Updates (self-update) is ONLY allowed when the user explicitly asks for it.",
           "Do not run config.apply or update.run unless the user explicitly requests an update or config change; if it's not explicit, ask first.",
           "Use config.schema.lookup with a specific dot path to inspect only the relevant config subtree before making config changes or answering config-field questions; avoid guessing field names/types.",
-          "Actions: config.schema.lookup, config.get, config.apply (validate + write full config, then restart), config.patch (partial update, merges with existing), update.run (update deps or git, then restart).",
+          "Actions: config.schema.lookup, config.get, config.apply (validate + write full config, then restart), config.patch (partial update, merges with existing, hot-reloads when possible), update.run (update deps or git, then restart).",
           "After restart, OpenClaw pings the last active session automatically.",
         ].join("\n")
       : "",

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -76,7 +76,7 @@ export function createGatewayTool(opts?: {
     name: "gateway",
     ownerOnly: true,
     description:
-      "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Both trigger restart after writing. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart.",
+      "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing) and let the gateway hot-reload when possible. Use config.apply only when replacing the entire config. Always pass a human-readable completion message via the `note` parameter so the system can deliver it after any required restart.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -9,6 +9,7 @@ import {
   buildGatewayReloadPlan,
   diffConfigPaths,
   resolveGatewayReloadSettings,
+  shouldConfigPatchTriggerGatewayRestart,
   startGatewayConfigReloader,
 } from "./config-reload.js";
 
@@ -250,6 +251,61 @@ describe("resolveGatewayReloadSettings", () => {
     const settings = resolveGatewayReloadSettings({});
     expect(settings.mode).toBe("hybrid");
     expect(settings.debounceMs).toBe(300);
+  });
+});
+
+describe("shouldConfigPatchTriggerGatewayRestart", () => {
+  it("skips restart when the patch changes nothing", () => {
+    expect(
+      shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode: "restart" } } }, []),
+    ).toBe(false);
+  });
+
+  it.each(["hybrid", "hot"] as const)(
+    "skips restart for hot-reload browser changes in %s mode",
+    (mode) => {
+      expect(
+        shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode } } }, [
+          "browser.profiles.sandbox.cdpUrl",
+        ]),
+      ).toBe(false);
+    },
+  );
+
+  it("skips restart when all changed paths are hot-reloadable or no-op", () => {
+    expect(
+      shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode: "hybrid" } } }, [
+        "browser.profiles.sandbox.cdpUrl",
+        "gateway.reload.mode",
+      ]),
+    ).toBe(false);
+  });
+
+  it.each(["off", "restart"] as const)(
+    "still restarts explicit patches for browser changes in %s mode",
+    (mode) => {
+      expect(
+        shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode } } }, [
+          "browser.profiles.sandbox.cdpUrl",
+        ]),
+      ).toBe(true);
+    },
+  );
+
+  it("still restarts explicit patches for restart-required paths in hot mode", () => {
+    expect(
+      shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode: "hot" } } }, [
+        "gateway.port",
+      ]),
+    ).toBe(true);
+  });
+
+  it("restarts when a changed path needs a full gateway restart", () => {
+    expect(
+      shouldConfigPatchTriggerGatewayRestart({ gateway: { reload: { mode: "hybrid" } } }, [
+        "gateway.port",
+      ]),
+    ).toBe(true);
   });
 });
 

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -65,6 +65,27 @@ export function resolveGatewayReloadSettings(cfg: OpenClawConfig): GatewayReload
   return { mode, debounceMs };
 }
 
+/**
+ * Explicit config.patch writes should only skip SIGUSR1 when the changed paths
+ * can already take effect via hot reload (or the patch is effectively a no-op).
+ */
+export function shouldConfigPatchTriggerGatewayRestart(
+  cfg: OpenClawConfig,
+  changedPaths: string[],
+): boolean {
+  if (changedPaths.length === 0) {
+    return false;
+  }
+
+  const settings = resolveGatewayReloadSettings(cfg);
+  if (settings.mode === "off" || settings.mode === "restart") {
+    return true;
+  }
+
+  const plan = buildGatewayReloadPlan(changedPaths);
+  return plan.restartGateway;
+}
+
 export type GatewayConfigReloader = {
   stop: () => Promise<void>;
 };

--- a/src/gateway/server-methods/config.restart.test.ts
+++ b/src/gateway/server-methods/config.restart.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
+
+const writeConfigFileMock = vi.fn(async () => {});
+const writeRestartSentinelMock = vi.fn(
+  async (_payload: RestartSentinelPayload) => "/tmp/restart-sentinel.json",
+);
+const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
+
+const baseConfig = {
+  gateway: {
+    auth: { mode: "token", token: "test-token" },
+    reload: { mode: "restart" },
+  },
+};
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: () => "/tmp/openclaw",
+  resolveDefaultAgentId: () => "main",
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  listChannelPlugins: () => [],
+}));
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    createConfigIO: () => ({ configPath: "/tmp/openclaw.json" }),
+    loadConfig: () => ({}),
+    readConfigFileSnapshotForWrite: async () => ({
+      snapshot: {
+        path: "/tmp/openclaw.json",
+        exists: true,
+        raw: JSON.stringify(baseConfig),
+        parsed: baseConfig,
+        resolved: baseConfig,
+        valid: true,
+        config: baseConfig,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      },
+      writeOptions: {},
+    }),
+    resolveConfigSnapshotHash: () => "snapshot-hash",
+    validateConfigObjectWithPlugins: (config: unknown) => ({
+      ok: true,
+      config,
+      issues: [],
+    }),
+    writeConfigFile: writeConfigFileMock,
+  };
+});
+
+vi.mock("../../config/legacy.js", () => ({
+  applyLegacyMigrations: (config: unknown) => ({ next: config }),
+}));
+
+vi.mock("../../config/redact-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/redact-snapshot.js")>();
+  return {
+    ...actual,
+    redactConfigObject: (config: unknown) => config,
+    restoreRedactedValues: (config: unknown) => ({ ok: true, result: config }),
+  };
+});
+
+vi.mock("../../config/schema.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/schema.js")>();
+  return {
+    ...actual,
+    buildConfigSchema: () => ({ uiHints: {} }),
+  };
+});
+
+vi.mock("../../config/sessions.js", () => ({
+  extractDeliveryInfo: () => ({ deliveryContext: undefined, threadId: undefined }),
+}));
+
+vi.mock("../../infra/restart-sentinel.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/restart-sentinel.js")>();
+  return {
+    ...actual,
+    writeRestartSentinel: writeRestartSentinelMock,
+  };
+});
+
+vi.mock("../../infra/restart.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/restart.js")>();
+  return {
+    ...actual,
+    scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
+  };
+});
+
+vi.mock("../../plugins/loader.js", () => ({
+  loadOpenClawPlugins: () => ({ plugins: [] }),
+}));
+
+vi.mock("./validation.js", () => ({
+  assertValidParams: () => true,
+}));
+
+beforeEach(() => {
+  writeConfigFileMock.mockClear();
+  writeRestartSentinelMock.mockClear();
+  scheduleGatewaySigusr1RestartMock.mockClear();
+  scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
+});
+
+async function invokeConfigPatch(raw: Record<string, unknown>) {
+  const { configHandlers } = await import("./config.js");
+  let response:
+    | {
+        ok: boolean;
+        payload?: Record<string, unknown>;
+        error?: unknown;
+      }
+    | undefined;
+
+  await configHandlers["config.patch"]({
+    params: {
+      raw: JSON.stringify(raw),
+      baseHash: "snapshot-hash",
+    },
+    client: undefined,
+    context: {
+      logGateway: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    },
+    respond: ((ok: boolean, payload?: unknown, error?: unknown) => {
+      response = {
+        ok,
+        payload: (payload as Record<string, unknown> | undefined) ?? undefined,
+        error,
+      };
+    }) as never,
+  } as never);
+
+  if (!response) {
+    throw new Error("config.patch did not respond");
+  }
+  return response;
+}
+
+describe("config.patch restart scheduling", () => {
+  it("uses the patched reload mode before deciding whether browser changes need SIGUSR1", async () => {
+    const response = await invokeConfigPatch({
+      gateway: {
+        reload: {
+          mode: "hybrid",
+        },
+      },
+      browser: {
+        profiles: {
+          sandbox: {
+            cdpUrl: "http://127.0.0.1:9222",
+            color: "#0066CC",
+          },
+        },
+      },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(writeRestartSentinelMock).not.toHaveBeenCalled();
+    expect(response.payload?.restart).toBeNull();
+    expect(response.payload?.sentinel).toBeNull();
+    expect(response.payload?.config).toMatchObject({
+      gateway: {
+        auth: { mode: "token", token: "test-token" },
+        reload: { mode: "hybrid" },
+      },
+      browser: {
+        profiles: {
+          sandbox: {
+            cdpUrl: "http://127.0.0.1:9222",
+            color: "#0066CC",
+          },
+        },
+      },
+    });
+  });
+
+  it("still schedules restart and sentinel for restart-required paths", async () => {
+    const response = await invokeConfigPatch({
+      gateway: {
+        port: 18888,
+      },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(writeRestartSentinelMock).toHaveBeenCalledTimes(1);
+    expect(response.payload?.restart).toEqual({ scheduled: true });
+    expect(response.payload?.sentinel).toMatchObject({
+      path: "/tmp/restart-sentinel.json",
+      payload: expect.objectContaining({
+        kind: "config-patch",
+        stats: expect.objectContaining({
+          mode: "config.patch",
+        }),
+      }),
+    });
+  });
+});

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -33,7 +33,7 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { loadOpenClawPlugins } from "../../plugins/loader.js";
-import { diffConfigPaths } from "../config-reload.js";
+import { diffConfigPaths, shouldConfigPatchTriggerGatewayRestart } from "../config-reload.js";
 import {
   formatControlPlaneActor,
   resolveControlPlaneActor,
@@ -425,34 +425,46 @@ export const configHandlers: GatewayRequestHandlers = {
     const changedPaths = diffConfigPaths(snapshot.config, validated.config);
     const actor = resolveControlPlaneActor(client);
     context?.logGateway?.info(
-      `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
+      `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)}`,
     );
     await writeConfigFile(validated.config, writeOptions);
 
-    const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
-      resolveConfigRestartRequest(params);
-    const payload = buildConfigRestartSentinelPayload({
-      kind: "config-patch",
-      mode: "config.patch",
-      sessionKey,
-      deliveryContext,
-      threadId,
-      note,
-    });
-    const sentinelPath = await tryWriteRestartSentinelPayload(payload);
-    const restart = scheduleGatewaySigusr1Restart({
-      delayMs: restartDelayMs,
-      reason: "config.patch",
-      audit: {
-        actor: actor.actor,
-        deviceId: actor.deviceId,
-        clientIp: actor.clientIp,
-        changedPaths,
-      },
-    });
-    if (restart.coalesced) {
-      context?.logGateway?.warn(
-        `config.patch restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
+    let restart: ReturnType<typeof scheduleGatewaySigusr1Restart> | null = null;
+    let sentinel: { path: string | null; payload: RestartSentinelPayload } | null = null;
+    if (shouldConfigPatchTriggerGatewayRestart(validated.config, changedPaths)) {
+      const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
+        resolveConfigRestartRequest(params);
+      const payload = buildConfigRestartSentinelPayload({
+        kind: "config-patch",
+        mode: "config.patch",
+        sessionKey,
+        deliveryContext,
+        threadId,
+        note,
+      });
+      const sentinelPath = await tryWriteRestartSentinelPayload(payload);
+      sentinel = {
+        path: sentinelPath,
+        payload,
+      };
+      restart = scheduleGatewaySigusr1Restart({
+        delayMs: restartDelayMs,
+        reason: "config.patch",
+        audit: {
+          actor: actor.actor,
+          deviceId: actor.deviceId,
+          clientIp: actor.clientIp,
+          changedPaths,
+        },
+      });
+      if (restart.coalesced) {
+        context?.logGateway?.warn(
+          `config.patch restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
+        );
+      }
+    } else {
+      context?.logGateway?.info(
+        `config.patch restart skipped ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)}`,
       );
     }
     respond(
@@ -462,10 +474,7 @@ export const configHandlers: GatewayRequestHandlers = {
         path: createConfigIO().configPath,
         config: redactConfigObject(validated.config, schemaPatch.uiHints),
         restart,
-        sentinel: {
-          path: sentinelPath,
-          payload,
-        },
+        sentinel,
       },
       undefined,
     );


### PR DESCRIPTION
## Summary

- Problem: `config.patch` always queued `scheduleGatewaySigusr1Restart()` after writing the config, even when the changed paths were already classified as hot-reloadable or no-op by the gateway reload planner.
- Why it matters: control-plane and agent-driven config edits unnecessarily bounced the gateway for changes that the file watcher can already apply in-process.
- What changed: `config.patch` now reuses the existing reload planner plus the patched `gateway.reload.mode` to decide whether a restart is actually needed; when it is not, the handler skips both restart-sentinel creation and SIGUSR1 scheduling.
- What did NOT change (scope boundary): `config.apply` is unchanged, and explicit `config.patch` calls still restart for restart-required paths (and when reload mode is `off` or `restart`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46310
- Related #45624

## User-visible / Behavior Changes

- `config.patch` no longer forces a gateway restart for hot-reloadable / no-op config changes when the patched reload mode allows in-process reloads.
- In that no-restart path, the response now returns `restart: null` and `sentinel: null`.
- Gateway tool/system prompt wording now reflects that `config.patch` hot-reloads when possible.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev machine)
- Runtime/container: Node v25.6.1, pnpm 10.23.0
- Model/provider: n/a
- Integration/channel (if any): gateway control-plane config RPC
- Relevant config (redacted): base config with `gateway.reload.mode="restart"`, patched to `"hybrid"` for the hot-reload regression case

### Steps

1. Start from a config where `gateway.reload.mode` is `restart`.
2. Call `config.patch` with a browser-profile change plus `gateway.reload.mode: "hybrid"`.
3. Observe whether the handler still writes a restart sentinel / queues SIGUSR1.

### Expected

- Hot-reloadable `config.patch` writes should persist and return without scheduling a restart.

### Actual

- Before this change, `config.patch` always queued restart+sentry work even for hot-reloadable changes.
- After this change, the hot-reload case skips both, while restart-required paths still schedule them.

## Evidence

- Added regression coverage in `src/gateway/config-reload.test.ts` and `src/gateway/server-methods/config.restart.test.ts`.
- Verified with:
  - `pnpm exec vitest run src/gateway/config-reload.test.ts src/gateway/server-methods/config.restart.test.ts src/agents/system-prompt.test.ts src/agents/openclaw-gateway-tool.test.ts`
  - `pnpm exec oxfmt --check src/agents/system-prompt.ts src/agents/tools/gateway-tool.ts src/gateway/config-reload.test.ts src/gateway/config-reload.ts src/gateway/server-methods/config.ts src/gateway/server-methods/config.restart.test.ts`
  - `pnpm tsgo`
  - `pnpm build`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - hot-reloadable browser patch skips restart/sentinel
  - restart-required gateway patch still schedules restart/sentinel
  - patched `gateway.reload.mode` is used for the restart decision
- Edge cases checked:
  - no-op path set returns no restart from the planner helper
  - `off` / `restart` modes still keep explicit `config.patch` restart behavior
- What you did **not** verify:
  - I did not run a live LaunchAgent/systemd gateway and reproduce the end-to-end restart bounce outside the test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR; the previous behavior was unconditional restart on every `config.patch` write.
- Files/config to restore:
  - `src/gateway/config-reload.ts`
  - `src/gateway/server-methods/config.ts`
- Known bad symptoms reviewers should watch for:
  - hot-reloadable `config.patch` changes unexpectedly returning `restart` again
  - restart-required patches skipping restart/sentinel when they should not

## Risks and Mitigations

- Risk: the restart/no-restart boundary could drift from the file watcher’s reload classification in the future.
  - Mitigation: the handler now reuses the existing reload planner instead of open-coding its own path rules, and the new tests cover both hot/no-op and restart-required cases.
