### PR TITLE
sessions_send: preserve target route (rebased 43353 onto 45739+46308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 - macOS/runtime locator: require Node >=22.16.0 during macOS runtime discovery so the app no longer accepts Node versions that the main runtime guard rejects later. Thanks @sumleo.
 - Agents/custom providers: preserve blank API keys for loopback OpenAI-compatible custom providers by clearing the synthetic Authorization header at runtime, while keeping explicit apiKey and oauth/token config from silently downgrading into fake bearer auth. (#45631) Thanks @xinhuagu.
 - Models/google-vertex Gemini flash-lite normalization: apply existing bare-ID preview normalization to `google-vertex` model refs and provider configs so `google-vertex/gemini-3.1-flash-lite` resolves as `gemini-3.1-flash-lite-preview`. (#42435) thanks @scoootscooob.
+- ACP/parent streaming: backfill missing child assistant output and terminal completion from gateway `chat.history` and `agent.wait` when ACP relay events do not reach the local parent emitter, so `sessions_spawn` with `streamTo: "parent"` no longer gets stuck on start/stall-only updates. (#45205)
 
 ## 2026.3.12
 

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -5,11 +5,16 @@ import {
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
 
+const callGatewayMock = vi.fn();
 const enqueueSystemEventMock = vi.fn();
 const requestHeartbeatNowMock = vi.fn();
 const readAcpSessionEntryMock = vi.fn();
 const resolveSessionFilePathMock = vi.fn();
 const resolveSessionFilePathOptionsMock = vi.fn();
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (...args: unknown[]) => callGatewayMock(...args),
+}));
 
 vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
@@ -19,14 +24,23 @@ vi.mock("../infra/heartbeat-wake.js", () => ({
   requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
 }));
 
-vi.mock("../acp/runtime/session-meta.js", () => ({
-  readAcpSessionEntry: (...args: unknown[]) => readAcpSessionEntryMock(...args),
-}));
+vi.mock("../acp/runtime/session-meta.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../acp/runtime/session-meta.js")>();
+  return {
+    ...actual,
+    readAcpSessionEntry: (...args: unknown[]) => readAcpSessionEntryMock(...args),
+  };
+});
 
