### PR TITLE
fix(ui): dedupe cumulative streaming text around tool interruptions

### DIFF
--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -275,4 +275,73 @@ describe("app-tool-stream fallback lifecycle handling", () => {
 
     vi.useRealTimers();
   });
+
+  it("stores incremental suffixes for cumulative stream snapshots split by tools", () => {
+    vi.useFakeTimers();
+    const host = createHost({ chatRunId: "run-1", chatStream: "abc" });
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "tool", {
+        phase: "start",
+        name: "exec",
+        toolCallId: "tool-1",
+        args: { command: "first" },
+      }),
+    );
+    host.chatStream = "abcabc";
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 2, "tool", {
+        phase: "start",
+        name: "exec",
+        toolCallId: "tool-2",
+        args: { command: "second" },
+      }),
+    );
+    host.chatStream = "abcabcdef";
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 3, "tool", {
+        phase: "start",
+        name: "exec",
+        toolCallId: "tool-3",
+        args: { command: "third" },
+      }),
+    );
+
+    expect(host.chatStreamSegments).toEqual([
+      { text: "abc", ts: expect.any(Number) },
+      { text: "abc", ts: expect.any(Number) },
+      { text: "def", ts: expect.any(Number) },
+    ]);
+    expect(host.chatStream).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it("skips unchanged cumulative stream snapshots at tool boundaries", () => {
+    vi.useFakeTimers();
+    const host = createHost({
+      chatRunId: "run-1",
+      chatStreamSegments: [{ text: "abc", ts: Date.now() }],
+      chatStream: "abc",
+    });
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "tool", {
+        phase: "start",
+        name: "exec",
+        toolCallId: "tool-1",
+        args: { command: "first" },
+      }),
+    );
+
+    expect(host.chatStreamSegments).toEqual([{ text: "abc", ts: expect.any(Number) }]);
+    expect(host.chatStream).toBeNull();
+    vi.useRealTimers();
+  });
+
 });

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -1,4 +1,5 @@
 import { formatUnknownText, truncateText } from "./format.ts";
+import { getIncrementalStreamText } from "./stream-dedupe.ts";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 
 const TOOL_STREAM_LIMIT = 50;
@@ -507,7 +508,10 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       host.chatStream &&
       host.chatStream.trim().length > 0
     ) {
-      host.chatStreamSegments = [...host.chatStreamSegments, { text: host.chatStream, ts: now }];
+      const incrementalText = getIncrementalStreamText(host.chatStreamSegments, host.chatStream);
+      if (incrementalText.trim().length > 0) {
+        host.chatStreamSegments = [...host.chatStreamSegments, { text: incrementalText, ts: now }];
+      }
       host.chatStream = null;
       host.chatStreamStartedAt = null;
     }

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { MessageGroup } from "../types/chat-types.ts";
+import type { ChatItem, MessageGroup } from "../types/chat-types.ts";
 import { buildChatItems, type BuildChatItemsProps } from "./build-chat-items.ts";
 
 function createProps(overrides: Partial<BuildChatItemsProps> = {}): BuildChatItemsProps {
@@ -22,6 +22,10 @@ function messageGroups(props: Partial<BuildChatItemsProps>): MessageGroup[] {
 function firstMessageContent(group: MessageGroup): unknown[] {
   const message = group.messages[0]?.message as { content?: unknown };
   return Array.isArray(message.content) ? message.content : [];
+}
+
+function chatItems(props: Partial<BuildChatItemsProps>): Array<ChatItem | MessageGroup> {
+  return buildChatItems(createProps(props));
 }
 
 describe("buildChatItems", () => {
@@ -183,6 +187,37 @@ describe("buildChatItems", () => {
       },
     });
   });
+
+  it("dedupes live stream preview against committed stream segments", () => {
+    const items = chatItems({
+      streamSegments: [
+        { text: "abc", ts: 1 },
+        { text: "abc", ts: 2 },
+      ],
+      stream: "abcabcdef",
+      streamStartedAt: 3,
+    });
+
+    const streamTexts = items
+      .filter((item): item is Extract<ChatItem, { kind: "stream" }> => item.kind === "stream")
+      .map((item) => item.text);
+
+    expect(streamTexts).toEqual(["abc", "abc", "def"]);
+  });
+
+  it("shows a reading indicator instead of replaying an unchanged cumulative stream", () => {
+    const items = chatItems({
+      streamSegments: [{ text: "abc", ts: 1 }],
+      stream: "abc",
+      streamStartedAt: 2,
+    });
+
+    expect(items.filter((item) => item.kind === "stream").map((item) => item.key)).toEqual([
+      "stream-seg:main:0",
+    ]);
+    expect(items.some((item) => item.kind === "reading-indicator")).toBe(true);
+  });
+
 });
 
 function isCanvasBlock(block: unknown): boolean {

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -3,6 +3,7 @@ import { extractTextCached } from "./message-extract.ts";
 import { normalizeMessage } from "./message-normalizer.ts";
 import { normalizeRoleForGrouping } from "./role-normalizer.ts";
 import { messageMatchesSearchQuery } from "./search-match.ts";
+import { getLiveStreamPreviewText } from "../stream-dedupe.ts";
 import { extractToolCards, extractToolPreview } from "./tool-cards.ts";
 
 const CHAT_HISTORY_RENDER_LIMIT = 200;
@@ -270,6 +271,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     };
   }
   const segments = props.streamSegments ?? [];
