### PR TITLE
fix(session): check daily reset staleness before route metadata updates

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -258,6 +258,38 @@ describe("sessions", () => {
     expect(store[mainSessionKey]?.compactionCount).toBe(2);
   });
 
+  it("updateLastRoute preserves updatedAt for daily reset freshness (#46539)", async () => {
+    const sessionKey = "agent:main:telegram:direct:12345";
+    const oldUpdatedAt = Date.now() - 24 * 60 * 60 * 1000; // 24 hours ago
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "updateLastRoute-preserve-updatedAt",
+      entries: {
+        [sessionKey]: buildMainSessionEntry({
+          systemSent: true,
+          updatedAt: oldUpdatedAt,
+        }),
+      },
+    });
+
+    await updateLastRoute({
+      storePath,
+      sessionKey,
+      deliveryContext: {
+        channel: "telegram",
+        to: "12345",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    // updatedAt must NOT be bumped to Date.now(); it must remain at the
+    // original value so daily-reset freshness evaluation sees the session
+    // as stale when the reset hour has passed.
+    expect(store[sessionKey]?.updatedAt).toBe(oldUpdatedAt);
+    // Route fields should still be updated
+    expect(store[sessionKey]?.lastChannel).toBe("telegram");
+    expect(store[sessionKey]?.lastTo).toBe("12345");
+  });
+
   it("updateLastRoute prefers explicit deliveryContext", async () => {
     const mainSessionKey = "agent:main:main";
     const { storePath } = await createSessionStoreFixture({

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -886,7 +886,6 @@ export async function updateLastRoute(params: {
     const store = loadSessionStore(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey });
     const existing = resolved.existing;
-    const now = Date.now();
     const explicitContext = normalizeDeliveryContext(params.deliveryContext);
     const inlineContext = normalizeDeliveryContext({
       channel,
@@ -932,14 +931,16 @@ export async function updateLastRoute(params: {
         })
       : null;
     const basePatch: Partial<SessionEntry> = {
-      updatedAt: Math.max(existing?.updatedAt ?? 0, now),
       deliveryContext: normalized.deliveryContext,
       lastChannel: normalized.lastChannel,
       lastTo: normalized.lastTo,
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    const next = mergeSessionEntry(
+    // Route updates must not refresh activity timestamps; daily/idle reset
+    // evaluation relies on updatedAt reflecting the last real session turn,
+    // not delivery-metadata bookkeeping.  See #46539.
+    const next = mergeSessionEntryPreserveActivity(
       existing,
       metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
     );


### PR DESCRIPTION
## Summary

`updateLastRoute()` was bumping `updatedAt` to `Date.now()` on every inbound message for delivery-context bookkeeping. This caused channel conversation sessions (e.g. Telegram DMs) to always appear fresh when `evaluateSessionFreshness()` checked `updatedAt` against the daily reset boundary, preventing daily session resets from ever firing.

The `main` session was unaffected because its session init path (`initSessionState` in `src/commands/agent/session.ts`) reads `updatedAt` directly from the session store before any metadata writes. Channel conversations, however, go through `recordInboundSession` → `updateLastRoute()` first, which refreshed `updatedAt` before freshness evaluation.

## Root Cause

In `src/config/sessions/store.ts`, `updateLastRoute()` built a `basePatch` with:

```ts
updatedAt: Math.max(existing?.updatedAt ?? 0, now),
```

This always bumped `updatedAt` to `Date.now()`, making the session appear fresh regardless of when the last actual conversation turn occurred.

## Fix

- Switch `updateLastRoute()` to use `mergeSessionEntryPreserveActivity()` (which preserves the existing `updatedAt`), consistent with how `recordSessionMetaFromInbound()` already handles metadata updates
- Remove the now-unused `now` variable
- Add a regression test verifying `updateLastRoute` preserves `updatedAt`

## Testing

- New test: `updateLastRoute preserves updatedAt for daily reset freshness (#46539)`
- All 71 existing session tests pass
- All 4 channel session tests pass

Fixes #46539