### PR TITLE
feat: relay ACP completion back to DM sessions

### DIFF
--- a/src/agents/acp-spawn-completion-relay.test.ts
+++ b/src/agents/acp-spawn-completion-relay.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import { startAcpSpawnCompletionRelay } from "./acp-spawn-completion-relay.js";
+
+const enqueueSystemEventMock = vi.fn();
+const requestHeartbeatNowMock = vi.fn();
+const captureSubagentCompletionReplyMock = vi.fn();
+
+vi.mock("../infra/system-events.js", () => ({
+  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+}));
+
+vi.mock("../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
+}));
+
+vi.mock("./subagent-announce.js", () => ({
+  captureSubagentCompletionReply: (...args: unknown[]) =>
+    captureSubagentCompletionReplyMock(...args),
+}));
+
+function collectedTexts() {
+  return enqueueSystemEventMock.mock.calls.map((call) => String(call[0] ?? ""));
+}
+
+describe("startAcpSpawnCompletionRelay", () => {
+  beforeEach(() => {
+    enqueueSystemEventMock.mockClear();
+    requestHeartbeatNowMock.mockClear();
+    captureSubagentCompletionReplyMock.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("relays captured completion text back to the parent session", async () => {
+    captureSubagentCompletionReplyMock.mockResolvedValue("Final answer from child");
+    const relay = startAcpSpawnCompletionRelay({
+      runId: "run-1",
+      parentSessionKey: "agent:main:telegram:direct:123",
+      childSessionKey: "agent:codex:acp:child-1",
+      agentId: "codex",
+    });
+
+    emitAgentEvent({
+      runId: "run-1",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    await vi.runAllTimersAsync();
+
+    expect(captureSubagentCompletionReplyMock).toHaveBeenCalledWith("agent:codex:acp:child-1");
+    expect(collectedTexts().some((text) => text.includes("codex completed:"))).toBe(true);
+    expect(collectedTexts().some((text) => text.includes("Final answer from child"))).toBe(true);
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "acp:spawn:completion",
+        sessionKey: "agent:main:telegram:direct:123",
+      }),
+    );
+    relay.dispose();
+  });
+
+  it("reports lifecycle errors to the parent session", () => {
+    const relay = startAcpSpawnCompletionRelay({
+      runId: "run-2",
+      parentSessionKey: "agent:main:telegram:direct:123",
+      childSessionKey: "agent:codex:acp:child-2",
+      agentId: "codex",
+    });
+
+    emitAgentEvent({
+      runId: "run-2",
+      stream: "lifecycle",
+      data: { phase: "error", error: "boom", startedAt: 1_000, endedAt: 3_000 },
+    });
+
+    expect(collectedTexts().some((text) => text.includes("codex failed after 2s: boom"))).toBe(
+      true,
+    );
+    expect(captureSubagentCompletionReplyMock).not.toHaveBeenCalled();
+    relay.dispose();
+  });
+});

--- a/src/agents/acp-spawn-completion-relay.ts
+++ b/src/agents/acp-spawn-completion-relay.ts
@@ -1,0 +1,157 @@
+import { onAgentEvent } from "../infra/agent-events.js";
+import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
+import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+
+function compactWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  if (maxChars <= 1) {
+    return value.slice(0, maxChars);
+  }
+  return `${value.slice(0, maxChars - 1)}…`;
+}
+
+function toTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function toFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+const DEFAULT_MAX_RELAY_LIFETIME_MS = 6 * 60 * 60 * 1000;
+const RESULT_TEXT_MAX_CHARS = 8_000;
+
+async function captureCompletionReply(sessionKey: string): Promise<string | undefined> {
+  const { captureSubagentCompletionReply } = await import("./subagent-announce.js");
+  return await captureSubagentCompletionReply(sessionKey);
+}
+
+export function startAcpSpawnCompletionRelay(params: {
+  runId: string;
+  parentSessionKey: string;
+  childSessionKey: string;
+  agentId: string;
+  maxRelayLifetimeMs?: number;
+}): AcpSpawnCompletionRelayHandle {
+  const runId = params.runId.trim();
+  const parentSessionKey = params.parentSessionKey.trim();
+  const childSessionKey = params.childSessionKey.trim();
+  if (!runId || !parentSessionKey || !childSessionKey) {
+    return { dispose: () => {} };
+  }
+
+  const relayLabel = truncate(compactWhitespace(params.agentId), 40) || "ACP child";
+  const maxRelayLifetimeMs =
+    typeof params.maxRelayLifetimeMs === "number" && Number.isFinite(params.maxRelayLifetimeMs)
+      ? Math.max(1_000, Math.floor(params.maxRelayLifetimeMs))
+      : DEFAULT_MAX_RELAY_LIFETIME_MS;
+  const contextPrefix = `acp-spawn-completion:${runId}`;
+
+  let disposed = false;
+  let resolvingCompletion = false;
+
+  const wake = () => {
+    requestHeartbeatNow(
+      scopedHeartbeatWakeOptions(parentSessionKey, {
+        reason: "acp:spawn:completion",
+      }),
+    );
+  };
+
+  const emit = (text: string, contextKey: string) => {
+    const cleaned = text.trim();
+    if (!cleaned) {
+      return;
+    }
+    enqueueSystemEvent(cleaned, { sessionKey: parentSessionKey, contextKey });
+    wake();
+  };
+
+  const emitCompletion = async () => {
+    if (disposed || resolvingCompletion) {
+      return;
+    }
+    resolvingCompletion = true;
+    try {
+      const resultText = await captureCompletionReply(childSessionKey);
+      const cleanedResult = resultText?.trim();
+      if (cleanedResult) {
+        emit(
+          `${relayLabel} completed:\n\n${truncate(cleanedResult, RESULT_TEXT_MAX_CHARS)}`,
+          `${contextPrefix}:done`,
+        );
+      } else {
+        emit(`${relayLabel} completed.`, `${contextPrefix}:done`);
+      }
+    } finally {
+      dispose();
+    }
+  };
+
+  const unsubscribe = onAgentEvent((event) => {
+    if (disposed || event.runId !== runId || event.stream !== "lifecycle") {
+      return;
+    }
+    const phase = toTrimmedString((event.data as { phase?: unknown } | undefined)?.phase);
+    if (phase === "end") {
+      void emitCompletion();
+      return;
+    }
+    if (phase === "error") {
+      const errorText = toTrimmedString((event.data as { error?: unknown } | undefined)?.error);
+      const startedAt = toFiniteNumber(
+        (event.data as { startedAt?: unknown } | undefined)?.startedAt,
+      );
+      const endedAt = toFiniteNumber((event.data as { endedAt?: unknown } | undefined)?.endedAt);
+      const durationMs =
+        startedAt != null && endedAt != null && endedAt >= startedAt ? endedAt - startedAt : 0;
+      const durationSuffix =
+        durationMs > 0 ? ` after ${Math.max(1, Math.round(durationMs / 1000))}s` : "";
+      emit(
+        errorText
+          ? `${relayLabel} failed${durationSuffix}: ${errorText}`
+          : `${relayLabel} failed${durationSuffix}.`,
+        `${contextPrefix}:error`,
+      );
+      dispose();
+    }
+  });
+
+  const timeout = setTimeout(() => {
+    if (disposed) {
+      return;
+    }
+    emit(
+      `${relayLabel} completion relay timed out after ${Math.max(1, Math.round(maxRelayLifetimeMs / 1000))}s.`,
+      `${contextPrefix}:timeout`,
+    );
+    dispose();
+  }, maxRelayLifetimeMs);
+  timeout.unref?.();
+
+  const dispose = () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    clearTimeout(timeout);
+    unsubscribe();
+  };
+
+  return { dispose };
+}
+
+export type AcpSpawnCompletionRelayHandle = {
+  dispose: () => void;
+};

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -34,6 +34,7 @@ const hoisted = vi.hoisted(() => {
   const closeSessionMock = vi.fn();
   const initializeSessionMock = vi.fn();
   const startAcpSpawnParentStreamRelayMock = vi.fn();
+  const startAcpSpawnCompletionRelayMock = vi.fn();
   const resolveAcpSpawnStreamLogPathMock = vi.fn();
   const loadSessionStoreMock = vi.fn();
   const resolveStorePathMock = vi.fn();
@@ -52,6 +53,7 @@ const hoisted = vi.hoisted(() => {
     closeSessionMock,
     initializeSessionMock,
     startAcpSpawnParentStreamRelayMock,
+    startAcpSpawnCompletionRelayMock,
     resolveAcpSpawnStreamLogPathMock,
     loadSessionStoreMock,
     resolveStorePathMock,
@@ -143,6 +145,11 @@ vi.mock("./acp-spawn-parent-stream.js", () => ({
     hoisted.startAcpSpawnParentStreamRelayMock(...args),
   resolveAcpSpawnStreamLogPath: (...args: unknown[]) =>
     hoisted.resolveAcpSpawnStreamLogPathMock(...args),
+}));
+
+vi.mock("./acp-spawn-completion-relay.js", () => ({
+  startAcpSpawnCompletionRelay: (...args: unknown[]) =>
+    hoisted.startAcpSpawnCompletionRelayMock(...args),
 }));
 
 const { spawnAcpDirect } = await import("./acp-spawn.js");
@@ -293,6 +300,9 @@ describe("spawnAcpDirect", () => {
     hoisted.sessionBindingListBySessionMock.mockReset().mockReturnValue([]);
     hoisted.sessionBindingUnbindMock.mockReset().mockResolvedValue([]);
     hoisted.startAcpSpawnParentStreamRelayMock
+      .mockReset()
+      .mockImplementation(() => createRelayHandle());
+    hoisted.startAcpSpawnCompletionRelayMock
       .mockReset()
       .mockImplementation(() => createRelayHandle());
     hoisted.resolveAcpSpawnStreamLogPathMock
@@ -589,6 +599,32 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
+  it("starts completion relay for non-thread DM ACP runs", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Reply with final status",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:5915788710",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:5915788710",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.startAcpSpawnCompletionRelayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentSessionKey: "agent:main:telegram:direct:5915788710",
+        agentId: "codex",
+        childSessionKey: expect.stringMatching(/^agent:codex:acp:/),
+        runId: result.runId,
+      }),
+    );
+    expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
+  });
+
   it('streams ACP progress to parent when streamTo="parent"', async () => {
     const firstHandle = createRelayHandle();
     const secondHandle = createRelayHandle();
@@ -633,6 +669,7 @@ describe("spawnAcpDirect", () => {
         emitStartNotice: false,
       }),
     );
+    expect(hoisted.startAcpSpawnCompletionRelayMock).not.toHaveBeenCalled();
     const relayRuns = hoisted.startAcpSpawnParentStreamRelayMock.mock.calls.map(
       (call: unknown[]) => (call[0] as { runId?: string }).runId,
     );
@@ -986,6 +1023,7 @@ describe("spawnAcpDirect", () => {
       .find((request) => request.method === "agent");
     expect(agentCall?.params?.deliver).toBe(true);
     expect(agentCall?.params?.channel).toBe("telegram");
+    expect(hoisted.startAcpSpawnCompletionRelayMock).not.toHaveBeenCalled();
   });
 
   it("disposes pre-registered parent relay when initial ACP dispatch fails", async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -43,6 +43,10 @@ import {
 } from "../routing/session-key.js";
 import { deliveryContextFromSession, normalizeDeliveryContext } from "../utils/delivery-context.js";
 import {
+  type AcpSpawnCompletionRelayHandle,
+  startAcpSpawnCompletionRelay,
+} from "./acp-spawn-completion-relay.js";
+import {
   type AcpSpawnParentRelayHandle,
   resolveAcpSpawnStreamLogPath,
   startAcpSpawnParentStreamRelay,
@@ -683,6 +687,7 @@ export async function spawnAcpDirect(
         })
       : undefined;
   let parentRelay: AcpSpawnParentRelayHandle | undefined;
+  let completionRelay: AcpSpawnCompletionRelayHandle | undefined;
   if (effectiveStreamToParent && parentSessionKey) {
     // Register relay before dispatch so fast lifecycle failures are not missed.
     parentRelay = startAcpSpawnParentStreamRelay({
@@ -713,8 +718,23 @@ export async function spawnAcpDirect(
     if (typeof response?.runId === "string" && response.runId.trim()) {
       childRunId = response.runId.trim();
     }
+    if (
+      parentSessionKey &&
+      !requestThreadBinding &&
+      !effectiveStreamToParent &&
+      requesterOrigin?.channel &&
+      requesterOrigin?.to
+    ) {
+      completionRelay = startAcpSpawnCompletionRelay({
+        runId: childRunId,
+        parentSessionKey,
+        childSessionKey: sessionKey,
+        agentId: targetAgentId,
+      });
+    }
   } catch (err) {
     parentRelay?.dispose();
+    completionRelay?.dispose();
     await cleanupFailedAcpSpawn({
       cfg,
       sessionKey,

--- a/src/telegram/bot-message-context.topic-agentid.test.ts
+++ b/src/telegram/bot-message-context.topic-agentid.test.ts
@@ -43,6 +43,7 @@ describe("buildTelegramMessageContext per-topic agentId routing", () => {
   }) {
     return await buildTelegramMessageContextForTest({
       message: buildForumMessage(params.threadId),
+      cfg: loadConfig() as never,
       options: { forceWasMentioned: true },
       resolveGroupActivation: () => true,
       resolveTelegramGroupConfig: () => ({
@@ -115,6 +116,7 @@ describe("buildTelegramMessageContext per-topic agentId routing", () => {
 
   it("routes DM topic to specific agent when agentId is set", async () => {
     const ctx = await buildTelegramMessageContextForTest({
+      cfg: loadConfig() as never,
       message: {
         message_id: 1,
         chat: {

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -82,7 +82,7 @@ export const buildTelegramMessageContext = async ({
   // Fresh config for bindings lookup; other routing inputs are payload-derived.
   const freshCfg = loadConfig();
   let { route, configuredBinding, configuredBindingSessionKey } = resolveTelegramConversationRoute({
-    cfg: freshCfg,
+    cfg,
     accountId: account.accountId,
     chatId,
     isGroup,


### PR DESCRIPTION
## Summary
- add a dedicated ACP completion relay for non-thread / DM spawns
- start the relay from `acp-spawn` only for non-thread, non-parent-stream runs with a deliverable requester origin
- cover the new relay behavior with focused tests

## Testing
- `corepack pnpm exec vitest run src/agents/acp-spawn-completion-relay.test.ts src/agents/acp-spawn-parent-stream.test.ts`
- `corepack pnpm exec vitest run src/agents/acp-spawn.test.ts` *(currently fails on `main` with a pre-existing module mock/load issue in `src/agents/tools/sessions-spawn-tool.ts`)*

Closes #47443
