### PR TITLE
feat(feishu): add ACP and subagent session binding

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -532,6 +532,75 @@ Feishu supports streaming replies via interactive cards. When enabled, the bot u
 
 Set `streaming: false` to wait for the full reply before sending.
 
+### ACP sessions
+
+Feishu supports ACP for:
+
+- DMs
+- group topic conversations
+
+Feishu ACP is text-command driven. There are no native slash-command menus, so use `/acp ...` messages directly in the conversation.
+
+#### Persistent ACP bindings
+
+Use top-level typed ACP bindings to pin a Feishu DM or topic conversation to a persistent ACP session.
+
+```json5
+{
+  agents: {
+    list: [
+      {
+        id: "codex",
+        runtime: {
+          type: "acp",
+          acp: {
+            agent: "codex",
+            backend: "acpx",
+            mode: "persistent",
+            cwd: "/workspace/openclaw",
+          },
+        },
+      },
+    ],
+  },
+  bindings: [
+    {
+      type: "acp",
+      agentId: "codex",
+      match: {
+        channel: "feishu",
+        accountId: "default",
+        peer: { kind: "direct", id: "ou_1234567890" },
+      },
+    },
+    {
+      type: "acp",
+      agentId: "codex",
+      match: {
+        channel: "feishu",
+        accountId: "default",
+        peer: { kind: "group", id: "oc_group_chat:topic:om_topic_root" },
+      },
+      acp: { label: "codex-feishu-topic" },
+    },
+  ],
+}
+```
+
+#### Thread-bound ACP spawn from chat
+
+In a Feishu DM or topic conversation, you can spawn and bind an ACP session in place:
+
+```text
+/acp spawn codex --thread here
+```
+
+Notes:
+
+- `--thread here` works for DMs and Feishu topics.
+- Follow-up messages in the bound DM/topic route directly to that ACP session.
+- v1 does not target generic non-topic group chats.
+
 ### Multi-agent routing
 
 Use `bindings` to route Feishu DMs or groups to different agents.

--- a/extensions/feishu/index.test.ts
+++ b/extensions/feishu/index.test.ts
@@ -1,0 +1,68 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { describe, expect, it, vi } from "vitest";
+
+const registerFeishuDocToolsMock = vi.hoisted(() => vi.fn());
+const registerFeishuChatToolsMock = vi.hoisted(() => vi.fn());
+const registerFeishuWikiToolsMock = vi.hoisted(() => vi.fn());
+const registerFeishuDriveToolsMock = vi.hoisted(() => vi.fn());
+const registerFeishuPermToolsMock = vi.hoisted(() => vi.fn());
+const registerFeishuBitableToolsMock = vi.hoisted(() => vi.fn());
+const setFeishuRuntimeMock = vi.hoisted(() => vi.fn());
+const registerFeishuSubagentHooksMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./src/docx.js", () => ({
+  registerFeishuDocTools: registerFeishuDocToolsMock,
+}));
+
+vi.mock("./src/chat.js", () => ({
+  registerFeishuChatTools: registerFeishuChatToolsMock,
+}));
+
+vi.mock("./src/wiki.js", () => ({
+  registerFeishuWikiTools: registerFeishuWikiToolsMock,
+}));
+
+vi.mock("./src/drive.js", () => ({
+  registerFeishuDriveTools: registerFeishuDriveToolsMock,
+}));
+
+vi.mock("./src/perm.js", () => ({
+  registerFeishuPermTools: registerFeishuPermToolsMock,
+}));
+
+vi.mock("./src/bitable.js", () => ({
+  registerFeishuBitableTools: registerFeishuBitableToolsMock,
+}));
+
+vi.mock("./src/runtime.js", () => ({
+  setFeishuRuntime: setFeishuRuntimeMock,
+}));
+
+vi.mock("./src/subagent-hooks.js", () => ({
+  registerFeishuSubagentHooks: registerFeishuSubagentHooksMock,
+}));
+
+describe("feishu plugin register", () => {
+  it("registers the Feishu channel, tools, and subagent hooks", async () => {
+    const { default: plugin } = await import("./index.js");
+    const registerChannel = vi.fn();
+    const api = {
+      runtime: { log: vi.fn() },
+      registerChannel,
+      on: vi.fn(),
+      config: {},
+    } as unknown as OpenClawPluginApi;
+
+    plugin.register(api);
+
+    expect(setFeishuRuntimeMock).toHaveBeenCalledWith(api.runtime);
+    expect(registerChannel).toHaveBeenCalledTimes(1);
+    expect(registerFeishuSubagentHooksMock).toHaveBeenCalledWith(api);
+    expect(registerFeishuDocToolsMock).toHaveBeenCalledWith(api);
+    expect(registerFeishuChatToolsMock).toHaveBeenCalledWith(api);
+    expect(registerFeishuWikiToolsMock).toHaveBeenCalledWith(api);
+    expect(registerFeishuDriveToolsMock).toHaveBeenCalledWith(api);
+    expect(registerFeishuPermToolsMock).toHaveBeenCalledWith(api);
+    expect(registerFeishuBitableToolsMock).toHaveBeenCalledWith(api);
+  });
+});

--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
+import { registerFeishuSubagentHooks } from "./src/subagent-hooks.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
@@ -53,6 +54,7 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setFeishuRuntime(api.runtime);
     api.registerChannel({ plugin: feishuPlugin });