-vi.mock("../config/sessions/paths.js", () => ({
-  resolveSessionFilePath: (...args: unknown[]) => resolveSessionFilePathMock(...args),
-  resolveSessionFilePathOptions: (...args: unknown[]) => resolveSessionFilePathOptionsMock(...args),
-}));
+vi.mock("../config/sessions/paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions/paths.js")>();
+  return {
+    ...actual,
+    resolveSessionFilePath: (...args: unknown[]) => resolveSessionFilePathMock(...args),
+    resolveSessionFilePathOptions: (...args: unknown[]) =>
+      resolveSessionFilePathOptionsMock(...args),
+  };
+});
 
 function collectedTexts() {
   return enqueueSystemEventMock.mock.calls.map((call) => String(call[0] ?? ""));
@@ -34,6 +48,16 @@ function collectedTexts() {
 
 describe("startAcpSpawnParentStreamRelay", () => {
   beforeEach(() => {
+    callGatewayMock.mockReset();
+    callGatewayMock.mockImplementation(async (opts?: { method?: string }) => {
+      if (opts?.method === "chat.history") {
+        return { messages: [] };
+      }
+      if (opts?.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      throw new Error(`Unexpected method: ${String(opts?.method)}`);
+    });
     enqueueSystemEventMock.mockClear();
     requestHeartbeatNowMock.mockClear();
     readAcpSessionEntryMock.mockReset();
@@ -206,6 +230,148 @@ describe("startAcpSpawnParentStreamRelay", () => {
 
     const texts = collectedTexts();
     expect(texts.some((text) => text.includes("codex: hello world"))).toBe(true);
+    relay.dispose();
+  });
+
+  it("falls back to child history and gateway wait when local events never arrive", async () => {
+    callGatewayMock.mockImplementation(async (opts?: { method?: string }) => {
+      if (opts?.method === "chat.history") {
+        const isPrimingRead =
+          callGatewayMock.mock.calls.filter(([call]) => call?.method === "chat.history").length ===
+          1;
+        return isPrimingRead
+          ? { messages: [] }
+          : {
+              messages: [
+                {
+                  role: "assistant",
+                  content: [{ type: "text", text: "READY_FROM_HISTORY" }],
+                },
+              ],
+            };
+      }
+      if (opts?.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      throw new Error(`Unexpected method: ${String(opts?.method)}`);
+    });
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-6",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-6",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 120_000,
+      noOutputPollMs: 250,
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    const texts = collectedTexts();
+    expect(texts.some((text) => text.includes("codex: READY_FROM_HISTORY"))).toBe(true);
+    expect(texts.some((text) => text.includes("codex run completed."))).toBe(true);
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "chat.history",
+        params: expect.objectContaining({
+          sessionKey: "agent:codex:acp:child-6",
+        }),
+      }),
+    );
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent.wait",
+        params: expect.objectContaining({
+          runId: "run-6",
+          timeoutMs: 1,
+        }),
+      }),
+    );
+    relay.dispose();
+  });
+
+  it("falls back to gateway wait when assistant deltas arrive but lifecycle completion is missing", async () => {
+    callGatewayMock.mockImplementation(async (opts?: { method?: string }) => {
+      if (opts?.method === "chat.history") {
+        return { messages: [] };
+      }
+      if (opts?.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      throw new Error(`Unexpected method: ${String(opts?.method)}`);
+    });
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-7",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-7",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 120_000,
+      noOutputPollMs: 250,
+    });
+
+    emitAgentEvent({
+      runId: "run-7",
+      stream: "assistant",
+      data: {
+        delta: "READY_FROM_LOCAL",
+      },
+    });
+    await vi.advanceTimersByTimeAsync(250);
+
+    const texts = collectedTexts();
+    expect(texts.some((text) => text.includes("codex: READY_FROM_LOCAL"))).toBe(true);
+    expect(texts.some((text) => text.includes("codex run completed."))).toBe(true);
+    relay.dispose();
+  });
+
+  it("hydrates missing assistant output from history before a local lifecycle end completes", async () => {
+    callGatewayMock.mockImplementation(async (opts?: { method?: string }) => {
+      if (opts?.method === "chat.history") {
+        const isPrimingRead =
+          callGatewayMock.mock.calls.filter(([call]) => call?.method === "chat.history").length ===
+          1;
+        return isPrimingRead
+          ? { messages: [] }
+          : {
+              messages: [
+                {
+                  role: "assistant",
+                  content: [{ type: "text", text: "READY_BEFORE_LOCAL_END" }],
+                },
+              ],
+            };
+      }
+      if (opts?.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      throw new Error(`Unexpected method: ${String(opts?.method)}`);
+    });
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-8",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-8",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 120_000,
+      noOutputPollMs: 250,
+    });
+
+    emitAgentEvent({
+      runId: "run-8",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+      },
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    const texts = collectedTexts();
+    expect(texts.some((text) => text.includes("codex: READY_BEFORE_LOCAL_END"))).toBe(true);
+    expect(texts.some((text) => text.includes("codex run completed."))).toBe(true);
     relay.dispose();
   });
 

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -2,10 +2,12 @@ import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
+import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { extractAssistantText, stripToolMessages } from "./tools/sessions-helpers.js";
 
 const DEFAULT_STREAM_FLUSH_MS = 2_500;
 const DEFAULT_NO_OUTPUT_NOTICE_MS = 60_000;
@@ -205,8 +207,15 @@ export function startAcpSpawnParentStreamRelay(params: {
   let pendingText = "";
   let lastProgressAt = Date.now();
   let stallNotified = false;
+  let sawLocalAssistantEvent = false;
+  let sawLocalTerminalEvent = false;
+  let fallbackPollInFlight = false;
+  let historyBaselineReady = false;
+  let historyOutputRelayed = false;
+  let lastHistoryAssistant = "";
   let flushTimer: NodeJS.Timeout | undefined;
   let relayLifetimeTimer: NodeJS.Timeout | undefined;
+  let fallbackPollTimer: NodeJS.Timeout | undefined;
 
   const clearFlushTimer = () => {
     if (!flushTimer) {
@@ -246,6 +255,152 @@ export function startAcpSpawnParentStreamRelay(params: {
     flushTimer.unref?.();
   };
 
+  const recordAssistantOutput = (delta: string | undefined, kind: string) => {
+    if (!delta || !delta.trim()) {
+      return false;
+    }
+    logEvent(kind, { delta });
+
+    if (stallNotified) {
+      stallNotified = false;
+      emit(`${relayLabel} resumed output.`, `${contextPrefix}:resumed`);
+    }
+
+    lastProgressAt = Date.now();
+    pendingText += delta;
+    if (pendingText.length > STREAM_BUFFER_MAX_CHARS) {
+      pendingText = pendingText.slice(-STREAM_BUFFER_MAX_CHARS);
+    }
+    if (pendingText.length >= STREAM_SNIPPET_MAX_CHARS || delta.includes("\n\n")) {
+      flushPending();
+      return true;
+    }
+    scheduleFlush();
+    return true;
+  };
+
+  const readLatestAssistantFromChildHistory = async (): Promise<string | undefined> => {
+    const history = await callGateway<{ messages?: unknown[] }>({
+      method: "chat.history",
+      params: {
+        sessionKey: params.childSessionKey,
+        limit: 24,
+      },
+      timeoutMs: 10_000,
+    }).catch(() => null);
+    const filtered = stripToolMessages(Array.isArray(history?.messages) ? history.messages : []);
+    const assistantMessages = filtered.filter(
+      (msg) => (msg as { role?: unknown } | undefined)?.role === "assistant",
+    );
+    const last =
+      assistantMessages.length > 0 ? assistantMessages[assistantMessages.length - 1] : undefined;
+    return toTrimmedString(extractAssistantText(last));
+  };
+
+  const primeHistoryBaseline = async () => {
+    if (historyBaselineReady || disposed) {
+      return;
+    }
+    const reply = await readLatestAssistantFromChildHistory();
+    if (disposed) {
+      return;
+    }
+    historyBaselineReady = true;
+    lastHistoryAssistant = reply ?? "";
+  };
+
+  const maybeRelayHistoryAssistant = async (force = false) => {
+    const reply = await readLatestAssistantFromChildHistory();
+    if (disposed) {
+      return false;
+    }
+    if (!historyBaselineReady) {
+      historyBaselineReady = true;
+      lastHistoryAssistant = reply ?? "";
+      if (!force || !reply || sawLocalAssistantEvent) {
+        return false;
+      }
+      const relayed = recordAssistantOutput(reply, "assistant_history");
+      if (relayed) {
+        historyOutputRelayed = true;
+      }
+      return relayed;
+    }
+    if (!reply) {
+      return false;
+    }
+    const changed = reply !== lastHistoryAssistant;
+    lastHistoryAssistant = reply;
+    if (sawLocalAssistantEvent) {
+      return false;
+    }
+    if (!force && !changed) {
+      return false;
+    }
+    if (historyOutputRelayed && !changed) {
+      return false;
+    }
+    const relayed = recordAssistantOutput(reply, "assistant_history");
+    if (relayed) {
+      historyOutputRelayed = true;
+    }
+    return relayed;
+  };
+
+  const maybeFinalizeFromGateway = async () => {
+    if (disposed || sawLocalTerminalEvent) {
+      return false;
+    }
+    const wait = await callGateway<{ status?: unknown; error?: unknown }>({
+      method: "agent.wait",
+      params: {
+        runId,
+        timeoutMs: 1,
+      },
+      timeoutMs: 5_000,
+    }).catch(() => null);
+    const status = toTrimmedString(wait?.status);
+    if (disposed || !status || status === "timeout") {
+      return false;
+    }
+    if (status !== "ok" && status !== "error") {
+      return false;
+    }
+    sawLocalTerminalEvent = true;
+    if (status === "error") {
+      flushPending();
+      const errorText = toTrimmedString(wait?.error);
+      if (errorText) {
+        emit(`${relayLabel} run failed: ${errorText}`, `${contextPrefix}:error`);
+      } else {
+        emit(`${relayLabel} run failed.`, `${contextPrefix}:error`);
+      }
+      dispose();
+      return true;
+    }
+    await maybeRelayHistoryAssistant(true);
+    flushPending();
+    emit(`${relayLabel} run completed.`, `${contextPrefix}:done`);
+    dispose();
+    return true;
+  };
+
+  const fallbackPollIntervalMs = Math.min(noOutputPollMs, 5_000);
+  const runFallbackPoll = async () => {
+    if (disposed || fallbackPollInFlight) {
+      return;
+    }
+    fallbackPollInFlight = true;
+    try {
+      if (!sawLocalAssistantEvent) {
+        await maybeRelayHistoryAssistant(false);
+      }
+      await maybeFinalizeFromGateway();
+    } finally {
+      fallbackPollInFlight = false;
+    }
+  };
+
   const noOutputWatcherTimer = setInterval(() => {
     if (disposed || noOutputNoticeMs <= 0) {
       return;
@@ -276,6 +431,15 @@ export function startAcpSpawnParentStreamRelay(params: {
   }, maxRelayLifetimeMs);
   relayLifetimeTimer.unref?.();
 
+  if (fallbackPollIntervalMs > 0) {
+    fallbackPollTimer = setInterval(() => {
+      void runFallbackPoll();
+    }, fallbackPollIntervalMs);
+    fallbackPollTimer.unref?.();
+  }
+
+  void primeHistoryBaseline();
+
   if (params.emitStartNotice !== false) {
     emitStartNotice();
   }
@@ -286,31 +450,13 @@ export function startAcpSpawnParentStreamRelay(params: {
     }
 
     if (event.stream === "assistant") {
+      sawLocalAssistantEvent = true;
       const data = event.data;
       const deltaCandidate =
         (data as { delta?: unknown } | undefined)?.delta ??
         (data as { text?: unknown } | undefined)?.text;
       const delta = typeof deltaCandidate === "string" ? deltaCandidate : undefined;
-      if (!delta || !delta.trim()) {
-        return;
-      }
-      logEvent("assistant_delta", { delta });
-
-      if (stallNotified) {
-        stallNotified = false;
-        emit(`${relayLabel} resumed output.`, `${contextPrefix}:resumed`);
-      }
-
-      lastProgressAt = Date.now();
-      pendingText += delta;
-      if (pendingText.length > STREAM_BUFFER_MAX_CHARS) {
-        pendingText = pendingText.slice(-STREAM_BUFFER_MAX_CHARS);
-      }
-      if (pendingText.length >= STREAM_SNIPPET_MAX_CHARS || delta.includes("\n\n")) {
-        flushPending();
-        return;
-      }
-      scheduleFlush();
+      recordAssistantOutput(delta, "assistant_delta");
       return;
     }
 
@@ -321,7 +467,6 @@ export function startAcpSpawnParentStreamRelay(params: {
     const phase = toTrimmedString((event.data as { phase?: unknown } | undefined)?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
     if (phase === "end") {
-      flushPending();
       const startedAt = toFiniteNumber(
         (event.data as { startedAt?: unknown } | undefined)?.startedAt,
       );
@@ -330,19 +475,27 @@ export function startAcpSpawnParentStreamRelay(params: {
         startedAt != null && endedAt != null && endedAt >= startedAt
           ? endedAt - startedAt
           : undefined;
-      if (durationMs != null) {
-        emit(
-          `${relayLabel} run completed in ${Math.max(1, Math.round(durationMs / 1000))}s.`,
-          `${contextPrefix}:done`,
-        );
-      } else {
-        emit(`${relayLabel} run completed.`, `${contextPrefix}:done`);
-      }
-      dispose();
+      sawLocalTerminalEvent = true;
+      void (async () => {
+        if (!sawLocalAssistantEvent) {
+          await maybeRelayHistoryAssistant(true);
+        }
+        flushPending();
+        if (durationMs != null) {
+          emit(
+            `${relayLabel} run completed in ${Math.max(1, Math.round(durationMs / 1000))}s.`,
+            `${contextPrefix}:done`,
+          );
+        } else {
+          emit(`${relayLabel} run completed.`, `${contextPrefix}:done`);
+        }
+        dispose();
+      })();
       return;
     }
 
     if (phase === "error") {
+      sawLocalTerminalEvent = true;
       flushPending();
       const errorText = toTrimmedString((event.data as { error?: unknown } | undefined)?.error);
       if (errorText) {
@@ -363,6 +516,9 @@ export function startAcpSpawnParentStreamRelay(params: {
     clearRelayLifetimeTimer();
     flushLogBuffer();
     clearInterval(noOutputWatcherTimer);
+    if (fallbackPollTimer) {
+      clearInterval(fallbackPollTimer);
+    }
     unsubscribe();
   };
 

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -39,11 +39,13 @@ const hoisted = vi.hoisted(() => {
   const resolveStorePathMock = vi.fn();
   const resolveSessionTranscriptFileMock = vi.fn();
   const areHeartbeatsEnabledMock = vi.fn();
+  const registerSubagentRunMock = vi.fn();
   const state = {
     cfg: createDefaultSpawnConfig(),
   };
   return {
     callGatewayMock,
+    registerSubagentRunMock,
     sessionBindingCapabilitiesMock,
     sessionBindingBindMock,
     sessionBindingUnbindMock,
@@ -138,6 +140,10 @@ vi.mock("../infra/heartbeat-wake.js", async (importOriginal) => {
   };
 });
 
+vi.mock("./subagent-registry.js", () => ({
+  registerSubagentRun: (...args: unknown[]) => hoisted.registerSubagentRunMock(...args),
+}));
+
 vi.mock("./acp-spawn-parent-stream.js", () => ({
   startAcpSpawnParentStreamRelay: (...args: unknown[]) =>
     hoisted.startAcpSpawnParentStreamRelayMock(...args),
@@ -201,6 +207,7 @@ function expectResolvedIntroTextInBindMetadata(): void {
 
 describe("spawnAcpDirect", () => {
   beforeEach(() => {
+    hoisted.registerSubagentRunMock.mockReset();
     hoisted.state.cfg = createDefaultSpawnConfig();
     hoisted.areHeartbeatsEnabledMock.mockReset().mockReturnValue(true);
 
@@ -1040,5 +1047,56 @@ describe("spawnAcpDirect", () => {
     expect(result.error).toContain('streamTo="parent"');
     expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
     expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
+  });
+
+  it("registers the ACP run in the subagent registry after successful dispatch", async () => {
+    await spawnAcpDirect(
+      {
+        task: "Run analysis",
+        agentId: "codex",
+        mode: "run",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        childSessionKey: expect.stringMatching(/^agent:codex:acp:/),
+        requesterSessionKey: "main",
+        task: "Run analysis",
+        cleanup: "keep",
+      }),
+    );
+  });
+
+  it("still returns success when registerSubagentRun throws", async () => {
+    hoisted.registerSubagentRunMock.mockImplementation(() => {
+      throw new Error("registry unavailable");
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Run analysis",
+        agentId: "codex",
+        mode: "run",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.childSessionKey).toMatch(/^agent:codex:acp:/);
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -274,16 +274,17 @@ function summarizeError(err: unknown): string {
 function resolveRequesterInternalSessionKey(params: {
   cfg: OpenClawConfig;
   requesterSessionKey?: string;
-}): string {
+}): { key: string; mainKey: string; alias: string } {
   const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
   const requesterSessionKey = params.requesterSessionKey?.trim();
-  return requesterSessionKey
+  const key = requesterSessionKey
     ? resolveInternalSessionKey({
         key: requesterSessionKey,
         alias,
         mainKey,
       })
     : alias;
+  return { key, mainKey, alias };
 }
 
 async function persistAcpSpawnSessionFileBestEffort(params: {
@@ -410,7 +411,11 @@ export async function spawnAcpDirect(
   ctx: SpawnAcpContext,
 ): Promise<SpawnAcpResult> {
   const cfg = loadConfig();
-  const requesterInternalKey = resolveRequesterInternalSessionKey({
+  const {
+    key: requesterInternalKey,
+    mainKey,
+    alias,
+  } = resolveRequesterInternalSessionKey({
     cfg,
     requesterSessionKey: ctx.agentSessionKey,
   });
@@ -737,24 +742,33 @@ export async function spawnAcpDirect(
   // subagent_ended) are emitted when the ACP session completes or exits.
   // Without this, ACP sessions are invisible to the registry and their
   // completion is never propagated back to the requester.
-  const { mainKey, alias } = resolveMainSessionAlias(cfg);
-  const requesterDisplayKey = resolveDisplaySessionKey({
-    key: requesterInternalKey,
-    alias,
-    mainKey,
-  });
-  registerSubagentRun({
-    runId: childRunId,
-    childSessionKey: sessionKey,
-    controllerSessionKey: requesterInternalKey,
-    requesterSessionKey: requesterInternalKey,
-    requesterOrigin,
-    requesterDisplayKey,
-    task: params.task,
-    cleanup: "keep",
-    label: params.label || undefined,
-    spawnMode,
-  });
+  // Wrapped in try/catch: registration failure after a successful dispatch must
+  // not surface as an error to the caller, since the ACP session is already live.
+  try {
+    const requesterDisplayKey = resolveDisplaySessionKey({
+      key: requesterInternalKey,
+      alias,
+      mainKey,
+    });
+    registerSubagentRun({
+      runId: childRunId,
+      childSessionKey: sessionKey,
+      controllerSessionKey: requesterInternalKey,
+      requesterSessionKey: requesterInternalKey,
+      requesterOrigin,
+      requesterDisplayKey,
+      task: params.task,
+      cleanup: "keep",
+      label: params.label || undefined,
+      spawnMode,
+    });
+  } catch (err) {
+    log.warn("Failed to register ACP run in subagent registry (session is still live)", {
+      runId: childRunId,
+      childSessionKey: sessionKey,
+      error: summarizeError(err),
+    });
+  }
 
   if (effectiveStreamToParent && parentSessionKey) {
     if (parentRelay && childRunId !== childIdem) {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -49,7 +49,12 @@ import {
 } from "./acp-spawn-parent-stream.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
-import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
+import { registerSubagentRun } from "./subagent-registry.js";
+import {
+  resolveDisplaySessionKey,
+  resolveInternalSessionKey,
+  resolveMainSessionAlias,
+} from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
 
@@ -727,6 +732,29 @@ export async function spawnAcpDirect(
       childSessionKey: sessionKey,
     };
   }
+
+  // Register ACP run in the subagent registry so lifecycle events (including
+  // subagent_ended) are emitted when the ACP session completes or exits.
+  // Without this, ACP sessions are invisible to the registry and their
+  // completion is never propagated back to the requester.
+  const { mainKey, alias } = resolveMainSessionAlias(cfg);
+  const requesterDisplayKey = resolveDisplaySessionKey({
+    key: requesterInternalKey,
+    alias,
+    mainKey,
+  });
+  registerSubagentRun({
+    runId: childRunId,
+    childSessionKey: sessionKey,
+    controllerSessionKey: requesterInternalKey,
+    requesterSessionKey: requesterInternalKey,
+    requesterOrigin,
+    requesterDisplayKey,
+    task: params.task,
+    cleanup: "keep",
+    label: params.label || undefined,
+    spawnMode,
+  });
 
   if (effectiveStreamToParent && parentSessionKey) {
     if (parentRelay && childRunId !== childIdem) {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -4,10 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
-import {
-  type GatewayMessageChannel,
-  INTERNAL_MESSAGE_CHANNEL,
-} from "../../utils/message-channel.js";
+import { type GatewayMessageChannel, INTER_SESSION_CHANNEL } from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
@@ -248,7 +245,7 @@ export function createSessionsSendTool(opts?: {
         sessionKey: resolvedKey,
         idempotencyKey,
         deliver: false,
-        channel: INTERNAL_MESSAGE_CHANNEL,
+        channel: INTER_SESSION_CHANNEL,
         lane: AGENT_LANE_NESTED,
         extraSystemPrompt: agentMessageContext,
         inputProvenance: {

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -449,4 +449,82 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ method: "sessions.list" });
     expect(result.details).toMatchObject({ status: "forbidden" });
   });
+
+  it("uses INTER_SESSION_CHANNEL sentinel instead of hardcoding webchat or threading sender channel", async () => {
+    // Regression test for: sessions_send hardcoded INTERNAL_MESSAGE_CHANNEL ("webchat"),
+    // causing the receiver's reply to flip from its external channel to the webchat UI.
+    //
+    // First fix attempt threaded agentChannel directly, but that caused a different bug:
+    // channel alone without paired to/accountId/threadId leaves the receiver with a
+    // mismatched channel+to state (resolveLastToRaw falls back to stale persistedLastTo).
+    //
+    // Correct fix: always use INTER_SESSION_CHANNEL ("inter_session") as a sentinel so
+    // resolveLastChannelRaw/resolveLastToRaw preserve the receiver's established route.
+    //
+    // See: https://github.com/openclaw/openclaw/issues/43318
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: { agentToAgent: { enabled: true }, sessions: { visibility: "all" } },
+    });
+
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [{ key: "agent:other:main" }],
+    });
+    callGatewayMock.mockResolvedValueOnce({ runId: "run-test-123" });
+
+    const tool = createSessionsSendTool({
+      agentSessionKey: MAIN_AGENT_SESSION_KEY,
+      agentChannel: MAIN_AGENT_CHANNEL, // "whatsapp" — should NOT be injected as channel
+    });
+
+    await tool.execute("call-inter-session-sentinel", {
+      sessionKey: "agent:other:main",
+      message: "hello from whatsapp agent",
+      timeoutSeconds: 0,
+    });
+
+    const agentCall = callGatewayMock.mock.calls.find(
+      (call) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(agentCall).toBeDefined();
+    const channel = (agentCall![0] as { params?: { channel?: string } })?.params?.channel;
+    // Must be the inter_session sentinel — NOT the sender's channel, NOT "webchat"
+    expect(channel).toBe("inter_session");
+    expect(channel).not.toBe("webchat");
+    expect(channel).not.toBe(MAIN_AGENT_CHANNEL);
+  });
+
+  it("uses INTER_SESSION_CHANNEL sentinel even when agentChannel is not provided", async () => {
+    // Even for internal spawns with no agentChannel, we use the sentinel so that
+    // resolveLastChannelRaw can still preserve any established external route on
+    // the receiver rather than unconditionally flipping to webchat.
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: { agentToAgent: { enabled: true }, sessions: { visibility: "all" } },
+    });
+
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [{ key: "agent:other:main" }],
+    });
+    callGatewayMock.mockResolvedValueOnce({ runId: "run-test-456" });
+
+    const tool = createSessionsSendTool({
+      agentSessionKey: MAIN_AGENT_SESSION_KEY,
+      // no agentChannel
+    });
+
+    await tool.execute("call-no-channel-sentinel", {
+      sessionKey: "agent:other:main",
+      message: "internal message",
+      timeoutSeconds: 0,
+    });
+
+    const agentCall = callGatewayMock.mock.calls.find(
+      (call) => (call[0] as { method?: string })?.method === "agent",
+    );
+    expect(agentCall).toBeDefined();
+    expect((agentCall![0] as { params?: { channel?: string } })?.params?.channel).toBe(
+      "inter_session",
+    );
+  });
 });

--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -1,5 +1,172 @@
 import { describe, expect, it } from "vitest";
+import { INTER_SESSION_CHANNEL } from "../../utils/message-channel.js";
 import { resolveLastChannelRaw, resolveLastToRaw } from "./session-delivery.js";
+
+describe("INTER_SESSION_CHANNEL sentinel routing", () => {
+  it("preserves an established external channel for a main session", () => {
+    // sessions_send uses INTER_SESSION_CHANNEL so the receiver's Discord route
+    // is not flipped to webchat or replaced with the sender's channel.
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        persistedLastChannel: "discord",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBe("discord");
+  });
+
+  it("does not flip to webchat for a main session (original bug regression)", () => {
+    // Before the fix, INTERNAL_MESSAGE_CHANNEL ("webchat") was injected here,
+    // which caused resolveLastChannelRaw to return "webchat" for main sessions,
+    // overriding the Discord route. INTER_SESSION_CHANNEL must never produce "webchat".
+    const result = resolveLastChannelRaw({
+      originatingChannelRaw: INTER_SESSION_CHANNEL,
+      persistedLastChannel: "discord",
+      sessionKey: "agent:navi:main",
+    });
+    expect(result).not.toBe("webchat");
+    expect(result).toBe("discord");
+  });
+
+  it("returns undefined when persisted channel is absent and only session-key hint exists (no channel synthesis)", () => {
+    // Inter-session turns must not synthesise a channel from the session key alone.
+    // Without a persisted external channel, returning a channel-only route would leave
+    // lastTo undefined and risk misdelivery via the channel defaultTo fallback.
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        persistedLastChannel: undefined,
+        sessionKey: "agent:navi:discord:direct:channel:123",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no external route can be determined", () => {
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        persistedLastChannel: undefined,
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves the receiver's persisted destination (resolveLastToRaw)", () => {
+    // Threading the sender's to/accountId/threadId would leave the receiver with
+    // a mismatched channel+to pair. The sentinel signals: keep the receiver's own dest.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        originatingToRaw: "channel:sender-discord-channel",
+        persistedLastChannel: "discord",
+        persistedLastTo: "channel:receiver-discord-channel",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBe("channel:receiver-discord-channel");
+  });
+
+  it("returns undefined from resolveLastToRaw when no persisted destination exists", () => {
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        originatingToRaw: "channel:sender-discord-channel",
+        persistedLastChannel: undefined,
+        persistedLastTo: undefined,
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined from resolveLastToRaw when channel will be resolved via session-key hint (Codex P1 fix)", () => {
+    // Scenario: persisted state is webchat (not external), so resolveLastChannelRaw
+    // falls back to the session-key hint and returns "discord". Blindly returning
+    // persistedLastTo here would create a mismatched lastChannel/lastTo pair
+    // (discord channel + stale webchat target). The sentinel must return undefined
+    // so the caller can derive an appropriate target from the new channel.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        originatingToRaw: "channel:sender-discord-channel",
+        persistedLastChannel: "webchat",
+        persistedLastTo: "session:stale-webchat-target",
+        sessionKey: "agent:navi:discord:direct:channel:123",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves persistedLastTo when persisted channel is already external (consistent pair)", () => {
+    // When the receiver already has an established external route (e.g. discord),
+    // both channel and to come from persisted state — no mismatch risk.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        originatingToRaw: "channel:sender-channel",
+        persistedLastChannel: "discord",
+        persistedLastTo: "channel:receiver-discord-channel",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBe("channel:receiver-discord-channel");
+  });
+
+  it("returns undefined from resolveLastToRaw when persistedLastChannel is empty string", () => {
+    // Empty string is not an external routing channel — treat same as absent.
+    // Returning stale persistedLastTo would risk a channel/to mismatch.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        persistedLastChannel: "",
+        persistedLastTo: "channel:some-target",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined from resolveLastToRaw when persistedLastChannel is the sentinel itself (leaked state)", () => {
+    // Guard against corrupted persisted state where persistedLastChannel was
+    // accidentally set to "inter_session". The sentinel is not a deliverable
+    // channel and should never be treated as an established external route.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        persistedLastChannel: INTER_SESSION_CHANNEL,
+        persistedLastTo: "channel:some-target",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves persistedLastTo for non-discord external channels (e.g. telegram)", () => {
+    // The sentinel path should work for any external channel, not just discord.
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: INTER_SESSION_CHANNEL,
+        originatingToRaw: "channel:sender-telegram",
+        persistedLastChannel: "telegram",
+        persistedLastTo: "user:987654321",
+        sessionKey: "agent:navi:main",
+      }),
+    ).toBe("user:987654321");
+  });
+
+  it("does not treat a real deliverable channel named 'inter_session' as the sentinel (Codex P2 guard)", () => {
+    // isInterSessionChannel guards against plugin channel collision:
+    // if a real channel plugin registers with id="inter_session", it must not
+    // be silently swallowed by the sentinel path.
+    // With no such plugin registered in the test registry, isDeliverableMessageChannel
+    // returns false for "inter_session" so the sentinel fires as expected.
+    // This test documents the invariant: sentinel only applies when the value is
+    // NOT a real deliverable channel.
+    const result = resolveLastChannelRaw({
+      originatingChannelRaw: INTER_SESSION_CHANNEL,
+      persistedLastChannel: "discord",
+      sessionKey: "agent:navi:main",
+    });
+    // In test env, "inter_session" is not a registered plugin channel, so
+    // isInterSessionChannel returns true and the sentinel path preserves "discord".
+    expect(result).toBe("discord");
+    expect(result).not.toBe(INTER_SESSION_CHANNEL);
+  });
+});
 
 describe("session delivery direct-session routing overrides", () => {
   it.each([

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -9,6 +9,7 @@ import {
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
+  isInterSessionChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import type { MsgContext } from "../templating.js";
@@ -89,7 +90,23 @@ export function resolveLastChannelRaw(params: {
   persistedLastChannel?: string;
   sessionKey?: string;
 }): string | undefined {
+  // Inter-session messages (from sessions_send): preserve the receiver's
+  // established external channel without injecting the sender's channel.
+  // Threading the sender's channel alone — without paired to/accountId/threadId —
+  // would leave the receiver with a mismatched channel+to state.
+  if (isInterSessionChannel(params.originatingChannelRaw)) {
+    const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
+    if (isExternalRoutingChannel(persistedChannel)) {
+      return persistedChannel;
+    }
+    return undefined;
+  }
+
+  // originatingChannel is only needed for the webchat-flip and external-routing
+  // checks below — declared after the inter-session guard to avoid computing it
+  // for the common inter-session fast path.
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
+
   // WebChat should own reply routing for direct-session UI turns, even when the
   // session previously replied through an external channel like iMessage.
   if (
@@ -121,6 +138,21 @@ export function resolveLastToRaw(params: {
   persistedLastChannel?: string;
   sessionKey?: string;
 }): string | undefined {
+  // Inter-session messages: preserve the receiver's established destination,
+  // but only when the persisted channel is already external. If the channel
+  // resolver falls back to a session-key hint (e.g. discord derived from the
+  // key while persistedLastChannel is still webchat), returning a stale
+  // persistedLastTo would create a mismatched lastChannel/lastTo pair and route
+  // replies to an invalid destination. In that case return undefined so the
+  // caller can derive an appropriate target from the new channel.
+  if (isInterSessionChannel(params.originatingChannelRaw)) {
+    const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
+    if (isExternalRoutingChannel(persistedChannel)) {
+      return params.persistedLastTo;
+    }
+    return undefined;
+  }
+
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
   if (
     originatingChannel === INTERNAL_MESSAGE_CHANNEL &&

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
+import * as channelSelection from "../../infra/outbound/channel-selection.js";
 import { agentHandlers } from "./agent.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -405,7 +406,177 @@ describe("gateway agent handler", () => {
     expect(callArgs.bestEffortDeliver).toBe(false);
   });
 
-  it("rejects public spawned-run metadata fields", async () => {
+  it("rejects the inter_session sentinel from non-backend callers", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+
+    const respond = await invokeAgent(
+      {
+        message: "strict delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        channel: "inter_session",
+        idempotencyKey: "test-inter-session-public",
+      },
+      {
+        reqId: "inter-session-public-1",
+        client: {
+          connect: {
+            role: "operator",
+            scopes: ["operator.write"],
+            client: { id: "test-client", mode: "ui", version: "1.0.0", platform: "test" },
+          },
+        } as unknown as AgentHandlerArgs["client"],
+      },
+    );
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("unknown channel: inter_session"),
+    });
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+  });
+
+  it("rejects spoofed backend metadata for the inter_session sentinel", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+
+    const respond = await invokeAgent(
+      {
+        message: "strict delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        channel: "inter_session",
+        idempotencyKey: "test-inter-session-spoofed-backend",
+      },
+      {
+        reqId: "inter-session-spoofed-backend-1",
+        client: {
+          connect: {
+            role: "operator",
+            scopes: ["operator.write"],
+            client: {
+              id: "gateway-client",
+              mode: "backend",
+              version: "1.0.0",
+              platform: "node",
+            },
+          },
+        } as unknown as AgentHandlerArgs["client"],
+      },
+    );
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("unknown channel: inter_session"),
+    });
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+  });
+
+  it("allows the inter_session sentinel only for server-attested internal backend callers", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+
+    await invokeAgent(
+      {
+        message: "strict delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        channel: "inter_session",
+        idempotencyKey: "test-inter-session-backend",
+      },
+      {
+        reqId: "inter-session-backend-1",
+        client: {
+          connect: {
+            role: "operator",
+            scopes: ["operator.write"],
+            client: {
+              id: "gateway-client",
+              mode: "backend",
+              version: "1.0.0",
+              platform: "node",
+            },
+          },
+          isInternalBackendClient: true,
+        } as unknown as AgentHandlerArgs["client"],
+      },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as
+      | { messageChannel?: string; runContext?: { messageChannel?: string } }
+      | undefined;
+    expect(callArgs?.messageChannel).toBe("inter_session");
+    expect(callArgs?.runContext?.messageChannel).toBe("inter_session");
+  });
+
+  it("rejects deliver=true when backend callers use the inter_session sentinel", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+    const context = makeContext();
+    const selectionSpy = vi.spyOn(channelSelection, "resolveMessageChannelSelection");
+    selectionSpy.mockResolvedValue({
+      channel: "telegram",
+      configured: ["telegram"],
+      source: "single-configured",
+    });
+
+    const respond = await invokeAgent(
+      {
+        message: "strict delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        channel: "inter_session",
+        deliver: true,
+        idempotencyKey: "test-inter-session-backend-deliver",
+      },
+      {
+        reqId: "inter-session-backend-deliver-1",
+        context,
+        client: {
+          connect: {
+            role: "operator",
+            scopes: ["operator.write"],
+            client: {
+              id: "gateway-client",
+              mode: "backend",
+              version: "1.0.0",
+              platform: "node",
+            },
+          },
+          isInternalBackendClient: true,
+        } as unknown as AgentHandlerArgs["client"],
+      },
+    );
+
+    selectionSpy.mockRestore();
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = respond.mock.calls[0] ?? [];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("inter_session"),
+    });
+    expect(context.addChatRun).not.toHaveBeenCalled();
+    expect(mocks.registerAgentRunContext).not.toHaveBeenCalledWith(
+      "test-inter-session-backend-deliver",
+      expect.anything(),
+    );
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+  });
+
+  it("only forwards workspaceDir for spawned subagent runs", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();
     const respond = vi.fn();

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -31,6 +31,7 @@ import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
   isGatewayMessageChannel,
+  isInterSessionChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
@@ -69,6 +70,10 @@ const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
 function resolveSenderIsOwnerFromClient(client: GatewayRequestHandlerOptions["client"]): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
   return scopes.includes(ADMIN_SCOPE);
+}
+
+function isInternalInterSessionCaller(client: GatewayRequestHandlerOptions["client"]): boolean {
+  return client?.isInternalBackendClient === true;
 }
 
 async function runSessionResetFromAgent(params: {
@@ -231,7 +236,9 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const isKnownGatewayChannel = (value: string): boolean => isGatewayMessageChannel(value);
+    const allowInterSessionSentinel = isInternalInterSessionCaller(client);
+    const isKnownGatewayChannel = (raw: string): boolean =>
+      isGatewayMessageChannel(raw) || (allowInterSessionSentinel && isInterSessionChannel(raw));
     const channelHints = [request.channel, request.replyChannel]
       .filter((value): value is string => typeof value === "string")
       .map((value) => value.trim())
@@ -306,6 +313,23 @@ export const agentHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+
+    const wantsDelivery = request.deliver === true;
+    const requestedInterSessionForDelivery = [request.channel, request.replyChannel].some((value) =>
+      isInterSessionChannel(normalizeMessageChannel(value)),
+    );
+    if (wantsDelivery && requestedInterSessionForDelivery) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "delivery channel cannot use the inter_session sentinel",
+        ),
+      );
+      return;
+    }
+
     let resolvedSessionId = request.sessionId?.trim() || undefined;
     let sessionEntry: SessionEntry | undefined;
     let bestEffortDeliver = requestedBestEffortDeliver ?? false;
@@ -465,7 +489,6 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const wantsDelivery = request.deliver === true;
     const explicitTo =
       typeof request.replyTo === "string" && request.replyTo.trim()
         ? request.replyTo.trim()
@@ -549,8 +572,13 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     const normalizedTurnSource = normalizeMessageChannel(turnSourceChannel);
+    // Only backend-internal gateway callers may propagate the inter-session
+    // sentinel so resolveLastChannelRaw can preserve an established external
+    // route. Public RPC callers must not inject sentinel channels here.
     const turnSourceMessageChannel =
-      normalizedTurnSource && isGatewayMessageChannel(normalizedTurnSource)
+      normalizedTurnSource &&
+      (isGatewayMessageChannel(normalizedTurnSource) ||
+        (allowInterSessionSentinel && isInterSessionChannel(normalizedTurnSource)))
         ? normalizedTurnSource
         : undefined;
     const originMessageChannel =

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -21,6 +21,8 @@ export type GatewayClient = {
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;
+  /** Server-attested marker for gateway-created internal backend clients. */
+  isInternalBackendClient?: boolean;
 };
 
 export type RespondFn = (

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -61,6 +61,7 @@ function createSyntheticOperatorClient(): GatewayRequestOptions["client"] {
       role: "operator",
       scopes: ["operator.admin", "operator.approvals", "operator.pairing"],
     },
+    isInternalBackendClient: true,
   };
 }
 

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -140,9 +140,18 @@ describe("sessions_send gateway loopback", () => {
     expect(details.sessionKey).toBe("main");
 
     const firstCall = spy.mock.calls[0]?.[0] as
-      | { lane?: string; inputProvenance?: { kind?: string; sourceTool?: string } }
+      | {
+          lane?: string;
+          channel?: string;
+          messageChannel?: string;
+          runContext?: { messageChannel?: string };
+          inputProvenance?: { kind?: string; sourceTool?: string };
+        }
       | undefined;
     expect(firstCall?.lane).toBe("nested");
+    expect(firstCall?.channel).toBe("inter_session");
+    expect(firstCall?.messageChannel).toBe("inter_session");
+    expect(firstCall?.runContext?.messageChannel).toBe("inter_session");
     expect(firstCall?.inputProvenance).toMatchObject({
       kind: "inter_session",
       sourceTool: "sessions_send",

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -178,6 +178,40 @@ describe("createGatewayPluginRequestHandler", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("missing scope: operator.admin"));
   });
 
+  it("does not mark unauthenticated plugin routes as internal backend clients", async () => {
+    loadOpenClawPlugins.mockReset();
+    handleGatewayRequest.mockReset();
+    handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
+      opts.respond(true, { internal: opts.client?.isInternalBackendClient === true });
+    });
+
+    const subagent = await createSubagentRuntime();
+    const handler = createGatewayPluginRequestHandler({
+      registry: createTestRegistry({
+        httpRoutes: [
+          createRoute({
+            path: "/hook",
+            auth: "plugin",
+            handler: async (_req, _res) => {
+              await subagent.deleteSession({ sessionKey: "agent:main:subagent:child" });
+              return true;
+            },
+          }),
+        ],
+      }),
+      log: createPluginLog(),
+    });
+
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/hook" } as IncomingMessage, res, undefined, {
+      gatewayAuthSatisfied: false,
+    });
+
+    expect(handled).toBe(true);
+    expect(handleGatewayRequest).toHaveBeenCalledTimes(1);
+    expect(handleGatewayRequest.mock.calls[0]?.[0]?.client?.isInternalBackendClient).toBe(false);
+  });
+
   it("returns false when no routes are registered", async () => {
     const log = createPluginLog();
     const handler = createGatewayPluginRequestHandler({

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -49,6 +49,7 @@ function createPluginRouteRuntimeClient(params: {
       role: "operator",
       scopes,
     },
+    isInternalBackendClient: params.requiresGatewayAuth && params.gatewayAuthSatisfied !== false,
   };
 }
 

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "vitest";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
+import type { ConnectParams } from "../../protocol/index.js";
 import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
   resolveControlUiAuthPolicy,
+  resolveInternalBackendClientAttestation,
+  shouldSkipBackendSelfPairing,
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
 
@@ -275,5 +279,401 @@ describe("ws connect policy", () => {
         }),
       ).toBe(tc.expected);
     }
+  });
+
+  test("backend self-pairing skip requires trusted local backend handshake conditions", () => {
+    const makeConnectParams = (
+      clientId: ConnectParams["client"]["id"],
+      mode: ConnectParams["client"]["mode"],
+    ): ConnectParams => ({
+      client: {
+        id: clientId,
+        mode,
+        version: "1.0.0",
+        platform: "node",
+      },
+      minProtocol: 1,
+      maxProtocol: 1,
+    });
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(true);
+
+    // Remote shared-secret backend clients must still complete pairing; the
+    // client-reported gateway-client/backend label is not enough to skip it.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: true,
+        authOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: false,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authOk: true,
+        authMethod: "trusted-proxy",
+      }),
+    ).toBe(false);
+
+    // Backend client authenticated via verified Tailscale identity is trusted via authOk,
+    // not sharedAuthOk (sharedAuthOk stays false for tailscale per auth-context.ts).
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "tailscale",
+      }),
+    ).toBe(true);
+
+    // Remote Tailscale-authenticated backend clients still need pairing. A
+    // spoofed gateway-client/backend label must not create implicit trust.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "tailscale",
+      }),
+    ).toBe(false);
+
+    // Tailscale with authOk=false is rejected.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: false,
+        authMethod: "tailscale",
+      }),
+    ).toBe(false);
+
+    // Browser-origin Tailscale backend connection is still rejected.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "tailscale",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams("webchat", GATEWAY_CLIENT_MODES.BACKEND),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+
+    // auth.mode="none": local backend client with no browser origin is trusted even without a
+    // shared secret, because there is no secret to verify.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: false,
+        authMethod: "none",
+      }),
+    ).toBe(true);
+
+    // auth.mode="none" with remote client is still rejected (isLocalClient=false).
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: false,
+        authMethod: "none",
+      }),
+    ).toBe(false);
+
+    // Backend client authenticating via device-token is trusted via authOk, not sharedAuthOk
+    // (sharedAuthOk stays false for device-token in the WS flow per auth-context.ts).
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "device-token",
+      }),
+    ).toBe(true);
+
+    // device-token with authOk=false is rejected.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: false,
+        authMethod: "device-token",
+      }),
+    ).toBe(false);
+
+    // bootstrap-token is onboarding-only auth: first-time backend connects must still
+    // go through pairing so the session can mint/persist a device token.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "bootstrap-token",
+      }),
+    ).toBe(false);
+
+    // Remote device-token backend clients also keep the pairing check. Device
+    // token auth proves the credential, not the self-declared backend label.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "device-token",
+      }),
+    ).toBe(false);
+
+    // Remote bootstrap-token backend clients are also still onboarding and must pair.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "bootstrap-token",
+      }),
+    ).toBe(false);
+
+    // Duplicate regression guard: remote shared-secret backend clients must not
+    // bypass pairing just by claiming the backend client identity.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+
+    // Remote backend client with browser origin header is still rejected.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: true,
+        authOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+
+    // Browser-origin device-token / bootstrap-token backend connections are also rejected.
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "device-token",
+      }),
+    ).toBe(false);
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: false,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: false,
+        authOk: true,
+        authMethod: "bootstrap-token",
+      }),
+    ).toBe(false);
+
+    // auth.mode="none" with browser origin header is still rejected (hasBrowserOriginHeader=true).
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams: makeConnectParams(
+          GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          GATEWAY_CLIENT_MODES.BACKEND,
+        ),
+        isLocalClient: true,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: false,
+        authOk: false,
+        authMethod: "none",
+      }),
+    ).toBe(false);
+  });
+
+  test("promotes bootstrap-paired backend clients to internal attestation", () => {
+    const backendConnect: ConnectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+        version: "1.0.0",
+        platform: "node",
+      },
+      minProtocol: 1,
+      maxProtocol: 1,
+    };
+
+    expect(
+      resolveInternalBackendClientAttestation({
+        connectParams: backendConnect,
+        hasBrowserOriginHeader: false,
+        initialIsInternalBackendClient: false,
+        authMethod: "bootstrap-token",
+        deviceTokenIssued: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      resolveInternalBackendClientAttestation({
+        connectParams: backendConnect,
+        hasBrowserOriginHeader: true,
+        initialIsInternalBackendClient: false,
+        authMethod: "bootstrap-token",
+        deviceTokenIssued: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      resolveInternalBackendClientAttestation({
+        connectParams: {
+          client: {
+            id: "desktop",
+            mode: GATEWAY_CLIENT_MODES.TEST,
+            version: "1.0.0",
+            platform: "node",
+          },
+          minProtocol: 1,
+          maxProtocol: 1,
+        },
+        hasBrowserOriginHeader: false,
+        initialIsInternalBackendClient: false,
+        authMethod: "bootstrap-token",
+        deviceTokenIssued: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -1,3 +1,5 @@
+import type { GatewayAuthResult } from "../../auth.js";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
 import type { ConnectParams } from "../../protocol/index.js";
 import type { GatewayRole } from "../../role-policy.js";
 import { roleCanSkipDeviceIdentity } from "../../role-policy.js";
@@ -60,6 +62,62 @@ export function isTrustedProxyControlUiOperatorAuth(params: {
     params.authOk &&
     params.authMethod === "trusted-proxy"
   );
+}
+
+export function shouldSkipBackendSelfPairing(params: {
+  connectParams: ConnectParams;
+  isLocalClient: boolean;
+  hasBrowserOriginHeader: boolean;
+  sharedAuthOk: boolean;
+  authOk: boolean;
+  authMethod: GatewayAuthResult["method"];
+}): boolean {
+  const isGatewayBackendClient =
+    params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+    params.connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND;
+  if (!isGatewayBackendClient) {
+    return false;
+  }
+  if (params.hasBrowserOriginHeader || !params.isLocalClient) {
+    return false;
+  }
+  // token/password: sharedAuthOk is set specifically for these in auth-context.ts.
+  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  // device-token and tailscale are valid backend auth methods, but sharedAuthOk is never
+  // set for them in the WS flow (auth-context.ts only sets it for token/password/
+  // trusted-proxy). Gate on authOk directly for these instead.
+  // bootstrap-token is intentionally excluded: first-time bootstrap connects must still
+  // complete pairing so the gateway can mint and persist a device token.
+  const usesAuthOkMethod =
+    params.authMethod === "device-token" || params.authMethod === "tailscale";
+  // When auth is disabled entirely (mode="none"), there is no credential to verify. Restricting
+  // backend self-pairing skip to locally attested clients keeps remote callers from turning a
+  // client-reported gateway-client/backend label into implicit trust.
+  const authIsDisabled = params.authMethod === "none";
+  return (
+    (params.sharedAuthOk && usesSharedSecretAuth) ||
+    (params.authOk && usesAuthOkMethod) ||
+    authIsDisabled
+  );
+}
+
+export function resolveInternalBackendClientAttestation(params: {
+  connectParams: ConnectParams;
+  hasBrowserOriginHeader: boolean;
+  initialIsInternalBackendClient: boolean;
+  authMethod: GatewayAuthResult["method"];
+  deviceTokenIssued: boolean;
+}): boolean {
+  if (params.initialIsInternalBackendClient) {
+    return true;
+  }
+  const isGatewayBackendClient =
+    params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+    params.connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND;
+  if (!isGatewayBackendClient || params.hasBrowserOriginHeader) {
+    return false;
+  }
+  return params.authMethod === "bootstrap-token" && params.deviceTokenIssued;
 }
 
 export type MissingDeviceIdentityDecision =

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -83,6 +83,8 @@ import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
   resolveControlUiAuthPolicy,
+  resolveInternalBackendClientAttestation,
+  shouldSkipBackendSelfPairing,
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
 import {
@@ -90,7 +92,6 @@ import {
   resolveHandshakeBrowserSecurityContext,
   resolveUnauthorizedHandshakeContext,
   shouldAllowSilentLocalPairing,
-  shouldSkipBackendSelfPairing,
 } from "./handshake-auth-helpers.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
 
@@ -680,6 +681,7 @@ export function attachGatewayWsMessageHandler(params: {
             isLocalClient,
             hasBrowserOriginHeader,
             sharedAuthOk,
+            authOk,
             authMethod,
           }) || shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
         if (device && devicePublicKey && !skipPairing) {
@@ -880,6 +882,13 @@ export function attachGatewayWsMessageHandler(params: {
         const deviceToken = device
           ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
           : null;
+        const attestedInternalBackendClient = resolveInternalBackendClientAttestation({
+          connectParams,
+          hasBrowserOriginHeader,
+          initialIsInternalBackendClient: isInternalBackendClient,
+          authMethod,
+          deviceTokenIssued: deviceToken !== null,
+        });
 
         if (role === "node") {
           const cfg = loadConfig();
@@ -984,6 +993,7 @@ export function attachGatewayWsMessageHandler(params: {
           canvasHostUrl,
           canvasCapability,
           canvasCapabilityExpiresAtMs,
+          isInternalBackendClient: attestedInternalBackendClient,
         };
         setSocketMaxPayload(socket, MAX_PAYLOAD_BYTES);
         setClient(nextClient);

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -41,7 +41,7 @@ import {
 } from "../../net.js";
 import { resolveNodeCommandAllowlist } from "../../node-command-policy.js";
 import { checkBrowserOrigin } from "../../origin-check.js";
-import { GATEWAY_CLIENT_IDS } from "../../protocol/client-info.js";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
 import {
   ConnectErrorDetailCodes,
   resolveDeviceAuthConnectErrorDetailCode,
@@ -882,6 +882,9 @@ export function attachGatewayWsMessageHandler(params: {
         const deviceToken = device
           ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
           : null;
+        const isInternalBackendClient =
+          connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+          connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND;
         const attestedInternalBackendClient = resolveInternalBackendClientAttestation({
           connectParams,
           hasBrowserOriginHeader,

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -10,4 +10,6 @@ export type GatewayWsClient = {
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;
+  /** Server-attested marker for gateway-created internal backend clients. */
+  isInternalBackendClient?: boolean;
 };

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -5,6 +5,7 @@ import { normalizeAccountId } from "../../utils/account-id.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
+  isReservedChannelId,
   isGatewayMessageChannel,
   normalizeMessageChannel,
   type GatewayMessageChannel,
@@ -87,6 +88,17 @@ export function resolveAgentDeliveryPlan(params: {
   });
 
   const resolvedChannel = (() => {
+    // Internal sentinels must never resolve to a deliverable channel. Keep
+    // them on the internal/webchat path here so non-delivery flows stay
+    // internal; callers that request real delivery must reject sentinels
+    // before reaching this planner.
+    if (
+      requestedChannel &&
+      isReservedChannelId(requestedChannel) &&
+      requestedChannel !== INTERNAL_MESSAGE_CHANNEL
+    ) {
+      return INTERNAL_MESSAGE_CHANNEL;
+    }
     if (requestedChannel === INTERNAL_MESSAGE_CHANNEL) {
       return INTERNAL_MESSAGE_CHANNEL;
     }

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -495,6 +495,25 @@ describe("installPluginFromArchive", () => {
     });
   });
 
+  it("rejects internal sentinel channel ids as plugin names", async () => {
+    for (const reservedId of ["inter_session", "webchat"]) {
+      const result = await installArchivePackageAndReturnResult({
+        packageJson: {
+          name: `@evil/${reservedId}`,
+          version: "0.0.1",
+          openclaw: { extensions: ["./dist/index.js"] },
+        },
+        outName: `reserved-channel-${reservedId}.tgz`,
+        withDistIndex: true,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        return;
+      }
+      expect(result.error).toContain("reserved internal channel id");
+    }
+  });
+
   it("rejects packages without openclaw.extensions", async () => {
     const result = await installArchivePackageAndReturnResult({
       packageJson: { name: "@openclaw/nope", version: "0.0.1" },

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -30,6 +30,7 @@ import { validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import * as skillScanner from "../security/skill-scanner.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
+import { isReservedChannelId } from "../utils/message-channel.js";
 import {
   loadPluginManifest,
   resolvePackageExtensionEntries,
@@ -84,6 +85,9 @@ function safeFileName(input: string): string {
   return safeDirName(input);
 }
 
+// Reserved plugin ids are checked through message-channel.ts so plugin install
+// and runtime registration share one immutable source of truth.
+
 function validatePluginId(pluginId: string): string | null {
   if (!pluginId) {
     return "invalid plugin name: missing";
@@ -93,6 +97,9 @@ function validatePluginId(pluginId: string): string | null {
   }
   if (pluginId.includes("/") || pluginId.includes("\\")) {
     return "invalid plugin name: path separators not allowed";
+  }
+  if (isReservedChannelId(pluginId)) {
+    return `invalid plugin name: "${pluginId}" is a reserved internal channel id`;
   }
   return null;
 }

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -957,6 +957,56 @@ describe("loadOpenClawPlugins", () => {
     ).toBe(true);
   });
 
+  it("strips reserved names from channel aliases and emits an error diagnostic (Codex P2)", () => {
+    // A plugin whose meta.aliases includes "inter_session" or "webchat" would
+    // cause normalizeMessageChannel to remap the sentinel into a real deliverable
+    // channel, bypassing resolveLastChannelRaw / resolveLastToRaw guards.
+    // Reserved aliases must be stripped at registration time.
+    useNoBundledPlugins();
+    for (const reservedAlias of ["inter_session", "webchat"]) {
+      const plugin = writePlugin({
+        id: `alias-bypass-${reservedAlias}`,
+        filename: `alias-bypass-${reservedAlias}.cjs`,
+        body: `module.exports = { id: "alias-bypass-${reservedAlias}", register(api) {
+  api.registerChannel({
+    plugin: {
+      id: "legit-channel",
+      meta: {
+        id: "legit-channel",
+        label: "Legit",
+        selectionLabel: "Legit",
+        docsPath: "/channels/legit",
+        blurb: "legit channel",
+        aliases: ["${reservedAlias}", "legit-alias"]
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({ accountId: "default" })
+      },
+      outbound: { deliveryMode: "direct" }
+    }
+  });
+} };`,
+      });
+
+      const registry = loadRegistryFromSinglePlugin({
+        plugin,
+        pluginConfig: { allow: [`alias-bypass-${reservedAlias}`] },
+      });
+
+      const channel = registry.channels.find((entry) => entry.plugin.id === "legit-channel");
+      expect(channel).toBeDefined();
+
+      const aliases = channel?.plugin.meta?.aliases ?? [];
+      expect(aliases).not.toContain(reservedAlias);
+      expect(aliases).toContain("legit-alias");
+
+      expect(
+        registry.diagnostics.some((d) => d.level === "error" && d.message.includes(reservedAlias)),
+      ).toBe(true);
+    }
+  });
   it("registers http routes with auth and match options", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -10,6 +10,7 @@ import type {
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import { resolveUserPath } from "../utils.js";
+import { isReservedChannelId } from "../utils/message-channel.js";
 import { registerPluginCommand } from "./commands.js";
 import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
@@ -418,6 +419,33 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         message: "channel registration missing id",
       });
       return;
+    }
+    if (isReservedChannelId(id)) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `channel id "${id}" is reserved for internal OpenClaw routing and cannot be registered by a plugin`,
+      });
+      return;
+    }
+    // Strip reserved names from aliases too. A plugin alias that maps to
+    // "inter_session" or "webchat" would cause normalizeMessageChannel to
+    // remap the sentinel into a real deliverable channel, bypassing the guards
+    // in resolveLastChannelRaw / resolveLastToRaw.
+    const reservedAliases = plugin.meta?.aliases?.filter((a) => isReservedChannelId(a)) ?? [];
+    if (reservedAliases.length > 0) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `channel aliases [${reservedAliases.join(", ")}] are reserved for internal OpenClaw routing and cannot be used by a plugin`,
+      });
+      // Strip reserved aliases rather than blocking the whole registration so
+      // the rest of the channel can still be used normally.
+      if (plugin.meta?.aliases) {
+        plugin.meta.aliases = plugin.meta.aliases.filter((a) => !isReservedChannelId(a));
+      }
     }
     const existing = registry.channels.find((entry) => entry.plugin.id === id);
     if (existing) {

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createMSTeamsTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { resolveGatewayMessageChannel } from "./message-channel.js";
+import {
+  INTER_SESSION_CHANNEL,
+  listReservedChannelIds,
+  normalizeMessageChannel,
+  resolveGatewayMessageChannel,
+} from "./message-channel.js";
 
 const emptyRegistry = createTestRegistry([]);
 const msteamsPlugin: ChannelPlugin = {
@@ -30,5 +35,45 @@ describe("message-channel", () => {
       createTestRegistry([{ pluginId: "msteams", plugin: msteamsPlugin, source: "test" }]),
     );
     expect(resolveGatewayMessageChannel("teams")).toBe("msteams");
+  });
+
+  it("does not remap reserved sentinel ids through mutable plugin aliases", () => {
+    const plugin: ChannelPlugin = {
+      ...createMSTeamsTestPluginBase(),
+      meta: {
+        ...createMSTeamsTestPluginBase().meta,
+        aliases: ["teams"],
+      },
+    };
+    setActivePluginRegistry(createTestRegistry([{ pluginId: "msteams", plugin, source: "test" }]));
+
+    plugin.meta.aliases?.push(INTER_SESSION_CHANNEL);
+
+    expect(normalizeMessageChannel(INTER_SESSION_CHANNEL)).toBe(INTER_SESSION_CHANNEL);
+  });
+
+  it("ignores non-string plugin aliases during channel normalization", () => {
+    const plugin: ChannelPlugin = {
+      ...createMSTeamsTestPluginBase(),
+      meta: {
+        ...createMSTeamsTestPluginBase().meta,
+        aliases: ["teams", 42 as never, null as never],
+      },
+    };
+    setActivePluginRegistry(createTestRegistry([{ pluginId: "msteams", plugin, source: "test" }]));
+
+    expect(resolveGatewayMessageChannel("teams")).toBe("msteams");
+    expect(() => normalizeMessageChannel("unknown-channel")).not.toThrow();
+    expect(normalizeMessageChannel("unknown-channel")).toBe("unknown-channel");
+  });
+
+  it("does not let callers mutate the reserved channel source of truth", () => {
+    const reserved = listReservedChannelIds();
+
+    reserved.length = 0;
+    reserved.push("discord");
+
+    expect(normalizeMessageChannel(INTER_SESSION_CHANNEL)).toBe(INTER_SESSION_CHANNEL);
+    expect(normalizeMessageChannel("webchat")).toBe("webchat");
   });
 });

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -17,6 +17,49 @@ import { getActivePluginRegistry } from "../plugins/runtime.js";
 export const INTERNAL_MESSAGE_CHANNEL = "webchat" as const;
 export type InternalMessageChannel = typeof INTERNAL_MESSAGE_CHANNEL;
 
+/**
+ * Sentinel channel used when sessions_send injects a message into a target
+ * session. Distinct from INTERNAL_MESSAGE_CHANNEL so that resolveLastChannelRaw
+ * does NOT flip the receiver's route to webchat. Instead it falls through to
+ * the persisted external channel, preserving the receiver's established route.
+ */
+export const INTER_SESSION_CHANNEL = "inter_session" as const;
+export type InterSessionChannel = typeof INTER_SESSION_CHANNEL;
+
+/**
+ * Channel IDs that are reserved for internal OpenClaw routing.
+ * No plugin may register a channel with these IDs — doing so would shadow
+ * a sentinel value and silently break cross-session message delivery.
+ * Checked in both plugin install (validatePluginId) and runtime channel
+ * registration (registerChannel) to cover all registration paths.
+ */
+const RESERVED_CHANNEL_IDS: ReadonlySet<string> = new Set([
+  INTER_SESSION_CHANNEL,
+  INTERNAL_MESSAGE_CHANNEL,
+]);
+
+export function isReservedChannelId(raw?: unknown): boolean {
+  if (typeof raw !== "string") {
+    return false;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return Boolean(normalized) && RESERVED_CHANNEL_IDS.has(normalized);
+}
+
+export function listReservedChannelIds(): string[] {
+  return Array.from(RESERVED_CHANNEL_IDS);
+}
+
+export function isInterSessionChannel(raw?: string | null): boolean {
+  // Guard against collision with real deliverable plugin channels: a plugin
+  // could theoretically register a channel named "inter_session", which must
+  // not be silently treated as our sentinel.
+  if (raw?.trim().toLowerCase() !== INTER_SESSION_CHANNEL) {
+    return false;
+  }
+  return !isDeliverableMessageChannel(INTER_SESSION_CHANNEL);
+}
+
 const MARKDOWN_CAPABLE_CHANNELS = new Set<string>([
   "slack",
   "telegram",
@@ -57,8 +100,8 @@ export function normalizeMessageChannel(raw?: string | null): string | undefined
   if (!normalized) {
     return undefined;
   }
-  if (normalized === INTERNAL_MESSAGE_CHANNEL) {
-    return INTERNAL_MESSAGE_CHANNEL;
+  if (isReservedChannelId(normalized)) {
+    return normalized;
   }
   const builtIn = normalizeChatChannelId(normalized);
   if (builtIn) {
@@ -70,7 +113,7 @@ export function normalizeMessageChannel(raw?: string | null): string | undefined
       return true;
     }
     return (entry.plugin.meta.aliases ?? []).some(
-      (alias) => alias.trim().toLowerCase() === normalized,
+      (alias) => typeof alias === "string" && alias.trim().toLowerCase() === normalized,
     );
   });
   return pluginMatch?.plugin.id ?? normalized;
@@ -89,7 +132,9 @@ const listPluginChannelAliases = (): string[] => {
   if (!registry) {
     return [];
   }
-  return registry.channels.flatMap((entry) => entry.plugin.meta.aliases ?? []);
+  return registry.channels.flatMap((entry) =>
+    (entry.plugin.meta.aliases ?? []).filter((alias): alias is string => typeof alias === "string"),
+  );
 };
 
 export const listDeliverableMessageChannels = (): ChannelId[] =>
@@ -97,8 +142,15 @@ export const listDeliverableMessageChannels = (): ChannelId[] =>
 
 export type DeliverableMessageChannel = ChannelId;
 
-export type GatewayMessageChannel = DeliverableMessageChannel | InternalMessageChannel;
+export type GatewayMessageChannel =
+  | DeliverableMessageChannel
+  | InternalMessageChannel
+  | InterSessionChannel;
 
+// NOTE: INTER_SESSION_CHANNEL is intentionally excluded from the runtime list.
+// It exists in the GatewayMessageChannel type so internal tools can use it,
+// but it must not be accepted from external RPC callers or the delivery path.
+// isGatewayMessageChannel("inter_session") → false by design.
 export const listGatewayMessageChannels = (): GatewayMessageChannel[] => [
   ...listDeliverableMessageChannels(),
   INTERNAL_MESSAGE_CHANNEL,


### PR DESCRIPTION
Rebased and conflict-resolved version of #43353 on top of:
- PR #45739 (ACP parent relay backfill) via stevenayl/openclaw `fix/acp-parent-relay-fallback-45205`
- PR #46308 (ACP subagent registry)

**Changes:** Thread `agentChannel` through `sessions_send`, `INTER_SESSION_CHANNEL` sentinel, reserved channel ids, gateway attestation for inter-session. Resolved `message-handler.ts`: add `authOk` to `shouldSkipBackendSelfPairing` call.

Original: #43353 (fixes #43318).

Made with [Cursor](https://cursor.com)