### PR TITLE
fix(ui): refresh avatar when switching sessions via switchChatSession

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -2,7 +2,7 @@ import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { t } from "../i18n/index.ts";
-import { refreshChat } from "./app-chat.ts";
+import { type ChatHost, refreshChat, refreshChatAvatar } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { OpenClawApp } from "./app.ts";
@@ -503,6 +503,7 @@ function switchChatSession(state: AppViewState, nextSessionKey: string) {
     lastActiveSessionKey: nextSessionKey,
   });
   void state.loadAssistantIdentity();
+  void refreshChatAvatar(state as unknown as ChatHost);
   syncUrlWithSessionKey(
     state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
     nextSessionKey,


### PR DESCRIPTION
## Summary                            

  - **Problem:** In the Web UI, switching sessions via the session dropdown (`switchChatSession`) did not update the agent avatar — the previous session's avatar remained visible.
  - **Why it matters:** Workspaces with multiple agents each have distinct avatars; a stale avatar misleads the user about which agent is active.
  - **Root cause:** `switchChatSession` called `loadAssistantIdentity()` but never called `refreshChatAvatar()`. Because `state.chatAvatarUrl` (set by a previous successful avatar
   fetch) takes priority over the synchronous `assistantAvatarUrl` fallback, the stale value persisted across session switches.
  - **What changed:** Added `void refreshChatAvatar(state as unknown as ChatHost)` to `switchChatSession` in `ui/src/ui/app-render.helpers.ts`, matching the existing behavior in
  the `onSessionKeyChange` callback path in `app-render.ts`.
  - **What did NOT change:** No gateway logic, no avatar serving endpoints, no other UI paths, no config surface.

  ## Change Type (select all)

  - [x] Bug fix

  ## Scope (select all touched areas)

  - [x] UI / DX

  ## Linked Issue/PR

  - Closes #
  - Related #

  ## User-visible / Behavior Changes

  When switching sessions in a workspace with multiple agents, the avatar in the chat view now immediately clears and updates to reflect the newly selected agent.

  ## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No — `refreshChatAvatar` was already called on other session-switch paths; this aligns `switchChatSession` with that existing behavior.
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Node 22+
  - Model/provider: Any
  - Integration/channel: Web UI (Control UI served from gateway at `127.0.0.1:18789`)
  - Relevant config: workspace with 2+ agents, each with a distinct avatar

  ### Steps

  1. Configure a workspace with at least two agents, each with a different avatar.
  2. Open the Control UI served by the gateway (`http://127.0.0.1:18789`).
  3. Start on any agent session — confirm its avatar is visible in the chat view.
  4. Use the session dropdown to switch to a different agent's session.

  ### Expected

  - Avatar clears immediately and updates to the newly selected agent's avatar.

  ### Actual (before fix)

  - Avatar remains stuck on the previous agent's avatar after switching sessions.

  ### Note on dev vs. prod behavior

  The bug does **not** manifest on a local Vite dev server (`localhost:5173`) connected to a remote gateway, because in that configuration the avatar fetch endpoint is unreachable
   (cross-origin), so `state.chatAvatarUrl` stays `null` and the synchronous `assistantAvatarUrl` fallback (which reads `state.agentsList` and updates correctly) is used instead.
  The bug only appears when the Control UI is served directly by the gateway and the avatar endpoint is reachable.

  ## Evidence

  - [ ] Failing test/log before + passing after
  - [x] Trace/log snippets — see root-cause analysis in PR description above
  - [x] Screenshot/recording

abnormal behavior
<img width="1280" height="813" alt="f55da31f4ece2e2a847b7c5801097885_720" src="https://github.com/user-attachments/assets/e02eb4c2-8dca-4d7c-a19d-55c6c4e816c2" />
<img width="1280" height="893" alt="824217e8f2706e80df8469d4554a6b4d_720" src="https://github.com/user-attachments/assets/ccd36f0c-1fe0-4c1c-9556-005257fad38f" />

Post-repair performance
<img width="1280" height="651" alt="1e4e8ead7af899954b035a4e87f809c6_720" src="https://github.com/user-attachments/assets/fa9b6093-a206-4036-b5ff-17d30f9b5b7a" />
<img width="1280" height="806" alt="0e46f775cbb739aac3f2ff7448ebea66_720" src="https://github.com/user-attachments/assets/cffb4478-2c11-4661-b279-6884a531863e" />


  ## Human Verification (required)

  - Verified scenarios: session switch updates avatar when Control UI is served by gateway; dev-server path unaffected.
  - Edge cases checked: agent with no avatar configured (falls back to logo correctly); rapid consecutive session switches (each switch sets `chatAvatarUrl = null` immediately
  before fetching).
  - What you did **not** verify: mobile Web UI.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  ## Failure Recovery (if this breaks)

  - How to revert: revert the single line addition in `ui/src/ui/app-render.helpers.ts`.
  - Known bad symptoms: avatar flickers to blank momentarily on session switch (acceptable; same behavior as the existing `onSessionKeyChange` path).

  ## Risks and Mitigations

  - Risk: extra network request on every session switch (one `GET /avatar/{agentId}?meta=1`).
    - Mitigation: this request was already issued on the `onSessionKeyChange` path; aligning behavior adds no new surface. Request is lightweight and idempotent.