### PR TITLE
docs(linux): add production setup guide for nvm, Tailscale, GPU, and firewall

### DIFF
--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -149,7 +149,7 @@ tailscale serve --bg 18789
 Your dashboard is then available at `https://<machine-name>.tail<id>.ts.net`
 from any device on your Tailscale network.
 
-> **Security note:** keep `gateway.bind = "loopback"` in your config.
+> **Security note:** keep `{ gateway: { bind: "loopback" } }` in your config.
 > Tailscale Serve proxies externally; the Gateway itself never binds to a public interface.
 
 ### Using a local GPU with Ollama
@@ -171,16 +171,27 @@ ollama run qwen3:14b "hello"
 
 Then add the Ollama provider to your OpenClaw config:
 
-```json
+```json5
 {
-  "models": {
-    "providers": {
-      "ollama": {
-        "baseUrl": "http://localhost:11434/v1",
-        "models": [{ "id": "qwen3:14b", "name": "Qwen3 14B (local)" }]
-      }
-    }
-  }
+  models: {
+    providers: {
+      ollama: {
+        baseUrl: "http://localhost:11434",
+        apiKey: "ollama-local",
+        models: [
+          {
+            id: "qwen3:14b",
+            name: "Qwen3 14B (local)",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 32768,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
 }
 ```
 

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -178,6 +178,7 @@ Then add the Ollama provider to your OpenClaw config:
       ollama: {
         baseUrl: "http://localhost:11434",
         apiKey: "ollama-local",
+        api: "ollama",
         models: [
           {
             id: "qwen3:14b",

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -92,3 +92,117 @@ Enable it:
 ```
 systemctl --user enable --now openclaw-gateway[-<profile>].service
 ```
+
+## Running on a desktop Linux server (Ubuntu 24.04+)
+
+This section covers a production setup on a **bare-metal or desktop Ubuntu machine**
+with a display, GPU, and always-on connectivity — a common setup for running
+OpenClaw as a personal AI server at home or in an office.
+
+### Node version manager (nvm) caveat
+
+If you install Node via `nvm`, systemd **cannot find it** by default because
+nvm sets PATH only in interactive shells. Fix: use the absolute path in your
+service unit.
+
+```bash
+# Find your node path
+which node
+# e.g. /home/user/.nvm/versions/node/v22.22.0/bin/node
+
+# Find openclaw path
+which openclaw
+# e.g. /home/user/.nvm/versions/node/v22.22.0/bin/openclaw
+```
+
+Then in your service file use the full path:
+
+```ini
+[Service]
+ExecStart=/home/user/.nvm/versions/node/v22.22.0/bin/openclaw gateway --port 18789
+Environment=PATH=/home/user/.nvm/versions/node/v22.22.0/bin:/usr/local/bin:/usr/bin:/bin
+Environment=NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache
+Restart=always
+RestartSec=5
+```
+
+Alternatively, install a system Node (avoids nvm/systemd friction entirely):
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt install -y nodejs
+```
+
+### Remote access via Tailscale (recommended over SSH tunnels)
+
+Tailscale gives you a stable private IP across devices without open ports.
+
+```bash
+# Install Tailscale
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+
+# Expose the dashboard over Tailscale Serve (HTTPS, no open ports)
+tailscale serve --bg 18789
+```
+
+Your dashboard is then available at `https://<machine-name>.tail<id>.ts.net`
+from any device on your Tailscale network.
+
+> **Security note:** keep `gateway.bind = "loopback"` in your config.
+> Tailscale Serve proxies externally; the Gateway itself never binds to a public interface.
+
+### Using a local GPU with Ollama
+
+If your machine has an NVIDIA GPU, you can run local models via Ollama alongside
+cloud models:
+
+```bash
+# Install Ollama
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Pull a model (example: qwen3:14b fits in 16 GB VRAM)
+ollama pull qwen3:14b
+
+# Verify GPU is used
+ollama run qwen3:14b "hello"
+# should show GPU layers in ollama logs
+```
+
+Then add the Ollama provider to your OpenClaw config:
+
+```json
+{
+  "models": {
+    "providers": {
+      "ollama": {
+        "baseUrl": "http://localhost:11434/v1",
+        "models": [{ "id": "qwen3:14b", "name": "Qwen3 14B (local)" }]
+      }
+    }
+  }
+}
+```
+
+Use `ollama list` to see available models and their VRAM requirements.
+
+### Updating OpenClaw without downtime
+
+```bash
+npm i -g openclaw@latest
+openclaw gateway restart
+# or: systemctl --user restart openclaw-gateway.service
+```
+
+The service auto-restarts via `Restart=always`; active sessions resume after reconnect.
+
+### Firewall (ufw)
+
+Keep the Gateway on loopback. Only open ports you explicitly need:
+
+```bash
+sudo ufw enable
+sudo ufw allow ssh
+# Do NOT expose 18789 publicly — use Tailscale or SSH tunnel instead
+sudo ufw status
+```


### PR DESCRIPTION
## Summary

Extends `docs/platforms/linux.md` with a practical production setup section
for Ubuntu 24.04+ desktop/server machines.

## What's added

- **nvm caveat**: systemd can't find nvm-installed Node; shows absolute paths or system Node alternative
- **Tailscale**: recommended over SSH tunnels for stable remote access with `tailscale serve`
- **GPU/Ollama**: run local models (e.g. qwen3:14b) and wire them into OpenClaw config
- **Updating without downtime**: `npm i -g openclaw@latest` + service restart
- **ufw firewall**: keep Gateway on loopback, don't expose 18789

## Motivation

These are the most common friction points when running OpenClaw on a desktop
Linux server. The existing docs cover VPS/cloud well but miss bare-metal
desktop setups with GPU and Tailscale.

Tested on: Ubuntu 24.04, Node v22.22.0 (nvm), RTX 5060 Ti 16GB, Tailscale.

## AI disclosure

- [x] AI-assisted (drafted with Claude)
- [x] Lightly tested — verified commands and config format against codebase schema
- [x] I understand what this documentation covers