### PR TITLE
docs: add AI-assisted PR guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@
 ## AI-Assisted PRs
 
 - Follow `CONTRIBUTING.md` for the current AI-assisted PR expectations.
-- If AI materially helped write the PR, mark it as AI-assisted in the PR title or description.
+- Mark the PR as AI-assisted in the PR title or description.
 - In the PR description, state the testing level truthfully (`untested`, `lightly tested`, or `fully tested`).
 - Confirm you understand the code you are submitting; do not present generated code as reviewed if you have not validated it.
 - Include prompts or session logs when practical.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,16 @@
 - PR submission template (canonical): `.github/pull_request_template.md`
 - Issue submission templates (canonical): `.github/ISSUE_TEMPLATE/`
 
+## AI-Assisted PRs
+
+- Follow `CONTRIBUTING.md` for the current AI-assisted PR expectations.
+- If AI materially helped write the PR, mark it as AI-assisted in the PR title or description.
+- In the PR description, state the testing level truthfully (`untested`, `lightly tested`, or `fully tested`).
+- Confirm you understand the code you are submitting; do not present generated code as reviewed if you have not validated it.
+- Include prompts or session logs when practical.
+- If Codex is available, run `codex review --base origin/main` before opening or updating the PR and address the findings.
+- Resolve or reply to bot review conversations you addressed before asking for review again.
+
 ## Shorthand Commands
 
 - `sync`: if working tree is dirty, commit all changes (pick a sensible Conventional Commit message), then `git pull --rebase`; if rebase conflicts and cannot resolve, stop; otherwise `git push`.


### PR DESCRIPTION
## Summary
- add an AI-assisted PR section to `AGENTS.md`
- point agents to `CONTRIBUTING.md` for the canonical policy
- mirror the required disclosure and review-follow-up items in a short operational form

## Testing
- untested (docs-only)

## AI
- AI-assisted
- local `codex review --base origin/main` completed with no actionable issues found
