### PR TITLE
fix: use punycode/ instead of punycode to avoid deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -450,6 +450,7 @@
       "qs": "6.14.2",
       "node-domexception": "npm:@nolyfill/domexception@^1.0.28",
       "@sinclair/typebox": "0.34.48",
+      "punycode": "npm:punycode.js@^2.3.1",
       "tar": "7.5.11",
       "tough-cookie": "4.1.3",
       "yauzl": "3.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   qs: 6.14.2
   node-domexception: npm:@nolyfill/domexception@^1.0.28
   '@sinclair/typebox': 0.34.48
+  punycode: npm:punycode.js@^2.3.1
   tar: 7.5.11
   tough-cookie: 4.1.3
   yauzl: 3.2.1
@@ -5850,10 +5851,6 @@ packages:
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
-    engines: {node: '>=6'}
-
-  punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   qified@0.6.0:
@@ -13211,7 +13208,7 @@ snapshots:
 
   psl@1.15.0:
     dependencies:
-      punycode: 2.3.1
+      punycode: punycode.js@2.3.1
 
   pug-attrs@3.0.0:
     dependencies:
@@ -13286,8 +13283,6 @@ snapshots:
       once: 1.4.0
 
   punycode.js@2.3.1: {}
-
-  punycode@2.3.1: {}
 
   qified@0.6.0:
     dependencies:
@@ -13948,7 +13943,7 @@ snapshots:
   tough-cookie@4.1.3:
     dependencies:
       psl: 1.15.0
-      punycode: 2.3.1
+      punycode: punycode.js@2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
 
@@ -13956,7 +13951,7 @@ snapshots:
 
   tr46@6.0.0:
     dependencies:
-      punycode: 2.3.1
+      punycode: punycode.js@2.3.1
 
   tree-kill@1.2.2: {}
 


### PR DESCRIPTION
Fixes #47088

## Summary

This PR fixes the DEP0040 deprecation warning for the `punycode` module by adding a pnpm override that aliases `punycode` to `punycode.js`.

## Problem

OpenClaw gateway shows deprecation warning `[DEP0040] DeprecationWarning: The `punycode` module is deprecated` on startup.

## Solution

Added a pnpm override to force all `require("punycode")` calls to use the userland `punycode.js` package instead of the built-in deprecated Node.js module.

The override follows the same pattern as other overrides in package.json:
```json
"punycode": "npm:punycode.js@^2.3.1"
```

This is equivalent to changing `require("punycode")` to `require("punycode/")` as suggested in the issue, but works for all transitive dependencies without modifying their code.

## Testing

- The change is a simple package alias that doesn't affect runtime behavior
- The userland `punycode.js` package is API-compatible with the built-in `punycode` module

Fixes #47088
