### PR TITLE
feat: add runtime="claude-code" with session continuation support

### DIFF
--- a/docs/claude-code-runtime.md
+++ b/docs/claude-code-runtime.md
@@ -1,0 +1,224 @@
+# runtime="claude-code" 使用说明
+
+## 概述
+
+`runtime="claude-code"` 是 openclaw 的新运行时选项，允许在独立的工作空间会话中异步执行 Claude Code CLI 任务。
+
+## 与其他 runtime 的对比
+
+| 特性         | subagent   | acp  | claude-code   |
+| ------------ | ---------- | ---- | ------------- |
+| 执行方式     | 同步       | 异步 | 异步          |
+| 工作空间隔离 | 继承父进程 | 独立 | 独立 (按 cwd) |
+| 会话持久化   | 否         | 是   | 是            |
+| 并发支持     | 受限       | 受限 | 完全支持      |
+| 附件支持     | 是         | 否   | 否            |
+
+## 基本用法
+
+### 工具调用
+
+```
+sessions_spawn(
+  task: "你的任务描述",
+  runtime: "claude-code",
+  cwd: "/path/to/workspace",
+  mode: "run" | "session",
+  label: "可选标签",
+  timeoutSeconds: 300
+)
+```
+
+### 参数说明
+
+| 参数             | 类型    | 必需 | 说明                                  |
+| ---------------- | ------- | ---- | ------------------------------------- |
+| `task`           | string  | ✅   | 要执行的任务描述                      |
+| `runtime`        | string  | ✅   | 固定为 `"claude-code"`                |
+| `cwd`            | string  | ❌   | 工作目录，默认当前目录                |
+| `mode`           | string  | ❌   | `"run"` 一次性 / `"session"` 持久会话 |
+| `label`          | string  | ❌   | 任务标签，用于识别                    |
+| `timeoutSeconds` | number  | ❌   | 超时时间（秒）                        |
+| `thread`         | boolean | ❌   | 是否恢复已有会话                      |
+
+## 工作原理
+
+### 会话隔离
+
+每个 `cwd` 对应一个独立的 Claude Code 会话：
+
+```
+cwd: /project/A  →  session: agent:claude-code:workspace:a1b2c3d4
+cwd: /project/B  →  session: agent:claude-code:workspace:e5f6g7h8
+```
+
+相同 `cwd` 的后续调用会复用已有会话（当 `thread=true` 或 `mode="session"` 时）。
+
+### 执行流程
+
+1. **注册任务** → 生成 `runId`
+2. **解析会话** → 按工作空间创建/复用会话
+3. **启动进程** → 调用 `claude` CLI
+4. **异步执行** → 父进程不阻塞
+5. **结果回调** → 完成后通知
+
+## 使用场景
+
+### 场景 1：一次性任务
+
+```
+sessions_spawn(
+  task: "分析代码库结构并生成 README",
+  runtime: "claude-code",
+  cwd: "/home/user/my-project",
+  mode: "run"
+)
+```
+
+执行完成后会话自动清理。
+
+### 场景 2：持续会话
+
+```
+# 首次调用
+sessions_spawn(
+  task: "帮我实现用户认证功能",
+  runtime: "claude-code",
+  cwd: "/home/user/my-project",
+  mode: "session"
+)
+
+# 后续调用（继续同一会话）
+sessions_spawn(
+  task: "现在添加密码重置功能",
+  runtime: "claude-code",
+  cwd: "/home/user/my-project",
+  thread: true
+)
+```
+
+会话会保持，可跨多次调用。
+
+### 场景 3：并行任务
+
+```
+# 同时启动多个独立任务
+sessions_spawn(task: "修复 bug #123", runtime: "claude-code", cwd: "/project/A")
+sessions_spawn(task: "实现 feature #456", runtime: "claude-code", cwd: "/project/B")
+sessions_spawn(task: "编写测试用例", runtime: "claude-code", cwd: "/project/C")
+```
+
+## 返回值
+
+```json
+{
+  "status": "accepted",
+  "childSessionKey": "agent:claude-code:workspace:a1b2c3d4",
+  "runId": "550e8400-e29b-41d4-a716-446655440000",
+  "mode": "run",
+  "note": "Claude Code task queued in isolated workspace session; results will be announced when complete."
+}
+```
+
+| 字段              | 说明                               |
+| ----------------- | ---------------------------------- |
+| `status`          | `accepted` / `forbidden` / `error` |
+| `childSessionKey` | 子会话标识                         |
+| `runId`           | 任务 ID，用于追踪                  |
+| `mode`            | 实际执行模式                       |
+| `note`            | 状态说明                           |
+
+## 限制
+
+1. **沙箱环境限制**：沙箱会话无法调用 `claude-code`（需要主机环境）
+2. **附件不支持**：暂不支持传递附件
+3. **需要 Claude CLI**：系统需安装 `claude` 命令行工具
+
+## 配置
+
+可在 `openclaw.config.toml` 中自定义：
+
+```toml
+[agents.defaults.cliBackends.claude-code]
+command = "claude"
+args = ["--non-interactive", "--output-format", "json", "--permission-mode", "bypassPermissions"]
+```
+
+## 会话延续机制
+
+### 工作原理
+
+当使用 `thread=true` 或 `mode="session"` 时，系统会尝试恢复已有的 Claude Code 会话：
+
+1. **查找会话**：根据 `cwd` 路径查找已存储的 Claude Session ID
+2. **恢复会话**：使用 `--resume` 参数恢复对话上下文
+3. **保存会话**：执行完成后更新会话信息
+
+### 关键区别
+
+| 参数           | 用途                     | 上下文   |
+| -------------- | ------------------------ | -------- |
+| `--session-id` | 创建新会话时指定 ID      | 全新会话 |
+| `--resume`     | 恢复已有会话，保留上下文 | 延续会话 |
+
+**重要**：只有使用 `--resume` 才能真正恢复会话上下文。`--session-id` 只是给新会话指定一个 ID，不会保留之前的对话记忆。
+
+### 验证会话延续
+
+```bash
+# 第一次调用
+sessions_spawn(
+  task: "记住数字 123",
+  runtime: "claude-code",
+  cwd: "/tmp/test-project",
+  mode: "session"
+)
+
+# 第二次调用（应该记得 123）
+sessions_spawn(
+  task: "我之前让你记住的数字是什么？",
+  runtime: "claude-code",
+  cwd: "/tmp/test-project",
+  thread: true
+)
+```
+
+如果会话延续正常工作，第二次调用应该能正确回答 "123"。
+
+### 会话存储位置
+
+Claude CLI 的会话 ID 映射存储在：
+
+```
+~/.openclaw/claude-code-sessions.json
+```
+
+每个工作空间路径通过 SHA-256 哈希映射到对应的 Claude Session ID：
+
+```bash
+# 查看所有 session
+cat ~/.openclaw/claude-code-sessions.json | jq '.sessions'
+
+# 验证特定路径的 session
+path="/your/project/path"
+hash=$(echo -n "$(cd "$path" && pwd)" | sha256sum | cut -c1-16)
+cat ~/.openclaw/claude-code-sessions.json | jq --arg h "$hash" '.sessions[$h]'
+```
+
+## 架构说明
+
+### 文件结构
+
+```
+src/agents/
+├── claude-code-spawn.ts      # 主要 spawn 函数
+├── claude-code-sessions.ts   # 会话隔离逻辑
+├── claude-code-registry.ts   # 进程状态管理
+└── tools/
+    └── sessions-spawn-tool.ts # 工具入口（已添加 runtime 选项）
+```
+
+### 与现有系统集成
+
+- **cli-backends.ts**: 新增 `DEFAULT_CLAUDE_CODE_BACKEND` 配置
+- **sessions-spawn-tool.ts**: `SESSIONS_SPAWN_RUNTIMES` 已扩展为 `["subagent", "acp", "claude-code"]`

--- a/docs/claude-code-runtime.md
+++ b/docs/claude-code-runtime.md
@@ -222,3 +222,62 @@ src/agents/
 
 - **cli-backends.ts**: 新增 `DEFAULT_CLAUDE_CODE_BACKEND` 配置
 - **sessions-spawn-tool.ts**: `SESSIONS_SPAWN_RUNTIMES` 已扩展为 `["subagent", "acp", "claude-code"]`
+
+## 错误处理与状态管理
+
+### 进程状态流转
+
+任务执行过程中状态流转如下：
+
+```
+pending → running → completed | error | timeout
+```
+
+### 中止处理
+
+当调用 `abortClaudeCodeRun(runId)` 时：
+
+1. 设置 `status = "error"` 和 `outcome = { error: "Aborted by user" }`
+2. 发送 SIGTERM 信号终止进程
+3. 进程退出时保留 abort 设置的状态（不会被覆盖）
+
+### 超时处理
+
+当任务超过 `timeoutSeconds` 时：
+
+1. 设置 `status = "timeout"` 和 `outcome = { status: "timeout" }`
+2. 发送 SIGTERM 信号终止进程
+3. 进程退出时保留 timeout 设置的状态
+
+### 通知机制
+
+任务完成后，系统会通过 `runSubagentAnnounceFlow` 发送通知：
+
+- 通知会显示正确的请求者 session 名称（`requesterDisplayKey`）
+- 通过 `resolveDisplaySessionKey` 解析用户友好的 session 标识
+- 主 session 显示为 "main"，其他 session 显示完整 key
+
+## CLI 输出解析
+
+### Session ID 提取
+
+Claude CLI 输出可能包含多个 JSON 对象，系统会逐行解析：
+
+```
+{"type":"text","text":"Hello"}        ← 跳过（无 session_id）
+{"session_id":"abc-123","result":"ok"} ← 提取 session_id
+```
+
+支持的 session ID 字段名（按优先级）：
+
+1. `session_id`
+2. `sessionId`
+3. `conversation_id`
+4. `conversationId`
+
+### 解析逻辑
+
+1. 尝试将整个输出解析为单个 JSON
+2. 失败则逐行查找以 `{` 开头的行
+3. 对每行尝试 JSON 解析并提取 session ID
+4. 返回第一个找到的有效 session ID

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -31,16 +31,26 @@ import {
   type SessionBindingRecord,
 } from "../infra/outbound/session-binding-service.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import {
   type AcpSpawnParentRelayHandle,
   resolveAcpSpawnStreamLogPath,
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import {
+  extractRequesterOrigin,
+  resolveSpawnMode,
+  summarizeError,
+  type SpawnBaseContext,
+  type SpawnBaseResult,
+  type SpawnMode,
+  SPAWN_MODES,
+} from "./spawn-utils.js";
 
