### PR TITLE
fix: include session archive files in cost dashboard aggregation

### DIFF
--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -3,7 +3,7 @@ export type SessionArchiveReason = "bak" | "reset" | "deleted";
 const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$/;
 const LEGACY_STORE_BACKUP_RE = /^sessions\.json\.bak\.\d+$/;
 
-function hasArchiveSuffix(fileName: string, reason: SessionArchiveReason): boolean {
+export function hasArchiveSuffix(fileName: string, reason: SessionArchiveReason): boolean {
   const marker = `.${reason}.`;
   const index = fileName.lastIndexOf(marker);
   if (index < 0) {

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -264,6 +264,114 @@ describe("session cost usage", () => {
     });
   });
 
+  it("includes archived .jsonl.deleted.* files in cost summary", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-deleted-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const now = new Date();
+    const entry = {
+      type: "message",
+      timestamp: now.toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.2",
+        usage: {
+          input: 10,
+          output: 10,
+          totalTokens: 20,
+          cost: { total: 0.05 },
+        },
+      },
+    };
+
+    // Active session file
+    const activeFile = path.join(sessionsDir, "sess-active.jsonl");
+    await fs.writeFile(activeFile, JSON.stringify(entry), "utf-8");
+
+    // Deleted session archive
+    const deletedFile = path.join(
+      sessionsDir,
+      "sess-removed.jsonl.deleted.2026-03-14T20-28-29.627Z",
+    );
+    await fs.writeFile(deletedFile, JSON.stringify(entry), "utf-8");
+
+    const config = {
+      models: {
+        providers: {
+          openai: {
+            models: [
+              {
+                id: "gpt-5.2",
+                cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.totals.totalTokens).toBe(40);
+      expect(summary.totals.totalCost).toBeCloseTo(0.1, 5);
+    });
+  });
+
+  it("excludes .jsonl.bak.* compaction archives from cost summary", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-bak-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const now = new Date();
+    const entry = {
+      type: "message",
+      timestamp: now.toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.2",
+        usage: {
+          input: 10,
+          output: 10,
+          totalTokens: 20,
+          cost: { total: 0.05 },
+        },
+      },
+    };
+
+    // Active session file (compacted, only recent data)
+    const activeFile = path.join(sessionsDir, "sess-compacted.jsonl");
+    await fs.writeFile(activeFile, JSON.stringify(entry), "utf-8");
+
+    // Bak archive (full pre-compaction transcript — overlaps with active)
+    const bakFile = path.join(sessionsDir, "sess-compacted.jsonl.bak.2026-03-14T20-28-29.627Z");
+    await fs.writeFile(bakFile, JSON.stringify(entry), "utf-8");
+
+    const config = {
+      models: {
+        providers: {
+          openai: {
+            models: [
+              {
+                id: "gpt-5.2",
+                cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      // Only the active file should be counted, not the bak archive
+      expect(summary.totals.totalTokens).toBe(20);
+      expect(summary.totals.totalCost).toBeCloseTo(0.05, 5);
+    });
+  });
+
   it("does not exclude sessions with mtime after endMs during discovery", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1,31 +1,29 @@
-import fs from "node:fs/promises"
-import os from "node:os"
-import path from "node:path"
-import { describe, expect, it } from "vitest"
-import type { OpenClawConfig } from "../config/config.js"
-import { withEnvAsync } from "../test-utils/env.js"
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   discoverAllSessions,
   loadCostUsageSummary,
   loadSessionCostSummary,
   loadSessionLogs,
   loadSessionUsageTimeSeries,
-} from "./session-cost-usage.js"
+} from "./session-cost-usage.js";
 
 describe("session cost usage", () => {
-  const withStateDir = async <T,>(
-    stateDir: string,
-    fn: () => Promise<T>,
-  ): Promise<T> => await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, fn)
+  const withStateDir = async <T>(stateDir: string, fn: () => Promise<T>): Promise<T> =>
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, fn);
 
   it("aggregates daily totals with log cost and pricing fallback", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-"))
-    const sessionsDir = path.join(root, "agents", "main", "sessions")
-    await fs.mkdir(sessionsDir, { recursive: true })
-    const sessionFile = path.join(sessionsDir, "sess-1.jsonl")
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-1.jsonl");
 
-    const now = new Date()
-    const older = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000)
+    const now = new Date();
+    const older = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
 
     const entries = [
       {
@@ -76,13 +74,13 @@ describe("session cost usage", () => {
           },
         },
       },
-    ]
+    ];
 
     await fs.writeFile(
       sessionFile,
       entries.map((entry) => JSON.stringify(entry)).join("\n"),
       "utf-8",
-    )
+    );
 
     const config = {
       models: {
@@ -102,22 +100,20 @@ describe("session cost usage", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig
+    } as unknown as OpenClawConfig;
 
     await withStateDir(root, async () => {
-      const summary = await loadCostUsageSummary({ days: 30, config })
-      expect(summary.daily.length).toBe(1)
-      expect(summary.totals.totalTokens).toBe(50)
-      expect(summary.totals.totalCost).toBeCloseTo(0.03003, 5)
-    })
-  })
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.daily.length).toBe(1);
+      expect(summary.totals.totalTokens).toBe(50);
+      expect(summary.totals.totalCost).toBeCloseTo(0.03003, 5);
+    });
+  });
 
   it("summarizes a single session file", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-cost-session-"),
-    )
-    const sessionFile = path.join(root, "session.jsonl")
-    const now = new Date()
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-session-"));
+    const sessionFile = path.join(root, "session.jsonl");
+    const now = new Date();
 
     await fs.writeFile(
       sessionFile,
@@ -137,23 +133,21 @@ describe("session cost usage", () => {
         },
       }),
       "utf-8",
-    )
+    );
 
     const summary = await loadSessionCostSummary({
       sessionFile,
-    })
-    expect(summary?.totalCost).toBeCloseTo(0.03, 5)
-    expect(summary?.totalTokens).toBe(30)
-    expect(summary?.lastActivity).toBeGreaterThan(0)
-  })
+    });
+    expect(summary?.totalCost).toBeCloseTo(0.03, 5);
+    expect(summary?.totalTokens).toBe(30);
+    expect(summary?.lastActivity).toBeGreaterThan(0);
+  });
 
   it("captures message counts, tool usage, and model usage", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-cost-session-meta-"),
-    )
-    const sessionFile = path.join(root, "session.jsonl")
-    const start = new Date("2026-02-01T10:00:00.000Z")
-    const end = new Date("2026-02-01T10:05:00.000Z")
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-session-meta-"));
+    const sessionFile = path.join(root, "session.jsonl");
+    const start = new Date("2026-02-01T10:00:00.000Z");
+    const end = new Date("2026-02-01T10:05:00.000Z");
 
     const entries = [
       {
@@ -185,15 +179,15 @@ describe("session cost usage", () => {
           },
         },
       },
-    ]
+    ];
 
     await fs.writeFile(
       sessionFile,
       entries.map((entry) => JSON.stringify(entry)).join("\n"),
       "utf-8",
-    )
+    );
 
-    const summary = await loadSessionCostSummary({ sessionFile })
+    const summary = await loadSessionCostSummary({ sessionFile });
     expect(summary?.messageCounts).toEqual({
       total: 2,
       user: 1,
@@ -201,30 +195,28 @@ describe("session cost usage", () => {
       toolCalls: 1,
       toolResults: 1,
       errors: 2,
-    })
-    expect(summary?.toolUsage?.totalCalls).toBe(1)
-    expect(summary?.toolUsage?.uniqueTools).toBe(1)
-    expect(summary?.toolUsage?.tools[0]?.name).toBe("weather")
-    expect(summary?.modelUsage?.[0]?.provider).toBe("openai")
-    expect(summary?.modelUsage?.[0]?.model).toBe("gpt-5.2")
-    expect(summary?.durationMs).toBe(5 * 60 * 1000)
-    expect(summary?.latency?.count).toBe(1)
-    expect(summary?.latency?.avgMs).toBe(5 * 60 * 1000)
-    expect(summary?.latency?.p95Ms).toBe(5 * 60 * 1000)
-    expect(summary?.dailyLatency?.[0]?.date).toBe("2026-02-01")
-    expect(summary?.dailyLatency?.[0]?.count).toBe(1)
-    expect(summary?.dailyModelUsage?.[0]?.date).toBe("2026-02-01")
-    expect(summary?.dailyModelUsage?.[0]?.model).toBe("gpt-5.2")
-  })
+    });
+    expect(summary?.toolUsage?.totalCalls).toBe(1);
+    expect(summary?.toolUsage?.uniqueTools).toBe(1);
+    expect(summary?.toolUsage?.tools[0]?.name).toBe("weather");
+    expect(summary?.modelUsage?.[0]?.provider).toBe("openai");
+    expect(summary?.modelUsage?.[0]?.model).toBe("gpt-5.2");
+    expect(summary?.durationMs).toBe(5 * 60 * 1000);
+    expect(summary?.latency?.count).toBe(1);
+    expect(summary?.latency?.avgMs).toBe(5 * 60 * 1000);
+    expect(summary?.latency?.p95Ms).toBe(5 * 60 * 1000);
+    expect(summary?.dailyLatency?.[0]?.date).toBe("2026-02-01");
+    expect(summary?.dailyLatency?.[0]?.count).toBe(1);
+    expect(summary?.dailyModelUsage?.[0]?.date).toBe("2026-02-01");
+    expect(summary?.dailyModelUsage?.[0]?.model).toBe("gpt-5.2");
+  });
 
   it("includes archived .jsonl.reset.* files in cost summary", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-cost-archive-"),
-    )
-    const sessionsDir = path.join(root, "agents", "main", "sessions")
-    await fs.mkdir(sessionsDir, { recursive: true })
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-archive-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
 
-    const now = new Date()
+    const now = new Date();
     const entry = {
       type: "message",
       timestamp: now.toISOString(),
@@ -239,18 +231,15 @@ describe("session cost usage", () => {
           cost: { total: 0.05 },
         },
       },
-    }
+    };
 
     // Active session file
-    const activeFile = path.join(sessionsDir, "sess-active.jsonl")
-    await fs.writeFile(activeFile, JSON.stringify(entry), "utf-8")
+    const activeFile = path.join(sessionsDir, "sess-active.jsonl");
+    await fs.writeFile(activeFile, JSON.stringify(entry), "utf-8");
 
     // Archived session file (created by /new or /reset)
-    const archiveFile = path.join(
-      sessionsDir,
-      "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z",
-    )
-    await fs.writeFile(archiveFile, JSON.stringify(entry), "utf-8")
+    const archiveFile = path.join(sessionsDir, "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z");
+    await fs.writeFile(archiveFile, JSON.stringify(entry), "utf-8");
 
     const config = {
       models: {
@@ -265,77 +254,67 @@ describe("session cost usage", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig
+    } as unknown as OpenClawConfig;
 
     await withStateDir(root, async () => {
-      const summary = await loadCostUsageSummary({ days: 30, config })
+      const summary = await loadCostUsageSummary({ days: 30, config });
       // Both files should be included: 20 + 20 = 40 tokens, $0.05 + $0.05 = $0.10
-      expect(summary.totals.totalTokens).toBe(40)
-      expect(summary.totals.totalCost).toBeCloseTo(0.1, 5)
-    })
-  })
+      expect(summary.totals.totalTokens).toBe(40);
+      expect(summary.totals.totalCost).toBeCloseTo(0.1, 5);
+    });
+  });
 
   it("discovers archived sessions and extracts correct session IDs", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-discover-archive-"),
-    )
-    const sessionsDir = path.join(root, "agents", "main", "sessions")
-    await fs.mkdir(sessionsDir, { recursive: true })
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-archive-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
 
-    const activeFile = path.join(sessionsDir, "sess-active.jsonl")
-    await fs.writeFile(activeFile, "", "utf-8")
+    const activeFile = path.join(sessionsDir, "sess-active.jsonl");
+    await fs.writeFile(activeFile, "", "utf-8");
 
-    const archiveFile = path.join(
-      sessionsDir,
-      "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z",
-    )
-    await fs.writeFile(archiveFile, "", "utf-8")
+    const archiveFile = path.join(sessionsDir, "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z");
+    await fs.writeFile(archiveFile, "", "utf-8");
 
-    const now = Date.now()
-    await fs.utimes(activeFile, now / 1000, now / 1000)
-    await fs.utimes(archiveFile, now / 1000, now / 1000)
+    const now = Date.now();
+    await fs.utimes(activeFile, now / 1000, now / 1000);
+    await fs.utimes(archiveFile, now / 1000, now / 1000);
 
     await withStateDir(root, async () => {
       const sessions = await discoverAllSessions({
         startMs: now - 7 * 24 * 60 * 60 * 1000,
-      })
-      expect(sessions.length).toBe(2)
-      const ids = sessions.map((s) => s.sessionId).sort()
-      expect(ids).toEqual(["sess-active", "sess-old"])
-    })
-  })
+      });
+      expect(sessions.length).toBe(2);
+      const ids = sessions.map((s) => s.sessionId).sort();
+      expect(ids).toEqual(["sess-active", "sess-old"]);
+    });
+  });
 
   it("does not exclude sessions with mtime after endMs during discovery", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-"))
-    const sessionsDir = path.join(root, "agents", "main", "sessions")
-    await fs.mkdir(sessionsDir, { recursive: true })
-    const sessionFile = path.join(sessionsDir, "sess-late.jsonl")
-    await fs.writeFile(sessionFile, "", "utf-8")
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-late.jsonl");
+    await fs.writeFile(sessionFile, "", "utf-8");
 
-    const now = Date.now()
-    await fs.utimes(sessionFile, now / 1000, now / 1000)
+    const now = Date.now();
+    await fs.utimes(sessionFile, now / 1000, now / 1000);
 
     await withStateDir(root, async () => {
       const sessions = await discoverAllSessions({
         startMs: now - 7 * 24 * 60 * 60 * 1000,
         endMs: now - 24 * 60 * 60 * 1000,
-      })
-      expect(sessions.length).toBe(1)
-      expect(sessions[0]?.sessionId).toBe("sess-late")
-    })
-  })
+      });
+      expect(sessions.length).toBe(1);
+      expect(sessions[0]?.sessionId).toBe("sess-late");
+    });
+  });
 
   it("resolves non-main absolute sessionFile using explicit agentId for cost summary", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-cost-agent-"),
-    )
-    const workerSessionsDir = path.join(root, "agents", "worker1", "sessions")
-    await fs.mkdir(workerSessionsDir, { recursive: true })
-    const workerSessionFile = path.join(
-      workerSessionsDir,
-      "sess-worker-1.jsonl",
-    )
-    const now = new Date("2026-02-12T10:00:00.000Z")
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-agent-"));
+    const workerSessionsDir = path.join(root, "agents", "worker1", "sessions");
+    await fs.mkdir(workerSessionsDir, { recursive: true });
+    const workerSessionFile = path.join(workerSessionsDir, "sess-worker-1.jsonl");
+    const now = new Date("2026-02-12T10:00:00.000Z");
 
     await fs.writeFile(
       workerSessionFile,
@@ -355,7 +334,7 @@ describe("session cost usage", () => {
         },
       }),
       "utf-8",
-    )
+    );
 
     await withStateDir(root, async () => {
       const summary = await loadSessionCostSummary({
@@ -366,22 +345,17 @@ describe("session cost usage", () => {
           sessionFile: workerSessionFile,
         },
         agentId: "worker1",
-      })
-      expect(summary?.totalTokens).toBe(18)
-      expect(summary?.totalCost).toBeCloseTo(0.01, 5)
-    })
-  })
+      });
+      expect(summary?.totalTokens).toBe(18);
+      expect(summary?.totalCost).toBeCloseTo(0.01, 5);
+    });
+  });
 
   it("resolves non-main absolute sessionFile using explicit agentId for timeseries", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-timeseries-agent-"),
-    )
-    const workerSessionsDir = path.join(root, "agents", "worker2", "sessions")
-    await fs.mkdir(workerSessionsDir, { recursive: true })
-    const workerSessionFile = path.join(
-      workerSessionsDir,
-      "sess-worker-2.jsonl",
-    )
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeseries-agent-"));
+    const workerSessionsDir = path.join(root, "agents", "worker2", "sessions");
+    await fs.mkdir(workerSessionsDir, { recursive: true });
+    const workerSessionFile = path.join(workerSessionsDir, "sess-worker-2.jsonl");
 
     await fs.writeFile(
       workerSessionFile,
@@ -403,7 +377,7 @@ describe("session cost usage", () => {
         }),
       ].join("\n"),
       "utf-8",
-    )
+    );
 
     await withStateDir(root, async () => {
       const timeseries = await loadSessionUsageTimeSeries({
@@ -414,22 +388,17 @@ describe("session cost usage", () => {
           sessionFile: workerSessionFile,
         },
         agentId: "worker2",
-      })
-      expect(timeseries?.points.length).toBe(1)
-      expect(timeseries?.points[0]?.totalTokens).toBe(8)
-    })
-  })
+      });
+      expect(timeseries?.points.length).toBe(1);
+      expect(timeseries?.points[0]?.totalTokens).toBe(8);
+    });
+  });
 
   it("resolves non-main absolute sessionFile using explicit agentId for logs", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-logs-agent-"),
-    )
-    const workerSessionsDir = path.join(root, "agents", "worker3", "sessions")
-    await fs.mkdir(workerSessionsDir, { recursive: true })
-    const workerSessionFile = path.join(
-      workerSessionsDir,
-      "sess-worker-3.jsonl",
-    )
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-logs-agent-"));
+    const workerSessionsDir = path.join(root, "agents", "worker3", "sessions");
+    await fs.mkdir(workerSessionsDir, { recursive: true });
+    const workerSessionFile = path.join(workerSessionsDir, "sess-worker-3.jsonl");
 
     await fs.writeFile(
       workerSessionFile,
@@ -444,7 +413,7 @@ describe("session cost usage", () => {
         }),
       ].join("\n"),
       "utf-8",
-    )
+    );
 
     await withStateDir(root, async () => {
       const logs = await loadSessionLogs({
@@ -455,20 +424,18 @@ describe("session cost usage", () => {
           sessionFile: workerSessionFile,
         },
         agentId: "worker3",
-      })
-      expect(logs).toHaveLength(1)
-      expect(logs?.[0]?.content).toContain("hello worker")
-      expect(logs?.[0]?.role).toBe("user")
-    })
-  })
+      });
+      expect(logs).toHaveLength(1);
+      expect(logs?.[0]?.content).toContain("hello worker");
+      expect(logs?.[0]?.role).toBe("user");
+    });
+  });
 
   it("strips inbound and untrusted metadata blocks from session usage logs", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-logs-sanitize-"),
-    )
-    const sessionsDir = path.join(root, "agents", "main", "sessions")
-    await fs.mkdir(sessionsDir, { recursive: true })
-    const sessionFile = path.join(sessionsDir, "sess-sanitize.jsonl")
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-logs-sanitize-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-sanitize.jsonl");
 
     await fs.writeFile(
       sessionFile,
@@ -498,24 +465,22 @@ example
         }),
       ].join("\n"),
       "utf-8",
