### PR TITLE
fix(discord): prevent internal tool/commentary payloads from leaking to visible output

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -669,4 +669,20 @@ describe("processDiscordMessage draft streaming", () => {
 
     expect(draftStream.update).not.toHaveBeenCalled();
   });
+
+  it("suppresses isReasoning partial payloads from draft stream", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPartialReply?.({
+        text: "Internal commentary that should not be visible",
+        isReasoning: true,
+      });
+      return createNoQueuedDispatchResult();
+    });
+
+    await runInPartialStreamMode();
+
+    expect(draftStream.update).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -739,7 +739,15 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           (typeof discordConfig?.blockStreaming === "boolean"
             ? !discordConfig.blockStreaming
             : undefined),
-        onPartialReply: draftStream ? (payload) => updateDraftFromPartial(payload.text) : undefined,
+        onPartialReply: draftStream
+          ? (payload) => {
+              // Skip reasoning/commentary payloads in partial stream updates.
+              if (payload.isReasoning) {
+                return;
+              }
+              updateDraftFromPartial(payload.text);
+            }
+          : undefined,
         onAssistantMessageStart: draftStream
           ? () => {
               if (shouldSplitPreviewMessages && hasStreamedMessage) {


### PR DESCRIPTION
Fixes #46696

## Problem
Internal tool/commentary payloads were leaking into visible Discord output during proactive bot handling when requireMention=false. This exposed internal processing details to users.

## Root Cause
The onPartialReply callback in the Discord message handler was only passing payload.text to updateDraftFromPartial() without checking the isReasoning flag on the payload. This allowed internal commentary/thinking payloads to be processed and displayed.

## Fix
Modified the onPartialReply callback to check payload.isReasoning before processing. When true, the callback returns early, preventing the internal content from being added to the draft stream.

## Changes
- extensions/discord/src/monitor/message-handler.process.ts: Added isReasoning check in onPartialReply callback
- extensions/discord/src/monitor/message-handler.process.test.ts: Added test case to verify isReasoning payloads are suppressed