### PR TITLE
fix(acpx): preserve macOS system admin paths for spawned children

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -243,7 +243,7 @@ describe("ensurePlatformPathDefaults", () => {
       "darwin",
     );
 
-    expect(env.PATH?.split(path.delimiter)).toEqual([
+    expect(env.PATH?.split(":")).toEqual([
       "/usr/local/bin",
       "/usr/bin",
       "/bin",
@@ -260,7 +260,7 @@ describe("ensurePlatformPathDefaults", () => {
       "darwin",
     );
 
-    expect(env.PATH?.split(path.delimiter)).toEqual([
+    expect(env.PATH?.split(":")).toEqual([
       "/usr/local/bin",
       "/usr/sbin",
       "/usr/bin",

--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createWindowsCmdShimFixture } from "../../../shared/windows-cmd-shim-test-fixtures.js";
 import {
+  ensurePlatformPathDefaults,
   resolveSpawnCommand,
   spawnAndCollect,
   type SpawnCommandCache,
@@ -230,6 +231,53 @@ describe("resolveSpawnCommand", () => {
     expect(second.command).toBe("C:\\node\\node.exe");
     expect(first.args[0]).toBe(scriptPath);
     expect(second.args[0]).toBe(scriptPath);
+  });
+});
+
+describe("ensurePlatformPathDefaults", () => {
+  it("adds macOS system admin paths when missing", () => {
+    const env = ensurePlatformPathDefaults(
+      {
+        PATH: "/usr/local/bin:/usr/bin:/bin",
+      },
+      "darwin",
+    );
+
+    expect(env.PATH?.split(path.delimiter)).toEqual([
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+    ]);
+  });
+
+  it("does not duplicate macOS system admin paths when already present", () => {
+    const env = ensurePlatformPathDefaults(
+      {
+        PATH: "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      },
+      "darwin",
+    );
+
+    expect(env.PATH?.split(path.delimiter)).toEqual([
+      "/usr/local/bin",
+      "/usr/sbin",
+      "/usr/bin",
+      "/sbin",
+      "/bin",
+    ]);
+  });
+
+  it("leaves non-macOS paths unchanged", () => {
+    const env = ensurePlatformPathDefaults(
+      {
+        PATH: "/usr/local/bin:/usr/bin:/bin",
+      },
+      "linux",
+    );
+
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin");
   });
 });
 

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
+import path from "node:path";
 import type {
   WindowsSpawnProgram,
   WindowsSpawnProgramCandidate,
@@ -122,6 +123,27 @@ function createAbortError(): Error {
   return error;
 }
 
+export function ensurePlatformPathDefaults(
+  env: NodeJS.ProcessEnv,
+  runtimePlatform: NodeJS.Platform = process.platform,
+): NodeJS.ProcessEnv {
+  const nextEnv = { ...env };
+  if (runtimePlatform === "darwin") {
+    const current = nextEnv.PATH ?? "";
+    const parts = current
+      .split(path.delimiter)
+      .map((part) => part.trim())
+      .filter(Boolean);
+    for (const required of ["/usr/sbin", "/sbin"]) {
+      if (!parts.includes(required)) {
+        parts.push(required);
+      }
+    }
+    nextEnv.PATH = parts.join(path.delimiter);
+  }
+  return nextEnv;
+}
+
 export function spawnWithResolvedCommand(
   params: {
     command: string;
@@ -139,9 +161,11 @@ export function spawnWithResolvedCommand(
     options,
   );
 
-  const childEnv = omitEnvKeysCaseInsensitive(
-    process.env,
-    params.stripProviderAuthEnvVars ? listKnownProviderAuthEnvVarNames() : [],
+  const childEnv = ensurePlatformPathDefaults(
+    omitEnvKeysCaseInsensitive(
+      process.env,
+      params.stripProviderAuthEnvVars ? listKnownProviderAuthEnvVarNames() : [],
+    ),
   );
   childEnv.OPENCLAW_SHELL = "acp";
 

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -1,6 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
-import path from "node:path";
 import type {
   WindowsSpawnProgram,
   WindowsSpawnProgramCandidate,
@@ -131,7 +130,7 @@ export function ensurePlatformPathDefaults(
   if (runtimePlatform === "darwin") {
     const current = nextEnv.PATH ?? "";
     const parts = current
-      .split(path.delimiter)
+      .split(":")
       .map((part) => part.trim())
       .filter(Boolean);
     for (const required of ["/usr/sbin", "/sbin"]) {
@@ -139,7 +138,7 @@ export function ensurePlatformPathDefaults(
         parts.push(required);
       }
     }
-    nextEnv.PATH = parts.join(path.delimiter);
+    nextEnv.PATH = parts.join(":");
   }
   return nextEnv;
 }


### PR DESCRIPTION
## Summary
- preserve `/usr/sbin` and `/sbin` in the spawned child PATH on macOS
- prevent `acpx opencode sessions ensure/new` from silently returning exit 0 with empty stdout under the gateway runtime environment
- add focused unit coverage for the PATH-normalization helper

## Problem
On macOS, the gateway runtime can launch ACPX children with a PATH that omits `/usr/sbin:/sbin`.

That breaks `acpx opencode sessions ensure/new` in a particularly nasty way: the command exits successfully but emits no JSON, so ACP session init fails with:

`ACP session init failed: neither 'sessions ensure' nor 'sessions new' returned valid session identifiers ...`

Direct `acpx` invocation from an interactive shell still works, which makes the bug look like an OpenCode auth/session problem when it is really an environment propagation bug.

## Fix
Normalize the child PATH on macOS before spawning and append `/usr/sbin` and `/sbin` when they are missing.

## Verification
- reproduced the failure through the installed OpenClaw ACP runtime on macOS
- verified direct `acpx` succeeded with a fuller PATH and failed with the stripped gateway-like PATH
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/acpx/src/runtime-internals/process.test.ts`
