### PR TITLE
fix(gateway): handle opaque origins for custom URL schemes in allowedOrigins

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -88,6 +88,33 @@ describe("checkBrowserOrigin", () => {
       },
       expected: { ok: false as const, reason: "origin not allowed" },
     },
+    {
+      name: "accepts tauri:// custom scheme in allowedOrigins",
+      input: {
+        requestHost: "gateway.local:18789",
+        origin: "tauri://localhost",
+        allowedOrigins: ["tauri://localhost"],
+      },
+      expected: { ok: true as const, matchedBy: "allowlist" as const },
+    },
+    {
+      name: "accepts electron:// custom scheme in allowedOrigins",
+      input: {
+        requestHost: "gateway.local:18789",
+        origin: "electron://app",
+        allowedOrigins: ["electron://app"],
+      },
+      expected: { ok: true as const, matchedBy: "allowlist" as const },
+    },
+    {
+      name: "rejects custom scheme not in allowedOrigins",
+      input: {
+        requestHost: "gateway.local:18789",
+        origin: "tauri://localhost",
+        allowedOrigins: ["https://example.com"],
+      },
+      expected: { ok: false as const, reason: "origin not allowed" },
+    },
   ])("$name", ({ input, expected }) => {
     expect(checkBrowserOrigin(input)).toEqual(expected);
   });

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -16,8 +16,12 @@ function parseOrigin(
   }
   try {
     const url = new URL(trimmed);
+    // Non-standard schemes (tauri://, electron://) produce an opaque "null"
+    // origin per the URL spec. Reconstruct from protocol + host so the
+    // allowlist comparison works.
+    const derived = url.origin === "null" ? `${url.protocol}//${url.host}` : url.origin;
     return {
-      origin: url.origin.toLowerCase(),
+      origin: derived.toLowerCase(),
       host: url.host.toLowerCase(),
       hostname: url.hostname.toLowerCase(),
     };


### PR DESCRIPTION
## Summary

Reconstruct origin from `protocol + host` when `URL.origin` returns `"null"` (opaque origin per WHATWG spec), so custom URL schemes like `tauri://` and `electron://` work in `gateway.controlUi.allowedOrigins`.

## Why this matters

`new URL("tauri://localhost").origin` returns `"null"` in Node.js per the URL spec. This means Tauri and Electron desktop apps can never match against specific `allowedOrigins` entries - the only workaround is `"*"`, which disables origin security entirely.

Fixes #46520

## Changes

`src/gateway/origin-check.ts`: When `url.origin === "null"`, derive the origin from `url.protocol + "//" + url.host` instead.

`src/gateway/origin-check.test.ts`: 3 new test cases - tauri:// accepted, electron:// accepted, custom scheme rejected when not in allowlist.

## Testing

- All 13 origin-check tests pass (10 existing + 3 new)
- `pnpm check` passes
- Verified locally: `new URL("tauri://localhost")` now produces origin `"tauri://localhost"` after the fix

This contribution was developed with AI assistance (Claude Code).