### PR TITLE
Synology Chat: reject duplicate webhook path ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Configure/startup: move outbound send-deps resolution into a lightweight helper so `openclaw configure` no longer stalls after the banner while eagerly loading channel plugins. (#46301) thanks @scoootscooob.
 - Zalo Personal/group gating: stop reapplying `dmPolicy.allowFrom` as a sender gate for already-allowlisted groups when `groupAllowFrom` is unset, so any member of an allowed group can trigger replies while DMs stay restricted. (#40146)
 - Plugins/install precedence: keep bundled plugins ahead of auto-discovered globals by default, but let an explicitly installed plugin record win its own duplicate-id tie so installed channel plugins load from `~/.openclaw/extensions` after `openclaw plugins install`.
+- Synology Chat/webhooks: refuse to register when multiple enabled accounts resolve to the same webhook path, instead of silently replacing the active route owner. Thanks @vincentkoc.
 
 ### Fixes
 

--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -94,3 +94,20 @@ export function resolveAccount(cfg: any, accountId?: string | null): ResolvedSyn
     allowInsecureSsl: accountOverride.allowInsecureSsl ?? channelCfg.allowInsecureSsl ?? false,
   };
 }
+
+export function findConflictingWebhookPathAccountIds(cfg: any, accountId: string): string[] {
+  const current = resolveAccount(cfg, accountId);
+  const currentPath = current.webhookPath.trim();
+  if (!current.enabled || !current.token.trim() || !currentPath) {
+    return [];
+  }
+
+  return listAccountIds(cfg)
+    .filter((candidateId) => candidateId !== accountId)
+    .map((candidateId) => resolveAccount(cfg, candidateId))
+    .filter(
+      (candidate) =>
+        candidate.enabled && candidate.token.trim() && candidate.webhookPath.trim() === currentPath,
+    )
+    .map((candidate) => candidate.accountId);
+}

--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -98,7 +98,7 @@ export function resolveAccount(cfg: any, accountId?: string | null): ResolvedSyn
 export function findConflictingWebhookPathAccountIds(cfg: any, accountId: string): string[] {
   const current = resolveAccount(cfg, accountId);
   const currentPath = current.webhookPath.trim();
-  if (!current.enabled || !current.token.trim() || !currentPath) {
+  if (!current.enabled || !current.token.trim() || !current.incomingUrl.trim() || !currentPath) {
     return [];
   }
 
@@ -107,7 +107,10 @@ export function findConflictingWebhookPathAccountIds(cfg: any, accountId: string
     .map((candidateId) => resolveAccount(cfg, candidateId))
     .filter(
       (candidate) =>
-        candidate.enabled && candidate.token.trim() && candidate.webhookPath.trim() === currentPath,
+        candidate.enabled &&
+        candidate.token.trim() &&
+        candidate.incomingUrl.trim() &&
+        candidate.webhookPath.trim() === currentPath,
     )
     .map((candidate) => candidate.accountId);
 }

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -334,5 +334,46 @@ describe("createSynologyChatPlugin", () => {
       abortSecond.abort();
       await Promise.allSettled([firstPromise, secondPromise]);
     });
+
+    it("refuses to register when another enabled account resolves to the same webhook path", async () => {
+      const registerMock = registerPluginHttpRouteMock;
+      registerMock.mockClear();
+      const plugin = createSynologyChatPlugin();
+      const abortController = new AbortController();
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      const result = plugin.gateway.startAccount({
+        cfg: {
+          channels: {
+            "synology-chat": {
+              enabled: true,
+              token: "base-token",
+              incomingUrl: "https://nas/incoming",
+              webhookPath: "/webhook/synology/shared",
+              dmPolicy: "allowlist",
+              allowedUserIds: ["owner-a"],
+              accounts: {
+                alerts: {
+                  enabled: true,
+                  token: "alerts-token",
+                  incomingUrl: "https://nas/incoming-alerts",
+                  webhookPath: "/webhook/synology/shared",
+                  dmPolicy: "open",
+                },
+              },
+            },
+          },
+        },
+        accountId: "default",
+        log,
+        abortSignal: abortController.signal,
+      });
+
+      await expectPendingStartAccountPromise(result, abortController);
+      expect(registerMock).not.toHaveBeenCalled();
+      expect(log.error).toHaveBeenCalledWith(
+        expect.stringContaining("Each enabled account must use a unique webhookPath."),
+      );
+    });
   });
 });

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -375,5 +375,46 @@ describe("createSynologyChatPlugin", () => {
         expect.stringContaining("Each enabled account must use a unique webhookPath."),
       );
     });
