### PR TITLE
fix(windows): use detached restart script for scheduled task restart

### DIFF
--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -24,7 +24,7 @@ const relaunchGatewayScheduledTask = vi.hoisted(() =>
 );
 
 vi.mock("../infra/windows-task-restart.js", () => ({
-  relaunchGatewayScheduledTask: (env: NodeJS.ProcessEnv) => relaunchGatewayScheduledTask(env),
+  relaunchGatewayScheduledTask,
 }));
 
 const { restartScheduledTask, stopScheduledTask } = await import("./schtasks.js");

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -19,6 +19,14 @@ vi.mock("../infra/gateway-processes.js", () => ({
     findVerifiedGatewayListenerPidsOnPortSync(port),
 }));
 
+const relaunchGatewayScheduledTask = vi.hoisted(() =>
+  vi.fn(() => ({ ok: true as const, method: "schtasks" as const, tried: [] })),
+);
+
+vi.mock("../infra/windows-task-restart.js", () => ({
+  relaunchGatewayScheduledTask: (env: NodeJS.ProcessEnv) => relaunchGatewayScheduledTask(env),
+}));
+
 const { restartScheduledTask, stopScheduledTask } = await import("./schtasks.js");
 const GATEWAY_PORT = 18789;
 const SUCCESS_RESPONSE = { code: 0, stdout: "", stderr: "" } as const;
