### PR TITLE
fix(config): preserve $schema field across config rewrites

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -47,6 +47,16 @@ describe("$schema key in config (#14998)", () => {
     });
     expect(result.ok).toBe(true);
   });
+
+  it("preserves $schema through validateConfigObject round-trip", () => {
+    const res = validateConfigObject({
+      $schema: "https://openclaw.ai/config.json",
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.$schema).toBe("https://openclaw.ai/config.json");
+    }
+  });
 });
 
 describe("plugins.slots.contextEngine", () => {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1469,6 +1469,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         runtimeConfig: snapshot.config,
         sourceConfig: snapshot.resolved,
         nextConfig: cfg,
+        rootAuthoredConfig: snapshot.parsed,
       });
       try {
         const resolvedIncludes = resolveConfigIncludes(snapshot.parsed, configPath, {

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -226,6 +226,41 @@ describe("config io write", () => {
     });
   });
 
+  it("does not inject include-only $schema into the root config during partial writes", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const includePath = path.join(home, ".openclaw", "extra.json5");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        includePath,
+        `${JSON.stringify({ $schema: "https://openclaw.ai/config-from-include.json" }, null, 2)}\n`,
+        "utf-8",
+      );
+      await fs.writeFile(
+        configPath,
+        `{\n  "$include": "./extra.json5",\n  "gateway": { "mode": "local" }\n}\n`,
+        "utf-8",
+      );
+
+      const io = createConfigIO({
+        env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+
+      await io.writeConfigFile({
+        gateway: { mode: "local", port: 18789 },
+      });
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        $schema?: string;
+        gateway?: { mode?: string; port?: number };
+      };
+      expect(persisted).not.toHaveProperty("$schema");
+      expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
+    });
+  });
+
   it("writes disabled plugin entries without requiring plugin config", async () => {
     mockLoadPluginManifestRegistry.mockReturnValue({
       diagnostics: [],

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -190,6 +190,42 @@ describe("config io write", () => {
     });
   });
 
+  it("preserves root $schema during partial writes", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            $schema: "https://openclaw.ai/config.json",
+            gateway: { mode: "local" },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      const io = createConfigIO({
+        env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+
+      await io.writeConfigFile({
+        gateway: { mode: "local", port: 18789 },
+      });
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        $schema?: string;
+        gateway?: { mode?: string; port?: number };
+      };
+      expect(persisted.$schema).toBe("https://openclaw.ai/config.json");
+      expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
+    });
+  });
+
   it("writes disabled plugin entries without requiring plugin config", async () => {
     mockLoadPluginManifestRegistry.mockReturnValue({
       diagnostics: [],

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -433,4 +433,42 @@ describe("config io write prepare", () => {
     expect(persisted.$schema).toBe("https://openclaw.ai/config.json");
     expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
   });
+
+  it("does not restore root $schema when the next config explicitly clears it", () => {
+    const sourceConfig = {
+      $schema: "https://openclaw.ai/config.json",
+      gateway: { mode: "local" },
+    };
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig: sourceConfig,
+      sourceConfig,
+      nextConfig: {
+        $schema: null,
+        gateway: { mode: "local", port: 18789 },
+      },
+    }) as Record<string, unknown>;
+
+    expect(persisted).not.toHaveProperty("$schema");
+    expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
+  });
+
+  it("does not restore root $schema when the next config sets an invalid value", () => {
+    const sourceConfig = {
+      $schema: "https://openclaw.ai/config.json",
+      gateway: { mode: "local" },
+    };
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig: sourceConfig,
+      sourceConfig,
+      nextConfig: {
+        $schema: 123,
+        gateway: { mode: "local", port: 18789 },
+      },
+    }) as Record<string, unknown>;
+
+    expect(persisted.$schema).toBe(123);
+    expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
+  });
 });

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -415,4 +415,22 @@ describe("config io write prepare", () => {
       enabled: false,
     });
   });
+
+  it("preserves root $schema during unrelated partial writes", () => {
+    const sourceConfig: OpenClawConfig = {
+      $schema: "https://openclaw.ai/config.json",
+      gateway: { mode: "local" },
+    } satisfies OpenClawConfig;
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig: sourceConfig,
+      sourceConfig,
+      nextConfig: {
+        gateway: { mode: "local", port: 18789 },
+      } satisfies OpenClawConfig,
+    }) as OpenClawConfig;
+
+    expect(persisted.$schema).toBe("https://openclaw.ai/config.json");
+    expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
+  });
 });

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -434,6 +434,28 @@ describe("config io write prepare", () => {
     expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
   });
 