-    )
+    );
 
-    const logs = await loadSessionLogs({ sessionFile })
-    expect(logs).toHaveLength(1)
-    expect(logs?.[0]?.role).toBe("user")
-    expect(logs?.[0]?.content).toBe("hello there")
-  })
+    const logs = await loadSessionLogs({ sessionFile });
+    expect(logs).toHaveLength(1);
+    expect(logs?.[0]?.role).toBe("user");
+    expect(logs?.[0]?.content).toBe("hello there");
+  });
 
   it("preserves totals and cumulative values when downsampling timeseries", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-timeseries-downsample-"),
-    )
-    const sessionsDir = path.join(root, "agents", "main", "sessions")
-    await fs.mkdir(sessionsDir, { recursive: true })
-    const sessionFile = path.join(sessionsDir, "sess-downsample.jsonl")
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeseries-downsample-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-downsample.jsonl");
 
     const entries = Array.from({ length: 10 }, (_, i) => {
-      const idx = i + 1
+      const idx = i + 1;
       return {
         type: "message",
         timestamp: new Date(Date.UTC(2026, 1, 12, 10, idx, 0)).toISOString(),
@@ -532,35 +497,32 @@ example
             cost: { total: idx * 0.001 },
           },
         },
-      }
-    })
+      };
+    });
 
     await fs.writeFile(
       sessionFile,
       entries.map((entry) => JSON.stringify(entry)).join("\n"),
       "utf-8",
-    )
+    );
 
     const timeseries = await loadSessionUsageTimeSeries({
       sessionFile,
       maxPoints: 3,
-    })
+    });
 
-    expect(timeseries).toBeTruthy()
-    expect(timeseries?.points.length).toBe(3)
+    expect(timeseries).toBeTruthy();
+    expect(timeseries?.points.length).toBe(3);
 
-    const points = timeseries?.points ?? []
-    const totalTokens = points.reduce(
-      (sum, point) => sum + point.totalTokens,
-      0,
-    )
-    const totalCost = points.reduce((sum, point) => sum + point.cost, 0)
-    const lastPoint = points[points.length - 1]
+    const points = timeseries?.points ?? [];
+    const totalTokens = points.reduce((sum, point) => sum + point.totalTokens, 0);
+    const totalCost = points.reduce((sum, point) => sum + point.cost, 0);
+    const lastPoint = points[points.length - 1];
 
     // Full-series totals: sum(1..10)*3 = 165 tokens, sum(1..10)*0.001 = 0.055 cost.
-    expect(totalTokens).toBe(165)
-    expect(totalCost).toBeCloseTo(0.055, 8)
-    expect(lastPoint?.cumulativeTokens).toBe(165)
-    expect(lastPoint?.cumulativeCost).toBeCloseTo(0.055, 8)
-  })
-})
+    expect(totalTokens).toBe(165);
+    expect(totalCost).toBeCloseTo(0.055, 8);
+    expect(lastPoint?.cumulativeTokens).toBe(165);
+    expect(lastPoint?.cumulativeCost).toBeCloseTo(0.055, 8);
+  });
+});

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1,29 +1,31 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { describe, expect, it } from "vitest";
-import type { OpenClawConfig } from "../config/config.js";
-import { withEnvAsync } from "../test-utils/env.js";
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+import type { OpenClawConfig } from "../config/config.js"
+import { withEnvAsync } from "../test-utils/env.js"
 import {
   discoverAllSessions,
   loadCostUsageSummary,
   loadSessionCostSummary,
   loadSessionLogs,
   loadSessionUsageTimeSeries,
-} from "./session-cost-usage.js";
+} from "./session-cost-usage.js"
 
 describe("session cost usage", () => {
-  const withStateDir = async <T>(stateDir: string, fn: () => Promise<T>): Promise<T> =>
-    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, fn);
+  const withStateDir = async <T,>(
+    stateDir: string,
+    fn: () => Promise<T>,
+  ): Promise<T> => await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, fn)
 
   it("aggregates daily totals with log cost and pricing fallback", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-"));
-    const sessionsDir = path.join(root, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
-    const sessionFile = path.join(sessionsDir, "sess-1.jsonl");
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-"))
+    const sessionsDir = path.join(root, "agents", "main", "sessions")
+    await fs.mkdir(sessionsDir, { recursive: true })
+    const sessionFile = path.join(sessionsDir, "sess-1.jsonl")
 
-    const now = new Date();
-    const older = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+    const now = new Date()
+    const older = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000)
 
     const entries = [
       {
@@ -74,13 +76,13 @@ describe("session cost usage", () => {
           },
         },
       },
-    ];
+    ]
 
     await fs.writeFile(
       sessionFile,
       entries.map((entry) => JSON.stringify(entry)).join("\n"),
       "utf-8",
-    );
+    )
 
     const config = {
       models: {
@@ -100,20 +102,22 @@ describe("session cost usage", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    } as unknown as OpenClawConfig
 
     await withStateDir(root, async () => {
-      const summary = await loadCostUsageSummary({ days: 30, config });
-      expect(summary.daily.length).toBe(1);
-      expect(summary.totals.totalTokens).toBe(50);
-      expect(summary.totals.totalCost).toBeCloseTo(0.03003, 5);
-    });
-  });
+      const summary = await loadCostUsageSummary({ days: 30, config })
+      expect(summary.daily.length).toBe(1)
+      expect(summary.totals.totalTokens).toBe(50)
+      expect(summary.totals.totalCost).toBeCloseTo(0.03003, 5)
+    })
+  })
 
   it("summarizes a single session file", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-session-"));
-    const sessionFile = path.join(root, "session.jsonl");
-    const now = new Date();
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-cost-session-"),
+    )
+    const sessionFile = path.join(root, "session.jsonl")
+    const now = new Date()
 
     await fs.writeFile(
       sessionFile,
@@ -133,21 +137,23 @@ describe("session cost usage", () => {
         },
       }),
       "utf-8",
-    );
+    )
 
     const summary = await loadSessionCostSummary({
       sessionFile,
-    });
-    expect(summary?.totalCost).toBeCloseTo(0.03, 5);
-    expect(summary?.totalTokens).toBe(30);
-    expect(summary?.lastActivity).toBeGreaterThan(0);
-  });
+    })
+    expect(summary?.totalCost).toBeCloseTo(0.03, 5)
+    expect(summary?.totalTokens).toBe(30)
+    expect(summary?.lastActivity).toBeGreaterThan(0)
+  })
 
   it("captures message counts, tool usage, and model usage", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-session-meta-"));
-    const sessionFile = path.join(root, "session.jsonl");
-    const start = new Date("2026-02-01T10:00:00.000Z");
-    const end = new Date("2026-02-01T10:05:00.000Z");
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-cost-session-meta-"),
+    )
+    const sessionFile = path.join(root, "session.jsonl")
+    const start = new Date("2026-02-01T10:00:00.000Z")
+    const end = new Date("2026-02-01T10:05:00.000Z")
 
     const entries = [
       {
@@ -179,15 +185,15 @@ describe("session cost usage", () => {
           },
         },
       },
-    ];
+    ]
 
     await fs.writeFile(
       sessionFile,
       entries.map((entry) => JSON.stringify(entry)).join("\n"),
       "utf-8",
-    );
+    )
 
-    const summary = await loadSessionCostSummary({ sessionFile });
+    const summary = await loadSessionCostSummary({ sessionFile })
     expect(summary?.messageCounts).toEqual({
       total: 2,
       user: 1,
@@ -195,28 +201,30 @@ describe("session cost usage", () => {
       toolCalls: 1,
       toolResults: 1,
       errors: 2,
-    });
-    expect(summary?.toolUsage?.totalCalls).toBe(1);
-    expect(summary?.toolUsage?.uniqueTools).toBe(1);
-    expect(summary?.toolUsage?.tools[0]?.name).toBe("weather");
-    expect(summary?.modelUsage?.[0]?.provider).toBe("openai");
-    expect(summary?.modelUsage?.[0]?.model).toBe("gpt-5.2");
-    expect(summary?.durationMs).toBe(5 * 60 * 1000);
-    expect(summary?.latency?.count).toBe(1);
-    expect(summary?.latency?.avgMs).toBe(5 * 60 * 1000);
-    expect(summary?.latency?.p95Ms).toBe(5 * 60 * 1000);
-    expect(summary?.dailyLatency?.[0]?.date).toBe("2026-02-01");
-    expect(summary?.dailyLatency?.[0]?.count).toBe(1);
-    expect(summary?.dailyModelUsage?.[0]?.date).toBe("2026-02-01");
-    expect(summary?.dailyModelUsage?.[0]?.model).toBe("gpt-5.2");
-  });
+    })
+    expect(summary?.toolUsage?.totalCalls).toBe(1)
+    expect(summary?.toolUsage?.uniqueTools).toBe(1)
+    expect(summary?.toolUsage?.tools[0]?.name).toBe("weather")
+    expect(summary?.modelUsage?.[0]?.provider).toBe("openai")
+    expect(summary?.modelUsage?.[0]?.model).toBe("gpt-5.2")
+    expect(summary?.durationMs).toBe(5 * 60 * 1000)
+    expect(summary?.latency?.count).toBe(1)
+    expect(summary?.latency?.avgMs).toBe(5 * 60 * 1000)
+    expect(summary?.latency?.p95Ms).toBe(5 * 60 * 1000)
+    expect(summary?.dailyLatency?.[0]?.date).toBe("2026-02-01")
+    expect(summary?.dailyLatency?.[0]?.count).toBe(1)
+    expect(summary?.dailyModelUsage?.[0]?.date).toBe("2026-02-01")
+    expect(summary?.dailyModelUsage?.[0]?.model).toBe("gpt-5.2")
+  })
 
   it("includes archived .jsonl.reset.* files in cost summary", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-archive-"));
-    const sessionsDir = path.join(root, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-cost-archive-"),
+    )
+    const sessionsDir = path.join(root, "agents", "main", "sessions")
+    await fs.mkdir(sessionsDir, { recursive: true })
 
-    const now = new Date();
+    const now = new Date()
     const entry = {
       type: "message",
       timestamp: now.toISOString(),
@@ -231,85 +239,103 @@ describe("session cost usage", () => {
           cost: { total: 0.05 },
         },
       },
-    };
+    }
 
     // Active session file
-    const activeFile = path.join(sessionsDir, "sess-active.jsonl");
-    await fs.writeFile(activeFile, JSON.stringify(entry), "utf-8");
+    const activeFile = path.join(sessionsDir, "sess-active.jsonl")
+    await fs.writeFile(activeFile, JSON.stringify(entry), "utf-8")
 
     // Archived session file (created by /new or /reset)
-    const archiveFile = path.join(sessionsDir, "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z");
-    await fs.writeFile(archiveFile, JSON.stringify(entry), "utf-8");
+    const archiveFile = path.join(
+      sessionsDir,
+      "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z",
+    )
+    await fs.writeFile(archiveFile, JSON.stringify(entry), "utf-8")
 
     const config = {
       models: {
         providers: {
           openai: {
-            models: [{ id: "gpt-5.2", cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } }],
+            models: [
+              {
+                id: "gpt-5.2",
+                cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    } as unknown as OpenClawConfig
 
     await withStateDir(root, async () => {
-      const summary = await loadCostUsageSummary({ days: 30, config });
+      const summary = await loadCostUsageSummary({ days: 30, config })
       // Both files should be included: 20 + 20 = 40 tokens, $0.05 + $0.05 = $0.10
-      expect(summary.totals.totalTokens).toBe(40);
-      expect(summary.totals.totalCost).toBeCloseTo(0.1, 5);
-    });
-  });
+      expect(summary.totals.totalTokens).toBe(40)
+      expect(summary.totals.totalCost).toBeCloseTo(0.1, 5)
+    })
+  })
 
   it("discovers archived sessions and extracts correct session IDs", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-archive-"));
-    const sessionsDir = path.join(root, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-discover-archive-"),
+    )
+    const sessionsDir = path.join(root, "agents", "main", "sessions")
+    await fs.mkdir(sessionsDir, { recursive: true })
 
-    const activeFile = path.join(sessionsDir, "sess-active.jsonl");
-    await fs.writeFile(activeFile, "", "utf-8");
+    const activeFile = path.join(sessionsDir, "sess-active.jsonl")
+    await fs.writeFile(activeFile, "", "utf-8")
 
-    const archiveFile = path.join(sessionsDir, "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z");
-    await fs.writeFile(archiveFile, "", "utf-8");
+    const archiveFile = path.join(
+      sessionsDir,
+      "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z",
+    )
+    await fs.writeFile(archiveFile, "", "utf-8")
 
-    const now = Date.now();
-    await fs.utimes(activeFile, now / 1000, now / 1000);
-    await fs.utimes(archiveFile, now / 1000, now / 1000);
+    const now = Date.now()
+    await fs.utimes(activeFile, now / 1000, now / 1000)
+    await fs.utimes(archiveFile, now / 1000, now / 1000)
 
     await withStateDir(root, async () => {
       const sessions = await discoverAllSessions({
         startMs: now - 7 * 24 * 60 * 60 * 1000,
-      });
-      expect(sessions.length).toBe(2);
-      const ids = sessions.map((s) => s.sessionId).sort();
-      expect(ids).toEqual(["sess-active", "sess-old"]);
-    });
-  });
+      })
+      expect(sessions.length).toBe(2)
+      const ids = sessions.map((s) => s.sessionId).sort()
+      expect(ids).toEqual(["sess-active", "sess-old"])
+    })
+  })
 
   it("does not exclude sessions with mtime after endMs during discovery", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-"));
-    const sessionsDir = path.join(root, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
-    const sessionFile = path.join(sessionsDir, "sess-late.jsonl");
-    await fs.writeFile(sessionFile, "", "utf-8");
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-"))
+    const sessionsDir = path.join(root, "agents", "main", "sessions")
+    await fs.mkdir(sessionsDir, { recursive: true })
+    const sessionFile = path.join(sessionsDir, "sess-late.jsonl")
+    await fs.writeFile(sessionFile, "", "utf-8")
 
-    const now = Date.now();
-    await fs.utimes(sessionFile, now / 1000, now / 1000);
+    const now = Date.now()
+    await fs.utimes(sessionFile, now / 1000, now / 1000)
 
     await withStateDir(root, async () => {
       const sessions = await discoverAllSessions({
         startMs: now - 7 * 24 * 60 * 60 * 1000,
         endMs: now - 24 * 60 * 60 * 1000,
-      });
-      expect(sessions.length).toBe(1);
-      expect(sessions[0]?.sessionId).toBe("sess-late");
-    });
-  });
+      })
+      expect(sessions.length).toBe(1)
+      expect(sessions[0]?.sessionId).toBe("sess-late")
+    })
+  })
 
   it("resolves non-main absolute sessionFile using explicit agentId for cost summary", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-agent-"));
-    const workerSessionsDir = path.join(root, "agents", "worker1", "sessions");
-    await fs.mkdir(workerSessionsDir, { recursive: true });
-    const workerSessionFile = path.join(workerSessionsDir, "sess-worker-1.jsonl");
-    const now = new Date("2026-02-12T10:00:00.000Z");
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-cost-agent-"),
+    )
+    const workerSessionsDir = path.join(root, "agents", "worker1", "sessions")
+    await fs.mkdir(workerSessionsDir, { recursive: true })
+    const workerSessionFile = path.join(
+      workerSessionsDir,
+      "sess-worker-1.jsonl",
+    )
+    const now = new Date("2026-02-12T10:00:00.000Z")
 
     await fs.writeFile(
       workerSessionFile,
@@ -329,7 +355,7 @@ describe("session cost usage", () => {
         },
       }),
       "utf-8",
-    );
+    )
 
     await withStateDir(root, async () => {
       const summary = await loadSessionCostSummary({
@@ -340,17 +366,22 @@ describe("session cost usage", () => {
           sessionFile: workerSessionFile,
         },
         agentId: "worker1",
-      });
-      expect(summary?.totalTokens).toBe(18);
-      expect(summary?.totalCost).toBeCloseTo(0.01, 5);
-    });
-  });
+      })
+      expect(summary?.totalTokens).toBe(18)
+      expect(summary?.totalCost).toBeCloseTo(0.01, 5)
+    })
+  })
 
   it("resolves non-main absolute sessionFile using explicit agentId for timeseries", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeseries-agent-"));
-    const workerSessionsDir = path.join(root, "agents", "worker2", "sessions");
-    await fs.mkdir(workerSessionsDir, { recursive: true });
-    const workerSessionFile = path.join(workerSessionsDir, "sess-worker-2.jsonl");
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-timeseries-agent-"),
+    )
+    const workerSessionsDir = path.join(root, "agents", "worker2", "sessions")
+    await fs.mkdir(workerSessionsDir, { recursive: true })
+    const workerSessionFile = path.join(
+      workerSessionsDir,
+      "sess-worker-2.jsonl",
+    )
 
     await fs.writeFile(
       workerSessionFile,
@@ -362,12 +393,17 @@ describe("session cost usage", () => {
             role: "assistant",
             provider: "openai",
             model: "gpt-5.2",
-            usage: { input: 5, output: 3, totalTokens: 8, cost: { total: 0.001 } },
+            usage: {
+              input: 5,
+              output: 3,
+              totalTokens: 8,
+              cost: { total: 0.001 },
+            },
           },
         }),
       ].join("\n"),
       "utf-8",
-    );
+    )
 
     await withStateDir(root, async () => {
       const timeseries = await loadSessionUsageTimeSeries({
@@ -378,17 +414,22 @@ describe("session cost usage", () => {
           sessionFile: workerSessionFile,
         },
         agentId: "worker2",
-      });
-      expect(timeseries?.points.length).toBe(1);
-      expect(timeseries?.points[0]?.totalTokens).toBe(8);
-    });
-  });
+      })
+      expect(timeseries?.points.length).toBe(1)
+      expect(timeseries?.points[0]?.totalTokens).toBe(8)
+    })
+  })
 
   it("resolves non-main absolute sessionFile using explicit agentId for logs", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-logs-agent-"));
-    const workerSessionsDir = path.join(root, "agents", "worker3", "sessions");
-    await fs.mkdir(workerSessionsDir, { recursive: true });
-    const workerSessionFile = path.join(workerSessionsDir, "sess-worker-3.jsonl");
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-logs-agent-"),
+    )
+    const workerSessionsDir = path.join(root, "agents", "worker3", "sessions")
+    await fs.mkdir(workerSessionsDir, { recursive: true })
+    const workerSessionFile = path.join(
+      workerSessionsDir,
+      "sess-worker-3.jsonl",
+    )
 
     await fs.writeFile(
       workerSessionFile,
@@ -403,7 +444,7 @@ describe("session cost usage", () => {
         }),
       ].join("\n"),
       "utf-8",
