### PR TITLE
fix(hooks): use local timezone for session-memory filenames

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -60,12 +60,76 @@ function createMockSessionContent(
     .join("\n");
 }
 
+function formatTimestampInTimezone(
+  timestamp: Date,
+  timezone: string,
+): {
+  dateStr: string;
+  timeStr: string;
+} {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(timestamp);
+
+  const readPart = (type: string) => parts.find((part) => part.type === type)?.value ?? "00";
+
+  return {
+    dateStr: `${readPart("year")}-${readPart("month")}-${readPart("day")}`,
+    timeStr: `${readPart("hour")}:${readPart("minute")}:${readPart("second")}`,
+  };
+}
+
+function pickTimezoneForUtcDateRegression(timestamp: Date): {
+  userTimezone: string;
+  dateStr: string;
+  timeStr: string;
+} {
+  const hostTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone?.trim();
+  const hostFormatted = hostTimezone
+    ? formatTimestampInTimezone(timestamp, hostTimezone)
+    : undefined;
+  const utcFormatted = formatTimestampInTimezone(timestamp, "UTC");
+
+  // Pick a negative-offset zone whose local date differs from UTC for this
+  // timestamp, and whose rendered date/time also differs from the host.
+  for (const candidate of ["America/Los_Angeles", "America/Anchorage", "Pacific/Honolulu"]) {
+    if (candidate === hostTimezone) {
+      continue;
+    }
+
+    const expected = formatTimestampInTimezone(timestamp, candidate);
+    if (expected.dateStr === utcFormatted.dateStr) {
+      continue;
+    }
+    if (
+      !hostFormatted ||
+      expected.dateStr !== hostFormatted.dateStr ||
+      expected.timeStr !== hostFormatted.timeStr
+    ) {
+      return {
+        userTimezone: candidate,
+        ...expected,
+      };
+    }
+  }
+
+  throw new Error("Unable to find a timezone that differs from both UTC and the host");
+}
+
 async function runNewWithPreviousSessionEntry(params: {
   tempDir: string;
   previousSessionEntry: { sessionId: string; sessionFile?: string };
   cfg?: OpenClawConfig;
   action?: "new" | "reset";
   sessionKey?: string;
+  timestamp?: Date;
   workspaceDirOverride?: string;
 }): Promise<{ files: string[]; memoryContent: string }> {
   const event = createHookEvent(
@@ -82,6 +146,9 @@ async function runNewWithPreviousSessionEntry(params: {
       ...(params.workspaceDirOverride ? { workspaceDir: params.workspaceDirOverride } : {}),
     },
   );
+  if (params.timestamp) {
+    event.timestamp = params.timestamp;
+  }
 
   await handler(event);
 
@@ -248,6 +315,45 @@ describe("session-memory hook", () => {
     expect(files.length).toBe(1);
     expect(memoryContent).toContain("user: Please reset and keep notes");
     expect(memoryContent).toContain("assistant: Captured before reset");
+  });
+
+  it("uses the user's local timezone for the memory filename and header", async () => {
+    const timestamp = new Date("2026-03-15T01:17:00.000Z");
+    const { userTimezone, dateStr, timeStr } = pickTimezoneForUtcDateRegression(timestamp);
+    const tempDir = await createCaseWorkspace("workspace");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const sessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "test-session.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "Keep the local date" },
+        { role: "assistant", content: "Using local timezone for memory output" },
+      ]),
+    });
+
+    const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+      tempDir,
+      cfg: {
+        agents: {
+          defaults: {
+            workspace: tempDir,
+            userTimezone,
+          },
+        },
+      } satisfies OpenClawConfig,
+      previousSessionEntry: {
+        sessionId: "test-123",
+        sessionFile,
+      },
+      timestamp,
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.startsWith(`${dateStr}-`)).toBe(true);
+    expect(files[0]?.endsWith(".md")).toBe(true);
+    expect(memoryContent).toContain(`# Session: ${dateStr} ${timeStr} (${userTimezone})`);
   });
 
   it("prefers workspaceDir from hook context when sessionKey points at main", async () => {

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -330,7 +330,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
         timeZone: timezone,
         hour: "2-digit",
         minute: "2-digit",
-        hour12: false,
+        hourCycle: "h23",
       }).formatToParts(now);
       const hh = timeParts.find((p) => p.type === "hour")?.value ?? "00";
       const mm = timeParts.find((p) => p.type === "minute")?.value ?? "00";
@@ -346,8 +346,17 @@ const saveSessionToMemory: HookHandler = async (event) => {
       path: memoryFilePath.replace(os.homedir(), "~"),
     });
 
-    // Format time as HH:MM:SS UTC
-    const timeStr = now.toISOString().split("T")[1].split(".")[0];
+    // Format time as HH:MM:SS in the user's timezone
+    const localTimeParts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(now);
+    const timeStr = ["hour", "minute", "second"]
+      .map((t) => localTimeParts.find((p) => p.type === t)?.value ?? "00")
+      .join(":");
 
     // Extract context details
     const sessionId = (sessionEntry.sessionId as string) || "unknown";
