### PR TITLE
fix(bootstrap-cache): invalidate on mtime + fix(exec): skip resolveWorkdir for host=node (#46396, #46395)

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -357,6 +357,9 @@ export function createExecTool(
         });
         workdir = resolved.hostWorkdir;
         containerWorkdir = resolved.containerWorkdir;
+      } else if (host === "node") {
+        // host=node: workdir lives on the remote node — skip gateway-side validation
+        workdir = rawWorkdir;
       } else {
         workdir = resolveWorkdir(rawWorkdir, warnings);
       }

--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, statSync: vi.fn() };
+});
+
+import { statSync } from "node:fs";
 import {
   clearAllBootstrapSnapshots,
   clearBootstrapSnapshot,
@@ -13,6 +20,9 @@ vi.mock("./workspace.js", () => ({
 import { loadWorkspaceBootstrapFiles } from "./workspace.js";
 
 const mockLoad = vi.mocked(loadWorkspaceBootstrapFiles);
+const mockStatSync = vi.mocked(statSync);
+
+let mtimeCounter = 1;
 
 function makeFile(name: string, content: string): WorkspaceBootstrapFile {
   return {
@@ -23,12 +33,28 @@ function makeFile(name: string, content: string): WorkspaceBootstrapFile {
   };
 }
 
+/** Make statSync return a stable mtimeMs for every known file path. */
+function setupStatSync(files: WorkspaceBootstrapFile[]): void {
+  const mtimes = new Map<string, number>();
+  for (const f of files) {
+    mtimes.set(f.path, mtimeCounter++);
+  }
+  mockStatSync.mockImplementation((p: any) => {
+    const ms = mtimes.get(String(p));
+    if (ms === undefined) {
+      throw new Error(`ENOENT: ${p}`);
+    }
+    return { mtimeMs: ms } as any;
+  });
+}
+
 describe("getOrLoadBootstrapFiles", () => {
   const files = [makeFile("AGENTS.md", "# Agent"), makeFile("SOUL.md", "# Soul")];
 
   beforeEach(() => {
     clearAllBootstrapSnapshots();
     mockLoad.mockResolvedValue(files);
+    setupStatSync(files);
   });
 
   afterEach(() => {
@@ -65,12 +91,38 @@ describe("getOrLoadBootstrapFiles", () => {
     expect(r2).toBe(files2);
     expect(mockLoad).toHaveBeenCalledTimes(2);
   });
+
+  it("reloads when a file mtime changes (staleness check)", async () => {
+    await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+
+    // Simulate mtime change on AGENTS.md
+    mockStatSync.mockImplementation((p: any) => {
+      if (String(p) === "/ws/AGENTS.md") {
+        return { mtimeMs: Date.now() + 99999 } as any;
+      }
+      if (String(p) === "/ws/SOUL.md") {
+        return { mtimeMs: 0 } as any;
+      }
+      throw new Error(`ENOENT: ${p}`);
+    });
+
+    const updatedFiles = [makeFile("AGENTS.md", "# Agent v2"), makeFile("SOUL.md", "# Soul")];
+    mockLoad.mockResolvedValueOnce(updatedFiles);
+
+    const result = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    expect(result).toBe(updatedFiles);
+    expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("clearBootstrapSnapshot", () => {
+  const clearFiles = [makeFile("AGENTS.md", "content")];
+
   beforeEach(() => {
     clearAllBootstrapSnapshots();
-    mockLoad.mockResolvedValue([makeFile("AGENTS.md", "content")]);
+    mockLoad.mockResolvedValue(clearFiles);
+    setupStatSync(clearFiles);
   });
 
   afterEach(() => {

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -1,18 +1,49 @@
+import { statSync } from "node:fs";
 import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./workspace.js";
 
-const cache = new Map<string, WorkspaceBootstrapFile[]>();
+interface CachedSnapshot {
+  files: WorkspaceBootstrapFile[];
+  mtimes: Map<string, number>; // path → mtimeMs
+}
+
+function isStale(snap: CachedSnapshot): boolean {
+  for (const [filePath, cachedMtime] of snap.mtimes) {
+    try {
+      if (statSync(filePath).mtimeMs !== cachedMtime) {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
+function collectMtimes(files: WorkspaceBootstrapFile[]): Map<string, number> {
+  const mtimes = new Map<string, number>();
+  for (const file of files) {
+    try {
+      mtimes.set(file.path, statSync(file.path).mtimeMs);
+    } catch {
+      // File may have been removed; skip it
+    }
+  }
+  return mtimes;
+}
+
+const cache = new Map<string, CachedSnapshot>();
 
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
 }): Promise<WorkspaceBootstrapFile[]> {
   const existing = cache.get(params.sessionKey);
-  if (existing) {
-    return existing;
+  if (existing && !isStale(existing)) {
+    return existing.files;
   }
 
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  cache.set(params.sessionKey, files);
+  cache.set(params.sessionKey, { files, mtimes: collectMtimes(files) });
   return files;
 }
 


### PR DESCRIPTION
Combines fixes from upstream PRs:
- #46396: fix(bootstrap-cache): invalidate cache when file mtime changes (Closes #28594)
- #46395: fix(exec): skip resolveWorkdir for host=node to avoid gateway-side validation (Fixes #44508)

Merged from openclaw/openclaw PRs.