-    );
+    )
 
     await withStateDir(root, async () => {
       const logs = await loadSessionLogs({
@@ -414,18 +455,20 @@ describe("session cost usage", () => {
           sessionFile: workerSessionFile,
         },
         agentId: "worker3",
-      });
-      expect(logs).toHaveLength(1);
-      expect(logs?.[0]?.content).toContain("hello worker");
-      expect(logs?.[0]?.role).toBe("user");
-    });
-  });
+      })
+      expect(logs).toHaveLength(1)
+      expect(logs?.[0]?.content).toContain("hello worker")
+      expect(logs?.[0]?.role).toBe("user")
+    })
+  })
 
   it("strips inbound and untrusted metadata blocks from session usage logs", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-logs-sanitize-"));
-    const sessionsDir = path.join(root, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
-    const sessionFile = path.join(sessionsDir, "sess-sanitize.jsonl");
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-logs-sanitize-"),
+    )
+    const sessionsDir = path.join(root, "agents", "main", "sessions")
+    await fs.mkdir(sessionsDir, { recursive: true })
+    const sessionFile = path.join(sessionsDir, "sess-sanitize.jsonl")
 
     await fs.writeFile(
       sessionFile,
@@ -455,22 +498,24 @@ example
         }),
       ].join("\n"),
       "utf-8",
-    );
+    )
 
-    const logs = await loadSessionLogs({ sessionFile });
-    expect(logs).toHaveLength(1);
-    expect(logs?.[0]?.role).toBe("user");
-    expect(logs?.[0]?.content).toBe("hello there");
-  });
+    const logs = await loadSessionLogs({ sessionFile })
+    expect(logs).toHaveLength(1)
+    expect(logs?.[0]?.role).toBe("user")
+    expect(logs?.[0]?.content).toBe("hello there")
+  })
 
   it("preserves totals and cumulative values when downsampling timeseries", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeseries-downsample-"));
-    const sessionsDir = path.join(root, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
-    const sessionFile = path.join(sessionsDir, "sess-downsample.jsonl");
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-timeseries-downsample-"),
+    )
+    const sessionsDir = path.join(root, "agents", "main", "sessions")
+    await fs.mkdir(sessionsDir, { recursive: true })
+    const sessionFile = path.join(sessionsDir, "sess-downsample.jsonl")
 
     const entries = Array.from({ length: 10 }, (_, i) => {
-      const idx = i + 1;
+      const idx = i + 1
       return {
         type: "message",
         timestamp: new Date(Date.UTC(2026, 1, 12, 10, idx, 0)).toISOString(),
@@ -487,32 +532,35 @@ example
             cost: { total: idx * 0.001 },
           },
         },
-      };
-    });
+      }
+    })
 
     await fs.writeFile(
       sessionFile,
       entries.map((entry) => JSON.stringify(entry)).join("\n"),
       "utf-8",
-    );
+    )
 
     const timeseries = await loadSessionUsageTimeSeries({
       sessionFile,
       maxPoints: 3,
-    });
+    })
 
-    expect(timeseries).toBeTruthy();
-    expect(timeseries?.points.length).toBe(3);
+    expect(timeseries).toBeTruthy()
+    expect(timeseries?.points.length).toBe(3)
 
-    const points = timeseries?.points ?? [];
-    const totalTokens = points.reduce((sum, point) => sum + point.totalTokens, 0);
-    const totalCost = points.reduce((sum, point) => sum + point.cost, 0);
-    const lastPoint = points[points.length - 1];
+    const points = timeseries?.points ?? []
+    const totalTokens = points.reduce(
+      (sum, point) => sum + point.totalTokens,
+      0,
+    )
+    const totalCost = points.reduce((sum, point) => sum + point.cost, 0)
+    const lastPoint = points[points.length - 1]
 
     // Full-series totals: sum(1..10)*3 = 165 tokens, sum(1..10)*0.001 = 0.055 cost.
-    expect(totalTokens).toBe(165);
-    expect(totalCost).toBeCloseTo(0.055, 8);
-    expect(lastPoint?.cumulativeTokens).toBe(165);
-    expect(lastPoint?.cumulativeCost).toBeCloseTo(0.055, 8);
-  });
-});
+    expect(totalTokens).toBe(165)
+    expect(totalCost).toBeCloseTo(0.055, 8)
+    expect(lastPoint?.cumulativeTokens).toBe(165)
+    expect(lastPoint?.cumulativeCost).toBeCloseTo(0.055, 8)
+  })
+})

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -264,31 +264,6 @@ describe("session cost usage", () => {
     });
   });
 
-  it("discovers archived sessions and extracts correct session IDs", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-archive-"));
-    const sessionsDir = path.join(root, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
-
-    const activeFile = path.join(sessionsDir, "sess-active.jsonl");
-    await fs.writeFile(activeFile, "", "utf-8");
-
-    const archiveFile = path.join(sessionsDir, "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z");
-    await fs.writeFile(archiveFile, "", "utf-8");
-
-    const now = Date.now();
-    await fs.utimes(activeFile, now / 1000, now / 1000);
-    await fs.utimes(archiveFile, now / 1000, now / 1000);
-
-    await withStateDir(root, async () => {
-      const sessions = await discoverAllSessions({
-        startMs: now - 7 * 24 * 60 * 60 * 1000,
-      });
-      expect(sessions.length).toBe(2);
-      const ids = sessions.map((s) => s.sessionId).sort();
-      expect(ids).toEqual(["sess-active", "sess-old"]);
-    });
-  });
-
   it("does not exclude sessions with mtime after endMs during discovery", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -211,6 +211,79 @@ describe("session cost usage", () => {
     expect(summary?.dailyModelUsage?.[0]?.model).toBe("gpt-5.2");
   });
 
+  it("includes archived .jsonl.reset.* files in cost summary", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-archive-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const now = new Date();
+    const entry = {
+      type: "message",
+      timestamp: now.toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.2",
+        usage: {
+          input: 10,
+          output: 10,
+          totalTokens: 20,
+          cost: { total: 0.05 },
+        },
+      },
+    };
+
+    // Active session file
+    const activeFile = path.join(sessionsDir, "sess-active.jsonl");
+    await fs.writeFile(activeFile, JSON.stringify(entry), "utf-8");
+
+    // Archived session file (created by /new or /reset)
+    const archiveFile = path.join(sessionsDir, "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z");
+    await fs.writeFile(archiveFile, JSON.stringify(entry), "utf-8");
+
+    const config = {
+      models: {
+        providers: {
+          openai: {
+            models: [{ id: "gpt-5.2", cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      // Both files should be included: 20 + 20 = 40 tokens, $0.05 + $0.05 = $0.10
+      expect(summary.totals.totalTokens).toBe(40);
+      expect(summary.totals.totalCost).toBeCloseTo(0.1, 5);
+    });
+  });
+
+  it("discovers archived sessions and extracts correct session IDs", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-archive-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const activeFile = path.join(sessionsDir, "sess-active.jsonl");
+    await fs.writeFile(activeFile, "", "utf-8");
+
+    const archiveFile = path.join(sessionsDir, "sess-old.jsonl.reset.2026-03-14T20-28-29.627Z");
+    await fs.writeFile(archiveFile, "", "utf-8");
+
+    const now = Date.now();
+    await fs.utimes(activeFile, now / 1000, now / 1000);
+    await fs.utimes(archiveFile, now / 1000, now / 1000);
+
+    await withStateDir(root, async () => {
+      const sessions = await discoverAllSessions({
+        startMs: now - 7 * 24 * 60 * 60 * 1000,
+      });
+      expect(sessions.length).toBe(2);
+      const ids = sessions.map((s) => s.sessionId).sort();
+      expect(ids).toEqual(["sess-active", "sess-old"]);
+    });
+  });
+
   it("does not exclude sessions with mtime after endMs during discovery", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1,19 +1,25 @@
-import fs from "node:fs";
-import path from "node:path";
-import readline from "node:readline";
-import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
-import { normalizeUsage } from "../agents/usage.js";
-import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
-import type { OpenClawConfig } from "../config/config.js";
+import fs from "node:fs"
+import path from "node:path"
+import readline from "node:readline"
+import type { NormalizedUsage, UsageLike } from "../agents/usage.js"
+import { normalizeUsage } from "../agents/usage.js"
+import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js"
+import type { OpenClawConfig } from "../config/config.js"
 import {
   resolveSessionFilePath,
   resolveSessionTranscriptsDirForAgent,
-} from "../config/sessions/paths.js";
-import { isSessionArchiveArtifactName } from "../config/sessions/artifacts.js";
-import type { SessionEntry } from "../config/sessions/types.js";
-import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
-import { countToolResults, extractToolCallNames } from "../utils/transcript-tools.js";
-import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
+} from "../config/sessions/paths.js"
+import { isSessionArchiveArtifactName } from "../config/sessions/artifacts.js"
+import type { SessionEntry } from "../config/sessions/types.js"
+import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js"
+import {
+  countToolResults,
+  extractToolCallNames,
+} from "../utils/transcript-tools.js"
+import {
+  estimateUsageCost,
+  resolveModelCostConfig,
+} from "../utils/usage-format.js"
 import type {
   CostBreakdown,
   CostUsageTotals,
@@ -33,7 +39,7 @@ import type {
   SessionToolUsage,
   SessionUsageTimePoint,
   SessionUsageTimeSeries,
-} from "./session-cost-usage.types.js";
+} from "./session-cost-usage.types.js"
 
 export type {
   CostUsageDailyEntry,
@@ -52,7 +58,7 @@ export type {
   SessionToolUsage,
   SessionUsageTimePoint,
   SessionUsageTimeSeries,
-} from "./session-cost-usage.types.js";
+} from "./session-cost-usage.types.js"
 
 const emptyTotals = (): CostUsageTotals => ({
   input: 0,
@@ -66,31 +72,33 @@ const emptyTotals = (): CostUsageTotals => ({
   cacheReadCost: 0,
   cacheWriteCost: 0,
   missingCostEntries: 0,
-});
+})
 
 const toFiniteNumber = (value: unknown): number | undefined => {
   if (typeof value !== "number") {
-    return undefined;
+    return undefined
   }
   if (!Number.isFinite(value)) {
-    return undefined;
+    return undefined
   }
-  return value;
-};
+  return value
+}
 
-const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | undefined => {
+const extractCostBreakdown = (
+  usageRaw?: UsageLike | null,
+): CostBreakdown | undefined => {
   if (!usageRaw || typeof usageRaw !== "object") {
-    return undefined;
+    return undefined
   }
-  const record = usageRaw as Record<string, unknown>;
-  const cost = record.cost as Record<string, unknown> | undefined;
+  const record = usageRaw as Record<string, unknown>
+  const cost = record.cost as Record<string, unknown> | undefined
   if (!cost) {
-    return undefined;
+    return undefined
   }
 
-  const total = toFiniteNumber(cost.total);
+  const total = toFiniteNumber(cost.total)
   if (total === undefined || total < 0) {
-    return undefined;
+    return undefined
   }
 
   return {
@@ -99,54 +107,59 @@ const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | unde
     output: toFiniteNumber(cost.output),
     cacheRead: toFiniteNumber(cost.cacheRead),
     cacheWrite: toFiniteNumber(cost.cacheWrite),
-  };
-};
+  }
+}
 
 const parseTimestamp = (entry: Record<string, unknown>): Date | undefined => {
-  const raw = entry.timestamp;
+  const raw = entry.timestamp
   if (typeof raw === "string") {
-    const parsed = new Date(raw);
+    const parsed = new Date(raw)
     if (!Number.isNaN(parsed.valueOf())) {
-      return parsed;
+      return parsed
     }
   }
-  const message = entry.message as Record<string, unknown> | undefined;
-  const messageTimestamp = toFiniteNumber(message?.timestamp);
+  const message = entry.message as Record<string, unknown> | undefined
+  const messageTimestamp = toFiniteNumber(message?.timestamp)
   if (messageTimestamp !== undefined) {
-    const parsed = new Date(messageTimestamp);
+    const parsed = new Date(messageTimestamp)
     if (!Number.isNaN(parsed.valueOf())) {
-      return parsed;
+      return parsed
     }
   }
-  return undefined;
-};
+  return undefined
+}
 
-const parseTranscriptEntry = (entry: Record<string, unknown>): ParsedTranscriptEntry | null => {
-  const message = entry.message as Record<string, unknown> | undefined;
+const parseTranscriptEntry = (
+  entry: Record<string, unknown>,
+): ParsedTranscriptEntry | null => {
+  const message = entry.message as Record<string, unknown> | undefined
   if (!message || typeof message !== "object") {
-    return null;
+    return null
   }
 
-  const roleRaw = message.role;
-  const role = roleRaw === "user" || roleRaw === "assistant" ? roleRaw : undefined;
+  const roleRaw = message.role
+  const role =
+    roleRaw === "user" || roleRaw === "assistant" ? roleRaw : undefined
   if (!role) {
-    return null;
+    return null
   }
 
   const usageRaw =
-    (message.usage as UsageLike | undefined) ?? (entry.usage as UsageLike | undefined);
-  const usage = usageRaw ? (normalizeUsage(usageRaw) ?? undefined) : undefined;
+    message.usage as UsageLike | undefined ??
+    entry.usage as UsageLike | undefined
+  const usage = usageRaw ? (normalizeUsage(usageRaw) ?? undefined) : undefined
 
   const provider =
     (typeof message.provider === "string" ? message.provider : undefined) ??
-    (typeof entry.provider === "string" ? entry.provider : undefined);
+    (typeof entry.provider === "string" ? entry.provider : undefined)
   const model =
     (typeof message.model === "string" ? message.model : undefined) ??
-    (typeof entry.model === "string" ? entry.model : undefined);
+    (typeof entry.model === "string" ? entry.model : undefined)
 
-  const costBreakdown = extractCostBreakdown(usageRaw);
-  const stopReason = typeof message.stopReason === "string" ? message.stopReason : undefined;
-  const durationMs = toFiniteNumber(message.durationMs ?? entry.durationMs);
+  const costBreakdown = extractCostBreakdown(usageRaw)
+  const stopReason =
+    typeof message.stopReason === "string" ? message.stopReason : undefined
+  const durationMs = toFiniteNumber(message.durationMs ?? entry.durationMs)
 
   return {
     message,
@@ -161,94 +174,112 @@ const parseTranscriptEntry = (entry: Record<string, unknown>): ParsedTranscriptE
     stopReason,
     toolNames: extractToolCallNames(message),
     toolResultCounts: countToolResults(message),
-  };
-};
+  }
+}
 
 const formatDayKey = (date: Date): string =>
-  date.toLocaleDateString("en-CA", { timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone });
+  date.toLocaleDateString("en-CA", {
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  })
 
-const computeLatencyStats = (values: number[]): SessionLatencyStats | undefined => {
+const computeLatencyStats = (
+  values: number[],
+): SessionLatencyStats | undefined => {
   if (!values.length) {
-    return undefined;
+    return undefined
   }
-  const sorted = values.toSorted((a, b) => a - b);
-  const total = sorted.reduce((sum, v) => sum + v, 0);
-  const count = sorted.length;
-  const p95Index = Math.max(0, Math.ceil(count * 0.95) - 1);
+  const sorted = values.toSorted((a, b) => a - b)
+  const total = sorted.reduce((sum, v) => sum + v, 0)
+  const count = sorted.length
+  const p95Index = Math.max(0, Math.ceil(count * 0.95) - 1)
   return {
     count,
     avgMs: total / count,
     p95Ms: sorted[p95Index] ?? sorted[count - 1],
     minMs: sorted[0],
     maxMs: sorted[count - 1],
-  };
-};
+  }
+}
 
 const applyUsageTotals = (totals: CostUsageTotals, usage: NormalizedUsage) => {
-  totals.input += usage.input ?? 0;
-  totals.output += usage.output ?? 0;
-  totals.cacheRead += usage.cacheRead ?? 0;
-  totals.cacheWrite += usage.cacheWrite ?? 0;
+  totals.input += usage.input ?? 0
+  totals.output += usage.output ?? 0
+  totals.cacheRead += usage.cacheRead ?? 0
+  totals.cacheWrite += usage.cacheWrite ?? 0
   const totalTokens =
     usage.total ??
-    (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
-  totals.totalTokens += totalTokens;
-};
+    (usage.input ?? 0) +
+      (usage.output ?? 0) +
+      (usage.cacheRead ?? 0) +
+      (usage.cacheWrite ?? 0)
+  totals.totalTokens += totalTokens
+}
 
-const applyCostBreakdown = (totals: CostUsageTotals, costBreakdown: CostBreakdown | undefined) => {
+const applyCostBreakdown = (
+  totals: CostUsageTotals,
+  costBreakdown: CostBreakdown | undefined,
+) => {
   if (costBreakdown === undefined || costBreakdown.total === undefined) {
-    return;
+    return
   }
-  totals.totalCost += costBreakdown.total;
-  totals.inputCost += costBreakdown.input ?? 0;
-  totals.outputCost += costBreakdown.output ?? 0;
-  totals.cacheReadCost += costBreakdown.cacheRead ?? 0;
-  totals.cacheWriteCost += costBreakdown.cacheWrite ?? 0;
-};
+  totals.totalCost += costBreakdown.total
+  totals.inputCost += costBreakdown.input ?? 0
+  totals.outputCost += costBreakdown.output ?? 0
+  totals.cacheReadCost += costBreakdown.cacheRead ?? 0
+  totals.cacheWriteCost += costBreakdown.cacheWrite ?? 0
+}
 
 // Legacy function for backwards compatibility (no cost breakdown available)
-const applyCostTotal = (totals: CostUsageTotals, costTotal: number | undefined) => {
+const applyCostTotal = (
+  totals: CostUsageTotals,
+  costTotal: number | undefined,
+) => {
   if (costTotal === undefined) {
-    totals.missingCostEntries += 1;
-    return;
+    totals.missingCostEntries += 1
+    return
   }
-  totals.totalCost += costTotal;
-};
+  totals.totalCost += costTotal
+}
 
