### PR TITLE
fix(models): resolve bare model id across providers in sessions.patch

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -453,6 +453,38 @@ describe("model-selection", () => {
       });
     });
 
+    it("resolves bare model id to correct provider via catalog fallback", () => {
+      // Scenario: session default is openai-codex, user picks bare "glm-4.7"
+      // which only exists under the "zhipu" provider. With an explicit allowlist,
+      // "openai-codex/glm-4.7" is not allowed, but "zhipu/glm-4.7" is.
+      // See https://github.com/openclaw/openclaw/issues/46859
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "openai-codex/gpt-5.4": {},
+              "zhipu/glm-4.7": {},
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const catalog = [
+        { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+        { provider: "zhipu", id: "glm-4.7", name: "glm-4.7" },
+      ];
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog,
+        raw: "glm-4.7",
+        defaultProvider: "openai-codex",
+      });
+
+      expect(result).toEqual({
+        key: "zhipu/glm-4.7",
+        ref: { provider: "zhipu", model: "glm-4.7" },
+      });
+    });
+
     it("strips trailing auth profile suffix before allowlist matching", () => {
       const cfg: OpenClawConfig = {
         agents: {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -485,6 +485,61 @@ describe("model-selection", () => {
       });
     });
 
+    it("returns error when bare model id matches multiple allowed providers", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "provider-a/shared-model": {},
+              "provider-b/shared-model": {},
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const catalog = [
+        { provider: "provider-a", id: "shared-model", name: "shared-model" },
+        { provider: "provider-b", id: "shared-model", name: "shared-model" },
+      ];
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog,
+        raw: "shared-model",
+        defaultProvider: "provider-c",
+      });
+
+      expect(result).toEqual({
+        error: expect.stringContaining("ambiguous model"),
+      });
+    });
+
+    it("resolves bare model id with trailing auth profile via catalog fallback", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "openai-codex/gpt-5.4": {},
+              "zhipu/glm-4.7": {},
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const catalog = [
+        { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+        { provider: "zhipu", id: "glm-4.7", name: "glm-4.7" },
+      ];
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog,
+        raw: "glm-4.7@zhipu:default",
+        defaultProvider: "openai-codex",
+      });
+
+      expect(result).toEqual({
+        key: "zhipu/glm-4.7",
+        ref: { provider: "zhipu", model: "glm-4.7" },
+      });
+    });
+
     it("strips trailing auth profile suffix before allowlist matching", () => {
       const cfg: OpenClawConfig = {
         agents: {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -631,22 +631,32 @@ export function resolveAllowedModelRef(params: {
   // This handles the case where a UI model picker or user sends a bare model
   // ID that belongs to a different provider than the session's current default.
   // See https://github.com/openclaw/openclaw/issues/46859
-  if (!trimmed.includes("/")) {
+  const { model: bareModel } = splitTrailingAuthProfile(trimmed);
+  if (bareModel && !bareModel.includes("/")) {
+    const allowed = buildAllowedModelSet({
+      cfg: params.cfg,
+      catalog: params.catalog,
+      defaultProvider: params.defaultProvider,
+      defaultModel: params.defaultModel,
+    });
+    const candidates: Array<{ ref: ModelRef; key: string }> = [];
     for (const entry of params.catalog) {
-      if (entry.id !== trimmed) {
+      if (entry.id !== bareModel) {
         continue;
       }
-      const candidateRef: ModelRef = { provider: entry.provider, model: entry.id };
-      const candidateStatus = getModelRefStatus({
-        cfg: params.cfg,
-        catalog: params.catalog,
-        ref: candidateRef,
-        defaultProvider: params.defaultProvider,
-        defaultModel: params.defaultModel,
-      });
-      if (candidateStatus.allowed) {
-        return { ref: candidateRef, key: candidateStatus.key };
+      const key = modelKey(entry.provider, entry.id);
+      if (allowed.allowAny || allowed.allowedKeys.has(key)) {
+        candidates.push({ ref: { provider: entry.provider, model: entry.id }, key });
       }
+    }
+    if (candidates.length === 1) {
+      return candidates[0];
+    }
+    if (candidates.length > 1) {
+      const providers = candidates.map((c) => c.ref.provider).join(", ");
+      return {
+        error: `ambiguous model: ${bareModel} matches multiple providers (${providers}). Use a qualified ref like provider/${bareModel}.`,
+      };
     }
   }
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -622,11 +622,35 @@ export function resolveAllowedModelRef(params: {
     defaultProvider: params.defaultProvider,
     defaultModel: params.defaultModel,
   });
-  if (!status.allowed) {
-    return { error: `model not allowed: ${status.key}` };
+  if (status.allowed) {
+    return { ref: resolved.ref, key: status.key };
   }
 
-  return { ref: resolved.ref, key: status.key };
+  // When a bare model ID (no provider prefix) is not found under the default
+  // provider, search the catalog for a matching entry from any provider.
+  // This handles the case where a UI model picker or user sends a bare model
+  // ID that belongs to a different provider than the session's current default.
+  // See https://github.com/openclaw/openclaw/issues/46859
+  if (!trimmed.includes("/")) {
+    for (const entry of params.catalog) {
+      if (entry.id !== trimmed) {
+        continue;
+      }
+      const candidateRef: ModelRef = { provider: entry.provider, model: entry.id };
+      const candidateStatus = getModelRefStatus({
+        cfg: params.cfg,
+        catalog: params.catalog,
+        ref: candidateRef,
+        defaultProvider: params.defaultProvider,
+        defaultModel: params.defaultModel,
+      });
+      if (candidateStatus.allowed) {
+        return { ref: candidateRef, key: candidateStatus.key };
+      }
+    }
+  }
+
+  return { error: `model not allowed: ${status.key}` };
 }
 
 export function resolveThinkingDefault(params: {


### PR DESCRIPTION
## Summary

- When `sessions.patch` receives a bare model ID (e.g. `glm-4.7`) without a provider prefix, `resolveAllowedModelRef` now searches the model catalog for a matching entry from any provider, instead of only trying the session's current default provider.
- Previously, selecting `glm-4.7` from a session pinned to `openai-codex` would produce the error `model not allowed: openai-codex/glm-4.7` because the bare ID was always resolved under the default provider. Now it correctly resolves to `zhipu/glm-4.7` (or whichever provider owns the model in the catalog).

Fixes #46859

## Test plan

- [x] Added regression test: bare model ID resolves to correct provider via catalog fallback
- [x] Existing `resolveAllowedModelRef` tests still pass
- [x] Verify in Control UI: switch from `openai-codex/gpt-5.4` session to a model from another provider using the model picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)