### PR TITLE
fix(cli): prevent plugin double-registration via runtime boundary

### DIFF
--- a/src/cli/plugin-registry.runtime.ts
+++ b/src/cli/plugin-registry.runtime.ts
@@ -1,0 +1,6 @@
+// Dynamic-import boundary: this file is the only entry point for lazy callers.
+// plugin-registry.ts is statically imported from route.ts; keeping it out of
+// any dynamic import() target ensures the bundler emits a single shared module
+// instance and avoids the static-vs-dynamic double-registration hazard.
+// See CLAUDE.md: "Dynamic import guardrail".
+export { ensurePluginRegistryLoaded } from "./plugin-registry.js";

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -38,7 +38,9 @@ const PLUGIN_REQUIRED_COMMANDS = new Set([
 const CONFIG_GUARD_BYPASS_COMMANDS = new Set(["backup", "doctor", "completion", "secrets"]);
 const JSON_PARSE_ONLY_COMMANDS = new Set(["config set"]);
 let configGuardModulePromise: Promise<typeof import("./config-guard.js")> | undefined;
-let pluginRegistryModulePromise: Promise<typeof import("../plugin-registry.js")> | undefined;
+let pluginRegistryModulePromise:
+  | Promise<typeof import("../plugin-registry.runtime.js")>
+  | undefined;
 
 function shouldBypassConfigGuard(commandPath: string[]): boolean {
   const [primary, secondary] = commandPath;
@@ -62,7 +64,11 @@ function loadConfigGuardModule() {
 }
 
 function loadPluginRegistryModule() {
-  pluginRegistryModulePromise ??= import("../plugin-registry.js");
+  // Import the runtime boundary, not plugin-registry.ts directly.
+  // plugin-registry.ts is already statically imported from route.ts; importing
+  // it here via dynamic import() would create a second module instance in the
+  // bundled output, causing plugins to register twice (see CLAUDE.md guardrail).
+  pluginRegistryModulePromise ??= import("../plugin-registry.runtime.js");
   return pluginRegistryModulePromise;
 }
 


### PR DESCRIPTION
## Summary

- `src/cli/plugin-registry.ts` was both **statically imported** (from `src/cli/route.ts`) and **dynamically imported** (from `src/cli/program/preaction.ts`), violating the CLAUDE.md dynamic-import guardrail
- In the bundled output tsdown/rolldown emits two separate module instances — each with its own `pluginRegistryLoaded = false` flag and empty `registryCache`
- This caused `loadOpenClawPlugins()` to run twice: once from `registerPluginCliCommands` and again when the Commander `preAction` hook called `ensurePluginRegistryLoaded()` from the second instance
- The `getActivePluginRegistry()` short-circuit in `ensurePluginRegistryLoaded()` exists for exactly this case, but it reads from a different `runtime.ts` instance that has never had `setActivePluginRegistry` called on it → guard always misses → plugins always register twice

## Fix

Introduce `src/cli/plugin-registry.runtime.ts` as the sole dynamic-import boundary:

```ts
// plugin-registry.runtime.ts
export { ensurePluginRegistryLoaded } from "./plugin-registry.js";
```

`preaction.ts` now dynamically imports the runtime boundary instead of `plugin-registry.ts` directly. This ensures:
1. `plugin-registry.ts` is **only ever statically imported** (by `route.ts`)
2. The bundler emits a single shared module instance
3. `ensurePluginRegistryLoaded()` correctly sees the active registry set by the first load and short-circuits

No `[INEFFECTIVE_DYNAMIC_IMPORT]` warning emitted for `plugin-registry` after the fix.

## Test plan

- [ ] Enable a third-party plugin (`openclaw plugins enable feishu` or similar)
- [ ] Run `openclaw message send ... --dry-run` — confirm each plugin's registration log appears **once**, not twice
- [ ] Run `pnpm build` and confirm no `[INEFFECTIVE_DYNAMIC_IMPORT]` warning for `plugin-registry`
- [ ] Run `pnpm check` clean

Fixes #47429

🤖 Generated with [Claude Code](https://claude.com/claude-code)