### PR TITLE
fix: add extensionAPI to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
       "types": "./dist/plugin-sdk/keyed-async-queue.d.ts",
       "default": "./dist/plugin-sdk/keyed-async-queue.js"
     },
+    "./extensionAPI": "./dist/extensionAPI.js",
     "./cli-entry": "./openclaw.mjs"
   },
   "scripts": {


### PR DESCRIPTION
Fixes #45551

## Problem

The `extensionAPI.js` module exists in `dist/` but was not exposed in the `exports` field, causing Node's ESM resolver to reject imports with `ERR_PACKAGE_PATH_NOT_EXPORTED`. This caused plugins that depend on the embedded runtime API (like `memory-lancedb-pro`) to fail and fall back to CLI execution.

## Solution

Add `"./extensionAPI": "./dist/extensionAPI.js"` to the exports field in package.json.

## Testing

- Verified `dist/extensionAPI.js` exists in the build output
- Confirmed the export path resolves correctly

## Workaround (before this fix)

Users could set the environment variable:
```bash
export OPENCLAW_EXTENSION_API_PATH=/path/to/openclaw/dist/extensionAPI.js
```