### PR TITLE
fix(ui): keep provider in chat model picker values

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -562,8 +562,14 @@ function buildChatModelOptions(
   };
 
   for (const entry of catalog) {
-    const provider = entry.provider?.trim();
-    addOption(entry.id, provider ? `${entry.id} · ${provider}` : entry.id);
+    const provider = entry.provider?.trim() ?? "";
+    const id = entry.id?.trim() ?? "";
+    if (!id) {
+      continue;
+    }
+    const value = id.includes("/") ? id : provider ? `${provider}/${id}` : id;
+    const labelId = id.includes("/") ? id.split("/").slice(1).join("/") : id;
+    addOption(value, provider ? `${labelId} · ${provider}` : labelId);
   }
 
   if (currentOverride) {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -565,16 +565,16 @@ describe("chat view", () => {
     expect(modelSelect).not.toBeNull();
     expect(modelSelect?.value).toBe("");
 
-    modelSelect!.value = "gpt-5-mini";
+    modelSelect!.value = "openai/gpt-5-mini";
     modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
     await flushTasks();
 
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
-      model: "gpt-5-mini",
+      model: "openai/gpt-5-mini",
     });
     expect(request).not.toHaveBeenCalledWith("chat.history", expect.anything());
-    expect(state.sessionsResult?.sessions[0]?.model).toBe("gpt-5-mini");
+    expect(state.sessionsResult?.sessions[0]?.model).toBe("openai/gpt-5-mini");
     vi.unstubAllGlobals();
   });
 
@@ -585,7 +585,7 @@ describe("chat view", () => {
         ok: false,
       } satisfies Partial<Response>),
     );
-    const { state, request } = createChatHeaderState({ model: "gpt-5-mini" });
+    const { state, request } = createChatHeaderState({ model: "openai/gpt-5-mini" });
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
@@ -593,7 +593,7 @@ describe("chat view", () => {
       'select[data-chat-model-select="true"]',
     );
     expect(modelSelect).not.toBeNull();
-    expect(modelSelect?.value).toBe("gpt-5-mini");
+    expect(modelSelect?.value).toBe("openai/gpt-5-mini");
 
     modelSelect!.value = "";
     modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
@@ -604,6 +604,40 @@ describe("chat view", () => {
       model: null,
     });
     expect(state.sessionsResult?.sessions[0]?.model).toBeNull();
+    vi.unstubAllGlobals();
+  });
+
+  it("submits the selected provider/model ref for cross-provider choices", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+      } satisfies Partial<Response>),
+    );
+    const { state, request } = createChatHeaderState({
+      model: "openai/gpt-5",
+      models: [
+        { id: "gpt-5", name: "GPT-5", provider: "openai" },
+        { id: "claude-opus-4-6", name: "Claude Opus 4.6", provider: "terminal" },
+      ],
+    });
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect).not.toBeNull();
+
+    modelSelect!.value = "terminal/claude-opus-4-6";
+    modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushTasks();
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "terminal/claude-opus-4-6",
+    });
+    expect(state.sessionsResult?.sessions[0]?.model).toBe("terminal/claude-opus-4-6");
     vi.unstubAllGlobals();
   });
 
@@ -637,7 +671,7 @@ describe("chat view", () => {
     );
     expect(modelSelect).not.toBeNull();
 
-    modelSelect!.value = "gpt-5-mini";
+    modelSelect!.value = "openai/gpt-5-mini";
     modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
     await flushTasks();
     render(renderChatSessionSelect(state), container);
@@ -645,7 +679,7 @@ describe("chat view", () => {
     const rerendered = container.querySelector<HTMLSelectElement>(
       'select[data-chat-model-select="true"]',
     );
-    expect(rerendered?.value).toBe("gpt-5-mini");
+    expect(rerendered?.value).toBe("openai/gpt-5-mini");
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
## Summary
- keep `provider/model` refs in chat model picker option values instead of submitting bare model ids
- preserve the friendly `model · provider` label in the dropdown
- add a regression test covering cross-provider switches from the chat header picker

## Problem
The Control UI chat model picker was building option labels with provider context, but submitting `entry.id` as the option value. When `models.list` returned bare model ids like `claude-opus-4-6`, the subsequent `sessions.patch` request could inherit or resolve against the wrong provider, producing invalid refs like `openai-codex/claude-opus-4-6` and failing with `model not allowed`.

## Fix
Normalize picker option values to full refs:
- if the catalog entry already includes a slash, keep it as-is
- otherwise submit `${provider}/${id}` when a provider is present
- keep labels readable by showing `model · provider`

## Testing
- `corepack pnpm vitest run --config vitest.unit.config.ts ui/src/ui/views/chat.test.ts ui/src/ui/app-chat.test.ts`

## Related
- Closes #46859
- Related: #46480, #45630, #46179