### PR TITLE
fix(discord): fail startup when bot identity fetch fails

### DIFF
--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -456,6 +456,23 @@ describe("monitorDiscordProvider", () => {
     expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
   });
 
+  it("fails startup when bot identity fetch fails instead of continuing with undefined botUserId", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    clientFetchUserMock.mockRejectedValueOnce(new Error("fetch user boom"));
+
+    await expect(
+      monitorDiscordProvider({
+        config: baseConfig(),
+        runtime: baseRuntime(),
+      }),
+    ).rejects.toThrow("fetch user boom");
+
+    expect(createDiscordMessageHandlerMock).not.toHaveBeenCalled();
+    expect(monitorLifecycleMock).not.toHaveBeenCalled();
+    expect(createdBindingManagers).toHaveLength(1);
+    expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
+  });
+
   it("does not double-stop thread bindings when lifecycle performs cleanup", async () => {
     const { monitorDiscordProvider } = await import("./provider.js");
 

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -864,6 +864,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         gateway: lifecycleGateway,
         details: String(err),
       });
+      throw err;
+    }
+
+    if (!botUserId) {
+      throw new Error("discord: failed to resolve bot identity");
     }
 
     if (voiceEnabled) {


### PR DESCRIPTION
## Summary
- abort Discord provider startup when `fetchUser("@me")` fails
- prevent continuing with an undefined `botUserId`
- add a regression test covering failed bot identity fetch

## Why
Fixes #46847. A transient startup failure could leave Discord running with `botUserId = undefined`, which then cascaded into routing and security failures.

## Validation
- added regression test for failed bot identity fetch
- minimal startup-path change