### PR TITLE
fix(feishu): add WebSocket heartbeat config to prevent silent disconnection

### DIFF
--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -164,6 +164,10 @@ export function createFeishuWSClient(account: ResolvedFeishuAccount): Lark.WSCli
     domain: resolveDomain(domain),
     loggerLevel: Lark.LoggerLevel.info,
     ...(agent ? { agent } : {}),
+    wsConfig: {
+      PingInterval: 30,
+      PingTimeout: 5,
+    },
   });
 }
 


### PR DESCRIPTION
## Problem

The Feishu WebSocket connection silently drops after extended idle periods. The connection object remains alive but stops receiving messages, causing the bot to miss all incoming messages until a gateway restart.

This is because `createFeishuWSClient()` does not pass `wsConfig` to `Lark.WSClient`, so no WebSocket-level keep-alive pings are sent.

## Fix

Add `wsConfig: { PingInterval: 30, PingTimeout: 5 }` to the `Lark.WSClient` constructor in `extensions/feishu/src/client.ts`.

- **PingInterval: 30** — send a ping every 30 seconds
- **PingTimeout: 5** — consider the connection dead if no pong within 5 seconds

## Testing

- Applied this patch locally on OpenClaw 3.13
- Monitored for 2+ hours with no silent disconnection (previously occurred within ~30 min of idle)
- Verified via `gateway.log` that Feishu messages continue to be received after idle periods

Ref: larksuiteoapi/node-sdk#42354