### PR TITLE
fix(ui): Chat UI shows correct token count instead of inflated cumulative value

### DIFF
--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -1,0 +1,419 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../gateway.ts";
+import type { GatewaySessionRow } from "../types.ts";
+import { executeSlashCommand } from "./slash-command-executor.ts";
+
+function row(key: string, overrides?: Partial<GatewaySessionRow>): GatewaySessionRow {
+  return {
+    key,
+    spawnedBy: overrides?.spawnedBy,
+    kind: "direct",
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+describe("executeSlashCommand /kill", () => {
+  it("aborts every sub-agent session for /kill all", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("main"),
+            row("agent:main:subagent:one", { spawnedBy: "main" }),
+            row("agent:main:subagent:parent", { spawnedBy: "main" }),
+            row("agent:main:subagent:parent:subagent:child", {
+              spawnedBy: "agent:main:subagent:parent",
+            }),
+            row("agent:other:main"),
+          ],
+        };
+      }
+      if (method === "chat.abort") {
+        return { ok: true, aborted: true };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "kill",
+      "all",
+    );
+
+    expect(result.content).toBe("Aborted 3 sub-agent sessions.");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+    expect(request).toHaveBeenNthCalledWith(2, "chat.abort", {
+      sessionKey: "agent:main:subagent:one",
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "chat.abort", {
+      sessionKey: "agent:main:subagent:parent",
+    });
+    expect(request).toHaveBeenNthCalledWith(4, "chat.abort", {
+      sessionKey: "agent:main:subagent:parent:subagent:child",
+    });
+  });
+
+  it("aborts matching sub-agent sessions for /kill <agentId>", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("agent:main:subagent:one", { spawnedBy: "agent:main:main" }),
+            row("agent:main:subagent:two", { spawnedBy: "agent:main:main" }),
+            row("agent:other:subagent:three", { spawnedBy: "agent:other:main" }),
+          ],
+        };
+      }
+      if (method === "chat.abort") {
+        return { ok: true, aborted: true };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "kill",
+      "main",
+    );
+
+    expect(result.content).toBe("Aborted 2 matching sub-agent sessions for `main`.");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+    expect(request).toHaveBeenNthCalledWith(2, "chat.abort", {
+      sessionKey: "agent:main:subagent:one",
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "chat.abort", {
+      sessionKey: "agent:main:subagent:two",
+    });
+  });
+
+  it("does not exact-match a session key outside the current subagent subtree", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("agent:main:subagent:parent", { spawnedBy: "agent:main:main" }),
+            row("agent:main:subagent:parent:subagent:child", {
+              spawnedBy: "agent:main:subagent:parent",
+            }),
+            row("agent:main:subagent:sibling", { spawnedBy: "agent:main:main" }),
+          ],
+        };
+      }
+      if (method === "chat.abort") {
+        return { ok: true, aborted: true };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:subagent:parent",
+      "kill",
+      "agent:main:subagent:sibling",
+    );
+
+    expect(result.content).toBe(
+      "No matching sub-agent sessions found for `agent:main:subagent:sibling`.",
+    );
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+  });
+
+  it("returns a no-op summary when matching sessions have no active runs", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("agent:main:subagent:one", { spawnedBy: "agent:main:main" }),
+            row("agent:main:subagent:two", { spawnedBy: "agent:main:main" }),
+          ],
+        };
+      }
+      if (method === "chat.abort") {
+        return { ok: true, aborted: false };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "kill",
+      "all",
+    );
+
+    expect(result.content).toBe("No active sub-agent runs to abort.");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+    expect(request).toHaveBeenNthCalledWith(2, "chat.abort", {
+      sessionKey: "agent:main:subagent:one",
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "chat.abort", {
+      sessionKey: "agent:main:subagent:two",
+    });
+  });
+
+  it("treats the legacy main session key as the default agent scope", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("main"),
+            row("agent:main:subagent:one", { spawnedBy: "agent:main:main" }),
+            row("agent:main:subagent:two", { spawnedBy: "agent:main:main" }),
+            row("agent:other:subagent:three", { spawnedBy: "agent:other:main" }),
+          ],
+        };
+      }
+      if (method === "chat.abort") {
+        return { ok: true, aborted: true };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "kill",
+      "all",
+    );
+
+    expect(result.content).toBe("Aborted 2 sub-agent sessions.");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+    expect(request).toHaveBeenNthCalledWith(2, "chat.abort", {
+      sessionKey: "agent:main:subagent:one",
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "chat.abort", {
+      sessionKey: "agent:main:subagent:two",
+    });
+  });
+
+  it("does not abort unrelated same-agent subagents from another root session", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("agent:main:main"),
+            row("agent:main:subagent:mine", { spawnedBy: "agent:main:main" }),
+            row("agent:main:subagent:mine:subagent:child", {
+              spawnedBy: "agent:main:subagent:mine",
+            }),
+            row("agent:main:subagent:other-root", {
+              spawnedBy: "agent:main:discord:dm:alice",
+            }),
+          ],
+        };
+      }
+      if (method === "chat.abort") {
+        return { ok: true, aborted: true };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "kill",
+      "all",
+    );
+
+    expect(result.content).toBe("Aborted 2 sub-agent sessions.");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+    expect(request).toHaveBeenNthCalledWith(2, "chat.abort", {
+      sessionKey: "agent:main:subagent:mine",
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "chat.abort", {
+      sessionKey: "agent:main:subagent:mine:subagent:child",
+    });
+  });
+});
+
+describe("executeSlashCommand directives", () => {
+  it("resolves the legacy main alias for bare /model", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          defaults: { model: "default-model" },
+          sessions: [
+            row("agent:main:main", {
+              model: "gpt-4.1-mini",
+            }),
+          ],
+        };
+      }
+      if (method === "models.list") {
+        return {
+          models: [{ id: "gpt-4.1-mini" }, { id: "gpt-4.1" }],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "",
+    );
+
+    expect(result.content).toBe(
+      "**Current model:** `gpt-4.1-mini`\n**Available:** `gpt-4.1-mini`, `gpt-4.1`",
+    );
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+    expect(request).toHaveBeenNthCalledWith(2, "models.list", {});
+  });
+
+  it("resolves the legacy main alias for /usage", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("agent:main:main", {
+              model: "gpt-4.1-mini",
+              inputTokens: 1200,
+              outputTokens: 300,
+              totalTokens: 1500,
+              contextTokens: 4000,
+            }),
+          ],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "usage",
+      "",
+    );
+
+    expect(result.content).toBe(
+      "**Session Usage**\nInput: **1.2k** tokens\nOutput: **300** tokens\nTotal: **1.5k** tokens\nContext: **38%** of 4k\nModel: `gpt-4.1-mini`",
+    );
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+  });
+
+  it("reports the current thinking level for bare /think", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            row("agent:main:main", {
+              modelProvider: "openai",
+              model: "gpt-4.1-mini",
+            }),
+          ],
+        };
+      }
+      if (method === "models.list") {
+        return {
+          models: [{ id: "gpt-4.1-mini", provider: "openai", reasoning: true }],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "think",
+      "",
+    );
+
+    expect(result.content).toBe(
+      "Current thinking level: low.\nOptions: off, minimal, low, medium, high, adaptive.",
+    );
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+    expect(request).toHaveBeenNthCalledWith(2, "models.list", {});
+  });
+
+  it("accepts minimal and xhigh thinking levels", async () => {
+    const request = vi.fn().mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({ ok: true });
+
+    const minimal = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "think",
+      "minimal",
+    );
+    const xhigh = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "think",
+      "xhigh",
+    );
+
+    expect(minimal.content).toBe("Thinking level set to **minimal**.");
+    expect(xhigh.content).toBe("Thinking level set to **xhigh**.");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.patch", {
+      key: "agent:main:main",
+      thinkingLevel: "minimal",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.patch", {
+      key: "agent:main:main",
+      thinkingLevel: "xhigh",
+    });
+  });
+
+  it("reports the current verbose level for bare /verbose", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [row("agent:main:main", { verboseLevel: "full" })],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "verbose",
+      "",
+    );
+
+    expect(result.content).toBe("Current verbose level: full.\nOptions: on, full, off.");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+  });
+
+  it("reports the current fast mode for bare /fast", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [row("agent:main:main", { fastMode: true })],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "fast",
+      "",
+    );
+
+    expect(result.content).toBe("Current fast mode: on.\nOptions: status, on, off.");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
+  });
+
+  it("patches fast mode for /fast on", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "fast",
+      "on",
+    );
+
+    expect(result.content).toBe("Fast mode enabled.");
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "agent:main:main",
+      fastMode: true,
+    });
+  });
+});

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -1,0 +1,573 @@
+/**
+ * Client-side execution engine for slash commands.
+ * Calls gateway RPC methods and returns formatted results.
+ */
+
+import type { ModelCatalogEntry } from "../../../../src/agents/model-catalog.js";
+import {
+  formatThinkingLevels,
+  normalizeThinkLevel,
+  normalizeVerboseLevel,
+  resolveThinkingDefaultForModel,
+} from "../../../../src/auto-reply/thinking.js";
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_MAIN_KEY,
+  isSubagentSessionKey,
+  parseAgentSessionKey,
+} from "../../../../src/routing/session-key.js";
+import type { GatewayBrowserClient } from "../gateway.ts";
+import type { AgentsListResult, GatewaySessionRow, SessionsListResult } from "../types.ts";
+import { SLASH_COMMANDS } from "./slash-commands.ts";
+
+export type SlashCommandResult = {
+  /** Markdown-formatted result to display in chat. */
+  content: string;
+  /** Side-effect action the caller should perform after displaying the result. */
+  action?:
+    | "refresh"
+    | "export"
+    | "new-session"
+    | "reset"
+    | "stop"
+    | "clear"
+    | "toggle-focus"
+    | "navigate-usage";
+  /** Optional session-level directive changes that the caller should mirror locally. */
+  sessionPatch?: {
+    model?: string | null;
+  };
+};
+
+export async function executeSlashCommand(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  commandName: string,
+  args: string,
+): Promise<SlashCommandResult> {
+  switch (commandName) {
+    case "help":
+      return executeHelp();
+    case "new":
+      return { content: "Starting new session...", action: "new-session" };
+    case "reset":
+      return { content: "Resetting session...", action: "reset" };
+    case "stop":
+      return { content: "Stopping current run...", action: "stop" };
+    case "clear":
+      return { content: "Chat history cleared.", action: "clear" };
+    case "focus":
+      return { content: "Toggled focus mode.", action: "toggle-focus" };
+    case "compact":
+      return await executeCompact(client, sessionKey);
+    case "model":
+      return await executeModel(client, sessionKey, args);
+    case "think":
+      return await executeThink(client, sessionKey, args);
+    case "fast":
+      return await executeFast(client, sessionKey, args);
+    case "verbose":
+      return await executeVerbose(client, sessionKey, args);
+    case "export":
+      return { content: "Exporting session...", action: "export" };
+    case "usage":
+      return await executeUsage(client, sessionKey);
+    case "agents":
+      return await executeAgents(client);
+    case "kill":
+      return await executeKill(client, sessionKey, args);
+    default:
+      return { content: `Unknown command: \`/${commandName}\`` };
+  }
+}
+
+// ── Command Implementations ──
+
+function executeHelp(): SlashCommandResult {
+  const lines = ["**Available Commands**\n"];
+  let currentCategory = "";
+
+  for (const cmd of SLASH_COMMANDS) {
+    const cat = cmd.category ?? "session";
+    if (cat !== currentCategory) {
+      currentCategory = cat;
+      lines.push(`**${cat.charAt(0).toUpperCase() + cat.slice(1)}**`);
+    }
+    const argStr = cmd.args ? ` ${cmd.args}` : "";
+    const local = cmd.executeLocal ? "" : " *(agent)*";
+    lines.push(`\`/${cmd.name}${argStr}\` — ${cmd.description}${local}`);
+  }
+
+  lines.push("\nType `/` to open the command menu.");
+  return { content: lines.join("\n") };
+}
+
+async function executeCompact(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+): Promise<SlashCommandResult> {
+  try {
+    await client.request("sessions.compact", { key: sessionKey });
+    return { content: "Context compacted successfully.", action: "refresh" };
+  } catch (err) {
+    return { content: `Compaction failed: ${String(err)}` };
+  }
+}
+
+async function executeModel(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  args: string,
+): Promise<SlashCommandResult> {
+  if (!args) {
+    try {
+      const [sessions, models] = await Promise.all([
+        client.request<SessionsListResult>("sessions.list", {}),
+        client.request<{ models: ModelCatalogEntry[] }>("models.list", {}),
+      ]);
+      const session = resolveCurrentSession(sessions, sessionKey);
+      const model = session?.model || sessions?.defaults?.model || "default";
+      const available = models?.models?.map((m: ModelCatalogEntry) => m.id) ?? [];
+      const lines = [`**Current model:** \`${model}\``];
+      if (available.length > 0) {
+        lines.push(
+          `**Available:** ${available
+            .slice(0, 10)
+            .map((m: string) => `\`${m}\``)
+            .join(", ")}${available.length > 10 ? ` +${available.length - 10} more` : ""}`,
+        );
+      }
+      return { content: lines.join("\n") };
+    } catch (err) {
+      return { content: `Failed to get model info: ${String(err)}` };
+    }
+  }
+
+  try {
+    await client.request("sessions.patch", { key: sessionKey, model: args.trim() });
+    return {
+      content: `Model set to \`${args.trim()}\`.`,
+      action: "refresh",
+      sessionPatch: { model: args.trim() },
+    };
+  } catch (err) {
+    return { content: `Failed to set model: ${String(err)}` };
+  }
+}
+
+async function executeThink(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  args: string,
+): Promise<SlashCommandResult> {
+  const rawLevel = args.trim();
+
+  if (!rawLevel) {
+    try {
+      const { session, models } = await loadThinkingCommandState(client, sessionKey);
+      return {
+        content: formatDirectiveOptions(
+          `Current thinking level: ${resolveCurrentThinkingLevel(session, models)}.`,
+          formatThinkingLevels(session?.modelProvider, session?.model),
+        ),
+      };
+    } catch (err) {
+      return { content: `Failed to get thinking level: ${String(err)}` };
+    }
+  }
+
+  const level = normalizeThinkLevel(rawLevel);
+  if (!level) {
+    try {
+      const session = await loadCurrentSession(client, sessionKey);
+      return {
+        content: `Unrecognized thinking level "${rawLevel}". Valid levels: ${formatThinkingLevels(session?.modelProvider, session?.model)}.`,
+      };
+    } catch (err) {
+      return { content: `Failed to validate thinking level: ${String(err)}` };
+    }
+  }
+
+  try {
+    await client.request("sessions.patch", { key: sessionKey, thinkingLevel: level });
+    return {
+      content: `Thinking level set to **${level}**.`,
+      action: "refresh",
+    };
+  } catch (err) {
+    return { content: `Failed to set thinking level: ${String(err)}` };
+  }
+}
+
+async function executeVerbose(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  args: string,
+): Promise<SlashCommandResult> {
+  const rawLevel = args.trim();
+
+  if (!rawLevel) {
+    try {
+      const session = await loadCurrentSession(client, sessionKey);
+      return {
+        content: formatDirectiveOptions(
+          `Current verbose level: ${normalizeVerboseLevel(session?.verboseLevel) ?? "off"}.`,
+          "on, full, off",
+        ),
+      };
+    } catch (err) {
+      return { content: `Failed to get verbose level: ${String(err)}` };
+    }
+  }
+
+  const level = normalizeVerboseLevel(rawLevel);
+  if (!level) {
+    return {
+      content: `Unrecognized verbose level "${rawLevel}". Valid levels: off, on, full.`,
+    };
+  }
+
+  try {
+    await client.request("sessions.patch", { key: sessionKey, verboseLevel: level });
+    return {
+      content: `Verbose mode set to **${level}**.`,
+      action: "refresh",
+    };
+  } catch (err) {
+    return { content: `Failed to set verbose mode: ${String(err)}` };
+  }
+}
+
+async function executeFast(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  args: string,
+): Promise<SlashCommandResult> {
+  const rawMode = args.trim().toLowerCase();
+
+  if (!rawMode || rawMode === "status") {
+    try {
+      const session = await loadCurrentSession(client, sessionKey);
+      return {
+        content: formatDirectiveOptions(
+          `Current fast mode: ${resolveCurrentFastMode(session)}.`,
+          "status, on, off",
+        ),
+      };
+    } catch (err) {
+      return { content: `Failed to get fast mode: ${String(err)}` };
+    }
+  }
+
+  if (rawMode !== "on" && rawMode !== "off") {
+    return {
+      content: `Unrecognized fast mode "${args.trim()}". Valid levels: status, on, off.`,
+    };
+  }
+
+  try {
+    await client.request("sessions.patch", { key: sessionKey, fastMode: rawMode === "on" });
+    return {
+      content: `Fast mode ${rawMode === "on" ? "enabled" : "disabled"}.`,
+      action: "refresh",
+    };
+  } catch (err) {
+    return { content: `Failed to set fast mode: ${String(err)}` };
+  }
+}
+
+async function executeUsage(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+): Promise<SlashCommandResult> {
+  try {
+    const sessions = await client.request<SessionsListResult>("sessions.list", {});
+    const session = resolveCurrentSession(sessions, sessionKey);
+    if (!session) {
+      return { content: "No active session." };
+    }
+    const input = session.inputTokens ?? 0;
+    const output = session.outputTokens ?? 0;
+    const total = session.totalTokens ?? input + output;
+    const ctx = session.contextTokens ?? 0;
+    const pct = ctx > 0 ? Math.round((total / ctx) * 100) : null;
+
+    const lines = [
+      "**Session Usage**",
+      `Input: **${fmtTokens(input)}** tokens`,
+      `Output: **${fmtTokens(output)}** tokens`,
+      `Total: **${fmtTokens(total)}** tokens`,
+    ];
+    if (pct !== null) {
+      lines.push(`Context: **${pct}%** of ${fmtTokens(ctx)}`);
+    }
+    if (session.model) {
+      lines.push(`Model: \`${session.model}\``);
+    }
+    return { content: lines.join("\n") };
+  } catch (err) {
+    return { content: `Failed to get usage: ${String(err)}` };
+  }
+}
+
+async function executeAgents(client: GatewayBrowserClient): Promise<SlashCommandResult> {
+  try {
+    const result = await client.request<AgentsListResult>("agents.list", {});
+    const agents = result?.agents ?? [];
+    if (agents.length === 0) {
+      return { content: "No agents configured." };
+    }
+    const lines = [`**Agents** (${agents.length})\n`];
+    for (const agent of agents) {
+      const isDefault = agent.id === result?.defaultId;
+      const name = agent.identity?.name || agent.name || agent.id;
+      const marker = isDefault ? " *(default)*" : "";
+      lines.push(`- \`${agent.id}\` — ${name}${marker}`);
+    }
+    return { content: lines.join("\n") };
+  } catch (err) {
+    return { content: `Failed to list agents: ${String(err)}` };
+  }
+}
+
+async function executeKill(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  args: string,
+): Promise<SlashCommandResult> {
+  const target = args.trim();
+  if (!target) {
+    return { content: "Usage: `/kill <id|all>`" };
+  }
+  try {
+    const sessions = await client.request<SessionsListResult>("sessions.list", {});
+    const matched = resolveKillTargets(sessions?.sessions ?? [], sessionKey, target);
+    if (matched.length === 0) {
+      return {
+        content:
+          target.toLowerCase() === "all"
+            ? "No active sub-agent sessions found."
+            : `No matching sub-agent sessions found for \`${target}\`.`,
+      };
+    }
+
+    const results = await Promise.allSettled(
+      matched.map((key) =>
+        client.request<{ aborted?: boolean }>("chat.abort", { sessionKey: key }),
+      ),
+    );
+    const rejected = results.filter((entry) => entry.status === "rejected");
+    const successCount = results.filter(
+      (entry) =>
+        entry.status === "fulfilled" && (entry.value as { aborted?: boolean })?.aborted !== false,
+    ).length;
+    if (successCount === 0) {
+      if (rejected.length === 0) {
+        return {
+          content:
+            target.toLowerCase() === "all"
+              ? "No active sub-agent runs to abort."
+              : `No active runs matched \`${target}\`.`,
+        };
+      }
+      throw rejected[0]?.reason ?? new Error("abort failed");
+    }
+
+    if (target.toLowerCase() === "all") {
+      return {
+        content:
+          successCount === matched.length
+            ? `Aborted ${successCount} sub-agent session${successCount === 1 ? "" : "s"}.`
+            : `Aborted ${successCount} of ${matched.length} sub-agent sessions.`,
+      };
+    }
+
+    return {
+      content:
+        successCount === matched.length
+          ? `Aborted ${successCount} matching sub-agent session${successCount === 1 ? "" : "s"} for \`${target}\`.`
+          : `Aborted ${successCount} of ${matched.length} matching sub-agent sessions for \`${target}\`.`,
+    };
+  } catch (err) {
+    return { content: `Failed to abort: ${String(err)}` };
+  }
+}
+
+function resolveKillTargets(
+  sessions: GatewaySessionRow[],
+  currentSessionKey: string,
+  target: string,
+): string[] {
+  const normalizedTarget = target.trim().toLowerCase();
+  if (!normalizedTarget) {
+    return [];
+  }
+
+  const keys = new Set<string>();
+  const normalizedCurrentSessionKey = currentSessionKey.trim().toLowerCase();
+  const currentParsed = parseAgentSessionKey(normalizedCurrentSessionKey);
+  const currentAgentId =
+    currentParsed?.agentId ??
+    (normalizedCurrentSessionKey === DEFAULT_MAIN_KEY ? DEFAULT_AGENT_ID : undefined);
+  const sessionIndex = buildSessionIndex(sessions);
+  for (const session of sessions) {
+    const key = session?.key?.trim();
+    if (!key || !isSubagentSessionKey(key)) {
+      continue;
+    }
+    const normalizedKey = key.toLowerCase();
+    const parsed = parseAgentSessionKey(normalizedKey);
+    const belongsToCurrentSession = isWithinCurrentSessionSubtree(
+      normalizedKey,
+      normalizedCurrentSessionKey,
+      sessionIndex,
+      currentAgentId,
+      parsed?.agentId,
+    );
+    const isMatch =
+      (normalizedTarget === "all" && belongsToCurrentSession) ||
+      (belongsToCurrentSession && normalizedKey === normalizedTarget) ||
+      (belongsToCurrentSession &&
+        ((parsed?.agentId ?? "") === normalizedTarget ||
+          normalizedKey.endsWith(`:subagent:${normalizedTarget}`) ||
+          normalizedKey === `subagent:${normalizedTarget}`));
+    if (isMatch) {
+      keys.add(key);
+    }
+  }
+  return [...keys];
+}
+
+function isWithinCurrentSessionSubtree(
+  candidateSessionKey: string,
+  currentSessionKey: string,
+  sessionIndex: Map<string, GatewaySessionRow>,
+  currentAgentId: string | undefined,
+  candidateAgentId: string | undefined,
+): boolean {
+  if (!currentAgentId || candidateAgentId !== currentAgentId) {
+    return false;
+  }
+
+  const currentAliases = resolveEquivalentSessionKeys(currentSessionKey, currentAgentId);
+  const seen = new Set<string>();
+  let parentSessionKey = normalizeSessionKey(sessionIndex.get(candidateSessionKey)?.spawnedBy);
+  while (parentSessionKey && !seen.has(parentSessionKey)) {
+    if (currentAliases.has(parentSessionKey)) {
+      return true;
+    }
+    seen.add(parentSessionKey);
+    parentSessionKey = normalizeSessionKey(sessionIndex.get(parentSessionKey)?.spawnedBy);
+  }
+
+  // Older gateways may not include spawnedBy on session rows yet; keep prefix
+  // matching for nested subagent sessions as a compatibility fallback.
+  return isSubagentSessionKey(currentSessionKey)
+    ? candidateSessionKey.startsWith(`${currentSessionKey}:subagent:`)
+    : false;
+}
+
+function buildSessionIndex(sessions: GatewaySessionRow[]): Map<string, GatewaySessionRow> {
+  const index = new Map<string, GatewaySessionRow>();
+  for (const session of sessions) {
+    const normalizedKey = normalizeSessionKey(session?.key);
+    if (!normalizedKey) {
+      continue;
+    }
+    index.set(normalizedKey, session);
+  }
+  return index;
+}
+
+function normalizeSessionKey(key?: string | null): string | undefined {
+  const normalized = key?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function resolveEquivalentSessionKeys(
+  currentSessionKey: string,
+  currentAgentId: string | undefined,
+): Set<string> {
+  const keys = new Set<string>([currentSessionKey]);
+  if (currentAgentId === DEFAULT_AGENT_ID) {
+    const canonicalDefaultMain = `agent:${DEFAULT_AGENT_ID}:main`;
+    if (currentSessionKey === DEFAULT_MAIN_KEY) {
+      keys.add(canonicalDefaultMain);
+    } else if (currentSessionKey === canonicalDefaultMain) {
+      keys.add(DEFAULT_MAIN_KEY);
+    }
+  }
+  return keys;
+}
+
+function formatDirectiveOptions(text: string, options: string): string {
+  return `${text}\nOptions: ${options}.`;
+}
+
+async function loadCurrentSession(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+): Promise<GatewaySessionRow | undefined> {
+  const sessions = await client.request<SessionsListResult>("sessions.list", {});
+  return resolveCurrentSession(sessions, sessionKey);
+}
+
+function resolveCurrentSession(
+  sessions: SessionsListResult | undefined,
+  sessionKey: string,
+): GatewaySessionRow | undefined {
+  const normalizedSessionKey = normalizeSessionKey(sessionKey);
+  const currentAgentId =
+    parseAgentSessionKey(normalizedSessionKey ?? "")?.agentId ??
+    (normalizedSessionKey === DEFAULT_MAIN_KEY ? DEFAULT_AGENT_ID : undefined);
+  const aliases = normalizedSessionKey
+    ? resolveEquivalentSessionKeys(normalizedSessionKey, currentAgentId)
+    : new Set<string>();
+  return sessions?.sessions?.find((session: GatewaySessionRow) => {
+    const key = normalizeSessionKey(session.key);
+    return key ? aliases.has(key) : false;
+  });
+}
+
+async function loadThinkingCommandState(client: GatewayBrowserClient, sessionKey: string) {
+  const [sessions, models] = await Promise.all([
+    client.request<SessionsListResult>("sessions.list", {}),
+    client.request<{ models: ModelCatalogEntry[] }>("models.list", {}),
+  ]);
+  return {
+    session: resolveCurrentSession(sessions, sessionKey),
+    models: models?.models ?? [],
+  };
+}
+
+function resolveCurrentThinkingLevel(
+  session: GatewaySessionRow | undefined,
+  models: ModelCatalogEntry[],
+): string {
+  const persisted = normalizeThinkLevel(session?.thinkingLevel);
+  if (persisted) {
+    return persisted;
+  }
+  if (!session?.modelProvider || !session.model) {
+    return "off";
+  }
+  return resolveThinkingDefaultForModel({
+    provider: session.modelProvider,
+    model: session.model,
+    catalog: models,
+  });
+}
+
+function resolveCurrentFastMode(session: GatewaySessionRow | undefined): "on" | "off" {
+  return session?.fastMode === true ? "on" : "off";
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  }
+  if (n >= 1_000) {
+    return `${(n / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
+  }
+  return String(n);
+}

--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -1,0 +1,143 @@
+import { render } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import "../../styles.css";
+import { renderChat, type ChatProps } from "./chat.ts";
+
+function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
+  return {
+    sessionKey: "main",
+    onSessionKeyChange: () => undefined,
+    thinkingLevel: null,
+    showThinking: false,
+    loading: false,
+    sending: false,
+    canAbort: false,
+    compactionStatus: null,
+    fallbackStatus: null,
+    messages: [],
+    toolMessages: [],
+    streamSegments: [],
+    stream: null,
+    streamStartedAt: null,
+    assistantAvatarUrl: null,
+    draft: "",
+    queue: [],
+    connected: true,
+    canSend: true,
+    disabledReason: null,
+    error: null,
+    sessions: {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: null,
+          inputTokens: 3_800,
+          totalTokens: 3_800,
+          contextTokens: 4_000,
+        },
+      ],
+    },
+    focusMode: false,
+    assistantName: "OpenClaw",
+    assistantAvatar: null,
+    onRefresh: () => undefined,
+    onToggleFocusMode: () => undefined,
+    onDraftChange: () => undefined,
+    onSend: () => undefined,
+    onQueueRemove: () => undefined,
+    onNewSession: () => undefined,
+    agentsList: null,
+    currentAgentId: "",
+    onAgentChange: () => undefined,
+    ...overrides,
+  };
+}
+
+describe("chat context notice", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("keeps the warning icon badge-sized", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(renderChat(createProps()), container);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const icon = container.querySelector<SVGElement>(".context-notice__icon");
+    expect(icon).not.toBeNull();
+    if (!icon) {
+      return;
+    }
+
+    const iconStyle = getComputedStyle(icon);
+    expect(iconStyle.width).toBe("16px");
+    expect(iconStyle.height).toBe("16px");
+    expect(icon.getBoundingClientRect().width).toBeLessThan(24);
+  });
+
+  it("uses totalTokens not inputTokens for context usage (#46632)", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    // inputTokens is cumulative (inflated), totalTokens reflects actual context
+    const props = createProps({
+      sessions: {
+        ts: 0,
+        path: "",
+        count: 1,
+        defaults: { model: "gpt-5", contextTokens: null },
+        sessions: [
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: null,
+            inputTokens: 647_600, // cumulative across all API calls
+            totalTokens: 173_000, // actual current context window
+            contextTokens: 200_000,
+          },
+        ],
+      },
+    });
+    render(renderChat(props), container);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const detail = container.querySelector(".context-notice__detail");
+    expect(detail).not.toBeNull();
+    // Should show 173k (totalTokens), not 647.6k (inputTokens)
+    expect(detail!.textContent).toContain("173k");
+    expect(detail!.textContent).not.toContain("647");
+  });
+
+  it("hides context notice when totalTokens is below 85% threshold", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const props = createProps({
+      sessions: {
+        ts: 0,
+        path: "",
+        count: 1,
+        defaults: { model: "gpt-5", contextTokens: null },
+        sessions: [
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: null,
+            inputTokens: 300_000, // cumulative is high
+            totalTokens: 100_000, // actual context is only 50%
+            contextTokens: 200_000,
+          },
+        ],
+      },
+    });
+    render(renderChat(props), container);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const notice = container.querySelector(".context-notice");
+    expect(notice).toBeNull();
+  });
+});

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1,17 +1,37 @@
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
+import {
+  CHAT_ATTACHMENT_ACCEPT,
+  isSupportedChatAttachmentMimeType,
+} from "../chat/attachment-support.ts";
+import { DeletedMessages } from "../chat/deleted-messages.ts";
+import { exportChatMarkdown } from "../chat/export.ts";
 import {
   renderMessageGroup,
   renderReadingIndicatorGroup,
   renderStreamingGroup,
 } from "../chat/grouped-render.ts";
+import { InputHistory } from "../chat/input-history.ts";
 import { normalizeMessage, normalizeRoleForGrouping } from "../chat/message-normalizer.ts";
+import { PinnedMessages } from "../chat/pinned-messages.ts";
+import { getPinnedMessageSummary } from "../chat/pinned-summary.ts";
+import { messageMatchesSearchQuery } from "../chat/search-match.ts";
+import { getOrCreateSessionCacheValue } from "../chat/session-cache.ts";
+import {
+  CATEGORY_LABELS,
+  SLASH_COMMANDS,
+  getSlashCommandCompletions,
+  type SlashCommandCategory,
+  type SlashCommandDef,
+} from "../chat/slash-commands.ts";
+import { isSttSupported, startStt, stopStt } from "../chat/speech.ts";
 import { icons } from "../icons.ts";
 import { detectTextDirection } from "../text-direction.ts";
-import type { SessionsListResult } from "../types.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../types.ts";
 import type { ChatItem, MessageGroup } from "../types/chat-types.ts";
 import type { ChatAttachment, ChatQueueItem } from "../ui-types.ts";
+import { agentLogoUrl, resolveAgentAvatarUrl } from "./agents-utils.ts";
 import { renderMarkdownSidebar } from "./markdown-sidebar.ts";
 import "../components/resizable-divider.ts";
 
@@ -19,6 +39,16 @@ export type CompactionIndicatorStatus = {
   active: boolean;
   startedAt: number | null;
   completedAt: number | null;
+};
+
+export type FallbackIndicatorStatus = {
+  phase?: "active" | "cleared";
+  selected: string;
+  active: string;
+  previous?: string;
+  reason?: string;
+  attempts: string[];
+  occurredAt: number;
 };
 
 export type ChatProps = {
@@ -30,8 +60,10 @@ export type ChatProps = {
   sending: boolean;
   canAbort?: boolean;
   compactionStatus?: CompactionIndicatorStatus | null;
+  fallbackStatus?: FallbackIndicatorStatus | null;
   messages: unknown[];
   toolMessages: unknown[];
+  streamSegments: Array<{ text: string; ts: number }>;
   stream: string | null;
   streamStartedAt: number | null;
   assistantAvatarUrl?: string | null;
@@ -42,48 +74,124 @@ export type ChatProps = {
   disabledReason: string | null;
   error: string | null;
   sessions: SessionsListResult | null;
-  // Focus mode
   focusMode: boolean;
-  // Sidebar state
   sidebarOpen?: boolean;
   sidebarContent?: string | null;
   sidebarError?: string | null;
   splitRatio?: number;
   assistantName: string;
   assistantAvatar: string | null;
-  // Image attachments
   attachments?: ChatAttachment[];
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
-  // Scroll control
   showNewMessages?: boolean;
   onScrollToBottom?: () => void;
-  // Event handlers
   onRefresh: () => void;
   onToggleFocusMode: () => void;
+  getDraft?: () => string;
   onDraftChange: (next: string) => void;
+  onRequestUpdate?: () => void;
   onSend: () => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
   onNewSession: () => void;
+  onClearHistory?: () => void;
+  agentsList: {
+    agents: Array<{ id: string; name?: string; identity?: { name?: string; avatarUrl?: string } }>;
+    defaultId?: string;
+  } | null;
+  currentAgentId: string;
+  onAgentChange: (agentId: string) => void;
+  onNavigateToAgent?: () => void;
+  onSessionSelect?: (sessionKey: string) => void;
   onOpenSidebar?: (content: string) => void;
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  basePath?: string;
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
+const FALLBACK_TOAST_DURATION_MS = 8000;
+
+// Persistent instances keyed by session
+const inputHistories = new Map<string, InputHistory>();
+const pinnedMessagesMap = new Map<string, PinnedMessages>();
+const deletedMessagesMap = new Map<string, DeletedMessages>();
+
+function getInputHistory(sessionKey: string): InputHistory {
+  return getOrCreateSessionCacheValue(inputHistories, sessionKey, () => new InputHistory());
+}
+
+function getPinnedMessages(sessionKey: string): PinnedMessages {
+  return getOrCreateSessionCacheValue(
+    pinnedMessagesMap,
+    sessionKey,
+    () => new PinnedMessages(sessionKey),
+  );
+}
+
+function getDeletedMessages(sessionKey: string): DeletedMessages {
+  return getOrCreateSessionCacheValue(
+    deletedMessagesMap,
+    sessionKey,
+    () => new DeletedMessages(sessionKey),
+  );
+}
+
+interface ChatEphemeralState {
+  sttRecording: boolean;
+  sttInterimText: string;
+  slashMenuOpen: boolean;
+  slashMenuItems: SlashCommandDef[];
+  slashMenuIndex: number;
+  slashMenuMode: "command" | "args";
+  slashMenuCommand: SlashCommandDef | null;
+  slashMenuArgItems: string[];
+  searchOpen: boolean;
+  searchQuery: string;
+  pinnedExpanded: boolean;
+}
+
+function createChatEphemeralState(): ChatEphemeralState {
+  return {
+    sttRecording: false,
+    sttInterimText: "",
+    slashMenuOpen: false,
+    slashMenuItems: [],
+    slashMenuIndex: 0,
+    slashMenuMode: "command",
+    slashMenuCommand: null,
+    slashMenuArgItems: [],
+    searchOpen: false,
+    searchQuery: "",
+    pinnedExpanded: false,
+  };
+}
+
+const vs = createChatEphemeralState();
+
+/**
+ * Reset chat view ephemeral state when navigating away.
+ * Stops STT recording and clears search/slash UI that should not survive navigation.
+ */
+export function resetChatViewState() {
+  if (vs.sttRecording) {
+    stopStt();
+  }
+  Object.assign(vs, createChatEphemeralState());
+}
+
+export const cleanupChatModuleState = resetChatViewState;
 
 function adjustTextareaHeight(el: HTMLTextAreaElement) {
   el.style.height = "auto";
-  el.style.height = `${el.scrollHeight}px`;
+  el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
 }
 
 function renderCompactionIndicator(status: CompactionIndicatorStatus | null | undefined) {
   if (!status) {
     return nothing;
   }
-
-  // Show "compacting..." while active
   if (status.active) {
     return html`
       <div class="compaction-indicator compaction-indicator--active" role="status" aria-live="polite">
@@ -91,8 +199,6 @@ function renderCompactionIndicator(status: CompactionIndicatorStatus | null | un
       </div>
     `;
   }
-
-  // Show "compaction complete" briefly after completion
   if (status.completedAt) {
     const elapsed = Date.now() - status.completedAt;
     if (elapsed < COMPACTION_TOAST_DURATION_MS) {
@@ -103,8 +209,88 @@ function renderCompactionIndicator(status: CompactionIndicatorStatus | null | un
       `;
     }
   }
-
   return nothing;
+}
+
+function renderFallbackIndicator(status: FallbackIndicatorStatus | null | undefined) {
+  if (!status) {
+    return nothing;
+  }
+  const phase = status.phase ?? "active";
+  const elapsed = Date.now() - status.occurredAt;
+  if (elapsed >= FALLBACK_TOAST_DURATION_MS) {
+    return nothing;
+  }
+  const details = [
+    `Selected: ${status.selected}`,
+    phase === "cleared" ? `Active: ${status.selected}` : `Active: ${status.active}`,
+    phase === "cleared" && status.previous ? `Previous fallback: ${status.previous}` : null,
+    status.reason ? `Reason: ${status.reason}` : null,
+    status.attempts.length > 0 ? `Attempts: ${status.attempts.slice(0, 3).join(" | ")}` : null,
+  ]
+    .filter(Boolean)
+    .join(" • ");
+  const message =
+    phase === "cleared"
+      ? `Fallback cleared: ${status.selected}`
+      : `Fallback active: ${status.active}`;
+  const className =
+    phase === "cleared"
+      ? "compaction-indicator compaction-indicator--fallback-cleared"
+      : "compaction-indicator compaction-indicator--fallback";
+  const icon = phase === "cleared" ? icons.check : icons.brain;
+  return html`
+    <div class=${className} role="status" aria-live="polite" title=${details}>
+      ${icon} ${message}
+    </div>
+  `;
+}
+
+/**
+ * Compact notice when context usage reaches 85%+.
+ * Progressively shifts from amber (85%) to red (90%+).
+ */
+function renderContextNotice(
+  session: GatewaySessionRow | undefined,
+  defaultContextTokens: number | null,
+) {
+  const used = session?.totalTokens ?? 0;
+  const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
+  if (!used || !limit) {
+    return nothing;
+  }
+  const ratio = used / limit;
+  if (ratio < 0.85) {
+    return nothing;
+  }
+  const pct = Math.min(Math.round(ratio * 100), 100);
+  // Lerp from amber (#d97706) at 85% to red (#dc2626) at 95%+
+  const t = Math.min(Math.max((ratio - 0.85) / 0.1, 0), 1);
+  // RGB: amber(217,119,6) → red(220,38,38)
+  const r = Math.round(217 + (220 - 217) * t);
+  const g = Math.round(119 + (38 - 119) * t);
+  const b = Math.round(6 + (38 - 6) * t);
+  const color = `rgb(${r}, ${g}, ${b})`;
+  const bgOpacity = 0.08 + 0.08 * t;
+  const bg = `rgba(${r}, ${g}, ${b}, ${bgOpacity})`;
+  return html`
+    <div class="context-notice" role="status" style="--ctx-color:${color};--ctx-bg:${bg}">
+      <svg class="context-notice__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+      <span>${pct}% context used</span>
+      <span class="context-notice__detail">${formatTokensCompact(used)} / ${formatTokensCompact(limit)}</span>
+    </div>
+  `;
+}
+
+/** Format token count compactly (e.g. 128000 → "128k"). */
+function formatTokensCompact(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  }
+  if (n >= 1_000) {
+    return `${(n / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
+  }
+  return String(n);
 }
 
 function generateAttachmentId(): string {
@@ -116,7 +302,6 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
   if (!items || !props.onAttachmentsChange) {
     return;
   }
-
   const imageItems: DataTransferItem[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
@@ -124,19 +309,15 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
       imageItems.push(item);
     }
   }
-
   if (imageItems.length === 0) {
     return;
   }
-
   e.preventDefault();
-
   for (const item of imageItems) {
     const file = item.getAsFile();
     if (!file) {
       continue;
     }
-
     const reader = new FileReader();
     reader.addEventListener("load", () => {
       const dataUrl = reader.result as string;
@@ -152,36 +333,467 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
   }
 }
 
-function renderAttachmentPreview(props: ChatProps) {
+function handleFileSelect(e: Event, props: ChatProps) {
+  const input = e.target as HTMLInputElement;
+  if (!input.files || !props.onAttachmentsChange) {
+    return;
+  }
+  const current = props.attachments ?? [];
+  const additions: ChatAttachment[] = [];
+  let pending = 0;
+  for (const file of input.files) {
+    if (!isSupportedChatAttachmentMimeType(file.type)) {
+      continue;
+    }
+    pending++;
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      additions.push({
+        id: generateAttachmentId(),
+        dataUrl: reader.result as string,
+        mimeType: file.type,
+      });
+      pending--;
+      if (pending === 0) {
+        props.onAttachmentsChange?.([...current, ...additions]);
+      }
+    });
+    reader.readAsDataURL(file);
+  }
+  input.value = "";
+}
+
+function handleDrop(e: DragEvent, props: ChatProps) {
+  e.preventDefault();
+  const files = e.dataTransfer?.files;
+  if (!files || !props.onAttachmentsChange) {
+    return;
+  }
+  const current = props.attachments ?? [];
+  const additions: ChatAttachment[] = [];
+  let pending = 0;
+  for (const file of files) {
+    if (!isSupportedChatAttachmentMimeType(file.type)) {
+      continue;
+    }
+    pending++;
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      additions.push({
+        id: generateAttachmentId(),
+        dataUrl: reader.result as string,
+        mimeType: file.type,
+      });
+      pending--;
+      if (pending === 0) {
+        props.onAttachmentsChange?.([...current, ...additions]);
+      }
+    });
+    reader.readAsDataURL(file);
+  }
+}
+
+function renderAttachmentPreview(props: ChatProps): TemplateResult | typeof nothing {
   const attachments = props.attachments ?? [];
   if (attachments.length === 0) {
     return nothing;
   }
-
   return html`
-    <div class="chat-attachments">
+    <div class="chat-attachments-preview">
       ${attachments.map(
         (att) => html`
-          <div class="chat-attachment">
-            <img
-              src=${att.dataUrl}
-              alt="Attachment preview"
-              class="chat-attachment__img"
-            />
+          <div class="chat-attachment-thumb">
+            <img src=${att.dataUrl} alt="Attachment preview" />
             <button
-              class="chat-attachment__remove"
+              class="chat-attachment-remove"
               type="button"
               aria-label="Remove attachment"
               @click=${() => {
                 const next = (props.attachments ?? []).filter((a) => a.id !== att.id);
                 props.onAttachmentsChange?.(next);
               }}
-            >
-              ${icons.x}
-            </button>
+            >&times;</button>
           </div>
         `,
       )}
+    </div>
+  `;
+}
+
+function resetSlashMenuState(): void {
+  vs.slashMenuMode = "command";
+  vs.slashMenuCommand = null;
+  vs.slashMenuArgItems = [];
+  vs.slashMenuItems = [];
+}
+
+function updateSlashMenu(value: string, requestUpdate: () => void): void {
+  // Arg mode: /command <partial-arg>
+  const argMatch = value.match(/^\/(\S+)\s(.*)$/);
+  if (argMatch) {
+    const cmdName = argMatch[1].toLowerCase();
+    const argFilter = argMatch[2].toLowerCase();
+    const cmd = SLASH_COMMANDS.find((c) => c.name === cmdName);
+    if (cmd?.argOptions?.length) {
+      const filtered = argFilter
+        ? cmd.argOptions.filter((opt) => opt.toLowerCase().startsWith(argFilter))
+        : cmd.argOptions;
+      if (filtered.length > 0) {
+        vs.slashMenuMode = "args";
+        vs.slashMenuCommand = cmd;
+        vs.slashMenuArgItems = filtered;
+        vs.slashMenuOpen = true;
+        vs.slashMenuIndex = 0;
+        vs.slashMenuItems = [];
+        requestUpdate();
+        return;
+      }
+    }
+    vs.slashMenuOpen = false;
+    resetSlashMenuState();
+    requestUpdate();
+    return;
+  }
+
+  // Command mode: /partial-command
+  const match = value.match(/^\/(\S*)$/);
+  if (match) {
+    const items = getSlashCommandCompletions(match[1]);
+    vs.slashMenuItems = items;
+    vs.slashMenuOpen = items.length > 0;
+    vs.slashMenuIndex = 0;
+    vs.slashMenuMode = "command";
+    vs.slashMenuCommand = null;
+    vs.slashMenuArgItems = [];
+  } else {
+    vs.slashMenuOpen = false;
+    resetSlashMenuState();
+  }
+  requestUpdate();
+}
+
+function selectSlashCommand(
+  cmd: SlashCommandDef,
+  props: ChatProps,
+  requestUpdate: () => void,
+): void {
+  // Transition to arg picker when the command has fixed options
+  if (cmd.argOptions?.length) {
+    props.onDraftChange(`/${cmd.name} `);
+    vs.slashMenuMode = "args";
+    vs.slashMenuCommand = cmd;
+    vs.slashMenuArgItems = cmd.argOptions;
+    vs.slashMenuOpen = true;
+    vs.slashMenuIndex = 0;
+    vs.slashMenuItems = [];
+    requestUpdate();
+    return;
+  }
+
+  vs.slashMenuOpen = false;
+  resetSlashMenuState();
+
+  if (cmd.executeLocal && !cmd.args) {
+    props.onDraftChange(`/${cmd.name}`);
+    requestUpdate();
+    props.onSend();
+  } else {
+    props.onDraftChange(`/${cmd.name} `);
+    requestUpdate();
+  }
+}
+
+function tabCompleteSlashCommand(
+  cmd: SlashCommandDef,
+  props: ChatProps,
+  requestUpdate: () => void,
+): void {
+  // Tab: fill in the command text without executing
+  if (cmd.argOptions?.length) {
+    props.onDraftChange(`/${cmd.name} `);
+    vs.slashMenuMode = "args";
+    vs.slashMenuCommand = cmd;
+    vs.slashMenuArgItems = cmd.argOptions;
+    vs.slashMenuOpen = true;
+    vs.slashMenuIndex = 0;
+    vs.slashMenuItems = [];
+    requestUpdate();
+    return;
+  }
+
+  vs.slashMenuOpen = false;
+  resetSlashMenuState();
+  props.onDraftChange(cmd.args ? `/${cmd.name} ` : `/${cmd.name}`);
+  requestUpdate();
+}
+
+function selectSlashArg(
+  arg: string,
+  props: ChatProps,
+  requestUpdate: () => void,
+  execute: boolean,
+): void {
+  const cmdName = vs.slashMenuCommand?.name ?? "";
+  vs.slashMenuOpen = false;
+  resetSlashMenuState();
+  props.onDraftChange(`/${cmdName} ${arg}`);
+  requestUpdate();
+  if (execute) {
+    props.onSend();
+  }
+}
+
+function tokenEstimate(draft: string): string | null {
+  if (draft.length < 100) {
+    return null;
+  }
+  return `~${Math.ceil(draft.length / 4)} tokens`;
+}
+
+/**
+ * Export chat markdown - delegates to shared utility.
+ */
+function exportMarkdown(props: ChatProps): void {
+  exportChatMarkdown(props.messages, props.assistantName);
+}
+
+const WELCOME_SUGGESTIONS = [
+  "What can you do?",
+  "Summarize my recent sessions",
+  "Help me configure a channel",
+  "Check system health",
+];
+
+function renderWelcomeState(props: ChatProps): TemplateResult {
+  const name = props.assistantName || "Assistant";
+  const avatar = resolveAgentAvatarUrl({
+    identity: {
+      avatar: props.assistantAvatar ?? undefined,
+      avatarUrl: props.assistantAvatarUrl ?? undefined,
+    },
+  });
+  const logoUrl = agentLogoUrl(props.basePath ?? "");
+
+  return html`
+    <div class="agent-chat__welcome" style="--agent-color: var(--accent)">
+      <div class="agent-chat__welcome-glow"></div>
+      ${
+        avatar
+          ? html`<img src=${avatar} alt=${name} style="width:56px; height:56px; border-radius:50%; object-fit:cover;" />`
+          : html`<div class="agent-chat__avatar agent-chat__avatar--logo"><img src=${logoUrl} alt="OpenClaw" /></div>`
+      }
+      <h2>${name}</h2>
+      <div class="agent-chat__badges">
+        <span class="agent-chat__badge"><img src=${logoUrl} alt="" /> Ready to chat</span>
+      </div>
+      <p class="agent-chat__hint">
+        Type a message below &middot; <kbd>/</kbd> for commands
+      </p>
+      <div class="agent-chat__suggestions">
+        ${WELCOME_SUGGESTIONS.map(
+          (text) => html`
+            <button
+              type="button"
+              class="agent-chat__suggestion"
+              @click=${() => {
+                props.onDraftChange(text);
+                props.onSend();
+              }}
+            >${text}</button>
+          `,
+        )}
+      </div>
+    </div>
+  `;
+}
+
+function renderSearchBar(requestUpdate: () => void): TemplateResult | typeof nothing {
+  if (!vs.searchOpen) {
+    return nothing;
+  }
+  return html`
+    <div class="agent-chat__search-bar">
+      ${icons.search}
+      <input
+        type="text"
+        placeholder="Search messages..."
+        .value=${vs.searchQuery}
+        @input=${(e: Event) => {
+          vs.searchQuery = (e.target as HTMLInputElement).value;
+          requestUpdate();
+        }}
+      />
+      <button class="btn-ghost" @click=${() => {
+        vs.searchOpen = false;
+        vs.searchQuery = "";
+        requestUpdate();
+      }}>
+        ${icons.x}
+      </button>
+    </div>
+  `;
+}
+
+function renderPinnedSection(
+  props: ChatProps,
+  pinned: PinnedMessages,
+  requestUpdate: () => void,
+): TemplateResult | typeof nothing {
+  const messages = Array.isArray(props.messages) ? props.messages : [];
+  const entries: Array<{ index: number; text: string; role: string }> = [];
+  for (const idx of pinned.indices) {
+    const msg = messages[idx] as Record<string, unknown> | undefined;
+    if (!msg) {
+      continue;
+    }
+    const text = getPinnedMessageSummary(msg);
+    const role = typeof msg.role === "string" ? msg.role : "unknown";
+    entries.push({ index: idx, text, role });
+  }
+  if (entries.length === 0) {
+    return nothing;
+  }
+  return html`
+    <div class="agent-chat__pinned">
+      <button class="agent-chat__pinned-toggle" @click=${() => {
+        vs.pinnedExpanded = !vs.pinnedExpanded;
+        requestUpdate();
+      }}>
+        ${icons.bookmark}
+        ${entries.length} pinned
+        ${vs.pinnedExpanded ? icons.chevronDown : icons.chevronRight}
+      </button>
+      ${
+        vs.pinnedExpanded
+          ? html`
+            <div class="agent-chat__pinned-list">
+              ${entries.map(
+                ({ index, text, role }) => html`
+                <div class="agent-chat__pinned-item">
+                  <span class="agent-chat__pinned-role">${role === "user" ? "You" : "Assistant"}</span>
+                  <span class="agent-chat__pinned-text">${text.slice(0, 100)}${text.length > 100 ? "..." : ""}</span>
+                  <button class="btn-ghost" @click=${() => {
+                    pinned.unpin(index);
+                    requestUpdate();
+                  }} title="Unpin">
+                    ${icons.x}
+                  </button>
+                </div>
+              `,
+              )}
+            </div>
+          `
+          : nothing
+      }
+    </div>
+  `;
+}
+
+function renderSlashMenu(
+  requestUpdate: () => void,
+  props: ChatProps,
+): TemplateResult | typeof nothing {
+  if (!vs.slashMenuOpen) {
+    return nothing;
+  }
+
+  // Arg-picker mode: show options for the selected command
+  if (vs.slashMenuMode === "args" && vs.slashMenuCommand && vs.slashMenuArgItems.length > 0) {
+    return html`
+      <div class="slash-menu">
+        <div class="slash-menu-group">
+          <div class="slash-menu-group__label">/${vs.slashMenuCommand.name} ${vs.slashMenuCommand.description}</div>
+          ${vs.slashMenuArgItems.map(
+            (arg, i) => html`
+              <div
+                class="slash-menu-item ${i === vs.slashMenuIndex ? "slash-menu-item--active" : ""}"
+                @click=${() => selectSlashArg(arg, props, requestUpdate, true)}
+                @mouseenter=${() => {
+                  vs.slashMenuIndex = i;
+                  requestUpdate();
+                }}
+              >
+                ${vs.slashMenuCommand?.icon ? html`<span class="slash-menu-icon">${icons[vs.slashMenuCommand.icon]}</span>` : nothing}
+                <span class="slash-menu-name">${arg}</span>
+                <span class="slash-menu-desc">/${vs.slashMenuCommand?.name} ${arg}</span>
+              </div>
+            `,
+          )}
+        </div>
+        <div class="slash-menu-footer">
+          <kbd>↑↓</kbd> navigate
+          <kbd>Tab</kbd> fill
+          <kbd>Enter</kbd> run
+          <kbd>Esc</kbd> close
+        </div>
+      </div>
+    `;
+  }
+
+  // Command mode: show grouped commands
+  if (vs.slashMenuItems.length === 0) {
+    return nothing;
+  }
+
+  const grouped = new Map<
+    SlashCommandCategory,
+    Array<{ cmd: SlashCommandDef; globalIdx: number }>
+  >();
+  for (let i = 0; i < vs.slashMenuItems.length; i++) {
+    const cmd = vs.slashMenuItems[i];
+    const cat = cmd.category ?? "session";
+    let list = grouped.get(cat);
+    if (!list) {
+      list = [];
+      grouped.set(cat, list);
+    }
+    list.push({ cmd, globalIdx: i });
+  }
+
+  const sections: TemplateResult[] = [];
+  for (const [cat, entries] of grouped) {
+    sections.push(html`
+      <div class="slash-menu-group">
+        <div class="slash-menu-group__label">${CATEGORY_LABELS[cat]}</div>
+        ${entries.map(
+          ({ cmd, globalIdx }) => html`
+            <div
+              class="slash-menu-item ${globalIdx === vs.slashMenuIndex ? "slash-menu-item--active" : ""}"
+              @click=${() => selectSlashCommand(cmd, props, requestUpdate)}
+              @mouseenter=${() => {
+                vs.slashMenuIndex = globalIdx;
+                requestUpdate();
+              }}
+            >
+              ${cmd.icon ? html`<span class="slash-menu-icon">${icons[cmd.icon]}</span>` : nothing}
+              <span class="slash-menu-name">/${cmd.name}</span>
+              ${cmd.args ? html`<span class="slash-menu-args">${cmd.args}</span>` : nothing}
+              <span class="slash-menu-desc">${cmd.description}</span>
+              ${
+                cmd.argOptions?.length
+                  ? html`<span class="slash-menu-badge">${cmd.argOptions.length} options</span>`
+                  : cmd.executeLocal && !cmd.args
+                    ? html`
+                        <span class="slash-menu-badge">instant</span>
+                      `
+                    : nothing
+              }
+            </div>
+          `,
+        )}
+      </div>
+    `);
+  }
+
+  return html`
+    <div class="slash-menu">
+      ${sections}
+      <div class="slash-menu-footer">
+        <kbd>↑↓</kbd> navigate
+        <kbd>Tab</kbd> fill
+        <kbd>Enter</kbd> select
+        <kbd>Esc</kbd> close
+      </div>
     </div>
   `;
 }
@@ -195,34 +807,101 @@ export function renderChat(props: ChatProps) {
   const showReasoning = props.showThinking && reasoningLevel !== "off";
   const assistantIdentity = {
     name: props.assistantName,
-    avatar: props.assistantAvatar ?? props.assistantAvatarUrl ?? null,
+    avatar:
+      resolveAgentAvatarUrl({
+        identity: {
+          avatar: props.assistantAvatar ?? undefined,
+          avatarUrl: props.assistantAvatarUrl ?? undefined,
+        },
+      }) ?? null,
   };
-
+  const pinned = getPinnedMessages(props.sessionKey);
+  const deleted = getDeletedMessages(props.sessionKey);
+  const inputHistory = getInputHistory(props.sessionKey);
   const hasAttachments = (props.attachments?.length ?? 0) > 0;
-  const composePlaceholder = props.connected
+  const tokens = tokenEstimate(props.draft);
+
+  const placeholder = props.connected
     ? hasAttachments
       ? "Add a message or paste more images..."
-      : "Message (↩ to send, Shift+↩ for line breaks, paste images)"
-    : "Connect to the gateway to start chatting…";
+      : `Message ${props.assistantName || "agent"} (Enter to send)`
+    : "Connect to the gateway to start chatting...";
+
+  const requestUpdate = props.onRequestUpdate ?? (() => {});
+  const getDraft = props.getDraft ?? (() => props.draft);
 
   const splitRatio = props.splitRatio ?? 0.6;
   const sidebarOpen = Boolean(props.sidebarOpen && props.onCloseSidebar);
+
+  const handleCodeBlockCopy = (e: Event) => {
+    const btn = (e.target as HTMLElement).closest(".code-block-copy");
+    if (!btn) {
+      return;
+    }
+    const code = (btn as HTMLElement).dataset.code ?? "";
+    navigator.clipboard.writeText(code).then(
+      () => {
+        btn.classList.add("copied");
+        setTimeout(() => btn.classList.remove("copied"), 1500);
+      },
+      () => {},
+    );
+  };
+
+  const chatItems = buildChatItems(props);
+  const isEmpty = chatItems.length === 0 && !props.loading;
+
   const thread = html`
     <div
       class="chat-thread"
       role="log"
       aria-live="polite"
       @scroll=${props.onChatScroll}
+      @click=${handleCodeBlockCopy}
     >
+      <div class="chat-thread-inner">
       ${
         props.loading
           ? html`
-              <div class="muted">Loading chat…</div>
+              <div class="chat-loading-skeleton" aria-label="Loading chat">
+                <div class="chat-line assistant">
+                  <div class="chat-msg">
+                    <div class="chat-bubble">
+                      <div class="skeleton skeleton-line skeleton-line--long" style="margin-bottom: 8px"></div>
+                      <div class="skeleton skeleton-line skeleton-line--medium" style="margin-bottom: 8px"></div>
+                      <div class="skeleton skeleton-line skeleton-line--short"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="chat-line user" style="margin-top: 12px">
+                  <div class="chat-msg">
+                    <div class="chat-bubble">
+                      <div class="skeleton skeleton-line skeleton-line--medium"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="chat-line assistant" style="margin-top: 12px">
+                  <div class="chat-msg">
+                    <div class="chat-bubble">
+                      <div class="skeleton skeleton-line skeleton-line--long" style="margin-bottom: 8px"></div>
+                      <div class="skeleton skeleton-line skeleton-line--short"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            `
+          : nothing
+      }
+      ${isEmpty && !vs.searchOpen ? renderWelcomeState(props) : nothing}
+      ${
+        isEmpty && vs.searchOpen
+          ? html`
+              <div class="agent-chat__empty">No matching messages</div>
             `
           : nothing
       }
       ${repeat(
-        buildChatItems(props),
+        chatItems,
         (item) => item.key,
         (item) => {
           if (item.kind === "divider") {
@@ -234,39 +913,168 @@ export function renderChat(props: ChatProps) {
               </div>
             `;
           }
-
           if (item.kind === "reading-indicator") {
-            return renderReadingIndicatorGroup(assistantIdentity);
+            return renderReadingIndicatorGroup(assistantIdentity, props.basePath);
           }
-
           if (item.kind === "stream") {
             return renderStreamingGroup(
               item.text,
               item.startedAt,
               props.onOpenSidebar,
               assistantIdentity,
+              props.basePath,
             );
           }
-
           if (item.kind === "group") {
+            if (deleted.has(item.key)) {
+              return nothing;
+            }
             return renderMessageGroup(item, {
               onOpenSidebar: props.onOpenSidebar,
               showReasoning,
               assistantName: props.assistantName,
               assistantAvatar: assistantIdentity.avatar,
+              basePath: props.basePath,
+              contextWindow:
+                activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null,
+              onDelete: () => {
+                deleted.delete(item.key);
+                requestUpdate();
+              },
             });
           }
-
           return nothing;
         },
       )}
+      </div>
     </div>
   `;
 
-  return html`
-    <section class="card chat">
-      ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
+  const handleKeyDown = (e: KeyboardEvent) => {
+    // Slash menu navigation — arg mode
+    if (vs.slashMenuOpen && vs.slashMenuMode === "args" && vs.slashMenuArgItems.length > 0) {
+      const len = vs.slashMenuArgItems.length;
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          vs.slashMenuIndex = (vs.slashMenuIndex + 1) % len;
+          requestUpdate();
+          return;
+        case "ArrowUp":
+          e.preventDefault();
+          vs.slashMenuIndex = (vs.slashMenuIndex - 1 + len) % len;
+          requestUpdate();
+          return;
+        case "Tab":
+          e.preventDefault();
+          selectSlashArg(vs.slashMenuArgItems[vs.slashMenuIndex], props, requestUpdate, false);
+          return;
+        case "Enter":
+          e.preventDefault();
+          selectSlashArg(vs.slashMenuArgItems[vs.slashMenuIndex], props, requestUpdate, true);
+          return;
+        case "Escape":
+          e.preventDefault();
+          vs.slashMenuOpen = false;
+          resetSlashMenuState();
+          requestUpdate();
+          return;
+      }
+    }
 
+    // Slash menu navigation — command mode
+    if (vs.slashMenuOpen && vs.slashMenuItems.length > 0) {
+      const len = vs.slashMenuItems.length;
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          vs.slashMenuIndex = (vs.slashMenuIndex + 1) % len;
+          requestUpdate();
+          return;
+        case "ArrowUp":
+          e.preventDefault();
+          vs.slashMenuIndex = (vs.slashMenuIndex - 1 + len) % len;
+          requestUpdate();
+          return;
+        case "Tab":
+          e.preventDefault();
+          tabCompleteSlashCommand(vs.slashMenuItems[vs.slashMenuIndex], props, requestUpdate);
+          return;
+        case "Enter":
+          e.preventDefault();
+          selectSlashCommand(vs.slashMenuItems[vs.slashMenuIndex], props, requestUpdate);
+          return;
+        case "Escape":
+          e.preventDefault();
+          vs.slashMenuOpen = false;
+          resetSlashMenuState();
+          requestUpdate();
+          return;
+      }
+    }
+
+    // Input history (only when input is empty)
+    if (!props.draft.trim()) {
+      if (e.key === "ArrowUp") {
+        const prev = inputHistory.up();
+        if (prev !== null) {
+          e.preventDefault();
+          props.onDraftChange(prev);
+        }
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        const next = inputHistory.down();
+        e.preventDefault();
+        props.onDraftChange(next ?? "");
+        return;
+      }
+    }
+
+    // Cmd+F for search
+    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === "f") {
+      e.preventDefault();
+      vs.searchOpen = !vs.searchOpen;
+      if (!vs.searchOpen) {
+        vs.searchQuery = "";
+      }
+      requestUpdate();
+      return;
+    }
+
+    // Send on Enter (without shift)
+    if (e.key === "Enter" && !e.shiftKey) {
+      if (e.isComposing || e.keyCode === 229) {
+        return;
+      }
+      if (!props.connected) {
+        return;
+      }
+      e.preventDefault();
+      if (canCompose) {
+        if (props.draft.trim()) {
+          inputHistory.push(props.draft);
+        }
+        props.onSend();
+      }
+    }
+  };
+
+  const handleInput = (e: Event) => {
+    const target = e.target as HTMLTextAreaElement;
+    adjustTextareaHeight(target);
+    updateSlashMenu(target.value, requestUpdate);
+    inputHistory.reset();
+    props.onDraftChange(target.value);
+  };
+
+  return html`
+    <section
+      class="card chat"
+      @drop=${(e: DragEvent) => handleDrop(e, props)}
+      @dragover=${(e: DragEvent) => e.preventDefault()}
+    >
+      ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
       ${props.error ? html`<div class="callout danger">${props.error}</div>` : nothing}
 
       ${
@@ -285,9 +1093,10 @@ export function renderChat(props: ChatProps) {
           : nothing
       }
 
-      <div
-        class="chat-split-container ${sidebarOpen ? "chat-split-container--open" : ""}"
-      >
+      ${renderSearchBar(requestUpdate)}
+      ${renderPinnedSection(props, pinned, requestUpdate)}
+
+      <div class="chat-split-container ${sidebarOpen ? "chat-split-container--open" : ""}">
         <div
           class="chat-main"
           style="flex: ${sidebarOpen ? `0 0 ${splitRatio * 100}%` : "1 1 100%"}"
@@ -352,74 +1161,164 @@ export function renderChat(props: ChatProps) {
           : nothing
       }
 
+      ${renderFallbackIndicator(props.fallbackStatus)}
       ${renderCompactionIndicator(props.compactionStatus)}
+      ${renderContextNotice(activeSession, props.sessions?.defaults?.contextTokens ?? null)}
 
       ${
         props.showNewMessages
           ? html`
             <button
-              class="btn chat-new-messages"
+              class="chat-new-messages"
               type="button"
               @click=${props.onScrollToBottom}
             >
-              New messages ${icons.arrowDown}
+              ${icons.arrowDown} New messages
             </button>
           `
           : nothing
       }
 
-      <div class="chat-compose">
+      <!-- Input bar -->
+      <div class="agent-chat__input">
+        ${renderSlashMenu(requestUpdate, props)}
         ${renderAttachmentPreview(props)}
-        <div class="chat-compose__row">
-          <label class="field chat-compose__field">
-            <span>Message</span>
-            <textarea
-              ${ref((el) => el && adjustTextareaHeight(el as HTMLTextAreaElement))}
-              .value=${props.draft}
-              dir=${detectTextDirection(props.draft)}
-              ?disabled=${!props.connected}
-              @keydown=${(e: KeyboardEvent) => {
-                if (e.key !== "Enter") {
-                  return;
-                }
-                if (e.isComposing || e.keyCode === 229) {
-                  return;
-                }
-                if (e.shiftKey) {
-                  return;
-                } // Allow Shift+Enter for line breaks
-                if (!props.connected) {
-                  return;
-                }
-                e.preventDefault();
-                if (canCompose) {
-                  props.onSend();
-                }
-              }}
-              @input=${(e: Event) => {
-                const target = e.target as HTMLTextAreaElement;
-                adjustTextareaHeight(target);
-                props.onDraftChange(target.value);
-              }}
-              @paste=${(e: ClipboardEvent) => handlePaste(e, props)}
-              placeholder=${composePlaceholder}
-            ></textarea>
-          </label>
-          <div class="chat-compose__actions">
+
+        <input
+          type="file"
+          accept=${CHAT_ATTACHMENT_ACCEPT}
+          multiple
+          class="agent-chat__file-input"
+          @change=${(e: Event) => handleFileSelect(e, props)}
+        />
+
+        ${vs.sttRecording && vs.sttInterimText ? html`<div class="agent-chat__stt-interim">${vs.sttInterimText}</div>` : nothing}
+
+        <textarea
+          ${ref((el) => el && adjustTextareaHeight(el as HTMLTextAreaElement))}
+          .value=${props.draft}
+          dir=${detectTextDirection(props.draft)}
+          ?disabled=${!props.connected}
+          @keydown=${handleKeyDown}
+          @input=${handleInput}
+          @paste=${(e: ClipboardEvent) => handlePaste(e, props)}
+          placeholder=${vs.sttRecording ? "Listening..." : placeholder}
+          rows="1"
+        ></textarea>
+
+        <div class="agent-chat__toolbar">
+          <div class="agent-chat__toolbar-left">
             <button
-              class="btn"
-              ?disabled=${!props.connected || (!canAbort && props.sending)}
-              @click=${canAbort ? props.onAbort : props.onNewSession}
-            >
-              ${canAbort ? "Stop" : "New session"}
-            </button>
-            <button
-              class="btn primary"
+              class="agent-chat__input-btn"
+              @click=${() => {
+                document.querySelector<HTMLInputElement>(".agent-chat__file-input")?.click();
+              }}
+              title="Attach file"
               ?disabled=${!props.connected}
-              @click=${props.onSend}
             >
-              ${isBusy ? "Queue" : "Send"}<kbd class="btn-kbd">↵</kbd>
+              ${icons.paperclip}
             </button>
+
+            ${
+              isSttSupported()
+                ? html`
+                  <button
+                    class="agent-chat__input-btn ${vs.sttRecording ? "agent-chat__input-btn--recording" : ""}"
+                    @click=${() => {
+                      if (vs.sttRecording) {
+                        stopStt();
+                        vs.sttRecording = false;
+                        vs.sttInterimText = "";
+                        requestUpdate();
+                      } else {
+                        const started = startStt({
+                          onTranscript: (text, isFinal) => {
+                            if (isFinal) {
+                              const current = getDraft();
+                              const sep = current && !current.endsWith(" ") ? " " : "";
+                              props.onDraftChange(current + sep + text);
+                              vs.sttInterimText = "";
+                            } else {
+                              vs.sttInterimText = text;
+                            }
+                            requestUpdate();
+                          },
+                          onStart: () => {
+                            vs.sttRecording = true;
+                            requestUpdate();
+                          },
+                          onEnd: () => {
+                            vs.sttRecording = false;
+                            vs.sttInterimText = "";
+                            requestUpdate();
+                          },
+                          onError: () => {
+                            vs.sttRecording = false;
+                            vs.sttInterimText = "";
+                            requestUpdate();
+                          },
+                        });
+                        if (started) {
+                          vs.sttRecording = true;
+                          requestUpdate();
+                        }
+                      }
+                    }}
+                    title=${vs.sttRecording ? "Stop recording" : "Voice input"}
+                    ?disabled=${!props.connected}
+                  >
+                    ${vs.sttRecording ? icons.micOff : icons.mic}
+                  </button>
+                `
+                : nothing
+            }
+
+            ${tokens ? html`<span class="agent-chat__token-count">${tokens}</span>` : nothing}
+          </div>
+
+          <div class="agent-chat__toolbar-right">
+            ${nothing /* search hidden for now */}
+            ${
+              canAbort
+                ? nothing
+                : html`
+                    <button
+                      class="btn-ghost"
+                      @click=${props.onNewSession}
+                      title="New session"
+                      aria-label="New session"
+                    >
+                      ${icons.plus}
+                    </button>
+                  `
+            }
+            <button class="btn-ghost" @click=${() => exportMarkdown(props)} title="Export" ?disabled=${props.messages.length === 0}>
+              ${icons.download}
+            </button>
+
+            ${
+              canAbort && (isBusy || props.sending)
+                ? html`
+                  <button class="chat-send-btn chat-send-btn--stop" @click=${props.onAbort} title="Stop">
+                    ${icons.stop}
+                  </button>
+                `
+                : html`
+                  <button
+                    class="chat-send-btn"
+                    @click=${() => {
+                      if (props.draft.trim()) {
+                        inputHistory.push(props.draft);
+                      }
+                      props.onSend();
+                    }}
+                    ?disabled=${!props.connected || props.sending}
+                    title=${isBusy ? "Queue" : "Send"}
+                  >
+                    ${icons.send}
+                  </button>
+                `
+            }
           </div>
         </div>
       </div>
@@ -445,9 +1344,14 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
 
     const normalized = normalizeMessage(item.message);
     const role = normalizeRoleForGrouping(normalized.role);
+    const senderLabel = role.toLowerCase() === "user" ? (normalized.senderLabel ?? null) : null;
     const timestamp = normalized.timestamp || Date.now();
 
-    if (!currentGroup || currentGroup.role !== role) {
+    if (
+      !currentGroup ||
+      currentGroup.role !== role ||
+      (role.toLowerCase() === "user" && currentGroup.senderLabel !== senderLabel)
+    ) {
       if (currentGroup) {
         result.push(currentGroup);
       }
@@ -455,6 +1359,7 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
         kind: "group",
         key: `group:${role}:${item.key}`,
         role,
+        senderLabel,
         messages: [{ message: item.message, key: item.key }],
         timestamp,
         isStreaming: false,
@@ -508,14 +1413,32 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
       continue;
     }
 
+    // Apply search filter if active
+    if (vs.searchOpen && vs.searchQuery.trim() && !messageMatchesSearchQuery(msg, vs.searchQuery)) {
+      continue;
+    }
+
     items.push({
       kind: "message",
       key: messageKey(msg, i),
       message: msg,
     });
   }
-  if (props.showThinking) {
-    for (let i = 0; i < tools.length; i++) {
+  // Interleave stream segments and tool cards in order. Each segment
+  // contains text that was streaming before the corresponding tool started.
+  // This ensures correct visual ordering: text → tool → text → tool → ...
+  const segments = props.streamSegments ?? [];
+  const maxLen = Math.max(segments.length, tools.length);
+  for (let i = 0; i < maxLen; i++) {
+    if (i < segments.length && segments[i].text.trim().length > 0) {
+      items.push({
+        kind: "stream" as const,
+        key: `stream-seg:${props.sessionKey}:${i}`,
+        text: segments[i].text,
+        startedAt: segments[i].ts,
+      });
+    }
+    if (i < tools.length) {
       items.push({
         kind: "message",
         key: messageKey(tools[i], i + history.length),


### PR DESCRIPTION
## Summary
- Chat UI context notice used `session.inputTokens` (cumulative across all API calls in a run) instead of `session.totalTokens` (derived from last API call, reflecting actual context window size)
- This caused inflated display like "100% context used 647.6k / 200k" when actual usage was 173k/200k (87%)
- Fixed both `renderContextNotice` in `chat.ts` and the `/usage` slash command in `slash-command-executor.ts` to use `totalTokens`

Fixes #46632

## Test plan
- [x] Existing browser test updated to include `totalTokens` in fixture data
- [x] New test: verifies context notice shows `totalTokens` (173k) not `inputTokens` (647.6k) when they differ
- [x] New test: verifies context notice is hidden when `totalTokens` is below 85% threshold even if `inputTokens` would exceed it
- [x] Slash command `/usage` test updated to reflect corrected percentage calculation
- [x] All tests pass (3 browser tests, 13 node tests)

> [!NOTE]
> AI-assisted fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)