### PR TITLE
fix(exec): fail closed for effective sandbox host

### DIFF
--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -203,14 +203,14 @@ describe("exec host env validation", () => {
     }
   });
 
-  it("defaults to sandbox when sandbox runtime is unavailable", async () => {
+  it("fails closed when implicit exec host resolves to sandbox without sandbox runtime", async () => {
     const tool = createExecTool({ security: "full", ask: "off" });
 
-    const result = await tool.execute("call1", {
-      command: "echo ok",
-    });
-    const text = normalizeText(result.content.find((c) => c.type === "text")?.text);
-    expect(text).toContain("ok");
+    await expect(
+      tool.execute("call1", {
+        command: "echo ok",
+      }),
+    ).rejects.toThrow(/sandbox runtime is unavailable/);
 
     const err = await tool
       .execute("call2", {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -305,7 +305,6 @@ export function createExecTool(
         logInfo(`exec: elevated command ${truncateMiddle(params.command, 120)}`);
       }
       const configuredHost = defaults?.host ?? "sandbox";
-      const sandboxHostConfigured = defaults?.host === "sandbox";
       const requestedHost = normalizeExecHost(params.host) ?? null;
       let host: ExecHost = requestedHost ?? configuredHost;
       if (!elevatedRequested && requestedHost && requestedHost !== configuredHost) {
@@ -334,14 +333,10 @@ export function createExecTool(
       }
 
       const sandbox = host === "sandbox" ? defaults?.sandbox : undefined;
-      if (
-        host === "sandbox" &&
-        !sandbox &&
-        (sandboxHostConfigured || requestedHost === "sandbox")
-      ) {
+      if (host === "sandbox" && !sandbox) {
         throw new Error(
           [
-            "exec host=sandbox is configured, but sandbox runtime is unavailable for this session.",
+            "exec host resolves to sandbox, but sandbox runtime is unavailable for this session.",
             'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or set tools.exec.host to "gateway"/"node".',
           ].join("\n"),
         );

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -612,6 +612,7 @@ describe("Agent-specific tool filtering", () => {
       tools: {
         deny: ["process"],
         exec: {
+          host: "gateway",
           security: "full",
           ask: "off",
         },
@@ -636,7 +637,7 @@ describe("Agent-specific tool filtering", () => {
     expect(resultDetails?.status).toBe("completed");
   });
 
-  it("keeps sandbox as the implicit exec host default without forcing gateway approvals", async () => {
+  it("fails closed when the implicit exec host resolves to sandbox without sandbox runtime", async () => {
     const tools = createOpenClawCodingTools({
       config: {},
       sessionKey: "agent:main:main",
@@ -646,11 +647,11 @@ describe("Agent-specific tool filtering", () => {
     const execTool = tools.find((tool) => tool.name === "exec");
     expect(execTool).toBeDefined();
 
-    const result = await execTool!.execute("call-implicit-sandbox-default", {
-      command: "echo done",
-    });
-    const details = result?.details as { status?: string } | undefined;
-    expect(details?.status).toBe("completed");
+    await expect(
+      execTool!.execute("call-implicit-sandbox-default", {
+        command: "echo done",
+      }),
+    ).rejects.toThrow("exec host resolves to sandbox");
 
     await expect(
       execTool!.execute("call-implicit-sandbox-gateway", {
@@ -674,7 +675,7 @@ describe("Agent-specific tool filtering", () => {
         command: "echo done",
         host: "sandbox",
       }),
-    ).rejects.toThrow("exec host=sandbox is configured");
+    ).rejects.toThrow("exec host resolves to sandbox");
   });
 
   it("should apply agent-specific exec host defaults over global defaults", async () => {
@@ -717,14 +718,14 @@ describe("Agent-specific tool filtering", () => {
         command: "echo done",
         yieldMs: 1000,
       }),
-    ).rejects.toThrow("exec host=sandbox is configured");
+    ).rejects.toThrow("exec host resolves to sandbox");
     await expect(
       helperExecTool!.execute("call-helper", {
         command: "echo done",
         host: "sandbox",
         yieldMs: 1000,
       }),
-    ).rejects.toThrow("exec host=sandbox is configured");
+    ).rejects.toThrow("exec host resolves to sandbox");
   });
 
   it("applies explicit agentId exec defaults when sessionKey is opaque", async () => {

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -466,6 +466,19 @@ description: test skill
         checkId: "tools.exec.host_sandbox_no_sandbox_defaults",
       },
       {
+        name: "defaults host implicitly resolves to sandbox in non-main mode",
+        cfg: {
+          agents: {
+            defaults: {
+              sandbox: {
+                mode: "non-main",
+              },
+            },
+          },
+        },
+        checkId: "tools.exec.host_sandbox_no_sandbox_defaults",
+      },
+      {
         name: "agent inherits implicit sandbox host while agent sandbox mode is off",
         cfg: {
           agents: {
@@ -479,6 +492,27 @@ description: test skill
                 id: "ops",
                 sandbox: {
                   mode: "off",
+                },
+              },
+            ],
+          },
+        },
+        checkId: "tools.exec.host_sandbox_no_sandbox_agents",
+      },
+      {
+        name: "agent override non-main sandbox still warns when exec resolves to sandbox",
+        cfg: {
+          agents: {
+            defaults: {
+              sandbox: {
+                mode: "all",
+              },
+            },
+            list: [
+              {
+                id: "ops",
+                sandbox: {
+                  mode: "non-main",
                 },
               },
             ],

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -435,6 +435,19 @@ description: test skill
         | "tools.exec.host_sandbox_no_sandbox_agents";
     }> = [
       {
+        name: "defaults host implicitly resolves to sandbox",
+        cfg: {
+          agents: {
+            defaults: {
+              sandbox: {
+                mode: "off",
+              },
+            },
+          },
+        },
+        checkId: "tools.exec.host_sandbox_no_sandbox_defaults",
+      },
+      {
         name: "defaults host is sandbox",
         cfg: {
           tools: {
@@ -451,6 +464,27 @@ description: test skill
           },
         },
         checkId: "tools.exec.host_sandbox_no_sandbox_defaults",
+      },
+      {
+        name: "agent inherits implicit sandbox host while agent sandbox mode is off",
+        cfg: {
+          agents: {
+            defaults: {
+              sandbox: {
+                mode: "non-main",
+              },
+            },
+            list: [
+              {
+                id: "ops",
+                sandbox: {
+                  mode: "off",
+                },
+              },
+            ],
+          },
+        },
+        checkId: "tools.exec.host_sandbox_no_sandbox_agents",
       },
       {
         name: "agent override host is sandbox",

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -849,20 +849,20 @@ function collectElevatedFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
 
 function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
-  const globalExecHost = cfg.tools?.exec?.host;
+  const globalExecHost = cfg.tools?.exec?.host ?? "sandbox";
   const defaultSandboxMode = resolveSandboxConfigForAgent(cfg).mode;
-  const defaultHostIsExplicitSandbox = globalExecHost === "sandbox";
+  const defaultHostResolvesToSandbox = globalExecHost === "sandbox";
 
-  if (defaultHostIsExplicitSandbox && defaultSandboxMode === "off") {
+  if (defaultHostResolvesToSandbox && defaultSandboxMode === "off") {
     findings.push({
       checkId: "tools.exec.host_sandbox_no_sandbox_defaults",
       severity: "warn",
       title: "Exec host is sandbox but sandbox mode is off",
       detail:
-        "tools.exec.host is explicitly set to sandbox while agents.defaults.sandbox.mode=off. " +
-        "In this mode, exec runs directly on the gateway host.",
+        "tools.exec.host resolves to sandbox while agents.defaults.sandbox.mode=off. " +
+        "Exec will fail closed unless sandbox mode is enabled or tools.exec.host is switched to gateway/node.",
       remediation:
-        'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or set tools.exec.host to "gateway" with approvals.',
+        'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or set tools.exec.host to "gateway"/"node" with the intended approvals policy.',
     });
   }
 
@@ -873,8 +873,13 @@ function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFinding[]
         entry &&
         typeof entry === "object" &&
         typeof entry.id === "string" &&
-        entry.tools?.exec?.host === "sandbox" &&
-        resolveSandboxConfigForAgent(cfg, entry.id).mode === "off",
+        resolveSandboxConfigForAgent(cfg, entry.id).mode === "off" &&
+        (entry.tools?.exec?.host ?? globalExecHost) === "sandbox" &&
+        !(
+          defaultHostResolvesToSandbox &&
+          defaultSandboxMode === "off" &&
+          entry.tools?.exec?.host == null
+        ),
     )
     .map((entry) => entry.id)
     .slice(0, 5);
@@ -885,10 +890,10 @@ function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFinding[]
       severity: "warn",
       title: "Agent exec host uses sandbox while sandbox mode is off",
       detail:
-        `agents.list.*.tools.exec.host is set to sandbox for: ${riskyAgents.join(", ")}. ` +
-        "With sandbox mode off, exec runs directly on the gateway host.",
+        `agents.list.*.tools.exec.host resolves to sandbox for: ${riskyAgents.join(", ")}. ` +
+        "With sandbox mode off, exec will fail closed unless sandbox mode is enabled or host is changed.",
       remediation:
-        'Enable sandbox mode for these agents (`agents.list[].sandbox.mode`) or set their tools.exec.host to "gateway".',
+        'Enable sandbox mode for these agents (`agents.list[].sandbox.mode`) or set their tools.exec.host to "gateway"/"node".',
     });
   }
 

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -852,15 +852,22 @@ function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFinding[]
   const globalExecHost = cfg.tools?.exec?.host ?? "sandbox";
   const defaultSandboxMode = resolveSandboxConfigForAgent(cfg).mode;
   const defaultHostResolvesToSandbox = globalExecHost === "sandbox";
+  const defaultsNeedSandboxWarning =
+    defaultHostResolvesToSandbox &&
+    (defaultSandboxMode === "off" || defaultSandboxMode === "non-main");
 
-  if (defaultHostResolvesToSandbox && defaultSandboxMode === "off") {
+  if (defaultsNeedSandboxWarning) {
+    const defaultsDetail =
+      defaultSandboxMode === "off"
+        ? "tools.exec.host resolves to sandbox while agents.defaults.sandbox.mode=off. " +
+          "Exec will fail closed unless sandbox mode is enabled or tools.exec.host is switched to gateway/node."
+        : "tools.exec.host resolves to sandbox while agents.defaults.sandbox.mode=non-main. " +
+          "Agent main sessions stay unsandboxed in non-main mode, so exec will fail closed there unless sandbox mode is switched to all or tools.exec.host is changed to gateway/node.";
     findings.push({
       checkId: "tools.exec.host_sandbox_no_sandbox_defaults",
       severity: "warn",
-      title: "Exec host is sandbox but sandbox mode is off",
-      detail:
-        "tools.exec.host resolves to sandbox while agents.defaults.sandbox.mode=off. " +
-        "Exec will fail closed unless sandbox mode is enabled or tools.exec.host is switched to gateway/node.",
+      title: "Exec host resolves to sandbox while some sessions are unsandboxed",
+      detail: defaultsDetail,
       remediation:
         'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or set tools.exec.host to "gateway"/"node" with the intended approvals policy.',
     });
@@ -873,12 +880,12 @@ function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFinding[]
         entry &&
         typeof entry === "object" &&
         typeof entry.id === "string" &&
-        resolveSandboxConfigForAgent(cfg, entry.id).mode === "off" &&
+        resolveSandboxConfigForAgent(cfg, entry.id).mode !== "all" &&
         (entry.tools?.exec?.host ?? globalExecHost) === "sandbox" &&
         !(
-          defaultHostResolvesToSandbox &&
-          defaultSandboxMode === "off" &&
-          entry.tools?.exec?.host == null
+          defaultsNeedSandboxWarning &&
+          entry.tools?.exec?.host == null &&
+          entry.sandbox?.mode == null
         ),
     )
     .map((entry) => entry.id)
@@ -888,7 +895,7 @@ function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFinding[]
     findings.push({
       checkId: "tools.exec.host_sandbox_no_sandbox_agents",
       severity: "warn",
-      title: "Agent exec host uses sandbox while sandbox mode is off",
+      title: "Agent exec host resolves to sandbox while some sessions are unsandboxed",
       detail:
         `agents.list.*.tools.exec.host resolves to sandbox for: ${riskyAgents.join(", ")}. ` +
         "With sandbox mode off, exec will fail closed unless sandbox mode is enabled or host is changed.",


### PR DESCRIPTION
## Summary
- fail closed whenever the **effective** exec host resolves to `sandbox` but no sandbox runtime is available
- stop distinguishing between explicit sandbox and implicit/default sandbox at the runtime rejection point
- align security audit findings with effective host resolution so implicit sandbox defaults are warned too
- add/update regression tests for implicit default sandbox, inherited agent sandbox defaults, and audit wording

## Problem
Today `tools.exec.host` still defaults to `"sandbox"`, but the runtime rejection only fires when sandbox was explicitly configured/requested.

That leaves a gap:
- effective host can still resolve to `sandbox`
- sandbox runtime can still be unavailable
- but exec may fall through instead of failing closed

This creates a mismatch between:
- runtime behavior
- approval / allowlist expectations
- audit wording

## Fix
### Runtime
In `src/agents/bash-tools.exec.ts`, change the guard to use the **effective resolved host**:

- before: only reject when sandbox was explicitly configured/requested
- after: reject whenever `host === "sandbox" && !sandbox`

### Audit
In `src/security/audit.ts`:
- treat global host as `cfg.tools?.exec?.host ?? "sandbox"`
- treat agent host as `entry.tools?.exec?.host ?? globalExecHost`
- update wording to reflect fail-closed behavior instead of saying exec runs directly on the gateway host
- warn on inherited implicit sandbox cases too, while avoiding duplicate inherited-agent noise when the default warning already covers the same risk

## Why this matters
Operators can otherwise believe sandbox / approvals are still the enforcement boundary even when runtime has already escaped that path.

With this patch:
- implicit sandbox defaults behave like explicit sandbox for runtime safety
- audit matches runtime intent
- sandbox-unavailable exec is fail-closed instead of silently broadening execution

## Validation
Ran:
- `pnpm exec vitest run src/agents/pi-tools-agent-config.test.ts src/agents/bash-tools.exec.path.test.ts src/security/audit.test.ts`
- `pnpm exec oxfmt --check src/agents/bash-tools.exec.ts src/agents/pi-tools-agent-config.test.ts src/agents/bash-tools.exec.path.test.ts src/security/audit.ts src/security/audit.test.ts`

## Related
- Related #41549
- Follow-up / regression context from #23398
