### PR TITLE
fix(docker): include src in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,7 @@ COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
 COPY --from=runtime-assets --chown=node:node /app/extensions ./extensions
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
+COPY --from=runtime-assets --chown=node:node /app/src ./src
 
 # Keep pnpm available in the runtime image for container-local workflows.
 # Use a shared Corepack home so the non-root `node` user does not need a


### PR DESCRIPTION
## Summary\n- Fixes Docker runtime plugin load failures for Telegram/Discord by including /app/src in the runtime image.\n\n## Problem\n- Bundled extensions import core modules from ../../../src/..., but the runtime image does not include /app/src. This causes module resolution failures at startup.\n\n## Fix\n- Copy /app/src into the runtime stage.\n\n## Test plan\n- Not run locally (Docker image build).\n\nCloses #47401