### PR TITLE
feat(security): add MCP tool call approval system

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -1554,7 +1554,7 @@
       "deprecated": false,
       "sensitive": false,
       "tags": ["automation"],
-      "help": "Delivery target (\"last\", \"none\", or a channel id). Known channels: telegram, whatsapp, discord, irc, googlechat, slack, signal, imessage, line, zalouser, zalo, tlon, feishu, nextcloud-talk, msteams, bluebubbles, synology-chat, mattermost, twitch, matrix, nostr.",
+      "help": "Delivery target (\"last\", \"none\", or a channel id). Known channels: telegram, whatsapp, discord, irc, googlechat, slack, signal, imessage, line, bluebubbles, feishu, matrix, mattermost, msteams, nextcloud-talk, nostr, synology-chat, tlon, twitch, zalo, zalouser.",
       "hasChildren": false
     },
     {
@@ -3727,7 +3727,7 @@
       "deprecated": false,
       "sensitive": false,
       "tags": ["automation"],
-      "help": "Delivery target (\"last\", \"none\", or a channel id). Known channels: telegram, whatsapp, discord, irc, googlechat, slack, signal, imessage, line, zalouser, zalo, tlon, feishu, nextcloud-talk, msteams, bluebubbles, synology-chat, mattermost, twitch, matrix, nostr.",
+      "help": "Delivery target (\"last\", \"none\", or a channel id). Known channels: telegram, whatsapp, discord, irc, googlechat, slack, signal, imessage, line, bluebubbles, feishu, matrix, mattermost, msteams, nextcloud-talk, nostr, synology-chat, tlon, twitch, zalo, zalouser.",
       "hasChildren": false
     },
     {
@@ -6292,6 +6292,292 @@
       "tags": ["advanced"],
       "label": "Approval Target Destination",
       "help": "Destination identifier inside the target channel (channel ID, user ID, or thread root depending on provider). Verify semantics per provider because destination format differs across channel integrations.",
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.tool",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.tool.agentFilter",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.tool.agentFilter.*",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.tool.enabled",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.tool.mode",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.tool.sessionFilter",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.tool.sessionFilter.*",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.tool.targets",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.tool.targets.*",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.tool.targets.*.accountId",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.tool.targets.*.channel",
+      "kind": "core",
+      "type": "string",
+      "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.tool.targets.*.threadId",
+      "kind": "core",
+      "type": ["number", "string"],
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.tool.targets.*.to",
+      "kind": "core",
+      "type": "string",
+      "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.toolPolicy",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.toolPolicy.agents",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.toolPolicy.agents.*",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.toolPolicy.agents.*.allowlist",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.toolPolicy.agents.*.allowlist.*",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.toolPolicy.agents.*.allowlist.*.pattern",
+      "kind": "core",
+      "type": "string",
+      "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.toolPolicy.agents.*.ask",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "enumValues": ["off", "on-miss", "always"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.toolPolicy.agents.*.askFallback",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "enumValues": ["deny", "allowlist", "full"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.toolPolicy.agents.*.security",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "enumValues": ["deny", "allowlist", "full"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.toolPolicy.allowlist",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.toolPolicy.allowlist.*",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "approvals.toolPolicy.allowlist.*.pattern",
+      "kind": "core",
+      "type": "string",
+      "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.toolPolicy.ask",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "enumValues": ["off", "on-miss", "always"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.toolPolicy.askFallback",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "enumValues": ["deny", "allowlist", "full"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "approvals.toolPolicy.security",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "enumValues": ["deny", "allowlist", "full"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
       "hasChildren": false
     },
     {
@@ -9591,6 +9877,26 @@
       "hasChildren": false
     },
     {
+      "path": "channels.discord.accounts.*.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.discord.accounts.*.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.discord.accounts.*.heartbeat",
       "kind": "channel",
       "type": "object",
@@ -12180,6 +12486,26 @@
       "hasChildren": false
     },
     {
+      "path": "channels.discord.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.discord.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.discord.heartbeat",
       "kind": "channel",
       "type": "object",
@@ -13392,6 +13718,46 @@
       "hasChildren": true
     },
     {
+      "path": "channels.feishu.accounts.*.actions",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.actions.reactions",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.allowFrom",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.allowFrom.*",
+      "kind": "channel",
+      "type": ["number", "string"],
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.feishu.accounts.*.appId",
       "kind": "channel",
       "type": "string",
@@ -13436,7 +13802,87 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": ["env", "file", "exec"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.blockStreamingCoalesce",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.blockStreamingCoalesce.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.blockStreamingCoalesce.maxDelayMs",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.blockStreamingCoalesce.minDelayMs",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.capabilities",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.capabilities.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.chunkMode",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["length", "newline"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.configWrites",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13448,6 +13894,67 @@
       "type": "string",
       "required": false,
       "enumValues": ["websocket", "webhook"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.dmHistoryLimit",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.dmPolicy",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["open", "pairing", "allowlist"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13509,7 +14016,334 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": ["env", "file", "exec"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groupAllowFrom",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.groupAllowFrom.*",
+      "kind": "channel",
+      "type": ["number", "string"],
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groupPolicy",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["open", "allowlist", "disabled"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.allowFrom",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.allowFrom.*",
+      "kind": "channel",
+      "type": ["number", "string"],
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.groupSessionScope",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["group", "group_sender", "group_topic", "group_topic_sender"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.replyInThread",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["disabled", "enabled"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.requireMention",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.skills",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.skills.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.tools",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.tools.allow",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.tools.allow.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.tools.deny",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.tools.deny.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groups.*.topicSessionMode",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["disabled", "enabled"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groupSenderAllowFrom",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.groupSenderAllowFrom.*",
+      "kind": "channel",
+      "type": ["number", "string"],
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.groupSessionScope",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["group", "group_sender", "group_topic", "group_topic_sender"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.heartbeat",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.heartbeat.intervalMs",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.heartbeat.visibility",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["visible", "hidden"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.historyLimit",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.httpTimeoutMs",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.markdown",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.markdown.mode",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["native", "escape", "strip"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.markdown.tableMode",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["native", "ascii", "simple"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.mediaMaxMb",
+      "kind": "channel",
+      "type": "number",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13519,6 +14353,170 @@
       "path": "channels.feishu.accounts.*.name",
       "kind": "channel",
       "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.reactionNotifications",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["off", "own", "all"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.renderMode",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["auto", "raw", "card"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.replyInThread",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["disabled", "enabled"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.requireMention",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.resolveSenderNames",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.streaming",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.textChunkLimit",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.tools",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.tools.chat",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.tools.doc",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.tools.drive",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.tools.perm",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.tools.scopes",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.tools.wiki",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.topicSessionMode",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["disabled", "enabled"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.typingIndicator",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -13560,7 +14558,6 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": ["env", "file", "exec"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13590,6 +14587,26 @@
       "path": "channels.feishu.accounts.*.webhookPort",
       "kind": "channel",
       "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.actions",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.actions.reactions",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -13661,7 +14678,66 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": ["env", "file", "exec"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.blockStreamingCoalesce",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.blockStreamingCoalesce.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.blockStreamingCoalesce.maxDelayMs",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.blockStreamingCoalesce.minDelayMs",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.capabilities",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.capabilities.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13679,11 +14755,22 @@
       "hasChildren": false
     },
     {
+      "path": "channels.feishu.configWrites",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.feishu.connectionMode",
       "kind": "channel",
       "type": "string",
-      "required": false,
+      "required": true,
       "enumValues": ["websocket", "webhook"],
+      "defaultValue": "websocket",
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13713,8 +14800,49 @@
       "path": "channels.feishu.dmPolicy",
       "kind": "channel",
       "type": "string",
-      "required": false,
+      "required": true,
       "enumValues": ["open", "pairing", "allowlist"],
+      "defaultValue": "pairing",
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dms",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dms.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13724,8 +14852,58 @@
       "path": "channels.feishu.domain",
       "kind": "channel",
       "type": "string",
-      "required": false,
+      "required": true,
       "enumValues": ["feishu", "lark"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dynamicAgentCreation",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dynamicAgentCreation.agentDirTemplate",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dynamicAgentCreation.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dynamicAgentCreation.maxAgents",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dynamicAgentCreation.workspaceTemplate",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13776,7 +14954,6 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": ["env", "file", "exec"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13806,8 +14983,201 @@
       "path": "channels.feishu.groupPolicy",
       "kind": "channel",
       "type": "string",
-      "required": false,
+      "required": true,
       "enumValues": ["open", "allowlist", "disabled"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groups",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.groups.*",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.groups.*.allowFrom",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.groups.*.allowFrom.*",
+      "kind": "channel",
+      "type": ["number", "string"],
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groups.*.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groups.*.groupSessionScope",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["group", "group_sender", "group_topic", "group_topic_sender"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groups.*.replyInThread",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["disabled", "enabled"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groups.*.requireMention",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groups.*.skills",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.groups.*.skills.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groups.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groups.*.tools",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.groups.*.tools.allow",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.groups.*.tools.allow.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groups.*.tools.deny",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.groups.*.tools.deny.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groups.*.topicSessionMode",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["disabled", "enabled"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.groupSenderAllowFrom",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.groupSenderAllowFrom.*",
+      "kind": "channel",
+      "type": ["number", "string"],
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13825,6 +15195,37 @@
       "hasChildren": false
     },
     {
+      "path": "channels.feishu.heartbeat",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.heartbeat.intervalMs",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.heartbeat.visibility",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["visible", "hidden"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.feishu.historyLimit",
       "kind": "channel",
       "type": "integer",
@@ -13835,10 +15236,64 @@
       "hasChildren": false
     },
     {
+      "path": "channels.feishu.httpTimeoutMs",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.markdown",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.markdown.mode",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["native", "escape", "strip"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.markdown.tableMode",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": ["native", "ascii", "simple"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.feishu.mediaMaxMb",
       "kind": "channel",
       "type": "number",
       "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.reactionNotifications",
+      "kind": "channel",
+      "type": "string",
+      "required": true,
+      "enumValues": ["off", "own", "all"],
+      "defaultValue": "own",
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13870,6 +15325,28 @@
       "path": "channels.feishu.requireMention",
       "kind": "channel",
       "type": "boolean",
+      "required": true,
+      "defaultValue": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.resolveSenderNames",
+      "kind": "channel",
+      "type": "boolean",
+      "required": true,
+      "defaultValue": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.streaming",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -13887,11 +15364,92 @@
       "hasChildren": false
     },
     {
+      "path": "channels.feishu.tools",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.tools.chat",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.tools.doc",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.tools.drive",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.tools.perm",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.tools.scopes",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.tools.wiki",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.feishu.topicSessionMode",
       "kind": "channel",
       "type": "string",
       "required": false,
       "enumValues": ["disabled", "enabled"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.typingIndicator",
+      "kind": "channel",
+      "type": "boolean",
+      "required": true,
+      "defaultValue": true,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13932,7 +15490,6 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": ["env", "file", "exec"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13952,7 +15509,8 @@
       "path": "channels.feishu.webhookPath",
       "kind": "channel",
       "type": "string",
-      "required": false,
+      "required": true,
+      "defaultValue": "/feishu/events",
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14380,6 +15938,26 @@
       "path": "channels.googlechat.accounts.*.groups.*.users.*",
       "kind": "channel",
       "type": ["number", "string"],
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.googlechat.accounts.*.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.googlechat.accounts.*.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -14988,6 +16566,26 @@
       "path": "channels.googlechat.groups.*.users.*",
       "kind": "channel",
       "type": ["number", "string"],
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.googlechat.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.googlechat.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -15674,6 +17272,26 @@
       "hasChildren": false
     },
     {
+      "path": "channels.imessage.accounts.*.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.imessage.accounts.*.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.imessage.accounts.*.heartbeat",
       "kind": "channel",
       "type": "object",
@@ -16289,6 +17907,26 @@
       "path": "channels.imessage.groups.*.toolsBySender.*.deny.*",
       "kind": "channel",
       "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.imessage.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.imessage.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -20422,6 +22060,26 @@
       "hasChildren": false
     },
     {
+      "path": "channels.msteams.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.msteams.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.msteams.heartbeat",
       "kind": "channel",
       "type": "object",
@@ -22903,6 +24561,26 @@
       "hasChildren": false
     },
     {
+      "path": "channels.signal.accounts.*.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.signal.accounts.*.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.signal.accounts.*.heartbeat",
       "kind": "channel",
       "type": "object",
@@ -23588,6 +25266,26 @@
       "path": "channels.signal.groups.*.toolsBySender.*.deny.*",
       "kind": "channel",
       "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.signal.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.signal.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -24638,6 +26336,26 @@
       "type": "string",
       "required": false,
       "enumValues": ["open", "disabled", "allowlist"],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.slack.accounts.*.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.slack.accounts.*.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -25898,6 +27616,26 @@
       "required": true,
       "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.slack.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.slack.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -27733,6 +29471,26 @@
       "hasChildren": false
     },
     {
+      "path": "channels.telegram.accounts.*.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.telegram.accounts.*.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.telegram.accounts.*.heartbeat",
       "kind": "channel",
       "type": "object",
@@ -29516,6 +31274,26 @@
       "hasChildren": false
     },
     {
+      "path": "channels.telegram.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.telegram.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.telegram.heartbeat",
       "kind": "channel",
       "type": "object",
@@ -31265,6 +33043,26 @@
       "hasChildren": false
     },
     {
+      "path": "channels.whatsapp.accounts.*.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.whatsapp.accounts.*.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.whatsapp.accounts.*.heartbeat",
       "kind": "channel",
       "type": "object",
@@ -31904,6 +33702,26 @@
       "path": "channels.whatsapp.groups.*.toolsBySender.*.deny.*",
       "kind": "channel",
       "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.whatsapp.healthMonitor",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.whatsapp.healthMonitor.enabled",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -34439,6 +36257,30 @@
       "tags": ["network", "reliability"],
       "label": "Gateway Channel Health Check Interval (min)",
       "help": "Interval in minutes for automatic channel health probing and status updates. Use lower intervals for faster detection, or higher intervals to reduce periodic probe noise.",
+      "hasChildren": false
+    },
+    {
+      "path": "gateway.channelMaxRestartsPerHour",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": ["network", "performance"],
+      "label": "Gateway Channel Max Restarts Per Hour",
+      "help": "Maximum number of health-monitor-initiated channel restarts allowed within a rolling one-hour window. Once hit, further restarts are skipped until the window expires. Default: 10.",
+      "hasChildren": false
+    },
+    {
+      "path": "gateway.channelStaleEventThresholdMinutes",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": ["network"],
+      "label": "Gateway Channel Stale Event Threshold (min)",
+      "help": "How many minutes a connected channel can go without receiving any event before the health monitor treats it as a stale socket and triggers a restart. Default: 30.",
       "hasChildren": false
     },
     {

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":4733}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":4914}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -143,7 +143,7 @@
 {"recordType":"path","path":"agents.defaults.heartbeat.prompt","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.defaults.heartbeat.session","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.defaults.heartbeat.suppressToolErrorWarnings","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":["automation"],"label":"Heartbeat Suppress Tool Error Warnings","help":"Suppress tool error warning payloads during heartbeat runs.","hasChildren":false}
-{"recordType":"path","path":"agents.defaults.heartbeat.target","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["automation"],"help":"Delivery target (\"last\", \"none\", or a channel id). Known channels: telegram, whatsapp, discord, irc, googlechat, slack, signal, imessage, line, zalouser, zalo, tlon, feishu, nextcloud-talk, msteams, bluebubbles, synology-chat, mattermost, twitch, matrix, nostr.","hasChildren":false}
+{"recordType":"path","path":"agents.defaults.heartbeat.target","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["automation"],"help":"Delivery target (\"last\", \"none\", or a channel id). Known channels: telegram, whatsapp, discord, irc, googlechat, slack, signal, imessage, line, bluebubbles, feishu, matrix, mattermost, msteams, nextcloud-talk, nostr, synology-chat, tlon, twitch, zalo, zalouser.","hasChildren":false}
 {"recordType":"path","path":"agents.defaults.heartbeat.to","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.defaults.humanDelay","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"agents.defaults.humanDelay.maxMs","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":["performance"],"label":"Human Delay Max (ms)","help":"Maximum delay in ms for custom humanDelay (default: 2500).","hasChildren":false}
@@ -347,7 +347,7 @@
 {"recordType":"path","path":"agents.list.*.heartbeat.prompt","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.list.*.heartbeat.session","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.list.*.heartbeat.suppressToolErrorWarnings","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":["automation"],"label":"Agent Heartbeat Suppress Tool Error Warnings","help":"Suppress tool error warning payloads during heartbeat runs.","hasChildren":false}
-{"recordType":"path","path":"agents.list.*.heartbeat.target","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["automation"],"help":"Delivery target (\"last\", \"none\", or a channel id). Known channels: telegram, whatsapp, discord, irc, googlechat, slack, signal, imessage, line, zalouser, zalo, tlon, feishu, nextcloud-talk, msteams, bluebubbles, synology-chat, mattermost, twitch, matrix, nostr.","hasChildren":false}
+{"recordType":"path","path":"agents.list.*.heartbeat.target","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["automation"],"help":"Delivery target (\"last\", \"none\", or a channel id). Known channels: telegram, whatsapp, discord, irc, googlechat, slack, signal, imessage, line, bluebubbles, feishu, matrix, mattermost, msteams, nextcloud-talk, nostr, synology-chat, tlon, twitch, zalo, zalouser.","hasChildren":false}
 {"recordType":"path","path":"agents.list.*.heartbeat.to","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.list.*.humanDelay","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"agents.list.*.humanDelay.maxMs","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -599,6 +599,34 @@
 {"recordType":"path","path":"approvals.exec.targets.*.channel","kind":"core","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Approval Target Channel","help":"Channel/provider ID used for forwarded approval delivery, such as discord, slack, or a plugin channel id. Use valid channel IDs only so approvals do not silently fail due to unknown routes.","hasChildren":false}
 {"recordType":"path","path":"approvals.exec.targets.*.threadId","kind":"core","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Approval Target Thread ID","help":"Optional thread/topic target for channels that support threaded delivery of forwarded approvals. Use this to keep approval traffic contained in operational threads instead of main channels.","hasChildren":false}
 {"recordType":"path","path":"approvals.exec.targets.*.to","kind":"core","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Approval Target Destination","help":"Destination identifier inside the target channel (channel ID, user ID, or thread root depending on provider). Verify semantics per provider because destination format differs across channel integrations.","hasChildren":false}
+{"recordType":"path","path":"approvals.tool","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.tool.agentFilter","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.tool.agentFilter.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.tool.enabled","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.tool.mode","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.tool.sessionFilter","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.tool.sessionFilter.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.tool.targets","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.tool.targets.*","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.tool.targets.*.accountId","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.tool.targets.*.channel","kind":"core","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.tool.targets.*.threadId","kind":"core","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.tool.targets.*.to","kind":"core","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.toolPolicy","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.toolPolicy.agents","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.toolPolicy.agents.*","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.toolPolicy.agents.*.allowlist","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.toolPolicy.agents.*.allowlist.*","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.toolPolicy.agents.*.allowlist.*.pattern","kind":"core","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.toolPolicy.agents.*.ask","kind":"core","type":"string","required":false,"enumValues":["off","on-miss","always"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.toolPolicy.agents.*.askFallback","kind":"core","type":"string","required":false,"enumValues":["deny","allowlist","full"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.toolPolicy.agents.*.security","kind":"core","type":"string","required":false,"enumValues":["deny","allowlist","full"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.toolPolicy.allowlist","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.toolPolicy.allowlist.*","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"approvals.toolPolicy.allowlist.*.pattern","kind":"core","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.toolPolicy.ask","kind":"core","type":"string","required":false,"enumValues":["off","on-miss","always"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.toolPolicy.askFallback","kind":"core","type":"string","required":false,"enumValues":["deny","allowlist","full"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"approvals.toolPolicy.security","kind":"core","type":"string","required":false,"enumValues":["deny","allowlist","full"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"audio","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Audio","help":"Global audio ingestion settings used before higher-level tools process speech or media content. Configure this when you need deterministic transcription behavior for voice notes and clips.","hasChildren":true}
 {"recordType":"path","path":"audio.transcription","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["media"],"label":"Audio Transcription","help":"Command-based transcription settings for converting audio files into text before agent handling. Keep a simple, deterministic command path here so failures are easy to diagnose in logs.","hasChildren":true}
 {"recordType":"path","path":"audio.transcription.command","kind":"core","type":"array","required":true,"deprecated":false,"sensitive":false,"tags":["media"],"label":"Audio Transcription Command","help":"Executable + args used to transcribe audio (first token must be a safe binary/path), for example `[\"whisper-cli\", \"--model\", \"small\", \"{input}\"]`. Prefer a pinned command so runtime environments behave consistently.","hasChildren":true}
@@ -912,6 +940,8 @@
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.users","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.users.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.discord.accounts.*.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1165,6 +1195,8 @@
 {"recordType":"path","path":"channels.discord.guilds.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.users","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.guilds.*.users.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.discord.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1280,61 +1312,182 @@
 {"recordType":"path","path":"channels.feishu","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Feishu","help":"飞书/Lark enterprise messaging.","hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.actions","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.actions.reactions","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.appId","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.appSecret","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.appSecret.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.appSecret.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.accounts.*.appSecret.source","kind":"channel","type":"string","required":true,"enumValues":["env","file","exec"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.appSecret.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.blockStreamingCoalesce","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.blockStreamingCoalesce.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.blockStreamingCoalesce.maxDelayMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.blockStreamingCoalesce.minDelayMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.capabilities","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.capabilities.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.chunkMode","kind":"channel","type":"string","required":false,"enumValues":["length","newline"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.configWrites","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.connectionMode","kind":"channel","type":"string","required":false,"enumValues":["websocket","webhook"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["open","pairing","allowlist"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.domain","kind":"channel","type":"string","required":false,"enumValues":["feishu","lark"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.encryptKey","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.encryptKey.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.encryptKey.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.accounts.*.encryptKey.source","kind":"channel","type":"string","required":true,"enumValues":["env","file","exec"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.encryptKey.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.groupAllowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groupPolicy","kind":"channel","type":"string","required":false,"enumValues":["open","allowlist","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.groupSessionScope","kind":"channel","type":"string","required":false,"enumValues":["group","group_sender","group_topic","group_topic_sender"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.replyInThread","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.skills","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.skills.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.tools.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.tools.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.tools.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.topicSessionMode","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groupSenderAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.groupSenderAllowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groupSessionScope","kind":"channel","type":"string","required":false,"enumValues":["group","group_sender","group_topic","group_topic_sender"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.heartbeat.intervalMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.heartbeat.visibility","kind":"channel","type":"string","required":false,"enumValues":["visible","hidden"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.httpTimeoutMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.markdown","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.markdown.mode","kind":"channel","type":"string","required":false,"enumValues":["native","escape","strip"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.markdown.tableMode","kind":"channel","type":"string","required":false,"enumValues":["native","ascii","simple"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.mediaMaxMb","kind":"channel","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.name","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.reactionNotifications","kind":"channel","type":"string","required":false,"enumValues":["off","own","all"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.renderMode","kind":"channel","type":"string","required":false,"enumValues":["auto","raw","card"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.replyInThread","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.resolveSenderNames","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.streaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.tools.chat","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.tools.doc","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.tools.drive","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.tools.perm","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.tools.scopes","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.tools.wiki","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.topicSessionMode","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.typingIndicator","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.verificationToken","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.verificationToken.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.verificationToken.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.accounts.*.verificationToken.source","kind":"channel","type":"string","required":true,"enumValues":["env","file","exec"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.verificationToken.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.webhookHost","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.webhookPath","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.webhookPort","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.actions","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.actions.reactions","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.appId","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.appSecret","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.appSecret.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.appSecret.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.appSecret.source","kind":"channel","type":"string","required":true,"enumValues":["env","file","exec"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.appSecret.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.blockStreamingCoalesce","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.blockStreamingCoalesce.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.blockStreamingCoalesce.maxDelayMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.blockStreamingCoalesce.minDelayMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.capabilities","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.capabilities.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.chunkMode","kind":"channel","type":"string","required":false,"enumValues":["length","newline"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.connectionMode","kind":"channel","type":"string","required":false,"enumValues":["websocket","webhook"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.configWrites","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.connectionMode","kind":"channel","type":"string","required":true,"enumValues":["websocket","webhook"],"defaultValue":"websocket","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.defaultAccount","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.dmHistoryLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.dmPolicy","kind":"channel","type":"string","required":false,"enumValues":["open","pairing","allowlist"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.domain","kind":"channel","type":"string","required":false,"enumValues":["feishu","lark"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dmPolicy","kind":"channel","type":"string","required":true,"enumValues":["open","pairing","allowlist"],"defaultValue":"pairing","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dms.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.domain","kind":"channel","type":"string","required":true,"enumValues":["feishu","lark"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dynamicAgentCreation","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dynamicAgentCreation.agentDirTemplate","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dynamicAgentCreation.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dynamicAgentCreation.maxAgents","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dynamicAgentCreation.workspaceTemplate","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.encryptKey","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.encryptKey.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.encryptKey.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.encryptKey.source","kind":"channel","type":"string","required":true,"enumValues":["env","file","exec"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.encryptKey.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.groupAllowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.groupPolicy","kind":"channel","type":"string","required":false,"enumValues":["open","allowlist","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groupPolicy","kind":"channel","type":"string","required":true,"enumValues":["open","allowlist","disabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.groups.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.groups.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.groups.*.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups.*.groupSessionScope","kind":"channel","type":"string","required":false,"enumValues":["group","group_sender","group_topic","group_topic_sender"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups.*.replyInThread","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups.*.skills","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.groups.*.skills.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.groups.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.groups.*.tools.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups.*.tools.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.groups.*.tools.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups.*.topicSessionMode","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groupSenderAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.groupSenderAllowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.groupSessionScope","kind":"channel","type":"string","required":false,"enumValues":["group","group_sender","group_topic","group_topic_sender"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.heartbeat.intervalMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.heartbeat.visibility","kind":"channel","type":"string","required":false,"enumValues":["visible","hidden"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.httpTimeoutMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.markdown","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.markdown.mode","kind":"channel","type":"string","required":false,"enumValues":["native","escape","strip"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.markdown.tableMode","kind":"channel","type":"string","required":false,"enumValues":["native","ascii","simple"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.mediaMaxMb","kind":"channel","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.reactionNotifications","kind":"channel","type":"string","required":true,"enumValues":["off","own","all"],"defaultValue":"own","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.renderMode","kind":"channel","type":"string","required":false,"enumValues":["auto","raw","card"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.replyInThread","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.requireMention","kind":"channel","type":"boolean","required":true,"defaultValue":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.resolveSenderNames","kind":"channel","type":"boolean","required":true,"defaultValue":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.streaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.tools.chat","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.tools.doc","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.tools.drive","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.tools.perm","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.tools.scopes","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.tools.wiki","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.topicSessionMode","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.typingIndicator","kind":"channel","type":"boolean","required":true,"defaultValue":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.verificationToken","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.verificationToken.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.verificationToken.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.verificationToken.source","kind":"channel","type":"string","required":true,"enumValues":["env","file","exec"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.verificationToken.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.webhookHost","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.webhookPath","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.webhookPath","kind":"channel","type":"string","required":true,"defaultValue":"/feishu/events","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.webhookPort","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Google Chat","help":"Google Workspace Chat app with HTTP webhook.","hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1377,6 +1530,8 @@
 {"recordType":"path","path":"channels.googlechat.accounts.*.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.accounts.*.groups.*.users","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.accounts.*.groups.*.users.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.googlechat.accounts.*.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.googlechat.accounts.*.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.accounts.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.accounts.*.mediaMaxMb","kind":"channel","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.accounts.*.name","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1437,6 +1592,8 @@
 {"recordType":"path","path":"channels.googlechat.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.groups.*.users","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.googlechat.groups.*.users.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.googlechat.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.googlechat.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.mediaMaxMb","kind":"channel","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.googlechat.name","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1504,6 +1661,8 @@
 {"recordType":"path","path":"channels.imessage.accounts.*.groups.*.toolsBySender.*.alsoAllow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.accounts.*.groups.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.imessage.accounts.*.groups.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.imessage.accounts.*.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.imessage.accounts.*.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.accounts.*.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.imessage.accounts.*.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.accounts.*.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1565,6 +1724,8 @@
 {"recordType":"path","path":"channels.imessage.groups.*.toolsBySender.*.alsoAllow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.groups.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.imessage.groups.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.imessage.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.imessage.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.imessage.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.imessage.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1969,6 +2130,8 @@
 {"recordType":"path","path":"channels.msteams.groupAllowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.msteams.groupAllowFrom.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.groupPolicy","kind":"channel","type":"string","required":true,"enumValues":["open","disabled","allowlist"],"defaultValue":"allowlist","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.msteams.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.msteams.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.msteams.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2214,6 +2377,8 @@
 {"recordType":"path","path":"channels.signal.accounts.*.groups.*.toolsBySender.*.alsoAllow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.accounts.*.groups.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.signal.accounts.*.groups.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.signal.accounts.*.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.signal.accounts.*.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.accounts.*.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.signal.accounts.*.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.accounts.*.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2282,6 +2447,8 @@
 {"recordType":"path","path":"channels.signal.groups.*.toolsBySender.*.alsoAllow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.groups.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.signal.groups.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.signal.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.signal.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.signal.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.signal.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2386,6 +2553,8 @@
 {"recordType":"path","path":"channels.slack.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.groupPolicy","kind":"channel","type":"string","required":false,"enumValues":["open","disabled","allowlist"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.slack.accounts.*.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.slack.accounts.*.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.accounts.*.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2509,6 +2678,8 @@
 {"recordType":"path","path":"channels.slack.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.groupPolicy","kind":"channel","type":"string","required":true,"enumValues":["open","disabled","allowlist"],"defaultValue":"allowlist","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.slack.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.slack.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2688,6 +2859,8 @@
 {"recordType":"path","path":"channels.telegram.accounts.*.groups.*.topics.*.skills","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.accounts.*.groups.*.topics.*.skills.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.groups.*.topics.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.telegram.accounts.*.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.telegram.accounts.*.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.accounts.*.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.accounts.*.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2862,6 +3035,8 @@
 {"recordType":"path","path":"channels.telegram.groups.*.topics.*.skills","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.groups.*.topics.*.skills.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.groups.*.topics.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.telegram.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.telegram.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.telegram.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.telegram.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3032,6 +3207,8 @@
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.toolsBySender.*.alsoAllow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3095,6 +3272,8 @@
 {"recordType":"path","path":"channels.whatsapp.groups.*.toolsBySender.*.alsoAllow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.groups.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.healthMonitor","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.whatsapp.healthMonitor.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.heartbeat","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.heartbeat.showAlerts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.heartbeat.showOk","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3330,6 +3509,8 @@
 {"recordType":"path","path":"gateway.auth.trustedProxy.userHeader","kind":"core","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"gateway.bind","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["network"],"label":"Gateway Bind Mode","help":"Network bind profile: \"auto\", \"lan\", \"loopback\", \"custom\", or \"tailnet\" to control interface exposure. Keep \"loopback\" or \"auto\" for safest local operation unless external clients must connect.","hasChildren":false}
 {"recordType":"path","path":"gateway.channelHealthCheckMinutes","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":["network","reliability"],"label":"Gateway Channel Health Check Interval (min)","help":"Interval in minutes for automatic channel health probing and status updates. Use lower intervals for faster detection, or higher intervals to reduce periodic probe noise.","hasChildren":false}
+{"recordType":"path","path":"gateway.channelMaxRestartsPerHour","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":["network","performance"],"label":"Gateway Channel Max Restarts Per Hour","help":"Maximum number of health-monitor-initiated channel restarts allowed within a rolling one-hour window. Once hit, further restarts are skipped until the window expires. Default: 10.","hasChildren":false}
+{"recordType":"path","path":"gateway.channelStaleEventThresholdMinutes","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":["network"],"label":"Gateway Channel Stale Event Threshold (min)","help":"How many minutes a connected channel can go without receiving any event before the health monitor treats it as a stale socket and triggers a restart. Default: 30.","hasChildren":false}
 {"recordType":"path","path":"gateway.controlUi","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["network"],"label":"Control UI","help":"Control UI hosting settings including enablement, pathing, and browser-origin/auth hardening behavior. Keep UI exposure minimal and pair with strong auth controls before internet-facing deployments.","hasChildren":true}
 {"recordType":"path","path":"gateway.controlUi.allowedOrigins","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access","network"],"label":"Control UI Allowed Origins","help":"Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com). Required for non-loopback Control UI deployments unless dangerous Host-header fallback is explicitly enabled.","hasChildren":true}
 {"recordType":"path","path":"gateway.controlUi.allowedOrigins.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/docs/tools/tool-approvals.md
+++ b/docs/tools/tool-approvals.md
@@ -1,0 +1,120 @@
+---
+summary: "MCP/plugin tool call approvals, allowlists, and policy configuration"
+read_when:
+  - Configuring MCP tool approvals or allowlists
+  - Gating MCP/plugin tool calls with operator approval
+  - Restricting which MCP tools agents can invoke
+title: "Tool Approvals"
+---
+
+# Tool approvals
+
+Tool approvals gate **MCP and plugin tool calls** with the same security/ask/askFallback pattern
+used by [exec approvals](/tools/exec-approvals) and HTTP approvals.
+
+By default the policy is **permissive** (`security: full`, `ask: off`) so existing
+deployments are unaffected. Operators can tighten the policy per-gateway or per-agent.
+
+## Config
+
+Tool approval policy lives under `approvals.toolPolicy` in the OpenClaw config:
+
+```yaml
+approvals:
+  toolPolicy:
+    # "deny" | "allowlist" | "full" (default: "full")
+    security: allowlist
+
+    # "off" | "on-miss" | "always" (default: "off")
+    ask: on-miss
+
+    # fallback when no operator responds (default: "full")
+    askFallback: deny
+
+    # tool name patterns (glob-style)
+    allowlist:
+      - pattern: "github__list_*"
+      - pattern: "github__get_*"
+      - pattern: "slack__send_*"
+
+    # per-agent overrides
+    agents:
+      ops:
+        security: deny
+      research:
+        security: allowlist
+        allowlist:
+          - pattern: "web_search"
+          - pattern: "web_fetch"
+```
+
+## Policy resolution
+
+1. `approvals.toolPolicy` sets global defaults.
+2. `approvals.toolPolicy.agents.<agentId>` overrides per agent.
+3. `approvals.toolPolicy.agents.*` provides wildcard agent defaults (per-agent values take priority).
+4. Built-in defaults: `security=full`, `ask=off`, `askFallback=full`.
+
+## Security modes
+
+| Mode        | Behavior                                             |
+| ----------- | ---------------------------------------------------- |
+| `full`      | Allow all tool calls (default).                      |
+| `allowlist` | Allow only tool calls matching an allowlist pattern. |
+| `deny`      | Deny all tool calls.                                 |
+
+## Ask modes
+
+| Mode      | Behavior                                                     |
+| --------- | ------------------------------------------------------------ |
+| `off`     | Never prompt the operator (default).                         |
+| `on-miss` | Prompt only when the tool name does not match the allowlist. |
+| `always`  | Always prompt, even on allowlist match.                      |
+
+## Allowlist patterns
+
+Patterns use glob-style matching against the full tool name:
+
+- `*` matches any characters
+- `?` matches a single character
+- Matching is case-insensitive
+
+Examples:
+
+| Pattern          | Matches                                     |
+| ---------------- | ------------------------------------------- |
+| `github__list_*` | `github__list_repos`, `github__list_issues` |
+| `github__*`      | Any tool from the `github` MCP server       |
+| `*__read_*`      | Any read tool across all servers            |
+| `exec__*`        | Any exec-prefixed tool                      |
+| `*`              | Everything (equivalent to `security: full`) |
+
+## Forwarding to chat channels
+
+Tool approval requests can be forwarded to chat channels for operator response,
+similar to exec approval forwarding:
+
+```yaml
+approvals:
+  tool:
+    enabled: true
+    mode: session # "session" | "targets" | "both"
+    targets:
+      - channel: telegram
+        to: "123456789"
+```
+
+## Gateway events
+
+| Event                     | Description                                    |
+| ------------------------- | ---------------------------------------------- |
+| `tool.approval.requested` | Emitted when a tool call requires approval.    |
+| `tool.approval.resolved`  | Emitted when an approval is granted or denied. |
+
+## Gateway RPC methods
+
+| Method                       | Description                                                  |
+| ---------------------------- | ------------------------------------------------------------ |
+| `tool.approval.request`      | Register a pending tool approval request.                    |
+| `tool.approval.waitDecision` | Wait for an operator decision on a pending request.          |
+| `tool.approval.resolve`      | Resolve a pending approval (allow-once, allow-always, deny). |

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveToolApprovalPolicy } from "../infra/tool-approval-policy.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
@@ -13,6 +14,7 @@ import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
+import { withToolApprovalGate } from "./tools/mcp-tool-approval.js";
 import { createMessageTool } from "./tools/message-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createPdfTool } from "./tools/pdf-tool.js";
@@ -216,15 +218,19 @@ export function createOpenClawTools(
     ...(pdfTool ? [pdfTool] : []),
   ];
 
+  const toolApprovalAgentId =
+    options?.requesterAgentIdOverride ??
+    resolveSessionAgentId({
+      sessionKey: options?.agentSessionKey,
+      config: options?.config,
+    });
+
   const pluginTools = resolvePluginTools({
     context: {
       config: options?.config,
       workspaceDir,
       agentDir: options?.agentDir,
-      agentId: resolveSessionAgentId({
-        sessionKey: options?.agentSessionKey,
-        config: options?.config,
-      }),
+      agentId: toolApprovalAgentId,
       sessionKey: options?.agentSessionKey,
       sessionId: options?.sessionId,
       messageChannel: options?.agentChannel,
@@ -237,5 +243,27 @@ export function createOpenClawTools(
     toolAllowlist: options?.pluginToolAllowlist,
   });
 
-  return [...tools, ...pluginTools];
+  // Resolve the tool approval policy once. If the policy is permissive (default),
+  // skip wrapping entirely to avoid overhead on every plugin tool call.
+  const toolPolicy = resolveToolApprovalPolicy({
+    cfg: options?.config ?? ({} as OpenClawConfig),
+    agentId: toolApprovalAgentId,
+  });
+  const needsToolApprovalGate = !(toolPolicy.security === "full" && toolPolicy.ask === "off");
+
+  const gatedPluginTools = needsToolApprovalGate
+    ? pluginTools.map((tool) =>
+        withToolApprovalGate(tool, {
+          config: options?.config,
+          agentId: toolApprovalAgentId,
+          sessionKey: options?.agentSessionKey,
+          turnSourceChannel: options?.agentChannel,
+          turnSourceTo: options?.agentTo,
+          turnSourceAccountId: options?.agentAccountId,
+          turnSourceThreadId: options?.agentThreadId,
+        }),
+      )
+    : pluginTools;
+
+  return [...tools, ...gatedPluginTools];
 }

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -254,7 +254,7 @@ export function createOpenClawTools(
   const gatedPluginTools = needsToolApprovalGate
     ? pluginTools.map((tool) =>
         withToolApprovalGate(tool, {
-          config: options?.config,
+          policy: toolPolicy,
           agentId: toolApprovalAgentId,
           sessionKey: options?.agentSessionKey,
           turnSourceChannel: options?.agentChannel,

--- a/src/agents/tools/mcp-tool-approval.test.ts
+++ b/src/agents/tools/mcp-tool-approval.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ResolvedToolApprovalPolicy } from "../../infra/tool-approval-policy.js";
+import type { AnyAgentTool } from "./common.js";
+import { withToolApprovalGate } from "./mcp-tool-approval.js";
+
+// Stub callGatewayTool so we never reach a real gateway.
+vi.mock("./gateway.js", () => ({
+  callGatewayTool: vi.fn(),
+}));
+
+function makeTool(name: string): AnyAgentTool {
+  return {
+    label: name,
+    name,
+    description: `test tool ${name}`,
+    parameters: {},
+    execute: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] }),
+  } as unknown as AnyAgentTool;
+}
+
+function permissivePolicy(): ResolvedToolApprovalPolicy {
+  return { security: "full", ask: "off", askFallback: "full", allowlist: [] };
+}
+
+function askPolicy(): ResolvedToolApprovalPolicy {
+  return { security: "full", ask: "always", askFallback: "full", allowlist: [] };
+}
+
+function denyPolicy(): ResolvedToolApprovalPolicy {
+  return { security: "deny", ask: "off", askFallback: "full", allowlist: [] };
+}
+
+describe("withToolApprovalGate", () => {
+  describe("allow-always cache scoping", () => {
+    it("does not share allow-always cache between different agents", async () => {
+      // Use callGatewayTool mock to simulate allow-always for agent-a.
+      const { callGatewayTool } = await import("./gateway.js");
+      const mockCallGateway = vi.mocked(callGatewayTool);
+
+      // First call: agent-a gets allow-always via gateway.
+      mockCallGateway
+        .mockResolvedValueOnce({ decision: "allow-always" }) // registration
+        .mockResolvedValueOnce({ decision: "allow-always" }); // waitDecision (fallback)
+
+      const toolA = makeTool("mcp-read");
+      const policy = askPolicy();
+      const wrappedA = withToolApprovalGate(toolA, {
+        agentId: "agent-a",
+        policy,
+      });
+      await wrappedA.execute("call-1", {});
+      expect(toolA.execute).toHaveBeenCalledTimes(1);
+
+      // Second call from agent-a should hit cache (no gateway call).
+      mockCallGateway.mockClear();
+      await wrappedA.execute("call-2", {});
+      expect(toolA.execute).toHaveBeenCalledTimes(2);
+      // No gateway calls because cache hit.
+      expect(mockCallGateway).not.toHaveBeenCalled();
+
+      // Third call from agent-b for same tool name should NOT hit cache.
+      const toolB = makeTool("mcp-read");
+      mockCallGateway
+        .mockResolvedValueOnce({ decision: "allow-once" }) // registration
+        .mockResolvedValueOnce({ decision: "allow-once" }); // waitDecision
+      const wrappedB = withToolApprovalGate(toolB, {
+        agentId: "agent-b",
+        policy,
+      });
+      await wrappedB.execute("call-3", {});
+      // agent-b had to go through gateway because cache is scoped.
+      expect(mockCallGateway).toHaveBeenCalled();
+    });
+
+    it("does not share allow-always cache between different policy contexts", async () => {
+      const { callGatewayTool } = await import("./gateway.js");
+      const mockCallGateway = vi.mocked(callGatewayTool);
+
+      // Grant allow-always under ask=always policy.
+      mockCallGateway.mockResolvedValueOnce({ decision: "allow-always" });
+      const tool1 = makeTool("mcp-write");
+      const wrapped1 = withToolApprovalGate(tool1, {
+        agentId: "agent-x",
+        policy: askPolicy(),
+      });
+      await wrapped1.execute("call-1", {});
+      expect(tool1.execute).toHaveBeenCalledTimes(1);
+
+      // Same agent, same tool, but different security policy: should not hit cache.
+      mockCallGateway.mockClear();
+      const tool2 = makeTool("mcp-write");
+      const allowlistPolicy: ResolvedToolApprovalPolicy = {
+        security: "allowlist",
+        ask: "always",
+        askFallback: "full",
+        allowlist: [],
+      };
+      mockCallGateway.mockResolvedValueOnce({ decision: "allow-once" });
+      const wrapped2 = withToolApprovalGate(tool2, {
+        agentId: "agent-x",
+        policy: allowlistPolicy,
+      });
+      await wrapped2.execute("call-2", {});
+      // Should have gone through gateway.
+      expect(mockCallGateway).toHaveBeenCalled();
+    });
+  });
+
+  describe("deny policy blocks cached allow-always", () => {
+    it("denies when policy changes to deny even if allow-always was cached", async () => {
+      const { callGatewayTool } = await import("./gateway.js");
+      const mockCallGateway = vi.mocked(callGatewayTool);
+
+      // Grant allow-always under deny policy context (hypothetical stale entry).
+      // We test the re-evaluation path: cache a tool under ask policy,
+      // then wrap it with deny policy using same agent/security combo.
+      mockCallGateway.mockResolvedValueOnce({ decision: "allow-always" });
+      const tool = makeTool("mcp-danger");
+      const wrapped = withToolApprovalGate(tool, {
+        agentId: "agent-z",
+        policy: askPolicy(),
+      });
+      await wrapped.execute("call-1", {});
+      expect(tool.execute).toHaveBeenCalledTimes(1);
+
+      // Wrap same tool name with deny policy and same agent.
+      // The cache key differs because policy.security differs, so it goes
+      // through the normal evaluateToolApprovalPolicy path and gets denied.
+      const tool2 = makeTool("mcp-danger");
+      const wrappedDeny = withToolApprovalGate(tool2, {
+        agentId: "agent-z",
+        policy: denyPolicy(),
+      });
+      const result = await wrappedDeny.execute("call-2", {});
+      expect(tool2.execute).not.toHaveBeenCalled();
+      expect(
+        JSON.parse((result as { content: Array<{ text: string }> }).content[0].text),
+      ).toMatchObject({
+        error: expect.stringContaining("TOOL_CALL_DENIED"),
+      });
+    });
+  });
+
+  describe("permissive policy skips approval", () => {
+    it("executes directly when security=full and ask=off", async () => {
+      const tool = makeTool("mcp-safe");
+      const wrapped = withToolApprovalGate(tool, {
+        agentId: "agent-a",
+        policy: permissivePolicy(),
+      });
+      await wrapped.execute("call-1", {});
+      expect(tool.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/agents/tools/mcp-tool-approval.ts
+++ b/src/agents/tools/mcp-tool-approval.ts
@@ -1,0 +1,193 @@
+/**
+ * MCP/plugin tool approval gate.
+ *
+ * Wraps an MCP/plugin tool so that before any call is executed, the tool name
+ * is evaluated against the tool approval policy. If the policy denies the tool
+ * or requires interactive approval, the tool returns an error or waits for
+ * an operator decision.
+ *
+ * This follows the same pattern as the exec and HTTP approval systems:
+ *   1. Evaluate the policy (security + allowlist + ask).
+ *   2. If approval is required, register a pending request via the gateway.
+ *   3. Wait for operator decision or timeout.
+ *   4. Apply askFallback on timeout.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  evaluateToolApprovalPolicy,
+  resolveToolApprovalPolicy,
+} from "../../infra/tool-approval-policy.js";
+import { DEFAULT_TOOL_APPROVAL_TIMEOUT_MS } from "../../infra/tool-approvals.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult } from "./common.js";
+import { callGatewayTool } from "./gateway.js";
+
+// Timeout for the gateway RPC call itself (not the approval wait).
+const APPROVAL_REQUEST_TIMEOUT_MS = 10_000;
+
+export type ToolApprovalGateOptions = {
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+  turnSourceChannel?: string;
+  turnSourceTo?: string;
+  turnSourceAccountId?: string;
+  turnSourceThreadId?: string | number;
+};
+
+/**
+ * Wraps an MCP/plugin tool with tool approval policy enforcement.
+ * Returns the original tool unmodified if the policy is security=full + ask=off
+ * (the default permissive configuration).
+ */
+export function withToolApprovalGate(
+  tool: AnyAgentTool,
+  opts: ToolApprovalGateOptions,
+): AnyAgentTool {
+  if (!tool) {
+    return tool;
+  }
+
+  const config = opts.config;
+  const policy = resolveToolApprovalPolicy({
+    cfg: config ?? ({} as OpenClawConfig),
+    agentId: opts.agentId,
+  });
+
+  // Fast path: default permissive policy needs no wrapping.
+  if (policy.security === "full" && policy.ask === "off") {
+    return tool;
+  }
+
+  const originalExecute = tool.execute;
+
+  return {
+    ...tool,
+    execute: async (toolCallId: string, args: Record<string, unknown>) => {
+      const toolName = tool.name || "";
+      if (!toolName) {
+        // Let the original tool handle the missing name.
+        return originalExecute(toolCallId, args);
+      }
+
+      const decision = evaluateToolApprovalPolicy({ toolName, policy });
+
+      // Denied outright (security=deny or allowlist miss with ask=off).
+      if (!decision.allowed && !decision.requiresApproval) {
+        const reason =
+          decision.security === "deny"
+            ? "TOOL_CALL_DENIED: security=deny"
+            : "TOOL_CALL_DENIED: tool not in allowlist";
+        return jsonResult({ error: reason, toolName });
+      }
+
+      // Approval required: register with the gateway and wait for decision.
+      if (decision.requiresApproval) {
+        const approvalId = randomUUID();
+        const approvalDecision = await requestToolApproval({
+          id: approvalId,
+          toolName,
+          args,
+          agentId: opts.agentId,
+          sessionKey: opts.sessionKey,
+          turnSourceChannel: opts.turnSourceChannel,
+          turnSourceTo: opts.turnSourceTo,
+          turnSourceAccountId: opts.turnSourceAccountId,
+          turnSourceThreadId: opts.turnSourceThreadId,
+        });
+
+        if (approvalDecision === "allow-once" || approvalDecision === "allow-always") {
+          // Approved. Proceed with the call.
+          return originalExecute(toolCallId, args);
+        }
+
+        // Denied or timed out. Apply askFallback.
+        if (approvalDecision === "deny") {
+          return jsonResult({ error: "TOOL_CALL_DENIED: operator denied the request", toolName });
+        }
+
+        // Timed out (null). Apply askFallback.
+        if (decision.askFallback === "full") {
+          return originalExecute(toolCallId, args);
+        }
+        if (decision.askFallback === "allowlist" && decision.evaluation.allowlistSatisfied) {
+          return originalExecute(toolCallId, args);
+        }
+
+        return jsonResult({
+          error: "TOOL_CALL_DENIED: approval timed out and askFallback denied",
+          toolName,
+        });
+      }
+
+      // Allowed by policy. Proceed.
+      return originalExecute(toolCallId, args);
+    },
+  };
+}
+
+type ToolApprovalDecision = "allow-once" | "allow-always" | "deny" | null;
+
+async function requestToolApproval(params: {
+  id: string;
+  toolName: string;
+  args?: Record<string, unknown>;
+  agentId?: string;
+  sessionKey?: string;
+  turnSourceChannel?: string;
+  turnSourceTo?: string;
+  turnSourceAccountId?: string;
+  turnSourceThreadId?: string | number;
+}): Promise<ToolApprovalDecision> {
+  try {
+    // Phase 1: register the approval request (two-phase).
+    const registrationResult = await callGatewayTool<{
+      id?: string;
+      decision?: string;
+      status?: string;
+    }>(
+      "tool.approval.request",
+      { timeoutMs: APPROVAL_REQUEST_TIMEOUT_MS },
+      {
+        id: params.id,
+        toolName: params.toolName,
+        args: params.args,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+        turnSourceChannel: params.turnSourceChannel,
+        turnSourceTo: params.turnSourceTo,
+        turnSourceAccountId: params.turnSourceAccountId,
+        turnSourceThreadId: params.turnSourceThreadId,
+        timeoutMs: DEFAULT_TOOL_APPROVAL_TIMEOUT_MS,
+        twoPhase: true,
+      },
+      { expectFinal: false },
+    );
+
+    // If the gateway returned a decision immediately (no approval clients),
+    // the decision field is present.
+    if (registrationResult && Object.hasOwn(registrationResult, "decision")) {
+      return normalizeDecision(registrationResult.decision);
+    }
+
+    // Phase 2: wait for the operator decision.
+    const decisionResult = await callGatewayTool<{ decision?: string }>(
+      "tool.approval.waitDecision",
+      { timeoutMs: DEFAULT_TOOL_APPROVAL_TIMEOUT_MS + APPROVAL_REQUEST_TIMEOUT_MS },
+      { id: params.id },
+    );
+    return normalizeDecision(decisionResult?.decision);
+  } catch {
+    // Network/gateway error: block (deny) to avoid failing open.
+    return "deny";
+  }
+}
+
+function normalizeDecision(value: unknown): ToolApprovalDecision {
+  if (value === "allow-once" || value === "allow-always" || value === "deny") {
+    return value;
+  }
+  return null;
+}

--- a/src/agents/tools/mcp-tool-approval.ts
+++ b/src/agents/tools/mcp-tool-approval.ts
@@ -24,11 +24,23 @@ import { jsonResult } from "./common.js";
 import { callGatewayTool } from "./gateway.js";
 
 // Timeout for the gateway RPC call itself (not the approval wait).
-const APPROVAL_REQUEST_TIMEOUT_MS = 10_000;
+// Aligned with DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS (exec flow) because the
+// registration RPC may block on forwarder.handleRequested before responding.
+const APPROVAL_REQUEST_TIMEOUT_MS = 130_000;
 
 // Runtime set of tool names that have been granted allow-always during this
 // process lifetime. This avoids re-prompting for the same tool within a session.
+// Keys are scoped by agent+policy context so that an approval granted under one
+// agent/policy does not leak to a different agent or stricter policy.
 const runtimeAllowedTools = new Set<string>();
+
+function allowAlwaysCacheKey(
+  toolName: string,
+  agentId: string | undefined,
+  policy: ResolvedToolApprovalPolicy,
+): string {
+  return `${agentId ?? ""}:${policy.security}:${policy.ask}:${toolName}`;
+}
 
 export type ToolApprovalGateOptions = {
   agentId?: string;
@@ -64,9 +76,17 @@ export function withToolApprovalGate(
         return originalExecute(toolCallId, args);
       }
 
-      // Runtime allow-always: skip approval if previously granted.
-      if (runtimeAllowedTools.has(toolName)) {
-        return originalExecute(toolCallId, args);
+      // Runtime allow-always: skip approval if previously granted under this
+      // agent+policy context. Re-evaluate the current policy first so a stricter
+      // policy (e.g. security=deny) is never bypassed by a stale cache entry.
+      const cacheKey = allowAlwaysCacheKey(toolName, opts.agentId, policy);
+      if (runtimeAllowedTools.has(cacheKey)) {
+        const currentDecision = evaluateToolApprovalPolicy({ toolName, policy });
+        if (currentDecision.allowed || currentDecision.requiresApproval) {
+          return originalExecute(toolCallId, args);
+        }
+        // Policy now denies this tool outright. Remove stale cache entry.
+        runtimeAllowedTools.delete(cacheKey);
       }
 
       const decision = evaluateToolApprovalPolicy({ toolName, policy });
@@ -96,7 +116,7 @@ export function withToolApprovalGate(
         });
 
         if (approvalDecision === "allow-always") {
-          runtimeAllowedTools.add(toolName);
+          runtimeAllowedTools.add(cacheKey);
           return originalExecute(toolCallId, args);
         }
         if (approvalDecision === "allow-once") {

--- a/src/agents/tools/mcp-tool-approval.ts
+++ b/src/agents/tools/mcp-tool-approval.ts
@@ -14,10 +14,9 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { OpenClawConfig } from "../../config/config.js";
 import {
   evaluateToolApprovalPolicy,
-  resolveToolApprovalPolicy,
+  type ResolvedToolApprovalPolicy,
 } from "../../infra/tool-approval-policy.js";
 import { DEFAULT_TOOL_APPROVAL_TIMEOUT_MS } from "../../infra/tool-approvals.js";
 import type { AnyAgentTool } from "./common.js";
@@ -27,8 +26,11 @@ import { callGatewayTool } from "./gateway.js";
 // Timeout for the gateway RPC call itself (not the approval wait).
 const APPROVAL_REQUEST_TIMEOUT_MS = 10_000;
 
+// Runtime set of tool names that have been granted allow-always during this
+// process lifetime. This avoids re-prompting for the same tool within a session.
+const runtimeAllowedTools = new Set<string>();
+
 export type ToolApprovalGateOptions = {
-  config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
   turnSourceChannel?: string;
@@ -44,23 +46,13 @@ export type ToolApprovalGateOptions = {
  */
 export function withToolApprovalGate(
   tool: AnyAgentTool,
-  opts: ToolApprovalGateOptions,
+  opts: ToolApprovalGateOptions & { policy: ResolvedToolApprovalPolicy },
 ): AnyAgentTool {
   if (!tool) {
     return tool;
   }
 
-  const config = opts.config;
-  const policy = resolveToolApprovalPolicy({
-    cfg: config ?? ({} as OpenClawConfig),
-    agentId: opts.agentId,
-  });
-
-  // Fast path: default permissive policy needs no wrapping.
-  if (policy.security === "full" && policy.ask === "off") {
-    return tool;
-  }
-
+  const { policy } = opts;
   const originalExecute = tool.execute;
 
   return {
@@ -69,6 +61,11 @@ export function withToolApprovalGate(
       const toolName = tool.name || "";
       if (!toolName) {
         // Let the original tool handle the missing name.
+        return originalExecute(toolCallId, args);
+      }
+
+      // Runtime allow-always: skip approval if previously granted.
+      if (runtimeAllowedTools.has(toolName)) {
         return originalExecute(toolCallId, args);
       }
 
@@ -98,8 +95,11 @@ export function withToolApprovalGate(
           turnSourceThreadId: opts.turnSourceThreadId,
         });
 
-        if (approvalDecision === "allow-once" || approvalDecision === "allow-always") {
-          // Approved. Proceed with the call.
+        if (approvalDecision === "allow-always") {
+          runtimeAllowedTools.add(toolName);
+          return originalExecute(toolCallId, args);
+        }
+        if (approvalDecision === "allow-once") {
           return originalExecute(toolCallId, args);
         }
 

--- a/src/agents/tools/mcp-tool-approval.ts
+++ b/src/agents/tools/mcp-tool-approval.ts
@@ -199,8 +199,13 @@ async function requestToolApproval(params: {
       { id: params.id },
     );
     return normalizeDecision(decisionResult?.decision);
-  } catch {
-    // Network/gateway error: block (deny) to avoid failing open.
+  } catch (err) {
+    // Timeout/cleanup path: treat missing/expired as no decision so askFallback applies.
+    const message = String(err).toLowerCase();
+    if (message.includes("approval expired or not found")) {
+      return null;
+    }
+    // Other network/gateway errors: block (deny) to avoid failing open.
     return "deny";
   }
 }

--- a/src/config/types.approvals.ts
+++ b/src/config/types.approvals.ts
@@ -24,6 +24,42 @@ export type ExecApprovalForwardingConfig = {
   targets?: ExecApprovalForwardTarget[];
 };
 
+export type ToolApprovalForwardingConfig = {
+  /** Enable forwarding tool approvals to chat channels. Default: false. */
+  enabled?: boolean;
+  /** Delivery mode (session=origin chat, targets=config targets, both=both). Default: session. */
+  mode?: ExecApprovalForwardingMode;
+  /** Only forward approvals for these agent IDs. Omit = all agents. */
+  agentFilter?: string[];
+  /** Only forward approvals matching these session key patterns (substring or regex). */
+  sessionFilter?: string[];
+  /** Explicit delivery targets (used when mode includes targets). */
+  targets?: ExecApprovalForwardTarget[];
+};
+
+export type ToolApprovalsToolConfig = {
+  /** Security mode for MCP/plugin tool calls. Default: "full" (allow all). */
+  security?: string;
+  /** Ask mode for MCP/plugin tool calls. Default: "off". */
+  ask?: string;
+  /** Fallback when ask prompt cannot reach an operator. Default: "full". */
+  askFallback?: string;
+  /** Per-agent tool allowlist overrides. */
+  agents?: Record<
+    string,
+    {
+      security?: string;
+      ask?: string;
+      askFallback?: string;
+      allowlist?: Array<{ pattern: string }>;
+    }
+  >;
+  /** Default tool name allowlist entries (apply to all agents unless overridden). */
+  allowlist?: Array<{ pattern: string }>;
+};
+
 export type ApprovalsConfig = {
   exec?: ExecApprovalForwardingConfig;
+  tool?: ToolApprovalForwardingConfig;
+  toolPolicy?: ToolApprovalsToolConfig;
 };

--- a/src/config/zod-schema.approvals.ts
+++ b/src/config/zod-schema.approvals.ts
@@ -37,20 +37,23 @@ const ToolAllowlistEntrySchema = z
   })
   .strict();
 
+const ToolSecuritySchema = z.enum(["deny", "allowlist", "full"]);
+const ToolAskSchema = z.enum(["off", "on-miss", "always"]);
+
 const ToolApprovalsAgentSchema = z
   .object({
-    security: z.string().optional(),
-    ask: z.string().optional(),
-    askFallback: z.string().optional(),
+    security: ToolSecuritySchema.optional(),
+    ask: ToolAskSchema.optional(),
+    askFallback: ToolSecuritySchema.optional(),
     allowlist: z.array(ToolAllowlistEntrySchema).optional(),
   })
   .strict();
 
 const ToolApprovalsToolConfigSchema = z
   .object({
-    security: z.string().optional(),
-    ask: z.string().optional(),
-    askFallback: z.string().optional(),
+    security: ToolSecuritySchema.optional(),
+    ask: ToolAskSchema.optional(),
+    askFallback: ToolSecuritySchema.optional(),
     agents: z.record(z.string(), ToolApprovalsAgentSchema).optional(),
     allowlist: z.array(ToolAllowlistEntrySchema).optional(),
   })

--- a/src/config/zod-schema.approvals.ts
+++ b/src/config/zod-schema.approvals.ts
@@ -20,9 +20,48 @@ const ExecApprovalForwardingSchema = z
   .strict()
   .optional();
 
+const ToolApprovalForwardingSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    mode: z.union([z.literal("session"), z.literal("targets"), z.literal("both")]).optional(),
+    agentFilter: z.array(z.string()).optional(),
+    sessionFilter: z.array(z.string()).optional(),
+    targets: z.array(ExecApprovalForwardTargetSchema).optional(),
+  })
+  .strict()
+  .optional();
+
+const ToolAllowlistEntrySchema = z
+  .object({
+    pattern: z.string().min(1),
+  })
+  .strict();
+
+const ToolApprovalsAgentSchema = z
+  .object({
+    security: z.string().optional(),
+    ask: z.string().optional(),
+    askFallback: z.string().optional(),
+    allowlist: z.array(ToolAllowlistEntrySchema).optional(),
+  })
+  .strict();
+
+const ToolApprovalsToolConfigSchema = z
+  .object({
+    security: z.string().optional(),
+    ask: z.string().optional(),
+    askFallback: z.string().optional(),
+    agents: z.record(z.string(), ToolApprovalsAgentSchema).optional(),
+    allowlist: z.array(ToolAllowlistEntrySchema).optional(),
+  })
+  .strict()
+  .optional();
+
 export const ApprovalsSchema = z
   .object({
     exec: ExecApprovalForwardingSchema,
+    tool: ToolApprovalForwardingSchema,
+    toolPolicy: ToolApprovalsToolConfigSchema,
   })
   .strict()
   .optional();

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -34,6 +34,9 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "exec.approval.request",
     "exec.approval.waitDecision",
     "exec.approval.resolve",
+    "tool.approval.request",
+    "tool.approval.waitDecision",
+    "tool.approval.resolve",
   ],
   [PAIRING_SCOPE]: [
     "node.pair.request",

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -9,6 +9,8 @@ const PAIRING_SCOPE = "operator.pairing";
 const EVENT_SCOPE_GUARDS: Record<string, string[]> = {
   "exec.approval.requested": [APPROVALS_SCOPE],
   "exec.approval.resolved": [APPROVALS_SCOPE],
+  "tool.approval.requested": [APPROVALS_SCOPE],
+  "tool.approval.resolved": [APPROVALS_SCOPE],
   "device.pair.requested": [PAIRING_SCOPE],
   "device.pair.resolved": [PAIRING_SCOPE],
   "node.pair.requested": [PAIRING_SCOPE],

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -29,6 +29,9 @@ const BASE_METHODS = [
   "exec.approval.request",
   "exec.approval.waitDecision",
   "exec.approval.resolve",
+  "tool.approval.request",
+  "tool.approval.waitDecision",
+  "tool.approval.resolve",
   "wizard.start",
   "wizard.next",
   "wizard.cancel",
@@ -129,5 +132,7 @@ export const GATEWAY_EVENTS = [
   "voicewake.changed",
   "exec.approval.requested",
   "exec.approval.resolved",
+  "tool.approval.requested",
+  "tool.approval.resolved",
   GATEWAY_EVENT_UPDATE_AVAILABLE,
 ];

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1088,4 +1088,45 @@ describe("tool approval handlers", () => {
       undefined,
     );
   });
+
+  it("excludes requesting client connId from approver presence check", async () => {
+    const { createToolApprovalHandlers } = await import("./tool-approval.js");
+    const manager = new ExecApprovalManager();
+    const handlers = createToolApprovalHandlers(manager);
+    const respond = vi.fn();
+    const hasToolApprovalClients = vi.fn((excludeConnId?: string) => {
+      // Simulate: only the requesting agent's own connection is present.
+      return excludeConnId !== "agent-conn-1";
+    });
+    const context = {
+      broadcast: (_event: string, _payload: unknown) => {},
+      hasToolApprovalClients,
+      hasExecApprovalClients: () => false,
+    };
+
+    await handlers["tool.approval.request"]({
+      params: { toolName: "mcp__read_file", timeoutMs: 2000 },
+      respond: respond as unknown as Parameters<
+        (typeof handlers)["tool.approval.request"]
+      >[0]["respond"],
+      context: context as unknown as Parameters<
+        (typeof handlers)["tool.approval.request"]
+      >[0]["context"],
+      client: {
+        connect: { scopes: ["operator.approvals"] },
+        connId: "agent-conn-1",
+      } as unknown as Parameters<(typeof handlers)["tool.approval.request"]>[0]["client"],
+      req: { id: "req-2", type: "req", method: "tool.approval.request" },
+      isWebchatConnect: () => false,
+    });
+
+    // Should pass the requesting client's connId to the presence check.
+    expect(hasToolApprovalClients).toHaveBeenCalledWith("agent-conn-1");
+    // No real approver connected, so should take the no-route path.
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ decision: null }),
+      undefined,
+    );
+  });
 });

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1065,7 +1065,7 @@ describe("tool approval handlers", () => {
     const context = {
       broadcast: (_event: string, _payload: unknown) => {},
       hasToolApprovalClients: () => false,
-      hasExecApprovalClients: () => true, // exec-approval clients exist but lack tool cap
+      hasExecApprovalClients: () => false, // no approval-scoped clients connected
     };
 
     await handlers["tool.approval.request"]({

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1055,3 +1055,37 @@ describe("logs.tail", () => {
     await fsPromises.rm(tempDir, { recursive: true, force: true });
   });
 });
+
+describe("tool approval handlers", () => {
+  it("takes no-route path when hasToolApprovalClients returns false", async () => {
+    const { createToolApprovalHandlers } = await import("./tool-approval.js");
+    const manager = new ExecApprovalManager();
+    const handlers = createToolApprovalHandlers(manager);
+    const respond = vi.fn();
+    const context = {
+      broadcast: (_event: string, _payload: unknown) => {},
+      hasToolApprovalClients: () => false,
+      hasExecApprovalClients: () => true, // exec-approval clients exist but lack tool cap
+    };
+
+    await handlers["tool.approval.request"]({
+      params: { toolName: "mcp__read_file", timeoutMs: 2000 },
+      respond: respond as unknown as Parameters<
+        (typeof handlers)["tool.approval.request"]
+      >[0]["respond"],
+      context: context as unknown as Parameters<
+        (typeof handlers)["tool.approval.request"]
+      >[0]["context"],
+      client: null,
+      req: { id: "req-1", type: "req", method: "tool.approval.request" },
+      isWebchatConnect: () => false,
+    });
+
+    // Should respond immediately with decision=null (no-route), not block.
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ decision: null }),
+      undefined,
+    );
+  });
+});

--- a/src/gateway/server-methods/tool-approval.ts
+++ b/src/gateway/server-methods/tool-approval.ts
@@ -1,0 +1,270 @@
+/**
+ * Gateway server methods for MCP/plugin tool approval requests.
+ *
+ * Reuses the ExecApprovalManager for pending request tracking since the
+ * approval lifecycle (request, wait, resolve) is identical. The only
+ * difference is the event names and the payload shape.
+ */
+
+import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
+import type { ExecApprovalDecision } from "../../infra/exec-approvals.js";
+import {
+  DEFAULT_TOOL_APPROVAL_TIMEOUT_MS,
+  type ToolApprovalRequestPayload,
+} from "../../infra/tool-approvals.js";
+import type { ExecApprovalManager } from "../exec-approval-manager.js";
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+export function createToolApprovalHandlers(
+  manager: ExecApprovalManager,
+  opts?: { forwarder?: ExecApprovalForwarder },
+): GatewayRequestHandlers {
+  return {
+    "tool.approval.request": async ({ params, respond, context, client }) => {
+      const p = params as {
+        id?: string;
+        toolName?: string;
+        args?: Record<string, unknown>;
+        agentId?: string;
+        sessionKey?: string;
+        turnSourceChannel?: string;
+        turnSourceTo?: string;
+        turnSourceAccountId?: string;
+        turnSourceThreadId?: string | number;
+        timeoutMs?: number;
+        twoPhase?: boolean;
+      };
+      const twoPhase = p.twoPhase === true;
+      const timeoutMs =
+        typeof p.timeoutMs === "number" ? p.timeoutMs : DEFAULT_TOOL_APPROVAL_TIMEOUT_MS;
+      const toolName = typeof p.toolName === "string" ? p.toolName.trim() : "";
+      if (!toolName) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "toolName is required"));
+        return;
+      }
+      const explicitId = typeof p.id === "string" && p.id.trim().length > 0 ? p.id.trim() : null;
+      if (explicitId && manager.getSnapshot(explicitId)) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "approval id already pending"),
+        );
+        return;
+      }
+
+      const request: ToolApprovalRequestPayload = {
+        toolName,
+        args: p.args ?? null,
+        agentId: typeof p.agentId === "string" ? p.agentId.trim() || null : null,
+        sessionKey: typeof p.sessionKey === "string" ? p.sessionKey.trim() || null : null,
+        host: "gateway",
+        security: null,
+        ask: null,
+        turnSourceChannel:
+          typeof p.turnSourceChannel === "string" ? p.turnSourceChannel.trim() || null : null,
+        turnSourceTo: typeof p.turnSourceTo === "string" ? p.turnSourceTo.trim() || null : null,
+        turnSourceAccountId:
+          typeof p.turnSourceAccountId === "string" ? p.turnSourceAccountId.trim() || null : null,
+        turnSourceThreadId: p.turnSourceThreadId ?? null,
+      };
+
+      // Reuse ExecApprovalManager by converting the tool payload to the
+      // format expected by the manager. The manager only cares about `command`
+      // for display purposes, so we pass the tool name as the command field.
+      const record = manager.create(
+        {
+          command: toolName,
+          commandPreview: `tool: ${toolName}`,
+          agentId: request.agentId,
+          sessionKey: request.sessionKey,
+          host: request.host,
+          security: request.security,
+          ask: request.ask,
+          turnSourceChannel: request.turnSourceChannel,
+          turnSourceTo: request.turnSourceTo,
+          turnSourceAccountId: request.turnSourceAccountId,
+          turnSourceThreadId: request.turnSourceThreadId,
+        },
+        timeoutMs,
+        explicitId,
+      );
+      record.requestedByConnId = client?.connId ?? null;
+      record.requestedByDeviceId = client?.connect?.device?.id ?? null;
+      record.requestedByClientId = client?.connect?.client?.id ?? null;
+
+      let decisionPromise: Promise<ExecApprovalDecision | null>;
+      try {
+        decisionPromise = manager.register(record, timeoutMs);
+      } catch (err) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, `registration failed: ${String(err)}`),
+        );
+        return;
+      }
+
+      context.broadcast(
+        "tool.approval.requested",
+        {
+          id: record.id,
+          request,
+          createdAtMs: record.createdAtMs,
+          expiresAtMs: record.expiresAtMs,
+        },
+        { dropIfSlow: true },
+      );
+
+      const hasApprovalClients = context.hasExecApprovalClients?.() ?? false;
+      let forwarded = false;
+      if (opts?.forwarder) {
+        try {
+          forwarded = await opts.forwarder.handleRequested({
+            id: record.id,
+            request: record.request,
+            createdAtMs: record.createdAtMs,
+            expiresAtMs: record.expiresAtMs,
+          });
+        } catch (err) {
+          context.logGateway?.error?.(`tool approvals: forward request failed: ${String(err)}`);
+        }
+      }
+
+      if (!hasApprovalClients && !forwarded) {
+        manager.expire(record.id, "no-approval-route");
+        respond(
+          true,
+          {
+            id: record.id,
+            decision: null,
+            createdAtMs: record.createdAtMs,
+            expiresAtMs: record.expiresAtMs,
+          },
+          undefined,
+        );
+        return;
+      }
+
+      if (twoPhase) {
+        respond(
+          true,
+          {
+            status: "accepted",
+            id: record.id,
+            createdAtMs: record.createdAtMs,
+            expiresAtMs: record.expiresAtMs,
+          },
+          undefined,
+        );
+      }
+
+      const decision = await decisionPromise;
+      respond(
+        true,
+        {
+          id: record.id,
+          decision,
+          createdAtMs: record.createdAtMs,
+          expiresAtMs: record.expiresAtMs,
+        },
+        undefined,
+      );
+    },
+
+    "tool.approval.waitDecision": async ({ params, respond }) => {
+      const p = params as { id?: string };
+      const id = typeof p.id === "string" ? p.id.trim() : "";
+      if (!id) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "id is required"));
+        return;
+      }
+      const decisionPromise = manager.awaitDecision(id);
+      if (!decisionPromise) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "approval expired or not found"),
+        );
+        return;
+      }
+      const snapshot = manager.getSnapshot(id);
+      const decision = await decisionPromise;
+      respond(
+        true,
+        {
+          id,
+          decision,
+          createdAtMs: snapshot?.createdAtMs,
+          expiresAtMs: snapshot?.expiresAtMs,
+        },
+        undefined,
+      );
+    },
+
+    "tool.approval.resolve": async ({ params, respond, client, context }) => {
+      const p = params as { id?: string; decision?: string };
+      const id = typeof p.id === "string" ? p.id.trim() : "";
+      const decision = typeof p.decision === "string" ? p.decision.trim() : "";
+      if (!id) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "id is required"));
+        return;
+      }
+      if (decision !== "allow-once" && decision !== "allow-always" && decision !== "deny") {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "invalid decision"));
+        return;
+      }
+      const resolvedId = manager.lookupPendingId(id);
+      if (resolvedId.kind === "none") {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "unknown or expired approval id"),
+        );
+        return;
+      }
+      if (resolvedId.kind === "ambiguous") {
+        const candidates = resolvedId.ids.slice(0, 3).join(", ");
+        const remainder = resolvedId.ids.length > 3 ? ` (+${resolvedId.ids.length - 3} more)` : "";
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `ambiguous approval id prefix; matches: ${candidates}${remainder}. Use the full id.`,
+          ),
+        );
+        return;
+      }
+      const approvalId = resolvedId.id;
+      const snapshot = manager.getSnapshot(approvalId);
+      const resolvedBy = client?.connect?.client?.displayName ?? client?.connect?.client?.id;
+      const ok = manager.resolve(approvalId, decision as ExecApprovalDecision, resolvedBy ?? null);
+      if (!ok) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "unknown or expired approval id"),
+        );
+        return;
+      }
+      context.broadcast(
+        "tool.approval.resolved",
+        { id: approvalId, decision, resolvedBy, ts: Date.now(), request: snapshot?.request },
+        { dropIfSlow: true },
+      );
+      void opts?.forwarder
+        ?.handleResolved({
+          id: approvalId,
+          decision,
+          resolvedBy,
+          ts: Date.now(),
+          request: snapshot?.request,
+        })
+        .catch((err) => {
+          context.logGateway?.error?.(`tool approvals: forward resolve failed: ${String(err)}`);
+        });
+      respond(true, { ok: true }, undefined);
+    },
+  };
+}

--- a/src/gateway/server-methods/tool-approval.ts
+++ b/src/gateway/server-methods/tool-approval.ts
@@ -118,7 +118,10 @@ export function createToolApprovalHandlers(
 
       // Use the tool-specific capability check so legacy exec-approval-only
       // clients do not cause the request to block until timeout.
-      const hasApprovalClients = context.hasToolApprovalClients?.() ?? false;
+      // Exclude the requesting client so the agent that submitted the
+      // tool.approval.request does not count as its own approver.
+      const hasApprovalClients =
+        context.hasToolApprovalClients?.(client?.connId ?? undefined) ?? false;
       let forwarded = false;
       if (opts?.forwarder) {
         try {

--- a/src/gateway/server-methods/tool-approval.ts
+++ b/src/gateway/server-methods/tool-approval.ts
@@ -116,7 +116,9 @@ export function createToolApprovalHandlers(
         { dropIfSlow: true },
       );
 
-      const hasApprovalClients = context.hasExecApprovalClients?.() ?? false;
+      // Use the tool-specific capability check so legacy exec-approval-only
+      // clients do not cause the request to block until timeout.
+      const hasApprovalClients = context.hasToolApprovalClients?.() ?? false;
       let forwarded = false;
       if (opts?.forwarder) {
         try {

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -51,6 +51,7 @@ export type GatewayRequestContext = {
   nodeUnsubscribeAll: (nodeId: string) => void;
   hasConnectedMobileNode: () => boolean;
   hasExecApprovalClients?: () => boolean;
+  hasToolApprovalClients?: () => boolean;
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -51,7 +51,7 @@ export type GatewayRequestContext = {
   nodeUnsubscribeAll: (nodeId: string) => void;
   hasConnectedMobileNode: () => boolean;
   hasExecApprovalClients?: () => boolean;
-  hasToolApprovalClients?: () => boolean;
+  hasToolApprovalClients?: (excludeConnId?: string) => boolean;
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -867,19 +867,14 @@ export async function startGatewayServer(
       return false;
     },
     hasToolApprovalClients: () => {
-      // A client is tool-approval-capable only when it has the approval scope
-      // AND declares the "tool-approvals" capability. Legacy exec-approval-only
-      // clients lack this cap, so tool requests fall through to the no-route
-      // path immediately instead of blocking until timeout.
+      // Accept any client with an approval scope. Built-in approver clients
+      // (Control UI, macOS app) already handle exec approvals and can handle
+      // tool approvals without declaring a separate "tool-approvals" cap.
       for (const gatewayClient of clients) {
         const scopes = Array.isArray(gatewayClient.connect.scopes)
           ? gatewayClient.connect.scopes
           : [];
-        if (!(scopes.includes("operator.admin") || scopes.includes("operator.approvals"))) {
-          continue;
-        }
-        const caps = Array.isArray(gatewayClient.connect.caps) ? gatewayClient.connect.caps : [];
-        if (caps.includes("tool-approvals")) {
+        if (scopes.includes("operator.admin") || scopes.includes("operator.approvals")) {
           return true;
         }
       }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -87,6 +87,7 @@ import { coreGatewayHandlers } from "./server-methods.js";
 import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
 import { safeParseJson } from "./server-methods/nodes.helpers.js";
 import { createSecretsHandlers } from "./server-methods/secrets.js";
+import { createToolApprovalHandlers } from "./server-methods/tool-approval.js";
 import { hasConnectedMobileNode } from "./server-mobile-nodes.js";
 import { loadGatewayModelCatalog } from "./server-model-catalog.js";
 import { createNodeSubscriptionManager } from "./server-node-subscriptions.js";
@@ -793,6 +794,13 @@ export async function startGatewayServer(
   const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
     forwarder: execApprovalForwarder,
   });
+  // Tool approvals share the same manager type but use a separate instance
+  // so pending IDs do not collide between exec and tool approval namespaces.
+  const toolApprovalManager = new ExecApprovalManager();
+  const toolApprovalForwarder = createExecApprovalForwarder();
+  const toolApprovalHandlers = createToolApprovalHandlers(toolApprovalManager, {
+    forwarder: toolApprovalForwarder,
+  });
   const secretsHandlers = createSecretsHandlers({
     reloadSecrets: async () => {
       const active = getActiveSecretsRuntimeSnapshot();
@@ -895,6 +903,7 @@ export async function startGatewayServer(
     extraHandlers: {
       ...pluginRegistry.gatewayHandlers,
       ...execApprovalHandlers,
+      ...toolApprovalHandlers,
       ...secretsHandlers,
     },
     broadcast,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -804,6 +804,10 @@ export async function startGatewayServer(
       // forwarder reads tool-specific settings instead of exec settings.
       return { ...cfg, approvals: { ...cfg.approvals, exec: cfg.approvals?.tool } };
     },
+    // Tool approval events are not consumed by the native Discord/Telegram
+    // exec-approval handlers. Skip channel suppression so tool approval
+    // prompts are not silently filtered out when exec approvals are enabled.
+    skipChannelSuppression: true,
   });
   const toolApprovalHandlers = createToolApprovalHandlers(toolApprovalManager, {
     forwarder: toolApprovalForwarder,
@@ -866,11 +870,16 @@ export async function startGatewayServer(
       }
       return false;
     },
-    hasToolApprovalClients: () => {
+    hasToolApprovalClients: (excludeConnId?: string) => {
       // Accept any client with an approval scope. Built-in approver clients
       // (Control UI, macOS app) already handle exec approvals and can handle
       // tool approvals without declaring a separate "tool-approvals" cap.
+      // Exclude the requesting client (by connId) so the agent that submitted
+      // the tool.approval.request does not count as its own approver.
       for (const gatewayClient of clients) {
+        if (excludeConnId && gatewayClient.connId === excludeConnId) {
+          continue;
+        }
         const scopes = Array.isArray(gatewayClient.connect.scopes)
           ? gatewayClient.connect.scopes
           : [];

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -866,6 +866,25 @@ export async function startGatewayServer(
       }
       return false;
     },
+    hasToolApprovalClients: () => {
+      // A client is tool-approval-capable only when it has the approval scope
+      // AND declares the "tool-approvals" capability. Legacy exec-approval-only
+      // clients lack this cap, so tool requests fall through to the no-route
+      // path immediately instead of blocking until timeout.
+      for (const gatewayClient of clients) {
+        const scopes = Array.isArray(gatewayClient.connect.scopes)
+          ? gatewayClient.connect.scopes
+          : [];
+        if (!(scopes.includes("operator.admin") || scopes.includes("operator.approvals"))) {
+          continue;
+        }
+        const caps = Array.isArray(gatewayClient.connect.caps) ? gatewayClient.connect.caps : [];
+        if (caps.includes("tool-approvals")) {
+          return true;
+        }
+      }
+      return false;
+    },
     nodeRegistry,
     agentRunSeq,
     chatAbortControllers,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -797,7 +797,14 @@ export async function startGatewayServer(
   // Tool approvals share the same manager type but use a separate instance
   // so pending IDs do not collide between exec and tool approval namespaces.
   const toolApprovalManager = new ExecApprovalManager();
-  const toolApprovalForwarder = createExecApprovalForwarder();
+  const toolApprovalForwarder = createExecApprovalForwarder({
+    getConfig: () => {
+      const cfg = loadConfig();
+      // Map the tool forwarding config into the exec slot so the shared
+      // forwarder reads tool-specific settings instead of exec settings.
+      return { ...cfg, approvals: { ...cfg.approvals, exec: cfg.approvals?.tool } };
+    },
+  });
   const toolApprovalHandlers = createToolApprovalHandlers(toolApprovalManager, {
     forwarder: toolApprovalForwarder,
   });

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -50,6 +50,12 @@ export type ExecApprovalForwarderDeps = {
     cfg: OpenClawConfig;
     request: ExecApprovalRequest;
   }) => ExecApprovalForwardTarget | null;
+  // Skip Discord/Telegram channel-specific suppression. Tool approval
+  // forwarders set this to true because the native exec-approval handlers on
+  // those channels only consume exec.approval.* events, not tool.approval.*
+  // events. Without this flag, tool approval prompts are silently dropped
+  // when exec approvals are enabled on those channels.
+  skipChannelSuppression?: boolean;
 };
 
 const DEFAULT_MODE = "session" as const;
@@ -439,6 +445,7 @@ export function createExecApprovalForwarder(
   const deliver = deps.deliver ?? deliverOutboundPayloads;
   const nowMs = deps.nowMs ?? Date.now;
   const resolveSessionTarget = deps.resolveSessionTarget ?? defaultResolveSessionTarget;
+  const skipChannelSuppression = deps.skipChannelSuppression === true;
   const pending = new Map<string, PendingApproval>();
 
   const handleRequested = async (request: ExecApprovalRequest): Promise<boolean> => {
@@ -455,8 +462,9 @@ export function createExecApprovalForwarder(
         : []),
     ].filter(
       (target) =>
-        !shouldSkipDiscordForwarding(target, cfg) &&
-        !shouldSkipTelegramForwarding({ target, cfg, request }),
+        skipChannelSuppression ||
+        (!shouldSkipDiscordForwarding(target, cfg) &&
+          !shouldSkipTelegramForwarding({ target, cfg, request })),
     );
 
     if (filteredTargets.length === 0) {
@@ -530,8 +538,9 @@ export function createExecApprovalForwarder(
           : []),
       ].filter(
         (target) =>
-          !shouldSkipDiscordForwarding(target, cfg) &&
-          !shouldSkipTelegramForwarding({ target, cfg, request }),
+          skipChannelSuppression ||
+          (!shouldSkipDiscordForwarding(target, cfg) &&
+            !shouldSkipTelegramForwarding({ target, cfg, request })),
       );
     }
     if (!targets || targets.length === 0) {

--- a/src/infra/tool-approval-policy.test.ts
+++ b/src/infra/tool-approval-policy.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { evaluateToolApprovalPolicy, resolveToolApprovalPolicy } from "./tool-approval-policy.js";
+
+function makeConfig(toolPolicy?: Record<string, unknown>): OpenClawConfig {
+  return { approvals: { toolPolicy } } as unknown as OpenClawConfig;
+}
+
+describe("resolveToolApprovalPolicy", () => {
+  it("returns permissive defaults when no config", () => {
+    const policy = resolveToolApprovalPolicy({ cfg: {} as OpenClawConfig });
+    expect(policy.security).toBe("full");
+    expect(policy.ask).toBe("off");
+    expect(policy.askFallback).toBe("full");
+    expect(policy.allowlist).toEqual([]);
+  });
+
+  it("reads global config values", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({ security: "allowlist", ask: "on-miss", askFallback: "deny" }),
+    });
+    expect(policy.security).toBe("allowlist");
+    expect(policy.ask).toBe("on-miss");
+    expect(policy.askFallback).toBe("deny");
+  });
+
+  it("merges global allowlist", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({
+        allowlist: [{ pattern: "github__list_*" }],
+      }),
+    });
+    expect(policy.allowlist).toHaveLength(1);
+    expect(policy.allowlist[0].pattern).toBe("github__list_*");
+  });
+
+  it("applies per-agent overrides", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({
+        security: "full",
+        agents: {
+          ops: { security: "allowlist", ask: "always" },
+        },
+      }),
+      agentId: "ops",
+    });
+    expect(policy.security).toBe("allowlist");
+    expect(policy.ask).toBe("always");
+  });
+
+  it("applies wildcard agent overrides", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({
+        agents: {
+          "*": { security: "allowlist" },
+        },
+      }),
+      agentId: "any-agent",
+    });
+    expect(policy.security).toBe("allowlist");
+  });
+
+  it("per-agent config takes priority over wildcard", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({
+        agents: {
+          "*": { security: "deny" },
+          main: { security: "allowlist" },
+        },
+      }),
+      agentId: "main",
+    });
+    expect(policy.security).toBe("allowlist");
+  });
+});
+
+describe("evaluateToolApprovalPolicy", () => {
+  it("denies when security=deny", () => {
+    const result = evaluateToolApprovalPolicy({
+      toolName: "github__list_repos",
+      policy: { security: "deny", ask: "off", askFallback: "deny", allowlist: [] },
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.requiresApproval).toBe(false);
+  });
+
+  it("allows when security=full and ask=off", () => {
+    const result = evaluateToolApprovalPolicy({
+      toolName: "github__list_repos",
+      policy: { security: "full", ask: "off", askFallback: "full", allowlist: [] },
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.requiresApproval).toBe(false);
+  });
+
+  it("allows when allowlist matches", () => {
+    const result = evaluateToolApprovalPolicy({
+      toolName: "github__list_repos",
+      policy: {
+        security: "allowlist",
+        ask: "off",
+        askFallback: "deny",
+        allowlist: [{ pattern: "github__list_*" }],
+      },
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.requiresApproval).toBe(false);
+  });
+
+  it("denies on allowlist miss when ask=off", () => {
+    const result = evaluateToolApprovalPolicy({
+      toolName: "github__delete_repos",
+      policy: {
+        security: "allowlist",
+        ask: "off",
+        askFallback: "deny",
+        allowlist: [{ pattern: "github__list_*" }],
+      },
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.requiresApproval).toBe(false);
+  });
+
+  it("requires approval on allowlist miss when ask=on-miss", () => {
+    const result = evaluateToolApprovalPolicy({
+      toolName: "github__delete_repos",
+      policy: {
+        security: "allowlist",
+        ask: "on-miss",
+        askFallback: "deny",
+        allowlist: [{ pattern: "github__list_*" }],
+      },
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.requiresApproval).toBe(true);
+  });
+
+  it("requires approval when ask=always even on match", () => {
+    const result = evaluateToolApprovalPolicy({
+      toolName: "github__list_repos",
+      policy: {
+        security: "allowlist",
+        ask: "always",
+        askFallback: "deny",
+        allowlist: [{ pattern: "github__list_*" }],
+      },
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.requiresApproval).toBe(true);
+  });
+});

--- a/src/infra/tool-approval-policy.test.ts
+++ b/src/infra/tool-approval-policy.test.ts
@@ -24,7 +24,7 @@ describe("resolveToolApprovalPolicy", () => {
     expect(policy.askFallback).toBe("deny");
   });
 
-  it("merges global allowlist", () => {
+  it("uses global allowlist when no agent allowlist is set", () => {
     const policy = resolveToolApprovalPolicy({
       cfg: makeConfig({
         allowlist: [{ pattern: "github__list_*" }],
@@ -32,6 +32,64 @@ describe("resolveToolApprovalPolicy", () => {
     });
     expect(policy.allowlist).toHaveLength(1);
     expect(policy.allowlist[0].pattern).toBe("github__list_*");
+  });
+
+  it("per-agent allowlist overrides global allowlist", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({
+        allowlist: [{ pattern: "*" }],
+        agents: {
+          ops: { allowlist: [{ pattern: "github__list_*" }] },
+        },
+      }),
+      agentId: "ops",
+    });
+    // Agent-specific allowlist replaces global, so only the agent pattern applies.
+    expect(policy.allowlist).toHaveLength(1);
+    expect(policy.allowlist[0].pattern).toBe("github__list_*");
+  });
+
+  it("wildcard agent allowlist overrides global allowlist", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({
+        allowlist: [{ pattern: "*" }],
+        agents: {
+          "*": { allowlist: [{ pattern: "safe__*" }] },
+        },
+      }),
+      agentId: "any-agent",
+    });
+    expect(policy.allowlist).toHaveLength(1);
+    expect(policy.allowlist[0].pattern).toBe("safe__*");
+  });
+
+  it("per-agent allowlist overrides wildcard agent allowlist", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({
+        allowlist: [{ pattern: "*" }],
+        agents: {
+          "*": { allowlist: [{ pattern: "safe__*" }] },
+          ops: { allowlist: [{ pattern: "github__list_*" }] },
+        },
+      }),
+      agentId: "ops",
+    });
+    expect(policy.allowlist).toHaveLength(1);
+    expect(policy.allowlist[0].pattern).toBe("github__list_*");
+  });
+
+  it("falls back to global allowlist when agent has no allowlist", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({
+        allowlist: [{ pattern: "global__*" }],
+        agents: {
+          ops: { security: "allowlist" },
+        },
+      }),
+      agentId: "ops",
+    });
+    expect(policy.allowlist).toHaveLength(1);
+    expect(policy.allowlist[0].pattern).toBe("global__*");
   });
 
   it("applies per-agent overrides", () => {

--- a/src/infra/tool-approval-policy.test.ts
+++ b/src/infra/tool-approval-policy.test.ts
@@ -130,6 +130,34 @@ describe("resolveToolApprovalPolicy", () => {
     });
     expect(policy.security).toBe("allowlist");
   });
+
+  it("honors explicit empty per-agent allowlist override", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({
+        allowlist: [{ pattern: "*" }],
+        agents: {
+          locked: { allowlist: [] },
+        },
+      }),
+      agentId: "locked",
+    });
+    // An explicit empty array means "no tools allowed" and must not
+    // fall back to the global wildcard allowlist.
+    expect(policy.allowlist).toEqual([]);
+  });
+
+  it("honors explicit empty wildcard agent allowlist override", () => {
+    const policy = resolveToolApprovalPolicy({
+      cfg: makeConfig({
+        allowlist: [{ pattern: "*" }],
+        agents: {
+          "*": { allowlist: [] },
+        },
+      }),
+      agentId: "any-agent",
+    });
+    expect(policy.allowlist).toEqual([]);
+  });
 });
 
 describe("evaluateToolApprovalPolicy", () => {

--- a/src/infra/tool-approval-policy.ts
+++ b/src/infra/tool-approval-policy.ts
@@ -40,7 +40,7 @@ export function resolveToolApprovalPolicy(params: {
   const globalAsk = normalizeToolAsk(toolPolicy?.ask) ?? DEFAULT_TOOL_ASK;
   const globalAskFallback =
     normalizeToolSecurity(toolPolicy?.askFallback) ?? DEFAULT_TOOL_ASK_FALLBACK;
-  const globalAllowlist = normalizeAllowlist(toolPolicy?.allowlist);
+  const globalAllowlist = normalizeAllowlist(toolPolicy?.allowlist) ?? [];
 
   const agentConfig = toolPolicy?.agents?.[agentKey];
   const wildcardConfig = toolPolicy?.agents?.["*"];
@@ -57,16 +57,16 @@ export function resolveToolApprovalPolicy(params: {
     globalAskFallback;
 
   // Per-agent allowlist overrides global. If the specific agent declares its
-  // own allowlist, use it exclusively. Otherwise fall back to the wildcard
-  // agent allowlist, and finally to the global allowlist. This prevents a
-  // permissive global rule (e.g. "*") from undermining a tighter per-agent
-  // restriction.
+  // own allowlist (even an empty one), use it exclusively. Otherwise fall back
+  // to the wildcard agent allowlist, and finally to the global allowlist. An
+  // explicit empty array means "no tools allowed", preventing a permissive
+  // global rule (e.g. "*") from undermining a tighter per-agent restriction.
   const agentSpecificAllowlist = normalizeAllowlist(agentConfig?.allowlist);
   const wildcardAllowlist = normalizeAllowlist(wildcardConfig?.allowlist);
   const agentAllowlist =
-    agentSpecificAllowlist.length > 0
+    agentSpecificAllowlist !== null
       ? agentSpecificAllowlist
-      : wildcardAllowlist.length > 0
+      : wildcardAllowlist !== null
         ? wildcardAllowlist
         : globalAllowlist;
 
@@ -78,9 +78,11 @@ export function resolveToolApprovalPolicy(params: {
   };
 }
 
-function normalizeAllowlist(entries?: Array<{ pattern: string }>): ToolAllowlistEntry[] {
+function normalizeAllowlist(entries?: Array<{ pattern: string }>): ToolAllowlistEntry[] | null {
   if (!Array.isArray(entries)) {
-    return [];
+    // Not set at all. Return null so the caller can distinguish "unset"
+    // (fall through to broader defaults) from "set to empty" (allow nothing).
+    return null;
   }
   return entries
     .filter((e) => typeof e?.pattern === "string" && e.pattern.trim().length > 0)

--- a/src/infra/tool-approval-policy.ts
+++ b/src/infra/tool-approval-policy.ts
@@ -56,11 +56,19 @@ export function resolveToolApprovalPolicy(params: {
     normalizeToolSecurity(wildcardConfig?.askFallback) ??
     globalAskFallback;
 
-  const agentAllowlist = [
-    ...normalizeAllowlist(wildcardConfig?.allowlist),
-    ...normalizeAllowlist(agentConfig?.allowlist),
-    ...globalAllowlist,
-  ];
+  // Per-agent allowlist overrides global. If the specific agent declares its
+  // own allowlist, use it exclusively. Otherwise fall back to the wildcard
+  // agent allowlist, and finally to the global allowlist. This prevents a
+  // permissive global rule (e.g. "*") from undermining a tighter per-agent
+  // restriction.
+  const agentSpecificAllowlist = normalizeAllowlist(agentConfig?.allowlist);
+  const wildcardAllowlist = normalizeAllowlist(wildcardConfig?.allowlist);
+  const agentAllowlist =
+    agentSpecificAllowlist.length > 0
+      ? agentSpecificAllowlist
+      : wildcardAllowlist.length > 0
+        ? wildcardAllowlist
+        : globalAllowlist;
 
   return {
     security: agentSecurity,

--- a/src/infra/tool-approval-policy.ts
+++ b/src/infra/tool-approval-policy.ts
@@ -1,0 +1,164 @@
+/**
+ * Resolves MCP/plugin tool approval policy from config for a given agent.
+ *
+ * The policy chain is:
+ *   1. approvals.toolPolicy (global defaults)
+ *   2. approvals.toolPolicy.agents.<agentId> (per-agent overrides)
+ *   3. Built-in defaults (security=full, ask=off, askFallback=full)
+ */
+
+import type { OpenClawConfig } from "../config/config.js";
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import { evaluateToolAllowlist, type ToolAllowlistEvaluation } from "./tool-approvals-allowlist.js";
+import {
+  DEFAULT_TOOL_ASK,
+  DEFAULT_TOOL_ASK_FALLBACK,
+  DEFAULT_TOOL_SECURITY,
+  normalizeToolAsk,
+  normalizeToolSecurity,
+  requiresToolApproval,
+  type ToolAllowlistEntry,
+  type ToolAsk,
+  type ToolSecurity,
+} from "./tool-approvals.js";
+
+export type ResolvedToolApprovalPolicy = {
+  security: ToolSecurity;
+  ask: ToolAsk;
+  askFallback: ToolSecurity;
+  allowlist: ToolAllowlistEntry[];
+};
+
+export function resolveToolApprovalPolicy(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+}): ResolvedToolApprovalPolicy {
+  const toolPolicy = params.cfg.approvals?.toolPolicy;
+  const agentKey = params.agentId ?? DEFAULT_AGENT_ID;
+
+  const globalSecurity = normalizeToolSecurity(toolPolicy?.security) ?? DEFAULT_TOOL_SECURITY;
+  const globalAsk = normalizeToolAsk(toolPolicy?.ask) ?? DEFAULT_TOOL_ASK;
+  const globalAskFallback =
+    normalizeToolSecurity(toolPolicy?.askFallback) ?? DEFAULT_TOOL_ASK_FALLBACK;
+  const globalAllowlist = normalizeAllowlist(toolPolicy?.allowlist);
+
+  const agentConfig = toolPolicy?.agents?.[agentKey];
+  const wildcardConfig = toolPolicy?.agents?.["*"];
+
+  const agentSecurity =
+    normalizeToolSecurity(agentConfig?.security) ??
+    normalizeToolSecurity(wildcardConfig?.security) ??
+    globalSecurity;
+  const agentAsk =
+    normalizeToolAsk(agentConfig?.ask) ?? normalizeToolAsk(wildcardConfig?.ask) ?? globalAsk;
+  const agentAskFallback =
+    normalizeToolSecurity(agentConfig?.askFallback) ??
+    normalizeToolSecurity(wildcardConfig?.askFallback) ??
+    globalAskFallback;
+
+  const agentAllowlist = [
+    ...normalizeAllowlist(wildcardConfig?.allowlist),
+    ...normalizeAllowlist(agentConfig?.allowlist),
+    ...globalAllowlist,
+  ];
+
+  return {
+    security: agentSecurity,
+    ask: agentAsk,
+    askFallback: agentAskFallback,
+    allowlist: agentAllowlist,
+  };
+}
+
+function normalizeAllowlist(entries?: Array<{ pattern: string }>): ToolAllowlistEntry[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries
+    .filter((e) => typeof e?.pattern === "string" && e.pattern.trim().length > 0)
+    .map((e) => ({ pattern: e.pattern.trim() }));
+}
+
+export type ToolApprovalDecisionResult = {
+  allowed: boolean;
+  requiresApproval: boolean;
+  evaluation: ToolAllowlistEvaluation;
+  security: ToolSecurity;
+  ask: ToolAsk;
+  askFallback: ToolSecurity;
+};
+
+/**
+ * Evaluate whether a tool call should be allowed, denied, or requires approval.
+ */
+export function evaluateToolApprovalPolicy(params: {
+  toolName: string;
+  policy: ResolvedToolApprovalPolicy;
+}): ToolApprovalDecisionResult {
+  const { policy, toolName } = params;
+
+  if (policy.security === "deny") {
+    return {
+      allowed: false,
+      requiresApproval: false,
+      evaluation: { allowlistSatisfied: false, matchedEntry: null },
+      security: policy.security,
+      ask: policy.ask,
+      askFallback: policy.askFallback,
+    };
+  }
+
+  if (policy.security === "full" && policy.ask === "off") {
+    return {
+      allowed: true,
+      requiresApproval: false,
+      evaluation: { allowlistSatisfied: true, matchedEntry: null },
+      security: policy.security,
+      ask: policy.ask,
+      askFallback: policy.askFallback,
+    };
+  }
+
+  const evaluation = evaluateToolAllowlist({
+    toolName,
+    allowlist: policy.allowlist,
+  });
+
+  const needsApproval = requiresToolApproval({
+    ask: policy.ask,
+    security: policy.security,
+    allowlistSatisfied: evaluation.allowlistSatisfied,
+  });
+
+  if (needsApproval) {
+    return {
+      allowed: false,
+      requiresApproval: true,
+      evaluation,
+      security: policy.security,
+      ask: policy.ask,
+      askFallback: policy.askFallback,
+    };
+  }
+
+  // In allowlist mode without ask, the allowlist must match.
+  if (policy.security === "allowlist" && !evaluation.allowlistSatisfied) {
+    return {
+      allowed: false,
+      requiresApproval: false,
+      evaluation,
+      security: policy.security,
+      ask: policy.ask,
+      askFallback: policy.askFallback,
+    };
+  }
+
+  return {
+    allowed: true,
+    requiresApproval: false,
+    evaluation,
+    security: policy.security,
+    ask: policy.ask,
+    askFallback: policy.askFallback,
+  };
+}

--- a/src/infra/tool-approvals-allowlist.test.ts
+++ b/src/infra/tool-approvals-allowlist.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { evaluateToolAllowlist, matchToolAllowlist } from "./tool-approvals-allowlist.js";
+
+describe("matchToolAllowlist", () => {
+  it("returns null for empty allowlist", () => {
+    expect(matchToolAllowlist([], "github__list_repos")).toBeNull();
+  });
+
+  it("returns null for empty tool name", () => {
+    expect(matchToolAllowlist([{ pattern: "*" }], "")).toBeNull();
+    expect(matchToolAllowlist([{ pattern: "*" }], "  ")).toBeNull();
+  });
+
+  it("matches exact tool name pattern", () => {
+    const entry = { pattern: "github__list_repos" };
+    expect(matchToolAllowlist([entry], "github__list_repos")).toBe(entry);
+    expect(matchToolAllowlist([entry], "github__delete_repos")).toBeNull();
+  });
+
+  it("matches wildcard suffix", () => {
+    const entry = { pattern: "github__list_*" };
+    expect(matchToolAllowlist([entry], "github__list_repos")).toBe(entry);
+    expect(matchToolAllowlist([entry], "github__list_issues")).toBe(entry);
+    expect(matchToolAllowlist([entry], "github__delete_repos")).toBeNull();
+  });
+
+  it("matches wildcard prefix", () => {
+    const entry = { pattern: "*__list_repos" };
+    expect(matchToolAllowlist([entry], "github__list_repos")).toBe(entry);
+    expect(matchToolAllowlist([entry], "gitlab__list_repos")).toBe(entry);
+    expect(matchToolAllowlist([entry], "github__delete_repos")).toBeNull();
+  });
+
+  it("matches server-level wildcard", () => {
+    const entry = { pattern: "github__*" };
+    expect(matchToolAllowlist([entry], "github__list_repos")).toBe(entry);
+    expect(matchToolAllowlist([entry], "github__delete_issue")).toBe(entry);
+    expect(matchToolAllowlist([entry], "slack__send_message")).toBeNull();
+  });
+
+  it("matches bare wildcard for any tool", () => {
+    const entry = { pattern: "*" };
+    expect(matchToolAllowlist([entry], "github__list_repos")).toBe(entry);
+    expect(matchToolAllowlist([entry], "any_tool_name")).toBe(entry);
+  });
+
+  it("matches double-star wildcard for any tool", () => {
+    const entry = { pattern: "**" };
+    expect(matchToolAllowlist([entry], "some_tool")).toBe(entry);
+  });
+
+  it("matching is case-insensitive", () => {
+    const entry = { pattern: "GitHub__List_*" };
+    expect(matchToolAllowlist([entry], "github__list_repos")).toBe(entry);
+  });
+
+  it("matches ? as single-character wildcard", () => {
+    const entry = { pattern: "tool_v?" };
+    expect(matchToolAllowlist([entry], "tool_v1")).toBe(entry);
+    expect(matchToolAllowlist([entry], "tool_v2")).toBe(entry);
+    expect(matchToolAllowlist([entry], "tool_v10")).toBeNull();
+  });
+
+  it("returns first matching entry", () => {
+    const first = { pattern: "github__list_*" };
+    const second = { pattern: "github__*" };
+    expect(matchToolAllowlist([first, second], "github__list_repos")).toBe(first);
+  });
+
+  it("skips entries with empty patterns", () => {
+    const empty = { pattern: "" };
+    const valid = { pattern: "github__*" };
+    expect(matchToolAllowlist([empty, valid], "github__list_repos")).toBe(valid);
+  });
+});
+
+describe("evaluateToolAllowlist", () => {
+  it("returns not satisfied for no match", () => {
+    const result = evaluateToolAllowlist({
+      toolName: "blocked_tool",
+      allowlist: [{ pattern: "allowed_*" }],
+    });
+    expect(result.allowlistSatisfied).toBe(false);
+    expect(result.matchedEntry).toBeNull();
+  });
+
+  it("returns satisfied with matching entry", () => {
+    const entry = { pattern: "github__*" };
+    const result = evaluateToolAllowlist({
+      toolName: "github__list_repos",
+      allowlist: [entry],
+    });
+    expect(result.allowlistSatisfied).toBe(true);
+    expect(result.matchedEntry).toBe(entry);
+  });
+});

--- a/src/infra/tool-approvals-allowlist.ts
+++ b/src/infra/tool-approvals-allowlist.ts
@@ -1,0 +1,122 @@
+/**
+ * Tool-name-based allowlist matching for MCP/plugin tool approvals.
+ *
+ * Patterns are glob-style matches against normalized tool names.
+ * Examples:
+ *   - "github__list_*"       matches any tool starting with "github__list_"
+ *   - "github__*"            matches any tool from the "github" MCP server
+ *   - "exec__*"              matches any exec-prefixed tool
+ *   - "*__read_*"            matches any read tool across servers
+ *   - "*"                    matches any tool name
+ *
+ * Glob semantics:
+ *   - `*`  matches any characters
+ *   - `?`  matches a single character
+ *
+ * Matching is case-insensitive.
+ */
+
+import type { ToolAllowlistEntry } from "./tool-approvals.js";
+
+const GLOB_REGEX_CACHE_LIMIT = 512;
+const globRegexCache = new Map<string, RegExp>();
+
+function escapeRegExpLiteral(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function compileToolGlobRegex(pattern: string): RegExp {
+  const cached = globRegexCache.get(pattern);
+  if (cached) {
+    return cached;
+  }
+
+  let regex = "^";
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === "*") {
+      // Tool names are flat strings (no path separators), so * matches everything.
+      regex += ".*";
+      i += 1;
+      continue;
+    }
+    if (ch === "?") {
+      regex += ".";
+      i += 1;
+      continue;
+    }
+    regex += escapeRegExpLiteral(ch);
+    i += 1;
+  }
+  regex += "$";
+
+  const compiled = new RegExp(regex, "i");
+  if (globRegexCache.size >= GLOB_REGEX_CACHE_LIMIT) {
+    globRegexCache.clear();
+  }
+  globRegexCache.set(pattern, compiled);
+  return compiled;
+}
+
+function normalizeToolNameForMatch(name: string): string | null {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.toLowerCase();
+}
+
+function matchesToolPattern(normalizedName: string, pattern: string): boolean {
+  const lowerPattern = pattern.toLowerCase().trim();
+  if (!lowerPattern) {
+    return false;
+  }
+  return compileToolGlobRegex(lowerPattern).test(normalizedName);
+}
+
+/**
+ * Match a tool name against the allowlist. Returns the first matching entry or null.
+ */
+export function matchToolAllowlist(
+  allowlist: readonly ToolAllowlistEntry[],
+  toolName: string,
+): ToolAllowlistEntry | null {
+  if (!allowlist || allowlist.length === 0) {
+    return null;
+  }
+  const normalized = normalizeToolNameForMatch(toolName);
+  if (!normalized) {
+    return null;
+  }
+  for (const entry of allowlist) {
+    const pattern = entry.pattern?.trim();
+    if (!pattern) {
+      continue;
+    }
+    // Bare wildcard matches any tool
+    if (pattern === "*" || pattern === "**") {
+      return entry;
+    }
+    if (matchesToolPattern(normalized, pattern)) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+export type ToolAllowlistEvaluation = {
+  allowlistSatisfied: boolean;
+  matchedEntry: ToolAllowlistEntry | null;
+};
+
+export function evaluateToolAllowlist(params: {
+  toolName: string;
+  allowlist: readonly ToolAllowlistEntry[];
+}): ToolAllowlistEvaluation {
+  const match = matchToolAllowlist(params.allowlist, params.toolName);
+  return {
+    allowlistSatisfied: match !== null,
+    matchedEntry: match,
+  };
+}

--- a/src/infra/tool-approvals.ts
+++ b/src/infra/tool-approvals.ts
@@ -1,0 +1,114 @@
+/**
+ * MCP/plugin tool call approval system.
+ *
+ * Parallels the exec and HTTP approval systems but for MCP/plugin tool calls.
+ * Uses the same security/ask/askFallback knobs and the same gateway
+ * approval manager for pending request tracking.
+ */
+
+import type { ExecApprovalDecision } from "./exec-approvals.js";
+
+export type ToolSecurity = "deny" | "allowlist" | "full";
+export type ToolAsk = "off" | "on-miss" | "always";
+
+export function normalizeToolSecurity(value?: string | null): ToolSecurity | null {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "deny" || normalized === "allowlist" || normalized === "full") {
+    return normalized;
+  }
+  return null;
+}
+
+export function normalizeToolAsk(value?: string | null): ToolAsk | null {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "off" || normalized === "on-miss" || normalized === "always") {
+    return normalized;
+  }
+  return null;
+}
+
+export type ToolApprovalRequestPayload = {
+  toolName: string;
+  /** Tool call arguments (serialized for display). */
+  args?: Record<string, unknown> | null;
+  agentId?: string | null;
+  sessionKey?: string | null;
+  host?: string | null;
+  security?: string | null;
+  ask?: string | null;
+  turnSourceChannel?: string | null;
+  turnSourceTo?: string | null;
+  turnSourceAccountId?: string | null;
+  turnSourceThreadId?: string | number | null;
+};
+
+export type ToolApprovalRequest = {
+  id: string;
+  request: ToolApprovalRequestPayload;
+  createdAtMs: number;
+  expiresAtMs: number;
+};
+
+export type ToolApprovalResolved = {
+  id: string;
+  decision: ExecApprovalDecision;
+  resolvedBy?: string | null;
+  ts: number;
+  request?: ToolApprovalRequest["request"];
+};
+
+export type ToolAllowlistEntry = {
+  id?: string;
+  pattern: string;
+  lastUsedAt?: number;
+  lastUsedToolName?: string;
+};
+
+export type ToolApprovalsDefaults = {
+  security?: ToolSecurity;
+  ask?: ToolAsk;
+  askFallback?: ToolSecurity;
+};
+
+export type ToolApprovalsAgent = ToolApprovalsDefaults & {
+  allowlist?: ToolAllowlistEntry[];
+};
+
+export const DEFAULT_TOOL_SECURITY: ToolSecurity = "full";
+export const DEFAULT_TOOL_ASK: ToolAsk = "off";
+export const DEFAULT_TOOL_ASK_FALLBACK: ToolSecurity = "full";
+export const DEFAULT_TOOL_APPROVAL_TIMEOUT_MS = 120_000;
+
+export function requiresToolApproval(params: {
+  ask: ToolAsk;
+  security: ToolSecurity;
+  allowlistSatisfied: boolean;
+}): boolean {
+  return (
+    params.ask === "always" ||
+    (params.ask === "on-miss" && params.security === "allowlist" && !params.allowlistSatisfied)
+  );
+}
+
+export function resolveToolApprovalDefaults(
+  defaults?: ToolApprovalsDefaults,
+): Required<ToolApprovalsDefaults> {
+  return {
+    security: normalizeToolSecurity(defaults?.security) ?? DEFAULT_TOOL_SECURITY,
+    ask: normalizeToolAsk(defaults?.ask) ?? DEFAULT_TOOL_ASK,
+    askFallback: normalizeToolSecurity(defaults?.askFallback) ?? DEFAULT_TOOL_ASK_FALLBACK,
+  };
+}
+
+export function resolveToolApprovalAgent(
+  agent?: ToolApprovalsAgent,
+  defaults?: Required<ToolApprovalsDefaults>,
+): Required<ToolApprovalsDefaults> & { allowlist: ToolAllowlistEntry[] } {
+  const resolved = defaults ?? resolveToolApprovalDefaults();
+  return {
+    security: normalizeToolSecurity(agent?.security) ?? resolved.security,
+    ask: normalizeToolAsk(agent?.ask) ?? resolved.ask,
+    askFallback: normalizeToolSecurity(agent?.askFallback) ?? resolved.askFallback,
+    allowlist: Array.isArray(agent?.allowlist) ? agent.allowlist : [],
+  };
+}


### PR DESCRIPTION
## Summary

- Problem: MCP/plugin tool calls have no approval gating. Exec and HTTP tool calls already have configurable security/ask/askFallback policies with operator approval via Telegram/UI, but MCP tools bypass this entirely.
- Why it matters: Operators cannot restrict or approve MCP tool calls, leaving a gap in the security model for agents that use third-party MCP servers.
- What changed: Added a complete tool approval system (`approvals.toolPolicy`) following the same patterns as exec and HTTP approvals. Includes config types, Zod schemas, policy resolver, allowlist glob matching, gateway RPC handlers, agent-side gate wrapper, and documentation.
- What did NOT change (scope boundary): Exec approvals and HTTP approvals are untouched. Default config is fully permissive (`security: full`, `ask: off`) so existing deployments are unaffected.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #46828 (HTTP approval system, same pattern)

## User-visible / Behavior Changes

- New config section `approvals.toolPolicy` with `security`, `ask`, `askFallback`, `allowlist`, and per-agent overrides.
- New config section `approvals.tool` for forwarding tool approvals to chat channels.
- New gateway events: `tool.approval.requested`, `tool.approval.resolved`.
- New gateway RPC methods: `tool.approval.request`, `tool.approval.waitDecision`, `tool.approval.resolve`.
- Default is fully permissive (no behavior change for existing users).

## Security Impact (required)

- New permissions/capabilities? `Yes` - adds tool call gating capability (opt-in)
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` - gateway RPC for tool approval lifecycle
- Command/tool execution surface changed? `Yes` - MCP/plugin tools can now be gated
- Data access scope changed? `No`
- Risk + mitigation: Default permissive policy ensures zero impact on existing deployments. Policy must be explicitly configured to restrict tool calls.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: N/A (infrastructure change)

### Steps

1. Set `approvals.toolPolicy.security: allowlist` and `approvals.toolPolicy.ask: on-miss` in config
2. Add allowlist entries for permitted tools
3. Trigger an MCP tool call not in the allowlist
4. Observe approval request via gateway event

### Expected

- Allowlisted tools proceed without prompting
- Non-allowlisted tools require operator approval or are denied per askFallback

### Actual

- Matches expected behavior per unit tests

## Evidence

- [x] Failing test/log before + passing after
- 26 unit tests covering allowlist matching, policy resolution, and policy evaluation

## Human Verification (required)

- Verified scenarios: Build passes, lint/format passes, 26 new unit tests pass
- Edge cases checked: Empty allowlists, wildcard patterns, case-insensitive matching, per-agent overrides, wildcard agent config
- What you did **not** verify: End-to-end with real MCP server and Telegram approval flow

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` - new optional config sections
- Migration needed? `No`
- Default behavior unchanged

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `approvals.toolPolicy` from config (default is fully permissive)
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: MCP tools being unexpectedly blocked when toolPolicy is configured

## Risks and Mitigations

- Risk: Policy misconfiguration could block all MCP tools
  - Mitigation: Default is `security: full` + `ask: off` (fully permissive), must be explicitly changed

> This PR was authored with AI assistance.