### PR TITLE
macOS exec: harden allowlist shell wrapper resolution

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecCommandResolution.swift
+++ b/apps/macos/Sources/OpenClaw/ExecCommandResolution.swift
@@ -25,8 +25,16 @@ struct ExecCommandResolution {
         cwd: String?,
         env: [String: String]?) -> [ExecCommandResolution]
     {
-        let shell = ExecShellWrapperParser.extract(command: command, rawCommand: rawCommand)
+        // Allowlist resolution must follow actual argv execution for wrappers.
+        // `rawCommand` is caller-supplied display text and may be canonicalized.
+        let shell = ExecShellWrapperParser.extract(command: command, rawCommand: nil)
         if shell.isWrapper {
+            // Fail closed when env modifiers precede a shell wrapper. This mirrors
+            // system-run binding behavior where such invocations must stay bound to
+            // full argv and must not be auto-allowlisted by payload-only matches.
+            if ExecSystemRunCommandValidator.hasEnvManipulationBeforeShellWrapper(command) {
+                return []
+            }
             guard let shellCommand = shell.command,
                   let segments = self.splitShellCommandChain(shellCommand)
             else {
@@ -46,13 +54,35 @@ struct ExecCommandResolution {
             return resolutions
         }
 
-        guard let resolution = self.resolve(command: command, rawCommand: rawCommand, cwd: cwd, env: env) else {
+        guard let resolution = self.resolveForAllowlistCommand(
+            command: command,
+            rawCommand: rawCommand,
+            cwd: cwd,
+            env: env)
+        else {
             return []
         }
         return [resolution]
     }
 
     static func resolve(command: [String], cwd: String?, env: [String: String]?) -> ExecCommandResolution? {
+        let effective = ExecEnvInvocationUnwrapper.unwrapTransparentDispatchWrappersForResolution(command)
+        guard let raw = effective.first?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return nil
+        }
+        return self.resolveExecutable(rawExecutable: raw, cwd: cwd, env: env)
+    }
+
+    private static func resolveForAllowlistCommand(
+        command: [String],
+        rawCommand: String?,
+        cwd: String?,
+        env: [String: String]?) -> ExecCommandResolution?
+    {
+        let trimmedRaw = rawCommand?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedRaw.isEmpty, let token = self.parseFirstToken(trimmedRaw) {
+            return self.resolveExecutable(rawExecutable: token, cwd: cwd, env: env)
+        }
         let effective = ExecEnvInvocationUnwrapper.unwrapDispatchWrappersForResolution(command)
         guard let raw = effective.first?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
             return nil

--- a/apps/macos/Sources/OpenClaw/ExecEnvInvocationUnwrapper.swift
+++ b/apps/macos/Sources/OpenClaw/ExecEnvInvocationUnwrapper.swift
@@ -92,4 +92,47 @@ enum ExecEnvInvocationUnwrapper {
         }
         return current
     }
+
+    private static func unwrapTransparentEnvInvocation(_ command: [String]) -> [String]? {
+        var idx = 1
+        while idx < command.count {
+            let token = command[idx].trimmingCharacters(in: .whitespacesAndNewlines)
+            if token.isEmpty {
+                idx += 1
+                continue
+            }
+            if token == "--" || token == "-" {
+                idx += 1
+                break
+            }
+            if self.isEnvAssignment(token) {
+                return nil
+            }
+            if token.hasPrefix("-"), token != "-" {
+                return nil
+            }
+            break
+        }
+        guard idx < command.count else { return nil }
+        return Array(command[idx...])
+    }
+
+    static func unwrapTransparentDispatchWrappersForResolution(_ command: [String]) -> [String] {
+        var current = command
+        var depth = 0
+        while depth < self.maxWrapperDepth {
+            guard let token = current.first?.trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty else {
+                break
+            }
+            guard ExecCommandToken.basenameLower(token) == "env" else {
+                break
+            }
+            guard let unwrapped = self.unwrapTransparentEnvInvocation(current), !unwrapped.isEmpty else {
+                break
+            }
+            current = unwrapped
+            depth += 1
+        }
+        return current
+    }
 }

--- a/apps/macos/Sources/OpenClaw/ExecEnvInvocationUnwrapper.swift
+++ b/apps/macos/Sources/OpenClaw/ExecEnvInvocationUnwrapper.swift
@@ -101,9 +101,12 @@ enum ExecEnvInvocationUnwrapper {
                 idx += 1
                 continue
             }
-            if token == "--" || token == "-" {
+            if token == "--" {
                 idx += 1
                 break
+            }
+            if token == "-" {
+                return nil
             }
             if self.isEnvAssignment(token) {
                 return nil

--- a/apps/macos/Sources/OpenClaw/ExecSystemRunCommandValidator.swift
+++ b/apps/macos/Sources/OpenClaw/ExecSystemRunCommandValidator.swift
@@ -52,18 +52,22 @@ enum ExecSystemRunCommandValidator {
         let envManipulationBeforeShellWrapper = self.hasEnvManipulationBeforeShellWrapper(command)
         let shellWrapperPositionalArgv = self.hasTrailingPositionalArgvAfterInlineCommand(command)
         let mustBindDisplayToFullArgv = envManipulationBeforeShellWrapper || shellWrapperPositionalArgv
-
-        let inferred: String = if let shellCommand, !mustBindDisplayToFullArgv {
+        let canonicalDisplay = ExecCommandFormatter.displayString(for: command)
+        let legacyShellDisplay: String? = if let shellCommand, !mustBindDisplayToFullArgv {
             shellCommand
         } else {
-            ExecCommandFormatter.displayString(for: command)
+            nil
         }
 
-        if let raw = normalizedRaw, raw != inferred {
-            return .invalid(message: "INVALID_REQUEST: rawCommand does not match command")
+        if let raw = normalizedRaw {
+            let matchesCanonical = raw == canonicalDisplay
+            let matchesLegacyShellText = legacyShellDisplay == raw
+            if !matchesCanonical, !matchesLegacyShellText {
+                return .invalid(message: "INVALID_REQUEST: rawCommand does not match command")
+            }
         }
 
-        return .ok(ResolvedCommand(displayCommand: normalizedRaw ?? inferred))
+        return .ok(ResolvedCommand(displayCommand: canonicalDisplay))
     }
 
     private static func normalizeRaw(_ rawCommand: String?) -> String? {
@@ -181,7 +185,7 @@ enum ExecSystemRunCommandValidator {
         return Array(argv[appletIndex...])
     }
 
-    private static func hasEnvManipulationBeforeShellWrapper(
+    static func hasEnvManipulationBeforeShellWrapper(
         _ argv: [String],
         depth: Int = 0,
         envManipulationSeen: Bool = false) -> Bool

--- a/apps/macos/Sources/OpenClaw/ExecSystemRunCommandValidator.swift
+++ b/apps/macos/Sources/OpenClaw/ExecSystemRunCommandValidator.swift
@@ -113,7 +113,12 @@ enum ExecSystemRunCommandValidator {
                 idx += 1
                 continue
             }
-            if token == "--" || token == "-" {
+            if token == "--" {
+                idx += 1
+                break
+            }
+            if token == "-" {
+                usesModifiers = true
                 idx += 1
                 break
             }

--- a/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
@@ -276,6 +276,17 @@ struct ExecAllowlistTests {
         #expect(resolutions.isEmpty)
     }
 
+    @Test func `resolve for allowlist fails closed for env dash shell wrappers`() {
+        let command = ["/usr/bin/env", "-", "bash", "-lc", "echo allowlisted"]
+        let canonicalRaw = "/usr/bin/env - bash -lc \"echo allowlisted\""
+        let resolutions = ExecCommandResolution.resolveForAllowlist(
+            command: command,
+            rawCommand: canonicalRaw,
+            cwd: nil,
+            env: ["PATH": "/usr/bin:/bin"])
+        #expect(resolutions.isEmpty)
+    }
+
     @Test func `resolve for allowlist unwraps env to effective direct executable`() {
         let command = ["/usr/bin/env", "FOO=bar", "/usr/bin/printf", "ok"]
         let resolutions = ExecCommandResolution.resolveForAllowlist(

--- a/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
@@ -252,6 +252,30 @@ struct ExecAllowlistTests {
         #expect(resolutions[0].executableName == "touch")
     }
 
+    @Test func `resolve for allowlist uses wrapper argv payload even with canonical raw command`() {
+        let command = ["/bin/sh", "-lc", "echo allowlisted && /usr/bin/touch /tmp/openclaw-allowlist-test"]
+        let canonicalRaw = "/bin/sh -lc \"echo allowlisted && /usr/bin/touch /tmp/openclaw-allowlist-test\""
+        let resolutions = ExecCommandResolution.resolveForAllowlist(
+            command: command,
+            rawCommand: canonicalRaw,
+            cwd: nil,
+            env: ["PATH": "/usr/bin:/bin"])
+        #expect(resolutions.count == 2)
+        #expect(resolutions[0].executableName == "echo")
+        #expect(resolutions[1].executableName == "touch")
+    }
+
+    @Test func `resolve for allowlist fails closed for env modified shell wrappers`() {
+        let command = ["/usr/bin/env", "BASH_ENV=/tmp/payload.sh", "bash", "-lc", "echo allowlisted"]
+        let canonicalRaw = "/usr/bin/env BASH_ENV=/tmp/payload.sh bash -lc \"echo allowlisted\""
+        let resolutions = ExecCommandResolution.resolveForAllowlist(
+            command: command,
+            rawCommand: canonicalRaw,
+            cwd: nil,
+            env: ["PATH": "/usr/bin:/bin"])
+        #expect(resolutions.isEmpty)
+    }
+
     @Test func `resolve for allowlist unwraps env to effective direct executable`() {
         let command = ["/usr/bin/env", "FOO=bar", "/usr/bin/printf", "ok"]
         let resolutions = ExecCommandResolution.resolveForAllowlist(

--- a/apps/macos/Tests/OpenClawIPCTests/ExecSystemRunCommandValidatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecSystemRunCommandValidatorTests.swift
@@ -50,6 +50,37 @@ struct ExecSystemRunCommandValidatorTests {
         }
     }
 
+    @Test func `env dash shell wrapper requires canonical raw command binding`() {
+        let command = ["/usr/bin/env", "-", "bash", "-lc", "echo hi"]
+
+        let legacy = ExecSystemRunCommandValidator.resolve(command: command, rawCommand: "echo hi")
+        switch legacy {
+        case .ok:
+            Issue.record("expected rawCommand mismatch for env dash prelude")
+        case let .invalid(message):
+            #expect(message.contains("rawCommand does not match command"))
+        }
+
+        let canonicalRaw = "/usr/bin/env - bash -lc \"echo hi\""
+        let canonical = ExecSystemRunCommandValidator.resolve(command: command, rawCommand: canonicalRaw)
+        switch canonical {
+        case let .ok(resolved):
+            #expect(resolved.displayCommand == canonicalRaw)
+        case let .invalid(message):
+            Issue.record("unexpected invalid result for canonical raw command: \(message)")
+        }
+    }
+
+    @Test func `resolve keeps env dash wrapper as effective executable`() {
+        let resolution = ExecCommandResolution.resolve(
+            command: ["/usr/bin/env", "-", "/usr/bin/printf", "ok"],
+            cwd: nil,
+            env: ["PATH": "/usr/bin:/bin"])
+        #expect(resolution?.rawExecutable == "/usr/bin/env")
+        #expect(resolution?.resolvedPath == "/usr/bin/env")
+        #expect(resolution?.executableName == "env")
+    }
+
     private static func loadContractCases() throws -> [SystemRunCommandContractCase] {
         let fixtureURL = try self.findContractFixtureURL()
         let data = try Data(contentsOf: fixtureURL)


### PR DESCRIPTION
## Summary

- Harden allowlist resolution to parse shell-wrapper payloads from actual `argv` execution context.
- Ignore canonicalized `rawCommand` for wrapper allowlist resolution so wrapper payload commands are resolved correctly.
- Fail closed when env manipulation appears before a shell wrapper (for example `env BASH_ENV=... bash -lc ...`), preventing payload-only allowlist matching.
- Keep `system.run` validation compatible with legacy shell-text `rawCommand` inputs while normalizing display output to canonical argv text.
- Add macOS IPC tests for:
  - wrapper payload resolution with canonical raw command input
  - fail-closed behavior for env-modified shell wrappers

## Change Type

- [x] Bug fix
- [x] Security hardening

## Scope

- [x] Skills / tool execution
- [x] Auth / tokens

## User-visible / Behavior Changes

- Stricter allowlist behavior for env-modified shell-wrapper invocations.
- Wrapper commands are resolved from real argv payload instead of display/canonicalized `rawCommand`.

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)

If any `Yes`, explain risk + mitigation:
- Risk: Some previously accepted wrapper edge cases may now be rejected.
- Mitigation: Intentional fail-closed behavior for risky env+shell wrapper forms; legacy raw command compatibility remains for validation paths.

## Human Verification

- Verified by code inspection and added tests in `apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift`.
- Ran full local suite: `pnpm build && pnpm check && pnpm test`.
- `build` and `check` passed.
- `test` had unrelated pre-existing failures outside this PR scope:
  - `src/infra/secret-file.test.ts`
  - `src/infra/warning-filter.test.ts`
  - `src/plugin-sdk/index.test.ts`