-async function* readJsonlRecords(filePath: string): AsyncGenerator<Record<string, unknown>> {
-  const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" });
-  const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+async function* readJsonlRecords(
+  filePath: string,
+): AsyncGenerator<Record<string, unknown>> {
+  const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" })
+  const rl = readline.createInterface({
+    input: fileStream,
+    crlfDelay: Infinity,
+  })
   try {
     for await (const line of rl) {
-      const trimmed = line.trim();
+      const trimmed = line.trim()
       if (!trimmed) {
-        continue;
+        continue
       }
       try {
-        const parsed = JSON.parse(trimmed) as unknown;
+        const parsed = JSON.parse(trimmed) as unknown
         if (!parsed || typeof parsed !== "object") {
-          continue;
+          continue
         }
-        yield parsed as Record<string, unknown>;
+        yield parsed as Record<string, unknown>
       } catch {
         // Ignore malformed lines
       }
     }
   } finally {
-    rl.close();
-    fileStream.destroy();
+    rl.close()
+    fileStream.destroy()
   }
 }
 
 async function scanTranscriptFile(params: {
-  filePath: string;
-  config?: OpenClawConfig;
-  onEntry: (entry: ParsedTranscriptEntry) => void;
+  filePath: string
+  config?: OpenClawConfig
+  onEntry: (entry: ParsedTranscriptEntry) => void
 }): Promise<void> {
   for await (const parsed of readJsonlRecords(params.filePath)) {
-    const entry = parseTranscriptEntry(parsed);
+    const entry = parseTranscriptEntry(parsed)
     if (!entry) {
-      continue;
+      continue
     }
 
     if (entry.usage && entry.costTotal === undefined) {
@@ -256,25 +287,25 @@ async function scanTranscriptFile(params: {
         provider: entry.provider,
         model: entry.model,
         config: params.config,
-      });
-      entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
+      })
+      entry.costTotal = estimateUsageCost({ usage: entry.usage, cost })
     }
 
-    params.onEntry(entry);
+    params.onEntry(entry)
   }
 }
 
 async function scanUsageFile(params: {
-  filePath: string;
-  config?: OpenClawConfig;
-  onEntry: (entry: ParsedUsageEntry) => void;
+  filePath: string
+  config?: OpenClawConfig
+  onEntry: (entry: ParsedUsageEntry) => void
 }): Promise<void> {
   await scanTranscriptFile({
     filePath: params.filePath,
     config: params.config,
     onEntry: (entry) => {
       if (!entry.usage) {
-        return;
+        return
       }
       params.onEntry({
         usage: entry.usage,
@@ -283,100 +314,107 @@ async function scanUsageFile(params: {
         provider: entry.provider,
         model: entry.model,
         timestamp: entry.timestamp,
-      });
+      })
     },
-  });
+  })
 }
 
 export async function loadCostUsageSummary(params?: {
-  startMs?: number;
-  endMs?: number;
-  days?: number; // Deprecated, for backwards compatibility
-  config?: OpenClawConfig;
-  agentId?: string;
+  startMs?: number
+  endMs?: number
+  days?: number // Deprecated, for backwards compatibility
+  config?: OpenClawConfig
+  agentId?: string
 }): Promise<CostUsageSummary> {
-  const now = new Date();
-  let sinceTime: number;
-  let untilTime: number;
+  const now = new Date()
+  let sinceTime: number
+  let untilTime: number
 
   if (params?.startMs !== undefined && params?.endMs !== undefined) {
-    sinceTime = params.startMs;
-    untilTime = params.endMs;
+    sinceTime = params.startMs
+    untilTime = params.endMs
   } else {
     // Fallback to days-based calculation for backwards compatibility
-    const days = Math.max(1, Math.floor(params?.days ?? 30));
-    const since = new Date(now);
-    since.setDate(since.getDate() - (days - 1));
-    sinceTime = since.getTime();
-    untilTime = now.getTime();
+    const days = Math.max(1, Math.floor(params?.days ?? 30))
+    const since = new Date(now)
+    since.setDate(since.getDate() - (days - 1))
+    sinceTime = since.getTime()
+    untilTime = now.getTime()
   }
 
-  const dailyMap = new Map<string, CostUsageTotals>();
-  const totals = emptyTotals();
+  const dailyMap = new Map<string, CostUsageTotals>()
+  const totals = emptyTotals()
 
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
-  const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId)
+  const entries = await fs.promises
+    .readdir(sessionsDir, { withFileTypes: true })
+    .catch(() => [])
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && (entry.name.endsWith(".jsonl") || isSessionArchiveArtifactName(entry.name)))
+        .filter(
+          (entry) =>
+            entry.isFile() &&
+            (entry.name.endsWith(".jsonl") ||
+              isSessionArchiveArtifactName(entry.name)),
+        )
         .map(async (entry) => {
-          const filePath = path.join(sessionsDir, entry.name);
-          const stats = await fs.promises.stat(filePath).catch(() => null);
+          const filePath = path.join(sessionsDir, entry.name)
+          const stats = await fs.promises.stat(filePath).catch(() => null)
           if (!stats) {
-            return null;
+            return null
           }
           // Include file if it was modified after our start time
           if (stats.mtimeMs < sinceTime) {
-            return null;
+            return null
           }
-          return filePath;
+          return filePath
         }),
     )
-  ).filter((filePath): filePath is string => Boolean(filePath));
+  ).filter((filePath): filePath is string => Boolean(filePath))
 
   for (const filePath of files) {
     await scanUsageFile({
       filePath,
       config: params?.config,
       onEntry: (entry) => {
-        const ts = entry.timestamp?.getTime();
+        const ts = entry.timestamp?.getTime()
         if (!ts || ts < sinceTime || ts > untilTime) {
-          return;
+          return
         }
-        const dayKey = formatDayKey(entry.timestamp ?? now);
-        const bucket = dailyMap.get(dayKey) ?? emptyTotals();
-        applyUsageTotals(bucket, entry.usage);
+        const dayKey = formatDayKey(entry.timestamp ?? now)
+        const bucket = dailyMap.get(dayKey) ?? emptyTotals()
+        applyUsageTotals(bucket, entry.usage)
         if (entry.costBreakdown?.total !== undefined) {
-          applyCostBreakdown(bucket, entry.costBreakdown);
+          applyCostBreakdown(bucket, entry.costBreakdown)
         } else {
-          applyCostTotal(bucket, entry.costTotal);
+          applyCostTotal(bucket, entry.costTotal)
         }
-        dailyMap.set(dayKey, bucket);
+        dailyMap.set(dayKey, bucket)
 
-        applyUsageTotals(totals, entry.usage);
+        applyUsageTotals(totals, entry.usage)
         if (entry.costBreakdown?.total !== undefined) {
-          applyCostBreakdown(totals, entry.costBreakdown);
+          applyCostBreakdown(totals, entry.costBreakdown)
         } else {
-          applyCostTotal(totals, entry.costTotal);
+          applyCostTotal(totals, entry.costTotal)
         }
       },
-    });
+    })
   }
 
   const daily = Array.from(dailyMap.entries())
     .map(([date, bucket]) => Object.assign({ date }, bucket))
-    .toSorted((a, b) => a.date.localeCompare(b.date));
+    .toSorted((a, b) => a.date.localeCompare(b.date))
 
   // Calculate days for backwards compatibility in response
-  const days = Math.ceil((untilTime - sinceTime) / (24 * 60 * 60 * 1000)) + 1;
+  const days = Math.ceil((untilTime - sinceTime) / (24 * 60 * 60 * 1000)) + 1
 
   return {
     updatedAt: Date.now(),
     days,
     daily,
     totals,
-  };
+  }
 }
 
 /**
@@ -384,46 +422,55 @@ export async function loadCostUsageSummary(params?: {
  * Returns basic metadata for each discovered session.
  */
 export async function discoverAllSessions(params?: {
-  agentId?: string;
-  startMs?: number;
-  endMs?: number;
+  agentId?: string
+  startMs?: number
+  endMs?: number
 }): Promise<DiscoveredSession[]> {
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
-  const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId)
+  const entries = await fs.promises
+    .readdir(sessionsDir, { withFileTypes: true })
+    .catch(() => [])
 
-  const discovered: DiscoveredSession[] = [];
+  const discovered: DiscoveredSession[] = []
 
   for (const entry of entries) {
-    if (!entry.isFile() || (!entry.name.endsWith(".jsonl") && !isSessionArchiveArtifactName(entry.name))) {
-      continue;
+    if (
+      !entry.isFile() ||
+      (!entry.name.endsWith(".jsonl") &&
+        !isSessionArchiveArtifactName(entry.name))
+    ) {
+      continue
     }
 
-    const filePath = path.join(sessionsDir, entry.name);
-    const stats = await fs.promises.stat(filePath).catch(() => null);
+    const filePath = path.join(sessionsDir, entry.name)
+    const stats = await fs.promises.stat(filePath).catch(() => null)
     if (!stats) {
-      continue;
+      continue
     }
 
     // Filter by date range if provided
     if (params?.startMs && stats.mtimeMs < params.startMs) {
-      continue;
+      continue
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
     // Extract session ID from filename (remove .jsonl and any archive suffix)
-    const jsonlIndex = entry.name.indexOf(".jsonl");
-    const sessionId = jsonlIndex >= 0 ? entry.name.slice(0, jsonlIndex) : entry.name.slice(0, -6);
+    const jsonlIndex = entry.name.indexOf(".jsonl")
+    const sessionId =
+      jsonlIndex >= 0
+        ? entry.name.slice(0, jsonlIndex)
+        : entry.name.slice(0, -6)
 
     // Try to read first user message for label extraction
-    let firstUserMessage: string | undefined;
+    let firstUserMessage: string | undefined
     try {
       for await (const parsed of readJsonlRecords(filePath)) {
         try {
-          const message = parsed.message as Record<string, unknown> | undefined;
+          const message = parsed.message as Record<string, unknown> | undefined
           if (message?.role === "user") {
-            const content = message.content;
+            const content = message.content
             if (typeof content === "string") {
-              firstUserMessage = content.slice(0, 100);
+              firstUserMessage = content.slice(0, 100)
             } else if (Array.isArray(content)) {
               for (const block of content) {
                 if (
@@ -431,15 +478,15 @@ export async function discoverAllSessions(params?: {
                   block &&
                   (block as Record<string, unknown>).type === "text"
                 ) {
-                  const text = (block as Record<string, unknown>).text;
+                  const text = (block as Record<string, unknown>).text
                   if (typeof text === "string") {
-                    firstUserMessage = text.slice(0, 100);
+                    firstUserMessage = text.slice(0, 100)
                   }
-                  break;
+                  break
                 }
               }
             }
-            break; // Found first user message
+            break // Found first user message
           }
         } catch {
           // Skip malformed lines
@@ -454,21 +501,21 @@ export async function discoverAllSessions(params?: {
       sessionFile: filePath,
       mtime: stats.mtimeMs,
       firstUserMessage,
-    });
+    })
   }
 
   // Sort by mtime descending (most recent first)
-  return discovered.toSorted((a, b) => b.mtime - a.mtime);
+  return discovered.toSorted((a, b) => b.mtime - a.mtime)
 }
 
 export async function loadSessionCostSummary(params: {
-  sessionId?: string;
-  sessionEntry?: SessionEntry;
-  sessionFile?: string;
-  config?: OpenClawConfig;
-  agentId?: string;
-  startMs?: number;
-  endMs?: number;
+  sessionId?: string
+  sessionEntry?: SessionEntry
+  sessionFile?: string
+  config?: OpenClawConfig
+  agentId?: string
+  startMs?: number
+  endMs?: number
 }): Promise<SessionCostSummary | null> {
   const sessionFile =
     params.sessionFile ??
@@ -476,19 +523,19 @@ export async function loadSessionCostSummary(params: {
       ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
           agentId: params.agentId,
         })
-      : undefined);
+      : undefined)
   if (!sessionFile || !fs.existsSync(sessionFile)) {
-    return null;
+    return null
   }
 
-  const totals = emptyTotals();
-  let firstActivity: number | undefined;
-  let lastActivity: number | undefined;
-  const activityDatesSet = new Set<string>();
-  const dailyMap = new Map<string, { tokens: number; cost: number }>();
-  const dailyMessageMap = new Map<string, SessionDailyMessageCounts>();
-  const dailyLatencyMap = new Map<string, number[]>();
-  const dailyModelUsageMap = new Map<string, SessionDailyModelUsage>();
+  const totals = emptyTotals()
+  let firstActivity: number | undefined
+  let lastActivity: number | undefined
+  const activityDatesSet = new Set<string>()
+  const dailyMap = new Map<string, { tokens: number cost: number }>()
+  const dailyMessageMap = new Map<string, SessionDailyMessageCounts>()
+  const dailyLatencyMap = new Map<string, number[]>()
+  const dailyModelUsageMap = new Map<string, SessionDailyModelUsage>()
   const messageCounts: SessionMessageCounts = {
     total: 0,
     user: 0,
@@ -496,85 +543,91 @@ export async function loadSessionCostSummary(params: {
     toolCalls: 0,
     toolResults: 0,
     errors: 0,
-  };
-  const toolUsageMap = new Map<string, number>();
-  const modelUsageMap = new Map<string, SessionModelUsage>();
-  const errorStopReasons = new Set(["error", "aborted", "timeout"]);
-  const latencyValues: number[] = [];
-  let lastUserTimestamp: number | undefined;
-  const MAX_LATENCY_MS = 12 * 60 * 60 * 1000;
+  }
+  const toolUsageMap = new Map<string, number>()
+  const modelUsageMap = new Map<string, SessionModelUsage>()
+  const errorStopReasons = new Set(["error", "aborted", "timeout"])
+  const latencyValues: number[] = []
+  let lastUserTimestamp: number | undefined
+  const MAX_LATENCY_MS = 12 * 60 * 60 * 1000
 
   await scanTranscriptFile({
     filePath: sessionFile,
     config: params.config,
     onEntry: (entry) => {
-      const ts = entry.timestamp?.getTime();
+      const ts = entry.timestamp?.getTime()
 
       // Filter by date range if specified
-      if (params.startMs !== undefined && ts !== undefined && ts < params.startMs) {
-        return;
+      if (
+        params.startMs !== undefined &&
+        ts !== undefined &&
+        ts < params.startMs
+      ) {
+        return
       }
       if (params.endMs !== undefined && ts !== undefined && ts > params.endMs) {
-        return;
+        return
       }
 
       if (ts !== undefined) {
         if (!firstActivity || ts < firstActivity) {
-          firstActivity = ts;
+          firstActivity = ts
         }
         if (!lastActivity || ts > lastActivity) {
-          lastActivity = ts;
+          lastActivity = ts
         }
       }
 
       if (entry.role === "user") {
-        messageCounts.user += 1;
-        messageCounts.total += 1;
+        messageCounts.user += 1
+        messageCounts.total += 1
         if (entry.timestamp) {
-          lastUserTimestamp = entry.timestamp.getTime();
+          lastUserTimestamp = entry.timestamp.getTime()
         }
       }
       if (entry.role === "assistant") {
-        messageCounts.assistant += 1;
-        messageCounts.total += 1;
-        const ts = entry.timestamp?.getTime();
+        messageCounts.assistant += 1
+        messageCounts.total += 1
+        const ts = entry.timestamp?.getTime()
         if (ts !== undefined) {
           const latencyMs =
             entry.durationMs ??
-            (lastUserTimestamp !== undefined ? Math.max(0, ts - lastUserTimestamp) : undefined);
+            (lastUserTimestamp !== undefined
+              ? Math.max(0, ts - lastUserTimestamp)
+              : undefined)
           if (
             latencyMs !== undefined &&
             Number.isFinite(latencyMs) &&
             latencyMs <= MAX_LATENCY_MS
           ) {
-            latencyValues.push(latencyMs);
-            const dayKey = formatDayKey(entry.timestamp ?? new Date(ts));
-            const dailyLatencies = dailyLatencyMap.get(dayKey) ?? [];
-            dailyLatencies.push(latencyMs);
-            dailyLatencyMap.set(dayKey, dailyLatencies);
+            latencyValues.push(latencyMs)
+            const dayKey = formatDayKey(entry.timestamp ?? new Date(ts))
+            const dailyLatencies = dailyLatencyMap.get(dayKey) ?? []
+            dailyLatencies.push(latencyMs)
+            dailyLatencyMap.set(dayKey, dailyLatencies)
           }
         }
       }
 
       if (entry.toolNames.length > 0) {
-        messageCounts.toolCalls += entry.toolNames.length;
+        messageCounts.toolCalls += entry.toolNames.length
         for (const name of entry.toolNames) {
-          toolUsageMap.set(name, (toolUsageMap.get(name) ?? 0) + 1);
+          toolUsageMap.set(name, (toolUsageMap.get(name) ?? 0) + 1)
         }
       }
 
       if (entry.toolResultCounts.total > 0) {
-        messageCounts.toolResults += entry.toolResultCounts.total;
-        messageCounts.errors += entry.toolResultCounts.errors;
+        messageCounts.toolResults += entry.toolResultCounts.total
+        messageCounts.errors += entry.toolResultCounts.errors
       }
 
       if (entry.stopReason && errorStopReasons.has(entry.stopReason)) {
-        messageCounts.errors += 1;
+        messageCounts.errors += 1
       }
 
       if (entry.timestamp) {
-        const dayKey = formatDayKey(entry.timestamp);
-        activityDatesSet.add(dayKey);
+        const dayKey = formatDayKey(entry.timestamp)
+        activityDatesSet.add(dayKey)
         const daily = dailyMessageMap.get(dayKey) ?? {
           date: dayKey,
           total: 0,
@@ -583,40 +636,41 @@ export async function loadSessionCostSummary(params: {
           toolCalls: 0,
           toolResults: 0,
           errors: 0,
-        };
-        daily.total += entry.role === "user" || entry.role === "assistant" ? 1 : 0;
+        }
+        daily.total +=
+          entry.role === "user" || entry.role === "assistant" ? 1 : 0
         if (entry.role === "user") {
-          daily.user += 1;
+          daily.user += 1
         } else if (entry.role === "assistant") {
-          daily.assistant += 1;
+          daily.assistant += 1
         }
-        daily.toolCalls += entry.toolNames.length;
-        daily.toolResults += entry.toolResultCounts.total;
-        daily.errors += entry.toolResultCounts.errors;
+        daily.toolCalls += entry.toolNames.length
+        daily.toolResults += entry.toolResultCounts.total
+        daily.errors += entry.toolResultCounts.errors
         if (entry.stopReason && errorStopReasons.has(entry.stopReason)) {
-          daily.errors += 1;
+          daily.errors += 1
         }
-        dailyMessageMap.set(dayKey, daily);
+        dailyMessageMap.set(dayKey, daily)
       }
 
       if (!entry.usage) {
-        return;
+        return
       }
 
-      applyUsageTotals(totals, entry.usage);
+      applyUsageTotals(totals, entry.usage)
       if (entry.costBreakdown?.total !== undefined) {
-        applyCostBreakdown(totals, entry.costBreakdown);
+        applyCostBreakdown(totals, entry.costBreakdown)
       } else {
-        applyCostTotal(totals, entry.costTotal);
+        applyCostTotal(totals, entry.costTotal)
       }
 
       if (entry.timestamp) {
-        const dayKey = formatDayKey(entry.timestamp);
+        const dayKey = formatDayKey(entry.timestamp)
         const entryTokens =
           (entry.usage.input ?? 0) +
           (entry.usage.output ?? 0) +
           (entry.usage.cacheRead ?? 0) +
-          (entry.usage.cacheWrite ?? 0);
+          (entry.usage.cacheWrite ?? 0)
         const entryCost =
           entry.costBreakdown?.total ??
           (entry.costBreakdown
@@ -624,98 +678,103 @@ export async function loadSessionCostSummary(params: {
               (entry.costBreakdown.output ?? 0) +
               (entry.costBreakdown.cacheRead ?? 0) +
               (entry.costBreakdown.cacheWrite ?? 0)
-            : (entry.costTotal ?? 0));
+            : (entry.costTotal ?? 0))
 
-        const existing = dailyMap.get(dayKey) ?? { tokens: 0, cost: 0 };
+        const existing = dailyMap.get(dayKey) ?? { tokens: 0, cost: 0 }
         dailyMap.set(dayKey, {
           tokens: existing.tokens + entryTokens,
           cost: existing.cost + entryCost,
-        });
+        })
 
         if (entry.provider || entry.model) {
-          const modelKey = `${dayKey}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+          const modelKey = `${dayKey}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`
           const dailyModel =
             dailyModelUsageMap.get(modelKey) ??
-            ({
+            {
               date: dayKey,
               provider: entry.provider,
               model: entry.model,
               tokens: 0,
               cost: 0,
               count: 0,
-            } as SessionDailyModelUsage);
-          dailyModel.tokens += entryTokens;
-          dailyModel.cost += entryCost;
-          dailyModel.count += 1;
-          dailyModelUsageMap.set(modelKey, dailyModel);
+            } as SessionDailyModelUsage
+          dailyModel.tokens += entryTokens
+          dailyModel.cost += entryCost
+          dailyModel.count += 1
+          dailyModelUsageMap.set(modelKey, dailyModel)
         }
       }
 
       if (entry.provider || entry.model) {
-        const key = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+        const key = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`
         const existing =
           modelUsageMap.get(key) ??
-          ({
+          {
             provider: entry.provider,
             model: entry.model,
             count: 0,
             totals: emptyTotals(),
-          } as SessionModelUsage);
-        existing.count += 1;
-        applyUsageTotals(existing.totals, entry.usage);
+          } as SessionModelUsage
+        existing.count += 1
+        applyUsageTotals(existing.totals, entry.usage)
         if (entry.costBreakdown?.total !== undefined) {
-          applyCostBreakdown(existing.totals, entry.costBreakdown);
+          applyCostBreakdown(existing.totals, entry.costBreakdown)
         } else {
-          applyCostTotal(existing.totals, entry.costTotal);
+          applyCostTotal(existing.totals, entry.costTotal)
         }
-        modelUsageMap.set(key, existing);
+        modelUsageMap.set(key, existing)
       }
     },
-  });
+  })
 
   // Convert daily map to sorted array
   const dailyBreakdown: SessionDailyUsage[] = Array.from(dailyMap.entries())
     .map(([date, data]) => ({ date, tokens: data.tokens, cost: data.cost }))
-    .toSorted((a, b) => a.date.localeCompare(b.date));
+    .toSorted((a, b) => a.date.localeCompare(b.date))
 
   const dailyMessageCounts: SessionDailyMessageCounts[] = Array.from(
     dailyMessageMap.values(),
-  ).toSorted((a, b) => a.date.localeCompare(b.date));
+  ).toSorted((a, b) => a.date.localeCompare(b.date))
 
-  const dailyLatency: SessionDailyLatency[] = Array.from(dailyLatencyMap.entries())
+  const dailyLatency: SessionDailyLatency[] = Array.from(
+    dailyLatencyMap.entries(),
+  )
     .map(([date, values]) => {
-      const stats = computeLatencyStats(values);
+      const stats = computeLatencyStats(values)
       if (!stats) {
-        return null;
+        return null
       }
-      return { date, ...stats };
+      return { date, ...stats }
     })
     .filter((entry): entry is SessionDailyLatency => Boolean(entry))
-    .toSorted((a, b) => a.date.localeCompare(b.date));
+    .toSorted((a, b) => a.date.localeCompare(b.date))
 
   const dailyModelUsage: SessionDailyModelUsage[] = Array.from(
     dailyModelUsageMap.values(),
-  ).toSorted((a, b) => a.date.localeCompare(b.date) || b.cost - a.cost);
+  ).toSorted((a, b) => a.date.localeCompare(b.date) || b.cost - a.cost)
 
   const toolUsage: SessionToolUsage | undefined = toolUsageMap.size
     ? {
-        totalCalls: Array.from(toolUsageMap.values()).reduce((sum, count) => sum + count, 0),
+        totalCalls: Array.from(toolUsageMap.values()).reduce(
+          (sum, count) => sum + count,
+          0,
+        ),
         uniqueTools: toolUsageMap.size,
         tools: Array.from(toolUsageMap.entries())
           .map(([name, count]) => ({ name, count }))
           .toSorted((a, b) => b.count - a.count),
       }
-    : undefined;
+    : undefined
 
   const modelUsage = modelUsageMap.size
     ? Array.from(modelUsageMap.values()).toSorted((a, b) => {
-        const costDiff = b.totals.totalCost - a.totals.totalCost;
+        const costDiff = b.totals.totalCost - a.totals.totalCost
         if (costDiff !== 0) {
-          return costDiff;
+          return costDiff
         }
-        return b.totals.totalTokens - a.totals.totalTokens;
+        return b.totals.totalTokens - a.totals.totalTokens
       })
-    : undefined;
+    : undefined
 
   return {
     sessionId: params.sessionId,
@@ -736,16 +795,16 @@ export async function loadSessionCostSummary(params: {
     modelUsage,
     latency: computeLatencyStats(latencyValues),
     ...totals,
-  };
+  }
 }
 
 export async function loadSessionUsageTimeSeries(params: {
-  sessionId?: string;
-  sessionEntry?: SessionEntry;
-  sessionFile?: string;
-  config?: OpenClawConfig;
-  agentId?: string;
-  maxPoints?: number;
+  sessionId?: string
+  sessionEntry?: SessionEntry
+  sessionFile?: string
+  config?: OpenClawConfig
+  agentId?: string
+  maxPoints?: number
 }): Promise<SessionUsageTimeSeries | null> {
   const sessionFile =
     params.sessionFile ??
@@ -753,33 +812,34 @@ export async function loadSessionUsageTimeSeries(params: {
       ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
           agentId: params.agentId,
         })
-      : undefined);
+      : undefined)
   if (!sessionFile || !fs.existsSync(sessionFile)) {
-    return null;
+    return null
   }
 
-  const points: SessionUsageTimePoint[] = [];
-  let cumulativeTokens = 0;
-  let cumulativeCost = 0;
+  const points: SessionUsageTimePoint[] = []
+  let cumulativeTokens = 0
+  let cumulativeCost = 0
 
   await scanUsageFile({
     filePath: sessionFile,
     config: params.config,
     onEntry: (entry) => {
-      const ts = entry.timestamp?.getTime();
+      const ts = entry.timestamp?.getTime()
       if (!ts) {
-        return;
+        return
       }
 
-      const input = entry.usage.input ?? 0;
-      const output = entry.usage.output ?? 0;
-      const cacheRead = entry.usage.cacheRead ?? 0;
-      const cacheWrite = entry.usage.cacheWrite ?? 0;
-      const totalTokens = entry.usage.total ?? input + output + cacheRead + cacheWrite;
-      const cost = entry.costTotal ?? 0;
+      const input = entry.usage.input ?? 0
+      const output = entry.usage.output ?? 0
+      const cacheRead = entry.usage.cacheRead ?? 0
+      const cacheWrite = entry.usage.cacheWrite ?? 0
+      const totalTokens =
+        entry.usage.total ?? input + output + cacheRead + cacheWrite
+      const cost = entry.costTotal ?? 0
 
-      cumulativeTokens += totalTokens;
-      cumulativeCost += cost;
+      cumulativeTokens += totalTokens
+      cumulativeCost += cost
 
       points.push({
         timestamp: ts,
@@ -791,44 +851,44 @@ export async function loadSessionUsageTimeSeries(params: {
         cost,
         cumulativeTokens,
         cumulativeCost,
-      });
+      })
     },
-  });
+  })
 
   // Sort by timestamp