@@ -151,7 +159,9 @@ describe("Scheduled Task stop/restart cleanup", () => {
 
   it("kills lingering verified gateway listeners and waits for port release before restart", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
-      pushSuccessfulSchtasksResponses(4);
+      // Only /Query and /End are called via execSchtasks; /Run is handled by
+      // the detached relaunchGatewayScheduledTask script.
+      pushSuccessfulSchtasksResponses(3);
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([5151]);
       inspectPortUsage
         .mockResolvedValueOnce(busyPortUsage(5151))
@@ -164,7 +174,10 @@ describe("Scheduled Task stop/restart cleanup", () => {
       expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(GATEWAY_PORT);
       expectGatewayTermination(5151);
       expect(inspectPortUsage).toHaveBeenCalledTimes(2);
-      expect(schtasksCalls.at(-1)).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+      // /Run is now delegated to the detached restart script; the last inline
+      // schtasks call must be /End.
+      expect(schtasksCalls.at(-1)).toEqual(["/End", "/TN", "OpenClaw Gateway"]);
+      expect(relaunchGatewayScheduledTask).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -712,23 +712,37 @@ export async function restartScheduledTask({
   }
   const taskName = resolveTaskName(effectiveEnv);
   const restartPort = await resolveScheduledTaskPort(effectiveEnv);
-  // Spawn the restart script in a detached process BEFORE stopping the task,
-  // because `schtasks /End` will kill the current agent process on Windows.
-  // The script waits 1 s and then calls `schtasks /Run` (with retries) once
-  // the port is free again.
-  const attempt = relaunchGatewayScheduledTask(effectiveEnv);
-  if (!attempt.ok) {
-    throw new Error(`failed to prepare restart script: ${attempt.detail ?? "unknown error"}`);
-  }
-  await execSchtasks(["/End", "/TN", taskName]);
+
+  // Perform all cleanup BEFORE spawning the restart script and stopping the
+  // task.  On Windows, `schtasks /End` terminates the current process
+  // immediately (the agent runs inside the scheduled task), so any code after
+  // that call is unreliable dead code in the common path.
   await terminateScheduledTaskGatewayListeners(effectiveEnv);
   await terminateInstalledStartupRuntime(effectiveEnv);
   if (restartPort) {
     const released = await waitForGatewayPortRelease(restartPort);
     if (!released) {
       await terminateBusyPortListeners(restartPort);
+      // Second check: confirm the port is actually free before the detached
+      // restart script fires `schtasks /Run`.  If it is still busy the script
+      // will start a gateway that cannot bind, and since `/Run` returns 0 the
+      // retry loop will not re-fire.
+      const releasedAfterForce = await waitForGatewayPortRelease(restartPort, 2_000);
+      if (!releasedAfterForce) {
+        throw new Error(`gateway port ${restartPort} is still busy before restart`);
+      }
     }
   }
+
+  // Spawn the detached restart script BEFORE calling `schtasks /End`.
+  // The script waits ~1 s then calls `schtasks /Run` with retries, allowing
+  // the task to be fully stopped before the relaunch attempt.
+  const attempt = relaunchGatewayScheduledTask(effectiveEnv);
+  if (!attempt.ok) {
+    throw new Error(`failed to prepare restart script: ${attempt.detail ?? "unknown error"}`);
+  }
+
+  await execSchtasks(["/End", "/TN", taskName]);
   stdout.write(`${formatLine("Restarted Scheduled Task", taskName)}\n`);
   return { outcome: "completed" };
 }

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { isGatewayArgv } from "../infra/gateway-process-argv.js";
 import { findVerifiedGatewayListenerPidsOnPortSync } from "../infra/gateway-processes.js";
 import { inspectPortUsage } from "../infra/ports.js";
+import { relaunchGatewayScheduledTask } from "../infra/windows-task-restart.js";
 import { killProcessTree } from "../process/kill-tree.js";
 import { sleep } from "../utils.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
@@ -710,23 +711,23 @@ export async function restartScheduledTask({
     }
   }
   const taskName = resolveTaskName(effectiveEnv);
-  await execSchtasks(["/End", "/TN", taskName]);
   const restartPort = await resolveScheduledTaskPort(effectiveEnv);
+  // Spawn the restart script in a detached process BEFORE stopping the task,
+  // because `schtasks /End` will kill the current agent process on Windows.
+  // The script waits 1 s and then calls `schtasks /Run` (with retries) once
+  // the port is free again.
+  const attempt = relaunchGatewayScheduledTask(effectiveEnv);
+  if (!attempt.ok) {
+    throw new Error(`failed to prepare restart script: ${attempt.detail ?? "unknown error"}`);
+  }
+  await execSchtasks(["/End", "/TN", taskName]);
   await terminateScheduledTaskGatewayListeners(effectiveEnv);
   await terminateInstalledStartupRuntime(effectiveEnv);
   if (restartPort) {
     const released = await waitForGatewayPortRelease(restartPort);
     if (!released) {
       await terminateBusyPortListeners(restartPort);
-      const releasedAfterForce = await waitForGatewayPortRelease(restartPort, 2_000);
-      if (!releasedAfterForce) {
-        throw new Error(`gateway port ${restartPort} is still busy before restart`);
-      }
     }
-  }
-  const res = await execSchtasks(["/Run", "/TN", taskName]);
-  if (res.code !== 0) {
-    throw new Error(`schtasks run failed: ${res.stderr || res.stdout}`.trim());
   }
   stdout.write(`${formatLine("Restarted Scheduled Task", taskName)}\n`);
   return { outcome: "completed" };


### PR DESCRIPTION
## Summary

Fixes #5065, #27802, #41804

On Windows, `openclaw gateway restart` (and the in-chat `/restart` command) stops the gateway but never relaunches it. The gateway remains offline until manually restarted.

## Root Cause

`restartScheduledTask()` in `src/daemon/schtasks.ts` calls `schtasks /End` and `schtasks /Run` **inline** in the same process. On Windows, the agent process is owned by the Scheduled Task — so `schtasks /End` terminates the current process immediately, before `schtasks /Run` ever executes.

## Fix

Call `relaunchGatewayScheduledTask()` (already present in `src/infra/windows-task-restart.ts`) **before** calling `schtasks /End`. This function:

1. Writes a temporary `.cmd` script to the OpenClaw tmp directory
2. Spawns it in a **detached** process (`stdio: ignore`, `child.unref()`)
3. The script waits 1 second, then calls `schtasks /Run` with up to 12 retries

The gateway process then shuts down cleanly, and the detached script handles the relaunch independently.

## Changes

- `src/daemon/schtasks.ts`: import `relaunchGatewayScheduledTask` and call it before `schtasks /End`; remove the now-unnecessary inline `schtasks /Run` call

## Testing

Verified locally on Windows 10 (x64) with OpenClaw v2026.3.8 — gateway successfully restarts after `openclaw gateway restart`.