-export const ACP_SPAWN_MODES = ["run", "session"] as const;
-export type SpawnAcpMode = (typeof ACP_SPAWN_MODES)[number];
+// Re-export spawn mode types for backward compatibility
+export { SPAWN_MODES, type SpawnMode };
+export const ACP_SPAWN_MODES = SPAWN_MODES;
+export type SpawnAcpMode = SpawnMode;
 export const ACP_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 export type SpawnAcpSandboxMode = (typeof ACP_SPAWN_SANDBOX_MODES)[number];
 export const ACP_SPAWN_STREAM_TARGETS = ["parent"] as const;
@@ -57,23 +67,10 @@ export type SpawnAcpParams = {
   streamTo?: SpawnAcpStreamTarget;
 };
 
-export type SpawnAcpContext = {
-  agentSessionKey?: string;
-  agentChannel?: string;
-  agentAccountId?: string;
-  agentTo?: string;
-  agentThreadId?: string | number;
-  sandboxed?: boolean;
-};
+export type SpawnAcpContext = SpawnBaseContext;
 
-export type SpawnAcpResult = {
-  status: "accepted" | "forbidden" | "error";
-  childSessionKey?: string;
-  runId?: string;
-  mode?: SpawnAcpMode;
+export type SpawnAcpResult = SpawnBaseResult & {
   streamLogPath?: string;
-  note?: string;
-  error?: string;
 };
 
 export const ACP_SPAWN_ACCEPTED_NOTE =
@@ -108,17 +105,6 @@ type PreparedAcpThreadBinding = {
   conversationId: string;
 };
 
-function resolveSpawnMode(params: {
-  requestedMode?: SpawnAcpMode;
-  threadRequested: boolean;
-}): SpawnAcpMode {
-  if (params.requestedMode === "run" || params.requestedMode === "session") {
-    return params.requestedMode;
-  }
-  // Thread-bound spawns should default to persistent sessions.
-  return params.threadRequested ? "session" : "run";
-}
-
 function resolveAcpSessionMode(mode: SpawnAcpMode): AcpRuntimeSessionMode {
   return mode === "session" ? "persistent" : "oneshot";
 }
@@ -150,16 +136,6 @@ function normalizeOptionalAgentId(value: string | undefined | null): string | un
     return undefined;
   }
   return normalizeAgentId(trimmed);
-}
-
-function summarizeError(err: unknown): string {
-  if (err instanceof Error) {
-    return err.message;
-  }
-  if (typeof err === "string") {
-    return err;
-  }
-  return "error";
 }
 
 function resolveConversationIdForThreadBinding(params: {
@@ -423,12 +399,7 @@ export async function spawnAcpDirect(
     };
   }
 
-  const requesterOrigin = normalizeDeliveryContext({
-    channel: ctx.agentChannel,
-    accountId: ctx.agentAccountId,
-    to: ctx.agentTo,
-    threadId: ctx.agentThreadId,
-  });
+  const requesterOrigin = extractRequesterOrigin(ctx);
   // For thread-bound ACP spawns, force bootstrap delivery to the new child thread.
   const boundThreadIdRaw = binding?.conversation.conversationId;
   const boundThreadId = boundThreadIdRaw ? String(boundThreadIdRaw).trim() || undefined : undefined;

--- a/src/agents/claude-code-registry.test.ts
+++ b/src/agents/claude-code-registry.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  registerClaudeCodeRun,
+  getClaudeCodeRun,
+  listClaudeCodeRuns,
+  getClaudeCodeRunsBySession,
+  resetClaudeCodeRegistryForTests,
+  parseClaudeOutput,
+} from "./claude-code-registry.js";
+
+describe("claude-code-registry", () => {
+  beforeEach(() => {
+    resetClaudeCodeRegistryForTests();
+  });
+
+  afterEach(() => {
+    resetClaudeCodeRegistryForTests();
+  });
+
+  describe("registerClaudeCodeRun", () => {
+    it("should register a new run", () => {
+      const record = registerClaudeCodeRun({
+        runId: "test-run-1",
+        sessionKey: "agent:claude-code:workspace:abc123",
+        workspacePath: "/tmp/workspace",
+        task: "Test task",
+        cleanup: "keep",
+      });
+
+      expect(record.runId).toBe("test-run-1");
+      expect(record.status).toBe("pending");
+      expect(record.startedAt).toBeGreaterThan(0);
+    });
+  });
+
+  describe("getClaudeCodeRun", () => {
+    it("should return an existing run", () => {
+      registerClaudeCodeRun({
+        runId: "test-run-2",
+        sessionKey: "agent:claude-code:workspace:abc123",
+        workspacePath: "/tmp/workspace",
+        task: "Test task",
+        cleanup: "keep",
+      });
+
+      const record = getClaudeCodeRun("test-run-2");
+      expect(record).toBeDefined();
+      expect(record?.runId).toBe("test-run-2");
+    });
+
+    it("should return undefined for non-existent run", () => {
+      const record = getClaudeCodeRun("non-existent");
+      expect(record).toBeUndefined();
+    });
+  });
+
+  describe("listClaudeCodeRuns", () => {
+    it("should list all runs", () => {
+      registerClaudeCodeRun({
+        runId: "run-1",
+        sessionKey: "agent:claude-code:workspace:abc",
+        workspacePath: "/tmp/w1",
+        task: "Task 1",
+        cleanup: "keep",
+      });
+
+      registerClaudeCodeRun({
+        runId: "run-2",
+        sessionKey: "agent:claude-code:workspace:def",
+        workspacePath: "/tmp/w2",
+        task: "Task 2",
+        cleanup: "delete",
+      });
+
+      const runs = listClaudeCodeRuns();
+      expect(runs.length).toBe(2);
+    });
+  });
+
+  describe("getClaudeCodeRunsBySession", () => {
+    it("should return runs for a specific session", () => {
+      registerClaudeCodeRun({
+        runId: "run-1",
+        sessionKey: "session-a",
+        workspacePath: "/tmp/w1",
+        task: "Task 1",
+        cleanup: "keep",
+      });
+
+      registerClaudeCodeRun({
+        runId: "run-2",
+        sessionKey: "session-b",
+        workspacePath: "/tmp/w2",
+        task: "Task 2",
+        cleanup: "keep",
+      });
+
+      const runs = getClaudeCodeRunsBySession("session-a");
+      expect(runs.length).toBe(1);
+      expect(runs[0].runId).toBe("run-1");
+    });
+  });
+
+  describe("parseClaudeOutput", () => {
+    it("should parse session_id from valid JSON", () => {
+      const output = JSON.stringify({ session_id: "test-session-123", result: "done" });
+      const result = parseClaudeOutput(output);
+      expect(result).not.toBeNull();
+      expect(result?.session_id).toBe("test-session-123");
+    });
+
+    it("should parse sessionId (camelCase) from valid JSON", () => {
+      const output = JSON.stringify({ sessionId: "test-session-456", result: "done" });
+      const result = parseClaudeOutput(output);
+      expect(result).not.toBeNull();
+      expect(result?.session_id).toBe("test-session-456");
+    });
+
+    it("should parse conversation_id from valid JSON", () => {
+      const output = JSON.stringify({ conversation_id: "conv-789", result: "done" });
+      const result = parseClaudeOutput(output);
+      expect(result).not.toBeNull();
+      expect(result?.session_id).toBe("conv-789");
+    });
+
+    it("should parse conversationId (camelCase) from valid JSON", () => {
+      const output = JSON.stringify({ conversationId: "conv-abc", result: "done" });
+      const result = parseClaudeOutput(output);
+      expect(result).not.toBeNull();
+      expect(result?.session_id).toBe("conv-abc");
+    });
+
+    it("should prefer session_id over other fields", () => {
+      const output = JSON.stringify({
+        session_id: "preferred-id",
+        sessionId: "other-id",
+        conversation_id: "another-id",
+      });
+      const result = parseClaudeOutput(output);
+      expect(result?.session_id).toBe("preferred-id");
+    });
+
+    it("should return null for empty output", () => {
+      expect(parseClaudeOutput("")).toBeNull();
+      expect(parseClaudeOutput("   ")).toBeNull();
+    });
+
+    it("should return null for output without session ID", () => {
+      const output = JSON.stringify({ result: "done", status: "ok" });
+      expect(parseClaudeOutput(output)).toBeNull();
+    });
+
+    it("should extract JSON from mixed output", () => {
+      const output = `Some prefix text\n{"session_id": "extracted-id"}\nSome suffix text`;
+      const result = parseClaudeOutput(output);
+      expect(result).not.toBeNull();
+      expect(result?.session_id).toBe("extracted-id");
+    });
+
+    it("should return null for invalid JSON", () => {
+      expect(parseClaudeOutput("not json at all")).toBeNull();
+    });
+
+    it("should handle session_id with empty string", () => {
+      const output = JSON.stringify({ session_id: "", result: "done" });
+      // Empty string should not be considered a valid session ID
+      expect(parseClaudeOutput(output)).toBeNull();
+    });
+  });
+});

--- a/src/agents/claude-code-registry.test.ts
+++ b/src/agents/claude-code-registry.test.ts
@@ -166,5 +166,22 @@ describe("claude-code-registry", () => {
       // Empty string should not be considered a valid session ID
       expect(parseClaudeOutput(output)).toBeNull();
     });
+
+    it("should parse session_id from multi-line output with multiple JSON objects", () => {
+      // Simulate Claude CLI output with multiple JSON objects on separate lines
+      const output =
+        '{"type":"text","text":"Hello"}\n{"session_id":"multi-json-id","result":"done"}';
+      const result = parseClaudeOutput(output);
+      expect(result).not.toBeNull();
+      expect(result?.session_id).toBe("multi-json-id");
+    });
+
+    it("should find session_id in first valid JSON line", () => {
+      const output =
+        'invalid line\n{"session_id":"found-in-second","status":"ok"}\n{"other":"data"}';
+      const result = parseClaudeOutput(output);
+      expect(result).not.toBeNull();
+      expect(result?.session_id).toBe("found-in-second");
+    });
   });
 });

