### PR TITLE
fix(skills): show correct source for workspace-installed skills

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -186,10 +186,10 @@ function buildSkillStatus(
       (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
     );
   const isConfigSatisfied = (pathStr: string) => isConfigPathTruthy(config, pathStr);
-  const bundled =
-    bundledNames && bundledNames.size > 0
-      ? bundledNames.has(entry.skill.name)
-      : entry.skill.source === "openclaw-bundled";
+  // Only mark as bundled if the actual source path is openclaw-bundled.
+  // Previously this checked bundledNames.has(entry.skill.name), which incorrectly
+  // marked workspace-installed skills as bundled when they shared names with bundled skills.
+  const bundled = entry.skill.source === "openclaw-bundled";
 
   const { emoji, homepage, required, missing, requirementsSatisfied, configChecks } =
     evaluateEntryRequirementsForCurrentPlatform({


### PR DESCRIPTION
## Summary

Fixes #47139

Previously, the Control Panel displayed workspace-installed skills as "bundled" when they shared names with bundled skills (e.g., summarize, nano-pdf, video-frames). This was because the bundled check used `bundledNames.has(entry.skill.name)` instead of checking the actual source path.

### Root Cause
The `bundled` property in `buildSkillStatus` checked if the skill name existed in `bundledNames` set, rather than checking the actual `source` field of the skill entry. This caused workspace-installed copies of bundled skills to be incorrectly displayed as bundled.

### Fix
Now the `bundled` property is determined solely by the skill's `source` field, which correctly reflects where the skill was loaded from.

### Test Plan
1. Install a skill from ClawHub that originally came bundled with OpenClaw (e.g., summarize, video-frames)
2. Open Control Panel Web UI
3. Check skills list
4. Verify the skill shows as "workspace" instead of "bundled"

Also verify `openclaw skills list` and Control Panel show consistent source values.
