### PR TITLE
docs(agents): read daily memory slug variants in template

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -19,7 +19,7 @@ Before doing anything else:
 
 1. Read `SOUL.md` — this is who you are
 2. Read `USER.md` — this is who you're helping
-3. Read `memory/YYYY-MM-DD.md` (today + yesterday) for recent context
+3. Read `memory/YYYY-MM-DD*.md` (today + yesterday) for recent context (covers both canonical daily files and session-memory `-slug` files)
 4. **If in MAIN SESSION** (direct chat with your human): Also read `MEMORY.md`
 
 Don't ask permission. Just do it.
@@ -28,7 +28,7 @@ Don't ask permission. Just do it.
 
 You wake up fresh each session. These files are your continuity:
 
-- **Daily notes:** `memory/YYYY-MM-DD.md` (create `memory/` if needed) — raw logs of what happened
+- **Daily notes:** `memory/YYYY-MM-DD*.md` (create `memory/` if needed) — raw logs of what happened
 - **Long-term:** `MEMORY.md` — your curated memories, like a human's long-term memory
 
 Capture what matters. Decisions, context, things to remember. Skip the secrets unless asked to keep them.
@@ -47,7 +47,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 
 - **Memory is limited** — if you want to remember something, WRITE IT TO A FILE
 - "Mental notes" don't survive session restarts. Files do.
-- When someone says "remember this" → update `memory/YYYY-MM-DD.md` or relevant file
+- When someone says "remember this" → update the relevant `memory/YYYY-MM-DD*.md` file (or create `memory/YYYY-MM-DD.md`)
 - When you learn a lesson → update AGENTS.md, TOOLS.md, or the relevant skill
 - When you make a mistake → document it so future-you doesn't repeat it
 - **Text > Brain** 📝
@@ -205,7 +205,7 @@ You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it
 
 Periodically (every few days), use a heartbeat to:
 
-1. Read through recent `memory/YYYY-MM-DD.md` files
+1. Read through recent `memory/YYYY-MM-DD*.md` files
 2. Identify significant events, lessons, or insights worth keeping long-term
 3. Update `MEMORY.md` with distilled learnings
 4. Remove outdated info from MEMORY.md that's no longer relevant


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: AGENTS template tells agents to read only `memory/YYYY-MM-DD.md`, but bundled session-memory hook writes `memory/YYYY-MM-DD-slug.md` files.
- Why it matters: startup instructions can miss recent memory files (and trigger noisy missing-file reads when only slug files exist).
- What changed: updated AGENTS template references from `memory/YYYY-MM-DD.md` to `memory/YYYY-MM-DD*.md` in startup/memory-maintenance guidance.
- What did NOT change (scope boundary): no runtime logic, hook behavior, or memory tool code changed; docs/template-only fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46687
- Related #

## User-visible / Behavior Changes

Default `docs/reference/templates/AGENTS.md` now instructs reading `memory/YYYY-MM-DD*.md` (today+yesterday), so both canonical daily files and session-memory slug files are covered.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.6 (Darwin 24.6.0 arm64)
- Runtime/container: host dev shell
- Model/provider: N/A (docs-only)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Open `docs/reference/templates/AGENTS.md`.
2. Verify memory guidance points to `memory/YYYY-MM-DD*.md` for startup, daily notes guidance, and memory maintenance checklist.
3. Run formatter check: `corepack pnpm dlx prettier --check docs/reference/templates/AGENTS.md`.

### Expected

- Template guidance covers both canonical and slug daily memory files.
- Prettier check passes.

### Actual

- Updated text uses wildcard pattern consistently in affected guidance lines.
- Prettier check passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before: guidance referenced `memory/YYYY-MM-DD.md` only.  
After: `corepack pnpm dlx prettier --check docs/reference/templates/AGENTS.md` → `All matched files use Prettier code style!`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: read-through of updated template sections and wildcard coverage for startup + maintenance instructions.
- Edge cases checked: canonical file (`YYYY-MM-DD.md`) still matches wildcard and remains valid.
- What you did **not** verify: end-to-end runtime behavior of session-memory hook (out of scope for docs-only change).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `docs/reference/templates/AGENTS.md`.
- Known bad symptoms reviewers should watch for: none expected beyond wording regressions in template docs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: wildcard wording could be interpreted as requiring glob expansion in all contexts.
  - Mitigation: kept wording explicit that it is file-selection guidance and still mentions canonical file creation as fallback.
