### PR TITLE
feat(telegram): expose apiRoot config for custom Bot API server

### DIFF
--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -211,11 +211,14 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
+  const apiRoot =
+    telegramCfg?.apiRoot?.trim() || process.env.TELEGRAM_API_ROOT?.trim() || undefined;
   const client: ApiClientOptions | undefined =
-    finalFetch || timeoutSeconds
+    finalFetch || timeoutSeconds || apiRoot
       ? {
           ...(finalFetch ? { fetch: finalFetch } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(apiRoot ? { apiRoot } : {}),
         }
       : undefined;
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -236,11 +236,14 @@ function resolveTelegramClientOptions(
   const fetchImpl = resolveTelegramFetch(proxyFetch, {
     network: account.config.network,
   });
+  const apiRoot =
+    account.config.apiRoot?.trim() || process.env.TELEGRAM_API_ROOT?.trim() || undefined;
   const clientOptions =
-    fetchImpl || timeoutSeconds
+    fetchImpl || timeoutSeconds || apiRoot
       ? {
           ...(fetchImpl ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(apiRoot ? { apiRoot } : {}),
         }
       : undefined;
   if (cacheKey) {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1411,6 +1411,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow Telegram to write config in response to channel events/commands (default: true).",
   "channels.telegram.botToken":
     "Telegram bot token used to authenticate Bot API requests for this account/provider config. Use secret/env substitution and rotate tokens if exposure is suspected.",
+  "channels.telegram.apiRoot":
+    "Custom base URL for all outbound Telegram Bot API calls. Defaults to https://api.telegram.org. Point this at a self-hosted Bot API server or a centralized gateway proxy.",
   "channels.telegram.capabilities.inlineButtons":
     "Enable Telegram inline button components for supported command and interaction surfaces. Disable if your deployment needs plain-text-only compatibility behavior.",
   "channels.telegram.execApprovals":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -723,6 +723,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.modelByChannel": "Channel Model Overrides",
   ...IRC_FIELD_LABELS,
   "channels.telegram.botToken": "Telegram Bot Token",
+  "channels.telegram.apiRoot": "Telegram API Root URL",
   "channels.telegram.dmPolicy": "Telegram DM Policy",
   "channels.telegram.configWrites": "Telegram Config Writes",
   "channels.telegram.commands.native": "Telegram Native Commands",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -152,6 +152,16 @@ export type TelegramAccountConfig = {
   /** Network transport overrides for Telegram. */
   network?: TelegramNetworkConfig;
   proxy?: string;
+  /**
+   * Custom base URL for all outbound Telegram Bot API calls.
+   * Defaults to `https://api.telegram.org`. Useful for:
+   * - Self-hosted Bot API servers (https://github.com/tdlib/telegram-bot-api)
+   * - Centralized gateway proxies that inject bot tokens
+   * - Testing with mock Bot API servers
+   *
+   * Env fallback: `TELEGRAM_API_ROOT`.
+   */
+  apiRoot?: string;
   webhookUrl?: string;
   webhookSecret?: string;
   webhookPath?: string;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -212,6 +212,14 @@ export const TelegramAccountSchemaBase = z
       .strict()
       .optional(),
     proxy: z.string().optional(),
+    apiRoot: z
+      .string()
+      .optional()
+      .describe(
+        "Custom base URL for all outbound Telegram Bot API calls. Defaults to https://api.telegram.org. " +
+          "Use this to route API calls through a self-hosted Bot API server or a centralized proxy. " +
+          "Env fallback: TELEGRAM_API_ROOT.",
+      ),
     webhookUrl: z
       .string()
       .optional()


### PR DESCRIPTION
## Summary

Add `channels.telegram.apiRoot` (string, optional) that passes through to grammY's `ApiClientOptions.apiRoot`. When unset, behavior is unchanged (defaults to `https://api.telegram.org`).

Also supports `TELEGRAM_API_ROOT` env var as fallback.

## Motivation

I'm building [@OpenClawBoxBot](https://web.telegram.org/k/#@OpenClawBoxBot) ([openclaw.vibebrowser.com](https://openclaw.vibebrowser.com)) — a managed OpenClaw hosting platform via Telegram. Each customer gets an isolated OpenClaw gateway instance running in Kubernetes.

The architecture uses a **centralized Telegram gateway proxy**: the bot pod receives Telegram updates via long-polling and forwards them to the tenant gateway's webhook. The gateway's Telegram channel processes everything natively (all media types, threading, reactions, streaming). For **outbound** API calls (`sendMessage`, `sendPhoto`, `getFile`), the gateway needs to route through a proxy in the bot pod that injects the real bot token.

Without `apiRoot`, the gateway always calls `api.telegram.org` directly, which means the real bot token must be in every tenant gateway — a security problem for multi-tenant deployments where customers could extract the token.

With `apiRoot`, I can point outbound calls at `http://bot-proxy:8081` and keep the real token centralized.

## Use cases

- **Self-hosted Telegram Bot API servers** ([tdlib/telegram-bot-api](https://github.com/tdlib/telegram-bot-api)) for higher upload limits (up to 2GB) and faster file access
- **Centralized gateway proxies** that inject bot tokens (multi-tenant security)
- **Testing** with mock Bot API servers

## Changes

- `src/config/types.telegram.ts`: add `apiRoot?: string` to `TelegramAccountConfig`
- `src/config/zod-schema.providers-core.ts`: add `apiRoot` to the Zod validation schema
- `extensions/telegram/src/bot.ts`: read `apiRoot` from config (with `TELEGRAM_API_ROOT` env fallback) and pass to grammY's `ApiClientOptions`
- `src/config/schema.help.ts`: add help text for the new key

grammY already supports `apiRoot` as a first-class option — this change just reads the config value and passes it through.

## Config example

```json5
{
  "channels": {
    "telegram": {
      "apiRoot": "http://my-proxy:8081",
      "botToken": "placeholder",
      // ...
    }
  }
}
```

Closes #28535
