### PR TITLE
fix(webchat): include provider prefix in model dropdown values (closes #47192)

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -574,8 +574,16 @@ function buildChatModelOptions(
     addOption(option.value, option.label);
   }
 
+  // Check if currentOverride is a bare model ID that matches a catalog entry.
+  // If so, don't add it again — the qualified version is already in the list.
   if (currentOverride) {
-    addOption(currentOverride);
+    const bareMatch = catalog.find((entry) => {
+      const provider = entry.provider?.trim();
+      return provider && currentOverride.trim() === entry.id.trim();
+    });
+    if (!bareMatch) {
+      addOption(currentOverride);
+    }
   }
   if (defaultModel) {
     addOption(defaultModel);

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -613,7 +613,13 @@ function renderChatModelSelect(state: AppViewState) {
           options,
           (entry) => entry.value,
           (entry) =>
-            html`<option value=${entry.value} ?selected=${entry.value === currentOverride}>
+            html`<option
+              value=${entry.value}
+              ?selected=${
+                entry.value === currentOverride ||
+                (currentOverride && entry.value.endsWith(`/${currentOverride}`))
+              }
+            >
               ${entry.label}
             </option>`,
         )}


### PR DESCRIPTION
## Problem
The webchat model picker was sending bare model IDs (e.g., `qwen2.5:7b`) to the backend without the provider prefix. When the backend's `resolveAllowedModelRef` received a bare ID, it would default to prepending `anthropic/` if no other provider was specified, causing selection of non-Anthropic models like Ollama to fail with 'model not allowed' errors.

## Solution
- **buildChatModelOptions**: Set dropdown option values to include the provider prefix in `provider/model` format (e.g., `ollama/qwen2.5:7b`), while keeping display labels unchanged for clarity
- **renderChatModelSelect**: Add backward-compatible matching using `endsWith` to handle old sessions that still store bare model IDs
- **Tests**: Updated to expect the prefixed model format

## Changes
- ui/src/ui/app-render.helpers.ts: 
  - Construct option values with provider prefix
  - Add endsWith fallback for legacy session compatibility
- ui/src/ui/views/chat.test.ts:
  - Update assertions to expect prefixed model format
  - Add backward-compatibility test

Fixes #47192