+    registerFeishuSubagentHooks(api);
     registerFeishuDocTools(api);
     registerFeishuChatTools(api);
     registerFeishuWikiTools(api);

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -21,6 +21,10 @@ const {
   mockResolveAgentRoute,
   mockReadSessionUpdatedAt,
   mockResolveStorePath,
+  mockResolveConfiguredAcpRoute,
+  mockEnsureConfiguredAcpRouteReady,
+  mockResolveBoundConversation,
+  mockTouchBinding,
 } = vi.hoisted(() => ({
   mockCreateFeishuReplyDispatcher: vi.fn(() => ({
     dispatcher: vi.fn(),
@@ -46,6 +50,13 @@ const {
   })),
   mockReadSessionUpdatedAt: vi.fn(),
   mockResolveStorePath: vi.fn(() => "/tmp/feishu-sessions.json"),
+  mockResolveConfiguredAcpRoute: vi.fn(({ route }) => ({
+    configuredBinding: null,
+    route,
+  })),
+  mockEnsureConfiguredAcpRouteReady: vi.fn(async (_params?: unknown) => ({ ok: true })),
+  mockResolveBoundConversation: vi.fn(() => null),
+  mockTouchBinding: vi.fn(),
 }));
 
 vi.mock("./reply-dispatcher.js", () => ({
@@ -64,6 +75,18 @@ vi.mock("./media.js", () => ({
 
 vi.mock("./client.js", () => ({
   createFeishuClient: mockCreateFeishuClient,
+}));
+
+vi.mock("../../../src/acp/persistent-bindings.route.js", () => ({
+  resolveConfiguredAcpRoute: (params: unknown) => mockResolveConfiguredAcpRoute(params),
+  ensureConfiguredAcpRouteReady: (params: unknown) => mockEnsureConfiguredAcpRouteReady(params),
+}));
+
+vi.mock("../../../src/infra/outbound/session-binding-service.js", () => ({
+  getSessionBindingService: () => ({
+    resolveByConversation: mockResolveBoundConversation,
+    touch: mockTouchBinding,
+  }),
 }));
 
 function createRuntimeEnv(): RuntimeEnv {
@@ -110,6 +133,261 @@ describe("buildFeishuAgentBody", () => {
   });
 });
 
+describe("handleFeishuMessage ACP routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveConfiguredAcpRoute.mockReset().mockImplementation(
+      ({ route }) =>
+        ({
+          configuredBinding: null,
+          route,
+        }) as any,
+    );
+    mockEnsureConfiguredAcpRouteReady.mockReset().mockResolvedValue({ ok: true });
+    mockResolveBoundConversation.mockReset().mockReturnValue(null);
+    mockTouchBinding.mockReset();
+    mockResolveAgentRoute.mockReset().mockReturnValue({
+      agentId: "main",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:main:feishu:direct:ou_sender_1",
+      mainSessionKey: "agent:main:main",
+      matchedBy: "default",
+    });
+    mockSendMessageFeishu
+      .mockReset()
+      .mockResolvedValue({ messageId: "reply-msg", chatId: "oc_dm" });
+    mockCreateFeishuReplyDispatcher.mockReset().mockReturnValue({
+      dispatcher: {
+        sendToolResult: vi.fn(),
+        sendBlockReply: vi.fn(),
+        sendFinalReply: vi.fn(),
+        waitForIdle: vi.fn(),
+        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        markComplete: vi.fn(),
+      } as any,
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+    });
+
+    setFeishuRuntime(
+      createPluginRuntimeMock({
+        channel: {
+          routing: {
+            resolveAgentRoute:
+              mockResolveAgentRoute as unknown as PluginRuntime["channel"]["routing"]["resolveAgentRoute"],
+          },
+          session: {
+            readSessionUpdatedAt:
+              mockReadSessionUpdatedAt as unknown as PluginRuntime["channel"]["session"]["readSessionUpdatedAt"],
+            resolveStorePath:
+              mockResolveStorePath as unknown as PluginRuntime["channel"]["session"]["resolveStorePath"],
+          },
+          reply: {
+            resolveEnvelopeFormatOptions: vi.fn(
+              () => ({}),
+            ) as unknown as PluginRuntime["channel"]["reply"]["resolveEnvelopeFormatOptions"],
+            formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+            finalizeInboundContext: ((ctx: unknown) =>
+              ctx) as unknown as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
+            dispatchReplyFromConfig: vi.fn().mockResolvedValue({
+              queuedFinal: false,
+              counts: { final: 1 },
+            }),
+            withReplyDispatcher: vi.fn(
+              async ({
+                run,
+              }: Parameters<PluginRuntime["channel"]["reply"]["withReplyDispatcher"]>[0]) =>
+                await run(),
+            ) as unknown as PluginRuntime["channel"]["reply"]["withReplyDispatcher"],
+          },
+          commands: {
+            shouldComputeCommandAuthorized: vi.fn(() => false),
+            resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+          },
+          pairing: {
+            readAllowFromStore: vi.fn().mockResolvedValue(["ou_sender_1"]),
+            upsertPairingRequest: vi.fn(),
+            buildPairingReply: vi.fn(),
+          },
+        },
+      }),
+    );
+  });
+
+  it("ensures configured ACP routes for Feishu DMs", async () => {
+    mockResolveConfiguredAcpRoute.mockReturnValue({
+      configuredBinding: {
+        spec: {
+          channel: "feishu",
+          accountId: "default",
+          conversationId: "ou_sender_1",
+          agentId: "codex",
+          mode: "persistent",
+        },
+        record: {
+          bindingId: "config:acp:feishu:default:ou_sender_1",
+          targetSessionKey: "agent:codex:acp:binding:feishu:default:abc123",
+          targetKind: "session",
+          conversation: {
+            channel: "feishu",
+            accountId: "default",
+            conversationId: "ou_sender_1",
+          },
+          status: "active",
+          boundAt: 0,
+          metadata: { source: "config" },
+        },
+      },
+      route: {
+        agentId: "codex",
+        channel: "feishu",
+        accountId: "default",
+        sessionKey: "agent:codex:acp:binding:feishu:default:abc123",
+        mainSessionKey: "agent:codex:main",
+        matchedBy: "binding.channel",
+      },
+    } as any);
+
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-1",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockResolveConfiguredAcpRoute).toHaveBeenCalledTimes(1);
+    expect(mockEnsureConfiguredAcpRouteReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces configured ACP initialization failures to the Feishu conversation", async () => {
+    mockResolveConfiguredAcpRoute.mockReturnValue({
+      configuredBinding: {
+        spec: {
+          channel: "feishu",
+          accountId: "default",
+          conversationId: "ou_sender_1",
+          agentId: "codex",
+          mode: "persistent",
+        },
+        record: {
+          bindingId: "config:acp:feishu:default:ou_sender_1",
+          targetSessionKey: "agent:codex:acp:binding:feishu:default:abc123",
+          targetKind: "session",
+          conversation: {
+            channel: "feishu",
+            accountId: "default",
+            conversationId: "ou_sender_1",
+          },
+          status: "active",
+          boundAt: 0,
+          metadata: { source: "config" },
+        },
+      },
+      route: {
+        agentId: "codex",
+        channel: "feishu",
+        accountId: "default",
+        sessionKey: "agent:codex:acp:binding:feishu:default:abc123",
+        mainSessionKey: "agent:codex:main",
+        matchedBy: "binding.channel",
+      },
+    } as any);
+    mockEnsureConfiguredAcpRouteReady.mockResolvedValue({
+      ok: false,
+      error: "runtime unavailable",
+    } as any);
+
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-2",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockSendMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:oc_dm",
+        text: expect.stringContaining("runtime unavailable"),
+      }),
+    );
+  });
+
+  it("routes Feishu topic messages through active bound conversations", async () => {
+    mockResolveBoundConversation.mockReturnValue({
+      bindingId: "default:oc_group_chat:topic:om_topic_root",
+      targetSessionKey: "agent:codex:acp:binding:feishu:default:feedface",
+      targetKind: "session",
+      conversation: {
+        channel: "feishu",
+        accountId: "default",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+        parentConversationId: "oc_group_chat",
+      },
+      status: "active",
+      boundAt: 0,
+    } as any);
+
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            groups: {
+              oc_group_chat: {
+                allow: true,
+                requireMention: false,
+                groupSessionScope: "group_topic",
+              },
+            },
+          },
+        },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-3",
+          chat_id: "oc_group_chat",
+          chat_type: "group",
+          message_type: "text",
+          root_id: "om_topic_root",
+          content: JSON.stringify({ text: "hello topic" }),
+        },
+      },
+    });
+
+    expect(mockResolveBoundConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "feishu",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+      }),
+    );
+    expect(mockTouchBinding).toHaveBeenCalledWith("default:oc_group_chat:topic:om_topic_root");
+  });
+});
+
 describe("handleFeishuMessage command authorization", () => {
   const mockFinalizeInboundContext = vi.fn((ctx: unknown) => ctx);
   const mockDispatchReplyFromConfig = vi
@@ -153,6 +431,16 @@ describe("handleFeishuMessage command authorization", () => {
     mockListFeishuThreadMessages.mockReset().mockResolvedValue([]);
     mockReadSessionUpdatedAt.mockReturnValue(undefined);
     mockResolveStorePath.mockReturnValue("/tmp/feishu-sessions.json");
+    mockResolveConfiguredAcpRoute.mockReset().mockImplementation(
+      ({ route }) =>
+        ({
+          configuredBinding: null,
+          route,
+        }) as any,
+    );
+    mockEnsureConfiguredAcpRouteReady.mockReset().mockResolvedValue({ ok: true });
+    mockResolveBoundConversation.mockReset().mockReturnValue(null);
+    mockTouchBinding.mockReset();
     mockResolveAgentRoute.mockReturnValue({
       agentId: "main",
       channel: "feishu",

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1262,6 +1262,9 @@ export async function handleFeishuMessage(params: {
       configuredBinding = configuredRoute.configuredBinding;
       route = configuredRoute.route;
 
+      // Bound Feishu conversations intentionally require an exact live conversation-id match.
+      // Sender-scoped topic sessions therefore bind on `chat:topic:root:sender:user`, while
+      // configured ACP bindings may still inherit the shared `chat:topic:root` topic session.
       const threadBinding = getSessionBindingService().resolveByConversation({
         channel: "feishu",
         accountId: account.accountId,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -14,8 +14,16 @@ import {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/feishu";
+import {
+  ensureConfiguredAcpRouteReady,
+  resolveConfiguredAcpRoute,
+} from "../../../src/acp/persistent-bindings.route.js";
+import { getSessionBindingService } from "../../../src/infra/outbound/session-binding-service.js";
+import { deriveLastRoutePolicy } from "../../../src/routing/resolve-route.js";
+import { resolveAgentIdFromSessionKey } from "../../../src/routing/session-key.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { buildFeishuConversationId } from "./conversation-id.js";
 import { finalizeFeishuMessageProcessing, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
@@ -273,15 +281,34 @@ function resolveFeishuGroupSession(params: {
   let peerId = chatId;
   switch (groupSessionScope) {
     case "group_sender":
-      peerId = `${chatId}:sender:${senderOpenId}`;
+      peerId = buildFeishuConversationId({
+        chatId,
+        scope: "group_sender",
+        senderOpenId,
+      });
       break;
     case "group_topic":
-      peerId = topicScope ? `${chatId}:topic:${topicScope}` : chatId;
+      peerId = topicScope
+        ? buildFeishuConversationId({
+            chatId,
+            scope: "group_topic",
+            topicId: topicScope,
+          })
+        : chatId;
       break;
     case "group_topic_sender":
       peerId = topicScope
-        ? `${chatId}:topic:${topicScope}:sender:${senderOpenId}`
-        : `${chatId}:sender:${senderOpenId}`;
+        ? buildFeishuConversationId({
+            chatId,
+            scope: "group_topic_sender",
+            topicId: topicScope,
+            senderOpenId,
+          })
+        : buildFeishuConversationId({
+            chatId,
+            scope: "group_sender",
+            senderOpenId,
+          });
       break;
     case "group":
     default:
@@ -1168,6 +1195,10 @@ export async function handleFeishuMessage(params: {
     const peerId = isGroup ? (groupSession?.peerId ?? ctx.chatId) : ctx.senderOpenId;
     const parentPeer = isGroup ? (groupSession?.parentPeer ?? null) : null;
     const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : false;
+    const feishuAcpConversationSupported =
+      !isGroup ||
+      groupSession?.groupSessionScope === "group_topic" ||
+      groupSession?.groupSessionScope === "group_topic_sender";
 
     if (isGroup && groupSession) {
       log(
@@ -1213,6 +1244,73 @@ export async function handleFeishuMessage(params: {
             `feishu[${account.accountId}]: dynamic agent created, new route: ${route.sessionKey}`,
           );
         }
+      }
+    }
+
+    const currentConversationId = peerId;
+    const parentConversationId = isGroup ? (parentPeer?.id ?? ctx.chatId) : undefined;
+    let configuredBinding = null;
+    if (feishuAcpConversationSupported) {
+      const configuredRoute = resolveConfiguredAcpRoute({
+        cfg: effectiveCfg,
+        route,
+        channel: "feishu",
+        accountId: account.accountId,
+        conversationId: currentConversationId,
+        parentConversationId,
+      });
+      configuredBinding = configuredRoute.configuredBinding;
+      route = configuredRoute.route;
+
+      const threadBinding = getSessionBindingService().resolveByConversation({
+        channel: "feishu",
+        accountId: account.accountId,
+        conversationId: currentConversationId,
+        ...(parentConversationId ? { parentConversationId } : {}),
+      });
+      const boundSessionKey = threadBinding?.targetSessionKey?.trim();
+      if (threadBinding && boundSessionKey) {
+        route = {
+          ...route,
+          sessionKey: boundSessionKey,
+          agentId: resolveAgentIdFromSessionKey(boundSessionKey) || route.agentId,
+          lastRoutePolicy: deriveLastRoutePolicy({
+            sessionKey: boundSessionKey,
+            mainSessionKey: route.mainSessionKey,
+          }),
+          matchedBy: "binding.channel",
+        };
+        configuredBinding = null;
+        getSessionBindingService().touch(threadBinding.bindingId);
+        log(
+          `feishu[${account.accountId}]: routed via bound conversation ${currentConversationId} -> ${boundSessionKey}`,
+        );
+      }
+    }
+
+    if (configuredBinding) {
+      const ensured = await ensureConfiguredAcpRouteReady({
+        cfg: effectiveCfg,
+        configuredBinding,
+      });
+      if (!ensured.ok) {
+        const replyTargetMessageId =
+          isGroup &&
+          (groupSession?.groupSessionScope === "group_topic" ||
+            groupSession?.groupSessionScope === "group_topic_sender")
+            ? (ctx.rootId ?? ctx.messageId)
+            : ctx.messageId;
+        await sendMessageFeishu({
+          cfg: effectiveCfg,
+          to: `chat:${ctx.chatId}`,
+          text: `⚠️ Failed to initialize the configured ACP session for this Feishu conversation: ${ensured.error}`,
+          replyToMessageId: replyTargetMessageId,
+          replyInThread: isGroup ? (groupSession?.replyInThread ?? false) : false,
+          accountId: account.accountId,
+        }).catch((err) => {
+          log(`feishu[${account.accountId}]: failed to send ACP init error reply: ${String(err)}`);
+        });
+        return;
       }
     }
 

--- a/extensions/feishu/src/conversation-id.ts
+++ b/extensions/feishu/src/conversation-id.ts
@@ -1,0 +1,125 @@
+export type FeishuGroupSessionScope =
+  | "group"
+  | "group_sender"
+  | "group_topic"
+  | "group_topic_sender";
+
+function normalizeText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function buildFeishuConversationId(params: {
+  chatId: string;
+  scope: FeishuGroupSessionScope;
+  senderOpenId?: string;
+  topicId?: string;
+}): string {
+  const chatId = normalizeText(params.chatId) ?? "unknown";
+  const senderOpenId = normalizeText(params.senderOpenId);
+  const topicId = normalizeText(params.topicId);
+
+  switch (params.scope) {
+    case "group_sender":
+      return senderOpenId ? `${chatId}:sender:${senderOpenId}` : chatId;
+    case "group_topic":
+      return topicId ? `${chatId}:topic:${topicId}` : chatId;
+    case "group_topic_sender":
+      if (topicId && senderOpenId) {
+        return `${chatId}:topic:${topicId}:sender:${senderOpenId}`;
+      }
+      if (topicId) {
+        return `${chatId}:topic:${topicId}`;
+      }
+      return senderOpenId ? `${chatId}:sender:${senderOpenId}` : chatId;
+    case "group":
+    default:
+      return chatId;
+  }
+}
+
+export function parseFeishuConversationId(params: {
+  conversationId: string;
+  parentConversationId?: string;
+}): {
+  canonicalConversationId: string;
+  chatId: string;
+  topicId?: string;
+  senderOpenId?: string;
+  scope: FeishuGroupSessionScope;
+} | null {
+  const conversationId = normalizeText(params.conversationId);
+  const parentConversationId = normalizeText(params.parentConversationId);
+  if (!conversationId) {
+    return null;
+  }
+
+  const topicSenderMatch = conversationId.match(/^(.+):topic:([^:]+):sender:([^:]+)$/);
+  if (topicSenderMatch) {
+    const [, chatId, topicId, senderOpenId] = topicSenderMatch;
+    return {
+      canonicalConversationId: buildFeishuConversationId({
+        chatId,
+        scope: "group_topic_sender",
+        topicId,
+        senderOpenId,
+      }),
+      chatId,
+      topicId,
+      senderOpenId,
+      scope: "group_topic_sender",
+    };
+  }
+
+  const topicMatch = conversationId.match(/^(.+):topic:([^:]+)$/);
+  if (topicMatch) {
+    const [, chatId, topicId] = topicMatch;
+    return {
+      canonicalConversationId: buildFeishuConversationId({
+        chatId,
+        scope: "group_topic",
+        topicId,
+      }),
+      chatId,
+      topicId,
+      scope: "group_topic",
+    };
+  }
+
+  const senderMatch = conversationId.match(/^(.+):sender:([^:]+)$/);
+  if (senderMatch) {
+    const [, chatId, senderOpenId] = senderMatch;
+    return {
+      canonicalConversationId: buildFeishuConversationId({
+        chatId,
+        scope: "group_sender",
+        senderOpenId,
+      }),
+      chatId,
+      senderOpenId,
+      scope: "group_sender",
+    };
+  }
+
+  if (parentConversationId) {
+    return {
+      canonicalConversationId: buildFeishuConversationId({
+        chatId: parentConversationId,
+        scope: "group_topic",
+        topicId: conversationId,
+      }),
+      chatId: parentConversationId,
+      topicId: conversationId,
+      scope: "group_topic",
+    };
+  }
+
+  return {
+    canonicalConversationId: conversationId,
+    chatId: conversationId,
+    scope: "group",
+  };
+}

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -24,6 +24,7 @@ import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
+import { createFeishuThreadBindingManager } from "./thread-bindings.js";
 import type { FeishuChatType, ResolvedFeishuAccount } from "./types.js";
 
 const FEISHU_REACTION_VERIFY_TIMEOUT_MS = 1_500;
@@ -631,19 +632,25 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
     log(`feishu[${accountId}]: dedup warmup loaded ${warmupCount} entries from disk`);
   }
 
-  const eventDispatcher = createEventDispatcher(account);
-  const chatHistories = new Map<string, HistoryEntry[]>();
+  let threadBindingManager: ReturnType<typeof createFeishuThreadBindingManager> | null = null;
+  try {
+    const eventDispatcher = createEventDispatcher(account);
+    const chatHistories = new Map<string, HistoryEntry[]>();
+    threadBindingManager = createFeishuThreadBindingManager({ accountId, cfg });
 
-  registerEventHandlers(eventDispatcher, {
-    cfg,
-    accountId,
-    runtime,
-    chatHistories,
-    fireAndForget: true,
-  });
+    registerEventHandlers(eventDispatcher, {
+      cfg,
+      accountId,
+      runtime,
+      chatHistories,
+      fireAndForget: true,
+    });
 
-  if (connectionMode === "webhook") {
-    return monitorWebhook({ account, accountId, runtime, abortSignal, eventDispatcher });
+    if (connectionMode === "webhook") {
+      return await monitorWebhook({ account, accountId, runtime, abortSignal, eventDispatcher });
+    }
+    return await monitorWebSocket({ account, accountId, runtime, abortSignal, eventDispatcher });
+  } finally {
+    threadBindingManager?.stop();
   }
-  return monitorWebSocket({ account, accountId, runtime, abortSignal, eventDispatcher });
 }

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -17,6 +17,7 @@ const handleFeishuMessageMock = vi.hoisted(() => vi.fn(async (_params: { event?:
 const createEventDispatcherMock = vi.hoisted(() => vi.fn());
 const monitorWebSocketMock = vi.hoisted(() => vi.fn(async () => {}));
 const monitorWebhookMock = vi.hoisted(() => vi.fn(async () => {}));
+const createFeishuThreadBindingManagerMock = vi.hoisted(() => vi.fn(() => ({ stop: vi.fn() })));
 
 let handlers: Record<string, (data: unknown) => Promise<void>> = {};
 
@@ -35,6 +36,10 @@ vi.mock("./bot.js", async () => {
 vi.mock("./monitor.transport.js", () => ({
   monitorWebSocket: monitorWebSocketMock,
   monitorWebhook: monitorWebhookMock,
+}));
+
+vi.mock("./thread-bindings.js", () => ({
+  createFeishuThreadBindingManager: createFeishuThreadBindingManagerMock,
 }));
 
 const cfg = {} as ClawdbotConfig;
@@ -416,6 +421,94 @@ describe("resolveReactionSyntheticEvent", () => {
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining("ignoring reaction on non-bot/unverified message om_msg1"),
     );
+  });
+});
+
+describe("monitorSingleAccount lifecycle", () => {
+  beforeEach(() => {
+    createFeishuThreadBindingManagerMock.mockReset().mockImplementation(() => ({
+      stop: vi.fn(),
+    }));
+    createEventDispatcherMock.mockReset().mockReturnValue({
+      register: vi.fn(),
+    });
+  });
+
+  it("stops the Feishu thread binding manager when the monitor exits", async () => {
+    setFeishuRuntime(
+      createPluginRuntimeMock({
+        channel: {
+          debounce: {
+            resolveInboundDebounceMs,
+            createInboundDebouncer,
+          },
+          text: {
+            hasControlCommand,
+          },
+        },
+      }),
+    );
+
+    await monitorSingleAccount({
+      cfg: buildDebounceConfig(),
+      account: buildDebounceAccount(),
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      } as RuntimeEnv,
+      botOpenIdSource: {
+        kind: "prefetched",
+        botOpenId: "ou_bot",
+      },
+    });
+
+    const manager = createFeishuThreadBindingManagerMock.mock.results[0]?.value as
+      | { stop: ReturnType<typeof vi.fn> }
+      | undefined;
+    expect(manager?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the Feishu thread binding manager when setup fails before transport starts", async () => {
+    setFeishuRuntime(
+      createPluginRuntimeMock({
+        channel: {
+          debounce: {
+            resolveInboundDebounceMs,
+            createInboundDebouncer,
+          },
+          text: {
+            hasControlCommand,
+          },
+        },
+      }),
+    );
+    createEventDispatcherMock.mockReturnValue({
+      get register() {
+        throw new Error("register failed");
+      },
+    });
+
+    await expect(
+      monitorSingleAccount({
+        cfg: buildDebounceConfig(),
+        account: buildDebounceAccount(),
+        runtime: {
+          log: vi.fn(),
+          error: vi.fn(),
+          exit: vi.fn(),
+        } as RuntimeEnv,
+        botOpenIdSource: {
+          kind: "prefetched",
+          botOpenId: "ou_bot",
+        },
+      }),
+    ).rejects.toThrow("register failed");
+
+    const manager = createFeishuThreadBindingManagerMock.mock.results[0]?.value as
+      | { stop: ReturnType<typeof vi.fn> }
+      | undefined;
+    expect(manager?.stop).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/extensions/feishu/src/subagent-hooks.test.ts
+++ b/extensions/feishu/src/subagent-hooks.test.ts
@@ -1,0 +1,623 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerFeishuSubagentHooks } from "./subagent-hooks.js";
+import {
+  __testing as threadBindingTesting,
+  createFeishuThreadBindingManager,
+} from "./thread-bindings.js";
+
+const baseConfig = {
+  session: { mainKey: "main", scope: "per-sender" },
+  channels: { feishu: {} },
+};
+
+function registerHandlersForTest(config: Record<string, unknown> = baseConfig) {
+  const handlers = new Map<string, (event: unknown, ctx: unknown) => unknown>();
+  const api = {
+    config,
+    on: (hookName: string, handler: (event: unknown, ctx: unknown) => unknown) => {
+      handlers.set(hookName, handler);
+    },
+  } as unknown as OpenClawPluginApi;
+  registerFeishuSubagentHooks(api);
+  return handlers;
+}
+
+function getRequiredHandler(
+  handlers: Map<string, (event: unknown, ctx: unknown) => unknown>,
+  hookName: string,
+): (event: unknown, ctx: unknown) => unknown {
+  const handler = handlers.get(hookName);
+  if (!handler) {
+    throw new Error(`expected ${hookName} hook handler`);
+  }
+  return handler;
+}
+
+describe("feishu subagent hook handlers", () => {
+  beforeEach(() => {
+    threadBindingTesting.resetFeishuThreadBindingsForTests();
+  });
+
+  it("registers Feishu subagent hooks", () => {
+    const handlers = registerHandlersForTest();
+    expect(handlers.has("subagent_spawning")).toBe(true);
+    expect(handlers.has("subagent_delivery_target")).toBe(true);
+    expect(handlers.has("subagent_ended")).toBe(true);
+    expect(handlers.has("subagent_spawned")).toBe(false);
+  });
+
+  it("binds a Feishu DM conversation on subagent_spawning", async () => {
+    const handlers = registerHandlersForTest();
+    const handler = getRequiredHandler(handlers, "subagent_spawning");
+    createFeishuThreadBindingManager({ cfg: baseConfig as any, accountId: "work" });
+
+    const result = await handler(
+      {
+        childSessionKey: "agent:main:subagent:child",
+        agentId: "codex",
+        label: "banana",
+        mode: "session",
+        requester: {
+          channel: "feishu",
+          accountId: "work",
+          to: "user:ou_sender_1",
+        },
+        threadRequested: true,
+      },
+      {},
+    );
+
+    expect(result).toEqual({ status: "ok", threadBindingReady: true });
+
+    const deliveryTargetHandler = getRequiredHandler(handlers, "subagent_delivery_target");
+    expect(
+      deliveryTargetHandler(
+        {
+          childSessionKey: "agent:main:subagent:child",
+          requesterSessionKey: "agent:main:main",
+          requesterOrigin: {
+            channel: "feishu",
+            accountId: "work",
+            to: "user:ou_sender_1",
+          },
+          expectsCompletionMessage: true,
+        },
+        {},
+      ),
+    ).toEqual({
+      origin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "user:ou_sender_1",
+      },
+    });
+  });
+
+  it("preserves the original Feishu DM delivery target", async () => {
+    const handlers = registerHandlersForTest();
+    const deliveryHandler = getRequiredHandler(handlers, "subagent_delivery_target");
+    const manager = createFeishuThreadBindingManager({ cfg: baseConfig as any, accountId: "work" });
+
+    manager.bindConversation({
+      conversationId: "ou_sender_1",
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:subagent:chat-dm-child",
+      metadata: {
+        deliveryTo: "chat:oc_dm_chat_1",
+        boundBy: "system",
+      },
+    });
+
+    expect(
+      deliveryHandler(
+        {
+          childSessionKey: "agent:main:subagent:chat-dm-child",
+          requesterSessionKey: "agent:main:main",
+          requesterOrigin: {
+            channel: "feishu",
+            accountId: "work",
+            to: "chat:oc_dm_chat_1",
+          },
+          expectsCompletionMessage: true,
+        },
+        {},
+      ),
+    ).toEqual({
+      origin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "chat:oc_dm_chat_1",
+      },
+    });
+  });
+
+  it("binds a Feishu topic conversation and preserves parent context", async () => {
+    const handlers = registerHandlersForTest();
+    const spawnHandler = getRequiredHandler(handlers, "subagent_spawning");
+    const deliveryHandler = getRequiredHandler(handlers, "subagent_delivery_target");
+    createFeishuThreadBindingManager({ cfg: baseConfig as any, accountId: "work" });
+
+    const result = await spawnHandler(
+      {
+        childSessionKey: "agent:main:subagent:topic-child",
+        agentId: "codex",
+        label: "topic-child",
+        mode: "session",
+        requester: {
+          channel: "feishu",
+          accountId: "work",
+          to: "chat:oc_group_chat",
+          threadId: "om_topic_root",
+        },
+        threadRequested: true,
+      },
+      {},
+    );
+
+    expect(result).toEqual({ status: "ok", threadBindingReady: true });
+    expect(
+      deliveryHandler(
+        {
+          childSessionKey: "agent:main:subagent:topic-child",
+          requesterSessionKey: "agent:main:main",
+          requesterOrigin: {
+            channel: "feishu",
+            accountId: "work",
+            to: "chat:oc_group_chat",
+            threadId: "om_topic_root",
+          },
+          expectsCompletionMessage: true,
+        },
+        {},
+      ),
+    ).toEqual({
+      origin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "chat:oc_group_chat",
+        threadId: "om_topic_root",
+      },
+    });
+  });
+
+  it("uses the requester session binding to preserve sender-scoped topic conversations", async () => {
+    const handlers = registerHandlersForTest();
+    const spawnHandler = getRequiredHandler(handlers, "subagent_spawning");
+    const deliveryHandler = getRequiredHandler(handlers, "subagent_delivery_target");
+    const manager = createFeishuThreadBindingManager({ cfg: baseConfig as any, accountId: "work" });
+
+    manager.bindConversation({
+      conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_sender_1",
+      parentConversationId: "oc_group_chat",
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:parent",
+      metadata: {
+        agentId: "codex",
+        label: "parent",
+        boundBy: "system",
+      },
+    });
+
+    const reboundResult = await spawnHandler(
+      {
+        childSessionKey: "agent:main:subagent:sender-child",
+        agentId: "codex",
+        label: "sender-child",
+        mode: "session",
+        requester: {
+          channel: "feishu",
+          accountId: "work",
+          to: "chat:oc_group_chat",
+          threadId: "om_topic_root",
+        },
+        threadRequested: true,
+      },
+      {
+        requesterSessionKey: "agent:main:parent",
+      },
+    );
+
+    expect(reboundResult).toEqual({ status: "ok", threadBindingReady: true });
+    expect(manager.listBySessionKey("agent:main:subagent:sender-child")).toMatchObject([
+      {
+        conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_sender_1",
+        parentConversationId: "oc_group_chat",
+      },
+    ]);
+    expect(
+      deliveryHandler(
+        {
+          childSessionKey: "agent:main:subagent:sender-child",
+          requesterSessionKey: "agent:main:parent",
+          requesterOrigin: {
+            channel: "feishu",
+            accountId: "work",
+            to: "chat:oc_group_chat",
+            threadId: "om_topic_root",
+          },
+          expectsCompletionMessage: true,
+        },
+        {},
+      ),
+    ).toEqual({
+      origin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "chat:oc_group_chat",
+        threadId: "om_topic_root",
+      },
+    });
+  });
+
+  it("prefers requester-matching bindings when multiple child bindings exist", async () => {
+    const handlers = registerHandlersForTest();
+    const spawnHandler = getRequiredHandler(handlers, "subagent_spawning");
+    const deliveryHandler = getRequiredHandler(handlers, "subagent_delivery_target");
+    createFeishuThreadBindingManager({ cfg: baseConfig as any, accountId: "work" });
+
+    await spawnHandler(
+      {
+        childSessionKey: "agent:main:subagent:shared",
+        agentId: "codex",
+        label: "shared",
+        mode: "session",
+        requester: {
+          channel: "feishu",
+          accountId: "work",
+          to: "user:ou_sender_1",
+        },
+        threadRequested: true,
+      },
+      {},
+    );
+    await spawnHandler(
+      {
+        childSessionKey: "agent:main:subagent:shared",
+        agentId: "codex",
+        label: "shared",
+        mode: "session",
+        requester: {
+          channel: "feishu",
+          accountId: "work",
+          to: "user:ou_sender_2",
+        },
+        threadRequested: true,
+      },
+      {},
+    );
+
+    expect(
+      deliveryHandler(
+        {
+          childSessionKey: "agent:main:subagent:shared",
+          requesterSessionKey: "agent:main:main",
+          requesterOrigin: {
+            channel: "feishu",
+            accountId: "work",
+            to: "user:ou_sender_2",
+          },
+          expectsCompletionMessage: true,
+        },
+        {},
+      ),
+    ).toEqual({
+      origin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "user:ou_sender_2",
+      },
+    });
+  });
+
+  it("fails closed when requester-session bindings remain ambiguous for the same topic", async () => {
+    const handlers = registerHandlersForTest();
+    const spawnHandler = getRequiredHandler(handlers, "subagent_spawning");
+    const deliveryHandler = getRequiredHandler(handlers, "subagent_delivery_target");
+    const manager = createFeishuThreadBindingManager({ cfg: baseConfig as any, accountId: "work" });
+
+    manager.bindConversation({
+      conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_sender_1",
+      parentConversationId: "oc_group_chat",
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:parent",
+      metadata: { boundBy: "system" },
+    });
+    manager.bindConversation({
+      conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_sender_2",
+      parentConversationId: "oc_group_chat",
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:parent",
+      metadata: { boundBy: "system" },
+    });
+
+    await expect(
+      spawnHandler(
+        {
+          childSessionKey: "agent:main:subagent:ambiguous-child",
+          agentId: "codex",
+          label: "ambiguous-child",
+          mode: "session",
+          requester: {
+            channel: "feishu",
+            accountId: "work",
+            to: "chat:oc_group_chat",
+            threadId: "om_topic_root",
+          },
+          threadRequested: true,
+        },
+        {
+          requesterSessionKey: "agent:main:parent",
+        },
+      ),
+    ).resolves.toMatchObject({
+      status: "error",
+      error: expect.stringContaining("direct messages or topic conversations"),
+    });
+
+    expect(
+      deliveryHandler(
+        {
+          childSessionKey: "agent:main:subagent:ambiguous-child",
+          requesterSessionKey: "agent:main:parent",
+          requesterOrigin: {
+            channel: "feishu",
+            accountId: "work",
+            to: "chat:oc_group_chat",
+            threadId: "om_topic_root",
+          },
+          expectsCompletionMessage: true,
+        },
+        {},
+      ),
+    ).toBeUndefined();
+  });
+
+  it("fails closed when both topic-level and sender-scoped requester bindings exist", async () => {
+    const handlers = registerHandlersForTest();
+    const spawnHandler = getRequiredHandler(handlers, "subagent_spawning");
+    const deliveryHandler = getRequiredHandler(handlers, "subagent_delivery_target");
+    const manager = createFeishuThreadBindingManager({ cfg: baseConfig as any, accountId: "work" });
+
+    manager.bindConversation({
+      conversationId: "oc_group_chat:topic:om_topic_root",
+      parentConversationId: "oc_group_chat",
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:parent",
+      metadata: { boundBy: "system" },
+    });
+    manager.bindConversation({
+      conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_sender_1",
+      parentConversationId: "oc_group_chat",
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:parent",
+      metadata: { boundBy: "system" },
+    });
+
+    await expect(
+      spawnHandler(
+        {
+          childSessionKey: "agent:main:subagent:mixed-topic-child",
+          agentId: "codex",
+          label: "mixed-topic-child",
+          mode: "session",
+          requester: {
+            channel: "feishu",
+            accountId: "work",
+            to: "chat:oc_group_chat",
+            threadId: "om_topic_root",
+          },
+          threadRequested: true,
+        },
+        {
+          requesterSessionKey: "agent:main:parent",
+        },
+      ),
+    ).resolves.toMatchObject({
+      status: "error",
+      error: expect.stringContaining("direct messages or topic conversations"),
+    });
+
+    expect(
+      deliveryHandler(
+        {
+          childSessionKey: "agent:main:subagent:mixed-topic-child",
+          requesterSessionKey: "agent:main:parent",
+          requesterOrigin: {
+            channel: "feishu",
+            accountId: "work",
+            to: "chat:oc_group_chat",
+            threadId: "om_topic_root",
+          },
+          expectsCompletionMessage: true,
+        },
+        {},
+      ),
+    ).toBeUndefined();
+  });
+
+  it("no-ops for non-Feishu channels and non-threaded spawns", async () => {
+    const handlers = registerHandlersForTest();
+    const spawnHandler = getRequiredHandler(handlers, "subagent_spawning");
+    const deliveryHandler = getRequiredHandler(handlers, "subagent_delivery_target");
+    const endedHandler = getRequiredHandler(handlers, "subagent_ended");
+
+    await expect(
+      spawnHandler(
+        {
+          childSessionKey: "agent:main:subagent:child",
+          agentId: "codex",
+          mode: "run",
+          requester: {
+            channel: "discord",
+            accountId: "work",
+            to: "channel:123",
+          },
+          threadRequested: true,
+        },
+        {},
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      spawnHandler(
+        {
+          childSessionKey: "agent:main:subagent:child",
+          agentId: "codex",
+          mode: "run",
+          requester: {
+            channel: "feishu",
+            accountId: "work",
+            to: "user:ou_sender_1",
+          },
+          threadRequested: false,
+        },
+        {},
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(
+      deliveryHandler(
+        {
+          childSessionKey: "agent:main:subagent:child",
+          requesterSessionKey: "agent:main:main",
+          requesterOrigin: {
+            channel: "discord",
+            accountId: "work",
+            to: "channel:123",
+          },
+          expectsCompletionMessage: true,
+        },
+        {},
+      ),
+    ).toBeUndefined();
+
+    expect(
+      endedHandler(
+        {
+          targetSessionKey: "agent:main:subagent:child",
+          targetKind: "subagent",
+          reason: "done",
+          accountId: "work",
+        },
+        {},
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns an error for unsupported non-topic Feishu group conversations", async () => {
+    const handler = getRequiredHandler(registerHandlersForTest(), "subagent_spawning");
+    createFeishuThreadBindingManager({ cfg: baseConfig as any, accountId: "work" });
+
+    await expect(
+      handler(
+        {
+          childSessionKey: "agent:main:subagent:child",
+          agentId: "codex",
+          mode: "session",
+          requester: {
+            channel: "feishu",
+            accountId: "work",
+            to: "chat:oc_group_chat",
+          },
+          threadRequested: true,
+        },
+        {},
+      ),
+    ).resolves.toMatchObject({
+      status: "error",
+      error: expect.stringContaining("direct messages or topic conversations"),
+    });
+  });
+
+  it("unbinds Feishu bindings on subagent_ended", async () => {
+    const handlers = registerHandlersForTest();
+    const spawnHandler = getRequiredHandler(handlers, "subagent_spawning");
+    const deliveryHandler = getRequiredHandler(handlers, "subagent_delivery_target");
+    const endedHandler = getRequiredHandler(handlers, "subagent_ended");
+    createFeishuThreadBindingManager({ cfg: baseConfig as any, accountId: "work" });
+
+    await spawnHandler(
+      {
+        childSessionKey: "agent:main:subagent:child",
+        agentId: "codex",
+        mode: "session",
+        requester: {
+          channel: "feishu",
+          accountId: "work",
+          to: "user:ou_sender_1",
+        },
+        threadRequested: true,
+      },
+      {},
+    );
+
+    endedHandler(
+      {
+        targetSessionKey: "agent:main:subagent:child",
+        targetKind: "subagent",
+        reason: "done",
+        accountId: "work",
+      },
+      {},
+    );
+
+    expect(
+      deliveryHandler(
+        {
+          childSessionKey: "agent:main:subagent:child",
+          requesterSessionKey: "agent:main:main",
+          requesterOrigin: {
+            channel: "feishu",
+            accountId: "work",
+            to: "user:ou_sender_1",
+          },
+          expectsCompletionMessage: true,
+        },
+        {},
+      ),
+    ).toBeUndefined();
+  });
+
+  it("fails closed when the Feishu monitor-owned binding manager is unavailable", async () => {
+    const handlers = registerHandlersForTest();
+    const spawnHandler = getRequiredHandler(handlers, "subagent_spawning");
+    const deliveryHandler = getRequiredHandler(handlers, "subagent_delivery_target");
+
+    await expect(
+      spawnHandler(
+        {
+          childSessionKey: "agent:main:subagent:no-manager",
+          agentId: "codex",
+          mode: "session",
+          requester: {
+            channel: "feishu",
+            accountId: "work",
+            to: "user:ou_sender_1",
+          },
+          threadRequested: true,
+        },
+        {},
+      ),
+    ).resolves.toMatchObject({
+      status: "error",
+      error: expect.stringContaining("monitor is not active"),
+    });
+
+    expect(
+      deliveryHandler(
+        {
+          childSessionKey: "agent:main:subagent:no-manager",
+          requesterSessionKey: "agent:main:main",
+          requesterOrigin: {
+            channel: "feishu",
+            accountId: "work",
+            to: "user:ou_sender_1",
+          },
+          expectsCompletionMessage: true,
+        },
+        {},
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/feishu/src/subagent-hooks.ts
+++ b/extensions/feishu/src/subagent-hooks.ts
@@ -1,0 +1,341 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { buildFeishuConversationId, parseFeishuConversationId } from "./conversation-id.js";
+import { normalizeFeishuTarget } from "./targets.js";
+import { getFeishuThreadBindingManager } from "./thread-bindings.js";
+
+function summarizeError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (typeof err === "string") {
+    return err;
+  }
+  return "error";
+}
+
+function stripProviderPrefix(raw: string): string {
+  return raw.replace(/^(feishu|lark):/i, "").trim();
+}
+
+function resolveFeishuRequesterConversation(params: {
+  accountId?: string;
+  to?: string;
+  threadId?: string | number;
+  requesterSessionKey?: string;
+}): {
+  accountId: string;
+  conversationId: string;
+  parentConversationId?: string;
+} | null {
+  const manager = getFeishuThreadBindingManager(params.accountId);
+  if (!manager) {
+    return null;
+  }
+  const rawTo = params.to?.trim();
+  const withoutProviderPrefix = rawTo ? stripProviderPrefix(rawTo) : "";
+  const normalizedTarget = rawTo ? normalizeFeishuTarget(rawTo) : null;
+  const threadId =
+    params.threadId != null && params.threadId !== "" ? String(params.threadId).trim() : "";
+  const isChatTarget = /^(chat|group|channel):/i.test(withoutProviderPrefix);
+  const parsedRequesterTopic =
+    normalizedTarget && threadId && isChatTarget
+      ? parseFeishuConversationId({
+          conversationId: buildFeishuConversationId({
+            chatId: normalizedTarget,
+            scope: "group_topic",
+            topicId: threadId,
+          }),
+          parentConversationId: normalizedTarget,
+        })
+      : null;
+  const requesterSessionKey = params.requesterSessionKey?.trim();
+  if (requesterSessionKey) {
+    const existingBindings = manager.listBySessionKey(requesterSessionKey);
+    if (existingBindings.length === 1) {
+      const existing = existingBindings[0];
+      return {
+        accountId: existing.accountId,
+        conversationId: existing.conversationId,
+        parentConversationId: existing.parentConversationId,
+      };
+    }
+    if (existingBindings.length > 1) {
+      if (rawTo && normalizedTarget && !threadId && !isChatTarget) {
+        const directMatches = existingBindings.filter(
+          (entry) =>
+            entry.accountId === manager.accountId &&
+            entry.conversationId === normalizedTarget &&
+            !entry.parentConversationId,
+        );
+        if (directMatches.length === 1) {
+          const existing = directMatches[0];
+          return {
+            accountId: existing.accountId,
+            conversationId: existing.conversationId,
+            parentConversationId: existing.parentConversationId,
+          };
+        }
+        return null;
+      }
+      if (parsedRequesterTopic) {
+        const matchingTopicBindings = existingBindings.filter((entry) => {
+          const parsed = parseFeishuConversationId({
+            conversationId: entry.conversationId,
+            parentConversationId: entry.parentConversationId,
+          });
+          return (
+            parsed?.chatId === parsedRequesterTopic.chatId &&
+            parsed?.topicId === parsedRequesterTopic.topicId
+          );
+        });
+        if (matchingTopicBindings.length === 1) {
+          const existing = matchingTopicBindings[0];
+          return {
+            accountId: existing.accountId,
+            conversationId: existing.conversationId,
+            parentConversationId: existing.parentConversationId,
+          };
+        }
+        const senderScopedTopicBindings = matchingTopicBindings.filter((entry) => {
+          const parsed = parseFeishuConversationId({
+            conversationId: entry.conversationId,
+            parentConversationId: entry.parentConversationId,
+          });
+          return parsed?.scope === "group_topic_sender";
+        });
+        if (
+          senderScopedTopicBindings.length === 1 &&
+          matchingTopicBindings.length === senderScopedTopicBindings.length
+        ) {
+          const existing = senderScopedTopicBindings[0];
+          return {
+            accountId: existing.accountId,
+            conversationId: existing.conversationId,
+            parentConversationId: existing.parentConversationId,
+          };
+        }
+        return null;
+      }
+    }
+  }
+
+  if (!rawTo) {
+    return null;
+  }
+  if (!normalizedTarget) {
+    return null;
+  }
+
+  if (threadId) {
+    if (!isChatTarget) {
+      return null;
+    }
+    return {
+      accountId: manager.accountId,
+      conversationId: buildFeishuConversationId({
+        chatId: normalizedTarget,
+        scope: "group_topic",
+        topicId: threadId,
+      }),
+      parentConversationId: normalizedTarget,
+    };
+  }
+
+  if (isChatTarget) {
+    return null;
+  }
+
+  return {
+    accountId: manager.accountId,
+    conversationId: normalizedTarget,
+  };
+}
+
+function resolveFeishuDeliveryOrigin(params: {
+  conversationId: string;
+  parentConversationId?: string;
+  accountId: string;
+  deliveryTo?: string;
+  deliveryThreadId?: string;
+}): {
+  channel: "feishu";
+  accountId: string;
+  to: string;
+  threadId?: string;
+} {
+  const deliveryTo = params.deliveryTo?.trim();
+  const deliveryThreadId = params.deliveryThreadId?.trim();
+  if (deliveryTo) {
+    return {
+      channel: "feishu",
+      accountId: params.accountId,
+      to: deliveryTo,
+      ...(deliveryThreadId ? { threadId: deliveryThreadId } : {}),
+    };
+  }
+  const parsed = parseFeishuConversationId({
+    conversationId: params.conversationId,
+    parentConversationId: params.parentConversationId,
+  });
+  if (parsed?.topicId) {
+    return {
+      channel: "feishu",
+      accountId: params.accountId,
+      to: `chat:${params.parentConversationId?.trim() || parsed.chatId}`,
+      threadId: parsed.topicId,
+    };
+  }
+  return {
+    channel: "feishu",
+    accountId: params.accountId,
+    to: `user:${params.conversationId}`,
+  };
+}
+
+function resolveMatchingChildBinding(params: {
+  accountId?: string;
+  childSessionKey: string;
+  requesterSessionKey?: string;
+  requesterOrigin?: {
+    to?: string;
+    threadId?: string | number;
+  };
+}) {
+  const manager = getFeishuThreadBindingManager(params.accountId);
+  if (!manager) {
+    return null;
+  }
+  const childBindings = manager.listBySessionKey(params.childSessionKey.trim());
+  if (childBindings.length === 0) {
+    return null;
+  }
+
+  const requesterConversation = resolveFeishuRequesterConversation({
+    accountId: manager.accountId,
+    to: params.requesterOrigin?.to,
+    threadId: params.requesterOrigin?.threadId,
+    requesterSessionKey: params.requesterSessionKey,
+  });
+  if (requesterConversation) {
+    const matched = childBindings.find(
+      (entry) =>
+        entry.accountId === requesterConversation.accountId &&
+        entry.conversationId === requesterConversation.conversationId &&
+        (entry.parentConversationId?.trim() || undefined) ===
+          (requesterConversation.parentConversationId?.trim() || undefined),
+    );
+    if (matched) {
+      return matched;
+    }
+  }
+
+  return childBindings.length === 1 ? childBindings[0] : null;
+}
+
+export function registerFeishuSubagentHooks(api: OpenClawPluginApi) {
+  api.on("subagent_spawning", async (event, ctx) => {
+    if (!event.threadRequested) {
+      return;
+    }
+    const requesterChannel = event.requester?.channel?.trim().toLowerCase();
+    if (requesterChannel !== "feishu") {
+      return;
+    }
+
+    const manager = getFeishuThreadBindingManager(event.requester?.accountId);
+    if (!manager) {
+      return {
+        status: "error" as const,
+        error:
+          "Feishu current-conversation binding is unavailable because the Feishu account monitor is not active.",
+      };
+    }
+
+    const conversation = resolveFeishuRequesterConversation({
+      accountId: event.requester?.accountId,
+      to: event.requester?.to,
+      threadId: event.requester?.threadId,
+      requesterSessionKey: ctx.requesterSessionKey,
+    });
+    if (!conversation) {
+      return {
+        status: "error" as const,
+        error:
+          "Feishu current-conversation binding is only available in direct messages or topic conversations.",
+      };
+    }
+
+    try {
+      const binding = manager.bindConversation({
+        conversationId: conversation.conversationId,
+        parentConversationId: conversation.parentConversationId,
+        targetKind: "subagent",
+        targetSessionKey: event.childSessionKey,
+        metadata: {
+          agentId: event.agentId,
+          label: event.label,
+          boundBy: "system",
+          deliveryTo: event.requester?.to,
+          deliveryThreadId:
+            event.requester?.threadId != null && event.requester.threadId !== ""
+              ? String(event.requester.threadId)
+              : undefined,
+        },
+      });
+      if (!binding) {
+        return {
+          status: "error" as const,
+          error:
+            "Unable to bind this Feishu conversation to the spawned subagent session. Session mode is unavailable for this target.",
+        };
+      }
+      return {
+        status: "ok" as const,
+        threadBindingReady: true,
+      };
+    } catch (err) {
+      return {
+        status: "error" as const,
+        error: `Feishu conversation bind failed: ${summarizeError(err)}`,
+      };
+    }
+  });
+
+  api.on("subagent_delivery_target", (event) => {
+    if (!event.expectsCompletionMessage) {
+      return;
+    }
+    const requesterChannel = event.requesterOrigin?.channel?.trim().toLowerCase();
+    if (requesterChannel !== "feishu") {
+      return;
+    }
+
+    const binding = resolveMatchingChildBinding({
+      accountId: event.requesterOrigin?.accountId,
+      childSessionKey: event.childSessionKey,
+      requesterSessionKey: event.requesterSessionKey,
+      requesterOrigin: {
+        to: event.requesterOrigin?.to,
+        threadId: event.requesterOrigin?.threadId,
+      },
+    });
+    if (!binding) {
+      return;
+    }
+
+    return {
+      origin: resolveFeishuDeliveryOrigin({
+        conversationId: binding.conversationId,
+        parentConversationId: binding.parentConversationId,
+        accountId: binding.accountId,
+        deliveryTo: binding.deliveryTo,
+        deliveryThreadId: binding.deliveryThreadId,
+      }),
+    };
+  });
+
+  api.on("subagent_ended", (event) => {
+    const manager = getFeishuThreadBindingManager(event.accountId);
+    manager?.unbindBySessionKey(event.targetSessionKey);
+  });
+}

--- a/extensions/feishu/src/thread-bindings.test.ts
+++ b/extensions/feishu/src/thread-bindings.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import { getSessionBindingService } from "../../../src/infra/outbound/session-binding-service.js";
+import { __testing, createFeishuThreadBindingManager } from "./thread-bindings.js";
+
+const baseCfg = {
+  session: { mainKey: "main", scope: "per-sender" },
+} satisfies OpenClawConfig;
+
+describe("Feishu thread bindings", () => {
+  beforeEach(() => {
+    __testing.resetFeishuThreadBindingsForTests();
+  });
+
+  it("registers current-placement adapter capabilities for Feishu", () => {
+    createFeishuThreadBindingManager({ cfg: baseCfg, accountId: "default" });
+
+    expect(
+      getSessionBindingService().getCapabilities({
+        channel: "feishu",
+        accountId: "default",
+      }),
+    ).toEqual({
+      adapterAvailable: true,
+      bindSupported: true,
+      unbindSupported: true,
+      placements: ["current"],
+    });
+  });
+
+  it("binds and resolves a Feishu topic conversation", async () => {
+    createFeishuThreadBindingManager({ cfg: baseCfg, accountId: "default" });
+
+    const binding = await getSessionBindingService().bind({
+      targetSessionKey: "agent:codex:acp:binding:feishu:default:abc123",
+      targetKind: "session",
+      conversation: {
+        channel: "feishu",
+        accountId: "default",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+        parentConversationId: "oc_group_chat",
+      },
+      placement: "current",
+      metadata: {
+        agentId: "codex",
+        label: "codex-main",
+      },
+    });
+
+    expect(binding.conversation.conversationId).toBe("oc_group_chat:topic:om_topic_root");
+    expect(
+      getSessionBindingService().resolveByConversation({
+        channel: "feishu",
+        accountId: "default",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+      }),
+    )?.toMatchObject({
+      targetSessionKey: "agent:codex:acp:binding:feishu:default:abc123",
+      metadata: expect.objectContaining({
+        agentId: "codex",
+        label: "codex-main",
+      }),
+    });
+  });
+
+  it("clears account-scoped bindings when the manager stops", async () => {
+    const manager = createFeishuThreadBindingManager({ cfg: baseCfg, accountId: "default" });
+
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:codex:acp:binding:feishu:default:abc123",
+      targetKind: "session",
+      conversation: {
+        channel: "feishu",
+        accountId: "default",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+        parentConversationId: "oc_group_chat",
+      },
+      placement: "current",
+      metadata: {
+        agentId: "codex",
+      },
+    });
+
+    manager.stop();
+
+    expect(
+      getSessionBindingService().resolveByConversation({
+        channel: "feishu",
+        accountId: "default",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+      }),
+    ).toBeNull();
+  });
+});

--- a/extensions/feishu/src/thread-bindings.ts
+++ b/extensions/feishu/src/thread-bindings.ts
@@ -22,6 +22,8 @@ type FeishuThreadBindingRecord = {
   accountId: string;
   conversationId: string;
   parentConversationId?: string;
+  deliveryTo?: string;
+  deliveryThreadId?: string;
   targetKind: FeishuBindingTargetKind;
   targetSessionKey: string;
   agentId?: string;
@@ -108,6 +110,8 @@ function toSessionBindingRecord(
       agentId: record.agentId,
       label: record.label,
       boundBy: record.boundBy,
+      deliveryTo: record.deliveryTo,
+      deliveryThreadId: record.deliveryThreadId,
       lastActivityAt: record.lastActivityAt,
       idleTimeoutMs: defaults.idleTimeoutMs,
       maxAgeMs: defaults.maxAgeMs,
@@ -160,6 +164,14 @@ export function createFeishuThreadBindingManager(params: {
         accountId,
         conversationId: normalizedConversationId,
         parentConversationId: parentConversationId?.trim() || undefined,
+        deliveryTo:
+          typeof metadata?.deliveryTo === "string" && metadata.deliveryTo.trim()
+            ? metadata.deliveryTo.trim()
+            : undefined,
+        deliveryThreadId:
+          typeof metadata?.deliveryThreadId === "string" && metadata.deliveryThreadId.trim()
+            ? metadata.deliveryThreadId.trim()
+            : undefined,
         targetKind: toFeishuTargetKind(targetKind),
         targetSessionKey: targetSessionKey.trim(),
         agentId:

--- a/extensions/feishu/src/thread-bindings.ts
+++ b/extensions/feishu/src/thread-bindings.ts
@@ -1,0 +1,304 @@
+import { resolveThreadBindingConversationIdFromBindingId } from "../../../src/channels/thread-binding-id.js";
+import {
+  resolveThreadBindingIdleTimeoutMsForChannel,
+  resolveThreadBindingMaxAgeMsForChannel,
+} from "../../../src/channels/thread-bindings-policy.js";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type BindingTargetKind,
+  type SessionBindingRecord,
+} from "../../../src/infra/outbound/session-binding-service.js";
+import {
+  normalizeAccountId,
+  resolveAgentIdFromSessionKey,
+} from "../../../src/routing/session-key.js";
+import { resolveGlobalSingleton } from "../../../src/shared/global-singleton.js";
+
+type FeishuBindingTargetKind = "subagent" | "acp";
+
+type FeishuThreadBindingRecord = {
+  accountId: string;
+  conversationId: string;
+  parentConversationId?: string;
+  targetKind: FeishuBindingTargetKind;
+  targetSessionKey: string;
+  agentId?: string;
+  label?: string;
+  boundBy?: string;
+  boundAt: number;
+  lastActivityAt: number;
+};
+
+type FeishuThreadBindingManager = {
+  accountId: string;
+  getByConversationId: (conversationId: string) => FeishuThreadBindingRecord | undefined;
+  listBySessionKey: (targetSessionKey: string) => FeishuThreadBindingRecord[];
+  bindConversation: (params: {
+    conversationId: string;
+    parentConversationId?: string;
+    targetKind: BindingTargetKind;
+    targetSessionKey: string;
+    metadata?: Record<string, unknown>;
+  }) => FeishuThreadBindingRecord | null;
+  touchConversation: (conversationId: string, at?: number) => FeishuThreadBindingRecord | null;
+  unbindConversation: (conversationId: string) => FeishuThreadBindingRecord | null;
+  unbindBySessionKey: (targetSessionKey: string) => FeishuThreadBindingRecord[];
+  stop: () => void;
+};
+
+type FeishuThreadBindingsState = {
+  managersByAccountId: Map<string, FeishuThreadBindingManager>;
+  bindingsByAccountConversation: Map<string, FeishuThreadBindingRecord>;
+};
+
+const FEISHU_THREAD_BINDINGS_STATE_KEY = Symbol.for("openclaw.feishuThreadBindingsState");
+const state = resolveGlobalSingleton<FeishuThreadBindingsState>(
+  FEISHU_THREAD_BINDINGS_STATE_KEY,
+  () => ({
+    managersByAccountId: new Map(),
+    bindingsByAccountConversation: new Map(),
+  }),
+);
+
+const MANAGERS_BY_ACCOUNT_ID = state.managersByAccountId;
+const BINDINGS_BY_ACCOUNT_CONVERSATION = state.bindingsByAccountConversation;
+
+function resolveBindingKey(params: { accountId: string; conversationId: string }): string {
+  return `${params.accountId}:${params.conversationId}`;
+}
+
+function toSessionBindingTargetKind(raw: FeishuBindingTargetKind): BindingTargetKind {
+  return raw === "subagent" ? "subagent" : "session";
+}
+
+function toFeishuTargetKind(raw: BindingTargetKind): FeishuBindingTargetKind {
+  return raw === "subagent" ? "subagent" : "acp";
+}
+
+function toSessionBindingRecord(
+  record: FeishuThreadBindingRecord,
+  defaults: { idleTimeoutMs: number; maxAgeMs: number },
+): SessionBindingRecord {
+  const idleExpiresAt =
+    defaults.idleTimeoutMs > 0 ? record.lastActivityAt + defaults.idleTimeoutMs : undefined;
+  const maxAgeExpiresAt = defaults.maxAgeMs > 0 ? record.boundAt + defaults.maxAgeMs : undefined;
+  const expiresAt =
+    idleExpiresAt != null && maxAgeExpiresAt != null
+      ? Math.min(idleExpiresAt, maxAgeExpiresAt)
+      : (idleExpiresAt ?? maxAgeExpiresAt);
+  return {
+    bindingId: resolveBindingKey({
+      accountId: record.accountId,
+      conversationId: record.conversationId,
+    }),
+    targetSessionKey: record.targetSessionKey,
+    targetKind: toSessionBindingTargetKind(record.targetKind),
+    conversation: {
+      channel: "feishu",
+      accountId: record.accountId,
+      conversationId: record.conversationId,
+      parentConversationId: record.parentConversationId,
+    },
+    status: "active",
+    boundAt: record.boundAt,
+    expiresAt,
+    metadata: {
+      agentId: record.agentId,
+      label: record.label,
+      boundBy: record.boundBy,
+      lastActivityAt: record.lastActivityAt,
+      idleTimeoutMs: defaults.idleTimeoutMs,
+      maxAgeMs: defaults.maxAgeMs,
+    },
+  };
+}
+
+export function createFeishuThreadBindingManager(params: {
+  accountId?: string;
+  cfg: OpenClawConfig;
+}): FeishuThreadBindingManager {
+  const accountId = normalizeAccountId(params.accountId);
+  const existing = MANAGERS_BY_ACCOUNT_ID.get(accountId);
+  if (existing) {
+    return existing;
+  }
+
+  const idleTimeoutMs = resolveThreadBindingIdleTimeoutMsForChannel({
+    cfg: params.cfg,
+    channel: "feishu",
+    accountId,
+  });
+  const maxAgeMs = resolveThreadBindingMaxAgeMsForChannel({
+    cfg: params.cfg,
+    channel: "feishu",
+    accountId,
+  });
+
+  const manager: FeishuThreadBindingManager = {
+    accountId,
+    getByConversationId: (conversationId) =>
+      BINDINGS_BY_ACCOUNT_CONVERSATION.get(resolveBindingKey({ accountId, conversationId })),
+    listBySessionKey: (targetSessionKey) =>
+      [...BINDINGS_BY_ACCOUNT_CONVERSATION.values()].filter(
+        (record) => record.accountId === accountId && record.targetSessionKey === targetSessionKey,
+      ),
+    bindConversation: ({
+      conversationId,
+      parentConversationId,
+      targetKind,
+      targetSessionKey,
+      metadata,
+    }) => {
+      const normalizedConversationId = conversationId.trim();
+      if (!normalizedConversationId || !targetSessionKey.trim()) {
+        return null;
+      }
+      const now = Date.now();
+      const record: FeishuThreadBindingRecord = {
+        accountId,
+        conversationId: normalizedConversationId,
+        parentConversationId: parentConversationId?.trim() || undefined,
+        targetKind: toFeishuTargetKind(targetKind),
+        targetSessionKey: targetSessionKey.trim(),
+        agentId:
+          typeof metadata?.agentId === "string" && metadata.agentId.trim()
+            ? metadata.agentId.trim()
+            : resolveAgentIdFromSessionKey(targetSessionKey),
+        label:
+          typeof metadata?.label === "string" && metadata.label.trim()
+            ? metadata.label.trim()
+            : undefined,
+        boundBy:
+          typeof metadata?.boundBy === "string" && metadata.boundBy.trim()
+            ? metadata.boundBy.trim()
+            : undefined,
+        boundAt: now,
+        lastActivityAt: now,
+      };
+      BINDINGS_BY_ACCOUNT_CONVERSATION.set(
+        resolveBindingKey({ accountId, conversationId: normalizedConversationId }),
+        record,
+      );
+      return record;
+    },
+    touchConversation: (conversationId, at = Date.now()) => {
+      const key = resolveBindingKey({ accountId, conversationId });
+      const existingRecord = BINDINGS_BY_ACCOUNT_CONVERSATION.get(key);
+      if (!existingRecord) {
+        return null;
+      }
+      const updated = { ...existingRecord, lastActivityAt: at };
+      BINDINGS_BY_ACCOUNT_CONVERSATION.set(key, updated);
+      return updated;
+    },
+    unbindConversation: (conversationId) => {
+      const key = resolveBindingKey({ accountId, conversationId });
+      const existingRecord = BINDINGS_BY_ACCOUNT_CONVERSATION.get(key);
+      if (!existingRecord) {
+        return null;
+      }
+      BINDINGS_BY_ACCOUNT_CONVERSATION.delete(key);
+      return existingRecord;
+    },
+    unbindBySessionKey: (targetSessionKey) => {
+      const removed: FeishuThreadBindingRecord[] = [];
+      for (const record of [...BINDINGS_BY_ACCOUNT_CONVERSATION.values()]) {
+        if (record.accountId !== accountId || record.targetSessionKey !== targetSessionKey) {
+          continue;
+        }
+        BINDINGS_BY_ACCOUNT_CONVERSATION.delete(
+          resolveBindingKey({ accountId, conversationId: record.conversationId }),
+        );
+        removed.push(record);
+      }
+      return removed;
+    },
+    stop: () => {
+      for (const key of [...BINDINGS_BY_ACCOUNT_CONVERSATION.keys()]) {
+        if (key.startsWith(`${accountId}:`)) {
+          BINDINGS_BY_ACCOUNT_CONVERSATION.delete(key);
+        }
+      }
+      MANAGERS_BY_ACCOUNT_ID.delete(accountId);
+      unregisterSessionBindingAdapter({ channel: "feishu", accountId });
+    },
+  };
+
+  registerSessionBindingAdapter({
+    channel: "feishu",
+    accountId,
+    capabilities: {
+      placements: ["current"],
+    },
+    bind: async (input) => {
+      if (input.conversation.channel !== "feishu" || input.placement === "child") {
+        return null;
+      }
+      const bound = manager.bindConversation({
+        conversationId: input.conversation.conversationId,
+        parentConversationId: input.conversation.parentConversationId,
+        targetKind: input.targetKind,
+        targetSessionKey: input.targetSessionKey,
+        metadata: input.metadata,
+      });
+      return bound ? toSessionBindingRecord(bound, { idleTimeoutMs, maxAgeMs }) : null;
+    },
+    listBySession: (targetSessionKey) =>
+      manager
+        .listBySessionKey(targetSessionKey)
+        .map((entry) => toSessionBindingRecord(entry, { idleTimeoutMs, maxAgeMs })),
+    resolveByConversation: (ref) => {
+      if (ref.channel !== "feishu") {
+        return null;
+      }
+      const found = manager.getByConversationId(ref.conversationId);
+      return found ? toSessionBindingRecord(found, { idleTimeoutMs, maxAgeMs }) : null;
+    },
+    touch: (bindingId, at) => {
+      const conversationId = resolveThreadBindingConversationIdFromBindingId({
+        accountId,
+        bindingId,
+      });
+      if (conversationId) {
+        manager.touchConversation(conversationId, at);
+      }
+    },
+    unbind: async (input) => {
+      if (input.targetSessionKey?.trim()) {
+        return manager
+          .unbindBySessionKey(input.targetSessionKey.trim())
+          .map((entry) => toSessionBindingRecord(entry, { idleTimeoutMs, maxAgeMs }));
+      }
+      const conversationId = resolveThreadBindingConversationIdFromBindingId({
+        accountId,
+        bindingId: input.bindingId,
+      });
+      if (!conversationId) {
+        return [];
+      }
+      const removed = manager.unbindConversation(conversationId);
+      return removed ? [toSessionBindingRecord(removed, { idleTimeoutMs, maxAgeMs })] : [];
+    },
+  });
+
+  MANAGERS_BY_ACCOUNT_ID.set(accountId, manager);
+  return manager;
+}
+
+export function getFeishuThreadBindingManager(
+  accountId?: string,
+): FeishuThreadBindingManager | null {
+  return MANAGERS_BY_ACCOUNT_ID.get(normalizeAccountId(accountId)) ?? null;
+}
+
+export const __testing = {
+  resetFeishuThreadBindingsForTests() {
+    for (const manager of MANAGERS_BY_ACCOUNT_ID.values()) {
+      manager.stop();
+    }
+    MANAGERS_BY_ACCOUNT_ID.clear();
+    BINDINGS_BY_ACCOUNT_CONVERSATION.clear();
+  },
+};

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -123,14 +123,23 @@ function resolveConfiguredBindingRecord(params: {
   bindings: AgentAcpBinding[];
   channel: ConfiguredAcpBindingChannel;
   accountId: string;
-  selectConversation: (
-    binding: AgentAcpBinding,
-  ) => { conversationId: string; parentConversationId?: string } | null;
+  selectConversation: (binding: AgentAcpBinding) => {
+    conversationId: string;
+    parentConversationId?: string;
+    matchPriority?: number;
+  } | null;
 }): ResolvedConfiguredAcpBinding | null {
   let wildcardMatch: {
     binding: AgentAcpBinding;
     conversationId: string;
     parentConversationId?: string;
+    matchPriority: number;
+  } | null = null;
+  let exactMatch: {
+    binding: AgentAcpBinding;
+    conversationId: string;
+    parentConversationId?: string;
+    matchPriority: number;
   } | null = null;
   for (const binding of params.bindings) {
     if (normalizeBindingChannel(binding.match.channel) !== params.channel) {
@@ -147,23 +156,40 @@ function resolveConfiguredBindingRecord(params: {
     if (!conversation) {
       continue;
     }
+    const matchPriority = conversation.matchPriority ?? 0;
+    if (accountMatchPriority === 2) {
+      if (!exactMatch || matchPriority > exactMatch.matchPriority) {
+        exactMatch = {
+          binding,
+          conversationId: conversation.conversationId,
+          parentConversationId: conversation.parentConversationId,
+          matchPriority,
+        };
+      }
+      continue;
+    }
+    if (!wildcardMatch || matchPriority > wildcardMatch.matchPriority) {
+      wildcardMatch = {
+        binding,
+        conversationId: conversation.conversationId,
+        parentConversationId: conversation.parentConversationId,
+        matchPriority,
+      };
+    }
+  }
+  if (exactMatch) {
     const spec = toConfiguredBindingSpec({
       cfg: params.cfg,
       channel: params.channel,
       accountId: params.accountId,
-      conversationId: conversation.conversationId,
-      parentConversationId: conversation.parentConversationId,
-      binding,
+      conversationId: exactMatch.conversationId,
+      parentConversationId: exactMatch.parentConversationId,
+      binding: exactMatch.binding,
     });
-    if (accountMatchPriority === 2) {
-      return {
-        spec,
-        record: toConfiguredAcpBindingRecord(spec),
-      };
-    }
-    if (!wildcardMatch) {
-      wildcardMatch = { binding, ...conversation };
-    }
+    return {
+      spec,
+      record: toConfiguredAcpBindingRecord(spec),
+    };
   }
   if (!wildcardMatch) {
     return null;
@@ -426,6 +452,7 @@ export function resolveConfiguredAcpBindingRecord(params: {
             parsed.scope === "group_topic" || parsed.scope === "group_topic_sender"
               ? parsed.chatId
               : undefined,
+          matchPriority: matchesCanonicalConversation ? 2 : 1,
         };
       },
     });

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -274,8 +274,7 @@ export function resolveConfiguredAcpBindingSpecBySessionKey(params: {
         !targetParsed ||
         (targetParsed.scope !== "group_topic" &&
           targetParsed.scope !== "group_topic_sender" &&
-          !targetParsed.canonicalConversationId.startsWith("ou_") &&
-          !targetParsed.canonicalConversationId.startsWith("on_"))
+          !isSupportedFeishuDirectConversationId(targetParsed.canonicalConversationId))
       ) {
         continue;
       }

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -247,6 +247,9 @@ export function resolveConfiguredAcpBindingSpecBySessionKey(params: {
         channel: "feishu",
         accountId: parsedSessionKey.accountId,
         conversationId: targetParsed.canonicalConversationId,
+        // Session-key recovery deliberately collapses sender-scoped topic bindings onto the
+        // canonical topic conversation id so `group_topic` and `group_topic_sender` reuse
+        // the same configured ACP session identity.
         parentConversationId:
           targetParsed.scope === "group_topic" || targetParsed.scope === "group_topic_sender"
             ? targetParsed.chatId

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -28,6 +28,17 @@ function normalizeBindingChannel(value: string | undefined): ConfiguredAcpBindin
   return null;
 }
 
+function isSupportedFeishuDirectConversationId(conversationId: string): boolean {
+  const trimmed = conversationId.trim();
+  if (!trimmed || trimmed.includes(":")) {
+    return false;
+  }
+  if (trimmed.startsWith("oc_") || trimmed.startsWith("on_")) {
+    return false;
+  }
+  return true;
+}
+
 function resolveAccountMatchPriority(match: string | undefined, actual: string): 0 | 1 | 2 {
   const trimmed = (match ?? "").trim();
   if (!trimmed) {
@@ -407,8 +418,7 @@ export function resolveConfiguredAcpBindingRecord(params: {
       !parsed ||
       (parsed.scope !== "group_topic" &&
         parsed.scope !== "group_topic_sender" &&
-        !parsed.canonicalConversationId.startsWith("ou_") &&
-        !parsed.canonicalConversationId.startsWith("on_"))
+        !isSupportedFeishuDirectConversationId(parsed.canonicalConversationId))
     ) {
       return null;
     }
@@ -429,8 +439,7 @@ export function resolveConfiguredAcpBindingRecord(params: {
           !targetParsed ||
           (targetParsed.scope !== "group_topic" &&
             targetParsed.scope !== "group_topic_sender" &&
-            !targetParsed.canonicalConversationId.startsWith("ou_") &&
-            !targetParsed.canonicalConversationId.startsWith("on_"))
+            !isSupportedFeishuDirectConversationId(targetParsed.canonicalConversationId))
         ) {
           return null;
         }

--- a/src/acp/persistent-bindings.resolve.ts
+++ b/src/acp/persistent-bindings.resolve.ts
@@ -1,3 +1,4 @@
+import { parseFeishuConversationId } from "../../extensions/feishu/src/conversation-id.js";
 import { listAcpBindings } from "../config/bindings.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AgentAcpBinding } from "../config/types.js";
@@ -21,7 +22,7 @@ import {
 
 function normalizeBindingChannel(value: string | undefined): ConfiguredAcpBindingChannel | null {
   const normalized = (value ?? "").trim().toLowerCase();
-  if (normalized === "discord" || normalized === "telegram") {
+  if (normalized === "discord" || normalized === "telegram" || normalized === "feishu") {
     return normalized;
   }
   return null;
@@ -228,6 +229,40 @@ export function resolveConfiguredAcpBindingSpecBySessionKey(params: {
       }
       continue;
     }
+    if (channel === "feishu") {
+      const targetParsed = parseFeishuConversationId({
+        conversationId: targetConversationId,
+      });
+      if (
+        !targetParsed ||
+        (targetParsed.scope !== "group_topic" &&
+          targetParsed.scope !== "group_topic_sender" &&
+          !targetParsed.canonicalConversationId.startsWith("ou_") &&
+          !targetParsed.canonicalConversationId.startsWith("on_"))
+      ) {
+        continue;
+      }
+      const spec = toConfiguredBindingSpec({
+        cfg: params.cfg,
+        channel: "feishu",
+        accountId: parsedSessionKey.accountId,
+        conversationId: targetParsed.canonicalConversationId,
+        parentConversationId:
+          targetParsed.scope === "group_topic" || targetParsed.scope === "group_topic_sender"
+            ? targetParsed.chatId
+            : undefined,
+        binding,
+      });
+      if (buildConfiguredAcpSessionKey(spec) === sessionKey) {
+        if (accountMatchPriority === 2) {
+          return spec;
+        }
+        if (!wildcardMatch) {
+          wildcardMatch = spec;
+        }
+      }
+      continue;
+    }
     const parsedTopic = parseTelegramTopicConversation({
       conversationId: targetConversationId,
     });
@@ -329,6 +364,65 @@ export function resolveConfiguredAcpBindingRecord(params: {
         return {
           conversationId: parsed.canonicalConversationId,
           parentConversationId: parsed.chatId,
+        };
+      },
+    });
+  }
+
+  if (channel === "feishu") {
+    const parsed = parseFeishuConversationId({
+      conversationId,
+      parentConversationId,
+    });
+    if (
+      !parsed ||
+      (parsed.scope !== "group_topic" &&
+        parsed.scope !== "group_topic_sender" &&
+        !parsed.canonicalConversationId.startsWith("ou_") &&
+        !parsed.canonicalConversationId.startsWith("on_"))
+    ) {
+      return null;
+    }
+    return resolveConfiguredBindingRecord({
+      cfg: params.cfg,
+      bindings: listAcpBindings(params.cfg),
+      channel: "feishu",
+      accountId,
+      selectConversation: (binding) => {
+        const targetConversationId = resolveBindingConversationId(binding);
+        if (!targetConversationId) {
+          return null;
+        }
+        const targetParsed = parseFeishuConversationId({
+          conversationId: targetConversationId,
+        });
+        if (
+          !targetParsed ||
+          (targetParsed.scope !== "group_topic" &&
+            targetParsed.scope !== "group_topic_sender" &&
+            !targetParsed.canonicalConversationId.startsWith("ou_") &&
+            !targetParsed.canonicalConversationId.startsWith("on_"))
+        ) {
+          return null;
+        }
+        const matchesCanonicalConversation =
+          targetParsed.canonicalConversationId === parsed.canonicalConversationId;
+        const matchesParentTopicForSenderScopedConversation =
+          parsed.scope === "group_topic_sender" &&
+          targetParsed.scope === "group_topic" &&
+          parsed.chatId === targetParsed.chatId &&
+          parsed.topicId === targetParsed.topicId;
+        if (!matchesCanonicalConversation && !matchesParentTopicForSenderScopedConversation) {
+          return null;
+        }
+        return {
+          conversationId: matchesParentTopicForSenderScopedConversation
+            ? targetParsed.canonicalConversationId
+            : parsed.canonicalConversationId,
+          parentConversationId:
+            parsed.scope === "group_topic" || parsed.scope === "group_topic_sender"
+              ? parsed.chatId
+              : undefined,
         };
       },
     });

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -536,6 +536,31 @@ describe("resolveConfiguredAcpBindingSpecBySessionKey", () => {
 
     expect(spec?.backend).toBe("exact");
   });
+
+  it("maps a configured Feishu user_id DM binding session key back to its spec", () => {
+    const cfg = createCfgWithBindings([
+      createFeishuBinding({
+        agentId: "codex",
+        conversationId: "user_123",
+        acp: { backend: "acpx" },
+      }),
+    ]);
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "user_123",
+    });
+    const spec = resolveConfiguredAcpBindingSpecBySessionKey({
+      cfg,
+      sessionKey: resolved?.record.targetSessionKey ?? "",
+    });
+
+    expect(spec?.channel).toBe("feishu");
+    expect(spec?.conversationId).toBe("user_123");
+    expect(spec?.agentId).toBe("codex");
+    expect(spec?.backend).toBe("acpx");
+  });
 });
 
 describe("buildConfiguredAcpSessionKey", () => {

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -226,6 +226,34 @@ describe("resolveConfiguredAcpBindingRecord", () => {
     expect(resolved?.spec.agentId).toBe("claude");
   });
 
+  it("prefers sender-scoped Feishu bindings over topic inheritance", () => {
+    const cfg = createCfgWithBindings([
+      createFeishuBinding({
+        agentId: "codex",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+        accountId: "work",
+      }),
+      createFeishuBinding({
+        agentId: "claude",
+        conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_sender_1",
+        accountId: "work",
+      }),
+    ]);
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "work",
+      conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_sender_1",
+      parentConversationId: "oc_group_chat",
+    });
+
+    expect(resolved?.spec.conversationId).toBe(
+      "oc_group_chat:topic:om_topic_root:sender:ou_sender_1",
+    );
+    expect(resolved?.spec.agentId).toBe("claude");
+  });
+
   it("prefers exact account binding over wildcard for the same discord conversation", () => {
     const cfg = createCfgWithBindings([
       createDiscordBinding({

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -353,6 +353,26 @@ describe("resolveConfiguredAcpBindingRecord", () => {
     expect(resolved?.record.targetSessionKey).toContain("agent:codex:acp:binding:feishu:default:");
   });
 
+  it("resolves Feishu DM bindings using user_id fallback peer ids", () => {
+    const cfg = createCfgWithBindings([
+      createFeishuBinding({
+        agentId: "codex",
+        conversationId: "user_123",
+      }),
+    ]);
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "user_123",
+    });
+
+    expect(resolved?.spec.channel).toBe("feishu");
+    expect(resolved?.spec.conversationId).toBe("user_123");
+    expect(resolved?.record.targetSessionKey).toContain("agent:codex:acp:binding:feishu:default:");
+  });
+
   it("resolves Feishu topic bindings with parent chat ids", () => {
     const cfg = createCfgWithBindings([
       createFeishuBinding({

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -90,6 +90,27 @@ function createTelegramGroupBinding(params: {
   } as ConfiguredBinding;
 }
 
+function createFeishuBinding(params: {
+  agentId: string;
+  conversationId: string;
+  accountId?: string;
+  acp?: Record<string, unknown>;
+}): ConfiguredBinding {
+  return {
+    type: "acp",
+    agentId: params.agentId,
+    match: {
+      channel: "feishu",
+      accountId: params.accountId ?? defaultDiscordAccountId,
+      peer: {
+        kind: params.conversationId.includes(":topic:") ? "group" : "direct",
+        id: params.conversationId,
+      },
+    },
+    ...(params.acp ? { acp: params.acp } : {}),
+  } as ConfiguredBinding;
+}
+
 function resolveBindingRecord(cfg: OpenClawConfig, overrides: Partial<BindingRecordInput> = {}) {
   return resolveConfiguredAcpBindingRecord({
     cfg,
@@ -281,6 +302,108 @@ describe("resolveConfiguredAcpBindingRecord", () => {
       accountId: "default",
       conversationId: "123456789:topic:42",
     });
+    expect(resolved).toBeNull();
+  });
+
+  it("resolves Feishu DM bindings using direct peer ids", () => {
+    const cfg = createCfgWithBindings([
+      createFeishuBinding({
+        agentId: "codex",
+        conversationId: "ou_user_1",
+      }),
+    ]);
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "ou_user_1",
+    });
+
+    expect(resolved?.spec.channel).toBe("feishu");
+    expect(resolved?.spec.conversationId).toBe("ou_user_1");
+    expect(resolved?.record.targetSessionKey).toContain("agent:codex:acp:binding:feishu:default:");
+  });
+
+  it("resolves Feishu topic bindings with parent chat ids", () => {
+    const cfg = createCfgWithBindings([
+      createFeishuBinding({
+        agentId: "claude",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+        acp: { backend: "acpx" },
+      }),
+    ]);
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "oc_group_chat:topic:om_topic_root",
+      parentConversationId: "oc_group_chat",
+    });
+
+    expect(resolved?.spec.conversationId).toBe("oc_group_chat:topic:om_topic_root");
+    expect(resolved?.spec.agentId).toBe("claude");
+    expect(resolved?.record.conversation.parentConversationId).toBe("oc_group_chat");
+  });
+
+  it("inherits configured Feishu topic bindings for sender-scoped topic conversations", () => {
+    const cfg = createCfgWithBindings([
+      createFeishuBinding({
+        agentId: "claude",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+        acp: { backend: "acpx" },
+      }),
+    ]);
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+      parentConversationId: "oc_group_chat",
+    });
+
+    expect(resolved?.spec.conversationId).toBe("oc_group_chat:topic:om_topic_root");
+    expect(resolved?.spec.agentId).toBe("claude");
+    expect(resolved?.spec.backend).toBe("acpx");
+    expect(resolved?.record.conversation.conversationId).toBe("oc_group_chat:topic:om_topic_root");
+  });
+
+  it("rejects non-matching Feishu topic roots", () => {
+    const cfg = createCfgWithBindings([
+      createFeishuBinding({
+        agentId: "claude",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+      }),
+    ]);
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "oc_group_chat:topic:om_other_root",
+      parentConversationId: "oc_group_chat",
+    });
+
+    expect(resolved).toBeNull();
+  });
+
+  it("rejects Feishu non-topic group ACP bindings", () => {
+    const cfg = createCfgWithBindings([
+      createFeishuBinding({
+        agentId: "claude",
+        conversationId: "oc_group_chat",
+      }),
+    ]);
+
+    const resolved = resolveConfiguredAcpBindingRecord({
+      cfg,
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "oc_group_chat",
+    });
+
     expect(resolved).toBeNull();
   });
 

--- a/src/acp/persistent-bindings.types.ts
+++ b/src/acp/persistent-bindings.types.ts
@@ -3,7 +3,7 @@ import type { SessionBindingRecord } from "../infra/outbound/session-binding-ser
 import { sanitizeAgentId } from "../routing/session-key.js";
 import type { AcpRuntimeSessionMode } from "./runtime/types.js";
 
-export type ConfiguredAcpBindingChannel = "discord" | "telegram";
+export type ConfiguredAcpBindingChannel = "discord" | "telegram" | "feishu";
 
 export type ConfiguredAcpBindingSpec = {
   channel: ConfiguredAcpBindingChannel;

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -118,7 +118,7 @@ type FakeBinding = {
   targetSessionKey: string;
   targetKind: "subagent" | "session";
   conversation: {
-    channel: "discord" | "telegram";
+    channel: "discord" | "telegram" | "feishu";
     accountId: string;
     conversationId: string;
     parentConversationId?: string;
@@ -243,7 +243,7 @@ function createSessionBindingCapabilities() {
 type AcpBindInput = {
   targetSessionKey: string;
   conversation: {
-    channel?: "discord" | "telegram";
+    channel?: "discord" | "telegram" | "feishu";
     accountId: string;
     conversationId: string;
   };
@@ -256,21 +256,28 @@ function createAcpThreadBinding(input: AcpBindInput): FakeBinding {
     input.placement === "child" ? "thread-created" : input.conversation.conversationId;
   const boundBy = typeof input.metadata?.boundBy === "string" ? input.metadata.boundBy : "user-1";
   const channel = input.conversation.channel ?? "discord";
-  return createSessionBinding({
-    targetSessionKey: input.targetSessionKey,
-    conversation:
-      channel === "discord"
+  const conversation =
+    channel === "discord"
+      ? {
+          channel: "discord" as const,
+          accountId: input.conversation.accountId,
+          conversationId: nextConversationId,
+          parentConversationId: "parent-1",
+        }
+      : channel === "feishu"
         ? {
-            channel: "discord",
+            channel: "feishu" as const,
             accountId: input.conversation.accountId,
             conversationId: nextConversationId,
-            parentConversationId: "parent-1",
           }
         : {
-            channel: "telegram",
+            channel: "telegram" as const,
             accountId: input.conversation.accountId,
             conversationId: nextConversationId,
-          },
+          };
+  return createSessionBinding({
+    targetSessionKey: input.targetSessionKey,
+    conversation,
     metadata: { boundBy, webhookId: "wh-1" },
   });
 }
@@ -348,6 +355,23 @@ async function runTelegramAcpCommand(commandBody: string, cfg: OpenClawConfig = 
 
 async function runTelegramDmAcpCommand(commandBody: string, cfg: OpenClawConfig = baseCfg) {
   return handleAcpCommand(createTelegramDmParams(commandBody, cfg), true);
+}
+
+function createFeishuDmParams(commandBody: string, cfg: OpenClawConfig = baseCfg) {
+  const params = buildCommandTestParams(commandBody, cfg, {
+    Provider: "feishu",
+    Surface: "feishu",
+    OriginatingChannel: "feishu",
+    OriginatingTo: "user:ou_sender_1",
+    AccountId: "default",
+    SenderId: "ou_sender_1",
+  });
+  params.command.senderId = "user-1";
+  return params;
+}
+
+async function runFeishuDmAcpCommand(commandBody: string, cfg: OpenClawConfig = baseCfg) {
+  return handleAcpCommand(createFeishuDmParams(commandBody, cfg), true);
 }
 
 describe("/acp command", () => {
@@ -548,6 +572,23 @@ describe("/acp command", () => {
           channel: "telegram",
           accountId: "default",
           conversationId: "123456789",
+        }),
+      }),
+    );
+  });
+
+  it("binds Feishu DM ACP spawns to the current DM conversation", async () => {
+    const result = await runFeishuDmAcpCommand("/acp spawn codex --thread here");
+
+    expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+    expect(result?.reply?.text).toContain("Bound this thread to");
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "current",
+        conversation: expect.objectContaining({
+          channel: "feishu",
+          accountId: "default",
+          conversationId: "ou_sender_1",
         }),
       }),
     );

--- a/src/auto-reply/reply/commands-acp/context.test.ts
+++ b/src/auto-reply/reply/commands-acp/context.test.ts
@@ -266,6 +266,24 @@ describe("commands-acp context", () => {
     expect(resolveAcpCommandConversationId(params)).toBe("ou_sender_1");
   });
 
+  it("resolves Feishu DM conversation ids from user_id fallback targets", () => {
+    const params = buildCommandTestParams("/acp status", baseCfg, {
+      Provider: "feishu",
+      Surface: "feishu",
+      OriginatingChannel: "feishu",
+      OriginatingTo: "user:user_123",
+    });
+
+    expect(resolveAcpCommandBindingContext(params)).toEqual({
+      channel: "feishu",
+      accountId: "default",
+      threadId: undefined,
+      conversationId: "user_123",
+      parentConversationId: undefined,
+    });
+    expect(resolveAcpCommandConversationId(params)).toBe("user_123");
+  });
+
   it("does not infer a Feishu DM parent conversation id during fallback binding lookup", () => {
     const params = buildCommandTestParams("/acp status", baseCfg, {
       Provider: "feishu",

--- a/src/auto-reply/reply/commands-acp/context.test.ts
+++ b/src/auto-reply/reply/commands-acp/context.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __testing as feishuThreadBindingTesting,
+  createFeishuThreadBindingManager,
+} from "../../../../extensions/feishu/src/thread-bindings.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import {
+  __testing as sessionBindingTesting,
+  getSessionBindingService,
+} from "../../../infra/outbound/session-binding-service.js";
 import { buildCommandTestParams } from "../commands-spawn.test-harness.js";
 import {
   isAcpCommandDiscordChannel,
@@ -12,6 +20,11 @@ const baseCfg = {
 } satisfies OpenClawConfig;
 
 describe("commands-acp context", () => {
+  beforeEach(() => {
+    feishuThreadBindingTesting.resetFeishuThreadBindingsForTests();
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+  });
+
   it("resolves channel/account/thread context from originating fields", () => {
     const params = buildCommandTestParams("/acp sessions", baseCfg, {
       Provider: "discord",
@@ -185,6 +198,43 @@ describe("commands-acp context", () => {
       AccountId: "work",
       ParentSessionKey:
         "agent:main:feishu:group:oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+    });
+    params.sessionKey = "agent:codex:acp:binding:feishu:work:abc123";
+
+    expect(resolveAcpCommandBindingContext(params)).toEqual({
+      channel: "feishu",
+      accountId: "work",
+      threadId: "om_topic_root",
+      conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+      parentConversationId: "oc_group_chat",
+    });
+  });
+
+  it("preserves sender-scoped Feishu topic ids after ACP takeover from the live binding record", async () => {
+    createFeishuThreadBindingManager({ cfg: baseCfg, accountId: "work" });
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:codex:acp:binding:feishu:work:abc123",
+      targetKind: "session",
+      conversation: {
+        channel: "feishu",
+        accountId: "work",
+        conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+        parentConversationId: "oc_group_chat",
+      },
+      placement: "current",
+      metadata: {
+        agentId: "codex",
+      },
+    });
+
+    const params = buildCommandTestParams("/acp status", baseCfg, {
+      Provider: "feishu",
+      Surface: "feishu",
+      OriginatingChannel: "feishu",
+      OriginatingTo: "chat:oc_group_chat",
+      MessageThreadId: "om_topic_root",
+      SenderId: "ou_topic_user",
+      AccountId: "work",
     });
     params.sessionKey = "agent:codex:acp:binding:feishu:work:abc123";
 

--- a/src/auto-reply/reply/commands-acp/context.test.ts
+++ b/src/auto-reply/reply/commands-acp/context.test.ts
@@ -13,6 +13,7 @@ import {
   isAcpCommandDiscordChannel,
   resolveAcpCommandBindingContext,
   resolveAcpCommandConversationId,
+  resolveAcpCommandParentConversationId,
 } from "./context.js";
 
 const baseCfg = {
@@ -260,8 +261,27 @@ describe("commands-acp context", () => {
       accountId: "default",
       threadId: undefined,
       conversationId: "ou_sender_1",
-      parentConversationId: "ou_sender_1",
+      parentConversationId: undefined,
     });
     expect(resolveAcpCommandConversationId(params)).toBe("ou_sender_1");
+  });
+
+  it("does not infer a Feishu DM parent conversation id during fallback binding lookup", () => {
+    const params = buildCommandTestParams("/acp status", baseCfg, {
+      Provider: "feishu",
+      Surface: "feishu",
+      OriginatingChannel: "feishu",
+      OriginatingTo: "user:ou_sender_1",
+      AccountId: "work",
+    });
+
+    expect(resolveAcpCommandParentConversationId(params)).toBeUndefined();
+    expect(resolveAcpCommandBindingContext(params)).toEqual({
+      channel: "feishu",
+      accountId: "work",
+      threadId: undefined,
+      conversationId: "ou_sender_1",
+      parentConversationId: undefined,
+    });
   });
 });

--- a/src/auto-reply/reply/commands-acp/context.test.ts
+++ b/src/auto-reply/reply/commands-acp/context.test.ts
@@ -174,6 +174,29 @@ describe("commands-acp context", () => {
     );
   });
 
+  it("preserves sender-scoped Feishu topic ids after ACP route takeover via ParentSessionKey", () => {
+    const params = buildCommandTestParams("/acp status", baseCfg, {
+      Provider: "feishu",
+      Surface: "feishu",
+      OriginatingChannel: "feishu",
+      OriginatingTo: "chat:oc_group_chat",
+      MessageThreadId: "om_topic_root",
+      SenderId: "ou_topic_user",
+      AccountId: "work",
+      ParentSessionKey:
+        "agent:main:feishu:group:oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+    });
+    params.sessionKey = "agent:codex:acp:binding:feishu:work:abc123";
+
+    expect(resolveAcpCommandBindingContext(params)).toEqual({
+      channel: "feishu",
+      accountId: "work",
+      threadId: "om_topic_root",
+      conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+      parentConversationId: "oc_group_chat",
+    });
+  });
+
   it("resolves Feishu DM conversation ids from user targets", () => {
     const params = buildCommandTestParams("/acp status", baseCfg, {
       Provider: "feishu",

--- a/src/auto-reply/reply/commands-acp/context.test.ts
+++ b/src/auto-reply/reply/commands-acp/context.test.ts
@@ -126,4 +126,69 @@ describe("commands-acp context", () => {
     });
     expect(resolveAcpCommandConversationId(params)).toBe("123456789");
   });
+
+  it("builds Feishu topic conversation ids from chat target + root message id", () => {
+    const params = buildCommandTestParams("/acp status", baseCfg, {
+      Provider: "feishu",
+      Surface: "feishu",
+      OriginatingChannel: "feishu",
+      OriginatingTo: "chat:oc_group_chat",
+      MessageThreadId: "om_topic_root",
+      SenderId: "ou_topic_user",
+      AccountId: "work",
+    });
+
+    expect(resolveAcpCommandBindingContext(params)).toEqual({
+      channel: "feishu",
+      accountId: "work",
+      threadId: "om_topic_root",
+      conversationId: "oc_group_chat:topic:om_topic_root",
+      parentConversationId: "oc_group_chat",
+    });
+    expect(resolveAcpCommandConversationId(params)).toBe("oc_group_chat:topic:om_topic_root");
+  });
+
+  it("builds sender-scoped Feishu topic conversation ids when current session is sender-scoped", () => {
+    const params = buildCommandTestParams("/acp status", baseCfg, {
+      Provider: "feishu",
+      Surface: "feishu",
+      OriginatingChannel: "feishu",
+      OriginatingTo: "chat:oc_group_chat",
+      MessageThreadId: "om_topic_root",
+      SenderId: "ou_topic_user",
+      AccountId: "work",
+      SessionKey: "agent:main:feishu:group:oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+    });
+    params.sessionKey =
+      "agent:main:feishu:group:oc_group_chat:topic:om_topic_root:sender:ou_topic_user";
+
+    expect(resolveAcpCommandBindingContext(params)).toEqual({
+      channel: "feishu",
+      accountId: "work",
+      threadId: "om_topic_root",
+      conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+      parentConversationId: "oc_group_chat",
+    });
+    expect(resolveAcpCommandConversationId(params)).toBe(
+      "oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+    );
+  });
+
+  it("resolves Feishu DM conversation ids from user targets", () => {
+    const params = buildCommandTestParams("/acp status", baseCfg, {
+      Provider: "feishu",
+      Surface: "feishu",
+      OriginatingChannel: "feishu",
+      OriginatingTo: "user:ou_sender_1",
+    });
+
+    expect(resolveAcpCommandBindingContext(params)).toEqual({
+      channel: "feishu",
+      accountId: "default",
+      threadId: undefined,
+      conversationId: "ou_sender_1",
+      parentConversationId: "ou_sender_1",
+    });
+    expect(resolveAcpCommandConversationId(params)).toBe("ou_sender_1");
+  });
 });

--- a/src/auto-reply/reply/commands-acp/context.ts
+++ b/src/auto-reply/reply/commands-acp/context.ts
@@ -31,7 +31,21 @@ function parseFeishuTargetId(raw: unknown): string | undefined {
 }
 
 function parseFeishuDirectConversationId(raw: unknown): string | undefined {
-  const id = parseFeishuTargetId(raw);
+  const target = normalizeConversationText(raw);
+  if (!target) {
+    return undefined;
+  }
+  const withoutProvider = target.replace(/^(feishu|lark):/i, "").trim();
+  if (!withoutProvider) {
+    return undefined;
+  }
+  const lowered = withoutProvider.toLowerCase();
+  for (const prefix of ["user:", "dm:", "open_id:"]) {
+    if (lowered.startsWith(prefix)) {
+      return normalizeConversationText(withoutProvider.slice(prefix.length));
+    }
+  }
+  const id = parseFeishuTargetId(target);
   if (!id) {
     return undefined;
   }

--- a/src/auto-reply/reply/commands-acp/context.ts
+++ b/src/auto-reply/reply/commands-acp/context.ts
@@ -195,6 +195,10 @@ export function resolveAcpCommandParentConversationId(
     );
   }
   if (channel === "feishu") {
+    const threadId = resolveAcpCommandThreadId(params);
+    if (!threadId) {
+      return undefined;
+    }
     return (
       parseFeishuTargetId(params.ctx.OriginatingTo) ??
       parseFeishuTargetId(params.command.to) ??

--- a/src/auto-reply/reply/commands-acp/context.ts
+++ b/src/auto-reply/reply/commands-acp/context.ts
@@ -66,8 +66,7 @@ function resolveFeishuSenderScopedConversationId(params: {
       .find((binding) => {
         if (
           binding.conversation.channel !== "feishu" ||
-          binding.conversation.accountId !== params.accountId ||
-          binding.conversation.parentConversationId !== parentConversationId
+          binding.conversation.accountId !== params.accountId
         ) {
           return false;
         }

--- a/src/auto-reply/reply/commands-acp/context.ts
+++ b/src/auto-reply/reply/commands-acp/context.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../acp/conversation-id.js";
 import { DISCORD_THREAD_BINDING_CHANNEL } from "../../../channels/thread-bindings-policy.js";
 import { resolveConversationIdFromTargets } from "../../../infra/outbound/conversation-id.js";
+import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 import { parseAgentSessionKey } from "../../../routing/session-key.js";
 import type { HandleCommandsParams } from "../commands-types.js";
 import { parseDiscordParentChannelFromSessionKey } from "../discord-parent-channel.js";
@@ -41,6 +42,7 @@ function parseFeishuDirectConversationId(raw: unknown): string | undefined {
 }
 
 function resolveFeishuSenderScopedConversationId(params: {
+  accountId: string;
   parentConversationId?: string;
   threadId?: string;
   senderId?: string;
@@ -55,7 +57,33 @@ function resolveFeishuSenderScopedConversationId(params: {
     const scopedRest = parseAgentSessionKey(candidate)?.rest?.trim().toLowerCase() ?? "";
     return Boolean(scopedRest && expectedScopePrefix && scopedRest.startsWith(expectedScopePrefix));
   });
-  if (!parentConversationId || !threadId || !senderId || !isSenderScopedSession) {
+  if (!parentConversationId || !threadId || !senderId) {
+    return undefined;
+  }
+  if (!isSenderScopedSession && params.sessionKey?.trim()) {
+    const boundConversation = getSessionBindingService()
+      .listBySession(params.sessionKey)
+      .find((binding) => {
+        if (
+          binding.conversation.channel !== "feishu" ||
+          binding.conversation.accountId !== params.accountId ||
+          binding.conversation.parentConversationId !== parentConversationId
+        ) {
+          return false;
+        }
+        return (
+          binding.conversation.conversationId ===
+          buildFeishuConversationId({
+            chatId: parentConversationId,
+            scope: "group_topic_sender",
+            topicId: threadId,
+            senderOpenId: senderId,
+          })
+        );
+      });
+    if (boundConversation) {
+      return boundConversation.conversation.conversationId;
+    }
     return undefined;
   }
   return buildFeishuConversationId({
@@ -120,6 +148,7 @@ export function resolveAcpCommandConversationId(params: HandleCommandsParams): s
     const parentConversationId = resolveAcpCommandParentConversationId(params);
     if (threadId && parentConversationId) {
       const senderScopedConversationId = resolveFeishuSenderScopedConversationId({
+        accountId: resolveAcpCommandAccountId(params),
         parentConversationId,
         threadId,
         senderId: params.command.senderId ?? params.ctx.SenderId,

--- a/src/auto-reply/reply/commands-acp/context.ts
+++ b/src/auto-reply/reply/commands-acp/context.ts
@@ -45,15 +45,16 @@ function resolveFeishuSenderScopedConversationId(params: {
   threadId?: string;
   senderId?: string;
   sessionKey?: string;
+  parentSessionKey?: string;
 }): string | undefined {
   const parentConversationId = normalizeConversationText(params.parentConversationId);
   const threadId = normalizeConversationText(params.threadId);
   const senderId = normalizeConversationText(params.senderId);
-  const scopedRest = parseAgentSessionKey(params.sessionKey)?.rest?.trim().toLowerCase() ?? "";
   const expectedScopePrefix = `feishu:group:${parentConversationId?.toLowerCase()}:topic:${threadId?.toLowerCase()}:sender:`;
-  const isSenderScopedSession = Boolean(
-    scopedRest && expectedScopePrefix && scopedRest.startsWith(expectedScopePrefix),
-  );
+  const isSenderScopedSession = [params.sessionKey, params.parentSessionKey].some((candidate) => {
+    const scopedRest = parseAgentSessionKey(candidate)?.rest?.trim().toLowerCase() ?? "";
+    return Boolean(scopedRest && expectedScopePrefix && scopedRest.startsWith(expectedScopePrefix));
+  });
   if (!parentConversationId || !threadId || !senderId || !isSenderScopedSession) {
     return undefined;
   }
@@ -123,6 +124,7 @@ export function resolveAcpCommandConversationId(params: HandleCommandsParams): s
         threadId,
         senderId: params.command.senderId ?? params.ctx.SenderId,
         sessionKey: params.sessionKey,
+        parentSessionKey: params.ctx.ParentSessionKey,
       });
       return (
         senderScopedConversationId ??

--- a/src/auto-reply/reply/commands-acp/context.ts
+++ b/src/auto-reply/reply/commands-acp/context.ts
@@ -1,3 +1,4 @@
+import { buildFeishuConversationId } from "../../../../extensions/feishu/src/conversation-id.js";
 import {
   buildTelegramTopicConversationId,
   normalizeConversationText,
@@ -5,9 +6,64 @@ import {
 } from "../../../acp/conversation-id.js";
 import { DISCORD_THREAD_BINDING_CHANNEL } from "../../../channels/thread-bindings-policy.js";
 import { resolveConversationIdFromTargets } from "../../../infra/outbound/conversation-id.js";
+import { parseAgentSessionKey } from "../../../routing/session-key.js";
 import type { HandleCommandsParams } from "../commands-types.js";
 import { parseDiscordParentChannelFromSessionKey } from "../discord-parent-channel.js";
 import { resolveTelegramConversationId } from "../telegram-context.js";
+
+function parseFeishuTargetId(raw: unknown): string | undefined {
+  const target = normalizeConversationText(raw);
+  if (!target) {
+    return undefined;
+  }
+  const withoutProvider = target.replace(/^(feishu|lark):/i, "").trim();
+  if (!withoutProvider) {
+    return undefined;
+  }
+  const lowered = withoutProvider.toLowerCase();
+  for (const prefix of ["chat:", "group:", "channel:", "user:", "dm:", "open_id:"]) {
+    if (lowered.startsWith(prefix)) {
+      return normalizeConversationText(withoutProvider.slice(prefix.length));
+    }
+  }
+  return withoutProvider;
+}
+
+function parseFeishuDirectConversationId(raw: unknown): string | undefined {
+  const id = parseFeishuTargetId(raw);
+  if (!id) {
+    return undefined;
+  }
+  if (id.startsWith("ou_") || id.startsWith("on_")) {
+    return id;
+  }
+  return undefined;
+}
+
+function resolveFeishuSenderScopedConversationId(params: {
+  parentConversationId?: string;
+  threadId?: string;
+  senderId?: string;
+  sessionKey?: string;
+}): string | undefined {
+  const parentConversationId = normalizeConversationText(params.parentConversationId);
+  const threadId = normalizeConversationText(params.threadId);
+  const senderId = normalizeConversationText(params.senderId);
+  const scopedRest = parseAgentSessionKey(params.sessionKey)?.rest?.trim().toLowerCase() ?? "";
+  const expectedScopePrefix = `feishu:group:${parentConversationId?.toLowerCase()}:topic:${threadId?.toLowerCase()}:sender:`;
+  const isSenderScopedSession = Boolean(
+    scopedRest && expectedScopePrefix && scopedRest.startsWith(expectedScopePrefix),
+  );
+  if (!parentConversationId || !threadId || !senderId || !isSenderScopedSession) {
+    return undefined;
+  }
+  return buildFeishuConversationId({
+    chatId: parentConversationId,
+    scope: "group_topic_sender",
+    topicId: threadId,
+    senderOpenId: senderId,
+  });
+}
 
 export function resolveAcpCommandChannel(params: HandleCommandsParams): string {
   const raw =
@@ -58,6 +114,31 @@ export function resolveAcpCommandConversationId(params: HandleCommandsParams): s
       );
     }
   }
+  if (channel === "feishu") {
+    const threadId = resolveAcpCommandThreadId(params);
+    const parentConversationId = resolveAcpCommandParentConversationId(params);
+    if (threadId && parentConversationId) {
+      const senderScopedConversationId = resolveFeishuSenderScopedConversationId({
+        parentConversationId,
+        threadId,
+        senderId: params.command.senderId ?? params.ctx.SenderId,
+        sessionKey: params.sessionKey,
+      });
+      return (
+        senderScopedConversationId ??
+        buildFeishuConversationId({
+          chatId: parentConversationId,
+          scope: "group_topic",
+          topicId: threadId,
+        })
+      );
+    }
+    return (
+      parseFeishuDirectConversationId(params.ctx.OriginatingTo) ??
+      parseFeishuDirectConversationId(params.command.to) ??
+      parseFeishuDirectConversationId(params.ctx.To)
+    );
+  }
   return resolveConversationIdFromTargets({
     threadId: params.ctx.MessageThreadId,
     targets: [params.ctx.OriginatingTo, params.command.to, params.ctx.To],
@@ -81,6 +162,13 @@ export function resolveAcpCommandParentConversationId(
       parseTelegramChatIdFromTarget(params.ctx.OriginatingTo) ??
       parseTelegramChatIdFromTarget(params.command.to) ??
       parseTelegramChatIdFromTarget(params.ctx.To)
+    );
+  }
+  if (channel === "feishu") {
+    return (
+      parseFeishuTargetId(params.ctx.OriginatingTo) ??
+      parseFeishuTargetId(params.command.to) ??
+      parseFeishuTargetId(params.ctx.To)
     );
   }
   if (channel === DISCORD_THREAD_BINDING_CHANNEL) {

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -125,7 +125,7 @@ async function bindSpawnedAcpSessionToThread(params: {
 
   const currentThreadId = bindingContext.threadId ?? "";
   const currentConversationId = bindingContext.conversationId?.trim() || "";
-  const requiresThreadIdForHere = channel !== "telegram";
+  const requiresThreadIdForHere = channel !== "telegram" && channel !== "feishu";
   if (
     threadMode === "here" &&
     ((requiresThreadIdForHere && !currentThreadId) ||
@@ -137,7 +137,12 @@ async function bindSpawnedAcpSessionToThread(params: {
     };
   }
 
-  const placement = channel === "telegram" ? "current" : currentThreadId ? "current" : "child";
+  const placement =
+    channel === "telegram" || channel === "feishu"
+      ? "current"
+      : currentThreadId
+        ? "current"
+        : "child";
   if (!capabilities.placements.includes(placement)) {
     return {
       ok: false,

--- a/src/config/config.acp-binding-cutover.test.ts
+++ b/src/config/config.acp-binding-cutover.test.ts
@@ -190,6 +190,24 @@ describe("ACP binding cutover schema", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("rejects Feishu ACP DM peer IDs keyed by union id", () => {
+    const parsed = OpenClawSchema.safeParse({
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            peer: { kind: "direct", id: "on_union_user_123" },
+          },
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
   it("rejects bare Feishu group chat ACP peer IDs", () => {
     const parsed = OpenClawSchema.safeParse({
       bindings: [

--- a/src/config/config.acp-binding-cutover.test.ts
+++ b/src/config/config.acp-binding-cutover.test.ts
@@ -208,6 +208,24 @@ describe("ACP binding cutover schema", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("rejects Feishu ACP topic peer IDs with non-canonical sender ids", () => {
+    const parsed = OpenClawSchema.safeParse({
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            peer: { kind: "group", id: "oc_group_chat:topic:om_topic_root:sender:user_123" },
+          },
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
   it("rejects bare Feishu group chat ACP peer IDs", () => {
     const parsed = OpenClawSchema.safeParse({
       bindings: [

--- a/src/config/config.acp-binding-cutover.test.ts
+++ b/src/config/config.acp-binding-cutover.test.ts
@@ -163,6 +163,15 @@ describe("ACP binding cutover schema", () => {
           match: {
             channel: "feishu",
             accountId: "default",
+            peer: { kind: "direct", id: "user_123" },
+          },
+        },
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "feishu",
+            accountId: "default",
             peer: { kind: "group", id: "oc_group_chat:topic:om_topic_root:sender:ou_user_123" },
           },
         },

--- a/src/config/config.acp-binding-cutover.test.ts
+++ b/src/config/config.acp-binding-cutover.test.ts
@@ -144,4 +144,67 @@ describe("ACP binding cutover schema", () => {
 
     expect(parsed.success).toBe(false);
   });
+
+  it("accepts canonical Feishu ACP DM and topic peer IDs", () => {
+    const parsed = OpenClawSchema.safeParse({
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            peer: { kind: "direct", id: "ou_user_123" },
+          },
+        },
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            peer: { kind: "group", id: "oc_group_chat:topic:om_topic_root:sender:ou_user_123" },
+          },
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects non-canonical Feishu ACP peer IDs", () => {
+    const parsed = OpenClawSchema.safeParse({
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            peer: { kind: "group", id: "oc_group_chat:sender:ou_user_123" },
+          },
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects bare Feishu group chat ACP peer IDs", () => {
+    const parsed = OpenClawSchema.safeParse({
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            peer: { kind: "group", id: "oc_group_chat" },
+          },
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
 });

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -90,13 +90,13 @@ const AcpBindingSchema = z
     }
     if (
       channel === "feishu" &&
-      !/^(ou_[^:]+|on_[^:]+|oc_[^:]+:topic:[^:]+(?::sender:[^:]+)?)$/.test(peerId)
+      !/^(ou_[^:]+|oc_[^:]+:topic:[^:]+(?::sender:[^:]+)?)$/.test(peerId)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["match", "peer", "id"],
         message:
-          "Feishu ACP bindings require canonical DM IDs (ou_xxx/on_xxx) or topic IDs in the form oc_group:topic:om_root[:sender:ou_xxx].",
+          "Feishu ACP bindings require canonical DM IDs (ou_xxx) or topic IDs in the form oc_group:topic:om_root[:sender:ou_xxx].",
       });
     }
   });

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -88,16 +88,23 @@ const AcpBindingSchema = z
           "Telegram ACP bindings require canonical topic IDs in the form -1001234567890:topic:42.",
       });
     }
-    if (
-      channel === "feishu" &&
-      !/^(ou_[^:]+|oc_[^:]+:topic:[^:]+(?::sender:ou_[^:]+)?)$/.test(peerId)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["match", "peer", "id"],
-        message:
-          "Feishu ACP bindings require canonical DM IDs (ou_xxx) or topic IDs in the form oc_group:topic:om_root[:sender:ou_xxx].",
-      });
+    if (channel === "feishu") {
+      const peerKind = value.match.peer?.kind;
+      const isDirectId =
+        (peerKind === "direct" || peerKind === "dm") &&
+        /^[^:]+$/.test(peerId) &&
+        !peerId.startsWith("oc_") &&
+        !peerId.startsWith("on_");
+      const isTopicId =
+        peerKind === "group" && /^oc_[^:]+:topic:[^:]+(?::sender:ou_[^:]+)?$/.test(peerId);
+      if (!isDirectId && !isTopicId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["match", "peer", "id"],
+          message:
+            "Feishu ACP bindings require direct peer IDs for DMs or topic IDs in the form oc_group:topic:om_root[:sender:ou_xxx].",
+        });
+      }
     }
   });
 

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -90,7 +90,7 @@ const AcpBindingSchema = z
     }
     if (
       channel === "feishu" &&
-      !/^(ou_[^:]+|on_[^:]+|[^:]+:topic:[^:]+(?::sender:[^:]+)?)$/.test(peerId)
+      !/^(ou_[^:]+|on_[^:]+|oc_[^:]+:topic:[^:]+(?::sender:[^:]+)?)$/.test(peerId)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -90,7 +90,7 @@ const AcpBindingSchema = z
     }
     if (
       channel === "feishu" &&
-      !/^(ou_[^:]+|oc_[^:]+:topic:[^:]+(?::sender:[^:]+)?)$/.test(peerId)
+      !/^(ou_[^:]+|oc_[^:]+:topic:[^:]+(?::sender:ou_[^:]+)?)$/.test(peerId)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -71,11 +71,12 @@ const AcpBindingSchema = z
       return;
     }
     const channel = value.match.channel.trim().toLowerCase();
-    if (channel !== "discord" && channel !== "telegram") {
+    if (channel !== "discord" && channel !== "telegram" && channel !== "feishu") {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["match", "channel"],
-        message: 'ACP bindings currently support only "discord" and "telegram" channels.',
+        message:
+          'ACP bindings currently support only "discord", "telegram", and "feishu" channels.',
       });
       return;
     }
@@ -85,6 +86,17 @@ const AcpBindingSchema = z
         path: ["match", "peer", "id"],
         message:
           "Telegram ACP bindings require canonical topic IDs in the form -1001234567890:topic:42.",
+      });
+    }
+    if (
+      channel === "feishu" &&
+      !/^(ou_[^:]+|on_[^:]+|[^:]+:topic:[^:]+(?::sender:[^:]+)?)$/.test(peerId)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["match", "peer", "id"],
+        message:
+          "Feishu ACP bindings require canonical DM IDs (ou_xxx/on_xxx) or topic IDs in the form oc_group:topic:om_root[:sender:ou_xxx].",
       });
     }
   });


### PR DESCRIPTION
## Summary

- Problem: OpenClaw did not support Feishu current-conversation ACP/session binding, so Feishu DMs and topic conversations could not host persistent ACP sessions or return delegated subagent completion back into the originating conversation.
- Why it matters: Feishu lagged behind Discord and Telegram for persistent ACP and thread-bound delegated workflows.
- What changed: this PR adds Feishu ACP binding support, Feishu-aware `/acp` binding context, Feishu current-conversation session binding, Feishu subagent spawn binding, Feishu completion delivery target resolution, and cleanup/lifecycle wiring on the existing Feishu binding manager.
- What did NOT change (scope boundary): v1 still does not create Feishu child topics/threads, does not support generic non-topic group chats, and does not add card UX or native command menus.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Feishu `bindings[]` entries can now use `type: "acp"` with `match.channel: "feishu"` for supported DM/topic conversation IDs.
- Feishu DMs and topic conversations can now host bound ACP sessions through the same current-conversation binding model used by `/acp spawn --thread here`.
- Feishu-originated delegated sessions can now bind to the originating Feishu conversation and deliver child completion back to that same DM/topic context.
- Unsupported generic non-topic Feishu group chats fail closed instead of partially binding.
- Unsupported Feishu ACP DM union-id targets (`on_...`) are rejected until union-id routing exists.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): top-level `bindings[]` ACP entries for `match.channel: "feishu"`, covering DM ids and topic ids

### Steps

1. Configure a Feishu ACP binding for a supported DM/topic, or run `/acp spawn ... --thread here` / Feishu-originated delegated work from a Feishu DM/topic.
2. Send follow-up messages in that same Feishu conversation and allow a child completion to announce back to the requester.
3. Verify ACP/subagent routing resolves the same bound conversation and unsupported Feishu targets fail closed.

### Expected

- Feishu DMs and topics route consistently to the correct bound ACP/subagent session.
- Child completion is delivered back to the original Feishu conversation context.
- Sender-scoped topic sessions preserve exact-scope binding only when uniquely recoverable.
- Unsupported bare group-chat ACP bindings and unsupported Feishu union-id DM bindings are rejected.

### Actual

- Matched expected behavior in targeted tests and local verification.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Feishu configured ACP binding resolution for DMs/topics, Feishu `/acp` command context in DMs/topics, sender-scoped topic inheritance, Feishu subagent spawn binding, completion delivery target resolution, exact-target DM delivery preservation, fail-closed behavior for ambiguous requester-session topic bindings, monitor-owned binding-manager lifecycle enforcement, and rejection of unsupported Feishu union-id / non-topic group ACP ids.
- Edge cases checked: topic root vs sender-scoped topic ids, mixed topic-level plus sender-scoped bindings, late-hook behavior without a live Feishu manager, DM fallback binding lookup, manager stop cleanup, config-schema rejection of invalid Feishu ACP ids.
- What you did **not** verify: end-to-end live Feishu traffic against a real tenant/app.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove Feishu ACP `bindings[]` entries / Feishu current-conversation session-binding usage, or revert commit `d5336973fe`.
- Files/config to restore: Feishu session-binding changes in `extensions/feishu/src/`, ACP context/config validation changes in `src/auto-reply/reply/commands-acp/` and `src/config/`.
- Known bad symptoms reviewers should watch for: Feishu delegated completions not returning to the originating conversation, sender-scoped topics binding to the wrong scope, or unsupported Feishu identifiers validating unexpectedly.

## Risks and Mitigations

- Risk: Feishu conversation-id canonicalization could drift between ingress, command binding, configured-binding resolution, and subagent completion delivery.
  - Mitigation: shared Feishu conversation-id helper plus targeted regression tests for DM, topic, sender-scoped topic, and ambiguous topic-binding paths.
- Risk: late Feishu hook execution could recreate orphaned binding state outside the monitor lifecycle.
  - Mitigation: subagent hooks now require a live monitor-owned Feishu binding manager and fail closed when the account monitor is inactive.
- Risk: Feishu DM/session delivery could use the wrong outbound target if reconstructed from the conversation key alone.
  - Mitigation: delivery target metadata is persisted on Feishu bindings and reused for completion delivery.
