### PR TITLE
fix(infra): install warning filter early to suppress punycode deprecation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+
+// Install warning filter early to suppress known deprecation warnings (e.g., punycode)
+// before any other modules are imported that might trigger these warnings.
+import { installProcessWarningFilter } from "./infra/warning-filter.js";
+installProcessWarningFilter();
+
 import { getReplyFromConfig } from "./auto-reply/reply.js";
 import { applyTemplate } from "./auto-reply/templating.js";
 import { monitorWebChannel } from "./channel-web.js";


### PR DESCRIPTION
The punycode deprecation warning (DEP0040) was still showing at startup because the warning filter was only installed when sqlite was required. This moves the warning filter installation to the very top of the main entry point, before any other imports that might trigger the warning.

Fixes #47088
