### PR TITLE
fix(failover): classify OpenRouter generic provider errors as timeout

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -356,6 +356,15 @@ describe("failover-error", () => {
     );
   });
 
+  it("classifies OpenRouter generic 'Provider returned error' as timeout (#45834)", () => {
+    expect(resolveFailoverReasonFromError({ message: "Provider returned error" })).toBe("timeout");
+    expect(
+      resolveFailoverReasonFromError({
+        message: "Provider returned error: upstream service failure",
+      }),
+    ).toBe("timeout");
+  });
+
   it("treats AbortError reason=abort as timeout", () => {
     const err = Object.assign(new Error("aborted"), {
       name: "AbortError",

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -50,6 +50,9 @@ const ERROR_PATTERNS = {
     /\bstop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     /\breason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     /\bunhandled stop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
+    // OpenRouter wraps upstream provider failures as "Provider returned error"
+    // without an HTTP status prefix, which falls through all other classifiers.
+    /\bprovider returned error\b/i,
   ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,


### PR DESCRIPTION
## Summary

OpenRouter wraps upstream provider failures as `Provider returned error` without an HTTP status prefix. This message falls through all failover classifiers in `classifyFailoverReason()`, returning `null` instead of triggering the fallback chain.

Adds a pattern to the `timeout` error list in `failover-matches.ts` to match this message shape and classify it as a retryable timeout error, allowing model failover to engage correctly.

Closes #45834

## Changes

- `src/agents/pi-embedded-helpers/failover-matches.ts`: add `/\bprovider returned error\b/i` to the `timeout` patterns array
- `src/agents/failover-error.test.ts`: add test covering the new classification

## Test plan

- [x] Existing failover tests pass (33/33)
- [x] New test verifies `"Provider returned error"` and `"Provider returned error: upstream service failure"` both classify as `"timeout"`