### PR TITLE
ACP: honor per-agent allowlists for spawned sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Configure/startup: move outbound send-deps resolution into a lightweight helper so `openclaw configure` no longer stalls after the banner while eagerly loading channel plugins. (#46301) thanks @scoootscooob.
 - Zalo Personal/group gating: stop reapplying `dmPolicy.allowFrom` as a sender gate for already-allowlisted groups when `groupAllowFrom` is unset, so any member of an allowed group can trigger replies while DMs stay restricted. (#40146)
 - Plugins/install precedence: keep bundled plugins ahead of auto-discovered globals by default, but let an explicitly installed plugin record win its own duplicate-id tie so installed channel plugins load from `~/.openclaw/extensions` after `openclaw plugins install`.
+- ACP/sessions_spawn: honor per-agent `allowAgents` limits for ACP-backed spawns, matching the existing subagent runtime behavior. Thanks @vincentkoc.
 
 ### Fixes
 

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -4,6 +4,23 @@ import type { SessionBindingRecord } from "../infra/outbound/session-binding-ser
 
 function createDefaultSpawnConfig(): OpenClawConfig {
   return {
+    agents: {
+      list: [
+        {
+          id: "main",
+          default: true,
+          subagents: {
+            allowAgents: ["codex"],
+          },
+        },
+        {
+          id: "research",
+          subagents: {
+            allowAgents: ["codex"],
+          },
+        },
+      ],
+    },
     acp: {
       enabled: true,
       backend: "acpx",
@@ -82,35 +99,25 @@ function buildSessionBindingServiceMock() {
   };
 }
 
-vi.mock("../config/config.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../config/config.js")>();
-  return {
-    ...actual,
-    loadConfig: () => hoisted.state.cfg,
-  };
-});
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => hoisted.state.cfg,
+}));
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: (opts: unknown) => hoisted.callGatewayMock(opts),
 }));
 
-vi.mock("../config/sessions.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../config/sessions.js")>();
-  return {
-    ...actual,
-    loadSessionStore: (storePath: string) => hoisted.loadSessionStoreMock(storePath),
-    resolveStorePath: (store: unknown, opts: unknown) => hoisted.resolveStorePathMock(store, opts),
-  };
-});
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: (storePath: string) => hoisted.loadSessionStoreMock(storePath),
+  resolveStorePath: (store: unknown, opts: unknown) => hoisted.resolveStorePathMock(store, opts),
+  resolveAgentMainSessionKey: ({ agentId }: { agentId: string }) => `agent:${agentId}:main`,
+  canonicalizeMainSessionAlias: ({ sessionKey }: { sessionKey: string }) => sessionKey,
+}));
 
