### PR TITLE
Move remaining channel send-deps imports off deliver.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - CI/channel test routing: move the built-in channel suites into `test:channels` and keep them out of `test:extensions`, so extension CI no longer fails after the channel migration while targeted test routing still sends Slack, Signal, and iMessage suites to the right lane. (#46066) Thanks @scoootscooob.
 - Agents/usage tracking: stop forcing `supportsUsageInStreaming: false` on non-native openai-completions endpoints so providers like DashScope, DeepSeek, and other OpenAI-compatible backends report token usage and cost instead of showing all zeros. (#46142)
 - Node/startup: remove leftover debug `console.log("node host PATH: ...")` that printed the resolved PATH on every `openclaw node run` invocation. (#46411)
+- Configure/startup: move the remaining channel-facing `OutboundSendDeps` imports onto the lightweight send-deps helper so `openclaw configure` no longer risks stalling on WhatsApp and other channel startup paths.
 
 ## 2026.3.13
 

--- a/src/channels/plugins/outbound/direct-text-media.ts
+++ b/src/channels/plugins/outbound/direct-text-media.ts
@@ -1,6 +1,6 @@
 import { chunkText } from "../../../auto-reply/chunk.js";
 import type { OpenClawConfig } from "../../../config/config.js";
-import type { OutboundSendDeps } from "../../../infra/outbound/deliver.js";
+import type { OutboundSendDeps } from "../../../infra/outbound/send-deps.js";
 import { resolveChannelMediaMaxBytes } from "../media-limits.js";
 import type { ChannelOutboundAdapter } from "../types.js";
 

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -1,8 +1,9 @@
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { GroupToolPolicyConfig } from "../../config/types.tools.js";
-import type { OutboundDeliveryResult, OutboundSendDeps } from "../../infra/outbound/deliver.js";
+import type { OutboundDeliveryResult } from "../../infra/outbound/deliver.js";
 import type { OutboundIdentity } from "../../infra/outbound/identity.js";
+import type { OutboundSendDeps } from "../../infra/outbound/send-deps.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type {

--- a/src/cli/outbound-send-deps.ts
+++ b/src/cli/outbound-send-deps.ts
@@ -1,4 +1,4 @@
-import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
+import type { OutboundSendDeps } from "../infra/outbound/send-deps.js";
 import {
   createOutboundSendDepsFromCliSource,
   type CliOutboundSendSource,

--- a/src/cli/outbound-send-mapping.ts
+++ b/src/cli/outbound-send-mapping.ts
@@ -1,4 +1,4 @@
-import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
+import type { OutboundSendDeps } from "../infra/outbound/send-deps.js";
 
 /**
  * CLI-internal send function sources, keyed by channel ID.

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -7,8 +7,8 @@ import { getChannelsCommandSecretTargetIds } from "../cli/command-secret-targets
 import { createOutboundSendDeps, type CliDeps } from "../cli/outbound-send-deps.js";
 import { withProgress } from "../cli/progress.js";
 import { loadConfig } from "../config/config.js";
-import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
+import type { OutboundSendDeps } from "../infra/outbound/send-deps.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { buildMessageCliJson, formatMessageCliText } from "./message-format.js";

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -64,8 +64,8 @@ import {
   setHeartbeatsEnabled,
   setHeartbeatWakeHandler,
 } from "./heartbeat-wake.js";
-import type { OutboundSendDeps } from "./outbound/deliver.js";
 import { deliverOutboundPayloads } from "./outbound/deliver.js";
+import type { OutboundSendDeps } from "./outbound/send-deps.js";
 import { buildOutboundSessionContext } from "./outbound/session-context.js";
 import {
   resolveHeartbeatDeliveryTarget,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -24,7 +24,6 @@ import {
   listConfiguredMessageChannels,
   resolveMessageChannelSelection,
 } from "./channel-selection.js";
-import type { OutboundSendDeps } from "./deliver.js";
 import { normalizeMessageActionInput } from "./message-action-normalization.js";
 import {
   hydrateAttachmentParamsForAction,
@@ -48,6 +47,7 @@ import {
 } from "./outbound-policy.js";
 import { executePollAction, executeSendAction } from "./outbound-send-service.js";
 import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
+import type { OutboundSendDeps } from "./send-deps.js";
 import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
 import { extractToolPayload } from "./tool-payload.js";
 

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -6,10 +6,10 @@ import { appendAssistantMessageToSessionTranscript } from "../../config/sessions
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
 import { throwIfAborted } from "./abort.js";
-import type { OutboundSendDeps } from "./deliver.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import { sendMessage, sendPoll } from "./message.js";
 import type { OutboundMirror } from "./mirror.js";
+import type { OutboundSendDeps } from "./send-deps.js";
 import { extractToolPayload } from "./tool-payload.js";
 
 export type OutboundGatewayContext = {


### PR DESCRIPTION
## Summary
- move the remaining channel-facing `OutboundSendDeps` type imports from `src/infra/outbound/deliver.ts` to `src/infra/outbound/send-deps.ts`
- keep the runtime `deliverOutboundPayloads` imports unchanged while finishing the lightweight helper migration from #46301
- add an unreleased changelog entry for the follow-up startup hotfix

## Why
#46301 fixed the main runtime plugin imports, but some channel/core helper paths still referenced `OutboundSendDeps` through `deliver.ts`. This follow-up applies the same lightweight-helper pattern consistently across the remaining channel-facing paths so `openclaw configure` does not risk dragging the heavyweight outbound delivery module into startup.

## Verification
- `rg` audit found no remaining `OutboundSendDeps` imports from `deliver.ts` in channel-facing source
- `/usr/bin/time -l pnpm openclaw configure --section channels`
  - reached `Where will the Gateway run?` on latest `main`
