### PR TITLE
fix(auth): persist final auth profile after successful fallback

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -628,7 +628,7 @@ export async function runEmbeddedPiAgent(
         } else {
           authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
         }
-        lastProfileId = apiKeyInfo.profileId;
+        lastProfileId = resolvedProfileId;
       };
 
       const advanceAuthProfile = async (): Promise<boolean> => {
@@ -1566,6 +1566,7 @@ export async function runEmbeddedPiAgent(
           }
           return {
             payloads: payloads.length ? payloads : undefined,
+            finalAuthProfileId: lastProfileId,
             meta: {
               durationMs: Date.now() - started,
               agentMeta,

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -59,6 +59,8 @@ export type EmbeddedRunAttemptResult = {
   messagingToolSentMediaUrls: string[];
   messagingToolSentTargets: MessagingToolSend[];
   successfulCronAdds?: number;
+  /** Final auth profile that actually succeeded for this run, after any rotation. */
+  finalAuthProfileId?: string;
   cloudCodeAssistFormatError: boolean;
   attemptUsage?: NormalizedUsage;
   compactionCount?: number;

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -74,6 +74,8 @@ export type EmbeddedPiRunResult = {
   messagingToolSentTargets?: MessagingToolSend[];
   // Count of successful cron.add tool calls in this run.
   successfulCronAdds?: number;
+  /** Final auth profile that actually succeeded for this run, after any rotation. */
+  finalAuthProfileId?: string;
 };
 
 export type EmbeddedPiCompactResult = {

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -7,6 +7,7 @@ import * as cliRunnerModule from "../agents/cli-runner.js";
 import { FailoverError } from "../agents/failover-error.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import * as modelSelectionModule from "../agents/model-selection.js";
+import type { EmbeddedPiRunResult } from "../agents/pi-embedded-runner/types.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import * as commandSecretGatewayModule from "../cli/command-secret-gateway.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -686,6 +687,61 @@ describe("agentCommand", () => {
       expect(entry?.fallbackNoticeSelectedModel).toBeUndefined();
       expect(entry?.fallbackNoticeActiveModel).toBeUndefined();
       expect(entry?.fallbackNoticeReason).toBeUndefined();
+    });
+  });
+
+  it("persists final rotated auth profile after a successful run", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:main": {
+          sessionId: "sess-rotated-profile",
+          updatedAt: Date.now(),
+          authProfileOverride: "openai-codex:default",
+          authProfileOverrideSource: "auto",
+          modelProvider: "openai-codex",
+          model: "gpt-5.4",
+        },
+      });
+      mockConfig(home, store, {
+        model: { primary: "openai-codex/gpt-5.4" },
+        auth: {
+          profiles: {
+            "openai-codex:default": { provider: "openai-codex", type: "oauth", access: "a" },
+            "openai-codex:account2": { provider: "openai-codex", type: "oauth", access: "b" },
+          },
+          order: {
+            "openai-codex": ["openai-codex:default", "openai-codex:account2"],
+          },
+        },
+      });
+
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValueOnce({
+        payloads: [{ text: "ok" }],
+        finalAuthProfileId: "openai-codex:account2",
+        meta: {
+          durationMs: 10,
+          aborted: false,
+          agentMeta: {
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            sessionId: "sess-rotated-profile",
+          },
+        },
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+        successfulCronAdds: 0,
+      } as unknown as EmbeddedPiRunResult);
+
+      await runAgentWithSessionKey("agent:main:main");
+
+      const saved = JSON.parse(fs.readFileSync(store, "utf-8")) as Record<string, unknown>;
+      const entry = saved["agent:main:main"];
+      expect(entry?.authProfileOverride).toBe("openai-codex:account2");
+      expect(entry?.authProfileOverrideSource).toBe("auto");
+      expect(entry?.authProfileOverrideCompactionCount).toBeUndefined();
     });
   });
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -745,7 +745,7 @@ describe("agentCommand", () => {
     });
   });
 