-  const sortedPoints = points.toSorted((a, b) => a.timestamp - b.timestamp);
+  const sortedPoints = points.toSorted((a, b) => a.timestamp - b.timestamp)
 
   // Optionally downsample if too many points
-  const maxPoints = params.maxPoints ?? 100;
+  const maxPoints = params.maxPoints ?? 100
   if (sortedPoints.length > maxPoints) {
-    const step = Math.ceil(sortedPoints.length / maxPoints);
-    const downsampled: SessionUsageTimePoint[] = [];
-    let downsampledCumulativeTokens = 0;
-    let downsampledCumulativeCost = 0;
+    const step = Math.ceil(sortedPoints.length / maxPoints)
+    const downsampled: SessionUsageTimePoint[] = []
+    let downsampledCumulativeTokens = 0
+    let downsampledCumulativeCost = 0
     for (let i = 0; i < sortedPoints.length; i += step) {
-      const bucket = sortedPoints.slice(i, i + step);
-      const bucketLast = bucket[bucket.length - 1];
+      const bucket = sortedPoints.slice(i, i + step)
+      const bucketLast = bucket[bucket.length - 1]
       if (!bucketLast) {
-        continue;
+        continue
       }
 
-      let bucketInput = 0;
-      let bucketOutput = 0;
-      let bucketCacheRead = 0;
-      let bucketCacheWrite = 0;
-      let bucketTotalTokens = 0;
-      let bucketCost = 0;
+      let bucketInput = 0
+      let bucketOutput = 0
+      let bucketCacheRead = 0
+      let bucketCacheWrite = 0
+      let bucketTotalTokens = 0
+      let bucketCost = 0
       for (const point of bucket) {
-        bucketInput += point.input;
-        bucketOutput += point.output;
-        bucketCacheRead += point.cacheRead;
-        bucketCacheWrite += point.cacheWrite;
-        bucketTotalTokens += point.totalTokens;
-        bucketCost += point.cost;
+        bucketInput += point.input
+        bucketOutput += point.output
+        bucketCacheRead += point.cacheRead
+        bucketCacheWrite += point.cacheWrite
+        bucketTotalTokens += point.totalTokens
+        bucketCost += point.cost
       }
 
-      downsampledCumulativeTokens += bucketTotalTokens;
-      downsampledCumulativeCost += bucketCost;
+      downsampledCumulativeTokens += bucketTotalTokens
+      downsampledCumulativeCost += bucketCost
 
       downsampled.push({
         timestamp: bucketLast.timestamp,
@@ -840,21 +900,21 @@ export async function loadSessionUsageTimeSeries(params: {
         cost: bucketCost,
         cumulativeTokens: downsampledCumulativeTokens,
         cumulativeCost: downsampledCumulativeCost,
-      });
+      })
     }
-    return { sessionId: params.sessionId, points: downsampled };
+    return { sessionId: params.sessionId, points: downsampled }
   }
 
-  return { sessionId: params.sessionId, points: sortedPoints };
+  return { sessionId: params.sessionId, points: sortedPoints }
 }
 
 export async function loadSessionLogs(params: {
-  sessionId?: string;
-  sessionEntry?: SessionEntry;
-  sessionFile?: string;
-  config?: OpenClawConfig;
-  agentId?: string;
-  limit?: number;
+  sessionId?: string
+  sessionEntry?: SessionEntry
+  sessionFile?: string
+  config?: OpenClawConfig
+  agentId?: string
+  limit?: number
 }): Promise<SessionLogEntry[] | null> {
   const sessionFile =
     params.sessionFile ??
@@ -862,134 +922,146 @@ export async function loadSessionLogs(params: {
       ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
           agentId: params.agentId,
         })
-      : undefined);
+      : undefined)
   if (!sessionFile || !fs.existsSync(sessionFile)) {
-    return null;
+    return null
   }
 
-  const logs: SessionLogEntry[] = [];
-  const limit = params.limit ?? 50;
+  const logs: SessionLogEntry[] = []
+  const limit = params.limit ?? 50
 
   for await (const parsed of readJsonlRecords(sessionFile)) {
     try {
-      const message = parsed.message as Record<string, unknown> | undefined;
+      const message = parsed.message as Record<string, unknown> | undefined
       if (!message) {
-        continue;
+        continue
       }
 
-      const role = message.role as string | undefined;
-      if (role !== "user" && role !== "assistant" && role !== "tool" && role !== "toolResult") {
-        continue;
+      const role = message.role as string | undefined
+      if (
+        role !== "user" &&
+        role !== "assistant" &&
+        role !== "tool" &&
+        role !== "toolResult"
+      ) {
+        continue
       }
 
-      const contentParts: string[] = [];
-      const rawToolName = message.toolName ?? message.tool_name ?? message.name ?? message.tool;
+      const contentParts: string[] = []
+      const rawToolName =
+        message.toolName ?? message.tool_name ?? message.name ?? message.tool
       const toolName =
-        typeof rawToolName === "string" && rawToolName.trim() ? rawToolName.trim() : undefined;
+        typeof rawToolName === "string" && rawToolName.trim()
+          ? rawToolName.trim()
+          : undefined
       if (role === "tool" || role === "toolResult") {
-        contentParts.push(`[Tool: ${toolName ?? "tool"}]`);
-        contentParts.push("[Tool Result]");
+        contentParts.push(`[Tool: ${toolName ?? "tool"}]`)
+        contentParts.push("[Tool Result]")
       }
 
       // Extract content
-      const rawContent = message.content;
+      const rawContent = message.content
       if (typeof rawContent === "string") {
-        contentParts.push(rawContent);
+        contentParts.push(rawContent)
       } else if (Array.isArray(rawContent)) {
         // Handle content blocks (text, tool_use, etc.)
         const contentText = rawContent
           .map((block: unknown) => {
             if (typeof block === "string") {
-              return block;
+              return block
             }
-            const b = block as Record<string, unknown>;
+            const b = block as Record<string, unknown>
             if (b.type === "text" && typeof b.text === "string") {
-              return b.text;
+              return b.text
             }
             if (b.type === "tool_use") {
-              const name = typeof b.name === "string" ? b.name : "unknown";
-              return `[Tool: ${name}]`;
+              const name = typeof b.name === "string" ? b.name : "unknown"
+              return `[Tool: ${name}]`
             }
             if (b.type === "tool_result") {
-              return `[Tool Result]`;
+              return `[Tool Result]`
             }
-            return "";
+            return ""
           })
           .filter(Boolean)
-          .join("\n");
+          .join("\n")
         if (contentText) {
-          contentParts.push(contentText);
+          contentParts.push(contentText)
         }
       }
 
       // OpenAI-style tool calls stored outside the content array.
       const rawToolCalls =
-        message.tool_calls ?? message.toolCalls ?? message.function_call ?? message.functionCall;
+        message.tool_calls ??
+        message.toolCalls ??
+        message.function_call ??
+        message.functionCall
       const toolCalls = Array.isArray(rawToolCalls)
         ? rawToolCalls
         : rawToolCalls
           ? [rawToolCalls]
-          : [];
+          : []
       if (toolCalls.length > 0) {
         for (const call of toolCalls) {
-          const callObj = call as Record<string, unknown>;
-          const directName = typeof callObj.name === "string" ? callObj.name : undefined;
-          const fn = callObj.function as Record<string, unknown> | undefined;
-          const fnName = typeof fn?.name === "string" ? fn.name : undefined;
-          const name = directName ?? fnName ?? "unknown";
-          contentParts.push(`[Tool: ${name}]`);
+          const callObj = call as Record<string, unknown>
+          const directName =
+            typeof callObj.name === "string" ? callObj.name : undefined
+          const fn = callObj.function as Record<string, unknown> | undefined
+          const fnName = typeof fn?.name === "string" ? fn.name : undefined
+          const name = directName ?? fnName ?? "unknown"
+          contentParts.push(`[Tool: ${name}]`)
         }
       }
 
-      let content = contentParts.join("\n").trim();
+      let content = contentParts.join("\n").trim()
       if (!content) {
-        continue;
+        continue
       }
-      content = stripInboundMetadata(content);
+      content = stripInboundMetadata(content)
       if (role === "user") {
-        content = stripMessageIdHints(stripEnvelope(content)).trim();
+        content = stripMessageIdHints(stripEnvelope(content)).trim()
       }
       if (!content) {
-        continue;
+        continue
       }
 
       // Truncate very long content
-      const maxLen = 2000;
+      const maxLen = 2000
       if (content.length > maxLen) {
-        content = content.slice(0, maxLen) + "…";
+        content = content.slice(0, maxLen) + "…"
       }
 
       // Get timestamp
-      let timestamp = 0;
+      let timestamp = 0
       if (typeof parsed.timestamp === "string") {
-        timestamp = new Date(parsed.timestamp).getTime();
+        timestamp = new Date(parsed.timestamp).getTime()
       } else if (typeof message.timestamp === "number") {
-        timestamp = message.timestamp;
+        timestamp = message.timestamp
       }
 
       // Get usage for assistant messages
-      let tokens: number | undefined;
-      let cost: number | undefined;
+      let tokens: number | undefined
+      let cost: number | undefined
       if (role === "assistant") {
-        const usageRaw = message.usage as Record<string, unknown> | undefined;
-        const usage = normalizeUsage(usageRaw);
+        const usageRaw = message.usage as Record<string, unknown> | undefined
+        const usage = normalizeUsage(usageRaw)
         if (usage) {
           tokens =
             usage.total ??
             (usage.input ?? 0) +
               (usage.output ?? 0) +
               (usage.cacheRead ?? 0) +
-              (usage.cacheWrite ?? 0);
-          const breakdown = extractCostBreakdown(usageRaw);
+              (usage.cacheWrite ?? 0)
+          const breakdown = extractCostBreakdown(usageRaw)
           if (breakdown?.total !== undefined) {
-            cost = breakdown.total;
+            cost = breakdown.total
           } else {
             const costConfig = resolveModelCostConfig({
               provider: message.provider as string | undefined,
               model: message.model as string | undefined,
               config: params.config,
-            });
-            cost = estimateUsageCost({ usage, cost: costConfig });
+            })
+            cost = estimateUsageCost({ usage, cost: costConfig })
           }
         }
       }
@@ -1000,19 +1072,19 @@ export async function loadSessionLogs(params: {
         content,
         tokens,
         cost,
-      });
+      })
     } catch {
       // Ignore malformed lines
     }
   }
 
   // Sort by timestamp and limit
-  const sortedLogs = logs.toSorted((a, b) => a.timestamp - b.timestamp);
+  const sortedLogs = logs.toSorted((a, b) => a.timestamp - b.timestamp)
 
   // Return most recent logs
   if (sortedLogs.length > limit) {
-    return sortedLogs.slice(-limit);
+    return sortedLogs.slice(-limit)
   }
 
