### PR TITLE
Fix ACP parent relay final delivery for non-threaded direct chats

### DIFF
--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -297,6 +297,36 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("keeps the relay alive when parent session delivery context lookup fails", () => {
+    loadSessionEntryMock.mockImplementation(() => {
+      throw new Error("bad config");
+    });
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-4d",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-4d",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-4d",
+      stream: "assistant",
+      data: {
+        delta: "still relays progress",
+      },
+    });
+    vi.advanceTimersByTime(15);
+
+    const texts = collectedTexts();
+    expect(texts.some((text) => text.includes("Started codex session"))).toBe(true);
+    expect(texts.some((text) => text.includes("codex: still relays progress"))).toBe(true);
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    relay.dispose();
+  });
+
   it("preserves delta whitespace boundaries in progress relays", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-5",

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -10,6 +10,9 @@ const requestHeartbeatNowMock = vi.fn();
 const readAcpSessionEntryMock = vi.fn();
 const resolveSessionFilePathMock = vi.fn();
 const resolveSessionFilePathOptionsMock = vi.fn();
+const routeReplyMock = vi.fn();
+const loadSessionEntryMock = vi.fn();
+const deliveryContextFromSessionMock = vi.fn();
 
 vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
@@ -23,9 +26,21 @@ vi.mock("../acp/runtime/session-meta.js", () => ({
   readAcpSessionEntry: (...args: unknown[]) => readAcpSessionEntryMock(...args),
 }));
 
+vi.mock("../auto-reply/reply/route-reply.js", () => ({
+  routeReply: (...args: unknown[]) => routeReplyMock(...args),
+}));
+
 vi.mock("../config/sessions/paths.js", () => ({
   resolveSessionFilePath: (...args: unknown[]) => resolveSessionFilePathMock(...args),
   resolveSessionFilePathOptions: (...args: unknown[]) => resolveSessionFilePathOptionsMock(...args),
+}));
+
+vi.mock("../gateway/session-utils.js", () => ({
+  loadSessionEntry: (...args: unknown[]) => loadSessionEntryMock(...args),
+}));
+
+vi.mock("../utils/delivery-context.js", () => ({
+  deliveryContextFromSession: (...args: unknown[]) => deliveryContextFromSessionMock(...args),
 }));
 
 function collectedTexts() {
@@ -39,7 +54,20 @@ describe("startAcpSpawnParentStreamRelay", () => {
     readAcpSessionEntryMock.mockReset();
     resolveSessionFilePathMock.mockReset();
     resolveSessionFilePathOptionsMock.mockReset();
+    routeReplyMock.mockReset();
+    loadSessionEntryMock.mockReset();
+    deliveryContextFromSessionMock.mockReset();
     resolveSessionFilePathOptionsMock.mockImplementation((value: unknown) => value);
+    routeReplyMock.mockResolvedValue(undefined);
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {
+        channels: {},
+      },
+      entry: {
+        sessionKey: "agent:main:main",
+      },
+    });
+    deliveryContextFromSessionMock.mockReturnValue(undefined);
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-04T01:00:00.000Z"));
   });
@@ -178,6 +206,97 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("delivers the final child output back to non-threaded direct chats", async () => {
+    deliveryContextFromSessionMock.mockReturnValue({
+      channel: "whatsapp",
+      to: "+15551234567",
+      accountId: "default",
+    });
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-4b",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-4b",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-4b",
+      stream: "assistant",
+      data: {
+        delta: "hello",
+      },
+    });
+    emitAgentEvent({
+      runId: "run-4b",
+      stream: "assistant",
+      data: {
+        delta: " world",
+      },
+    });
+    vi.advanceTimersByTime(15);
+
+    emitAgentEvent({
+      runId: "run-4b",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+      },
+    });
+    await Promise.resolve();
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "whatsapp",
+        to: "+15551234567",
+        accountId: "default",
+        sessionKey: "agent:main:main",
+        payload: { text: "hello world" },
+      }),
+    );
+    relay.dispose();
+  });
+
+  it("does not direct-reply for threaded delivery contexts", async () => {
+    deliveryContextFromSessionMock.mockReturnValue({
+      channel: "slack",
+      to: "C123",
+      threadId: "thread-1",
+    });
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-4c",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-4c",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-4c",
+      stream: "assistant",
+      data: {
+        delta: "thread reply should stay internal",
+      },
+    });
+    vi.advanceTimersByTime(15);
+
+    emitAgentEvent({
+      runId: "run-4c",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+      },
+    });
+    await Promise.resolve();
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    relay.dispose();
+  });
+
   it("preserves delta whitespace boundaries in progress relays", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-5",
@@ -206,6 +325,42 @@ describe("startAcpSpawnParentStreamRelay", () => {
 
     const texts = collectedTexts();
     expect(texts.some((text) => text.includes("codex: hello world"))).toBe(true);
+    relay.dispose();
+  });
+
+  it("delivers direct-chat child failures back to the parent channel", async () => {
+    deliveryContextFromSessionMock.mockReturnValue({
+      channel: "telegram",
+      to: "123456",
+    });
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-5b",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-5b",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-5b",
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        error: "boom",
+      },
+    });
+    await Promise.resolve();
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "123456",
+        sessionKey: "agent:main:main",
+        payload: { text: "boom" },
+      }),
+    );
     relay.dispose();
   });
 

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -1,11 +1,14 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
+import { routeReply } from "../auto-reply/reply/route-reply.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
+import { loadSessionEntry } from "../gateway/session-utils.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { deliveryContextFromSession } from "../utils/delivery-context.js";
 
 const DEFAULT_STREAM_FLUSH_MS = 2_500;
 const DEFAULT_NO_OUTPUT_NOTICE_MS = 60_000;
