### PR TITLE
fix(whatsapp): restore config-driven block streaming for WhatsApp delivery

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -280,7 +280,7 @@ describe("web processMessage inbound contract", () => {
     expect(groupHistories.get("whatsapp:default:group:123@g.us") ?? []).toHaveLength(0);
   });
 
-  it("suppresses non-final WhatsApp payload delivery", async () => {
+  it("suppresses tool payload delivery but allows block and final", async () => {
     const rememberSentText = vi.fn();
     await processMessage(createWhatsAppDirectStreamingArgs({ rememberSentText }));
 
@@ -291,21 +291,46 @@ describe("web processMessage inbound contract", () => {
     expect(deliver).toBeTypeOf("function");
 
     await deliver?.({ text: "tool payload" }, { kind: "tool" });
-    await deliver?.({ text: "block payload" }, { kind: "block" });
     expect(deliverWebReplyMock).not.toHaveBeenCalled();
-    expect(rememberSentText).not.toHaveBeenCalled();
+
+    await deliver?.({ text: "block payload" }, { kind: "block" });
+    expect(deliverWebReplyMock).toHaveBeenCalledTimes(1);
 
     await deliver?.({ text: "final payload" }, { kind: "final" });
-    expect(deliverWebReplyMock).toHaveBeenCalledTimes(1);
-    expect(rememberSentText).toHaveBeenCalledTimes(1);
+    expect(deliverWebReplyMock).toHaveBeenCalledTimes(2);
+    expect(rememberSentText).toHaveBeenCalledTimes(2);
   });
 
-  it("forces disableBlockStreaming for WhatsApp dispatch", async () => {
+  it("respects per-account blockStreaming config for disableBlockStreaming", async () => {
     await processMessage(createWhatsAppDirectStreamingArgs());
 
     // oxlint-disable-next-line typescript/no-explicit-any
     const replyOptions = (capturedDispatchParams as any)?.replyOptions;
-    expect(replyOptions?.disableBlockStreaming).toBe(true);
+    // blockStreaming: true in config → disableBlockStreaming: false
+    expect(replyOptions?.disableBlockStreaming).toBe(false);
+  });
+
+  it("leaves disableBlockStreaming undefined when blockStreaming not configured", async () => {
+    const args = makeProcessMessageArgs({
+      routeSessionKey: "agent:main:whatsapp:direct:+1555",
+      groupHistoryKey: "+1555",
+      cfg: {
+        messages: {},
+        session: { store: sessionStorePath },
+      } as unknown as ReturnType<typeof import("../../../../../src/config/config.js").loadConfig>,
+      msg: {
+        id: "msg1",
+        from: "+1555",
+        to: "+2000",
+        chatType: "direct",
+        body: "hi",
+      },
+    });
+    await processMessage(args);
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const replyOptions = (capturedDispatchParams as any)?.replyOptions;
+    expect(replyOptions?.disableBlockStreaming).toBeUndefined();
   });
 
   it("passes sendComposing through as the reply typing callback", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-contract.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-contract.test.ts
@@ -333,6 +333,31 @@ describe("web processMessage inbound contract", () => {
     expect(replyOptions?.disableBlockStreaming).toBeUndefined();
   });
 
+  it("disables block streaming when blockStreaming is explicitly false", async () => {
+    const args = makeProcessMessageArgs({
+      routeSessionKey: "agent:main:whatsapp:direct:+1555",
+      groupHistoryKey: "+1555",
+      cfg: {
+        channels: { whatsapp: { blockStreaming: false } },
+        messages: {},
+        session: { store: sessionStorePath },
+      } as unknown as ReturnType<typeof import("../../../../../src/config/config.js").loadConfig>,
+      msg: {
+        id: "msg1",
+        from: "+1555",
+        to: "+2000",
+        chatType: "direct",
+        body: "hi",
+      },
+    });
+    await processMessage(args);
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const replyOptions = (capturedDispatchParams as any)?.replyOptions;
+    // blockStreaming: false in config → disableBlockStreaming: true
+    expect(replyOptions?.disableBlockStreaming).toBe(true);
+  });
+
   it("passes sendComposing through as the reply typing callback", async () => {
     const sendComposing = vi.fn(async () => undefined);
     const args = createWhatsAppDirectStreamingArgs();

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -255,6 +255,7 @@ export async function processMessage(params: {
         })()
       : undefined;
 
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.route.accountId });
   const textLimit = params.maxMediaTextChunkLimit ?? resolveTextChunkLimit(params.cfg, "whatsapp");
   const chunkMode = resolveChunkMode(params.cfg, "whatsapp", params.route.accountId);
   const tableMode = resolveMarkdownTableMode({
@@ -402,12 +403,12 @@ export async function processMessage(params: {
         }
       },
       deliver: async (payload: ReplyPayload, info) => {
-        if (info.kind !== "final") {
-          // Only deliver final replies to external messaging channels (WhatsApp).
-          // Block (reasoning/thinking) and tool updates are meant for the internal
-          // web UI only; sending them here leaks chain-of-thought to end users.
+        if (info.kind === "tool") {
+          // Tool updates are internal-only; don't deliver to WhatsApp.
           return;
         }
+        // Reasoning blocks are already filtered upstream by shouldSuppressReasoningPayload
+        // in dispatch-from-config.ts. Only user-facing text/media blocks reach here.
         await deliverWebReply({
           replyResult: payload,
           msg: params.msg,
@@ -450,9 +451,8 @@ export async function processMessage(params: {
       onReplyStart: params.msg.sendComposing,
     },
     replyOptions: {
-      // WhatsApp delivery intentionally suppresses non-final payloads.
-      // Keep block streaming disabled so final replies are still produced.
-      disableBlockStreaming: true,
+      disableBlockStreaming:
+        typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
       onModelSelected,
     },
   });

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -403,12 +403,12 @@ export async function processMessage(params: {
         }
       },
       deliver: async (payload: ReplyPayload, info) => {
-        if (info.kind === "tool") {
+        if (info.kind === "tool" || payload.isReasoning) {
           // Tool updates are internal-only; don't deliver to WhatsApp.
+          // Reasoning blocks are suppressed upstream by shouldSuppressReasoningPayload,
+          // but we guard here too in case that filter is ever bypassed.
           return;
         }
-        // Reasoning blocks are already filtered upstream by shouldSuppressReasoningPayload
-        // in dispatch-from-config.ts. Only user-facing text/media blocks reach here.
         await deliverWebReply({
           replyResult: payload,
           msg: params.msg,


### PR DESCRIPTION
## Summary

- Problem: PR #24962 hardcoded `disableBlockStreaming: true` for WhatsApp to fix a reasoning/thinking content leak (#24954, #24605). This had the side effect of completely disabling block streaming — all messages are sent at once when the agent finishes, even when `blockStreamingDefault: "on"` and `blockStreamingBreak: "text_end"` are configured.
- Why it matters: Users who configure block streaming expect progressive message delivery on WhatsApp, matching the behavior of other channels like Telegram and Discord.
- What changed:
  1. The `deliver` callback now only suppresses `kind === "tool"` payloads (was suppressing everything except `"final"`). Reasoning blocks are already filtered upstream by `shouldSuppressReasoningPayload` in `dispatch-from-config.ts:446`, so they never reach the deliver callback.
  2. `disableBlockStreaming` is now config-driven from the per-account `blockStreaming` setting (was hardcoded `true`). When not configured, it falls through to the global `agents.defaults.blockStreamingDefault`.
- What did NOT change (scope boundary): Reasoning/thinking content is still suppressed from WhatsApp delivery — the upstream `shouldSuppressReasoningPayload` filter in `dispatch-from-config.ts` handles this. Tool payloads are still suppressed. The original bugs #24954 and #24605 remain fixed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #24962 (PR that introduced the hardcoded `disableBlockStreaming: true`)
- Related #24954, #24605 (original reasoning leak bugs — remain fixed)

## User-visible / Behavior Changes

- When `blockStreamingDefault: "on"` and `blockStreamingBreak: "text_end"` are configured, WhatsApp now delivers messages progressively at text boundaries instead of batching everything at the end.
- Per-account `channels.whatsapp.blockStreaming: true/false` config is now respected (was ignored since #24962).
- Default behavior (no config set) is unchanged — block streaming remains off unless explicitly enabled.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25
- Model/provider: Anthropic Claude
- Integration/channel: WhatsApp
- Relevant config:
  ```json
  {
    "agents": { "defaults": { "blockStreamingDefault": "on", "blockStreamingBreak": "text_end" } },
    "channels": { "whatsapp": { "blockStreaming": true } }
  }
  ```

### Steps

1. Configure block streaming as above
2. Send a message on WhatsApp that triggers a long response
3. Observe message delivery behavior

### Expected

Messages are delivered progressively at `text_end` boundaries during streaming.

### Actual (before fix)

All messages are batched and sent at once when the agent finishes.

## Evidence

- [x] Failing test/log before + passing after
- Tested on live WhatsApp with block streaming enabled — messages arrive progressively. No reasoning or tool call blocks were leaked to WhatsApp. The fix works exactly as expected.
- All 13 inbound contract tests pass (`pnpm test -- extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-contract.test.ts`)

## Human Verification (required)

- Verified scenarios: Live WhatsApp DM with `blockStreamingDefault: "on"` and `blockStreamingBreak: "text_end"` — blocks delivered progressively. Confirmed no reasoning content or tool call blocks leak to WhatsApp.
- Edge cases checked: Reasoning content does NOT leak (verified both in live testing and via `shouldSuppressReasoningPayload` filtering upstream); tool payloads still suppressed; unconfigured accounts fall through to global default
- What you did **not** verify: Group chat behavior; multiple WhatsApp accounts

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No — existing config keys (`blockStreaming`, `blockStreamingDefault`, `blockStreamingBreak`) are already defined; this PR makes WhatsApp respect them
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Set `channels.whatsapp.blockStreaming: false` in config, or remove `blockStreamingDefault` from agent defaults
- Files/config to restore: `extensions/whatsapp/src/auto-reply/monitor/process-message.ts`
- Known bad symptoms reviewers should watch for: Reasoning/thinking content appearing in WhatsApp messages (would indicate upstream filter regression)

## Risks and Mitigations

- Risk: If `shouldSuppressReasoningPayload` in `dispatch-from-config.ts` were ever removed or bypassed, reasoning blocks could leak to WhatsApp.
  - Mitigation: That function is used by all channels on the generic dispatch path (not just WhatsApp), so removing it would break multiple channels simultaneously — making it very unlikely to be removed silently.