### PR TITLE
docs(plugins): add MemoLite community listing

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -46,9 +46,9 @@ Use this format when adding entries:
 ## Listed plugins
 
 - **MemoLite** — Local long-term memory plugin for OpenClaw with search, store, recall, list, and auto-capture flows backed by the MemoLite memory service.
-  npm: `@wenrennow/openclaw-memolite`
+  npm: `@wenrennow/memolite`
   repo: `https://github.com/shaun17/MemoLite`
-  install: `openclaw plugins install @wenrennow/openclaw-memolite`
+  install: `openclaw plugins install @wenrennow/memolite`
 
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **MemoLite** — Local long-term memory plugin for OpenClaw with search, store, recall, list, and auto-capture flows backed by the MemoLite memory service.
+  npm: `@wenrennow/openclaw-memolite`
+  repo: `https://github.com/shaun17/MemoLite`
+  install: `openclaw plugins install @wenrennow/openclaw-memolite`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`


### PR DESCRIPTION
## Summary
- add MemoLite to the community plugins page
- include npm package, GitHub repo, and install command

## Plugin
- npm: `@wenrennow/memolite`
- repo: `https://github.com/shaun17/MemoLite`
- install: `openclaw plugins install @wenrennow/memolite`

## Testing
- docs only