-vi.mock("../config/sessions/transcript.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../config/sessions/transcript.js")>();
-  return {
-    ...actual,
-    resolveSessionTranscriptFile: (params: unknown) =>
-      hoisted.resolveSessionTranscriptFileMock(params),
-  };
-});
+vi.mock("../config/sessions/transcript.js", () => ({
+  resolveSessionTranscriptFile: (params: unknown) =>
+    hoisted.resolveSessionTranscriptFileMock(params),
+}));
 
 vi.mock("../acp/control-plane/manager.js", () => {
   return {
@@ -650,6 +657,21 @@ describe("spawnAcpDirect", () => {
     hoisted.state.cfg = {
       ...hoisted.state.cfg,
       agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            subagents: {
+              allowAgents: ["codex"],
+            },
+          },
+          {
+            id: "research",
+            subagents: {
+              allowAgents: ["codex"],
+            },
+          },
+        ],
         defaults: {
           heartbeat: {
             every: "30m",
@@ -728,6 +750,21 @@ describe("spawnAcpDirect", () => {
     hoisted.state.cfg = {
       ...hoisted.state.cfg,
       agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            subagents: {
+              allowAgents: ["codex"],
+            },
+          },
+          {
+            id: "research",
+            subagents: {
+              allowAgents: ["codex"],
+            },
+          },
+        ],
         defaults: {
           heartbeat: {
             every: "30m",
@@ -762,6 +799,21 @@ describe("spawnAcpDirect", () => {
         scope: "global",
       },
       agents: {
+        list: [
+          {
+            id: "main",
+            default: true,
+            subagents: {
+              allowAgents: ["codex"],
+            },
+          },
+          {
+            id: "research",
+            subagents: {
+              allowAgents: ["codex"],
+            },
+          },
+        ],
         defaults: {
           heartbeat: {
             every: "30m",
@@ -791,7 +843,21 @@ describe("spawnAcpDirect", () => {
     hoisted.state.cfg = {
       ...hoisted.state.cfg,
       agents: {
-        list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "research" }],
+        list: [
+          {
+            id: "main",
+            heartbeat: { every: "30m" },
+            subagents: {
+              allowAgents: ["codex"],
+            },
+          },
+          {
+            id: "research",
+            subagents: {
+              allowAgents: ["codex"],
+            },
+          },
+        ],
       },
     };
 
@@ -819,6 +885,9 @@ describe("spawnAcpDirect", () => {
           {
             id: "research",
             heartbeat: { every: "0m" },
+            subagents: {
+              allowAgents: ["codex"],
+            },
           },
         ],
       },
@@ -1040,5 +1109,45 @@ describe("spawnAcpDirect", () => {
     expect(result.error).toContain('streamTo="parent"');
     expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
     expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
+  });
+
+  it("forbids ACP cross-agent spawning when the requester allowlist does not include the target", async () => {
+    hoisted.state.cfg = {
+      ...createDefaultSpawnConfig(),
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        allowedAgents: ["ops"],
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            subagents: {
+              allowAgents: ["research"],
+            },
+          },
+          {
+            id: "ops",
+          },
+        ],
+      },
+    };
+
+    const result = await spawnAcpDirect(
+      {
+        task: "do thing",
+        agentId: "ops",
+      },
+      {
+        agentSessionKey: "agent:main:subagent:parent",
+      },
+    );
+
+    expect(result).toEqual({
+      status: "forbidden",
+      error: "agentId is not allowed for sessions_spawn (allowed: research)",
+    });
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1148,6 +1148,7 @@ describe("spawnAcpDirect", () => {
       status: "forbidden",
       error: "agentId is not allowed for sessions_spawn (allowed: research)",
     });
+    expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -256,6 +256,32 @@ function normalizeOptionalAgentId(value: string | undefined | null): string | un
   return normalizeAgentId(trimmed);
 }
 
+function resolveCrossAgentAllowlistError(params: {
+  cfg: OpenClawConfig;
+  requesterAgentId?: string;
+  targetAgentId: string;
+}): string | undefined {
+  const requesterAgentId = normalizeOptionalAgentId(params.requesterAgentId);
+  if (!requesterAgentId || requesterAgentId === params.targetAgentId) {
+    return undefined;
+  }
+
+  const allowAgents =
+    resolveAgentConfig(params.cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+  const allowAny = allowAgents.some((value) => value.trim() === "*");
+  const allowSet = new Set(
+    allowAgents
+      .filter((value) => value.trim() && value.trim() !== "*")
+      .map((value) => normalizeAgentId(value).toLowerCase()),
+  );
+  if (allowAny || allowSet.has(params.targetAgentId.toLowerCase())) {
+    return undefined;
+  }
+
+  const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
+  return `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`;
+}
+
 function summarizeError(err: unknown): string {
   if (err instanceof Error) {
     return err.message;
@@ -506,6 +532,17 @@ export async function spawnAcpDirect(
     };
   }
   const targetAgentId = targetAgentResult.agentId;
+  const crossAgentAllowlistError = resolveCrossAgentAllowlistError({
+    cfg,
+    requesterAgentId,
+    targetAgentId,
+  });
+  if (crossAgentAllowlistError) {
+    return {
+      status: "forbidden",
+      error: crossAgentAllowlistError,
+    };
+  }
   const agentPolicyError = resolveAcpAgentPolicyError(cfg, targetAgentId);
   if (agentPolicyError) {
     return {


### PR DESCRIPTION
## Summary

- Problem: ACP-backed `sessions_spawn` did not enforce the requester agent's `subagents.allowAgents` allowlist.
- Why it matters: ACP-backed spawns should match the same cross-agent gating behavior as the existing subagent runtime.
- What changed: added the requester-target allowlist check to the ACP spawn path and covered it with regression tests.
- What did NOT change: ACP-specific runtime policy checks and existing target-agent gating remain in place.

## Change Type

- [x] Bug fix
- [x] Gateway / orchestration

## User-visible / Behavior Changes

- Cross-agent ACP spawns now fail when the requester agent does not allow the target agent.
- Allowed targets and self-targeting continue to work.

## Verification

- `pnpm test -- src/agents/acp-spawn.test.ts`

## Human Verification

- Verified scenarios: allowed ACP targets still spawn; disallowed cross-agent targets now return the existing forbidden error.
- Edge cases checked: self-targeting still bypasses the cross-agent gate, and wildcard allowlists still pass.
- What I did not verify: no live ACP backend session was exercised in this branch.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? Only if an existing ACP caller relied on cross-agent targets not listed in `allowAgents`.

## Failure Recovery

- How to disable/revert this change quickly: revert this PR.
- Known bad symptoms reviewers should watch for: ACP `sessions_spawn` calls returning the allowlist forbidden message for callers with incomplete agent allowlists.
