### PR TITLE
fix(status): show configured fallback models in /status output

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -661,8 +661,10 @@ export function buildStatusMessage(args: StatusArgs): string {
     } (${fallbackState.reason ?? "selected model unavailable"})`;
   } else {
     const configuredFallbacks = resolveAgentModelFallbackValues(
-      args.config?.agents?.defaults?.model,
-    );
+      contextConfig?.agents?.defaults?.model,
+    )
+      .map((f) => String(f).trim())
+      .filter(Boolean);
     if (configuredFallbacks.length > 0) {
       fallbackLine = `↪️ Fallbacks: ${configuredFallbacks.join(", ")}`;
     }

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -13,6 +13,7 @@ import { derivePromptTokens, normalizeUsage, type UsageLike } from "../agents/us
 import { resolveChannelModelOverride } from "../channels/model-overrides.js";
 import { isCommandFlagEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import {
   resolveMainSessionKey,
   resolveSessionFilePath,
@@ -653,11 +654,19 @@ export function buildStatusMessage(args: StatusArgs): string {
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
-  const fallbackLine = fallbackState.active
-    ? `↪️ Fallback: ${activeModelLabel}${
-        showFallbackAuth ? ` · 🔑 ${activeAuthLabelValue}` : ""
-      } (${fallbackState.reason ?? "selected model unavailable"})`
-    : null;
+  let fallbackLine: string | null = null;
+  if (fallbackState.active) {
+    fallbackLine = `↪️ Fallback: ${activeModelLabel}${
+      showFallbackAuth ? ` · 🔑 ${activeAuthLabelValue}` : ""
+    } (${fallbackState.reason ?? "selected model unavailable"})`;
+  } else {
+    const configuredFallbacks = resolveAgentModelFallbackValues(
+      args.config?.agents?.defaults?.model,
+    );
+    if (configuredFallbacks.length > 0) {
+      fallbackLine = `↪️ Fallbacks: ${configuredFallbacks.join(", ")}`;
+    }
+  }
   const commit = resolveCommitHash({ moduleUrl: import.meta.url });
   const versionLine = `🦞 OpenClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
   const usagePair = formatUsagePair(inputTokens, outputTokens);


### PR DESCRIPTION
## Summary

`/status` now shows configured fallback models even when they are not actively in use, so users can verify their fallback setup at a glance.

Closes #33099

## Before / After

**Before** (fallbacks not active):
```
🧠 Model: anthropic/claude-opus-4-6
```

**After** (fallbacks configured but not active):
```
🧠 Model: anthropic/claude-opus-4-6
↪️ Fallbacks: google/gemini-2.5-flash
```

**When fallback is active** (unchanged):
```
🧠 Model: anthropic/claude-opus-4-6
↪️ Fallback: google/gemini-2.5-flash (selected model unavailable)
```

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm test -- src/auto-reply/status` — 29 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)