### PR TITLE
fix(security): guard mention patterns against ReDoS via compileSafeRegex

### DIFF
--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -2,6 +2,7 @@ import { resolveAgentConfig } from "../../agents/agent-scope.js";
 import { getChannelDock } from "../../channels/dock.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { compileSafeRegex } from "../../security/safe-regex.js";
 import { escapeRegExp } from "../../utils.js";
 import type { MsgContext } from "../templating.js";
 
@@ -65,13 +66,7 @@ export function buildMentionRegexes(cfg: OpenClawConfig | undefined, agentId?: s
     return [...cached];
   }
   const compiled = patterns
-    .map((pattern) => {
-      try {
-        return new RegExp(pattern, "i");
-      } catch {
-        return null;
-      }
-    })
+    .map((pattern) => compileSafeRegex(pattern, "i"))
     .filter((value): value is RegExp => Boolean(value));
   mentionRegexCompileCache.set(cacheKey, compiled);
   if (mentionRegexCompileCache.size > MAX_MENTION_REGEX_COMPILE_CACHE_KEYS) {
@@ -158,11 +153,9 @@ export function stripMentions(
     ...(providerMentions?.stripPatterns?.({ ctx, cfg, agentId }) ?? []),
   ]);
   for (const p of patterns) {
-    try {
-      const re = new RegExp(p, "gi");
+    const re = compileSafeRegex(p, "gi");
+    if (re) {
       result = result.replace(re, " ");
-    } catch {
-      // ignore invalid regex
     }
   }
   if (providerMentions?.stripMentions) {


### PR DESCRIPTION
## Problem

`mentionPatterns` from user config (`messages.groupChat.mentionPatterns` and per-agent `groupChat.mentionPatterns`) are compiled into `RegExp` objects and tested against every incoming group message. These patterns were compiled with raw `new RegExp(pattern, flags)` without any validation for catastrophic backtracking.

A pattern containing nested quantifiers (e.g. `(a+)+$`) in the config could cause the event loop to hang when tested against adversarial input, effectively denying service to all connected sessions.

The same issue existed in `stripMentions`, which also compiles config-sourced patterns into regex for replacement.

## Fix

Replace raw `new RegExp()` calls with the existing `compileSafeRegex()` utility from `src/security/safe-regex.ts`, which:

1. Rejects patterns with nested repetition (the primary cause of ReDoS)
2. Provides built-in compilation caching
3. Returns `null` for unsafe/invalid patterns instead of throwing

Patterns derived from identity names via `escapeRegExp` are inherently safe (no quantifiers), but now also benefit from the shared compilation path.

## Testing

- All existing mention tests pass (mentions.test.ts, mention-gating.test.ts, group-mentions.test.ts, inbound.test.ts)
- TypeScript compiles cleanly
- safe-regex.test.ts confirms nested-repetition detection works correctly