### PR TITLE
fix(acp): resolve ensured identities when session ids exist

### DIFF
--- a/src/acp/runtime/session-identity.test.ts
+++ b/src/acp/runtime/session-identity.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { createIdentityFromEnsure } from "./session-identity.js";
+
+describe("createIdentityFromEnsure", () => {
+  it("marks ensured sessions resolved when stable session ids already exist", () => {
+    const identity = createIdentityFromEnsure({
+      handle: {
+        sessionKey: "agent:codex:acp:session-1",
+        backend: "acpx",
+        runtimeSessionName: "runtime-1",
+        backendSessionId: "acpx-1",
+        agentSessionId: "codex-inner-1",
+      },
+      now: 123,
+    });
+
+    expect(identity).toEqual({
+      state: "resolved",
+      source: "ensure",
+      acpxSessionId: "acpx-1",
+      agentSessionId: "codex-inner-1",
+      lastUpdatedAt: 123,
+    });
+  });
+
+  it("keeps record-only ensure identities pending", () => {
+    const identity = createIdentityFromEnsure({
+      handle: {
+        sessionKey: "agent:codex:acp:session-2",
+        backend: "acpx",
+        runtimeSessionName: "runtime-2",
+        acpxRecordId: "rec-1",
+      } as {
+        sessionKey: string;
+        backend: string;
+        runtimeSessionName: string;
+        acpxRecordId: string;
+      },
+      now: 456,
+    });
+
+    expect(identity).toEqual({
+      state: "pending",
+      source: "ensure",
+      acpxRecordId: "rec-1",
+      lastUpdatedAt: 456,
+    });
+  });
+});

--- a/src/acp/runtime/session-identity.ts
+++ b/src/acp/runtime/session-identity.ts
@@ -156,8 +156,9 @@ export function createIdentityFromEnsure(params: {
   if (!acpxRecordId && !acpxSessionId && !agentSessionId) {
     return undefined;
   }
+  const resolved = Boolean(acpxSessionId || agentSessionId);
   return {
-    state: "pending",
+    state: resolved ? "resolved" : "pending",
     ...(acpxRecordId ? { acpxRecordId } : {}),
     ...(acpxSessionId ? { acpxSessionId } : {}),
     ...(agentSessionId ? { agentSessionId } : {}),

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -249,7 +249,7 @@ describe("spawnAcpDirect", () => {
           runtimeSessionName,
           ...(cwd ? { runtimeOptions: { cwd }, cwd } : {}),
           identity: {
-            state: "pending",
+            state: "resolved",
             source: "ensure",
             acpxSessionId: "acpx-1",
             agentSessionId: "codex-inner-1",


### PR DESCRIPTION
## Summary

- Problem: ACP sessions created from `ensureSession()` can already have stable `backendSessionId` / `agentSessionId`, but `createIdentityFromEnsure()` still marks them as `pending`.
- Why it matters: those sessions are reprocessed by startup identity reconciliation even though they are already bound, which amplifies stale ACP metadata and lines up with reports like #35028 (`sessions_history` empty, reconcile failures, `transcriptPath` null).
- What changed: ensured ACP identities now become `resolved` as soon as a stable session id is present; added focused tests for `createIdentityFromEnsure()` and updated the direct ACP spawn fixture to match the intended state.
- What did NOT change (scope boundary): this PR does not add any migration/self-heal for historical `pending` metadata and does not change transcript persistence or UI history rendering.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35028
- Related #32523

## User-visible / Behavior Changes

- Fresh ACP sessions that already return stable session ids from `ensureSession()` will no longer stay in a misleading `pending` identity state.
- Startup reconciliation will skip those already-bound sessions instead of retrying them as unresolved.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 / Darwin 25.3.0 arm64
- Runtime/container: local Node.js runtime
- Model/provider: Codex via ACP/acpx
- Integration/channel (if any): ACP/acpx (`sessions_spawn(runtime="acp")`)
- Relevant config (redacted): ACP backend `acpx`, Codex agent enabled

### Steps

1. Start an ACP session where `ensureSession()` already returns `backendSessionId` and `agentSessionId`.
2. Inspect the stored ACP identity right after ensure / first spawn metadata write.
3. Restart the gateway and run startup identity reconciliation.

### Expected

- If stable session ids are already present, the ensured ACP identity should be `resolved` immediately.
- Startup reconcile should not try to re-resolve already-bound sessions.

### Actual

- The ensured ACP identity was marked `pending` even with stable session ids present.
- Startup reconcile retried those sessions and produced noisy reconcile failures.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced the mismatch locally in a live OpenClaw install: ensured ACP sessions had `acpxSessionId` / `agentSessionId` but remained `pending`.
  - Confirmed startup reconcile noise dropped after applying the same logic locally.
  - Ran focused tests: `pnpm exec vitest run --config vitest.unit.config.ts src/acp/runtime/session-identity.test.ts src/acp/control-plane/manager.test.ts`
- Edge cases checked:
  - Record-only ensure identities remain `pending`.
  - Resolved sessions are still skipped by startup reconcile.
- What you did **not** verify:
  - I did not add or verify a migration for historical persisted ACP metadata.
  - I did not run the full `pnpm build && pnpm check && pnpm test` suite yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `src/acp/runtime/session-identity.ts`, related tests
- Known bad symptoms reviewers should watch for: ensured ACP sessions unexpectedly showing resolved ids too early in any workflow that intentionally relies on pending placeholder state

## Risks and Mitigations

- Risk: Some flows may have implicitly relied on `source: "ensure"` identities staying `pending` until first status poll.
  - Mitigation: the change only resolves when stable session ids already exist, matching existing `createIdentityFromStatus()` semantics and preserving record-only ensure states as `pending`.

---
AI-assisted: yes (local diagnosis, patching, and validation were performed with AI assistance). Lightly tested locally with focused unit tests plus live reproduction/verification on a local OpenClaw install.
