### PR TITLE
Agents: fix sessions_send announce delivery for thread-bound targets (#46645)

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1256,4 +1256,79 @@ describe("sessions tools", () => {
     const worker = descendants.find((entry) => entry.runId === "run-worker-active");
     expect(worker?.endedAt).toBeTypeOf("number");
   });
+
+  it("sessions_send includes threadId in announce delivery for thread-bound target", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    const requesterKey = "discord:group:req";
+    const targetKey = "agent:main:discord:group:target:thread:456";
+    let sendParams: { to?: string; channel?: string; message?: string; threadId?: string } = {};
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: targetKey,
+              kind: "group",
+              channel: "discord",
+              deliveryContext: {
+                channel: "discord",
+                to: "channel:target",
+                threadId: "456",
+              },
+            },
+          ],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-1", status: "accepted" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        const params = request.params as { sessionKey?: string } | undefined;
+        let text = "initial reply";
+        if (params?.sessionKey === targetKey) {
+          // Check if this is the announce step
+          const latestAgentCall = calls.filter((c) => c.method === "agent").pop();
+          if (
+            (latestAgentCall?.params as any)?.extraSystemPrompt?.includes(
+              "Agent-to-agent announce step",
+            )
+          ) {
+            text = "announce this";
+          }
+        }
+        return {
+          messages: [{ role: "assistant", content: [{ type: "text", text }] }],
+        };
+      }
+      if (request.method === "send") {
+        sendParams = request.params as any;
+        return { messageId: "m1" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+
+    await tool!.execute("call-thread-test", {
+      sessionKey: targetKey,
+      message: "hello",
+      timeoutSeconds: 1,
+    });
+
+    await vi.waitFor(() => expect(sendParams.message).toBe("announce this"), { timeout: 2000 });
+    expect(sendParams).toMatchObject({
+      to: "channel:target",
+      channel: "discord",
+      threadId: "456",
+    });
+  });
 });

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -47,8 +47,11 @@ export async function resolveAnnounceTarget(params: {
     const accountId =
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined);
+    const threadId =
+      (typeof deliveryContext?.threadId === "string" ? deliveryContext.threadId : undefined) ??
+      (typeof match?.lastThreadId === "string" ? match.lastThreadId : undefined);
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, threadId };
     }
   } catch {
     // ignore

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -44,6 +44,7 @@ export type SessionListDeliveryContext = {
   channel?: string;
   to?: string;
   accountId?: string;
+  threadId?: string;
 };
 
 export type SessionListRow = {
@@ -66,6 +67,7 @@ export type SessionListRow = {
   lastChannel?: string;
   lastTo?: string;
   lastAccountId?: string;
+  lastThreadId?: string;
   transcriptPath?: string;
   messages?: unknown[];
 };

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -127,6 +127,7 @@ export async function runSessionsSendA2AFlow(params: {
             message: announceReply.trim(),
             channel: announceTarget.channel,
             accountId: announceTarget.accountId,
+            threadId: announceTarget.threadId,
             idempotencyKey: crypto.randomUUID(),
           },
           timeoutMs: 10_000,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -681,7 +681,8 @@ export function attachGatewayWsMessageHandler(params: {
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,
-          }) || shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
+          }) ||
+          shouldSkipControlUiPairing(controlUiAuthPolicy, role, trustedProxyAuthOk);
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {


### PR DESCRIPTION
## Summary

- Problem: sessions_send internal replies are not mirrored into the target worker's bound Discord thread.
- Why it matters: Breaks autonomous multi-worker orchestration patterns in Discord where visible replies in threads are required for coordination.
- What changed: 
    - Plumbed 	hreadId through AnnounceTarget and esolveAnnounceTarget.
    - Added 	hreadId and lastThreadId to SessionListDeliveryContext and SessionListRow.
    - Passed 	hreadId to the gateway's send method in unSessionsSendA2AFlow.
- What did NOT change (scope boundary): Basic ACP worker execution or raw Discord channel access.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46645

## User-visible / Behavior Changes

Worker replies from sessions_send will now correctly appear in the target Discord thread/topic if the session is bound to one.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Windows 10
- Integration/channel (if any): Discord (simulated in tests)

### Steps

1. Spawn a persistent ACP worker thread in a worker channel.
2. From a separate coordinator channel session, send a sessions_send instruction.
3. Observe that the worker's reply does not appear in the Discord thread.

### Expected

The reply should appear in the thread.

### Actual

The reply is only returned internally to the sender.

## Evidence

- [x] Failing test/log before + passing after (Regression test added to src/agents/openclaw-tools.sessions.test.ts)

## Human Verification (required)

- Verified scenarios: Added a regression test sessions_send includes threadId in announce delivery for thread-bound target that mocks a thread-bound session and asserts the send call includes the 	hreadId.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the changes to sessions-announce-target.ts and sessions-send-tool.a2a.ts.

## Risks and Mitigations

- Risk: Incorrect 	hreadId might cause messages to be sent to wrong threads.
- Mitigation: 	hreadId is extracted directly from the session's delivery context or display key, maintaining consistency with existing routing.