### PR TITLE
fix(gateway): enable global undici proxy dispatcher at startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   PortInUseError,
 } from "./infra/ports.js";
 import { assertSupportedRuntime } from "./infra/runtime-guard.js";
+import { ensureGlobalUndiciEnvProxyDispatcher } from "./infra/net/undici-global-dispatcher.js";
 import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "./logging.js";
 import { runCommandWithTimeout, runExec } from "./process/exec.js";
@@ -35,6 +36,7 @@ import { assertWebChannel, normalizeE164, toWhatsappJid } from "./utils.js";
 
 loadDotEnv({ quiet: true });
 normalizeEnv();
+ensureGlobalUndiciEnvProxyDispatcher();
 ensureOpenClawCliOnPath();
 
 // Capture all console output into structured logs while keeping stdout/stderr behavior.


### PR DESCRIPTION
## Summary

Third-party libraries like `@buape/carbon` (Discord REST client) use Node.js native `fetch` directly, bypassing OpenClaw's proxy-aware fetch wrappers (`proxyFetch`, `FetchGuard`). Node.js native `fetch` (powered by `undici`) does not respect `HTTP_PROXY`/`HTTPS_PROXY` environment variables unless a global dispatcher is explicitly configured via `setGlobalDispatcher`.

`ensureGlobalUndiciEnvProxyDispatcher()` was already implemented and tested, but only called during embedded agent runs (`pi-embedded-runner`). The gateway startup path was missing this call, causing all Discord REST API operations (e.g., `fetch-bot-identity`, `deploy-rest:put`) to fail with `TypeError: fetch failed` / `Connection timed out` when running behind a network proxy.

### Changes

- Add `ensureGlobalUndiciEnvProxyDispatcher()` call in `src/index.ts` after `loadDotEnv()` and `normalizeEnv()`, before any channel plugins or REST clients initialize
- The function is already safe: no-op when no proxy is configured, idempotent when already applied

### Impact

- Fixes Discord REST API failures (`fetch-bot-identity`, command deployment) behind proxy
- Fixes `implicitMention` logic failure (bot couldnt get its own user ID, so couldnt detect reply-based mentions)
- No behavior change for environments without proxy configuration

## Test Plan

- [x] Existing unit tests in `undici-global-dispatcher.test.ts` cover all edge cases (5 test cases)
- [ ] Gateway starts successfully with HTTPS_PROXY set → Discord REST calls succeed (manual verification on proxy host)
- [ ] Gateway starts successfully without proxy → no behavior change