+  const liveStreamText = getLiveStreamPreviewText(segments, props.stream);
   const maxLen = Math.max(segments.length, tools.length);
   for (let i = 0; i < maxLen; i++) {
     if (i < segments.length && segments[i].text.trim().length > 0) {
@@ -291,11 +293,11 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
 
   if (props.stream !== null) {
     const key = `stream:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
-    if (props.stream.trim().length > 0) {
+    if ((liveStreamText ?? "").trim().length > 0) {
       items.push({
         kind: "stream",
         key,
-        text: props.stream,
+        text: liveStreamText ?? "",
         startedAt: props.streamStartedAt ?? Date.now(),
       });
     } else {

--- a/ui/src/ui/stream-dedupe.node.test.ts
+++ b/ui/src/ui/stream-dedupe.node.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendUniqueText,
+  getCommittedText,
+  getIncrementalStreamText,
+  getLiveStreamPreviewText,
+} from "./stream-dedupe.ts";
+
+describe("stream-dedupe", () => {
+  it("appends only the non-overlapping suffix", () => {
+    expect(appendUniqueText("hello", "lo world")).toBe("hello world");
+  });
+
+  it("reconstructs committed text from incremental segments", () => {
+    expect(getCommittedText([{ text: "abc" }, { text: "def" }])).toBe("abcdef");
+  });
+
+  it("does not collapse repeated incremental segments", () => {
+    expect(getCommittedText([{ text: "abc" }, { text: "abc" }])).toBe("abcabc");
+  });
+
+  it("extracts only the new suffix from a cumulative stream", () => {
+    expect(getIncrementalStreamText([{ text: "abc" }, { text: "abc" }], "abcabcdef")).toBe(
+      "def",
+    );
+  });
+
+  it("returns empty when the cumulative stream adds nothing new", () => {
+    expect(getIncrementalStreamText([{ text: "abc" }, { text: "abc" }], "abcabc")).toBe("");
+  });
+
+  it("uses the same dedupe rule for live preview text", () => {
+    expect(getLiveStreamPreviewText([{ text: "abc" }, { text: "abc" }], "abcabcdef")).toBe(
+      "def",
+    );
+  });
+});

--- a/ui/src/ui/stream-dedupe.ts
+++ b/ui/src/ui/stream-dedupe.ts
@@ -1,0 +1,65 @@
+export type TextStreamSegment = { text: string };
+
+export function appendUniqueText(base: string, suffix: string): string {
+  if (!suffix) {
+    return base;
+  }
+  if (!base) {
+    return suffix;
+  }
+  if (base.endsWith(suffix)) {
+    return base;
+  }
+  const maxOverlap = Math.min(base.length, suffix.length);
+  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+    if (base.slice(-overlap) === suffix.slice(0, overlap)) {
+      return base + suffix.slice(overlap);
+    }
+  }
+  return base + suffix;
+}
+
+export function getCommittedText<T extends TextStreamSegment>(segments: readonly T[]): string {
+  // Segments are incremental pieces, so two identical consecutive segments
+  // must remain two pieces instead of being collapsed by overlap detection.
+  return segments.map((segment) => segment.text).join("");
+}
+
+export function getIncrementalTextAgainstCommitted(committed: string, text: string): string {
+  if (!committed) {
+    return text;
+  }
+  if (!text || text === committed) {
+    return "";
+  }
+  if (text.startsWith(committed)) {
+    return text.slice(committed.length);
+  }
+  if (committed.endsWith(text)) {
+    return "";
+  }
+  const maxOverlap = Math.min(committed.length, text.length);
+  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+    if (committed.slice(-overlap) === text.slice(0, overlap)) {
+      return text.slice(overlap);
+    }
+  }
+  return text;
+}
+
+export function getIncrementalStreamText<T extends TextStreamSegment>(
+  segments: readonly T[],
+  text: string,
+): string {
+  return getIncrementalTextAgainstCommitted(getCommittedText(segments), text);
+}
+
+export function getLiveStreamPreviewText<T extends TextStreamSegment>(
+  segments: readonly T[],
+  stream: string | null,
+): string | null {
+  if (stream == null) {
+    return null;
+  }
+  return getIncrementalTextAgainstCommitted(getCommittedText(segments), stream);
+}


### PR DESCRIPTION
## Summary
- dedupe cumulative assistant text when tool cards interrupt WebChat streaming
- dedupe live stream preview against already committed stream segments
- keep the PR focused on the Web UI streaming fix only

## Problem
When assistant streaming is interrupted by tool execution, WebChat can treat cumulative assistant text as if it were new incremental content. That makes the UI appear to repeat previous output after tool cards.

## Changes
- add `ui/src/ui/stream-dedupe.ts` for shared cumulative-text dedupe helpers
- use the helper when committing stream segments before tool cards
- use the helper again when building the live stream preview in `ui/src/ui/chat/build-chat-items.ts`
- add focused regression tests for helper behavior, repeated identical segments, and multi text/tool/text cycles
- remove the unrelated metadata, plugin-diagnostic, and security-audit changes from this PR branch

## Validation
```bash
pnpm --dir /tmp/openclaw-pr46985/ui exec vitest run \
  src/ui/stream-dedupe.node.test.ts \
  src/ui/app-tool-stream.node.test.ts \
  src/ui/chat/build-chat-items.test.ts
```

## User-visible effect
Streaming text around tool cards now renders as:

`previous text -> tool card -> new suffix`

instead of replaying prior cumulative text in later assistant bubbles.