-  return sortedLogs;
+  return sortedLogs
 }

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1,25 +1,19 @@
-import fs from "node:fs"
-import path from "node:path"
-import readline from "node:readline"
-import type { NormalizedUsage, UsageLike } from "../agents/usage.js"
-import { normalizeUsage } from "../agents/usage.js"
-import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js"
-import type { OpenClawConfig } from "../config/config.js"
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
+import { normalizeUsage } from "../agents/usage.js";
+import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { isSessionArchiveArtifactName } from "../config/sessions/artifacts.js";
 import {
   resolveSessionFilePath,
   resolveSessionTranscriptsDirForAgent,
-} from "../config/sessions/paths.js"
-import { isSessionArchiveArtifactName } from "../config/sessions/artifacts.js"
-import type { SessionEntry } from "../config/sessions/types.js"
-import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js"
-import {
-  countToolResults,
-  extractToolCallNames,
-} from "../utils/transcript-tools.js"
-import {
-  estimateUsageCost,
-  resolveModelCostConfig,
-} from "../utils/usage-format.js"
+} from "../config/sessions/paths.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
+import { countToolResults, extractToolCallNames } from "../utils/transcript-tools.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 import type {
   CostBreakdown,
   CostUsageTotals,
@@ -39,7 +33,7 @@ import type {
   SessionToolUsage,
   SessionUsageTimePoint,
   SessionUsageTimeSeries,
-} from "./session-cost-usage.types.js"
+} from "./session-cost-usage.types.js";
 
 export type {
   CostUsageDailyEntry,
@@ -58,7 +52,7 @@ export type {
   SessionToolUsage,
   SessionUsageTimePoint,
   SessionUsageTimeSeries,
-} from "./session-cost-usage.types.js"
+} from "./session-cost-usage.types.js";
 
 const emptyTotals = (): CostUsageTotals => ({
   input: 0,
@@ -72,33 +66,31 @@ const emptyTotals = (): CostUsageTotals => ({
   cacheReadCost: 0,
   cacheWriteCost: 0,
   missingCostEntries: 0,
-})
+});
 
 const toFiniteNumber = (value: unknown): number | undefined => {
   if (typeof value !== "number") {
-    return undefined
+    return undefined;
   }
   if (!Number.isFinite(value)) {
-    return undefined
+    return undefined;
   }
-  return value
-}
+  return value;
+};
 
-const extractCostBreakdown = (
-  usageRaw?: UsageLike | null,
-): CostBreakdown | undefined => {
+const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | undefined => {
   if (!usageRaw || typeof usageRaw !== "object") {
-    return undefined
+    return undefined;
   }
-  const record = usageRaw as Record<string, unknown>
-  const cost = record.cost as Record<string, unknown> | undefined
+  const record = usageRaw as Record<string, unknown>;
+  const cost = record.cost as Record<string, unknown> | undefined;
   if (!cost) {
-    return undefined
+    return undefined;
   }
 
-  const total = toFiniteNumber(cost.total)
+  const total = toFiniteNumber(cost.total);
   if (total === undefined || total < 0) {
-    return undefined
+    return undefined;
   }
 
   return {
@@ -107,59 +99,54 @@ const extractCostBreakdown = (
     output: toFiniteNumber(cost.output),
     cacheRead: toFiniteNumber(cost.cacheRead),
     cacheWrite: toFiniteNumber(cost.cacheWrite),
-  }
-}
+  };
+};
 
 const parseTimestamp = (entry: Record<string, unknown>): Date | undefined => {
-  const raw = entry.timestamp
+  const raw = entry.timestamp;
   if (typeof raw === "string") {
-    const parsed = new Date(raw)
+    const parsed = new Date(raw);
     if (!Number.isNaN(parsed.valueOf())) {
-      return parsed
+      return parsed;
     }
   }
-  const message = entry.message as Record<string, unknown> | undefined
-  const messageTimestamp = toFiniteNumber(message?.timestamp)
+  const message = entry.message as Record<string, unknown> | undefined;
+  const messageTimestamp = toFiniteNumber(message?.timestamp);
   if (messageTimestamp !== undefined) {
-    const parsed = new Date(messageTimestamp)
+    const parsed = new Date(messageTimestamp);
     if (!Number.isNaN(parsed.valueOf())) {
-      return parsed
+      return parsed;
     }
   }
-  return undefined
-}
+  return undefined;
+};
 
-const parseTranscriptEntry = (
-  entry: Record<string, unknown>,
-): ParsedTranscriptEntry | null => {
-  const message = entry.message as Record<string, unknown> | undefined
+const parseTranscriptEntry = (entry: Record<string, unknown>): ParsedTranscriptEntry | null => {
+  const message = entry.message as Record<string, unknown> | undefined;
   if (!message || typeof message !== "object") {
-    return null
+    return null;
   }
 
-  const roleRaw = message.role
-  const role =
-    roleRaw === "user" || roleRaw === "assistant" ? roleRaw : undefined
+  const roleRaw = message.role;
+  const role = roleRaw === "user" || roleRaw === "assistant" ? roleRaw : undefined;
   if (!role) {
-    return null
+    return null;
   }
 
   const usageRaw =
-    message.usage as UsageLike | undefined ??
-    entry.usage as UsageLike | undefined
-  const usage = usageRaw ? (normalizeUsage(usageRaw) ?? undefined) : undefined
+    (message.usage as UsageLike | undefined) ?? (entry.usage as UsageLike | undefined);
+  const usage = usageRaw ? (normalizeUsage(usageRaw) ?? undefined) : undefined;
 
   const provider =
     (typeof message.provider === "string" ? message.provider : undefined) ??
-    (typeof entry.provider === "string" ? entry.provider : undefined)
+    (typeof entry.provider === "string" ? entry.provider : undefined);
   const model =
     (typeof message.model === "string" ? message.model : undefined) ??
-    (typeof entry.model === "string" ? entry.model : undefined)
+    (typeof entry.model === "string" ? entry.model : undefined);
 
-  const costBreakdown = extractCostBreakdown(usageRaw)
-  const stopReason =
-    typeof message.stopReason === "string" ? message.stopReason : undefined
-  const durationMs = toFiniteNumber(message.durationMs ?? entry.durationMs)
+  const costBreakdown = extractCostBreakdown(usageRaw);
+  const stopReason = typeof message.stopReason === "string" ? message.stopReason : undefined;
+  const durationMs = toFiniteNumber(message.durationMs ?? entry.durationMs);
 
   return {
     message,
@@ -174,112 +161,99 @@ const parseTranscriptEntry = (
     stopReason,
     toolNames: extractToolCallNames(message),
     toolResultCounts: countToolResults(message),
-  }
-}
+  };
+};
 
 const formatDayKey = (date: Date): string =>
   date.toLocaleDateString("en-CA", {
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-  })
+  });
 
-const computeLatencyStats = (
-  values: number[],
-): SessionLatencyStats | undefined => {
+const computeLatencyStats = (values: number[]): SessionLatencyStats | undefined => {
   if (!values.length) {
-    return undefined
+    return undefined;
   }
-  const sorted = values.toSorted((a, b) => a - b)
-  const total = sorted.reduce((sum, v) => sum + v, 0)
-  const count = sorted.length
-  const p95Index = Math.max(0, Math.ceil(count * 0.95) - 1)
+  const sorted = values.toSorted((a, b) => a - b);
+  const total = sorted.reduce((sum, v) => sum + v, 0);
+  const count = sorted.length;
+  const p95Index = Math.max(0, Math.ceil(count * 0.95) - 1);
   return {
     count,
     avgMs: total / count,
     p95Ms: sorted[p95Index] ?? sorted[count - 1],
     minMs: sorted[0],
     maxMs: sorted[count - 1],
-  }
-}
+  };
+};
 
 const applyUsageTotals = (totals: CostUsageTotals, usage: NormalizedUsage) => {
-  totals.input += usage.input ?? 0
-  totals.output += usage.output ?? 0
-  totals.cacheRead += usage.cacheRead ?? 0
-  totals.cacheWrite += usage.cacheWrite ?? 0
+  totals.input += usage.input ?? 0;
+  totals.output += usage.output ?? 0;
+  totals.cacheRead += usage.cacheRead ?? 0;
+  totals.cacheWrite += usage.cacheWrite ?? 0;
   const totalTokens =
     usage.total ??
-    (usage.input ?? 0) +
-      (usage.output ?? 0) +
-      (usage.cacheRead ?? 0) +
-      (usage.cacheWrite ?? 0)
-  totals.totalTokens += totalTokens
-}
+    (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+  totals.totalTokens += totalTokens;
+};
 
-const applyCostBreakdown = (
-  totals: CostUsageTotals,
-  costBreakdown: CostBreakdown | undefined,
-) => {
+const applyCostBreakdown = (totals: CostUsageTotals, costBreakdown: CostBreakdown | undefined) => {
   if (costBreakdown === undefined || costBreakdown.total === undefined) {
-    return
+    return;
   }
-  totals.totalCost += costBreakdown.total
-  totals.inputCost += costBreakdown.input ?? 0
-  totals.outputCost += costBreakdown.output ?? 0
-  totals.cacheReadCost += costBreakdown.cacheRead ?? 0
-  totals.cacheWriteCost += costBreakdown.cacheWrite ?? 0
-}
+  totals.totalCost += costBreakdown.total;
+  totals.inputCost += costBreakdown.input ?? 0;
+  totals.outputCost += costBreakdown.output ?? 0;
+  totals.cacheReadCost += costBreakdown.cacheRead ?? 0;
+  totals.cacheWriteCost += costBreakdown.cacheWrite ?? 0;
+};
 
 // Legacy function for backwards compatibility (no cost breakdown available)
-const applyCostTotal = (
-  totals: CostUsageTotals,
-  costTotal: number | undefined,
-) => {
+const applyCostTotal = (totals: CostUsageTotals, costTotal: number | undefined) => {
   if (costTotal === undefined) {
-    totals.missingCostEntries += 1
-    return
+    totals.missingCostEntries += 1;
+    return;
   }
-  totals.totalCost += costTotal
-}
+  totals.totalCost += costTotal;
+};
 
-async function* readJsonlRecords(
-  filePath: string,
-): AsyncGenerator<Record<string, unknown>> {
-  const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" })
+async function* readJsonlRecords(filePath: string): AsyncGenerator<Record<string, unknown>> {
+  const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" });
   const rl = readline.createInterface({
     input: fileStream,
     crlfDelay: Infinity,
-  })
+  });
   try {
     for await (const line of rl) {
-      const trimmed = line.trim()
+      const trimmed = line.trim();
       if (!trimmed) {
-        continue
+        continue;
       }
       try {
-        const parsed = JSON.parse(trimmed) as unknown
+        const parsed = JSON.parse(trimmed) as unknown;
         if (!parsed || typeof parsed !== "object") {
-          continue
+          continue;
         }
-        yield parsed as Record<string, unknown>
+        yield parsed as Record<string, unknown>;
       } catch {
         // Ignore malformed lines
       }
     }
   } finally {
-    rl.close()
-    fileStream.destroy()
+    rl.close();
+    fileStream.destroy();
   }
 }
 
 async function scanTranscriptFile(params: {
-  filePath: string
-  config?: OpenClawConfig
-  onEntry: (entry: ParsedTranscriptEntry) => void
+  filePath: string;
+  config?: OpenClawConfig;
+  onEntry: (entry: ParsedTranscriptEntry) => void;
 }): Promise<void> {
   for await (const parsed of readJsonlRecords(params.filePath)) {
-    const entry = parseTranscriptEntry(parsed)
+    const entry = parseTranscriptEntry(parsed);
     if (!entry) {
-      continue
+      continue;
     }
 
     if (entry.usage && entry.costTotal === undefined) {
@@ -287,25 +261,25 @@ async function scanTranscriptFile(params: {
         provider: entry.provider,
         model: entry.model,
         config: params.config,
-      })
-      entry.costTotal = estimateUsageCost({ usage: entry.usage, cost })
+      });
+      entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
     }
 
-    params.onEntry(entry)
+    params.onEntry(entry);
   }
 }
 
 async function scanUsageFile(params: {
-  filePath: string
-  config?: OpenClawConfig
-  onEntry: (entry: ParsedUsageEntry) => void
+  filePath: string;
+  config?: OpenClawConfig;
+  onEntry: (entry: ParsedUsageEntry) => void;
 }): Promise<void> {
   await scanTranscriptFile({
     filePath: params.filePath,
     config: params.config,
     onEntry: (entry) => {
       if (!entry.usage) {
-        return
+        return;
       }
       params.onEntry({
         usage: entry.usage,
@@ -314,107 +288,104 @@ async function scanUsageFile(params: {
         provider: entry.provider,
         model: entry.model,
         timestamp: entry.timestamp,
-      })
+      });
     },
-  })
+  });
 }
 
 export async function loadCostUsageSummary(params?: {
-  startMs?: number
-  endMs?: number
-  days?: number // Deprecated, for backwards compatibility
-  config?: OpenClawConfig
-  agentId?: string
+  startMs?: number;
+  endMs?: number;
+  days?: number; // Deprecated, for backwards compatibility
+  config?: OpenClawConfig;
+  agentId?: string;
 }): Promise<CostUsageSummary> {
-  const now = new Date()
-  let sinceTime: number
-  let untilTime: number
+  const now = new Date();
+  let sinceTime: number;
+  let untilTime: number;
 
   if (params?.startMs !== undefined && params?.endMs !== undefined) {
-    sinceTime = params.startMs
-    untilTime = params.endMs
+    sinceTime = params.startMs;
+    untilTime = params.endMs;
   } else {
     // Fallback to days-based calculation for backwards compatibility
-    const days = Math.max(1, Math.floor(params?.days ?? 30))
-    const since = new Date(now)
-    since.setDate(since.getDate() - (days - 1))
-    sinceTime = since.getTime()
-    untilTime = now.getTime()
+    const days = Math.max(1, Math.floor(params?.days ?? 30));
+    const since = new Date(now);
+    since.setDate(since.getDate() - (days - 1));
+    sinceTime = since.getTime();
+    untilTime = now.getTime();
   }
 
-  const dailyMap = new Map<string, CostUsageTotals>()
-  const totals = emptyTotals()
+  const dailyMap = new Map<string, CostUsageTotals>();
+  const totals = emptyTotals();
 
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId)
-  const entries = await fs.promises
-    .readdir(sessionsDir, { withFileTypes: true })
-    .catch(() => [])
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
+  const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
   const files = (
     await Promise.all(
       entries
         .filter(
           (entry) =>
             entry.isFile() &&
-            (entry.name.endsWith(".jsonl") ||
-              isSessionArchiveArtifactName(entry.name)),
+            (entry.name.endsWith(".jsonl") || isSessionArchiveArtifactName(entry.name)),
         )
         .map(async (entry) => {
-          const filePath = path.join(sessionsDir, entry.name)
-          const stats = await fs.promises.stat(filePath).catch(() => null)
+          const filePath = path.join(sessionsDir, entry.name);
+          const stats = await fs.promises.stat(filePath).catch(() => null);
           if (!stats) {
-            return null
+            return null;
           }
           // Include file if it was modified after our start time
           if (stats.mtimeMs < sinceTime) {
-            return null
+            return null;
           }
-          return filePath
+          return filePath;
         }),
     )
-  ).filter((filePath): filePath is string => Boolean(filePath))
+  ).filter((filePath): filePath is string => Boolean(filePath));
 
   for (const filePath of files) {
     await scanUsageFile({
       filePath,
       config: params?.config,
       onEntry: (entry) => {
-        const ts = entry.timestamp?.getTime()
+        const ts = entry.timestamp?.getTime();
         if (!ts || ts < sinceTime || ts > untilTime) {
-          return
+          return;
         }
-        const dayKey = formatDayKey(entry.timestamp ?? now)
-        const bucket = dailyMap.get(dayKey) ?? emptyTotals()
-        applyUsageTotals(bucket, entry.usage)
+        const dayKey = formatDayKey(entry.timestamp ?? now);
+        const bucket = dailyMap.get(dayKey) ?? emptyTotals();
+        applyUsageTotals(bucket, entry.usage);
         if (entry.costBreakdown?.total !== undefined) {
-          applyCostBreakdown(bucket, entry.costBreakdown)
+          applyCostBreakdown(bucket, entry.costBreakdown);
         } else {
-          applyCostTotal(bucket, entry.costTotal)
+          applyCostTotal(bucket, entry.costTotal);
         }
-        dailyMap.set(dayKey, bucket)
+        dailyMap.set(dayKey, bucket);
 
-        applyUsageTotals(totals, entry.usage)
+        applyUsageTotals(totals, entry.usage);
         if (entry.costBreakdown?.total !== undefined) {
-          applyCostBreakdown(totals, entry.costBreakdown)
+          applyCostBreakdown(totals, entry.costBreakdown);
         } else {
-          applyCostTotal(totals, entry.costTotal)
+          applyCostTotal(totals, entry.costTotal);
         }
       },
-    })
+    });
   }
 
   const daily = Array.from(dailyMap.entries())
     .map(([date, bucket]) => Object.assign({ date }, bucket))
-    .toSorted((a, b) => a.date.localeCompare(b.date))
+    .toSorted((a, b) => a.date.localeCompare(b.date));
 
   // Calculate days for backwards compatibility in response
-  const days = Math.ceil((untilTime - sinceTime) / (24 * 60 * 60 * 1000)) + 1
+  const days = Math.ceil((untilTime - sinceTime) / (24 * 60 * 60 * 1000)) + 1;
 
   return {
     updatedAt: Date.now(),
     days,
     daily,
     totals,
-  }
+  };
 }
 
 /**
@@ -422,55 +393,49 @@ export async function loadCostUsageSummary(params?: {
  * Returns basic metadata for each discovered session.
  */
 export async function discoverAllSessions(params?: {
-  agentId?: string
-  startMs?: number
-  endMs?: number
+  agentId?: string;
+  startMs?: number;
+  endMs?: number;
 }): Promise<DiscoveredSession[]> {
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId)
-  const entries = await fs.promises
-    .readdir(sessionsDir, { withFileTypes: true })
-    .catch(() => [])
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
+  const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
 
