### PR TITLE
fix(skills): warn on truncation + raise default prompt char limit to 50K

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -556,13 +556,17 @@ function applySkillsPromptLimits(params: { skills: Skill[]; config?: OpenClawCon
         hi = mid - 1;
       }
     }
-    const droppedSkills = skillsForPrompt.slice(lo);
+    const charsDropped = skillsForPrompt.slice(lo);
     skillsForPrompt = skillsForPrompt.slice(0, lo);
     truncated = true;
     truncatedReason = "chars";
+    // Collect ALL dropped skills: count-truncated (before binary search) + chars-truncated
+    const countDropped = params.skills.slice(Math.max(0, limits.maxSkillsInPrompt));
+    const allDropped = [...countDropped, ...charsDropped];
+    const uniqueDropped = [...new Map(allDropped.map((s) => [s.name, s])).values()];
     skillsLogger.warn(
-      `Skills truncated due to prompt char limit: included ${skillsForPrompt.length} of ${params.skills.length} skills (limit: ${limits.maxSkillsPromptChars} chars). ` +
-        `Dropped: ${droppedSkills.map((s) => s.name).join(", ")}. ` +
+      `Skills truncated due to prompt limits: included ${skillsForPrompt.length} of ${params.skills.length} skills (maxSkillsInPrompt: ${limits.maxSkillsInPrompt}, maxSkillsPromptChars: ${limits.maxSkillsPromptChars}). ` +
+        `Dropped: ${uniqueDropped.map((s) => s.name).join(", ")}. ` +
         `Increase skills.limits.maxSkillsPromptChars in config to include all skills.`,
     );
   }

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -96,7 +96,7 @@ const SKILL_COMMAND_DESCRIPTION_MAX_LENGTH = 100;
 const DEFAULT_MAX_CANDIDATES_PER_ROOT = 300;
 const DEFAULT_MAX_SKILLS_LOADED_PER_SOURCE = 200;
 const DEFAULT_MAX_SKILLS_IN_PROMPT = 150;
-const DEFAULT_MAX_SKILLS_PROMPT_CHARS = 30_000;
+const DEFAULT_MAX_SKILLS_PROMPT_CHARS = 50_000;
 const DEFAULT_MAX_SKILL_FILE_BYTES = 256_000;
 
 function sanitizeSkillCommandName(raw: string): string {
@@ -556,9 +556,15 @@ function applySkillsPromptLimits(params: { skills: Skill[]; config?: OpenClawCon
         hi = mid - 1;
       }
     }
+    const droppedSkills = skillsForPrompt.slice(lo);
     skillsForPrompt = skillsForPrompt.slice(0, lo);
     truncated = true;
     truncatedReason = "chars";
+    skillsLogger.warn(
+      `Skills truncated due to prompt char limit: included ${skillsForPrompt.length} of ${params.skills.length} skills (limit: ${limits.maxSkillsPromptChars} chars). ` +
+        `Dropped: ${droppedSkills.map((s) => s.name).join(", ")}. ` +
+        `Increase skills.limits.maxSkillsPromptChars in config to include all skills.`,
+    );
   }
 
   return { skillsForPrompt, truncated, truncatedReason };
@@ -624,8 +630,15 @@ function resolveWorkspaceSkillPromptState(
     skills: resolvedSkills,
     config: opts?.config,
   });
+  const droppedNames =
+    truncated && skillsForPrompt.length < resolvedSkills.length
+      ? resolvedSkills
+          .slice(skillsForPrompt.length)
+          .map((s) => s.name)
+          .join(", ")
+      : "";
   const truncationNote = truncated
-    ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}. Run \`openclaw skills check\` to audit.`
+    ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}.${droppedNames ? ` Dropped: ${droppedNames}.` : ""} Run \`openclaw skills check\` to audit or increase skills.limits.maxSkillsPromptChars in config.`
     : "";
   const prompt = [
     remoteNote,


### PR DESCRIPTION
## Summary

When the total skill description chars exceed `maxSkillsPromptChars` (default was 30,000), skills are silently dropped from the `<available_skills>` list in the system prompt. This makes it very hard to debug why a skill is not being detected by the agent.

## Changes

1. **Raise default limit** from 30K to 50K chars — 30K was too tight for users with many workspace skills (~80+). The overhead is minimal compared to 200K+ context windows.

2. **Log warning on truncation** — `skillsLogger.warn()` now fires when skills are dropped, listing exactly which skills were truncated and suggesting the config fix.

3. **List dropped skills in system prompt** — The existing truncation note now includes the names of dropped skills so the agent knows what is missing and can inform the user.

4. **Config hint** — Both the log warning and prompt note now mention `skills.limits.maxSkillsPromptChars` so users can self-service.

## Context

Discovered while debugging why a workspace skill (`family-finance`) was not appearing in the agent's `<available_skills>`. With 83 total skills (51 bundled + 2 managed + 30 workspace), the prompt was 30,638 chars — just 638 over the 30K limit — causing the last 2 skills to be silently dropped.

Fixes #46623