### PR TITLE
Docs: fix Node minimum version in README (≥22 → ≥22.16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Model note: while many providers/models are supported, for the best experience a
 
 ## Install (recommended)
 
-Runtime: **Node ≥22**.
+Runtime: **Node ≥22.16**.
 
 ```bash
 npm install -g openclaw@latest
@@ -62,7 +62,7 @@ The wizard installs the Gateway daemon (launchd/systemd user service) so it stay
 
 ## Quick start (TL;DR)
 
-Runtime: **Node ≥22**.
+Runtime: **Node ≥22.16**.
 
 Full beginner guide (auth, pairing, channels): [Getting started](https://docs.openclaw.ai/start/getting-started)
 


### PR DESCRIPTION
## Summary
Fixed two places in README.md that stated the Node minimum as `≥22` — the actual minimum enforced by `package.json` is `>=22.16.0`.

## Changes
- `README.md` (Install section): `Node ≥22` → `Node ≥22.16`
- `README.md` (Quick start section): `Node ≥22` → `Node ≥22.16`

## Why
`package.json` declares `"engines": {"node": ">=22.16.0"}`. All other docs (getting-started, node.md, installer.md, SECURITY.md) already say `22.16+`. README was the only outlier still showing the vague `≥22`.

## Testing
N/A — documentation accuracy fix only.