### PR TITLE
fix(agents): apply skillFilter when building prompt from entries

### DIFF
--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -29,4 +29,64 @@ describe("resolveSkillsPromptForRun", () => {
     expect(prompt).toContain("<available_skills>");
     expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
   });
+
+  it("respects skillFilter from snapshot when building from entries", () => {
+    const entry1: SkillEntry = {
+      skill: {
+        name: "allowed-skill",
+        description: "Allowed",
+        filePath: "/app/skills/allowed-skill/SKILL.md",
+        baseDir: "/app/skills/allowed-skill",
+        source: "openclaw-bundled",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+    };
+    const entry2: SkillEntry = {
+      skill: {
+        name: "filtered-skill",
+        description: "Filtered",
+        filePath: "/app/skills/filtered-skill/SKILL.md",
+        baseDir: "/app/skills/filtered-skill",
+        source: "openclaw-bundled",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt: "",
+        skills: [],
+        skillFilter: ["allowed-skill"],
+      },
+      entries: [entry1, entry2],
+      workspaceDir: "/tmp/openclaw",
+    });
+    expect(prompt).toContain("allowed-skill");
+    expect(prompt).not.toContain("filtered-skill");
+  });
+
+  it("applies empty skillFilter correctly (no skills in prompt)", () => {
+    const entry: SkillEntry = {
+      skill: {
+        name: "demo-skill",
+        description: "Demo",
+        filePath: "/app/skills/demo-skill/SKILL.md",
+        baseDir: "/app/skills/demo-skill",
+        source: "openclaw-bundled",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt: "",
+        skills: [],
+        skillFilter: [],
+      },
+      entries: [entry],
+      workspaceDir: "/tmp/openclaw",
+    });
+    expect(prompt).toBe("");
+  });
 });

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -651,6 +651,7 @@ export function resolveSkillsPromptForRun(params: {
     const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
       entries: params.entries,
       config: params.config,
+      skillFilter: params.skillsSnapshot?.skillFilter,
     });
     return prompt.trim() ? prompt : "";
   }

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -143,7 +143,7 @@ describe("GatewayBrowserClient", () => {
       deviceId: "device-1",
       role: "operator",
       token: "stored-device-token",
-      scopes: ["operator.admin", "operator.approvals", "operator.pairing"],
+      scopes: ["operator.admin", "operator.read", "operator.write", "operator.approvals", "operator.pairing"],
     });
   });
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -242,7 +242,7 @@ export class GatewayBrowserClient {
     // Gateways may reject this unless gateway.controlUi.allowInsecureAuth is enabled.
     const isSecureContext = typeof crypto !== "undefined" && !!crypto.subtle;
 
-    const scopes = ["operator.admin", "operator.read", "operator.write", "operator.approvals", "operator.pairing"];
+    const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
     const role = "operator";
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const explicitPassword = this.opts.password?.trim() || undefined;

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -242,7 +242,7 @@ export class GatewayBrowserClient {
     // Gateways may reject this unless gateway.controlUi.allowInsecureAuth is enabled.
     const isSecureContext = typeof crypto !== "undefined" && !!crypto.subtle;
 
-    const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+    const scopes = ["operator.admin", "operator.read", "operator.write", "operator.approvals", "operator.pairing"];
     const role = "operator";
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const explicitPassword = this.opts.password?.trim() || undefined;


### PR DESCRIPTION
Fixes #47019

## Problem
Agent-level `skills` filters (e.g. `skills: []`) were ignored — all skills were still injected into the system prompt.

## Root Cause
`resolveSkillsPromptForRun` in `src/agents/skills/workspace.ts` wasn't passing `skillFilter` to `buildWorkspaceSkillsPrompt`.

## Fix
Pass `skillFilter: params.skillsSnapshot?.skillFilter` to `buildWorkspaceSkillsPrompt`.

*Note: Resubmission of #47350 which was auto-closed due to PR queue limit.*