### PR TITLE
fix(hooks): append session memory to canonical daily file

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -357,17 +357,27 @@ const saveSessionToMemory: HookHandler = async (event) => {
     // in AGENTS.md instructs agents to read memory/YYYY-MM-DD.md, but the
     // slug-named file above is invisible to that path.
     const canonicalFilename = `${dateStr}.md`;
-    if (canonicalFilename !== filename) {
+    try {
+      const canonicalPath = path.join(memoryDir, canonicalFilename);
+      let existing = "";
       try {
-        const canonicalPath = path.join(memoryDir, canonicalFilename);
-        await fs.appendFile(canonicalPath, `\n${entry}`, "utf-8");
-        log.debug("Appended to canonical daily memory file", { canonicalFilename });
-      } catch (canonicalErr) {
-        log.warn("Failed to append to canonical daily memory file", {
-          canonicalFilename,
-          error: canonicalErr instanceof Error ? canonicalErr.message : String(canonicalErr),
-        });
+        existing = await fs.readFile(canonicalPath, "utf-8");
+      } catch {
+        // File doesn't exist yet — will be created.
       }
+      const appended = existing ? `${existing}\n${entry}` : entry;
+      await writeFileWithinRoot({
+        rootDir: memoryDir,
+        relativePath: canonicalFilename,
+        data: appended,
+        encoding: "utf-8",
+      });
+      log.debug("Appended to canonical daily memory file", { canonicalFilename });
+    } catch (canonicalErr) {
+      log.warn("Failed to append to canonical daily memory file", {
+        canonicalFilename,
+        error: canonicalErr instanceof Error ? canonicalErr.message : String(canonicalErr),
+      });
     }
 
     // Log completion (but don't send user-visible confirmation - it's internal housekeeping)

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -352,6 +352,24 @@ const saveSessionToMemory: HookHandler = async (event) => {
     });
     log.debug("Memory file written successfully");
 
+    // Also append to the canonical daily file (YYYY-MM-DD.md) so the boot
+    // sequence can find it without relying on memory_search. The boot prompt
+    // in AGENTS.md instructs agents to read memory/YYYY-MM-DD.md, but the
+    // slug-named file above is invisible to that path.
+    const canonicalFilename = `${dateStr}.md`;
+    if (canonicalFilename !== filename) {
+      try {
+        const canonicalPath = path.join(memoryDir, canonicalFilename);
+        await fs.appendFile(canonicalPath, `\n${entry}`, "utf-8");
+        log.debug("Appended to canonical daily memory file", { canonicalFilename });
+      } catch (canonicalErr) {
+        log.warn("Failed to append to canonical daily memory file", {
+          canonicalFilename,
+          error: canonicalErr instanceof Error ? canonicalErr.message : String(canonicalErr),
+        });
+      }
+    }
+
     // Log completion (but don't send user-visible confirmation - it's internal housekeeping)
     const relPath = memoryFilePath.replace(os.homedir(), "~");
     log.info(`Session context saved to ${relPath}`);


### PR DESCRIPTION
## Summary

The session-memory hook now also appends to the canonical `memory/YYYY-MM-DD.md` file so agents can find session memories on boot without relying on `memory_search`.

Closes #45607

## Root cause

The hook writes to `memory/YYYY-MM-DD-slug.md` (e.g., `memory/2026-03-13-api-refactor.md`), but the boot sequence in `AGENTS.md` instructs agents to read `memory/YYYY-MM-DD.md`. These are different files, so the hook's output was effectively invisible on startup.

## Fix

After writing the slug-named file (preserved for detailed per-session records), also append the same entry to the canonical daily file. This is a non-breaking addition — the slug file continues to be written as before.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [ ] Manual test: trigger `/new`, verify both `memory/YYYY-MM-DD-slug.md` and `memory/YYYY-MM-DD.md` exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)