-  const discovered: DiscoveredSession[] = []
+  const discovered: DiscoveredSession[] = [];
 
   for (const entry of entries) {
     if (
       !entry.isFile() ||
-      (!entry.name.endsWith(".jsonl") &&
-        !isSessionArchiveArtifactName(entry.name))
+      (!entry.name.endsWith(".jsonl") && !isSessionArchiveArtifactName(entry.name))
     ) {
-      continue
+      continue;
     }
 
-    const filePath = path.join(sessionsDir, entry.name)
-    const stats = await fs.promises.stat(filePath).catch(() => null)
+    const filePath = path.join(sessionsDir, entry.name);
+    const stats = await fs.promises.stat(filePath).catch(() => null);
     if (!stats) {
-      continue
+      continue;
     }
 
     // Filter by date range if provided
     if (params?.startMs && stats.mtimeMs < params.startMs) {
-      continue
+      continue;
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
     // Extract session ID from filename (remove .jsonl and any archive suffix)
-    const jsonlIndex = entry.name.indexOf(".jsonl")
-    const sessionId =
-      jsonlIndex >= 0
-        ? entry.name.slice(0, jsonlIndex)
-        : entry.name.slice(0, -6)
+    const jsonlIndex = entry.name.indexOf(".jsonl");
+    const sessionId = jsonlIndex >= 0 ? entry.name.slice(0, jsonlIndex) : entry.name.slice(0, -6);
 
     // Try to read first user message for label extraction
-    let firstUserMessage: string | undefined
+    let firstUserMessage: string | undefined;
     try {
       for await (const parsed of readJsonlRecords(filePath)) {
         try {
-          const message = parsed.message as Record<string, unknown> | undefined
+          const message = parsed.message as Record<string, unknown> | undefined;
           if (message?.role === "user") {
-            const content = message.content
+            const content = message.content;
             if (typeof content === "string") {
-              firstUserMessage = content.slice(0, 100)
+              firstUserMessage = content.slice(0, 100);
             } else if (Array.isArray(content)) {
               for (const block of content) {
                 if (
@@ -478,15 +443,15 @@ export async function discoverAllSessions(params?: {
                   block &&
                   (block as Record<string, unknown>).type === "text"
                 ) {
-                  const text = (block as Record<string, unknown>).text
+                  const text = (block as Record<string, unknown>).text;
                   if (typeof text === "string") {
-                    firstUserMessage = text.slice(0, 100)
+                    firstUserMessage = text.slice(0, 100);
                   }
-                  break
+                  break;
                 }
               }
             }
-            break // Found first user message
+            break; // Found first user message
           }
         } catch {
           // Skip malformed lines
@@ -501,21 +466,21 @@ export async function discoverAllSessions(params?: {
       sessionFile: filePath,
       mtime: stats.mtimeMs,
       firstUserMessage,
-    })
+    });
   }
 
   // Sort by mtime descending (most recent first)
-  return discovered.toSorted((a, b) => b.mtime - a.mtime)
+  return discovered.toSorted((a, b) => b.mtime - a.mtime);
 }
 
 export async function loadSessionCostSummary(params: {
-  sessionId?: string
-  sessionEntry?: SessionEntry
-  sessionFile?: string
-  config?: OpenClawConfig
-  agentId?: string
-  startMs?: number
-  endMs?: number
+  sessionId?: string;
+  sessionEntry?: SessionEntry;
+  sessionFile?: string;
+  config?: OpenClawConfig;
+  agentId?: string;
+  startMs?: number;
+  endMs?: number;
 }): Promise<SessionCostSummary | null> {
   const sessionFile =
     params.sessionFile ??
@@ -523,19 +488,19 @@ export async function loadSessionCostSummary(params: {
       ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
           agentId: params.agentId,
         })
-      : undefined)
+      : undefined);
   if (!sessionFile || !fs.existsSync(sessionFile)) {
-    return null
+    return null;
   }
 
-  const totals = emptyTotals()
-  let firstActivity: number | undefined
-  let lastActivity: number | undefined
-  const activityDatesSet = new Set<string>()
-  const dailyMap = new Map<string, { tokens: number cost: number }>()
-  const dailyMessageMap = new Map<string, SessionDailyMessageCounts>()
-  const dailyLatencyMap = new Map<string, number[]>()
-  const dailyModelUsageMap = new Map<string, SessionDailyModelUsage>()
+  const totals = emptyTotals();
+  let firstActivity: number | undefined;
+  let lastActivity: number | undefined;
+  const activityDatesSet = new Set<string>();
+  const dailyMap = new Map<string, { tokens: number; cost: number }>();
+  const dailyMessageMap = new Map<string, SessionDailyMessageCounts>();
+  const dailyLatencyMap = new Map<string, number[]>();
+  const dailyModelUsageMap = new Map<string, SessionDailyModelUsage>();
   const messageCounts: SessionMessageCounts = {
     total: 0,
     user: 0,
@@ -543,91 +508,85 @@ export async function loadSessionCostSummary(params: {
     toolCalls: 0,
     toolResults: 0,
     errors: 0,
-  }
-  const toolUsageMap = new Map<string, number>()
-  const modelUsageMap = new Map<string, SessionModelUsage>()
-  const errorStopReasons = new Set(["error", "aborted", "timeout"])
-  const latencyValues: number[] = []
-  let lastUserTimestamp: number | undefined
-  const MAX_LATENCY_MS = 12 * 60 * 60 * 1000
+  };
+  const toolUsageMap = new Map<string, number>();
+  const modelUsageMap = new Map<string, SessionModelUsage>();
+  const errorStopReasons = new Set(["error", "aborted", "timeout"]);
+  const latencyValues: number[] = [];
+  let lastUserTimestamp: number | undefined;
+  const MAX_LATENCY_MS = 12 * 60 * 60 * 1000;
 
   await scanTranscriptFile({
     filePath: sessionFile,
     config: params.config,
     onEntry: (entry) => {
-      const ts = entry.timestamp?.getTime()
+      const ts = entry.timestamp?.getTime();
 
       // Filter by date range if specified
-      if (
-        params.startMs !== undefined &&
-        ts !== undefined &&
-        ts < params.startMs
-      ) {
-        return
+      if (params.startMs !== undefined && ts !== undefined && ts < params.startMs) {
+        return;
       }
       if (params.endMs !== undefined && ts !== undefined && ts > params.endMs) {
-        return
+        return;
       }
 
       if (ts !== undefined) {
         if (!firstActivity || ts < firstActivity) {
-          firstActivity = ts
+          firstActivity = ts;
         }
         if (!lastActivity || ts > lastActivity) {
-          lastActivity = ts
+          lastActivity = ts;
         }
       }
 
       if (entry.role === "user") {
-        messageCounts.user += 1
-        messageCounts.total += 1
+        messageCounts.user += 1;
+        messageCounts.total += 1;
         if (entry.timestamp) {
-          lastUserTimestamp = entry.timestamp.getTime()
+          lastUserTimestamp = entry.timestamp.getTime();
         }
       }
       if (entry.role === "assistant") {
-        messageCounts.assistant += 1
-        messageCounts.total += 1
-        const ts = entry.timestamp?.getTime()
+        messageCounts.assistant += 1;
+        messageCounts.total += 1;
+        const ts = entry.timestamp?.getTime();
         if (ts !== undefined) {
           const latencyMs =
             entry.durationMs ??
-            (lastUserTimestamp !== undefined
-              ? Math.max(0, ts - lastUserTimestamp)
-              : undefined)
+            (lastUserTimestamp !== undefined ? Math.max(0, ts - lastUserTimestamp) : undefined);
           if (
             latencyMs !== undefined &&
             Number.isFinite(latencyMs) &&
             latencyMs <= MAX_LATENCY_MS
           ) {
-            latencyValues.push(latencyMs)
-            const dayKey = formatDayKey(entry.timestamp ?? new Date(ts))
-            const dailyLatencies = dailyLatencyMap.get(dayKey) ?? []
-            dailyLatencies.push(latencyMs)
-            dailyLatencyMap.set(dayKey, dailyLatencies)
+            latencyValues.push(latencyMs);
+            const dayKey = formatDayKey(entry.timestamp ?? new Date(ts));
+            const dailyLatencies = dailyLatencyMap.get(dayKey) ?? [];
+            dailyLatencies.push(latencyMs);
+            dailyLatencyMap.set(dayKey, dailyLatencies);
           }
         }
       }
 
       if (entry.toolNames.length > 0) {
-        messageCounts.toolCalls += entry.toolNames.length
+        messageCounts.toolCalls += entry.toolNames.length;
         for (const name of entry.toolNames) {
-          toolUsageMap.set(name, (toolUsageMap.get(name) ?? 0) + 1)
+          toolUsageMap.set(name, (toolUsageMap.get(name) ?? 0) + 1);
         }
       }
 
       if (entry.toolResultCounts.total > 0) {
-        messageCounts.toolResults += entry.toolResultCounts.total
-        messageCounts.errors += entry.toolResultCounts.errors
+        messageCounts.toolResults += entry.toolResultCounts.total;
+        messageCounts.errors += entry.toolResultCounts.errors;
       }
 
       if (entry.stopReason && errorStopReasons.has(entry.stopReason)) {
-        messageCounts.errors += 1
+        messageCounts.errors += 1;
       }
 
       if (entry.timestamp) {
-        const dayKey = formatDayKey(entry.timestamp)
-        activityDatesSet.add(dayKey)
+        const dayKey = formatDayKey(entry.timestamp);
+        activityDatesSet.add(dayKey);
         const daily = dailyMessageMap.get(dayKey) ?? {
           date: dayKey,
           total: 0,
@@ -636,41 +595,40 @@ export async function loadSessionCostSummary(params: {
           toolCalls: 0,
           toolResults: 0,
           errors: 0,
-        }
-        daily.total +=
-          entry.role === "user" || entry.role === "assistant" ? 1 : 0
+        };
+        daily.total += entry.role === "user" || entry.role === "assistant" ? 1 : 0;
         if (entry.role === "user") {
-          daily.user += 1
+          daily.user += 1;
         } else if (entry.role === "assistant") {
-          daily.assistant += 1
+          daily.assistant += 1;
         }
-        daily.toolCalls += entry.toolNames.length
-        daily.toolResults += entry.toolResultCounts.total
-        daily.errors += entry.toolResultCounts.errors
+        daily.toolCalls += entry.toolNames.length;
+        daily.toolResults += entry.toolResultCounts.total;
+        daily.errors += entry.toolResultCounts.errors;
         if (entry.stopReason && errorStopReasons.has(entry.stopReason)) {
-          daily.errors += 1
+          daily.errors += 1;
         }
-        dailyMessageMap.set(dayKey, daily)
+        dailyMessageMap.set(dayKey, daily);
       }
 
       if (!entry.usage) {
-        return
+        return;
       }
 
-      applyUsageTotals(totals, entry.usage)
+      applyUsageTotals(totals, entry.usage);
       if (entry.costBreakdown?.total !== undefined) {
-        applyCostBreakdown(totals, entry.costBreakdown)
+        applyCostBreakdown(totals, entry.costBreakdown);
       } else {
-        applyCostTotal(totals, entry.costTotal)
+        applyCostTotal(totals, entry.costTotal);
       }
 
       if (entry.timestamp) {
-        const dayKey = formatDayKey(entry.timestamp)
+        const dayKey = formatDayKey(entry.timestamp);
         const entryTokens =
           (entry.usage.input ?? 0) +
           (entry.usage.output ?? 0) +
           (entry.usage.cacheRead ?? 0) +
-          (entry.usage.cacheWrite ?? 0)
+          (entry.usage.cacheWrite ?? 0);
         const entryCost =
           entry.costBreakdown?.total ??
           (entry.costBreakdown
@@ -678,103 +636,98 @@ export async function loadSessionCostSummary(params: {
               (entry.costBreakdown.output ?? 0) +
               (entry.costBreakdown.cacheRead ?? 0) +
               (entry.costBreakdown.cacheWrite ?? 0)
-            : (entry.costTotal ?? 0))
+            : (entry.costTotal ?? 0));
 
-        const existing = dailyMap.get(dayKey) ?? { tokens: 0, cost: 0 }
+        const existing = dailyMap.get(dayKey) ?? { tokens: 0, cost: 0 };
         dailyMap.set(dayKey, {
           tokens: existing.tokens + entryTokens,
           cost: existing.cost + entryCost,
-        })
+        });
 
         if (entry.provider || entry.model) {
-          const modelKey = `${dayKey}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`
+          const modelKey = `${dayKey}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
           const dailyModel =
             dailyModelUsageMap.get(modelKey) ??
-            {
+            ({
               date: dayKey,
               provider: entry.provider,
               model: entry.model,
               tokens: 0,
               cost: 0,
               count: 0,
-            } as SessionDailyModelUsage
-          dailyModel.tokens += entryTokens
-          dailyModel.cost += entryCost
-          dailyModel.count += 1
-          dailyModelUsageMap.set(modelKey, dailyModel)
+            } as SessionDailyModelUsage);
+          dailyModel.tokens += entryTokens;
+          dailyModel.cost += entryCost;
+          dailyModel.count += 1;
+          dailyModelUsageMap.set(modelKey, dailyModel);
         }
       }
 
       if (entry.provider || entry.model) {
-        const key = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`
+        const key = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
         const existing =
           modelUsageMap.get(key) ??
-          {
+          ({
             provider: entry.provider,
             model: entry.model,
             count: 0,
             totals: emptyTotals(),
-          } as SessionModelUsage
-        existing.count += 1
-        applyUsageTotals(existing.totals, entry.usage)
+          } as SessionModelUsage);
+        existing.count += 1;
+        applyUsageTotals(existing.totals, entry.usage);
         if (entry.costBreakdown?.total !== undefined) {
-          applyCostBreakdown(existing.totals, entry.costBreakdown)
+          applyCostBreakdown(existing.totals, entry.costBreakdown);
         } else {
-          applyCostTotal(existing.totals, entry.costTotal)
+          applyCostTotal(existing.totals, entry.costTotal);
         }
-        modelUsageMap.set(key, existing)
+        modelUsageMap.set(key, existing);
       }
     },
-  })
+  });
 
   // Convert daily map to sorted array
   const dailyBreakdown: SessionDailyUsage[] = Array.from(dailyMap.entries())
     .map(([date, data]) => ({ date, tokens: data.tokens, cost: data.cost }))
-    .toSorted((a, b) => a.date.localeCompare(b.date))
+    .toSorted((a, b) => a.date.localeCompare(b.date));
 
   const dailyMessageCounts: SessionDailyMessageCounts[] = Array.from(
     dailyMessageMap.values(),
-  ).toSorted((a, b) => a.date.localeCompare(b.date))
+  ).toSorted((a, b) => a.date.localeCompare(b.date));
 
-  const dailyLatency: SessionDailyLatency[] = Array.from(
-    dailyLatencyMap.entries(),
-  )
+  const dailyLatency: SessionDailyLatency[] = Array.from(dailyLatencyMap.entries())
     .map(([date, values]) => {
-      const stats = computeLatencyStats(values)
+      const stats = computeLatencyStats(values);
       if (!stats) {
-        return null
+        return null;
       }
-      return { date, ...stats }
+      return { date, ...stats };
     })
     .filter((entry): entry is SessionDailyLatency => Boolean(entry))
-    .toSorted((a, b) => a.date.localeCompare(b.date))
+    .toSorted((a, b) => a.date.localeCompare(b.date));
 
   const dailyModelUsage: SessionDailyModelUsage[] = Array.from(
     dailyModelUsageMap.values(),
-  ).toSorted((a, b) => a.date.localeCompare(b.date) || b.cost - a.cost)
+  ).toSorted((a, b) => a.date.localeCompare(b.date) || b.cost - a.cost);
 
   const toolUsage: SessionToolUsage | undefined = toolUsageMap.size
     ? {
-        totalCalls: Array.from(toolUsageMap.values()).reduce(
-          (sum, count) => sum + count,
-          0,
-        ),
+        totalCalls: Array.from(toolUsageMap.values()).reduce((sum, count) => sum + count, 0),
         uniqueTools: toolUsageMap.size,
         tools: Array.from(toolUsageMap.entries())
           .map(([name, count]) => ({ name, count }))
           .toSorted((a, b) => b.count - a.count),
       }
-    : undefined
+    : undefined;
 
   const modelUsage = modelUsageMap.size
     ? Array.from(modelUsageMap.values()).toSorted((a, b) => {
-        const costDiff = b.totals.totalCost - a.totals.totalCost
+        const costDiff = b.totals.totalCost - a.totals.totalCost;
         if (costDiff !== 0) {
-          return costDiff
+          return costDiff;
         }
-        return b.totals.totalTokens - a.totals.totalTokens
+        return b.totals.totalTokens - a.totals.totalTokens;
       })
-    : undefined
+    : undefined;
 
   return {
     sessionId: params.sessionId,
@@ -795,16 +748,16 @@ export async function loadSessionCostSummary(params: {
     modelUsage,
     latency: computeLatencyStats(latencyValues),
     ...totals,
-  }
+  };
 }
 
 export async function loadSessionUsageTimeSeries(params: {
-  sessionId?: string
-  sessionEntry?: SessionEntry
-  sessionFile?: string
-  config?: OpenClawConfig
-  agentId?: string
-  maxPoints?: number
+  sessionId?: string;
+  sessionEntry?: SessionEntry;
+  sessionFile?: string;
+  config?: OpenClawConfig;
+  agentId?: string;
+  maxPoints?: number;
 }): Promise<SessionUsageTimeSeries | null> {
   const sessionFile =
     params.sessionFile ??
@@ -812,34 +765,33 @@ export async function loadSessionUsageTimeSeries(params: {
       ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
           agentId: params.agentId,
         })
-      : undefined)
+      : undefined);
   if (!sessionFile || !fs.existsSync(sessionFile)) {
-    return null
+    return null;
   }
 
-  const points: SessionUsageTimePoint[] = []
-  let cumulativeTokens = 0
-  let cumulativeCost = 0
+  const points: SessionUsageTimePoint[] = [];
+  let cumulativeTokens = 0;
+  let cumulativeCost = 0;
 
   await scanUsageFile({
     filePath: sessionFile,
     config: params.config,
     onEntry: (entry) => {
-      const ts = entry.timestamp?.getTime()
+      const ts = entry.timestamp?.getTime();
       if (!ts) {
-        return
+        return;
       }
 
-      const input = entry.usage.input ?? 0
-      const output = entry.usage.output ?? 0
-      const cacheRead = entry.usage.cacheRead ?? 0
-      const cacheWrite = entry.usage.cacheWrite ?? 0
-      const totalTokens =
-        entry.usage.total ?? input + output + cacheRead + cacheWrite
-      const cost = entry.costTotal ?? 0
+      const input = entry.usage.input ?? 0;
+      const output = entry.usage.output ?? 0;
+      const cacheRead = entry.usage.cacheRead ?? 0;
+      const cacheWrite = entry.usage.cacheWrite ?? 0;
+      const totalTokens = entry.usage.total ?? input + output + cacheRead + cacheWrite;
+      const cost = entry.costTotal ?? 0;
 
-      cumulativeTokens += totalTokens
-      cumulativeCost += cost
+      cumulativeTokens += totalTokens;
+      cumulativeCost += cost;
 
       points.push({
         timestamp: ts,
@@ -851,44 +803,44 @@ export async function loadSessionUsageTimeSeries(params: {
         cost,
         cumulativeTokens,
         cumulativeCost,
-      })
+      });
     },
-  })
+  });
 
   // Sort by timestamp
-  const sortedPoints = points.toSorted((a, b) => a.timestamp - b.timestamp)
+  const sortedPoints = points.toSorted((a, b) => a.timestamp - b.timestamp);
 
   // Optionally downsample if too many points