@@ -13,6 +16,7 @@ const DEFAULT_NO_OUTPUT_POLL_MS = 15_000;
 const DEFAULT_MAX_RELAY_LIFETIME_MS = 6 * 60 * 60 * 1000;
 const STREAM_BUFFER_MAX_CHARS = 4_000;
 const STREAM_SNIPPET_MAX_CHARS = 220;
+const DIRECT_REPLY_MAX_CHARS = 24_000;
 
 function compactWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
@@ -114,6 +118,18 @@ export function startAcpSpawnParentStreamRelay(params: {
   const relayLabel = truncate(compactWhitespace(params.agentId), 40) || "ACP child";
   const contextPrefix = `acp-spawn:${runId}`;
   const logPath = toTrimmedString(params.logPath);
+  const { cfg, entry } = loadSessionEntry(parentSessionKey);
+  const parentDeliveryContext = deliveryContextFromSession(entry);
+  const directReplyTarget =
+    parentDeliveryContext?.channel &&
+    parentDeliveryContext?.to &&
+    parentDeliveryContext?.threadId == null
+      ? {
+          channel: parentDeliveryContext.channel,
+          to: parentDeliveryContext.to,
+          accountId: parentDeliveryContext.accountId,
+        }
+      : undefined;
   let logDirReady = false;
   let pendingLogLines = "";
   let logFlushScheduled = false;
@@ -203,6 +219,8 @@ export function startAcpSpawnParentStreamRelay(params: {
 
   let disposed = false;
   let pendingText = "";
+  let directReplyText = "";
+  let directReplyTruncated = false;
   let lastProgressAt = Date.now();
   let stallNotified = false;
   let flushTimer: NodeJS.Timeout | undefined;
@@ -234,6 +252,44 @@ export function startAcpSpawnParentStreamRelay(params: {
       return;
     }
     emit(`${relayLabel}: ${snippet}`, `${contextPrefix}:progress`);
+  };
+
+  const appendDirectReplyText = (text: string) => {
+    if (!directReplyTarget || !text) {
+      return;
+    }
+    if (directReplyText.length >= DIRECT_REPLY_MAX_CHARS) {
+      directReplyTruncated = true;
+      return;
+    }
+    const remaining = DIRECT_REPLY_MAX_CHARS - directReplyText.length;
+    const accepted = remaining < text.length ? text.slice(0, remaining) : text;
+    if (accepted) {
+      directReplyText += accepted;
+    }
+    if (accepted.length < text.length) {
+      directReplyTruncated = true;
+    }
+  };
+
+  const sendDirectReply = (text: string) => {
+    if (!directReplyTarget) {
+      return;
+    }
+    const cleaned = text.trim();
+    if (!cleaned) {
+      return;
+    }
+    void routeReply({
+      payload: { text: cleaned },
+      channel: directReplyTarget.channel,
+      to: directReplyTarget.to,
+      sessionKey: parentSessionKey,
+      accountId: directReplyTarget.accountId,
+      cfg,
+    }).catch(() => {
+      // Preserve best-effort relay semantics if direct delivery fails.
+    });
   };
 
   const scheduleFlush = () => {
@@ -295,6 +351,7 @@ export function startAcpSpawnParentStreamRelay(params: {
         return;
       }
       logEvent("assistant_delta", { delta });
+      appendDirectReplyText(delta);
 
       if (stallNotified) {
         stallNotified = false;
@@ -322,6 +379,13 @@ export function startAcpSpawnParentStreamRelay(params: {
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
     if (phase === "end") {
       flushPending();
+      if (directReplyText.trim()) {
+        sendDirectReply(
+          directReplyTruncated
+            ? `${directReplyText.trimEnd()}\n\n[Output truncated by relay]`
+            : directReplyText,
+        );
+      }
       const startedAt = toFiniteNumber(
         (event.data as { startedAt?: unknown } | undefined)?.startedAt,
       );
@@ -345,6 +409,9 @@ export function startAcpSpawnParentStreamRelay(params: {
     if (phase === "error") {
       flushPending();
       const errorText = toTrimmedString((event.data as { error?: unknown } | undefined)?.error);
+      if (errorText) {
+        sendDirectReply(errorText);
+      }
       if (errorText) {
         emit(`${relayLabel} run failed: ${errorText}`, `${contextPrefix}:error`);
       } else {

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -118,18 +118,31 @@ export function startAcpSpawnParentStreamRelay(params: {
   const relayLabel = truncate(compactWhitespace(params.agentId), 40) || "ACP child";
   const contextPrefix = `acp-spawn:${runId}`;
   const logPath = toTrimmedString(params.logPath);
-  const { cfg, entry } = loadSessionEntry(parentSessionKey);
-  const parentDeliveryContext = deliveryContextFromSession(entry);
-  const directReplyTarget =
-    parentDeliveryContext?.channel &&
-    parentDeliveryContext?.to &&
-    parentDeliveryContext?.threadId == null
-      ? {
-          channel: parentDeliveryContext.channel,
-          to: parentDeliveryContext.to,
-          accountId: parentDeliveryContext.accountId,
-        }
-      : undefined;
+  let cfg: ReturnType<typeof loadSessionEntry>["cfg"] | undefined;
+  let directReplyTarget:
+    | {
+        channel: string;
+        to: string;
+        accountId?: string;
+      }
+    | undefined;
+  try {
+    const loaded = loadSessionEntry(parentSessionKey);
+    cfg = loaded.cfg;
+    const parentDeliveryContext = deliveryContextFromSession(loaded.entry);
+    directReplyTarget =
+      parentDeliveryContext?.channel &&
+      parentDeliveryContext?.to &&
+      parentDeliveryContext?.threadId == null
+        ? {
+            channel: parentDeliveryContext.channel,
+            to: parentDeliveryContext.to,
+            accountId: parentDeliveryContext.accountId,
+          }
+        : undefined;
+  } catch {
+    // Best-effort delivery context; never break relay initialization.
+  }
   let logDirReady = false;
   let pendingLogLines = "";
   let logFlushScheduled = false;
@@ -411,8 +424,6 @@ export function startAcpSpawnParentStreamRelay(params: {
       const errorText = toTrimmedString((event.data as { error?: unknown } | undefined)?.error);
       if (errorText) {
         sendDirectReply(errorText);
-      }
-      if (errorText) {
         emit(`${relayLabel} run failed: ${errorText}`, `${contextPrefix}:error`);
       } else {
         emit(`${relayLabel} run failed.`, `${contextPrefix}:error`);


### PR DESCRIPTION
Summary

This change teaches the ACP parent stream relay to deliver a child agent's final visible output back to the originating direct chat when the parent session has a non-threaded delivery context.

Today, `sessions_spawn(runtime="acp", streamTo="parent")` relays progress into the parent session as internal `system_event`s, but the final child output is not delivered back to direct-chat channels such as WhatsApp. In practice this means:

- the ACP child run completes successfully
- the final text is visible in logs/session state
- no outbound reply is sent to the original direct chat

This PR keeps the existing internal relay behavior intact and adds a minimal best-effort direct-channel delivery path for non-threaded parent sessions.

What changed

- detect direct-chat delivery context from the parent session
- accumulate assistant deltas for final outward delivery
- on child completion, send the aggregated final text through `routeReply(...)`
- on child error, send the error text through `routeReply(...)`
- keep the existing `system_event` progress relay unchanged
- avoid direct delivery for threaded contexts

Behavioral notes

- only non-threaded direct chats opt into the new delivery path
- progress/stall notices still remain internal to the parent session
- final delivery remains best-effort; relay failures do not break session execution
- long child output is capped before direct delivery and marked as truncated

Tests

- added direct-chat completion delivery coverage
- added threaded-context no-direct-reply coverage
- added direct-chat error delivery coverage

Validation

Ran:

`pnpm exec vitest run --config vitest.agents-local.config.ts`

Result:

- `1` test file passed
- `9` tests passed

Related

- Closes or addresses: https://github.com/openclaw/openclaw/issues/46814
