### PR TITLE
fix(health): use runtime snapshot for channel summaries

### DIFF
--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { telegramPlugin } from "../../extensions/telegram/src/channel.js";
+import type { ChannelRuntimeSnapshot } from "../gateway/server-channels.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import type { HealthSummary } from "./health.js";
@@ -221,6 +222,71 @@ describe("getHealthSnapshot", () => {
     expect(telegram.configured).toBe(true);
     expect(telegram.probe?.ok).toBe(false);
     expect(telegram.probe?.error).toMatch(/network down/i);
+  });
+
+  it("includes live runtime fields in telegram health summaries when provided", async () => {
+    testConfig = { channels: { telegram: { botToken: "t-live" } } };
+    testStore = {};
+    vi.stubEnv("DISCORD_BOT_TOKEN", "");
+
+    const startedAt = 1773508368414;
+    const runtimeSnapshot: ChannelRuntimeSnapshot = {
+      channels: {
+        telegram: {
+          accountId: "default",
+          running: true,
+          lastStartAt: startedAt,
+          lastStopAt: null,
+          lastError: null,
+          mode: "polling",
+          lastInboundAt: startedAt + 123,
+        },
+      },
+      channelAccounts: {
+        telegram: {
+          default: {
+            accountId: "default",
+            running: true,
+            lastStartAt: startedAt,
+            lastStopAt: null,
+            lastError: null,
+            mode: "polling",
+            lastInboundAt: startedAt + 123,
+          },
+        },
+      },
+    };
+
+    const snap = await getHealthSnapshot({
+      timeoutMs: 25,
+      probe: false,
+      runtimeSnapshot,
+    });
+    const telegram = snap.channels.telegram as {
+      configured?: boolean;
+      running?: boolean;
+      lastStartAt?: number | null;
+      mode?: string | null;
+      tokenSource?: string | null;
+      accounts?: Record<
+        string,
+        {
+          running?: boolean;
+          lastStartAt?: number | null;
+          mode?: string | null;
+          tokenSource?: string | null;
+        }
+      >;
+    };
+    expect(telegram.configured).toBe(true);
+    expect(telegram.running).toBe(true);
+    expect(telegram.lastStartAt).toBe(startedAt);
+    expect(telegram.mode).toBe("polling");
+    expect(telegram.tokenSource).toBe("config");
+    expect(telegram.accounts?.default?.running).toBe(true);
+    expect(telegram.accounts?.default?.lastStartAt).toBe(startedAt);
+    expect(telegram.accounts?.default?.mode).toBe("polling");
+    expect(telegram.accounts?.default?.tokenSource).toBe("config");
   });
 
   it("disables heartbeat for agents without heartbeat blocks", async () => {

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { telegramPlugin } from "../../extensions/telegram/src/channel.js";
+import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type { ChannelRuntimeSnapshot } from "../gateway/server-channels.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
@@ -287,6 +288,63 @@ describe("getHealthSnapshot", () => {
     expect(telegram.accounts?.default?.lastStartAt).toBe(startedAt);
     expect(telegram.accounts?.default?.mode).toBe("polling");
     expect(telegram.accounts?.default?.tokenSource).toBe("config");
+  });
+
+  it("preserves probe results when plugin snapshot builders omit probe fields", async () => {
+    const probeOnlyPlugin: ChannelPlugin<{ accountId: string; enabled: boolean }> = {
+      id: "zalo",
+      meta: {
+        id: "zalo",
+        label: "Zalo",
+        selectionLabel: "Zalo",
+        docsPath: "/channels/zalo",
+        blurb: "test stub.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ accountId: "default", enabled: true }),
+        defaultAccountId: () => "default",
+        isConfigured: () => true,
+      },
+      status: {
+        probeAccount: async () => ({
+          ok: false,
+          status: 401,
+          error: "unauthorized",
+        }),
+        buildAccountSnapshot: async ({ account, runtime }) => ({
+          accountId: account.accountId,
+          enabled: account.enabled,
+          configured: true,
+          running: runtime?.running ?? false,
+        }),
+      },
+    };
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "zalo", plugin: probeOnlyPlugin, source: "test" }]),
+    );
+    testConfig = { channels: { zalo: { botToken: "z-1" } } };
+    testStore = {};
+    vi.stubEnv("DISCORD_BOT_TOKEN", "");
+
+    const snap = await getHealthSnapshot({ timeoutMs: 25 });
+    const zalo = snap.channels.zalo as {
+      probe?: { ok?: boolean; status?: number; error?: string };
+      accounts?: Record<string, { probe?: { ok?: boolean; status?: number; error?: string } }>;
+    };
+
+    expect(zalo.probe).toMatchObject({
+      ok: false,
+      status: 401,
+      error: "unauthorized",
+    });
+    expect(zalo.accounts?.default?.probe).toMatchObject({
+      ok: false,
+      status: 401,
+      error: "unauthorized",
+    });
   });
 
   it("disables heartbeat for agents without heartbeat blocks", async () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -483,6 +483,9 @@ export async function getHealthSnapshot(params?: {
       if (snapshot.configured === undefined) {
         snapshot.configured = configured;
       }
+      if (snapshot.probe === undefined && probe !== undefined) {
+        snapshot.probe = probe;
+      }
       if (lastProbeAt) {
         snapshot.lastProbeAt = lastProbeAt;
       }

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -1,12 +1,14 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
+import { buildChannelAccountSnapshot } from "../channels/plugins/status.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.js";
 import { withProgress } from "../cli/progress.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig, readBestEffortConfig } from "../config/config.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import type { ChannelRuntimeSnapshot } from "../gateway/server-channels.js";
 import { info } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -348,6 +350,7 @@ export const formatHealthChannelLines = (
 export async function getHealthSnapshot(params?: {
   timeoutMs?: number;
   probe?: boolean;
+  runtimeSnapshot?: ChannelRuntimeSnapshot;
 }): Promise<HealthSummary> {
   const timeoutMs = params?.timeoutMs;
   const cfg = loadConfig();
@@ -380,6 +383,22 @@ export async function getHealthSnapshot(params?: {
   const channels: Record<string, ChannelHealthSummary> = {};
   const channelOrder = listChannelPlugins().map((plugin) => plugin.id);
   const channelLabels: Record<string, string> = {};
+  const resolveRuntimeSnapshot = (
+    channelId: string,
+    accountId: string,
+    defaultAccountId: string,
+  ): ChannelAccountSnapshot | undefined => {
+    const runtime = params?.runtimeSnapshot;
+    if (!runtime) {
+      return undefined;
+    }
+    const channelAccounts = runtime.channelAccounts[channelId as keyof typeof runtime.channelAccounts];
+    const defaultRuntime = runtime.channels[channelId as keyof typeof runtime.channels];
+    return (
+      channelAccounts?.[accountId] ??
+      (accountId === defaultAccountId ? defaultRuntime : undefined)
+    );
+  };
 
   for (const plugin of listChannelPlugins()) {
     channelLabels[plugin.id] = plugin.meta.label ?? plugin.id;
@@ -450,13 +469,19 @@ export async function getHealthSnapshot(params?: {
         debugHealth("probe.bot", { channel: plugin.id, accountId, username: bot.username });
       }
 
-      const snapshot: ChannelAccountSnapshot = {
+      const runtimeSnapshot = resolveRuntimeSnapshot(plugin.id, accountId, defaultAccountId);
+      const snapshot = await buildChannelAccountSnapshot({
+        plugin,
+        cfg,
         accountId,
-        enabled,
-        configured,
-      };
-      if (probe !== undefined) {
-        snapshot.probe = probe;
+        runtime: runtimeSnapshot,
+        probe,
+      });
+      if (snapshot.enabled === undefined) {
+        snapshot.enabled = enabled;
+      }
+      if (snapshot.configured === undefined) {
+        snapshot.configured = configured;
       }
       if (lastProbeAt) {
         snapshot.lastProbeAt = lastProbeAt;

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -392,11 +392,11 @@ export async function getHealthSnapshot(params?: {
     if (!runtime) {
       return undefined;
     }
-    const channelAccounts = runtime.channelAccounts[channelId as keyof typeof runtime.channelAccounts];
+    const channelAccounts =
+      runtime.channelAccounts[channelId as keyof typeof runtime.channelAccounts];
     const defaultRuntime = runtime.channels[channelId as keyof typeof runtime.channels];
     return (
-      channelAccounts?.[accountId] ??
-      (accountId === defaultAccountId ? defaultRuntime : undefined)
+      channelAccounts?.[accountId] ?? (accountId === defaultAccountId ? defaultRuntime : undefined)
     );
   };
 

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -1,6 +1,7 @@
 import { getStatusSummary } from "../../commands/status.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
+import { isGatewayHealthCacheStale } from "../server/health-state.js";
 import { formatError } from "../server-utils.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -13,7 +14,12 @@ export const healthHandlers: GatewayRequestHandlers = {
     const wantsProbe = params?.probe === true;
     const now = Date.now();
     const cached = getHealthCache();
-    if (!wantsProbe && cached && now - cached.ts < HEALTH_REFRESH_INTERVAL_MS) {
+    if (
+      !wantsProbe &&
+      cached &&
+      !isGatewayHealthCacheStale(cached) &&
+      now - cached.ts < HEALTH_REFRESH_INTERVAL_MS
+    ) {
       respond(true, cached, undefined, { cached: true });
       void refreshHealthSnapshot({ probe: false }).catch((err) =>
         logHealth.error(`background health refresh failed: ${formatError(err)}`),

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -1,8 +1,8 @@
 import { getStatusSummary } from "../../commands/status.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
-import { isGatewayHealthCacheStale } from "../server/health-state.js";
 import { formatError } from "../server-utils.js";
+import { isGatewayHealthCacheStale } from "../server/health-state.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers } from "./types.js";
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -106,6 +106,7 @@ import {
   getPresenceVersion,
   incrementPresenceVersion,
   refreshGatewayHealthSnapshot,
+  setHealthRuntimeSnapshotProvider,
 } from "./server/health-state.js";
 import { resolveHookClientIpConfig } from "./server/hooks.js";
 import { createReadinessChecker } from "./server/readiness.js";
@@ -657,6 +658,7 @@ export async function startGatewayServer(
 
   const { getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } =
     channelManager;
+  setHealthRuntimeSnapshotProvider(getRuntimeSnapshot);
 
   if (!minimalTestGateway) {
     const machineDisplayName = await getMachineDisplayName();
@@ -1064,6 +1066,7 @@ export async function startGatewayServer(
       browserAuthRateLimiter.dispose();
       channelHealthMonitor?.stop();
       clearSecretsRuntimeSnapshot();
+      setHealthRuntimeSnapshotProvider(null);
       await close(opts);
     },
   };

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelRuntimeSnapshot } from "../server-channels.js";
+
+const getHealthSnapshotMock = vi.fn();
+
+vi.mock("../../commands/health.js", () => ({
+  getHealthSnapshot: (...args: unknown[]) => getHealthSnapshotMock(...args),
+}));
+
+describe("refreshGatewayHealthSnapshot", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getHealthSnapshotMock.mockReset();
+    getHealthSnapshotMock.mockResolvedValue({
+      ok: true,
+      ts: Date.now(),
+      durationMs: 1,
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+      heartbeatSeconds: 0,
+      defaultAgentId: "main",
+      agents: [],
+      sessions: {
+        path: "/tmp/sessions.json",
+        count: 0,
+        recent: [],
+      },
+    });
+  });
+
+  it("passes the live runtime snapshot into health snapshot refreshes", async () => {
+    const mod = await import("./health-state.js");
+    const runtimeSnapshot: ChannelRuntimeSnapshot = {
+      channels: {
+        telegram: {
+          accountId: "default",
+          running: true,
+          lastStartAt: 123,
+        },
+      },
+      channelAccounts: {
+        telegram: {
+          default: {
+            accountId: "default",
+            running: true,
+            lastStartAt: 123,
+          },
+        },
+      },
+    };
+
+    mod.setHealthRuntimeSnapshotProvider(() => runtimeSnapshot);
+    await mod.refreshGatewayHealthSnapshot({ probe: false });
+
+    expect(getHealthSnapshotMock).toHaveBeenCalledWith({
+      probe: false,
+      runtimeSnapshot,
+    });
+    mod.setHealthRuntimeSnapshotProvider(null);
+  });
+});

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelRuntimeSnapshot } from "../server-channels.js";
 
 const getHealthSnapshotMock = vi.fn();
@@ -29,6 +29,11 @@ describe("refreshGatewayHealthSnapshot", () => {
     });
   });
 
+  afterEach(async () => {
+    const mod = await import("./health-state.js");
+    mod.setHealthRuntimeSnapshotProvider(null);
+  });
+
   it("passes the live runtime snapshot into health snapshot refreshes", async () => {
     const mod = await import("./health-state.js");
     const runtimeSnapshot: ChannelRuntimeSnapshot = {
@@ -57,6 +62,5 @@ describe("refreshGatewayHealthSnapshot", () => {
       probe: false,
       runtimeSnapshot,
     });
-    mod.setHealthRuntimeSnapshotProvider(null);
   });
 });

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -113,4 +113,53 @@ describe("refreshGatewayHealthSnapshot", () => {
       }),
     ).toBe(true);
   });
+
+  it("does not perpetually invalidate when cached summary omits lastStartAt", async () => {
+    const mod = await import("./health-state.js");
+    const runtimeSnapshot: ChannelRuntimeSnapshot = {
+      channels: {
+        whatsapp: {
+          accountId: "default",
+          running: true,
+          lastStartAt: 789,
+        },
+      },
+      channelAccounts: {
+        whatsapp: {
+          default: {
+            accountId: "default",
+            running: true,
+            lastStartAt: 789,
+          },
+        },
+      },
+    };
+
+    mod.setHealthRuntimeSnapshotProvider(() => runtimeSnapshot);
+
+    expect(
+      mod.isGatewayHealthCacheStale({
+        ok: true,
+        ts: Date.now(),
+        durationMs: 1,
+        channels: {
+          whatsapp: {
+            accountId: "default",
+            configured: true,
+            running: true,
+          },
+        },
+        channelOrder: ["whatsapp"],
+        channelLabels: { whatsapp: "WhatsApp" },
+        heartbeatSeconds: 0,
+        defaultAgentId: "main",
+        agents: [],
+        sessions: {
+          path: "/tmp/sessions.json",
+          count: 0,
+          recent: [],
+        },
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -63,4 +63,54 @@ describe("refreshGatewayHealthSnapshot", () => {
       runtimeSnapshot,
     });
   });
+
+  it("treats cached health as stale when runtime is newer", async () => {
+    const mod = await import("./health-state.js");
+    const runtimeSnapshot: ChannelRuntimeSnapshot = {
+      channels: {
+        telegram: {
+          accountId: "default",
+          running: true,
+          lastStartAt: 456,
+        },
+      },
+      channelAccounts: {
+        telegram: {
+          default: {
+            accountId: "default",
+            running: true,
+            lastStartAt: 456,
+          },
+        },
+      },
+    };
+
+    mod.setHealthRuntimeSnapshotProvider(() => runtimeSnapshot);
+
+    expect(
+      mod.isGatewayHealthCacheStale({
+        ok: true,
+        ts: Date.now(),
+        durationMs: 1,
+        channels: {
+          telegram: {
+            accountId: "default",
+            configured: true,
+            running: false,
+            lastStartAt: null,
+          },
+        },
+        channelOrder: ["telegram"],
+        channelLabels: { telegram: "Telegram" },
+        heartbeatSeconds: 0,
+        defaultAgentId: "main",
+        agents: [],
+        sessions: {
+          path: "/tmp/sessions.json",
+          count: 0,
+          recent: [],
+        },
+      }),
+    ).toBe(true);
+  });
 });

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -7,12 +7,14 @@ import { getUpdateAvailable } from "../../infra/update-startup.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolveGatewayAuth } from "../auth.js";
 import type { Snapshot } from "../protocol/index.js";
+import type { ChannelRuntimeSnapshot } from "../server-channels.js";
 
 let presenceVersion = 1;
 let healthVersion = 1;
 let healthCache: HealthSummary | null = null;
 let healthRefresh: Promise<HealthSummary> | null = null;
 let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
+let healthRuntimeSnapshotProvider: (() => ChannelRuntimeSnapshot) | null = null;
 
 export function buildGatewaySnapshot(): Snapshot {
   const cfg = loadConfig();
@@ -67,10 +69,20 @@ export function setBroadcastHealthUpdate(fn: ((snap: HealthSummary) => void) | n
   broadcastHealthUpdate = fn;
 }
 
+export function setHealthRuntimeSnapshotProvider(
+  fn: (() => ChannelRuntimeSnapshot) | null,
+) {
+  healthRuntimeSnapshotProvider = fn;
+}
+
 export async function refreshGatewayHealthSnapshot(opts?: { probe?: boolean }) {
   if (!healthRefresh) {
     healthRefresh = (async () => {
-      const snap = await getHealthSnapshot({ probe: opts?.probe });
+      const runtimeSnapshot = healthRuntimeSnapshotProvider?.();
+      const snap = await getHealthSnapshot({
+        probe: opts?.probe,
+        runtimeSnapshot,
+      });
       healthCache = snap;
       healthVersion += 1;
       if (broadcastHealthUpdate) {

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -34,11 +34,16 @@ function hasNewerRuntimeState(cache: HealthSummary): boolean {
     if (runtimeRunning && !cachedRunning) {
       return true;
     }
-    const runtimeLastStartAt =
-      typeof runtime.lastStartAt === "number" ? runtime.lastStartAt : null;
-    const cachedLastStartAt =
-      typeof cached.lastStartAt === "number" ? cached.lastStartAt : null;
-    if (runtimeLastStartAt !== cachedLastStartAt) {
+    const runtimeLastStartAt = typeof runtime.lastStartAt === "number" ? runtime.lastStartAt : null;
+    const cachedLastStartAt = typeof cached.lastStartAt === "number" ? cached.lastStartAt : null;
+    // Only compare lastStartAt when the cached summary actually carries it.
+    // Channels like WhatsApp omit lastStartAt, so cached is always null while
+    // runtime always has a number, which would force a rebuild every time.
+    if (
+      runtimeLastStartAt !== null &&
+      cachedLastStartAt !== null &&
+      runtimeLastStartAt !== cachedLastStartAt
+    ) {
       return true;
     }
   }
@@ -105,9 +110,7 @@ export function setBroadcastHealthUpdate(fn: ((snap: HealthSummary) => void) | n
   broadcastHealthUpdate = fn;
 }
 
-export function setHealthRuntimeSnapshotProvider(
-  fn: (() => ChannelRuntimeSnapshot) | null,
-) {
+export function setHealthRuntimeSnapshotProvider(fn: (() => ChannelRuntimeSnapshot) | null) {
   healthRuntimeSnapshotProvider = fn;
 }
 

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -16,6 +16,35 @@ let healthRefresh: Promise<HealthSummary> | null = null;
 let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
 let healthRuntimeSnapshotProvider: (() => ChannelRuntimeSnapshot) | null = null;
 
+function hasNewerRuntimeState(cache: HealthSummary): boolean {
+  const runtimeSnapshot = healthRuntimeSnapshotProvider?.();
+  if (!runtimeSnapshot) {
+    return false;
+  }
+  for (const [channelId, runtime] of Object.entries(runtimeSnapshot.channels)) {
+    if (!runtime) {
+      continue;
+    }
+    const cached = cache.channels?.[channelId];
+    if (!cached) {
+      return true;
+    }
+    const runtimeRunning = runtime.running === true;
+    const cachedRunning = cached.running === true;
+    if (runtimeRunning && !cachedRunning) {
+      return true;
+    }
+    const runtimeLastStartAt =
+      typeof runtime.lastStartAt === "number" ? runtime.lastStartAt : null;
+    const cachedLastStartAt =
+      typeof cached.lastStartAt === "number" ? cached.lastStartAt : null;
+    if (runtimeLastStartAt !== cachedLastStartAt) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function buildGatewaySnapshot(): Snapshot {
   const cfg = loadConfig();
   const configPath = createConfigIO().configPath;
@@ -54,6 +83,13 @@ export function getHealthCache(): HealthSummary | null {
 
 export function getHealthVersion(): number {
   return healthVersion;
+}
+
+export function isGatewayHealthCacheStale(cache: HealthSummary | null): boolean {
+  if (!cache) {
+    return true;
+  }
+  return hasNewerRuntimeState(cache);
 }
 
 export function incrementPresenceVersion(): number {


### PR DESCRIPTION
## Summary

- Problem: `openclaw health --json` rebuilt channel summaries from config plus probe, but did not feed in the live gateway channel runtime snapshot.
- Why it matters: Telegram could show `running: false`, `lastStartAt: null`, and `tokenSource: "none"` in `health` while `channels status` and live traffic showed the same account running normally.
- What changed: thread the live runtime snapshot into health refreshes, build per-account health snapshots through the normal channel snapshot builder, invalidate cached health snapshots when the runtime state is newer than the cached summary, and guard the staleness check so channels that omit `lastStartAt` (WhatsApp, Zalo) do not cause perpetual cache invalidation.
- What did NOT change (scope boundary): no channel runtime logic, probe behavior, or `channels.status` output path was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46494
- Related #31307

## User-visible / Behavior Changes

`openclaw health --json` now reflects live channel runtime fields when the gateway has them, instead of falling back to config/probe-only summaries for channels like Telegram.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.1
- Runtime/container: local gateway, npm global `openclaw@2026.3.13` for before-state; patched checkout on this branch for after-state
- Model/provider: not model-specific
- Integration/channel (if any): Telegram
- Relevant config (redacted): `~/.openclaw/openclaw.json5` with `channels.telegram.botToken`

### Steps

1. Configure Telegram and start the local gateway.
2. Confirm Telegram traffic is working.
3. Compare `openclaw health --json` with `openclaw channels status --json`.

### Expected

- `health` should agree with the live runtime state for fields like `running`, `lastStartAt`, `mode`, and `tokenSource`.

### Actual

- `health` reported Telegram as stopped / `tokenSource: "none"` while `channels status` reported the same account running from config.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [x] Perf numbers (if relevant)

### Screenshot: before

![Before repro: installed build health mismatch](https://raw.githubusercontent.com/0xble/openclaw/pr-assets-46527/pr-assets/46527/before.png)

### Screenshot: after

![After repro: patched branch health matches runtime](https://raw.githubusercontent.com/0xble/openclaw/pr-assets-46527/pr-assets/46527/after.png)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the mismatch on the installed `2026.3.13` build, traced the issue into `getHealthSnapshot`, confirmed the health cache could return a summary older than the live Telegram runtime, added regression tests for stale runtime-backed cache invalidation and for channels that omit `lastStartAt`, ran the targeted tests plus `pnpm build`, and captured a real before/after shell repro showing the mismatch on the installed build and agreement on this patched branch running from a proper git worktree.
- Edge cases checked: health refresh still works without a runtime provider; runtime provider is cleared on gateway shutdown; cached health snapshots are bypassed when runtime `running` or `lastStartAt` is newer than the cache; channels that omit `lastStartAt` (WhatsApp, Zalo) no longer cause perpetual cache invalidation.
- What you did **not** verify: I did not run a full multi-channel regression beyond Telegram for this cache invalidation path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `49415a3`, `710e3f1`, `8dff28d`, and `f30ce95`
- Files/config to restore: `src/gateway/server-methods/health.ts`, `src/gateway/server/health-state.ts`, `src/gateway/server/health-state.test.ts`, `src/commands/health.ts`
- Known bad symptoms reviewers should watch for: `health` stops reflecting live channel runtime fields after channels connect, or gateway shutdown leaves a stale health runtime provider behind

## Risks and Mitigations

- Risk: health summaries now depend on the gateway runtime snapshot being available during refresh.
  - Mitigation: the new code keeps the old behavior when no runtime snapshot provider exists, and only bypasses cached health when runtime state is clearly newer than the cache.

AI-assisted: yes.
