### PR TITLE
fix: replace console.log with logVerbose in tailscale funnel

### DIFF
--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -343,7 +343,7 @@ export async function ensureFunnel(
       },
     );
     if (stdout.trim()) {
-      console.log(stdout.trim());
+      logVerbose(stdout.trim());
     }
   } catch (err) {
     const errOutput = err as { stdout?: unknown; stderr?: unknown };


### PR DESCRIPTION
Replace debug console.log with proper logVerbose in tailscale funnel function to avoid unwanted output in production.