--- a/src/agents/claude-code-registry.ts
+++ b/src/agents/claude-code-registry.ts
@@ -81,6 +81,8 @@ export type ClaudeCodeRunRecord = {
   requesterDisplayKey?: string;
   label?: string;
   cleanup: "delete" | "keep";
+  /** Internal: tracks whether finalizeRun has been called to prevent double-finalization */
+  _finalized?: boolean;
 };
 
 const activeRuns = new Map<string, ClaudeCodeRunRecord>();
@@ -137,6 +139,12 @@ export function spawnClaudeCodeProcess(params: {
   }
 
   const env = { ...process.env, ...params.env };
+  // Delete empty string values (used by clearEnv to unset variables)
+  for (const [key, value] of Object.entries(params.env)) {
+    if (value === "") {
+      delete env[key];
+    }
+  }
 
   try {
     const childProcess = spawn(params.command, params.args, {
@@ -191,20 +199,22 @@ export function spawnClaudeCodeProcess(params: {
       }
       processesByRunId.delete(params.runId);
 
-      record.endedAt = Date.now();
-      record.output = stdout;
+      const alreadyFinalized = record.status === "timeout" || record.status === "error";
 
-      if (record.status === "timeout" || record.status === "error") {
-        // Already finalized by timeout or abort handler — preserve existing outcome
-      } else if (code === 0) {
-        record.status = "completed";
-        record.outcome = { status: "ok" };
-      } else if (signal) {
-        record.status = "error";
-        record.outcome = { status: "error", error: `Process killed by signal: ${signal}` };
-      } else {
-        record.status = "error";
-        record.outcome = { status: "error", error: stderr || `Process exited with code ${code}` };
+      if (!alreadyFinalized) {
+        record.endedAt = Date.now();
+        record.output = stdout;
+
+        if (code === 0) {
+          record.status = "completed";
+          record.outcome = { status: "ok" };
+        } else if (signal) {
+          record.status = "error";
+          record.outcome = { status: "error", error: `Process killed by signal: ${signal}` };
+        } else {
+          record.status = "error";
+          record.outcome = { status: "error", error: stderr || `Process exited with code ${code}` };
+        }
       }
 
       void finalizeRun(params.runId);
@@ -237,6 +247,7 @@ export function spawnClaudeCodeProcess(params: {
 
 /**
  * Finalize a run and trigger announce callback.
+ * Idempotent: subsequent calls are no-ops if already finalized.
  */
 async function finalizeRun(runId: string): Promise<void> {
   const record = activeRuns.get(runId);
@@ -244,6 +255,13 @@ async function finalizeRun(runId: string): Promise<void> {
     log.debug(`finalizeRun: no record found for runId ${runId}`);
     return;
   }
+
+  // Idempotency check: prevent double-finalization
+  if (record._finalized) {
+    log.debug(`finalizeRun: runId ${runId} already finalized, skipping`);
+    return;
+  }
+  record._finalized = true;
 
   log.debug(
     `finalizeRun: runId=${runId}, status=${record.status}, output length=${record.output?.length ?? 0}`,

--- a/src/agents/claude-code-registry.ts
+++ b/src/agents/claude-code-registry.ts
@@ -34,29 +34,30 @@ export function parseClaudeOutput(output: string): { session_id?: string } | nul
     return null;
   } catch (parseError) {
     // Output might contain multiple lines or non-JSON
-    // Try to find JSON object in the output
-    const jsonMatch = trimmed.match(/\{[\s\S]*\}/);
-    if (jsonMatch) {
+    // Try to find JSON objects line by line (handles multi-JSON output like: {"type":"text"} {"session_id":"abc"})
+    for (const line of trimmed.split("\n")) {
+      const trimmedLine = line.trim();
+      if (!trimmedLine.startsWith("{")) {
+        continue;
+      }
       try {
-        const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
-        // Check all possible session ID fields
+        const parsed = JSON.parse(trimmedLine) as Record<string, unknown>;
         for (const field of SESSION_ID_FIELDS) {
           const value = parsed[field];
           if (typeof value === "string" && value) {
             log.debug(
-              `parseClaudeOutput: found session ID in field "${field}" (from extracted JSON): ${value}`,
+              `parseClaudeOutput: found session ID in field "${field}" (from line): ${value}`,
             );
             return { session_id: value };
           }
         }
-        log.debug(`parseClaudeOutput: no session ID in extracted JSON`);
-        return null;
-      } catch (extractError) {
-        log.debug(`parseClaudeOutput: failed to parse extracted JSON: ${String(extractError)}`);
-        return null;
+      } catch {
+        // not valid JSON on this line, continue to next
       }
     }
-    log.debug(`parseClaudeOutput: no JSON found in output, parse error: ${String(parseError)}`);
+    log.debug(
+      `parseClaudeOutput: no valid JSON with session ID found, parse error: ${String(parseError)}`,
+    );
     return null;
   }
 }
@@ -193,8 +194,8 @@ export function spawnClaudeCodeProcess(params: {
       record.endedAt = Date.now();
       record.output = stdout;
 
-      if (record.status === "timeout") {
-        // Already handled by timeout
+      if (record.status === "timeout" || record.status === "error") {
+        // Already finalized by timeout or abort handler — preserve existing outcome
       } else if (code === 0) {
         record.status = "completed";
         record.outcome = { status: "ok" };

--- a/src/agents/claude-code-registry.ts
+++ b/src/agents/claude-code-registry.ts
@@ -1,0 +1,391 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { DeliveryContext } from "../utils/delivery-context.js";
+import { updateClaudeSessionId } from "./claude-code-sessions.js";
+import { runSubagentAnnounceFlow, type SubagentRunOutcome } from "./subagent-announce.js";
+
+const log = createSubsystemLogger("claude-code-registry");
+
+/**
+ * Parse Claude CLI JSON output to extract session_id.
+ * Claude CLI outputs a single JSON object per invocation.
+ * Supports multiple session ID field names for compatibility.
+ */
+const SESSION_ID_FIELDS = ["session_id", "sessionId", "conversation_id", "conversationId"] as const;
+
+export function parseClaudeOutput(output: string): { session_id?: string } | null {
+  const trimmed = output.trim();
+  if (!trimmed) {
+    log.debug("parseClaudeOutput: empty output");
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    // Check all possible session ID fields
+    for (const field of SESSION_ID_FIELDS) {
+      const value = parsed[field];
+      if (typeof value === "string" && value) {
+        log.debug(`parseClaudeOutput: found session ID in field "${field}": ${value}`);
+        return { session_id: value };
+      }
+    }
+    log.debug(`parseClaudeOutput: no session ID found in fields: ${SESSION_ID_FIELDS.join(", ")}`);
+    return null;
+  } catch (parseError) {
+    // Output might contain multiple lines or non-JSON
+    // Try to find JSON object in the output
+    const jsonMatch = trimmed.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      try {
+        const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+        // Check all possible session ID fields
+        for (const field of SESSION_ID_FIELDS) {
+          const value = parsed[field];
+          if (typeof value === "string" && value) {
+            log.debug(
+              `parseClaudeOutput: found session ID in field "${field}" (from extracted JSON): ${value}`,
+            );
+            return { session_id: value };
+          }
+        }
+        log.debug(`parseClaudeOutput: no session ID in extracted JSON`);
+        return null;
+      } catch (extractError) {
+        log.debug(`parseClaudeOutput: failed to parse extracted JSON: ${String(extractError)}`);
+        return null;
+      }
+    }
+    log.debug(`parseClaudeOutput: no JSON found in output, parse error: ${String(parseError)}`);
+    return null;
+  }
+}
+
+export type ClaudeCodeRunStatus = "pending" | "running" | "completed" | "error" | "timeout";
+
+export type ClaudeCodeRunRecord = {
+  runId: string;
+  sessionKey: string;
+  workspacePath: string;
+  task: string;
+  status: ClaudeCodeRunStatus;
+  pid?: number;
+  startedAt: number;
+  endedAt?: number;
+  outcome?: SubagentRunOutcome;
+  output?: string;
+  outputFile?: string;
+  requesterSessionKey?: string;
+  requesterOrigin?: DeliveryContext;
+  requesterDisplayKey?: string;
+  label?: string;
+  cleanup: "delete" | "keep";
+};
+
+const activeRuns = new Map<string, ClaudeCodeRunRecord>();
+const processesByRunId = new Map<string, ChildProcess>();
+
+/**
+ * Register a new Claude Code run.
+ */
+export function registerClaudeCodeRun(params: {
+  runId: string;
+  sessionKey: string;
+  workspacePath: string;
+  task: string;
+  requesterSessionKey?: string;
+  requesterOrigin?: DeliveryContext;
+  requesterDisplayKey?: string;
+  label?: string;
+  cleanup: "delete" | "keep";
+}): ClaudeCodeRunRecord {
+  const record: ClaudeCodeRunRecord = {
+    runId: params.runId,
+    sessionKey: params.sessionKey,
+    workspacePath: params.workspacePath,
+    task: params.task,
+    status: "pending",
+    startedAt: Date.now(),
+    requesterSessionKey: params.requesterSessionKey,
+    requesterOrigin: params.requesterOrigin,
+    requesterDisplayKey: params.requesterDisplayKey,
+    label: params.label,
+    cleanup: params.cleanup,
+  };
+  activeRuns.set(params.runId, record);
+  return record;
+}
+
+/**
+ * Spawn a Claude Code process asynchronously.
+ * The process runs in detached mode and callbacks are triggered on completion.
+ */
+export function spawnClaudeCodeProcess(params: {
+  runId: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+  outputFile?: string;
+  timeoutMs?: number;
+}): void {
+  const record = activeRuns.get(params.runId);
+  if (!record) {
+    log.warn(`No record found for runId: ${params.runId}`);
+    return;
+  }
+
+  const env = { ...process.env, ...params.env };
+
+  try {
+    const childProcess = spawn(params.command, params.args, {
+      cwd: params.cwd,
+      env,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    record.pid = childProcess.pid;
+    record.status = "running";
+    record.outputFile = params.outputFile;
+    processesByRunId.set(params.runId, childProcess);
+
+    // Emit start event
+    emitAgentEvent({
+      runId: params.runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: record.startedAt },
+      sessionKey: record.sessionKey,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    childProcess.stdout?.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    childProcess.stderr?.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    const timeoutId = params.timeoutMs
+      ? setTimeout(() => {
+          log.info(`Run ${params.runId} timed out after ${params.timeoutMs}ms`);
+          record.status = "timeout";
+          record.endedAt = Date.now();
+          record.outcome = { status: "timeout" };
+          try {
+            childProcess.kill("SIGTERM");
+          } catch {
+            // ignore
+          }
+          void finalizeRun(params.runId);
+        }, params.timeoutMs)
+      : undefined;
+
+    childProcess.on("exit", (code, signal) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      processesByRunId.delete(params.runId);
+
+      record.endedAt = Date.now();
+      record.output = stdout;
+
+      if (record.status === "timeout") {
+        // Already handled by timeout
+      } else if (code === 0) {
+        record.status = "completed";
+        record.outcome = { status: "ok" };
+      } else if (signal) {
+        record.status = "error";
+        record.outcome = { status: "error", error: `Process killed by signal: ${signal}` };
+      } else {
+        record.status = "error";
+        record.outcome = { status: "error", error: stderr || `Process exited with code ${code}` };
+      }
+
+      void finalizeRun(params.runId);
+    });
+
+    childProcess.on("error", (err) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      processesByRunId.delete(params.runId);
+
+      record.status = "error";
+      record.endedAt = Date.now();
+      record.outcome = { status: "error", error: err.message };
+
+      void finalizeRun(params.runId);
+    });
+
+    // Unref to allow parent process to exit independently
+    childProcess.unref();
+
+    log.info(`Spawned Claude Code process for run ${params.runId}, pid: ${childProcess.pid}`);
+  } catch (err) {
+    record.status = "error";
+    record.endedAt = Date.now();
+    record.outcome = { status: "error", error: String(err) };
+    void finalizeRun(params.runId);
+  }
+}
+
+/**
+ * Finalize a run and trigger announce callback.
+ */
+async function finalizeRun(runId: string): Promise<void> {
+  const record = activeRuns.get(runId);
+  if (!record) {
+    log.debug(`finalizeRun: no record found for runId ${runId}`);
+    return;
+  }
+
+  log.debug(
+    `finalizeRun: runId=${runId}, status=${record.status}, output length=${record.output?.length ?? 0}`,
+  );
+
+  // Extract and store Claude session ID for conversation continuity
+  if (record.output && record.status === "completed") {
+    log.debug(`finalizeRun: parsing output for session ID...`);
+    try {
+      const parsed = parseClaudeOutput(record.output);
+      if (parsed?.session_id) {
+        log.info(
+          `finalizeRun: extracted session_id=${parsed.session_id}, updating store for workspace=${record.workspacePath}`,
+        );
+        const updated = updateClaudeSessionId(record.workspacePath, parsed.session_id);
+        log.info(`finalizeRun: session ID store update result: ${updated}`);
+      } else {
+        log.warn(
+          `finalizeRun: no session_id found in output. Output preview: ${record.output.slice(0, 500)}`,
+        );
+      }
+    } catch (err) {
+      log.warn(`finalizeRun: failed to parse Claude output for session ID: ${String(err)}`);
+    }
+  } else {
+    log.debug(
+      `finalizeRun: skipping session ID extraction (output=${!!record.output}, status=${record.status})`,
+    );
+  }
+
+  // Emit end event
+  emitAgentEvent({
+    runId,
+    stream: "lifecycle",
+    data: {
+      phase: record.status === "completed" ? "end" : "error",
+      endedAt: record.endedAt,
+      error: record.outcome?.error,
+      aborted: record.status === "timeout",
+    },
+    sessionKey: record.sessionKey,
+  });
+
+  // Trigger announce if we have requester info
+  if (record.requesterSessionKey) {
+    try {
+      await runSubagentAnnounceFlow({
+        childSessionKey: record.sessionKey,
+        childRunId: runId,
+        requesterSessionKey: record.requesterSessionKey,
+        requesterOrigin: record.requesterOrigin,
+        requesterDisplayKey: record.requesterDisplayKey ?? "unknown",
+        task: record.task,
+        timeoutMs: 30_000,
+        cleanup: record.cleanup,
+        waitForCompletion: false,
+        startedAt: record.startedAt,
+        endedAt: record.endedAt,
+        label: record.label,
+        outcome: record.outcome,
+        roundOneReply: record.output,
+      });
+    } catch (err) {
+      log.warn(`Failed to announce run ${runId}: ${String(err)}`);
+    }
+  }
+
+  // Clean up record if delete mode
+  if (record.cleanup === "delete") {
+    activeRuns.delete(runId);
+  }
+}
+
+/**
+ * Get a run record by runId.
+ */
+export function getClaudeCodeRun(runId: string): ClaudeCodeRunRecord | undefined {
+  return activeRuns.get(runId);
+}
+
+/**
+ * List all active runs.
+ */
+export function listClaudeCodeRuns(): ClaudeCodeRunRecord[] {
+  return Array.from(activeRuns.values());
+}
+
+/**
+ * Get runs by session key.
+ */
+export function getClaudeCodeRunsBySession(sessionKey: string): ClaudeCodeRunRecord[] {
+  return Array.from(activeRuns.values()).filter((r) => r.sessionKey === sessionKey);
+}
+
+/**
+ * Abort a running process.
+ */
+export function abortClaudeCodeRun(runId: string): boolean {
+  const record = activeRuns.get(runId);
+  if (!record) {
+    return false;
+  }
+  const process = processesByRunId.get(runId);
+  if (process) {
+    try {
+      process.kill("SIGTERM");
+      record.status = "error";
+      record.endedAt = Date.now();
+      record.outcome = { status: "error", error: "Aborted by user" };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Send a message to a running process via stdin.
+ * Note: This requires the process to be spawned with stdin pipe.
+ */
+export function sendToClaudeCodeRun(runId: string, _message: string): boolean {
+  const process = processesByRunId.get(runId);
+  if (!process) {
+    return false;
+  }
+  // Claude Code CLI in non-interactive mode doesn't accept stdin input
+  // This is a placeholder for future interactive mode support
+  log.warn(`sendToClaudeCodeRun not supported for non-interactive mode: ${runId}`);
+  return false;
+}
+
+/**
+ * Reset the registry for tests.
+ */
+export function resetClaudeCodeRegistryForTests(): void {
+  for (const process of processesByRunId.values()) {
+    try {
+      process.kill("SIGTERM");
+    } catch {
+      // ignore
+    }
+  }
+  processesByRunId.clear();
+  activeRuns.clear();
+}

--- a/src/agents/claude-code-sessions.test.ts
+++ b/src/agents/claude-code-sessions.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   generateClaudeCodeSessionKey,
   parseClaudeCodeSessionKey,
@@ -16,21 +16,21 @@ import {
 
 describe("claude-code-sessions", () => {
   const testWorkspace = "/tmp/test-workspace";
-  const sessionsFilePath = path.join(os.homedir(), ".openclaw", "claude-code-sessions.json");
+  let tempDir: string;
 
   beforeEach(() => {
-    // Clean up any existing sessions file
-    try {
-      fs.unlinkSync(sessionsFilePath);
-    } catch {
-      // ignore
-    }
+    // Create a temporary isolated directory for each test
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-"));
+    // Mock os.homedir to return the temp directory to avoid polluting real user data
+    vi.spyOn(os, "homedir").mockReturnValue(tempDir);
   });
 
   afterEach(() => {
-    // Clean up after tests
+    // Restore all mocks
+    vi.restoreAllMocks();
+    // Clean up the temporary directory
     try {
-      fs.unlinkSync(sessionsFilePath);
+      fs.rmSync(tempDir, { recursive: true, force: true });
     } catch {
       // ignore
     }

--- a/src/agents/claude-code-sessions.test.ts
+++ b/src/agents/claude-code-sessions.test.ts
@@ -1,0 +1,253 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  generateClaudeCodeSessionKey,
+  parseClaudeCodeSessionKey,
+  isClaudeCodeSessionKey,
+  resolveClaudeCodeSession,
+  listClaudeCodeSessions,
+  deleteClaudeCodeSession,
+  cleanupOldSessions,
+  updateClaudeSessionId,
+  getClaudeSessionId,
+} from "./claude-code-sessions.js";
+
+describe("claude-code-sessions", () => {
+  const testWorkspace = "/tmp/test-workspace";
+  const sessionsFilePath = path.join(os.homedir(), ".openclaw", "claude-code-sessions.json");
+
+  beforeEach(() => {
+    // Clean up any existing sessions file
+    try {
+      fs.unlinkSync(sessionsFilePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  afterEach(() => {
+    // Clean up after tests
+    try {
+      fs.unlinkSync(sessionsFilePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  describe("generateClaudeCodeSessionKey", () => {
+    it("should generate a session key with workspace hash", () => {
+      const key = generateClaudeCodeSessionKey(testWorkspace);
+      expect(key).toMatch(/^agent:claude-code:workspace:[a-f0-9]{16}$/);
+    });
+
+    it("should generate the same key for the same workspace", () => {
+      const key1 = generateClaudeCodeSessionKey(testWorkspace);
+      const key2 = generateClaudeCodeSessionKey(testWorkspace);
+      expect(key1).toBe(key2);
+    });
+
+    it("should generate different keys for different workspaces", () => {
+      const key1 = generateClaudeCodeSessionKey("/workspace1");
+      const key2 = generateClaudeCodeSessionKey("/workspace2");
+      expect(key1).not.toBe(key2);
+    });
+
+    it("should normalize workspace paths", () => {
+      const key1 = generateClaudeCodeSessionKey("/tmp/test");
+      const key2 = generateClaudeCodeSessionKey("/tmp/../tmp/test");
+      expect(key1).toBe(key2);
+    });
+  });
+
+  describe("parseClaudeCodeSessionKey", () => {
+    it("should parse a valid session key", () => {
+      const key = generateClaudeCodeSessionKey(testWorkspace);
+      const parsed = parseClaudeCodeSessionKey(key);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.workspaceHash).toMatch(/^[a-f0-9]{16}$/);
+    });
+
+    it("should return null for invalid keys", () => {
+      expect(parseClaudeCodeSessionKey("invalid-key")).toBeNull();
+      expect(parseClaudeCodeSessionKey("agent:other:workspace:abc123")).toBeNull();
+    });
+  });
+
+  describe("isClaudeCodeSessionKey", () => {
+    it("should return true for valid claude-code session keys", () => {
+      const key = generateClaudeCodeSessionKey(testWorkspace);
+      expect(isClaudeCodeSessionKey(key)).toBe(true);
+    });
+
+    it("should return false for other session keys", () => {
+      expect(isClaudeCodeSessionKey("agent:main:session")).toBe(false);
+      expect(isClaudeCodeSessionKey("agent:claude-cli:session")).toBe(false);
+    });
+  });
+
+  describe("resolveClaudeCodeSession", () => {
+    it("should create a new session when resume is false", () => {
+      const result = resolveClaudeCodeSession({
+        workspacePath: testWorkspace,
+        resume: false,
+      });
+      expect(result.isNew).toBe(true);
+      expect(result.sessionKey).toMatch(/^agent:claude-code:workspace:/);
+    });
+
+    it("should create a new session when resume is true but no existing session", () => {
+      const result = resolveClaudeCodeSession({
+        workspacePath: testWorkspace,
+        resume: true,
+      });
+      expect(result.isNew).toBe(true);
+    });
+
+    it("should return existing session when resume is true", () => {
+      // Create first session
+      const first = resolveClaudeCodeSession({
+        workspacePath: testWorkspace,
+        resume: false,
+      });
+
+      // Resume should return the same session
+      const second = resolveClaudeCodeSession({
+        workspacePath: testWorkspace,
+        resume: true,
+      });
+
+      expect(second.isNew).toBe(false);
+      expect(second.sessionKey).toBe(first.sessionKey);
+    });
+  });
+
+  describe("listClaudeCodeSessions", () => {
+    it("should list all sessions", () => {
+      resolveClaudeCodeSession({ workspacePath: "/workspace1", resume: false });
+      resolveClaudeCodeSession({ workspacePath: "/workspace2", resume: false });
+
+      const sessions = listClaudeCodeSessions();
+      expect(sessions.length).toBe(2);
+    });
+  });
+
+  describe("deleteClaudeCodeSession", () => {
+    it("should delete a session", () => {
+      resolveClaudeCodeSession({ workspacePath: testWorkspace, resume: false });
+
+      const deleted = deleteClaudeCodeSession(testWorkspace);
+      expect(deleted).toBe(true);
+
+      const sessions = listClaudeCodeSessions();
+      expect(sessions.length).toBe(0);
+    });
+
+    it("should return false if session does not exist", () => {
+      const deleted = deleteClaudeCodeSession("/nonexistent");
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe("cleanupOldSessions", () => {
+    it("should not clean up fresh sessions", () => {
+      resolveClaudeCodeSession({ workspacePath: testWorkspace, resume: false });
+
+      // Fresh sessions should not be cleaned with reasonable maxAge
+      const cleaned = cleanupOldSessions(30);
+      expect(cleaned).toBe(0);
+
+      const sessions = listClaudeCodeSessions();
+      expect(sessions.length).toBe(1);
+    });
+
+    it("should clean up sessions older than maxAgeDays", async () => {
+      resolveClaudeCodeSession({ workspacePath: testWorkspace, resume: false });
+
+      // Wait a bit to ensure time passes
+      await new Promise((r) => setTimeout(r, 10));
+
+      // With very small maxAge, sessions should be cleaned
+      // Note: Due to timing, we use a very small window
+      const cleaned = cleanupOldSessions(0.0000001);
+      expect(cleaned).toBeGreaterThanOrEqual(1);
+
+      const sessions = listClaudeCodeSessions();
+      expect(sessions.length).toBe(0);
+    });
+  });
+
+  describe("updateClaudeSessionId", () => {
+    it("should store Claude session ID for an existing session", () => {
+      // First create a session
+      resolveClaudeCodeSession({ workspacePath: testWorkspace, resume: false });
+
+      // Update with Claude session ID
+      const claudeSessionId = "test-claude-session-123";
+      const result = updateClaudeSessionId(testWorkspace, claudeSessionId);
+      expect(result).toBe(true);
+
+      // Verify it was stored
+      const stored = getClaudeSessionId(testWorkspace);
+      expect(stored).toBe(claudeSessionId);
+    });
+
+    it("should create a new session entry if none exists", () => {
+      // No session created yet
+      const claudeSessionId = "test-claude-session-456";
+      const result = updateClaudeSessionId("/new-workspace", claudeSessionId);
+      expect(result).toBe(true);
+
+      // Verify it was stored
+      const stored = getClaudeSessionId("/new-workspace");
+      expect(stored).toBe(claudeSessionId);
+    });
+
+    it("should update existing Claude session ID", () => {
+      resolveClaudeCodeSession({ workspacePath: testWorkspace, resume: false });
+
+      const firstId = "first-session-id";
+      updateClaudeSessionId(testWorkspace, firstId);
+      expect(getClaudeSessionId(testWorkspace)).toBe(firstId);
+
+      const secondId = "second-session-id";
+      updateClaudeSessionId(testWorkspace, secondId);
+      expect(getClaudeSessionId(testWorkspace)).toBe(secondId);
+    });
+
+    it("should normalize workspace paths", () => {
+      resolveClaudeCodeSession({ workspacePath: testWorkspace, resume: false });
+
+      const claudeSessionId = "normalized-session-id";
+      updateClaudeSessionId(testWorkspace, claudeSessionId);
+
+      // Should work with different path representations
+      const stored = getClaudeSessionId("/tmp/../tmp/test-workspace");
+      expect(stored).toBe(claudeSessionId);
+    });
+  });
+
+  describe("getClaudeSessionId", () => {
+    it("should return undefined when no session exists", () => {
+      const sessionId = getClaudeSessionId("/nonexistent-workspace");
+      expect(sessionId).toBeUndefined();
+    });
+
+    it("should return undefined when session exists but no Claude session ID", () => {
+      resolveClaudeCodeSession({ workspacePath: testWorkspace, resume: false });
+
+      const sessionId = getClaudeSessionId(testWorkspace);
+      expect(sessionId).toBeUndefined();
+    });
+
+    it("should return stored Claude session ID", () => {
+      resolveClaudeCodeSession({ workspacePath: testWorkspace, resume: false });
+      const claudeSessionId = "stored-session-id";
+      updateClaudeSessionId(testWorkspace, claudeSessionId);
+
+      const sessionId = getClaudeSessionId(testWorkspace);
+      expect(sessionId).toBe(claudeSessionId);
+    });
+  });
+});

--- a/src/agents/claude-code-sessions.ts
+++ b/src/agents/claude-code-sessions.ts
@@ -1,0 +1,222 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("claude-code-sessions");
+
+/**
+ * Session key format: agent:claude-code:workspace:{hash}
+ * where hash is the first 16 chars of SHA-256 of the normalized workspace path.
+ */
+export function generateClaudeCodeSessionKey(workspacePath: string): string {
+  const normalizedPath = path.resolve(workspacePath);
+  const hash = crypto.createHash("sha256").update(normalizedPath).digest("hex").slice(0, 16);
+  return `agent:claude-code:workspace:${hash}`;
+}
+
+/**
+ * Parse a claude-code session key to extract the workspace hash.
+ */
+export function parseClaudeCodeSessionKey(sessionKey: string): { workspaceHash: string } | null {
+  const match = sessionKey.match(/^agent:claude-code:workspace:([a-f0-9]{16})$/);
+  if (!match) {
+    return null;
+  }
+  return { workspaceHash: match[1] };
+}
+
+/**
+ * Check if a session key is a claude-code workspace session.
+ */
+export function isClaudeCodeSessionKey(sessionKey: string): boolean {
+  return sessionKey.startsWith("agent:claude-code:workspace:");
+}
+
+/**
+ * Persistent mapping from workspace path to session key.
+ * Stored in ~/.openclaw/claude-code-sessions.json
+ */
+type SessionMapping = {
+  workspacePath: string;
+  sessionKey: string;
+  claudeSessionId?: string; // Claude CLI session ID for conversation continuity
+  createdAt: number;
+  lastUsedAt: number;
+};
+
+type SessionsStore = {
+  version: 1;
+  sessions: Record<string, SessionMapping>; // key: workspace hash
+};
+
+function getSessionsFilePath(): string {
+  const openclawDir = path.join(os.homedir(), ".openclaw");
+  return path.join(openclawDir, "claude-code-sessions.json");
+}
+
+function loadSessionsStore(): SessionsStore {
+  const filePath = getSessionsFilePath();
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    const data = JSON.parse(content) as SessionsStore;
+    if (data.version !== 1) {
+      log.warn(`Unknown sessions store version: ${String(data.version)}, resetting`);
+      return { version: 1, sessions: {} };
+    }
+    return data;
+  } catch {
+    return { version: 1, sessions: {} };
+  }
+}
+
+function saveSessionsStore(store: SessionsStore): void {
+  const filePath = getSessionsFilePath();
+  const dir = path.dirname(filePath);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    // ignore
+  }
+  try {
+    fs.writeFileSync(filePath, JSON.stringify(store, null, 2), "utf-8");
+  } catch (err) {
+    log.warn(`Failed to save claude-code sessions: ${String(err)}`);
+  }
+}
+
+/**
+ * Get or create a session key for a workspace.
+ * If resume is true, returns existing session if available.
+ * Otherwise, always creates a new session key.
+ */
+export function resolveClaudeCodeSession(params: { workspacePath: string; resume?: boolean }): {
+  sessionKey: string;
+  isNew: boolean;
+} {
+  const { workspacePath, resume } = params;
+  const normalizedPath = path.resolve(workspacePath);
+  const hash = crypto.createHash("sha256").update(normalizedPath).digest("hex").slice(0, 16);
+
+  if (resume) {
+    const store = loadSessionsStore();
+    const existing = store.sessions[hash];
+    if (existing) {
+      // Update last used time
+      existing.lastUsedAt = Date.now();
+      saveSessionsStore(store);
+      return { sessionKey: existing.sessionKey, isNew: false };
+    }
+  }
+
+  // Create new session
+  const sessionKey = generateClaudeCodeSessionKey(normalizedPath);
+  const now = Date.now();
+  const store = loadSessionsStore();
+  store.sessions[hash] = {
+    workspacePath: normalizedPath,
+    sessionKey,
+    createdAt: now,
+    lastUsedAt: now,
+  };
+  saveSessionsStore(store);
+
+  return { sessionKey, isNew: true };
+}
+
+/**
+ * List all known claude-code sessions.
+ */
+export function listClaudeCodeSessions(): SessionMapping[] {
+  const store = loadSessionsStore();
+  return Object.values(store.sessions);
+}
+
+/**
+ * Delete a session mapping by workspace path.
+ */
+export function deleteClaudeCodeSession(workspacePath: string): boolean {
+  const normalizedPath = path.resolve(workspacePath);
+  const hash = crypto.createHash("sha256").update(normalizedPath).digest("hex").slice(0, 16);
+  const store = loadSessionsStore();
+  if (store.sessions[hash]) {
+    delete store.sessions[hash];
+    saveSessionsStore(store);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Clean up old sessions that haven't been used in the specified number of days.
+ */
+export function cleanupOldSessions(maxAgeDays: number = 30): number {
+  const store = loadSessionsStore();
+  const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+  let cleaned = 0;
+  for (const [hash, session] of Object.entries(store.sessions)) {
+    if (session.lastUsedAt < cutoff) {
+      delete store.sessions[hash];
+      cleaned += 1;
+    }
+  }
+  if (cleaned > 0) {
+    saveSessionsStore(store);
+    log.info(`Cleaned up ${cleaned} old claude-code sessions`);
+  }
+  return cleaned;
+}
+
+/**
+ * Update the Claude CLI session ID for a workspace.
+ * This enables conversation continuity across multiple spawns.
+ */
+export function updateClaudeSessionId(workspacePath: string, claudeSessionId: string): boolean {
+  const normalizedPath = path.resolve(workspacePath);
+  const hash = crypto.createHash("sha256").update(normalizedPath).digest("hex").slice(0, 16);
+  log.debug(
+    `updateClaudeSessionId: normalizedPath=${normalizedPath}, hash=${hash}, claudeSessionId=${claudeSessionId}`,
+  );
+  const store = loadSessionsStore();
+  const session = store.sessions[hash];
+  if (!session) {
+    log.warn(`updateClaudeSessionId: no session found for hash=${hash}, creating new entry`);
+    // Create a new session entry if none exists
+    const sessionKey = generateClaudeCodeSessionKey(normalizedPath);
+    const now = Date.now();
+    store.sessions[hash] = {
+      workspacePath: normalizedPath,
+      sessionKey,
+      createdAt: now,
+      lastUsedAt: now,
+      claudeSessionId,
+    };
+    saveSessionsStore(store);
+    log.info(
+      `updateClaudeSessionId: created new session entry for ${normalizedPath}: ${claudeSessionId}`,
+    );
+    return true;
+  }
+  session.claudeSessionId = claudeSessionId;
+  session.lastUsedAt = Date.now();
+  saveSessionsStore(store);
+  log.info(
+    `updateClaudeSessionId: updated claude session ID for ${normalizedPath}: ${claudeSessionId}`,
+  );
+  return true;
+}
+
+/**
+ * Get the Claude CLI session ID for a workspace.
+ */
+export function getClaudeSessionId(workspacePath: string): string | undefined {
+  const normalizedPath = path.resolve(workspacePath);
+  const hash = crypto.createHash("sha256").update(normalizedPath).digest("hex").slice(0, 16);
+  const store = loadSessionsStore();
+  const sessionId = store.sessions[hash]?.claudeSessionId;
+  log.debug(
+    `getClaudeSessionId: normalizedPath=${normalizedPath}, hash=${hash}, sessionId=${sessionId ?? "none"}`,
+  );
+  return sessionId;
+}

--- a/src/agents/claude-code-spawn.ts
+++ b/src/agents/claude-code-spawn.ts
@@ -2,16 +2,25 @@ import crypto from "node:crypto";
 import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { registerClaudeCodeRun, spawnClaudeCodeProcess } from "./claude-code-registry.js";
 import { resolveClaudeCodeSession, getClaudeSessionId } from "./claude-code-sessions.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import {
+  extractRequesterOrigin,
+  resolveSpawnMode,
+  type SpawnBaseContext,
+  type SpawnBaseResult,
+  type SpawnMode,
+  SPAWN_MODES,
+} from "./spawn-utils.js";
 
 const log = createSubsystemLogger("claude-code-spawn");
 
-export const CLAUDE_CODE_SPAWN_MODES = ["run", "session"] as const;
-export type SpawnClaudeCodeMode = (typeof CLAUDE_CODE_SPAWN_MODES)[number];
+// Re-export spawn mode types for backward compatibility
+export { SPAWN_MODES, type SpawnMode };
+export const CLAUDE_CODE_SPAWN_MODES = SPAWN_MODES;
+export type SpawnClaudeCodeMode = SpawnMode;
 
 export type SpawnClaudeCodeParams = {
   task: string;
@@ -22,23 +31,9 @@ export type SpawnClaudeCodeParams = {
   timeoutSeconds?: number;
 };
 
-export type SpawnClaudeCodeContext = {
-  agentSessionKey?: string;
-  agentChannel?: string;
-  agentAccountId?: string;
-  agentTo?: string;
-  agentThreadId?: string | number;
-  sandboxed?: boolean;
-};
+export type SpawnClaudeCodeContext = SpawnBaseContext;
 
-export type SpawnClaudeCodeResult = {
-  status: "accepted" | "forbidden" | "error";
-  childSessionKey?: string;
-  runId?: string;
-  mode?: SpawnClaudeCodeMode;
-  note?: string;
-  error?: string;
-};
+export type SpawnClaudeCodeResult = SpawnBaseResult;
 
 export const CLAUDE_CODE_SPAWN_ACCEPTED_NOTE =
   "Claude Code task queued in isolated workspace session; results will be announced when complete.";
@@ -57,17 +52,6 @@ export function resolveClaudeCodeSpawnPolicyError(params: {
     return 'Sandboxed sessions cannot spawn Claude Code sessions because runtime="claude-code" runs on the host. Use runtime="subagent" from sandboxed sessions.';
   }
   return undefined;
-}
-
-function resolveSpawnMode(params: {
-  requestedMode?: SpawnClaudeCodeMode;
-  resumeRequested: boolean;
-}): SpawnClaudeCodeMode {
-  if (params.requestedMode === "run" || params.requestedMode === "session") {
-    return params.requestedMode;
-  }
-  // Resume should default to session mode
-  return params.resumeRequested ? "session" : "run";
 }
 
 export async function spawnClaudeCodeDirect(
@@ -114,12 +98,7 @@ export async function spawnClaudeCodeDirect(
     };
   }
 
-  const requesterOrigin = normalizeDeliveryContext({
-    channel: ctx.agentChannel,
-    accountId: ctx.agentAccountId,
-    to: ctx.agentTo,
-    threadId: ctx.agentThreadId,
-  });
+  const requesterOrigin = extractRequesterOrigin(ctx);
 
   // Generate run ID
   const runId = crypto.randomUUID();

--- a/src/agents/claude-code-spawn.ts
+++ b/src/agents/claude-code-spawn.ts
@@ -1,0 +1,197 @@
+import crypto from "node:crypto";
+import { loadConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { normalizeDeliveryContext } from "../utils/delivery-context.js";
+import { registerClaudeCodeRun, spawnClaudeCodeProcess } from "./claude-code-registry.js";
+import { resolveClaudeCodeSession, getClaudeSessionId } from "./claude-code-sessions.js";
+import { resolveCliBackendConfig } from "./cli-backends.js";
+import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+
+const log = createSubsystemLogger("claude-code-spawn");
+
+export const CLAUDE_CODE_SPAWN_MODES = ["run", "session"] as const;
+export type SpawnClaudeCodeMode = (typeof CLAUDE_CODE_SPAWN_MODES)[number];
+
+export type SpawnClaudeCodeParams = {
+  task: string;
+  label?: string;
+  cwd?: string;
+  mode?: SpawnClaudeCodeMode;
+  resume?: boolean;
+  timeoutSeconds?: number;
+};
+
+export type SpawnClaudeCodeContext = {
+  agentSessionKey?: string;
+  agentChannel?: string;
+  agentAccountId?: string;
+  agentTo?: string;
+  agentThreadId?: string | number;
+  sandboxed?: boolean;
+};
+
+export type SpawnClaudeCodeResult = {
+  status: "accepted" | "forbidden" | "error";
+  childSessionKey?: string;
+  runId?: string;
+  mode?: SpawnClaudeCodeMode;
+  note?: string;
+  error?: string;
+};
+
+export const CLAUDE_CODE_SPAWN_ACCEPTED_NOTE =
+  "Claude Code task queued in isolated workspace session; results will be announced when complete.";
+
+export function resolveClaudeCodeSpawnPolicyError(params: {
+  cfg: OpenClawConfig;
+  requesterSessionKey?: string;
+  requesterSandboxed?: boolean;
+}): string | undefined {
+  const requesterRuntime = resolveSandboxRuntimeStatus({
+    cfg: params.cfg,
+    sessionKey: params.requesterSessionKey,
+  });
+  const requesterSandboxed = params.requesterSandboxed === true || requesterRuntime.sandboxed;
+  if (requesterSandboxed) {
+    return 'Sandboxed sessions cannot spawn Claude Code sessions because runtime="claude-code" runs on the host. Use runtime="subagent" from sandboxed sessions.';
+  }
+  return undefined;
+}
+
+function resolveSpawnMode(params: {
+  requestedMode?: SpawnClaudeCodeMode;
+  resumeRequested: boolean;
+}): SpawnClaudeCodeMode {
+  if (params.requestedMode === "run" || params.requestedMode === "session") {
+    return params.requestedMode;
+  }
+  // Resume should default to session mode
+  return params.resumeRequested ? "session" : "run";
+}
+
+export async function spawnClaudeCodeDirect(
+  params: SpawnClaudeCodeParams,
+  ctx: SpawnClaudeCodeContext,
+): Promise<SpawnClaudeCodeResult> {
+  const cfg = loadConfig();
+
+  const parentSessionKey = ctx.agentSessionKey?.trim();
+
+  const runtimePolicyError = resolveClaudeCodeSpawnPolicyError({
+    cfg,
+    requesterSessionKey: ctx.agentSessionKey,
+    requesterSandboxed: ctx.sandboxed,
+  });
+  if (runtimePolicyError) {
+    return {
+      status: "forbidden",
+      error: runtimePolicyError,
+    };
+  }
+
+  const resumeRequested = params.resume === true;
+  const spawnMode = resolveSpawnMode({
+    requestedMode: params.mode,
+    resumeRequested,
+  });
+
+  // Resolve workspace path
+  const cwd = params.cwd?.trim() || process.cwd();
+
+  // Resolve or create session for workspace
+  const { sessionKey, isNew } = resolveClaudeCodeSession({
+    workspacePath: cwd,
+    resume: resumeRequested || spawnMode === "session",
+  });
+
+  // Get backend configuration
+  const backend = resolveCliBackendConfig("claude-code", cfg);
+  if (!backend) {
+    return {
+      status: "error",
+      error: "Failed to resolve claude-code backend configuration.",
+    };
+  }
+
+  const requesterOrigin = normalizeDeliveryContext({
+    channel: ctx.agentChannel,
+    accountId: ctx.agentAccountId,
+    to: ctx.agentTo,
+    threadId: ctx.agentThreadId,
+  });
+
+  // Generate run ID
+  const runId = crypto.randomUUID();
+
+  // Register the run
+  registerClaudeCodeRun({
+    runId,
+    sessionKey,
+    workspacePath: cwd,
+    task: params.task,
+    requesterSessionKey: parentSessionKey,
+    requesterOrigin,
+    label: params.label,
+    cleanup: spawnMode === "run" ? "delete" : "keep",
+  });
+
+  // Build CLI arguments
+  // Check for existing Claude session ID to resume conversation
+  const existingClaudeSessionId = getClaudeSessionId(cwd);
+  const shouldResume = existingClaudeSessionId && (resumeRequested || spawnMode === "session");
+
+  log.debug(
+    `spawnClaudeCodeDirect: workspace=${cwd}, resumeRequested=${resumeRequested}, spawnMode=${spawnMode}, existingClaudeSessionId=${existingClaudeSessionId ?? "none"}`,
+  );
+
+  let cliArgs: string[];
+  if (shouldResume && backend.config.resumeArgs) {
+    // Use resumeArgs with --resume for continuing existing session
+    cliArgs = backend.config.resumeArgs.map((arg) =>
+      arg === "{sessionId}" ? existingClaudeSessionId : arg,
+    );
+    log.info(
+      `spawnClaudeCodeDirect: resuming Claude session with --resume ${existingClaudeSessionId}`,
+    );
+  } else {
+    // Use regular args for new session
+    cliArgs = [...(backend.config.args ?? [])];
+    log.debug(`spawnClaudeCodeDirect: starting fresh Claude session (no --resume)`);
+  }
+
+  // Add task as the last argument
+  cliArgs.push(params.task);
+
+  // Build environment
+  const env: Record<string, string> = {};
+  for (const key of backend.config.clearEnv ?? []) {
+    env[key] = "";
+  }
+  for (const [key, value] of Object.entries(backend.config.env ?? {})) {
+    env[key] = value;
+  }
+
+  // Calculate timeout
+  const timeoutMs = params.timeoutSeconds ? params.timeoutSeconds * 1000 : undefined;
+
+  // Spawn the process
+  spawnClaudeCodeProcess({
+    runId,
+    command: backend.config.command,
+    args: cliArgs,
+    cwd,
+    env,
+    timeoutMs,
+  });
+
+  return {
+    status: "accepted",
+    childSessionKey: sessionKey,
+    runId,
+    mode: spawnMode,
+    note: isNew
+      ? CLAUDE_CODE_SPAWN_ACCEPTED_NOTE
+      : "Claude Code task queued in existing workspace session; results will be announced when complete.",
+  };
+}

--- a/src/agents/claude-code-spawn.ts
+++ b/src/agents/claude-code-spawn.ts
@@ -14,6 +14,11 @@ import {
   type SpawnMode,
   SPAWN_MODES,
 } from "./spawn-utils.js";
+import {
+  resolveDisplaySessionKey,
+  resolveInternalSessionKey,
+  resolveMainSessionAlias,
+} from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("claude-code-spawn");
 
@@ -100,6 +105,21 @@ export async function spawnClaudeCodeDirect(
 
   const requesterOrigin = extractRequesterOrigin(ctx);
 
+  // Resolve display key for the requester session (for user-friendly notification labels)
+  const { mainKey, alias } = resolveMainSessionAlias(cfg);
+  const requesterInternalKey = parentSessionKey
+    ? resolveInternalSessionKey({
+        key: parentSessionKey,
+        alias,
+        mainKey,
+      })
+    : alias;
+  const requesterDisplayKey = resolveDisplaySessionKey({
+    key: requesterInternalKey,
+    alias,
+    mainKey,
+  });
+
   // Generate run ID
   const runId = crypto.randomUUID();
 
@@ -111,6 +131,7 @@ export async function spawnClaudeCodeDirect(
     task: params.task,
     requesterSessionKey: parentSessionKey,
     requesterOrigin,
+    requesterDisplayKey,
     label: params.label,
     cleanup: spawnMode === "run" ? "delete" : "keep",
   });

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -37,29 +37,41 @@ const CLAUDE_LEGACY_SKIP_PERMISSIONS_ARG = "--dangerously-skip-permissions";
 const CLAUDE_PERMISSION_MODE_ARG = "--permission-mode";
 const CLAUDE_BYPASS_PERMISSIONS_MODE = "bypassPermissions";
 
-const DEFAULT_CLAUDE_BACKEND: CliBackendConfig = {
+// Shared base args for Claude CLI backends
+const CLAUDE_BASE_ARGS = [
+  "-p",
+  "--output-format",
+  "json",
+  "--permission-mode",
+  "bypassPermissions",
+] as const;
+const CLAUDE_SESSION_ID_FIELDS = [
+  "session_id",
+  "sessionId",
+  "conversation_id",
+  "conversationId",
+] as const;
+
+// Shared base config for Claude CLI backends (used by claude-cli and claude-code)
+const CLAUDE_BASE_BACKEND: Omit<CliBackendConfig, "reliability" | "serialize" | "resumeArgs"> = {
   command: "claude",
-  args: ["-p", "--output-format", "json", "--permission-mode", "bypassPermissions"],
-  resumeArgs: [
-    "-p",
-    "--output-format",
-    "json",
-    "--permission-mode",
-    "bypassPermissions",
-    "--resume",
-    "{sessionId}",
-  ],
+  args: [...CLAUDE_BASE_ARGS],
   output: "json",
   input: "arg",
   modelArg: "--model",
   modelAliases: CLAUDE_MODEL_ALIASES,
   sessionArg: "--session-id",
   sessionMode: "always",
-  sessionIdFields: ["session_id", "sessionId", "conversation_id", "conversationId"],
+  sessionIdFields: [...CLAUDE_SESSION_ID_FIELDS],
   systemPromptArg: "--append-system-prompt",
   systemPromptMode: "append",
   systemPromptWhen: "first",
   clearEnv: ["ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_OLD"],
+};
+
+const DEFAULT_CLAUDE_BACKEND: CliBackendConfig = {
+  ...CLAUDE_BASE_BACKEND,
+  resumeArgs: [...CLAUDE_BASE_ARGS, "--resume", "{sessionId}"],
   reliability: {
     watchdog: {
       fresh: { ...CLI_FRESH_WATCHDOG_DEFAULTS },
@@ -107,26 +119,10 @@ const DEFAULT_CODEX_BACKEND: CliBackendConfig = {
   serialize: true,
 };
 
+// Claude Code backend: shares base config with claude-cli but allows concurrent runs
 const DEFAULT_CLAUDE_CODE_BACKEND: CliBackendConfig = {
-  command: "claude",
-  args: ["-p", "--output-format", "json", "--permission-mode", "bypassPermissions"],
-  resumeArgs: [
-    "-p",
-    "--output-format",
-    "json",
-    "--permission-mode",
-    "bypassPermissions",
-    "--resume",
-    "{sessionId}",
-  ],
-  output: "json",
-  input: "arg",
-  modelArg: "--model",
-  modelAliases: CLAUDE_MODEL_ALIASES,
-  sessionArg: "--session-id",
-  sessionMode: "always",
-  sessionIdFields: ["session_id", "sessionId", "conversation_id", "conversationId"],
-  clearEnv: ["ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_OLD"],
+  ...CLAUDE_BASE_BACKEND,
+  resumeArgs: [...CLAUDE_BASE_ARGS, "--resume", "{sessionId}"],
   serialize: false, // Allow concurrent runs
 };
 

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -107,6 +107,29 @@ const DEFAULT_CODEX_BACKEND: CliBackendConfig = {
   serialize: true,
 };
 
+const DEFAULT_CLAUDE_CODE_BACKEND: CliBackendConfig = {
+  command: "claude",
+  args: ["-p", "--output-format", "json", "--permission-mode", "bypassPermissions"],
+  resumeArgs: [
+    "-p",
+    "--output-format",
+    "json",
+    "--permission-mode",
+    "bypassPermissions",
+    "--resume",
+    "{sessionId}",
+  ],
+  output: "json",
+  input: "arg",
+  modelArg: "--model",
+  modelAliases: CLAUDE_MODEL_ALIASES,
+  sessionArg: "--session-id",
+  sessionMode: "always",
+  sessionIdFields: ["session_id", "sessionId", "conversation_id", "conversationId"],
+  clearEnv: ["ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_OLD"],
+  serialize: false, // Allow concurrent runs
+};
+
 function normalizeBackendKey(key: string): string {
   return normalizeProviderId(key);
 }
@@ -206,6 +229,7 @@ export function resolveCliBackendIds(cfg?: OpenClawConfig): Set<string> {
   const ids = new Set<string>([
     normalizeBackendKey("claude-cli"),
     normalizeBackendKey("codex-cli"),
+    normalizeBackendKey("claude-code"),
   ]);
   const configured = cfg?.agents?.defaults?.cliBackends ?? {};
   for (const key of Object.keys(configured)) {
@@ -238,6 +262,16 @@ export function resolveCliBackendConfig(
       return null;
     }
     return { id: normalized, config: { ...merged, command } };
+  }
+
+  if (normalized === "claude-code") {
+    const merged = mergeBackendConfig(DEFAULT_CLAUDE_CODE_BACKEND, override);
+    const config = normalizeClaudeBackendConfig(merged);
+    const command = config.command?.trim();
+    if (!command) {
+      return null;
+    }
+    return { id: normalized, config: { ...config, command } };
   }
 
   if (!override) {

--- a/src/agents/spawn-utils.ts
+++ b/src/agents/spawn-utils.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared utilities for spawn operations across different runtimes.
+ * This module consolidates common patterns from acp-spawn, subagent-spawn, and claude-code-spawn.
+ */
+
+import type { DeliveryContext } from "../utils/delivery-context.js";
+import { normalizeDeliveryContext } from "../utils/delivery-context.js";
+
+// ============================================================================
+// Spawn Mode Types
+// ============================================================================
+
+/**
+ * Common spawn modes shared by all runtime types.
+ * - "run": One-shot execution that cleans up after completion.
+ * - "session": Persistent session that remains active for follow-ups.
+ */
+export const SPAWN_MODES = ["run", "session"] as const;
+export type SpawnMode = (typeof SPAWN_MODES)[number];
+
+// ============================================================================
+// Shared Context Types
+// ============================================================================
+
+/**
+ * Base context provided by the requester session when spawning a child.
+ * Used to track the origin of spawn requests and enable result delivery.
+ */
+export type SpawnBaseContext = {
+  agentSessionKey?: string;
+  agentChannel?: string;
+  agentAccountId?: string;
+  agentTo?: string;
+  agentThreadId?: string | number;
+  sandboxed?: boolean;
+};
+
+/**
+ * Base result type returned by all spawn functions.
+ */
+export type SpawnBaseResult = {
+  status: "accepted" | "forbidden" | "error";
+  childSessionKey?: string;
+  runId?: string;
+  mode?: SpawnMode;
+  note?: string;
+  error?: string;
+};
+
+// ============================================================================
+// Spawn Mode Resolution
+// ============================================================================
+
+/**
+ * Resolve the effective spawn mode based on request parameters.
+ *
+ * Priority:
+ * 1. Explicit mode request ("run" or "session")
+ * 2. Thread/resume preference defaults to "session"
+ * 3. Default to "run" for one-shot execution
+ */
+export function resolveSpawnMode(params: {
+  requestedMode?: SpawnMode;
+  threadRequested?: boolean;
+  resumeRequested?: boolean;
+}): SpawnMode {
+  if (params.requestedMode === "run" || params.requestedMode === "session") {
+    return params.requestedMode;
+  }
+  // Thread-bound or resume spawns should default to persistent sessions.
+  const wantsPersistence = params.threadRequested === true || params.resumeRequested === true;
+  return wantsPersistence ? "session" : "run";
+}
+
+// ============================================================================
+// Error Handling
+// ============================================================================
+
+/**
+ * Convert an unknown error value to a user-friendly string.
+ * Used consistently across spawn operations for error reporting.
+ */
+export function summarizeError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (typeof err === "string") {
+    return err;
+  }
+  return "error";
+}
+
+// ============================================================================
+// Delivery Context Helpers
+// ============================================================================
+
+/**
+ * Extract a normalized delivery context from spawn context.
+ * This consolidates the common pattern of extracting requester origin.
+ */
+export function extractRequesterOrigin(ctx: SpawnBaseContext): DeliveryContext | undefined {
+  return normalizeDeliveryContext({
+    channel: ctx.agentChannel,
+    accountId: ctx.agentAccountId,
+    to: ctx.agentTo,
+    threadId: ctx.agentThreadId,
+  });
+}

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -11,11 +11,19 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import {
+  extractRequesterOrigin,
+  resolveSpawnMode,
+  summarizeError,
+  type SpawnBaseContext,
+  type SpawnBaseResult,
+  type SpawnMode,
+  SPAWN_MODES,
+} from "./spawn-utils.js";
 import {
   mapToolContextToSpawnedRunMetadata,
   normalizeSpawnedRunMetadata,
@@ -36,8 +44,10 @@ import {
   resolveMainSessionAlias,
 } from "./tools/sessions-helpers.js";
 
-export const SUBAGENT_SPAWN_MODES = ["run", "session"] as const;
-export type SpawnSubagentMode = (typeof SUBAGENT_SPAWN_MODES)[number];
+// Re-export spawn mode types for backward compatibility
+export { SPAWN_MODES, type SpawnMode };
+export const SUBAGENT_SPAWN_MODES = SPAWN_MODES;
+export type SpawnSubagentMode = SpawnMode;
 export const SUBAGENT_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 export type SpawnSubagentSandboxMode = (typeof SUBAGENT_SPAWN_SANDBOX_MODES)[number];
 
@@ -64,12 +74,7 @@ export type SpawnSubagentParams = {
   attachMountPath?: string;
 };
 
-export type SpawnSubagentContext = {
-  agentSessionKey?: string;
-  agentChannel?: string;
-  agentAccountId?: string;
-  agentTo?: string;
-  agentThreadId?: string | number;
+export type SpawnSubagentContext = SpawnBaseContext & {
   agentGroupId?: string | null;
   agentGroupChannel?: string | null;
   agentGroupSpace?: string | null;
@@ -83,14 +88,8 @@ export const SUBAGENT_SPAWN_ACCEPTED_NOTE =
 export const SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE =
   "thread-bound session stays active after this task; continue in-thread for follow-ups.";
 
-export type SpawnSubagentResult = {
-  status: "accepted" | "forbidden" | "error";
-  childSessionKey?: string;
-  runId?: string;
-  mode?: SpawnSubagentMode;
-  note?: string;
+export type SpawnSubagentResult = SpawnBaseResult & {
   modelApplied?: boolean;
-  error?: string;
   attachments?: {
     count: number;
     totalBytes: number;
@@ -150,27 +149,6 @@ async function cleanupProvisionalSession(
   } catch {
     // Best-effort cleanup only.
   }
-}
-
-function resolveSpawnMode(params: {
-  requestedMode?: SpawnSubagentMode;
-  threadRequested: boolean;
-}): SpawnSubagentMode {
-  if (params.requestedMode === "run" || params.requestedMode === "session") {
-    return params.requestedMode;
-  }
-  // Thread-bound spawns should default to persistent sessions.
-  return params.threadRequested ? "session" : "run";
-}
-
-function summarizeError(err: unknown): string {
-  if (err instanceof Error) {
-    return err.message;
-  }
-  if (typeof err === "string") {
-    return err;
-  }
-  return "error";
 }
 
 async function ensureThreadBindingForSubagentSpawn(params: {
@@ -273,12 +251,7 @@ export async function spawnSubagentDirect(
         ? params.cleanup
         : "keep";
   const expectsCompletionMessage = params.expectsCompletionMessage !== false;
-  const requesterOrigin = normalizeDeliveryContext({
-    channel: ctx.agentChannel,
-    accountId: ctx.agentAccountId,
-    to: ctx.agentTo,
-    threadId: ctx.agentThreadId,
-  });
+  const requesterOrigin = extractRequesterOrigin(ctx);
   const hookRunner = getGlobalHookRunner();
   const cfg = loadConfig();
 

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -1,13 +1,14 @@
 import { Type } from "@sinclair/typebox";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { ACP_SPAWN_MODES, ACP_SPAWN_STREAM_TARGETS, spawnAcpDirect } from "../acp-spawn.js";
+import { CLAUDE_CODE_SPAWN_MODES, spawnClaudeCodeDirect } from "../claude-code-spawn.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { SpawnedToolContext } from "../spawned-context.js";
 import { SUBAGENT_SPAWN_MODES, spawnSubagentDirect } from "../subagent-spawn.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam, ToolInputError } from "./common.js";
 
-const SESSIONS_SPAWN_RUNTIMES = ["subagent", "acp"] as const;
+const SESSIONS_SPAWN_RUNTIMES = ["subagent", "acp", "claude-code"] as const;
 const SESSIONS_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 const UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS = [
   "target",
@@ -75,7 +76,7 @@ export function createSessionsSpawnTool(
     label: "Sessions",
     name: "sessions_spawn",
     description:
-      'Spawn an isolated session (runtime="subagent" or runtime="acp"). mode="run" is one-shot and mode="session" is persistent/thread-bound. Subagents inherit the parent workspace directory automatically.',
+      'Spawn an isolated session (runtime="subagent", runtime="acp", or runtime="claude-code"). mode="run" is one-shot and mode="session" is persistent/thread-bound. Subagents inherit the parent workspace directory automatically.',
     parameters: SessionsSpawnToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -89,7 +90,8 @@ export function createSessionsSpawnTool(
       }
       const task = readStringParam(params, "task", { required: true });
       const label = typeof params.label === "string" ? params.label.trim() : "";
-      const runtime = params.runtime === "acp" ? "acp" : "subagent";
+      const runtime =
+        params.runtime === "acp" || params.runtime === "claude-code" ? params.runtime : "subagent";
       const requestedAgentId = readStringParam(params, "agentId");
       const modelOverride = readStringParam(params, "model");
       const thinkingOverrideRaw = readStringParam(params, "thinking");
@@ -125,6 +127,35 @@ export function createSessionsSpawnTool(
           status: "error",
           error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
         });
+      }
+
+      if (runtime === "claude-code") {
+        if (Array.isArray(attachments) && attachments.length > 0) {
+          return jsonResult({
+            status: "error",
+            error:
+              "attachments are currently unsupported for runtime=claude-code; use runtime=subagent or remove attachments",
+          });
+        }
+        const result = await spawnClaudeCodeDirect(
+          {
+            task,
+            label: label || undefined,
+            cwd,
+            mode: mode && CLAUDE_CODE_SPAWN_MODES.includes(mode) ? mode : undefined,
+            resume: thread,
+            timeoutSeconds: runTimeoutSeconds,
+          },
+          {
+            agentSessionKey: opts?.agentSessionKey,
+            agentChannel: opts?.agentChannel,
+            agentAccountId: opts?.agentAccountId,
+            agentTo: opts?.agentTo,
+            agentThreadId: opts?.agentThreadId,
+            sandboxed: opts?.sandboxed,
+          },
+        );
+        return jsonResult(result);
       }
 
       if (runtime === "acp") {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,17 +36,16 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway =
-  vi.fn<
-    (opts: {
-      url: string;
-      auth?: { token?: string; password?: string };
-      timeoutMs: number;
-    }) => Promise<{
-      ok: boolean;
-      configSnapshot: unknown;
-    }>
-  >();
+const probeGateway = vi.fn<
+  (opts: {
+    url: string;
+    auth?: { token?: string; password?: string };
+    timeoutMs: number;
+  }) => Promise<{
+    ok: boolean;
+    configSnapshot: unknown;
+  }>
+>();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 


### PR DESCRIPTION
## Summary
This PR adds support for Claude Code runtime with session continuation.

## Changes
- Added `runtime="claude-code"` option to sessions_spawn
- Implemented session continuation support for persistent coding sessions
- Extracted shared spawn utilities to `spawn-utils.ts`

## Commits
- 763f5a9 feat: add runtime="claude-code" with session continuation support
- 80c8a3c refactor: extract shared spawn utilities to spawn-utils.ts

## Note
⚠️ This PR is based on v3.7 release (commit 42a1394). Willing to rebase onto latest main if needed.

## Testing
- Tested locally with session mode
- Verified session continuation works with Claude Code