### PR TITLE
fix(agents): use max_tokens for Mistral API compatibility

### DIFF
--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -167,6 +167,10 @@ export function buildMistralModelDefinition(): ModelDefinitionConfig {
     cost: MISTRAL_DEFAULT_COST,
     contextWindow: MISTRAL_DEFAULT_CONTEXT_WINDOW,
     maxTokens: MISTRAL_DEFAULT_MAX_TOKENS,
+    // Mistral API rejects max_completion_tokens, only accepts max_tokens
+    compat: {
+      maxTokensField: "max_tokens",
+    },
   };
 }
 

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -606,6 +606,14 @@ describe("applyMistralConfig", () => {
       MISTRAL_DEFAULT_MODEL_REF,
     );
   });
+
+  it("sets maxTokensField to max_tokens for Mistral API compatibility", () => {
+    const cfg = applyMistralConfig({});
+    const mistralDefault = cfg.models?.providers?.mistral?.models?.find(
+      (model) => model.id === "mistral-large-latest",
+    );
+    expect(mistralDefault?.compat?.maxTokensField).toBe("max_tokens");
+  });
 });
 
 describe("applyMistralProviderConfig", () => {


### PR DESCRIPTION
Mistral API rejects `max_completion_tokens` parameter and only accepts `max_tokens`. This fix adds the correct compat setting to the Mistral model definition to ensure proper API compatibility.

## Problem
When using Mistral as a provider with the `openai-completions` API adapter, all agent requests fail with `422 status code (no body)`.

## Root Cause
The `openai-completions` adapter sends `max_completion_tokens` in the request body. Mistral API does not support this parameter and returns a 422 error.

## Solution
Add `compat: { maxTokensField: "max_tokens" }` to the Mistral model definition in `buildMistralModelDefinition()`. This tells the adapter to use `max_tokens` instead of `max_completion_tokens` for Mistral API requests.

Fixes #47079
Fixes #47200
Fixes #45227
Fixes #41293
