### PR TITLE
fix(docker): copy src/ into runtime image for tsx-based extension loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,7 @@ COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules
 COPY --from=runtime-assets --chown=node:node /app/package.json .
 COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
 COPY --from=runtime-assets --chown=node:node /app/extensions ./extensions
+COPY --from=runtime-assets --chown=node:node /app/src ./src
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,7 @@ COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules
 COPY --from=runtime-assets --chown=node:node /app/package.json .
 COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
 COPY --from=runtime-assets --chown=node:node /app/extensions ./extensions
-COPY --from=runtime-assets --chown=node:node /app/src ./src
+COPY --from=runtime-assets --chown=node:node /app/src/infra/outbound ./src/infra/outbound
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
 


### PR DESCRIPTION
## Problem

After commit d9c285e93 (Mar 14) refactored `resolveOutboundSendDep` into `src/infra/outbound/send-deps.ts`, all channel extensions now import from a `src/` relative path:

```ts
import { resolveOutboundSendDep } from "../../../src/infra/outbound/send-deps.js";
```

Extensions are loaded at runtime via **tsx** (TypeScript execute), which resolves imports relative to the extension source file. In a Docker container, the runtime stage only copies `dist/`, `node_modules/`, and `extensions/` — but **not `src/`** — so the import fails:

```
Error: Cannot find module '/app/src/infra/outbound/send-deps.js'
```

Affects all channel extensions: Discord, Telegram, WhatsApp, Slack, Signal, iMessage, Matrix, MSTeams.

Reported in #47260.

## Fix

Add `src/` to the runtime-stage `COPY` directives (one line):

```diff
  COPY --from=runtime-assets --chown=node:node /app/extensions ./extensions
+ COPY --from=runtime-assets --chown=node:node /app/src ./src
  COPY --from=runtime-assets --chown=node:node /app/skills ./skills
```

This matches how tsx resolves TypeScript source imports at runtime — the same pattern already works in non-Docker deployments where `src/` is present alongside `extensions/`.

## Verification

Build the Docker image from source and start a container with any channel extension configured. Extensions load without module resolution errors.