### PR TITLE
Fix direct webchat sender metadata for interactive TUI sessions

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -122,6 +122,19 @@ describe("buildInboundUserContextPrefix", () => {
     expect(text).toBe("");
   });
 
+  it("omits sender metadata for direct webchat chats", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      Provider: "webchat",
+      Surface: "webchat",
+      SenderName: "openclaw-tui",
+      SenderId: "gateway-client",
+      SenderUsername: "openclaw-tui",
+    } as TemplateContext);
+
+    expect(text).toBe("");
+  });
+
   it("includes message identifiers for direct external-channel chats", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "direct",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -90,6 +90,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     directChannelValue && directChannelValue !== "webchat",
   );
   const shouldIncludeConversationInfo = !isDirect || includeDirectConversationInfo;
+  const shouldIncludeSenderInfo = !(isDirect && directChannelValue === "webchat");
 
   const messageId = safeTrim(ctx.MessageSid);
   const messageIdFull = safeTrim(ctx.MessageSidFull);
@@ -149,7 +150,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     tag: safeTrim(ctx.SenderTag),
     e164: safeTrim(ctx.SenderE164),
   };
-  if (senderInfo?.label) {
+  if (shouldIncludeSenderInfo && senderInfo?.label) {
     blocks.push(
       ["Sender (untrusted metadata):", "```json", JSON.stringify(senderInfo, null, 2), "```"].join(
         "\n",


### PR DESCRIPTION
## Summary
- suppress `Sender (untrusted metadata)` blocks for direct `webchat` chats
- keep existing sender metadata behavior for non-webchat and external-channel direct chats
- add regression coverage for transport-only sender identities like `gateway-client` / `openclaw-tui`

## Why
Direct interactive TUI/webchat sessions already provide trusted inbound metadata like `channel=webchat`, `surface=webchat`, and `chat_type=direct`. But `buildInboundUserContextPrefix` was still emitting an untrusted sender block for these sessions, and in the TUI path that sender is the transport client (`gateway-client` / `openclaw-tui`) rather than the human. That can skew caller-type inference in user-authored prompts that distinguish HUMAN vs AGENT callers.

This keeps the prompt consistent by omitting transport-only sender metadata for direct webchat chats while preserving sender context everywhere else.

## Testing
- added regression test covering direct webchat sender suppression