+  it("does not preserve include-only $schema into the root persisted candidate", () => {
+    const sourceConfig = {
+      $schema: "https://openclaw.ai/config-from-include.json",
+      gateway: { mode: "local" },
+    };
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig: sourceConfig,
+      sourceConfig,
+      rootAuthoredConfig: {
+        $include: "./extra.json5",
+        gateway: { mode: "local" },
+      },
+      nextConfig: {
+        gateway: { mode: "local", port: 18789 },
+      },
+    }) as Record<string, unknown>;
+
+    expect(persisted).not.toHaveProperty("$schema");
+    expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
+  });
+
   it("does not restore root $schema when the next config explicitly clears it", () => {
     const sourceConfig = {
       $schema: "https://openclaw.ai/config.json",

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -65,12 +65,13 @@ export function resolvePersistCandidateForWrite(params: {
   runtimeConfig: unknown;
   sourceConfig: unknown;
   nextConfig: unknown;
+  rootAuthoredConfig?: unknown;
 }): unknown {
   const patch = createMergePatch(params.runtimeConfig, params.nextConfig);
   const projectedSource = projectSourceOntoRuntimeShape(params.sourceConfig, params.runtimeConfig);
   const persisted = applyMergePatch(projectedSource, patch);
   return preserveRootSchemaUri({
-    sourceConfig: params.sourceConfig,
+    rootAuthoredConfig: params.rootAuthoredConfig ?? params.sourceConfig,
     nextConfig: params.nextConfig,
     persistedCandidate: persisted,
   });
@@ -88,14 +89,14 @@ function hasOwnRootSchemaKey(value: unknown): boolean {
 }
 
 function preserveRootSchemaUri(params: {
-  sourceConfig: unknown;
+  rootAuthoredConfig: unknown;
   nextConfig: unknown;
   persistedCandidate: unknown;
 }): unknown {
   if (hasOwnRootSchemaKey(params.nextConfig)) {
     return params.persistedCandidate;
   }
-  const sourceSchema = readRootSchemaUri(params.sourceConfig);
+  const sourceSchema = readRootSchemaUri(params.rootAuthoredConfig);
   if (sourceSchema === undefined || !isRecord(params.persistedCandidate)) {
     return params.persistedCandidate;
   }

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -83,13 +83,16 @@ function readRootSchemaUri(value: unknown): string | undefined {
   return value.$schema;
 }
 
+function hasOwnRootSchemaKey(value: unknown): boolean {
+  return isRecord(value) && Object.prototype.hasOwnProperty.call(value, "$schema");
+}
+
 function preserveRootSchemaUri(params: {
   sourceConfig: unknown;
   nextConfig: unknown;
   persistedCandidate: unknown;
 }): unknown {
-  const nextSchema = readRootSchemaUri(params.nextConfig);
-  if (nextSchema !== undefined) {
+  if (hasOwnRootSchemaKey(params.nextConfig)) {
     return params.persistedCandidate;
   }
   const sourceSchema = readRootSchemaUri(params.sourceConfig);

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -68,7 +68,38 @@ export function resolvePersistCandidateForWrite(params: {
 }): unknown {
   const patch = createMergePatch(params.runtimeConfig, params.nextConfig);
   const projectedSource = projectSourceOntoRuntimeShape(params.sourceConfig, params.runtimeConfig);
-  return applyMergePatch(projectedSource, patch);
+  const persisted = applyMergePatch(projectedSource, patch);
+  return preserveRootSchemaUri({
+    sourceConfig: params.sourceConfig,
+    nextConfig: params.nextConfig,
+    persistedCandidate: persisted,
+  });
+}
+
+function readRootSchemaUri(value: unknown): string | undefined {
+  if (!isRecord(value) || typeof value.$schema !== "string") {
+    return undefined;
+  }
+  return value.$schema;
+}
+
+function preserveRootSchemaUri(params: {
+  sourceConfig: unknown;
+  nextConfig: unknown;
+  persistedCandidate: unknown;
+}): unknown {
+  const nextSchema = readRootSchemaUri(params.nextConfig);
+  if (nextSchema !== undefined) {
+    return params.persistedCandidate;
+  }
+  const sourceSchema = readRootSchemaUri(params.sourceConfig);
+  if (sourceSchema === undefined || !isRecord(params.persistedCandidate)) {
+    return params.persistedCandidate;
+  }
+  return {
+    ...params.persistedCandidate,
+    $schema: sourceSchema,
+  };
 }
 
 export function formatConfigValidationFailure(pathLabel: string, issueMessage: string): string {

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -30,6 +30,8 @@ import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
 export type OpenClawConfig = {
+  /** JSON Schema URL for editor tooling (VS Code, etc.). Preserved across config rewrites. */
+  $schema?: string;
   meta?: {
     /** Last OpenClaw version that wrote this config. */
     lastTouchedVersion?: string;


### PR DESCRIPTION
## Summary

Preserves the root `$schema` field in `openclaw.json` when the gateway rewrites config during hot-reload or `config set`, so JSON Schema editor tooling keeps working.

Closes #43578

## Root cause

There were two gaps:

1. The root config type accepted by the write paths did not include `$schema`, even though the validation schema already did.
2. Partial config writes rebuilt the persisted config from the runtime/source snapshots in a way that dropped `$schema` when callers updated unrelated fields.

## Fix

- Add `$schema?: string` to `OpenClawConfig`
- Preserve the root `$schema` value during partial/unrelated writes when the caller omits the key
- Do not preserve it when the caller explicitly clears it or provides an invalid value, so write-time validation can still behave correctly
- Add regression coverage for validation round-trip, write-prepare merge behavior, and on-disk partial writes

## Test plan

- [x] `pnpm exec vitest run --config test/vitest/vitest.runtime-config.config.ts src/config/io.write-prepare.test.ts src/config/io.write-config.test.ts src/config/config-misc.test.ts`
- [x] Manual repro: start with a config containing `$schema`, run a partial `writeConfigFile(...)`, and verify `$schema` remains in the persisted file
- [x] Manual helper repro: confirm omission preserves `$schema`, explicit `null` clears it, and explicit invalid values remain invalid for later validation
