### PR TITLE
fix(slack): check interactiveReplies capability for inline buttons prompt

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -571,6 +571,19 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("`style` can be `primary`, `success`, or `danger`");
   });
 
+  it("enables inline buttons for Slack when interactiveReplies capability is set (#46647)", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["message"],
+      runtimeInfo: {
+        channel: "slack",
+        capabilities: ["interactiveReplies"],
+      },
+    });
+
+    expect(prompt).toContain("buttons=[[{text,callback_data,style?}]]");
+  });
+
   it("includes runtime provider capabilities when present", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -374,7 +374,9 @@ export function buildAgentSystemPrompt(params: {
     .map((cap) => String(cap).trim())
     .filter(Boolean);
   const runtimeCapabilitiesLower = new Set(runtimeCapabilities.map((cap) => cap.toLowerCase()));
-  const inlineButtonsEnabled = runtimeCapabilitiesLower.has("inlinebuttons");
+  const inlineButtonsEnabled =
+    runtimeCapabilitiesLower.has("inlinebuttons") ||
+    (runtimeChannel === "slack" && runtimeCapabilitiesLower.has("interactivereplies"));
   const messageChannelOptions = listDeliverableMessageChannels().join("|");
   const promptMode = params.promptMode ?? "full";
   const isMinimal = promptMode === "minimal" || promptMode === "none";


### PR DESCRIPTION
## Summary

Fixes system prompt incorrectly telling agents that inline buttons are not enabled for Slack when using the object config form `{ interactiveReplies: true }`.

Closes #46647

## Root cause

`system-prompt.ts` line 377 only checked `runtimeCapabilitiesLower.has("inlinebuttons")`, but the Slack interactive reply pipeline is gated on the `interactiveReplies` capability. When using the object config form, `interactiveReplies` is set but `inlineButtons` is not in the capabilities array.

## Fix

```typescript
const inlineButtonsEnabled =
  runtimeCapabilitiesLower.has("inlinebuttons") ||
  (runtimeChannel === "slack" && runtimeCapabilitiesLower.has("interactivereplies"));
```

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm test -- src/agents/system-prompt.test.ts` — 43 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)