### PR TITLE
fix: notify agent session on background exec completion by default

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -222,7 +222,10 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
   enqueueSystemEvent(summary, { sessionKey });
   requestHeartbeatNow(
-    scopedHeartbeatWakeOptions(sessionKey, { reason: `exec:${session.id}:exit` }),
+    scopedHeartbeatWakeOptions(sessionKey, {
+      reason: `exec:${session.id}:exit`,
+      coalesceMs: 50,
+    }),
   );
 }
 
@@ -321,7 +324,7 @@ export async function runExecProcess(opts: {
     scopeKey: opts.scopeKey,
     sessionKey: opts.sessionKey,
     notifyOnExit: opts.notifyOnExit,
-    notifyOnExitEmptySuccess: opts.notifyOnExitEmptySuccess === true,
+    notifyOnExitEmptySuccess: opts.notifyOnExitEmptySuccess !== false,
     exitNotified: false,
     child: undefined,
     stdin: undefined,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -191,7 +191,7 @@ export function createExecTool(
     );
   }
   const notifyOnExit = defaults?.notifyOnExit !== false;
-  const notifyOnExitEmptySuccess = defaults?.notifyOnExitEmptySuccess === true;
+  const notifyOnExitEmptySuccess = defaults?.notifyOnExitEmptySuccess !== false;
   const notifySessionKey = defaults?.sessionKey?.trim() || undefined;
   const approvalRunningNoticeMs = resolveApprovalRunningNoticeMs(defaults?.approvalRunningNoticeMs);
   // Derive agentId only when sessionKey is an agent session key.

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -268,9 +268,11 @@ type NotifyNoopCase = LabeledCase & {
   notifyOnExitEmptySuccess: boolean;
 };
 const NOOP_NOTIFY_CASES: NotifyNoopCase[] = [
-  withLabel("default behavior skips no-op completion events", { notifyOnExitEmptySuccess: false }),
-  withLabel("explicitly enabling no-op completion emits completion events", {
+  withLabel("default behavior emits completion events for empty-output success", {
     notifyOnExitEmptySuccess: true,
+  }),
+  withLabel("explicitly disabling no-op completion skips events", {
+    notifyOnExitEmptySuccess: false,
   }),
 ];
 const DISALLOWED_ELEVATION_CASES: DisallowedElevationCase[] = [
@@ -398,7 +400,7 @@ const runLongLogExpectationCase = async ({
 };
 const runNotifyNoopCase = async ({ label, notifyOnExitEmptySuccess }: NotifyNoopCase) => {
   const tool = createNotifyOnExitExecTool(
-    notifyOnExitEmptySuccess ? { notifyOnExitEmptySuccess: true } : {},
+    notifyOnExitEmptySuccess ? {} : { notifyOnExitEmptySuccess: false },
   );
 
   const { status } = await runBackgroundCommandToCompletion(tool, shortDelayCmd);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -551,7 +551,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.exec.notifyOnExit":
     "When true (default), backgrounded exec sessions on exit and node exec lifecycle events enqueue a system event and request a heartbeat.",
   "tools.exec.notifyOnExitEmptySuccess":
-    "When true, successful backgrounded exec exits with empty output still enqueue a completion system event (default: false).",
+    "When true (default), successful backgrounded exec exits with empty output still enqueue a completion system event. Set to false to suppress these notifications.",
   "tools.exec.pathPrepend": "Directories to prepend to PATH for exec runs (gateway/sandbox).",
   "tools.exec.safeBins":
     "Allow stdin-only safe binaries to run without explicit allowlist entries.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -254,7 +254,8 @@ export type ExecToolConfig = {
   notifyOnExit?: boolean;
   /**
    * Also emit success exit notifications when a backgrounded exec has no output.
-   * Default false to reduce context noise.
+   * Default true — agents should always be notified when background tasks complete.
+   * Set to false to suppress empty-success notifications and reduce context noise.
    */
   notifyOnExitEmptySuccess?: boolean;
   /** apply_patch subtool configuration (experimental). */


### PR DESCRIPTION
## Summary

Background exec processes that complete successfully with empty output currently **silently exit** without notifying the parent agent session. This is the #1 UX gap in multi-agent orchestration workflows.

### Problem

When an orchestrator agent (e.g., Hikari) dispatches a coding agent (Claude Code, Codex) via `exec background:true`, the coding agent finishes but the orchestrator is never woken up — users see silence until they manually check in.

**Root cause:** `notifyOnExitEmptySuccess` defaults to `false`, so successful exits with empty/cleared output skip the system event + heartbeat wake entirely.

Related issue: https://github.com/openclaw/openclaw/issues/18237

### Changes

| Change | Before | After |
|--------|--------|-------|
| `notifyOnExitEmptySuccess` default | `false` | `true` |
| Exec exit wake coalesce delay | 250ms | 50ms |
| Config docs | "default: false" | "default: true" |
| Tests | Assert empty-success is skipped | Assert empty-success is emitted |

### Why

1. **Agents should always know when background work finishes.** A silent success is indistinguishable from a hang or crash from the orchestrator's perspective.
2. **50ms coalesce** is appropriate for exec exit events — they are time-sensitive in orchestration flows where the agent needs to report results or start the next phase immediately.
3. **Backward compatible** — users who prefer the old behavior can set `tools.exec.notifyOnExitEmptySuccess: false`.

### Testing

- All 24 tests in `bash-tools.test.ts` pass ✅
- Test cases updated to reflect new default behavior

Fixes #18237