+
+    it("ignores accounts with a shared path when they are missing incomingUrl", async () => {
+      const registerMock = registerPluginHttpRouteMock;
+      registerMock.mockClear();
+      const plugin = createSynologyChatPlugin();
+      const abortController = new AbortController();
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      const result = plugin.gateway.startAccount({
+        cfg: {
+          channels: {
+            "synology-chat": {
+              enabled: true,
+              token: "base-token",
+              incomingUrl: "https://nas/incoming",
+              webhookPath: "/webhook/synology/shared",
+              dmPolicy: "allowlist",
+              allowedUserIds: ["owner-a"],
+              accounts: {
+                alerts: {
+                  enabled: true,
+                  token: "alerts-token",
+                  incomingUrl: "",
+                  webhookPath: "/webhook/synology/shared",
+                  dmPolicy: "open",
+                },
+              },
+            },
+          },
+        },
+        accountId: "default",
+        log,
+        abortSignal: abortController.signal,
+      });
+
+      await expectPendingStartAccountPromise(result, abortController);
+      expect(registerMock).toHaveBeenCalledTimes(1);
+      expect(log.error).not.toHaveBeenCalledWith(
+        expect.stringContaining("Each enabled account must use a unique webhookPath."),
+      );
+    });
   });
 });

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -11,7 +11,11 @@ import {
   buildChannelConfigSchema,
 } from "openclaw/plugin-sdk/synology-chat";
 import { z } from "zod";
-import { listAccountIds, resolveAccount } from "./accounts.js";
+import {
+  findConflictingWebhookPathAccountIds,
+  listAccountIds,
+  resolveAccount,
+} from "./accounts.js";
 import { sendMessage, sendFileUrl } from "./client.js";
 import { getSynologyRuntime } from "./runtime.js";
 import type { ResolvedSynologyChatAccount } from "./types.js";
@@ -249,6 +253,19 @@ export function createSynologyChatPlugin() {
           );
           return waitUntilAbort(ctx.abortSignal);
         }
+        const conflictingAccounts = findConflictingWebhookPathAccountIds(
+          ctx.cfg,
+          account.accountId,
+        );
+        if (conflictingAccounts.length > 0) {
+          log?.error?.(
+            `Conflicting webhookPath ${account.webhookPath} for Synology Chat accounts: ${[
+              account.accountId,
+              ...conflictingAccounts,
+            ].join(", ")}. Each enabled account must use a unique webhookPath.`,
+          );
+          return waitUntilAbort(ctx.abortSignal);
+        }
 
         log?.info?.(
           `Starting Synology Chat channel (account: ${accountId}, path: ${account.webhookPath})`,
@@ -325,7 +342,6 @@ export function createSynologyChatPlugin() {
         const unregister = registerPluginHttpRoute({
           path: account.webhookPath,
           auth: "plugin",
-          replaceExisting: true,
           pluginId: CHANNEL_ID,
           accountId: account.accountId,
           log: (msg: string) => log?.info?.(msg),


### PR DESCRIPTION
## Summary

- Problem: multiple enabled Synology Chat accounts could resolve to the same webhook path, and the later registration silently replaced the earlier route owner.
- Why it matters: path collisions should fail closed instead of collapsing account-specific routing context.
- What changed: detect conflicting enabled accounts that resolve to the same webhook path and refuse registration when a collision exists.
- What did NOT change: normal single-account and unique-path registrations still use the same route handling path.

## Change Type

- [x] Bug fix
- [x] Integrations

## User-visible / Behavior Changes

- Startup now logs and skips registration when two enabled Synology Chat accounts share the same resolved webhook path.
- Unique webhook paths keep registering normally.

## Verification

- `pnpm test -- extensions/synology-chat/src/channel.test.ts`

## Human Verification

- Verified scenarios: duplicate enabled account paths are rejected; normal unique-path registration still works.
- Edge cases checked: conflict detection trims configured webhook paths before comparison.
- What I did not verify: no live Synology Chat endpoint was exercised in this branch.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? Only if a config currently uses duplicate enabled webhook paths; those now need unique paths.

## Failure Recovery

- How to disable/revert this change quickly: revert this PR.
- Known bad symptoms reviewers should watch for: startup error logs for duplicate webhook paths in existing multi-account configs.