-  const maxPoints = params.maxPoints ?? 100
+  const maxPoints = params.maxPoints ?? 100;
   if (sortedPoints.length > maxPoints) {
-    const step = Math.ceil(sortedPoints.length / maxPoints)
-    const downsampled: SessionUsageTimePoint[] = []
-    let downsampledCumulativeTokens = 0
-    let downsampledCumulativeCost = 0
+    const step = Math.ceil(sortedPoints.length / maxPoints);
+    const downsampled: SessionUsageTimePoint[] = [];
+    let downsampledCumulativeTokens = 0;
+    let downsampledCumulativeCost = 0;
     for (let i = 0; i < sortedPoints.length; i += step) {
-      const bucket = sortedPoints.slice(i, i + step)
-      const bucketLast = bucket[bucket.length - 1]
+      const bucket = sortedPoints.slice(i, i + step);
+      const bucketLast = bucket[bucket.length - 1];
       if (!bucketLast) {
-        continue
+        continue;
       }
 
-      let bucketInput = 0
-      let bucketOutput = 0
-      let bucketCacheRead = 0
-      let bucketCacheWrite = 0
-      let bucketTotalTokens = 0
-      let bucketCost = 0
+      let bucketInput = 0;
+      let bucketOutput = 0;
+      let bucketCacheRead = 0;
+      let bucketCacheWrite = 0;
+      let bucketTotalTokens = 0;
+      let bucketCost = 0;
       for (const point of bucket) {
-        bucketInput += point.input
-        bucketOutput += point.output
-        bucketCacheRead += point.cacheRead
-        bucketCacheWrite += point.cacheWrite
-        bucketTotalTokens += point.totalTokens
-        bucketCost += point.cost
+        bucketInput += point.input;
+        bucketOutput += point.output;
+        bucketCacheRead += point.cacheRead;
+        bucketCacheWrite += point.cacheWrite;
+        bucketTotalTokens += point.totalTokens;
+        bucketCost += point.cost;
       }
 
-      downsampledCumulativeTokens += bucketTotalTokens
-      downsampledCumulativeCost += bucketCost
+      downsampledCumulativeTokens += bucketTotalTokens;
+      downsampledCumulativeCost += bucketCost;
 
       downsampled.push({
         timestamp: bucketLast.timestamp,
@@ -900,21 +852,21 @@ export async function loadSessionUsageTimeSeries(params: {
         cost: bucketCost,
         cumulativeTokens: downsampledCumulativeTokens,
         cumulativeCost: downsampledCumulativeCost,
-      })
+      });
     }
-    return { sessionId: params.sessionId, points: downsampled }
+    return { sessionId: params.sessionId, points: downsampled };
   }
 
-  return { sessionId: params.sessionId, points: sortedPoints }
+  return { sessionId: params.sessionId, points: sortedPoints };
 }
 
 export async function loadSessionLogs(params: {
-  sessionId?: string
-  sessionEntry?: SessionEntry
-  sessionFile?: string
-  config?: OpenClawConfig
-  agentId?: string
-  limit?: number
+  sessionId?: string;
+  sessionEntry?: SessionEntry;
+  sessionFile?: string;
+  config?: OpenClawConfig;
+  agentId?: string;
+  limit?: number;
 }): Promise<SessionLogEntry[] | null> {
   const sessionFile =
     params.sessionFile ??
@@ -922,146 +874,134 @@ export async function loadSessionLogs(params: {
       ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
           agentId: params.agentId,
         })
-      : undefined)
+      : undefined);
   if (!sessionFile || !fs.existsSync(sessionFile)) {
-    return null
+    return null;
   }
 
-  const logs: SessionLogEntry[] = []
-  const limit = params.limit ?? 50
+  const logs: SessionLogEntry[] = [];
+  const limit = params.limit ?? 50;
 
   for await (const parsed of readJsonlRecords(sessionFile)) {
     try {
-      const message = parsed.message as Record<string, unknown> | undefined
+      const message = parsed.message as Record<string, unknown> | undefined;
       if (!message) {
-        continue
+        continue;
       }
 
-      const role = message.role as string | undefined
-      if (
-        role !== "user" &&
-        role !== "assistant" &&
-        role !== "tool" &&
-        role !== "toolResult"
-      ) {
-        continue
+      const role = message.role as string | undefined;
+      if (role !== "user" && role !== "assistant" && role !== "tool" && role !== "toolResult") {
+        continue;
       }
 
-      const contentParts: string[] = []
-      const rawToolName =
-        message.toolName ?? message.tool_name ?? message.name ?? message.tool
+      const contentParts: string[] = [];
+      const rawToolName = message.toolName ?? message.tool_name ?? message.name ?? message.tool;
       const toolName =
-        typeof rawToolName === "string" && rawToolName.trim()
-          ? rawToolName.trim()
-          : undefined
+        typeof rawToolName === "string" && rawToolName.trim() ? rawToolName.trim() : undefined;
       if (role === "tool" || role === "toolResult") {
-        contentParts.push(`[Tool: ${toolName ?? "tool"}]`)
-        contentParts.push("[Tool Result]")
+        contentParts.push(`[Tool: ${toolName ?? "tool"}]`);
+        contentParts.push("[Tool Result]");
       }
 
       // Extract content
-      const rawContent = message.content
+      const rawContent = message.content;
       if (typeof rawContent === "string") {
-        contentParts.push(rawContent)
+        contentParts.push(rawContent);
       } else if (Array.isArray(rawContent)) {
         // Handle content blocks (text, tool_use, etc.)
         const contentText = rawContent
           .map((block: unknown) => {
             if (typeof block === "string") {
-              return block
+              return block;
             }
-            const b = block as Record<string, unknown>
+            const b = block as Record<string, unknown>;
             if (b.type === "text" && typeof b.text === "string") {
-              return b.text
+              return b.text;
             }
             if (b.type === "tool_use") {
-              const name = typeof b.name === "string" ? b.name : "unknown"
-              return `[Tool: ${name}]`
+              const name = typeof b.name === "string" ? b.name : "unknown";
+              return `[Tool: ${name}]`;
             }
             if (b.type === "tool_result") {
-              return `[Tool Result]`
+              return `[Tool Result]`;
             }
-            return ""
+            return "";
           })
           .filter(Boolean)
-          .join("\n")
+          .join("\n");
         if (contentText) {
-          contentParts.push(contentText)
+          contentParts.push(contentText);
         }
       }
 
       // OpenAI-style tool calls stored outside the content array.
       const rawToolCalls =
-        message.tool_calls ??
-        message.toolCalls ??
-        message.function_call ??
-        message.functionCall
+        message.tool_calls ?? message.toolCalls ?? message.function_call ?? message.functionCall;
       const toolCalls = Array.isArray(rawToolCalls)
         ? rawToolCalls
         : rawToolCalls
           ? [rawToolCalls]
-          : []
+          : [];
       if (toolCalls.length > 0) {
         for (const call of toolCalls) {
-          const callObj = call as Record<string, unknown>
-          const directName =
-            typeof callObj.name === "string" ? callObj.name : undefined
-          const fn = callObj.function as Record<string, unknown> | undefined
-          const fnName = typeof fn?.name === "string" ? fn.name : undefined
-          const name = directName ?? fnName ?? "unknown"
-          contentParts.push(`[Tool: ${name}]`)
+          const callObj = call as Record<string, unknown>;
+          const directName = typeof callObj.name === "string" ? callObj.name : undefined;
+          const fn = callObj.function as Record<string, unknown> | undefined;
+          const fnName = typeof fn?.name === "string" ? fn.name : undefined;
+          const name = directName ?? fnName ?? "unknown";
+          contentParts.push(`[Tool: ${name}]`);
         }
       }
 
-      let content = contentParts.join("\n").trim()
+      let content = contentParts.join("\n").trim();
       if (!content) {
-        continue
+        continue;
       }
-      content = stripInboundMetadata(content)
+      content = stripInboundMetadata(content);
       if (role === "user") {
-        content = stripMessageIdHints(stripEnvelope(content)).trim()
+        content = stripMessageIdHints(stripEnvelope(content)).trim();
       }
       if (!content) {
-        continue
+        continue;
       }
 
       // Truncate very long content
-      const maxLen = 2000
+      const maxLen = 2000;
       if (content.length > maxLen) {
-        content = content.slice(0, maxLen) + "…"
+        content = content.slice(0, maxLen) + "…";
       }
 
       // Get timestamp
-      let timestamp = 0
+      let timestamp = 0;
       if (typeof parsed.timestamp === "string") {
-        timestamp = new Date(parsed.timestamp).getTime()
+        timestamp = new Date(parsed.timestamp).getTime();
       } else if (typeof message.timestamp === "number") {
-        timestamp = message.timestamp
+        timestamp = message.timestamp;
       }
 
       // Get usage for assistant messages
-      let tokens: number | undefined
-      let cost: number | undefined
+      let tokens: number | undefined;
+      let cost: number | undefined;
       if (role === "assistant") {
-        const usageRaw = message.usage as Record<string, unknown> | undefined
-        const usage = normalizeUsage(usageRaw)
+        const usageRaw = message.usage as Record<string, unknown> | undefined;
+        const usage = normalizeUsage(usageRaw);
         if (usage) {
           tokens =
             usage.total ??
             (usage.input ?? 0) +
               (usage.output ?? 0) +
               (usage.cacheRead ?? 0) +
-              (usage.cacheWrite ?? 0)
-          const breakdown = extractCostBreakdown(usageRaw)
+              (usage.cacheWrite ?? 0);
+          const breakdown = extractCostBreakdown(usageRaw);
           if (breakdown?.total !== undefined) {
-            cost = breakdown.total
+            cost = breakdown.total;
           } else {
             const costConfig = resolveModelCostConfig({
               provider: message.provider as string | undefined,
               model: message.model as string | undefined,
               config: params.config,
-            })
-            cost = estimateUsageCost({ usage, cost: costConfig })
+            });
+            cost = estimateUsageCost({ usage, cost: costConfig });
           }
         }
       }
@@ -1072,19 +1012,19 @@ export async function loadSessionLogs(params: {
         content,
         tokens,
         cost,
-      })
+      });
     } catch {
       // Ignore malformed lines
     }
   }
 
   // Sort by timestamp and limit
-  const sortedLogs = logs.toSorted((a, b) => a.timestamp - b.timestamp)
+  const sortedLogs = logs.toSorted((a, b) => a.timestamp - b.timestamp);
 
   // Return most recent logs
   if (sortedLogs.length > limit) {
-    return sortedLogs.slice(-limit)
+    return sortedLogs.slice(-limit);
   }
 
-  return sortedLogs
+  return sortedLogs;
 }

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -5,7 +5,16 @@ import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { isSessionArchiveArtifactName } from "../config/sessions/artifacts.js";
+import { hasArchiveSuffix } from "../config/sessions/artifacts.js";
+
+/**
+ * Returns true for `.reset` and `.deleted` archive files, but NOT `.bak` files.
+ * Compaction `.bak` files overlap with the rewritten active `.jsonl` and must be
+ * excluded to avoid double-counting cost/usage.
+ */
+function isCostRelevantArchive(fileName: string): boolean {
+  return hasArchiveSuffix(fileName, "reset") || hasArchiveSuffix(fileName, "deleted");
+}
 import {
   resolveSessionFilePath,
   resolveSessionTranscriptsDirForAgent,
@@ -326,8 +335,7 @@ export async function loadCostUsageSummary(params?: {
       entries
         .filter(
           (entry) =>
-            entry.isFile() &&
-            (entry.name.endsWith(".jsonl") || isSessionArchiveArtifactName(entry.name)),
+            entry.isFile() && (entry.name.endsWith(".jsonl") || isCostRelevantArchive(entry.name)),
         )
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
@@ -403,10 +411,7 @@ export async function discoverAllSessions(params?: {
   const discovered: DiscoveredSession[] = [];
 
   for (const entry of entries) {
-    if (
-      !entry.isFile() ||
-      (!entry.name.endsWith(".jsonl") && !isSessionArchiveArtifactName(entry.name))
-    ) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
       continue;
     }
 
@@ -422,9 +427,8 @@ export async function discoverAllSessions(params?: {
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
-    // Extract session ID from filename (remove .jsonl and any archive suffix)
-    const jsonlIndex = entry.name.indexOf(".jsonl");
-    const sessionId = jsonlIndex >= 0 ? entry.name.slice(0, jsonlIndex) : entry.name.slice(0, -6);
+    // Extract session ID from filename (remove .jsonl)
+    const sessionId = entry.name.slice(0, -6);
 
     // Try to read first user message for label extraction
     let firstUserMessage: string | undefined;

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -9,6 +9,7 @@ import {
   resolveSessionFilePath,
   resolveSessionTranscriptsDirForAgent,
 } from "../config/sessions/paths.js";
+import { isSessionArchiveArtifactName } from "../config/sessions/artifacts.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
 import { countToolResults, extractToolCallNames } from "../utils/transcript-tools.js";
@@ -318,7 +319,7 @@ export async function loadCostUsageSummary(params?: {
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .filter((entry) => entry.isFile() && (entry.name.endsWith(".jsonl") || isSessionArchiveArtifactName(entry.name)))
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);
@@ -393,7 +394,7 @@ export async function discoverAllSessions(params?: {
   const discovered: DiscoveredSession[] = [];
 
   for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+    if (!entry.isFile() || (!entry.name.endsWith(".jsonl") && !isSessionArchiveArtifactName(entry.name))) {
       continue;
     }
 
@@ -409,8 +410,9 @@ export async function discoverAllSessions(params?: {
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
-    // Extract session ID from filename (remove .jsonl)
-    const sessionId = entry.name.slice(0, -6);
+    // Extract session ID from filename (remove .jsonl and any archive suffix)
+    const jsonlIndex = entry.name.indexOf(".jsonl");
+    const sessionId = jsonlIndex >= 0 ? entry.name.slice(0, jsonlIndex) : entry.name.slice(0, -6);
 
     // Try to read first user message for label extraction
     let firstUserMessage: string | undefined;


### PR DESCRIPTION
  ## Summary
  - Cost dashboard only counted active `.jsonl` files, ignoring `.jsonl.reset.*` and `.jsonl.deleted.*` archives created by `/new`, `/reset`, and session deletion
  - Expanded file discovery in `loadCostUsageSummary()` to include `.reset` and `.deleted` archive files, deliberately excluding `.bak` compaction archives to avoid double-counting
  - Exported `hasArchiveSuffix()` from `artifacts.ts` to enable selective archive type matching

- Problem: Cost dashboard undercounts spend because archived `.jsonl.reset.*` session files are excluded from file discovery
- Why it matters: Users who frequently use `/new` see severely understated costs (reporter saw $7 vs $57 actual)
- What changed: File filter in `loadCostUsageSummary()` in `src/infra/session-cost-usage.ts` now includes `.reset` and `.deleted` archive files via a new `isCostRelevantArchive()` helper. `.bak` compaction archives are excluded because they overlap with the rewritten active `.jsonl`. Exported `hasArchiveSuffix()` from `src/config/sessions/artifacts.ts`.
- What did NOT change (scope boundary): `discoverAllSessions()` is untouched — including archives there would break detail lookups (timeseries/logs) since `resolveSessionFilePath` re-derives the path as `{id}.jsonl`. `listSessionFilesForAgent()` in `src/memory/session-files.ts` is also untouched — it serves memory indexing, not cost reporting.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #46252

## User-visible / Behavior Changes
Cost dashboard and /usage cost now include spend from archived sessions. Reported totals will increase for users who use /new or /reset.

## Security Impact (required)
- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification
### Environment
  - OS: Debian 12 (Linux 6.12.73)
  - Runtime/container: Node.js v22.22.0
  - Model/provider: openai/gpt-4o-mini
  - Integration/channel: N/A
  - Relevant config: default gateway, local mode

### Steps
  1. Start gateway, send a message via `openclaw agent --agent main --message "hello"`
  2. Reset session: `openclaw agent --agent main --message "/new"`
  3. Repeat steps 1-2 twice more
  4. Check `~/.openclaw/agents/main/sessions/` — active `.jsonl` and `.jsonl.reset.*` files present
  5. Compare `grep -c "cost"` across all files vs only `.jsonl` files

### Expected
Cost aggregation includes all session files (active + archived)

### Actual
Only active `.jsonl` counted. Archive files silently excluded.

## Evidence
 - Before fix: grep -c "cost" on *.jsonl = 4 entries (1 file)
 - After fix: grep -c "cost" on all files = 11 entries (4 files)

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

  Before fix — only active file counted:
  ```
  $ grep -c "cost" ~/.openclaw/agents/*/sessions/*.jsonl
  4
  ```

  After fix — all files counted:
  ```
  $ grep -c "cost" ~/.openclaw/agents/*/sessions/*
  187d94aa...jsonl.reset.2026-03-14T20-28-29.627Z:1
  30530f03...jsonl.reset.2026-03-14T20-29-55.988Z:3
  748d6ba1...jsonl.reset.2026-03-14T21-19-32.436Z:4
  b0788626...jsonl:3
  ```

  Filter verification (standalone Node script):
  ```
  BEFORE fix (only .jsonl): [ 'b0788626-2604-4147-9893-a6b87c1b8472.jsonl' ]
  AFTER fix (includes archives): [
    '187d94aa-b0ec-410b-a7b6-49faf8b9940d.jsonl.reset.2026-03-14T20-28-29.627Z',
    '30530f03-afc1-47c8-b78d-87abc84f6a95.jsonl.reset.2026-03-14T20-29-55.988Z',
    '748d6ba1-ccfa-4411-9775-bb4f2b1db455.jsonl.reset.2026-03-14T21-19-32.436Z',
    'b0788626-2604-4147-9893-a6b87c1b8472.jsonl'
  ]
  ```

## Human Verification (required)
  - Verified scenarios: Deployed v2026.3.12 on DigitalOcean Debian 12 droplet, created 3 archived sessions via /new, confirmed archive files excluded from cost count before patch. Applied patch to installed dist bundle, confirmed archive files included after patch.
  - Edge cases checked: Confirmed .bak compaction archives are excluded (would double-count with rewritten active .jsonl). Confirmed sessions.json.bak.* legacy store backups are not matched by isCostRelevantArchive().
  - What I did not verify: Control UI dashboard rendering (no browser on headless server). Did not test .jsonl.deleted.* or .jsonl.bak.* archive variants (only .jsonl.reset.* was reproduced). Did not run full test suite on droplet (insufficient RAM for pnpm install).

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

## Failure Recovery (if this breaks)
  - How to disable/revert this change quickly: revert single commit, two files changed (session-cost-usage.ts + artifacts.ts)
  - Files/config to restore: src/infra/session-cost-usage.ts, src/config/sessions/artifacts.ts

## Risks and Mitigations
None. Only callers are usage.cost RPC handler and /usage cost chat command. No impact on session management, memory indexing, or cleanup.