@@ -355,7 +364,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Build Markdown entry
     const entryParts = [
-      `# Session: ${dateStr} ${timeStr} UTC`,
+      `# Session: ${dateStr} ${timeStr} (${timezone})`,
       "",
       `- **Session Key**: ${displaySessionKey}`,
       `- **Session ID**: ${sessionId}`,

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -12,6 +12,7 @@ import {
   resolveAgentIdByWorkspacePath,
   resolveAgentWorkspaceDir,
 } from "../../../agents/agent-scope.js";
+import { resolveUserTimezone } from "../../../agents/date-time.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveStateDir } from "../../../config/paths.js";
 import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
@@ -27,6 +28,24 @@ import type { HookHandler } from "../../hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
+
+/** Format a timestamp as YYYY-MM-DD in the given IANA timezone. */
+function formatLocalDate(nowMs: number, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(nowMs));
+  const year = parts.find((p) => p.type === "year")?.value;
+  const month = parts.find((p) => p.type === "month")?.value;
+  const day = parts.find((p) => p.type === "day")?.value;
+  if (year && month && day) {
+    return `${year}-${month}-${day}`;
+  }
+  // Fallback to UTC if Intl parsing fails
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
 
 function resolveDisplaySessionKey(params: {
   cfg?: OpenClawConfig;
@@ -226,9 +245,10 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 
-    // Get today's date for filename
+    // Get today's date for filename, using the user's local timezone
     const now = new Date(event.timestamp);
-    const dateStr = now.toISOString().split("T")[0]; // YYYY-MM-DD
+    const timezone = resolveUserTimezone(cfg?.agents?.defaults?.userTimezone);
+    const dateStr = formatLocalDate(now.getTime(), timezone);
 
     // Generate descriptive slug from session using LLM
     // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
@@ -304,10 +324,17 @@ const saveSessionToMemory: HookHandler = async (event) => {
       }
     }
 
-    // If no slug, use timestamp
+    // If no slug, use local-time HHMM as fallback
     if (!slug) {
-      const timeSlug = now.toISOString().split("T")[1].split(".")[0].replace(/:/g, "");
-      slug = timeSlug.slice(0, 4); // HHMM
+      const timeParts = new Intl.DateTimeFormat("en-US", {
+        timeZone: timezone,
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      }).formatToParts(now);
+      const hh = timeParts.find((p) => p.type === "hour")?.value ?? "00";
+      const mm = timeParts.find((p) => p.type === "minute")?.value ?? "00";
+      slug = `${hh}${mm}`;
       log.debug("Using fallback timestamp slug", { slug });
     }
 


### PR DESCRIPTION
## Summary

- **Problem:** `session-memory` hook uses `toISOString()` for memory filenames, which always outputs UTC. Users in negative-UTC timezones get the wrong date (e.g. PDT user at 18:17 local on March 14 gets `2026-03-15-*.md`).
- **Why it matters:** Memory files are named by date for human browsing and temporal decay; wrong dates are confusing and break chronological ordering.
- **What changed:** Replaced `toISOString().split("T")[0]` with `Intl.DateTimeFormat` + `resolveUserTimezone()` for the filename date, fallback HHMM slug, and markdown header time. Uses `hourCycle: "h23"` per codebase convention.
- **What did NOT change (scope boundary):** No new dependencies, no config schema changes, no changes to other hooks or memory subsystems.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46703

## User-visible / Behavior Changes

- Memory filenames from `session-memory` hook now use local timezone date instead of UTC date.
- Markdown header inside memory files now shows local time with timezone label (e.g. `2026-03-14 18:17:00 (America/Los_Angeles)`) instead of UTC.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any (reported on Linux, America/Los_Angeles)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.userTimezone` (optional)

### Steps

1. Set system timezone to a negative-UTC zone (e.g. `TZ=America/Los_Angeles`)
2. Start a session after midnight UTC but before midnight local (e.g. 18:17 PDT = 01:17 UTC next day)
3. Run `/new` to trigger session-memory hook
4. Check generated filename in `memory/`

### Expected

- Filename uses local date: `2026-03-14-*.md`

### Actual (before fix)

- Filename uses UTC date: `2026-03-15-*.md`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All 17 existing session-memory tests pass. Root cause confirmed by code inspection: `toISOString()` is hardcoded UTC per ECMA-262 spec.

## Human Verification (required)

- Verified scenarios: `pnpm build` passes, `pnpm test src/hooks/bundled/session-memory/handler.test.ts` passes (17 tests).
- Edge cases checked: `formatLocalDate` fallback when `Intl` parsing fails; `hourCycle: "h23"` ensures midnight outputs `"00"` not `"24"`.
- What you did **not** verify: Manual end-to-end test with real `/new` command in a negative-UTC timezone.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit, or set `agents.defaults.userTimezone: "UTC"` in config to restore old behavior.
- Files/config to restore: `src/hooks/bundled/session-memory/handler.ts`
- Known bad symptoms reviewers should watch for: Memory filenames with unexpected dates or `"24"` in fallback slug.

## Risks and Mitigations

- Risk: Existing memory files use UTC dates; new files use local dates, so same-day sessions could produce files with different date prefixes if the hook ran before and after this change.
  - Mitigation: This is cosmetic only; memory files are independent documents, not aggregated by date. No migration needed.

<!-- This PR was authored with AI assistance. -->