### PR TITLE
Docs: fix Node minimum version in setup.md (>=22 → >=22.16)

### DIFF
--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -23,7 +23,7 @@ Last updated: 2026-01-01
 
 ## Prereqs (from source)
 
-- Node `>=22`
+- Node `>=22.16`
 - `pnpm`
 - Docker (optional; only for containerized setup/e2e — see [Docker](/install/docker))
 

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -23,7 +23,7 @@ Last updated: 2026-01-01
 
 ## Prereqs (from source)
 
-- Node `>=22.16`
+- Node `>=22.16.0`
 - `pnpm`
 - Docker (optional; only for containerized setup/e2e — see [Docker](/install/docker))
 


### PR DESCRIPTION
## Summary
Fixed Node minimum version in `docs/start/setup.md` prereqs list.

## Changes
- `docs/start/setup.md`: `Node \`>=22\`` → `Node \`>=22.16\``

## Why
`package.json` enforces `>=22.16.0`. This prereqs page was showing `>=22` which understates the actual minimum and could mislead users on older patch versions of Node 22.

## Testing
N/A — documentation accuracy fix only.