### PR TITLE
Agents: fix reasoning_effort normalization for NVIDIA NIM (#46622)

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -321,6 +321,37 @@ function createParallelToolCallsWrapper(
   };
 }
 
+function createNvidiaThinkingWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const payloadObj = payload as Record<string, unknown>;
+          // NVIDIA NIM (vLLM) only supports low, medium, high for reasoning_effort.
+          // Map minimal to low to avoid 400 errors.
+          if (payloadObj.reasoning_effort === "minimal") {
+            payloadObj.reasoning_effort = "low";
+          }
+          if (
+            payloadObj.reasoning &&
+            typeof payloadObj.reasoning === "object" &&
+            !Array.isArray(payloadObj.reasoning)
+          ) {
+            const reasoningObj = payloadObj.reasoning as Record<string, unknown>;
+            if (reasoningObj.effort === "minimal") {
+              reasoningObj.effort = "low";
+            }
+          }
+        }
+        return originalOnPayload?.(payload, model);
+      },
+    });
+  };
+}
+
 /**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
@@ -420,6 +451,11 @@ export function applyExtraParamsToAgent(
     const kilocodeThinkingLevel =
       modelId === "kilo/auto" || isProxyReasoningUnsupported(modelId) ? undefined : thinkingLevel;
     agent.streamFn = createKilocodeWrapper(agent.streamFn, kilocodeThinkingLevel);
+  }
+
+  if (provider === "nvidia" || provider === "nvidia-nim") {
+    log.debug(`applying NVIDIA thinking wrapper for ${provider}/${modelId}`);
+    agent.streamFn = createNvidiaThinkingWrapper(agent.streamFn);
   }
 
   if (provider === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {


### PR DESCRIPTION
## Summary
Cron jobs configured with 	hinking: "minimal" and model: google/gemini-flash-latest work on Gemini but fail with a 400 error when OpenClaw falls back to NVIDIA NIM (vLLM) endpoints. This is because NVIDIA NIM only accepts low, medium, and high for easoning_effort, not minimal.

This PR adds a wrapper for 
vidia and 
vidia-nim providers to normalize easoning_effort: "minimal" to low, ensuring compatibility with these endpoints.

## Test plan
1. Configure a model using 
vidia provider (e.g. via NVIDIA NIM).
2. Run a task with 	hinking: "minimal".
3. Verify that the request no longer fails with a 400 error.
4. Manually verified payload normalization in a local test harness (simulated).