### PR TITLE
fix(sessions): preserve origin for heartbeat system turns

### DIFF
--- a/src/auto-reply/reply/session.heartbeat-origin.test.ts
+++ b/src/auto-reply/reply/session.heartbeat-origin.test.ts
@@ -37,60 +37,137 @@ async function writeSessionStore(
   await fs.writeFile(storePath, JSON.stringify(store), "utf-8");
 }
 
-describe("initSessionState heartbeat origin preservation", () => {
-  it("preserves existing origin for heartbeat runs in an existing session", async () => {
-    const storePath = await makeStorePath("heartbeat-origin-");
-    const sessionKey = "agent:main:main";
-    const originalOrigin = {
-      label: "My App — Project: Dashboard",
-      provider: "webchat",
-      surface: "webchat",
-      chatType: "direct",
-      from: "webchat:user-1",
-      to: "webchat:user-1",
-    } as const;
+const SESSION_KEY = "agent:main:main";
+const ORIGINAL_ORIGIN = {
+  label: "My App — Project: Dashboard",
+  provider: "webchat",
+  surface: "webchat",
+  chatType: "direct",
+  from: "webchat:user-1",
+  to: "webchat:user-1",
+} as const;
 
-    await writeSessionStore(storePath, {
-      [sessionKey]: {
-        sessionId: "sess-1",
-        updatedAt: Date.now(),
-        origin: originalOrigin,
-        deliveryContext: {
-          channel: "webchat",
-          to: "webchat:user-1",
-        },
-        lastChannel: "webchat",
-        lastTo: "webchat:user-1",
+function buildConfig(storePath: string): OpenClawConfig {
+  return {
+    session: { store: storePath },
+  } as OpenClawConfig;
+}
+
+function buildSyntheticCtx(provider: "heartbeat" | "cron-event" | "exec-event") {
+  return {
+    Body: "Read HEARTBEAT.md and check in.",
+    SessionKey: SESSION_KEY,
+    Provider: provider,
+    Surface: "webchat",
+    ChatType: "direct",
+    From: provider,
+    To: provider,
+    OriginatingChannel: "webchat",
+    OriginatingTo: "webchat:user-1",
+  } as const;
+}
+
+async function readPersistedOrigin(storePath: string) {
+  const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    SessionEntry
+  >;
+  return persisted[SESSION_KEY]?.origin;
+}
+
+async function seedExistingSession(storePath: string) {
+  await writeSessionStore(storePath, {
+    [SESSION_KEY]: {
+      sessionId: "sess-1",
+      updatedAt: Date.now(),
+      origin: ORIGINAL_ORIGIN,
+      deliveryContext: {
+        channel: "webchat",
+        to: "webchat:user-1",
       },
-    });
+      lastChannel: "webchat",
+      lastTo: "webchat:user-1",
+    },
+  });
+}
 
-    const cfg = {
-      session: { store: storePath },
-    } as OpenClawConfig;
+describe("initSessionState origin preservation", () => {
+  for (const provider of ["heartbeat", "cron-event", "exec-event"] as const) {
+    it(`preserves existing origin for ${provider} turns in an existing session`, async () => {
+      const storePath = await makeStorePath(`${provider}-origin-`);
+      await seedExistingSession(storePath);
+
+      const result = await initSessionState({
+        ctx: buildSyntheticCtx(provider),
+        cfg: buildConfig(storePath),
+        commandAuthorized: true,
+      });
+
+      expect(result.sessionKey).toBe(SESSION_KEY);
+      expect(result.sessionEntry.origin).toEqual(ORIGINAL_ORIGIN);
+      expect(await readPersistedOrigin(storePath)).toEqual(ORIGINAL_ORIGIN);
+    });
+  }
+
+  it("still updates origin for normal non-system providers", async () => {
+    const storePath = await makeStorePath("webchat-origin-");
+    await seedExistingSession(storePath);
 
     const result = await initSessionState({
       ctx: {
-        Body: "Read HEARTBEAT.md and check in.",
-        SessionKey: sessionKey,
-        Provider: "heartbeat",
+        Body: "hello",
+        SessionKey: SESSION_KEY,
+        Provider: "webchat",
         Surface: "webchat",
         ChatType: "direct",
-        From: "heartbeat",
-        To: "heartbeat",
+        From: "webchat:user-2",
+        To: "webchat:user-2",
         OriginatingChannel: "webchat",
-        OriginatingTo: "webchat:user-1",
+        OriginatingTo: "webchat:user-2",
+        SenderName: "Renamed User",
       },
-      cfg,
+      cfg: buildConfig(storePath),
       commandAuthorized: true,
     });
 
-    expect(result.sessionKey).toBe(sessionKey);
-    expect(result.sessionEntry.origin).toEqual(originalOrigin);
+    expect(result.sessionEntry.origin).toEqual({
+      ...ORIGINAL_ORIGIN,
+      label: "Renamed User",
+      from: "webchat:user-2",
+      to: "webchat:user-2",
+    });
+    expect(await readPersistedOrigin(storePath)).toEqual({
+      ...ORIGINAL_ORIGIN,
+      label: "Renamed User",
+      from: "webchat:user-2",
+      to: "webchat:user-2",
+    });
+  });
 
-    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
-      string,
-      SessionEntry
-    >;
-    expect(persisted[sessionKey]?.origin).toEqual(originalOrigin);
+  it("still creates origin metadata for brand-new heartbeat sessions", async () => {
+    const storePath = await makeStorePath("new-heartbeat-origin-");
+
+    const result = await initSessionState({
+      ctx: buildSyntheticCtx("heartbeat"),
+      cfg: buildConfig(storePath),
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.origin).toEqual({
+      label: "heartbeat",
+      provider: "webchat",
+      surface: "webchat",
+      chatType: "direct",
+      from: "heartbeat",
+      to: "webchat:user-1",
+    });
+    expect(await readPersistedOrigin(storePath)).toEqual({
+      label: "heartbeat",
+      provider: "webchat",
+      surface: "webchat",
+      chatType: "direct",
+      from: "heartbeat",
+      to: "webchat:user-1",
+    });
   });
 });

--- a/src/auto-reply/reply/session.heartbeat-origin.test.ts
+++ b/src/auto-reply/reply/session.heartbeat-origin.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import { initSessionState } from "./session.js";
+
+vi.mock("../../agents/session-write-lock.js", () => ({
+  acquireSessionWriteLock: async () => ({ release: async () => {} }),
+}));
+
+let suiteRoot = "";
+let suiteCase = 0;
+
+beforeAll(async () => {
+  suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-origin-suite-"));
+});
+
+afterAll(async () => {
+  await fs.rm(suiteRoot, { recursive: true, force: true });
+  suiteRoot = "";
+  suiteCase = 0;
+});
+
+async function makeStorePath(prefix: string): Promise<string> {
+  const dir = path.join(suiteRoot, `${prefix}${++suiteCase}`);
+  await fs.mkdir(dir, { recursive: true });
+  return path.join(dir, "sessions.json");
+}
+
+async function writeSessionStore(
+  storePath: string,
+  store: Record<string, SessionEntry | Record<string, unknown>>,
+): Promise<void> {
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(storePath, JSON.stringify(store), "utf-8");
+}
+
+describe("initSessionState heartbeat origin preservation", () => {
+  it("preserves existing origin for heartbeat runs in an existing session", async () => {
+    const storePath = await makeStorePath("heartbeat-origin-");
+    const sessionKey = "agent:main:main";
+    const originalOrigin = {
+      label: "My App — Project: Dashboard",
+      provider: "webchat",
+      surface: "webchat",
+      chatType: "direct",
+      from: "webchat:user-1",
+      to: "webchat:user-1",
+    } as const;
+
+    await writeSessionStore(storePath, {
+      [sessionKey]: {
+        sessionId: "sess-1",
+        updatedAt: Date.now(),
+        origin: originalOrigin,
+        deliveryContext: {
+          channel: "webchat",
+          to: "webchat:user-1",
+        },
+        lastChannel: "webchat",
+        lastTo: "webchat:user-1",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "Read HEARTBEAT.md and check in.",
+        SessionKey: sessionKey,
+        Provider: "heartbeat",
+        Surface: "webchat",
+        ChatType: "direct",
+        From: "heartbeat",
+        To: "heartbeat",
+        OriginatingChannel: "webchat",
+        OriginatingTo: "webchat:user-1",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionKey).toBe(sessionKey);
+    expect(result.sessionEntry.origin).toEqual(originalOrigin);
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      SessionEntry
+    >;
+    expect(persisted[sessionKey]?.origin).toEqual(originalOrigin);
+  });
+});

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -7,6 +7,8 @@ import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { buildGroupDisplayName, resolveGroupSessionKey } from "./group.js";
 import type { GroupKeyResolution, SessionEntry, SessionOrigin } from "./types.js";
 
+const STABLE_SESSION_ORIGIN_SYSTEM_PROVIDERS = new Set(["heartbeat", "cron-event", "exec-event"]);
+
 const mergeOrigin = (
   existing: SessionOrigin | undefined,
   next: SessionOrigin | undefined,
@@ -86,6 +88,22 @@ export function deriveSessionOrigin(ctx: MsgContext): SessionOrigin | undefined 
   return Object.keys(origin).length > 0 ? origin : undefined;
 }
 
+function shouldPreserveExistingOrigin(params: {
+  ctx: MsgContext;
+  existing?: SessionEntry;
+}): boolean {
+  if (!params.existing?.origin) {
+    return false;
+  }
+  const provider = params.ctx.Provider?.trim().toLowerCase();
+  if (!provider) {
+    return false;
+  }
+  // Synthetic heartbeat/cron/exec turns should not rebind an existing session's
+  // stable origin metadata to placeholders like "heartbeat".
+  return STABLE_SESSION_ORIGIN_SYSTEM_PROVIDERS.has(provider);
+}
+
 export function snapshotSessionOrigin(entry?: SessionEntry): SessionOrigin | undefined {
   if (!entry?.origin) {
     return undefined;
@@ -157,7 +175,8 @@ export function deriveSessionMetaPatch(params: {
   groupResolution?: GroupKeyResolution | null;
 }): Partial<SessionEntry> | null {
   const groupPatch = deriveGroupSessionPatch(params);
-  const origin = deriveSessionOrigin(params.ctx);
+  const preserveExistingOrigin = shouldPreserveExistingOrigin(params);
+  const origin = preserveExistingOrigin ? undefined : deriveSessionOrigin(params.ctx);
   if (!groupPatch && !origin) {
     return null;
   }


### PR DESCRIPTION
## Summary

- Problem: internal heartbeat/system turns could overwrite an existing session's persisted `origin` metadata with placeholder values like `heartbeat`.
- Why it matters: session lists and Control UI use persisted session metadata as a title fallback, so a normal session could suddenly show up as `heartbeat` after an internal poll.
- What changed: preserve existing `origin` for already-bound sessions when the incoming turn is a synthetic system provider (`heartbeat`, `cron-event`, or `exec-event`).
- What did NOT change: normal inbound user/channel messages still update session origin as before; delivery routing and session selection are unchanged.

## Linked Issue/PR

- Closes #46116
- Also addresses #42495

## Verification

- `pnpm test -- src/auto-reply/reply/session.heartbeat-origin.test.ts`
- `pnpm test -- src/config/sessions.test.ts`
