### PR TITLE
fix(skills): use skill source to determine bundled status instead of name

### DIFF
--- a/src/agents/skills-status.test.ts
+++ b/src/agents/skills-status.test.ts
@@ -76,15 +76,10 @@ describe("buildWorkspaceSkillStatus", () => {
 
     expect(report.skills).toHaveLength(2);
 
-    const workspaceResult = report.skills.find(
-      (s) => s.skill.source === "openclaw-workspace",
-    );
-    const bundledResult = report.skills.find(
-      (s) => s.skill.source === "openclaw-bundled",
-    );
+    const workspaceResult = report.skills.find((s) => s.source === "openclaw-workspace");
+    const bundledResult = report.skills.find((s) => s.source === "openclaw-bundled");
 
     expect(workspaceResult?.bundled).toBe(false);
     expect(bundledResult?.bundled).toBe(true);
   });
 });
-

--- a/src/agents/skills-status.test.ts
+++ b/src/agents/skills-status.test.ts
@@ -40,4 +40,51 @@ describe("buildWorkspaceSkillStatus", () => {
     expect(report.skills).toHaveLength(1);
     expect(report.skills[0]?.install).toEqual([]);
   });
+
+  it("marks skill as bundled only when source is openclaw-bundled, not by name", () => {
+    // Regression test for #47139: workspace skills with same name as a bundled skill
+    // were incorrectly displayed as "bundled" in the Control Panel.
+    const workspaceSkillWithBundledName: SkillEntry = {
+      skill: {
+        name: "summarize", // same name as a bundled skill
+        description: "summarize from workspace",
+        source: "openclaw-workspace", // but sourced from workspace
+        filePath: "/workspace/skills/summarize/SKILL.md",
+        baseDir: "/workspace/skills/summarize",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+      metadata: {},
+    };
+
+    const bundledSkillWithSameName: SkillEntry = {
+      skill: {
+        name: "summarize",
+        description: "summarize bundled",
+        source: "openclaw-bundled",
+        filePath: "/bundled/summarize/SKILL.md",
+        baseDir: "/bundled/summarize",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+      metadata: {},
+    };
+
+    const report = buildWorkspaceSkillStatus("/tmp/ws", {
+      entries: [workspaceSkillWithBundledName, bundledSkillWithSameName],
+    });
+
+    expect(report.skills).toHaveLength(2);
+
+    const workspaceResult = report.skills.find(
+      (s) => s.skill.source === "openclaw-workspace",
+    );
+    const bundledResult = report.skills.find(
+      (s) => s.skill.source === "openclaw-bundled",
+    );
+
+    expect(workspaceResult?.bundled).toBe(false);
+    expect(bundledResult?.bundled).toBe(true);
+  });
 });
+

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -171,7 +171,6 @@ function buildSkillStatus(
   config?: OpenClawConfig,
   prefs?: SkillsInstallPreferences,
   eligibility?: SkillEligibilityContext,
-  bundledNames?: Set<string>,
 ): SkillStatusEntry {
   const skillKey = resolveSkillKey(entry);
   const skillConfig = resolveSkillConfig(config, skillKey);
@@ -186,10 +185,7 @@ function buildSkillStatus(
       (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
     );
   const isConfigSatisfied = (pathStr: string) => isConfigPathTruthy(config, pathStr);
-  const bundled =
-    bundledNames && bundledNames.size > 0
-      ? bundledNames.has(entry.skill.name)
-      : entry.skill.source === "openclaw-bundled";
+  const bundled = entry.skill.source === "openclaw-bundled";
 
   const { emoji, homepage, required, missing, requirementsSatisfied, configChecks } =
     evaluateEntryRequirementsForCurrentPlatform({
@@ -247,7 +243,7 @@ export function buildWorkspaceSkillStatus(
     workspaceDir,
     managedSkillsDir,
     skills: skillEntries.map((entry) =>
-      buildSkillStatus(entry, opts?.config, prefs, opts?.eligibility, bundledContext.names),
+      buildSkillStatus(entry, opts?.config, prefs, opts?.eligibility),
     ),
   };
 }


### PR DESCRIPTION
## Problem

Control Panel shows workspace skills as "bundled" when they share a name with a built-in skill. For example, after installing `summarize` from ClawHub into the workspace directory, the Control Panel still shows it as "bundled" instead of "workspace".

Reported in #47139.

## Root Cause

`buildSkillStatus` resolved the `bundled` flag by checking if the skill name appeared in `bundledNames` (a set of bundled skill names):

```typescript
const bundled =
  bundledNames && bundledNames.size > 0
    ? bundledNames.has(entry.skill.name)   // ← matches by name only
    : entry.skill.source === "openclaw-bundled";
```

A workspace skill with the same name as a bundled skill would be classified as `bundled: true`, regardless of its actual source.

## Fix

Use `entry.skill.source === "openclaw-bundled"` exclusively. The `source` field is set at load time based on the actual directory the skill was loaded from — it is the canonical, authoritative source of truth and is not affected by name collisions.

```diff
- const bundled =
-   bundledNames && bundledNames.size > 0
-     ? bundledNames.has(entry.skill.name)
-     : entry.skill.source === "openclaw-bundled";
+ const bundled = entry.skill.source === "openclaw-bundled";
```

Also removes the now-unused `bundledNames` parameter from `buildSkillStatus`.

## Tests

Added regression test: workspace and bundled skills with the same name are both classified correctly by source.