### PR TITLE
Merge branch 'main' of github.com:openclaw/openclaw

### DIFF
--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -243,6 +243,52 @@ describe("runHeartbeatOnce ack handling", () => {
     });
   });
 
+  it("interpolates responsePrefix template variables for heartbeat alert replies", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createHeartbeatConfig({
+        tmpDir,
+        storePath,
+        heartbeat: { every: "5m", target: "telegram" },
+        channels: {
+          telegram: {
+            token: "test-token",
+            allowFrom: ["*"],
+            heartbeat: { showOk: false },
+          },
+        },
+        messages: { responsePrefix: "[{model}]" },
+      });
+
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+
+      replySpy.mockImplementation(async (_ctx, opts) => {
+        opts?.onModelSelected?.({
+          provider: "google",
+          model: "gemini-2.5-flash",
+          thinkLevel: "low",
+        });
+        return { text: "Check complete" };
+      });
+
+      const sendTelegram = createMessageSendSpy();
+      await runHeartbeatOnce({
+        cfg,
+        deps: makeTelegramDeps({ sendTelegram }),
+      });
+
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(
+        TELEGRAM_GROUP,
+        "[gemini-2.5-flash] Check complete",
+        expect.any(Object),
+      );
+    });
+  });
+
   it("skips heartbeat LLM calls when visibility disables all output", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createWhatsAppHeartbeatConfig({

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -6,7 +6,7 @@ import {
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
 import { appendCronStyleCurrentTimeLine } from "../agents/current-time.js";
-import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
+import { resolveEffectiveMessagesConfig, resolveIdentityName } from "../agents/identity.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
@@ -17,6 +17,11 @@ import {
   stripHeartbeatToken,
 } from "../auto-reply/heartbeat.js";
 import { getReplyFromConfig } from "../auto-reply/reply.js";
+import {
+  extractShortModelName,
+  resolveResponsePrefixTemplate,
+  type ResponsePrefixContext,
+} from "../auto-reply/reply/response-prefix-template.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { getChannelPlugin } from "../channels/plugins/index.js";
@@ -707,10 +712,14 @@ export async function runHeartbeatOnce(opts: {
         })
       : { showOk: false, showAlerts: true, useIndicator: true };
   const { sender } = resolveHeartbeatSenderContext({ cfg, entry, delivery });
-  const responsePrefix = resolveEffectiveMessagesConfig(cfg, agentId, {
+  const responsePrefixTemplate = resolveEffectiveMessagesConfig(cfg, agentId, {
     channel: delivery.channel !== "none" ? delivery.channel : undefined,
     accountId: delivery.accountId,
   }).responsePrefix;
+  const responsePrefixContext: ResponsePrefixContext = {
+    identityName: resolveIdentityName(cfg, agentId),
+  };
+  let responsePrefix = responsePrefixTemplate;
 
   const canRelayToUser = Boolean(
     delivery.channel !== "none" && delivery.to && visibility.showAlerts,
@@ -745,7 +754,6 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: "alerts-disabled" };
   }
 
-  const heartbeatOkText = responsePrefix ? `${responsePrefix} ${HEARTBEAT_TOKEN}` : HEARTBEAT_TOKEN;
   const outboundSession = buildOutboundSessionContext({
     cfg,
     agentId,
@@ -758,6 +766,9 @@ export async function runHeartbeatOnce(opts: {
     if (!canAttemptHeartbeatOk || delivery.channel === "none" || !delivery.to) {
       return false;
     }
+    const heartbeatOkText = responsePrefix
+      ? `${responsePrefix} ${HEARTBEAT_TOKEN}`
+      : HEARTBEAT_TOKEN;
     const heartbeatPlugin = getChannelPlugin(delivery.channel);
     if (heartbeatPlugin?.heartbeat?.checkReady) {
       const readiness = await heartbeatPlugin.heartbeat.checkReady({
@@ -795,15 +806,27 @@ export async function runHeartbeatOnce(opts: {
     const suppressToolErrorWarnings = heartbeat?.suppressToolErrorWarnings === true;
     const bootstrapContextMode: "lightweight" | undefined =
       heartbeat?.lightContext === true ? "lightweight" : undefined;
+    const onModelSelected = (selection: {
+      provider: string;
+      model: string;
+      thinkLevel?: string;
+    }) => {
+      responsePrefixContext.provider = selection.provider;
+      responsePrefixContext.model = extractShortModelName(selection.model);
+      responsePrefixContext.modelFull = `${selection.provider}/${selection.model}`;
+      responsePrefixContext.thinkingLevel = selection.thinkLevel ?? "off";
+    };
     const replyOpts = heartbeatModelOverride
       ? {
           isHeartbeat: true,
           heartbeatModelOverride,
           suppressToolErrorWarnings,
           bootstrapContextMode,
+          onModelSelected,
         }
-      : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode };
+      : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode, onModelSelected };
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
+    responsePrefix = resolveResponsePrefixTemplate(responsePrefixTemplate, responsePrefixContext);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;
     const reasoningPayloads = includeReasoning


### PR DESCRIPTION
## Summary

  - Problem: heartbeat replies treated `messages.responsePrefix` as a raw string, so template variables
  like `{model}` were delivered literally instead of being interpolated.
  - Why it matters: normal user-facing replies already resolve `{model}`, `{provider}`, and
  `{thinkingLevel}` from the actual selected model, but heartbeat alerts did not, which made channel
  output inconsistent and broke model-aware prefixes.
  - What changed: wired heartbeat runs into the existing model-selection callback path, captured the
  actual provider/model/think level, and resolved the heartbeat response prefix template before
  building outbound heartbeat text.
  - What did NOT change: heartbeat delivery routing, ack suppression behavior, and model selection
  itself are unchanged.

  ## Change Type

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #43064

  ## User-visible / Behavior Changes

  - Heartbeat alert replies now interpolate `messages.responsePrefix` template variables the same way
  normal replies do.
  - Example: `responsePrefix: "[{model}]"` now sends `[gemini-2.5-flash] Check complete` instead of
  `[{model}] Check complete`.
  - `HEARTBEAT_OK` detection still strips the resolved prefix before ack suppression logic runs.

  ## Security Impact

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: local repo checkout
  - Model/provider: simulated in heartbeat test callback
  - Integration/channel: Telegram heartbeat delivery
  - Relevant config (redacted): `messages.responsePrefix: "[{model}]"`

  ### Steps

  1. Configure heartbeat delivery to an external channel.
  2. Set `messages.responsePrefix` to a template such as `"[{model}]"`.
  3. Trigger a heartbeat alert reply that returns real text instead of `HEARTBEAT_OK`.
  4. Observe the outbound message prefix before and after the patch.

  ### Expected

  - Heartbeat alert replies use the resolved model name in the prefix.

  ### Actual

  - Verified in regression coverage: heartbeat alert reply delivers `[gemini-2.5-flash] Check
  complete`.

  ## Evidence

  - [x] Failing test/log before + passing after

  Focused verification run:

  - `pnpm test -- src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts -t
  "interpolates responsePrefix template variables for heartbeat alert replies|strips responsePrefix
  before HEARTBEAT_OK detection and suppresses short ack text"`
  - `pnpm test -- src/infra/heartbeat-runner.model-override.test.ts -t "passes heartbeatModelOverride
  from defaults heartbeat config|uses isolated session key when isolatedSession is enabled"`

  ## Human Verification

  - Verified scenarios: heartbeat alert replies interpolate `{model}` in `responsePrefix`; ack
  suppression still works with prefixed `HEARTBEAT_OK` replies.
  - Edge cases checked: heartbeat model override path still works; isolated heartbeat session path
  still works.
  - What you did **not** verify: live end-to-end delivery against a real Telegram bot/app in this
  branch.

  ## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  ## Failure Recovery

  - How to disable/revert this change quickly: revert this PR.
  - Known bad symptoms reviewers should watch for: heartbeat prefixes showing literal template
  variables again, or ack-only heartbeat replies no longer being suppressed correctly.

  ## Risks and Mitigations

  - Risk: heartbeat prefix handling could diverge from normal reply prefix handling again in future
  refactors.
    - Mitigation: added focused regression coverage for templated heartbeat prefixes and kept the
  change on the existing `onModelSelected` path.