-  it("preserves user-pinned auth profile source when persisting final rotated auth profile", async () => {
+  it("preserves user-pinned auth profile source when persisting the final rotated auth profile", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");
       writeSessionStoreSeed(store, {

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -745,6 +745,61 @@ describe("agentCommand", () => {
     });
   });
 
+  it("preserves user-pinned auth profile source when persisting final rotated auth profile", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:main": {
+          sessionId: "sess-user-pinned-profile",
+          updatedAt: Date.now(),
+          authProfileOverride: "openai-codex:default",
+          authProfileOverrideSource: "user",
+          modelProvider: "openai-codex",
+          model: "gpt-5.4",
+        },
+      });
+      mockConfig(home, store, {
+        model: { primary: "openai-codex/gpt-5.4" },
+        auth: {
+          profiles: {
+            "openai-codex:default": { provider: "openai-codex", type: "oauth", access: "a" },
+            "openai-codex:account2": { provider: "openai-codex", type: "oauth", access: "b" },
+          },
+          order: {
+            "openai-codex": ["openai-codex:default", "openai-codex:account2"],
+          },
+        },
+      });
+
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValueOnce({
+        payloads: [{ text: "ok" }],
+        finalAuthProfileId: "openai-codex:account2",
+        meta: {
+          durationMs: 10,
+          aborted: false,
+          agentMeta: {
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            sessionId: "sess-user-pinned-profile",
+          },
+        },
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+        successfulCronAdds: 0,
+      } as unknown as EmbeddedPiRunResult);
+
+      await runAgentWithSessionKey("agent:main:main");
+
+      const saved = JSON.parse(fs.readFileSync(store, "utf-8")) as Record<string, unknown>;
+      const entry = saved["agent:main:main"];
+      expect(entry?.authProfileOverride).toBe("openai-codex:account2");
+      expect(entry?.authProfileOverrideSource).toBe("user");
+      expect(entry?.authProfileOverrideCompactionCount).toBeUndefined();
+    });
+  });
+
   it("keeps explicit sessionKey even when sessionId exists elsewhere", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -439,7 +439,7 @@ async function runAgentAttempt(params: {
                   const authStore = ensureAuthProfileStore();
                   const providerKey = normalizeProviderId(params.primaryProvider);
                   const winningProfileId =
-                    authStore.lastGood?.[providerKey]?.trim() || result.finalAuthProfileId?.trim();
+                    result.finalAuthProfileId?.trim() || authStore.lastGood?.[providerKey]?.trim();
                   if (winningProfileId) {
                     updatedEntry.authProfileOverride = winningProfileId;
                     updatedEntry.authProfileOverrideSource = "auto";
@@ -524,7 +524,6 @@ async function runAgentAttempt(params: {
   });
   if (
     params.providerOverride === params.primaryProvider &&
-    params.sessionEntry &&
     params.sessionStore &&
     params.sessionKey &&
     params.storePath

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -15,7 +15,7 @@ import {
   resolveAgentSkillsFilter,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
-import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
+import { ensureAuthProfileStore, saveAuthProfileStore } from "../agents/auth-profiles.js";
 import { clearSessionAuthProfileOverride } from "../agents/auth-profiles/session-override.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../agents/bootstrap-budget.js";
 import { runCliAgent } from "../agents/cli-runner.js";
@@ -317,7 +317,7 @@ async function persistAcpTurnTranscript(params: {
   return sessionEntry;
 }
 
-function runAgentAttempt(params: {
+async function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
   cfg: ReturnType<typeof loadConfig>;
@@ -344,7 +344,7 @@ function runAgentAttempt(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
-}) {
+}): Promise<Awaited<ReturnType<typeof runEmbeddedPiAgent>>> {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
@@ -434,6 +434,29 @@ function runAgentAttempt(params: {
                 params.providerOverride,
                 result.meta.agentMeta.sessionId,
               );
+              if (params.providerOverride === params.primaryProvider) {
+                try {
+                  const authStore = ensureAuthProfileStore();
+                  const providerKey = normalizeProviderId(params.primaryProvider);
+                  const winningProfileId =
+                    authStore.lastGood?.[providerKey]?.trim() || result.finalAuthProfileId?.trim();
+                  if (winningProfileId) {
+                    updatedEntry.authProfileOverride = winningProfileId;
+                    updatedEntry.authProfileOverrideSource = "auto";
+                    delete updatedEntry.authProfileOverrideCompactionCount;
+                    const winningProfile = authStore.profiles[winningProfileId];
+                    if (winningProfile) {
+                      authStore.lastGood = {
+                        ...authStore.lastGood,
+                        [providerKey]: winningProfileId,
+                      };
+                      saveAuthProfileStore(authStore, params.agentDir);
+                    }
+                  }
+                } catch {
+                  // Best-effort sync only; session persistence remains authoritative for this path.
+                }
+              }
               updatedEntry.updatedAt = Date.now();
 
               await persistSessionEntry({
@@ -455,7 +478,7 @@ function runAgentAttempt(params: {
     params.providerOverride === params.primaryProvider
       ? params.sessionEntry?.authProfileOverride
       : undefined;
-  return runEmbeddedPiAgent({
+  const result = await runEmbeddedPiAgent({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     agentId: params.sessionAgentId,
@@ -499,6 +522,32 @@ function runAgentAttempt(params: {
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,
   });
+  if (
+    params.providerOverride === params.primaryProvider &&
+    params.sessionEntry &&
+    params.sessionStore &&
+    params.sessionKey &&
+    params.storePath
+  ) {
+    const finalAuthProfileId = result.finalAuthProfileId?.trim();
+    if (finalAuthProfileId) {
+      const entry = params.sessionStore[params.sessionKey];
+      if (entry) {
+        const updatedEntry = { ...entry };
+        updatedEntry.authProfileOverride = finalAuthProfileId;
+        updatedEntry.authProfileOverrideSource = "auto";
+        delete updatedEntry.authProfileOverrideCompactionCount;
+        updatedEntry.updatedAt = Date.now();
+        await persistSessionEntry({
+          sessionStore: params.sessionStore,
+          sessionKey: params.sessionKey,
+          storePath: params.storePath,
+          entry: updatedEntry,
+        });
+      }
+    }
+  }
+  return result;
 }
 
 async function prepareAgentCommandExecution(
@@ -1200,6 +1249,10 @@ async function agentCommandInternal(
         fallbackModel,
         result,
       });
+
+      // Note: authProfileOverride is now persisted in runAgentAttempt using
+      // finalAuthProfileId from the run result. This ensures the session
+      // remembers which profile actually succeeded after any fallback rotation.
     }
 
     const payloads = result.payloads ?? [];

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -341,10 +341,17 @@ async function runAgentAttempt(params: {
   agentDir: string;
   onAgentEvent: (evt: { stream: string; data?: Record<string, unknown> }) => void;
   primaryProvider: string;
+  originalAuthProfileOverrideSource?: SessionEntry["authProfileOverrideSource"];
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
 }): Promise<Awaited<ReturnType<typeof runEmbeddedPiAgent>>> {
+  const initialAuthProfileOverrideSource =
+    params.originalAuthProfileOverrideSource ??
+    params.sessionEntry?.authProfileOverrideSource ??
+    (params.sessionKey
+      ? params.sessionStore?.[params.sessionKey]?.authProfileOverrideSource
+      : undefined);
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
@@ -441,8 +448,11 @@ async function runAgentAttempt(params: {
                   const winningProfileId =
                     result.finalAuthProfileId?.trim() || authStore.lastGood?.[providerKey]?.trim();
                   if (winningProfileId) {
+                    const preserveUserPin =
+                      initialAuthProfileOverrideSource === "user" ||
+                      updatedEntry.authProfileOverrideSource === "user";
                     updatedEntry.authProfileOverride = winningProfileId;
-                    updatedEntry.authProfileOverrideSource = "auto";
+                    updatedEntry.authProfileOverrideSource = preserveUserPin ? "user" : "auto";
                     delete updatedEntry.authProfileOverrideCompactionCount;
                     const winningProfile = authStore.profiles[winningProfileId];
                     if (winningProfile) {
@@ -533,8 +543,11 @@ async function runAgentAttempt(params: {
       const entry = params.sessionStore[params.sessionKey];
       if (entry) {
         const updatedEntry = { ...entry };
+        const preserveUserPin =
+          initialAuthProfileOverrideSource === "user" ||
+          updatedEntry.authProfileOverrideSource === "user";
         updatedEntry.authProfileOverride = finalAuthProfileId;
-        updatedEntry.authProfileOverrideSource = "auto";
+        updatedEntry.authProfileOverrideSource = preserveUserPin ? "user" : "auto";
         delete updatedEntry.authProfileOverrideCompactionCount;
         updatedEntry.updatedAt = Date.now();
         await persistSessionEntry({
@@ -754,6 +767,7 @@ async function agentCommandInternal(
     acpResolution,
   } = prepared;
   let sessionEntry = prepared.sessionEntry;
+  const originalAuthProfileOverrideSource = sessionEntry?.authProfileOverrideSource;
 
   try {
     if (opts.deliver === true) {
@@ -1181,6 +1195,7 @@ async function agentCommandInternal(
             resolvedVerboseLevel,
             agentDir,
             primaryProvider: provider,
+            originalAuthProfileOverrideSource,
             sessionStore,
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,


### PR DESCRIPTION
## Summary
- return `finalAuthProfileId` from embedded runs after successful fallback rotation
- persist the winning auth profile back to session `authProfileOverride`
- fix winner tracking to use `resolvedProfileId` instead of raw `apiKeyInfo.profileId`
- add regression coverage for session override persistence

## Problem
When `openai-codex:default` hit rate limit and the run successfully rotated to `openai-codex:account2`:
- `lastGood` could be updated
- but the session `authProfileOverride` could remain pinned to `default`
- so the next request started from the stale profile again

## Root cause
The embedded runner did not reliably return the final winning auth profile id, and the successful run result was not persisted back into the session override.

## Fix
1. track the winning profile with `resolvedProfileId`
2. expose it as `finalAuthProfileId` in the embedded run result
3. persist that id to session `authProfileOverride` after a successful run

## Validation
Manual validation completed:
1. set `lastGood` = null
2. put `openai-codex:default` in cooldown
3. run a request
4. verify fallback succeeds on `account2`
5. verify both:
   - `lastGood = openai-codex:account2`
   - `authProfileOverride = openai-codex:account2`
6. run a second request and confirm it stays on `account2`
