### PR TITLE
fix(sessions): preserve announce threadId for sessions_send

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -8,9 +8,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP",
       "help": "ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.",
       "hasChildren": true
@@ -22,9 +20,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "ACP Allowed Agents",
       "help": "Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.",
       "hasChildren": true
@@ -46,9 +42,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Backend",
       "help": "Default ACP runtime backend id (for example: acpx). Must match a registered ACP runtime plugin backend.",
       "hasChildren": false
@@ -60,9 +54,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Default Agent",
       "help": "Fallback ACP target agent id used when ACP spawns do not specify an explicit target.",
       "hasChildren": false
@@ -84,9 +76,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Dispatch Enabled",
       "help": "Independent dispatch gate for ACP session turns (default: true). Set false to keep ACP commands available while blocking ACP turn execution.",
       "hasChildren": false
@@ -98,9 +88,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Enabled",
       "help": "Global ACP feature gate. Keep disabled unless ACP runtime + policy are configured.",
       "hasChildren": false
@@ -112,10 +100,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "ACP Max Concurrent Sessions",
       "help": "Maximum concurrently active ACP sessions across this gateway process.",
       "hasChildren": false
@@ -137,9 +122,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Runtime Install Command",
       "help": "Optional operator install/setup command shown by `/acp install` and `/acp doctor` when ACP backend wiring is missing.",
       "hasChildren": false
@@ -151,9 +134,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Runtime TTL (minutes)",
       "help": "Idle runtime TTL in minutes for ACP session workers before eligible cleanup.",
       "hasChildren": false
@@ -165,9 +146,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Stream",
       "help": "ACP streaming projection controls for chunk sizing, metadata visibility, and deduped delivery behavior.",
       "hasChildren": true
@@ -179,9 +158,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Stream Coalesce Idle (ms)",
       "help": "Coalescer idle flush window in milliseconds for ACP streamed text before block replies are emitted.",
       "hasChildren": false
@@ -193,9 +170,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Stream Delivery Mode",
       "help": "ACP delivery style: live streams projected output incrementally, final_only buffers all projected ACP output until terminal turn events.",
       "hasChildren": false
@@ -207,9 +182,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Stream Hidden Boundary Separator",
       "help": "Separator inserted before next visible assistant text when hidden ACP tool lifecycle events occurred (none|space|newline|paragraph). Default: paragraph.",
       "hasChildren": false
@@ -221,9 +194,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "ACP Stream Max Chunk Chars",
       "help": "Maximum chunk size for ACP streamed block projection before splitting into multiple block replies.",
       "hasChildren": false
@@ -235,9 +206,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "ACP Stream Max Output Chars",
       "help": "Maximum assistant output characters projected per ACP turn before truncation notice is emitted.",
       "hasChildren": false
@@ -249,10 +218,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "ACP Stream Max Session Update Chars",
       "help": "Maximum characters for projected ACP session/update lines (tool/status updates).",
       "hasChildren": false
@@ -264,9 +230,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Stream Repeat Suppression",
       "help": "When true (default), suppress repeated ACP status/tool projection lines in a turn while keeping raw ACP events unchanged.",
       "hasChildren": false
@@ -278,9 +242,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Stream Tag Visibility",
       "help": "Per-sessionUpdate visibility overrides for ACP projection (for example usage_update, available_commands_update).",
       "hasChildren": true
@@ -302,9 +264,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agents",
       "help": "Agent runtime configuration root covering defaults and explicit agent entries used for routing and execution context. Keep this section explicit so model/tool behavior stays predictable across multi-agent workflows.",
       "hasChildren": true
@@ -316,9 +276,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent Defaults",
       "help": "Shared default settings inherited by agents unless overridden per entry in agents.list. Use defaults to enforce consistent baseline behavior and reduce duplicated per-agent configuration.",
       "hasChildren": true
@@ -430,9 +388,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Bootstrap Max Chars",
       "help": "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
       "hasChildren": false
@@ -444,9 +400,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Bootstrap Prompt Truncation Warning",
       "help": "Inject agent-visible warning text when bootstrap files are truncated: \"off\", \"once\" (default), or \"always\".",
       "hasChildren": false
@@ -458,9 +412,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Bootstrap Total Max Chars",
       "help": "Max total characters across all injected workspace bootstrap files (default: 150000).",
       "hasChildren": false
@@ -472,9 +424,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "CLI Backends",
       "help": "Optional CLI backends for text-only fallback (claude-cli, etc.).",
       "hasChildren": true
@@ -896,9 +846,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction",
       "help": "Compaction tuning for when context nears token limits, including history share, reserve headroom, and pre-compaction memory flush behavior. Use this when long-running sessions need stable continuity under tight context windows.",
       "hasChildren": true
@@ -920,9 +868,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Identifier Instructions",
       "help": "Custom identifier-preservation instruction text used when identifierPolicy=\"custom\". Keep this explicit and safety-focused so compaction summaries do not rewrite opaque IDs, URLs, hosts, or ports.",
       "hasChildren": false
@@ -934,9 +880,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Compaction Identifier Policy",
       "help": "Identifier-preservation policy for compaction summaries: \"strict\" prepends built-in opaque-identifier retention guidance (default), \"off\" disables this prefix, and \"custom\" uses identifierInstructions. Keep \"strict\" unless you have a specific compatibility need.",
       "hasChildren": false
@@ -948,10 +892,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "label": "Compaction Keep Recent Tokens",
       "help": "Minimum token budget preserved from the most recent conversation window during compaction. Use higher values to protect immediate context continuity and lower values to keep more long-tail history.",
       "hasChildren": false
@@ -963,9 +904,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Compaction Max History Share",
       "help": "Maximum fraction of total context budget allowed for retained history after compaction (range 0.1-0.9). Use lower shares for more generation headroom or higher shares for deeper historical continuity.",
       "hasChildren": false
@@ -977,9 +916,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Memory Flush",
       "help": "Pre-compaction memory flush settings that run an agentic memory write before heavy compaction. Keep enabled for long sessions so salient context is persisted before aggressive trimming.",
       "hasChildren": true
@@ -991,9 +928,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Memory Flush Enabled",
       "help": "Enables pre-compaction memory flush before the runtime performs stronger history reduction near token limits. Keep enabled unless you intentionally disable memory side effects in constrained environments.",
       "hasChildren": false
@@ -1001,16 +936,11 @@
     {
       "path": "agents.defaults.compaction.memoryFlush.forceFlushTranscriptBytes",
       "kind": "core",
-      "type": [
-        "integer",
-        "string"
-      ],
+      "type": ["integer", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Memory Flush Transcript Size Threshold",
       "help": "Forces pre-compaction memory flush when transcript file size reaches this threshold (bytes or strings like \"2mb\"). Use this to prevent long-session hangs even when token counters are stale; set to 0 to disable.",
       "hasChildren": false
@@ -1022,9 +952,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Memory Flush Prompt",
       "help": "User-prompt template used for the pre-compaction memory flush turn when generating memory candidates. Use this only when you need custom extraction instructions beyond the default memory flush behavior.",
       "hasChildren": false
@@ -1036,10 +964,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "label": "Compaction Memory Flush Soft Threshold",
       "help": "Threshold distance to compaction (in tokens) that triggers pre-compaction memory flush execution. Use earlier thresholds for safer persistence, or tighter thresholds for lower flush frequency.",
       "hasChildren": false
@@ -1051,9 +976,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Memory Flush System Prompt",
       "help": "System-prompt override for the pre-compaction memory flush turn to control extraction style and safety constraints. Use carefully so custom instructions do not reduce memory quality or leak sensitive context.",
       "hasChildren": false
@@ -1065,9 +988,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Mode",
       "help": "Compaction strategy mode: \"default\" uses baseline behavior, while \"safeguard\" applies stricter guardrails to preserve recent context. Keep \"default\" unless you observe aggressive history loss near limit boundaries.",
       "hasChildren": false
@@ -1079,9 +1000,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Compaction Model Override",
       "help": "Optional provider/model override used only for compaction summarization. Set this when you want compaction to run on a different model than the session default, and leave it unset to keep using the primary agent model.",
       "hasChildren": false
@@ -1093,9 +1012,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Post-Compaction Context Sections",
       "help": "AGENTS.md H2/H3 section names re-injected after compaction so the agent reruns critical startup guidance. Leave unset to use \"Session Startup\"/\"Red Lines\" with legacy fallback to \"Every Session\"/\"Safety\"; set to [] to disable reinjection entirely.",
       "hasChildren": true
@@ -1115,16 +1032,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "async",
-        "await"
-      ],
+      "enumValues": ["off", "async", "await"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Post-Index Sync",
       "help": "Controls post-compaction session memory reindex mode: \"off\", \"async\", or \"await\" (default: \"async\"). Use \"await\" for strongest freshness, \"async\" for lower compaction latency, and \"off\" only when session-memory sync is handled elsewhere.",
       "hasChildren": false
@@ -1136,9 +1047,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Quality Guard",
       "help": "Optional quality-audit retry settings for safeguard compaction summaries. Leave this disabled unless you explicitly want summary audits and one-shot regeneration on failed checks.",
       "hasChildren": true
@@ -1150,9 +1059,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Quality Guard Enabled",
       "help": "Enables summary quality audits and regeneration retries for safeguard compaction. Default: false, so safeguard mode alone does not turn on retry behavior.",
       "hasChildren": false
@@ -1164,9 +1071,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Compaction Quality Guard Max Retries",
       "help": "Maximum number of regeneration retries after a failed safeguard summary quality audit. Use small values to bound extra latency and token cost.",
       "hasChildren": false
@@ -1178,9 +1083,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Compaction Preserve Recent Turns",
       "help": "Number of most recent user/assistant turns kept verbatim outside safeguard summarization (default: 3). Raise this to preserve exact recent dialogue context, or lower it to maximize compaction savings.",
       "hasChildren": false
@@ -1192,10 +1095,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "label": "Compaction Reserve Tokens",
       "help": "Token headroom reserved for reply generation and tool output after compaction runs. Use higher reserves for verbose/tool-heavy sessions, and lower reserves when maximizing retained history matters more.",
       "hasChildren": false
@@ -1207,10 +1107,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "label": "Compaction Reserve Token Floor",
       "help": "Minimum floor enforced for reserveTokens in Pi compaction paths (0 disables the floor guard). Use a non-zero floor to avoid over-aggressive compression under fluctuating token estimates.",
       "hasChildren": false
@@ -1222,9 +1119,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Compaction Timeout (Seconds)",
       "help": "Maximum time in seconds allowed for a single compaction operation before it is aborted (default: 900). Increase this for very large sessions that need more time to summarize, or decrease it to fail faster on unresponsive models.",
       "hasChildren": false
@@ -1446,9 +1341,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Embedded Pi",
       "help": "Embedded Pi runner hardening controls for how workspace-local Pi settings are trusted and applied in OpenClaw sessions.",
       "hasChildren": true
@@ -1460,9 +1353,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Embedded Pi Project Settings Policy",
       "help": "How embedded Pi handles workspace-local `.pi/config/settings.json`: \"sanitize\" (default) strips shellPath/shellCommandPrefix, \"ignore\" disables project settings entirely, and \"trusted\" applies project settings as-is.",
       "hasChildren": false
@@ -1474,9 +1365,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Envelope Elapsed",
       "help": "Include elapsed time in message envelopes (\"on\" or \"off\").",
       "hasChildren": false
@@ -1488,9 +1377,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Envelope Timestamp",
       "help": "Include absolute timestamps in message envelopes (\"on\" or \"off\").",
       "hasChildren": false
@@ -1502,9 +1389,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Envelope Timezone",
       "help": "Timezone for message envelopes (\"utc\", \"local\", \"user\", or an IANA timezone string).",
       "hasChildren": false
@@ -1586,11 +1471,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "automation",
-        "storage"
-      ],
+      "tags": ["access", "automation", "storage"],
       "label": "Heartbeat Direct Policy",
       "help": "Controls whether heartbeat delivery may target direct/DM chats: \"allow\" (default) permits DM delivery and \"block\" suppresses direct-target sends.",
       "hasChildren": false
@@ -1672,9 +1553,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "label": "Heartbeat Suppress Tool Error Warnings",
       "help": "Suppress tool error warning payloads during heartbeat runs.",
       "hasChildren": false
@@ -1686,9 +1565,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "help": "Delivery target (\"last\", \"none\", or a channel id). Known channels: telegram, whatsapp, discord, irc, googlechat, slack, signal, imessage, line, bluebubbles, feishu, matrix, mattermost, msteams, nextcloud-talk, nostr, synology-chat, tlon, twitch, zalo, zalouser.",
       "hasChildren": false
     },
@@ -1719,9 +1596,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Human Delay Max (ms)",
       "help": "Maximum delay in ms for custom humanDelay (default: 2500).",
       "hasChildren": false
@@ -1733,9 +1608,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Human Delay Min (ms)",
       "help": "Minimum delay in ms for custom humanDelay (default: 800).",
       "hasChildren": false
@@ -1747,9 +1620,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Human Delay Mode",
       "help": "Delay style for block replies (\"off\", \"natural\", \"custom\").",
       "hasChildren": false
@@ -1761,10 +1632,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance"
-      ],
+      "tags": ["media", "performance"],
       "label": "Image Max Dimension (px)",
       "help": "Max image side length in pixels when sanitizing transcript/tool-result image payloads (default: 1200).",
       "hasChildren": false
@@ -1772,10 +1640,7 @@
     {
       "path": "agents.defaults.imageModel",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -1789,11 +1654,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "models",
-        "reliability"
-      ],
+      "tags": ["media", "models", "reliability"],
       "label": "Image Model Fallbacks",
       "help": "Ordered fallback image models (provider/model).",
       "hasChildren": true
@@ -1815,10 +1676,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "models"
-      ],
+      "tags": ["media", "models"],
       "label": "Image Model",
       "help": "Optional image model (provider/model) used when the primary model lacks image input.",
       "hasChildren": false
@@ -1850,9 +1708,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search",
       "help": "Vector search over MEMORY.md and memory/*.md (per-agent overrides supported).",
       "hasChildren": true
@@ -1874,9 +1730,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Memory Search Embedding Cache",
       "help": "Caches computed chunk embeddings in SQLite so reindexing and incremental updates run faster (default: true). Keep this enabled unless investigating cache correctness or minimizing disk usage.",
       "hasChildren": false
@@ -1888,10 +1742,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "Memory Search Embedding Cache Max Entries",
       "help": "Sets a best-effort upper bound on cached embeddings kept in SQLite for memory search. Use this when controlling disk growth matters more than peak reindex speed.",
       "hasChildren": false
@@ -1913,9 +1764,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Chunk Overlap Tokens",
       "help": "Token overlap between adjacent memory chunks to preserve context continuity near split boundaries. Use modest overlap to reduce boundary misses without inflating index size too aggressively.",
       "hasChildren": false
@@ -1927,10 +1776,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "label": "Memory Chunk Tokens",
       "help": "Chunk size in tokens used when splitting memory sources before embedding/indexing. Increase for broader context per chunk, or lower to improve precision on pinpoint lookups.",
       "hasChildren": false
@@ -1942,9 +1788,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable Memory Search",
       "help": "Master toggle for memory search indexing and retrieval behavior on this agent profile. Keep enabled for semantic recall, and disable when you want fully stateless responses.",
       "hasChildren": false
@@ -1966,11 +1810,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "security",
-        "storage"
-      ],
+      "tags": ["advanced", "security", "storage"],
       "label": "Memory Search Session Index (Experimental)",
       "help": "Indexes session transcripts into memory search so responses can reference prior chat turns. Keep this off unless transcript recall is needed, because indexing cost and storage usage both increase.",
       "hasChildren": false
@@ -1982,9 +1822,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Extra Memory Paths",
       "help": "Adds extra directories or .md files to the memory index beyond default memory files. Use this when key reference docs live elsewhere in your repo; when multimodal memory is enabled, matching image/audio files under these paths are also eligible for indexing.",
       "hasChildren": true
@@ -2006,9 +1844,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "reliability"
-      ],
+      "tags": ["reliability"],
       "label": "Memory Search Fallback",
       "help": "Backup provider used when primary embeddings fail: \"openai\", \"gemini\", \"voyage\", \"mistral\", \"ollama\", \"local\", or \"none\". Set a real fallback for production reliability; use \"none\" only if you prefer explicit failures.",
       "hasChildren": false
@@ -2040,9 +1876,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Local Embedding Model Path",
       "help": "Specifies the local embedding model source for local memory search, such as a GGUF file path or `hf:` URI. Use this only when provider is `local`, and verify model compatibility before large index rebuilds.",
       "hasChildren": false
@@ -2054,9 +1888,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Memory Search Model",
       "help": "Embedding model override used by the selected memory provider when a non-default model is required. Set this only when you need explicit recall quality/cost tuning beyond provider defaults.",
       "hasChildren": false
@@ -2068,9 +1900,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Multimodal",
       "help": "Optional multimodal memory settings for indexing image and audio files from configured extra paths. Keep this off unless your embedding model explicitly supports cross-modal embeddings, and set `memorySearch.fallback` to \"none\" while it is enabled. Matching files are uploaded to the configured remote embedding provider during indexing.",
       "hasChildren": true
@@ -2082,9 +1912,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable Memory Search Multimodal",
       "help": "Enables image/audio memory indexing from extraPaths. This currently requires Gemini embedding-2, keeps the default memory roots Markdown-only, disables memory-search fallback providers, and uploads matching binary content to the configured remote embedding provider.",
       "hasChildren": false
@@ -2096,10 +1924,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "Memory Search Multimodal Max File Bytes",
       "help": "Sets the maximum bytes allowed per multimodal file before it is skipped during memory indexing. Use this to cap upload cost and indexing latency, or raise it for short high-quality audio clips.",
       "hasChildren": false
@@ -2111,9 +1936,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Multimodal Modalities",
       "help": "Selects which multimodal file types are indexed from extraPaths: \"image\", \"audio\", or \"all\". Keep this narrow to avoid indexing large binary corpora unintentionally.",
       "hasChildren": true
@@ -2135,9 +1958,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Output Dimensionality",
       "help": "Gemini embedding-2 only: chooses the output vector size for memory embeddings. Use 768, 1536, or 3072 (default), and expect a full reindex when you change it because stored vector dimensions must stay consistent.",
       "hasChildren": false
@@ -2149,9 +1970,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Provider",
       "help": "Selects the embedding backend used to build/query memory vectors: \"openai\", \"gemini\", \"voyage\", \"mistral\", \"ollama\", or \"local\". Keep your most reliable provider here and configure fallback for resilience.",
       "hasChildren": false
@@ -2183,9 +2002,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Hybrid Candidate Multiplier",
       "help": "Expands the candidate pool before reranking (default: 4). Raise this for better recall on noisy corpora, but expect more compute and slightly slower searches.",
       "hasChildren": false
@@ -2197,9 +2014,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Hybrid",
       "help": "Combines BM25 keyword matching with vector similarity for better recall on mixed exact + semantic queries. Keep enabled unless you are isolating ranking behavior for troubleshooting.",
       "hasChildren": false
@@ -2221,9 +2036,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search MMR Re-ranking",
       "help": "Adds MMR reranking to diversify results and reduce near-duplicate snippets in a single answer window. Enable when recall looks repetitive; keep off for strict score ordering.",
       "hasChildren": false
@@ -2235,9 +2048,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search MMR Lambda",
       "help": "Sets MMR relevance-vs-diversity balance (0 = most diverse, 1 = most relevant, default: 0.7). Lower values reduce repetition; higher values keep tightly relevant but may duplicate.",
       "hasChildren": false
@@ -2259,9 +2070,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Temporal Decay",
       "help": "Applies recency decay so newer memory can outrank older memory when scores are close. Enable when timeliness matters; keep off for timeless reference knowledge.",
       "hasChildren": false
@@ -2273,9 +2082,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Temporal Decay Half-life (Days)",
       "help": "Controls how fast older memory loses rank when temporal decay is enabled (half-life in days, default: 30). Lower values prioritize recent context more aggressively.",
       "hasChildren": false
@@ -2287,9 +2094,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Text Weight",
       "help": "Controls how strongly BM25 keyword relevance influences hybrid ranking (0-1). Increase for exact-term matching; decrease when semantic matches should rank higher.",
       "hasChildren": false
@@ -2301,9 +2106,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Vector Weight",
       "help": "Controls how strongly semantic similarity influences hybrid ranking (0-1). Increase when paraphrase matching matters more than exact terms; decrease for stricter keyword emphasis.",
       "hasChildren": false
@@ -2315,9 +2118,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Memory Search Max Results",
       "help": "Maximum number of memory hits returned from search before downstream reranking and prompt injection. Raise for broader recall, or lower for tighter prompts and faster responses.",
       "hasChildren": false
@@ -2329,9 +2130,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Min Score",
       "help": "Minimum relevance score threshold for including memory results in final recall output. Increase to reduce weak/noisy matches, or lower when you need more permissive retrieval.",
       "hasChildren": false
@@ -2349,17 +2148,11 @@
     {
       "path": "agents.defaults.memorySearch.remote.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "label": "Remote Embedding API Key",
       "help": "Supplies a dedicated API key for remote embedding calls used by memory indexing and query-time embeddings. Use this when memory embeddings should use different credentials than global defaults or environment variables.",
       "hasChildren": true
@@ -2401,9 +2194,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Remote Embedding Base URL",
       "help": "Overrides the embedding API endpoint, such as an OpenAI-compatible proxy or custom Gemini base URL. Use this only when routing through your own gateway or vendor endpoint; keep provider defaults otherwise.",
       "hasChildren": false
@@ -2425,9 +2216,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Remote Batch Concurrency",
       "help": "Limits how many embedding batch jobs run at the same time during indexing (default: 2). Increase carefully for faster bulk indexing, but watch provider rate limits and queue errors.",
       "hasChildren": false
@@ -2439,9 +2228,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Remote Batch Embedding Enabled",
       "help": "Enables provider batch APIs for embedding jobs when supported (OpenAI/Gemini), improving throughput on larger index runs. Keep this enabled unless debugging provider batch failures or running very small workloads.",
       "hasChildren": false
@@ -2453,9 +2240,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Remote Batch Poll Interval (ms)",
       "help": "Controls how often the system polls provider APIs for batch job status in milliseconds (default: 2000). Use longer intervals to reduce API chatter, or shorter intervals for faster completion detection.",
       "hasChildren": false
@@ -2467,9 +2252,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Remote Batch Timeout (min)",
       "help": "Sets the maximum wait time for a full embedding batch operation in minutes (default: 60). Increase for very large corpora or slower providers, and lower it to fail fast in automation-heavy flows.",
       "hasChildren": false
@@ -2481,9 +2264,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Remote Batch Wait for Completion",
       "help": "Waits for batch embedding jobs to fully finish before the indexing operation completes. Keep this enabled for deterministic indexing state; disable only if you accept delayed consistency.",
       "hasChildren": false
@@ -2495,9 +2276,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Remote Embedding Headers",
       "help": "Adds custom HTTP headers to remote embedding requests, merged with provider defaults. Use this for proxy auth and tenant routing headers, and keep values minimal to avoid leaking sensitive metadata.",
       "hasChildren": true
@@ -2519,9 +2298,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Search Sources",
       "help": "Chooses which sources are indexed: \"memory\" reads MEMORY.md + memory files, and \"sessions\" includes transcript history. Keep [\"memory\"] unless you need recall from prior chat transcripts.",
       "hasChildren": true
@@ -2563,9 +2340,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Memory Search Index Path",
       "help": "Sets where the SQLite memory index is stored on disk for each agent. Keep the default `~/.openclaw/memory/{agentId}.sqlite` unless you need custom storage placement or backup policy alignment.",
       "hasChildren": false
@@ -2587,9 +2362,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Memory Search Vector Index",
       "help": "Enables the sqlite-vec extension used for vector similarity queries in memory search (default: true). Keep this enabled for normal semantic recall; disable only for debugging or fallback-only operation.",
       "hasChildren": false
@@ -2601,9 +2374,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Memory Search Vector Extension Path",
       "help": "Overrides the auto-discovered sqlite-vec extension library path (`.dylib`, `.so`, or `.dll`). Use this when your runtime cannot find sqlite-vec automatically or you pin a known-good build.",
       "hasChildren": false
@@ -2635,9 +2406,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Index on Search (Lazy)",
       "help": "Uses lazy sync by scheduling reindex on search after content changes are detected. Keep enabled for lower idle overhead, or disable if you require pre-synced indexes before any query.",
       "hasChildren": false
@@ -2649,10 +2418,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "storage"
-      ],
+      "tags": ["automation", "storage"],
       "label": "Index on Session Start",
       "help": "Triggers a memory index sync when a session starts so early turns see fresh memory content. Keep enabled when startup freshness matters more than initial turn latency.",
       "hasChildren": false
@@ -2674,9 +2440,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Delta Bytes",
       "help": "Requires at least this many newly appended bytes before session transcript changes trigger reindex (default: 100000). Increase to reduce frequent small reindexes, or lower for faster transcript freshness.",
       "hasChildren": false
@@ -2688,9 +2452,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Delta Messages",
       "help": "Requires at least this many appended transcript messages before reindex is triggered (default: 50). Lower this for near-real-time transcript recall, or raise it to reduce indexing churn.",
       "hasChildren": false
@@ -2702,9 +2464,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Force Reindex After Compaction",
       "help": "Forces a session memory-search reindex after compaction-triggered transcript updates (default: true). Keep enabled when compacted summaries must be immediately searchable, or disable to reduce write-time indexing pressure.",
       "hasChildren": false
@@ -2716,9 +2476,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Watch Memory Files",
       "help": "Watches memory files and schedules index updates from file-change events (chokidar). Enable for near-real-time freshness; disable on very large workspaces if watch churn is too noisy.",
       "hasChildren": false
@@ -2730,10 +2488,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "performance"
-      ],
+      "tags": ["automation", "performance"],
       "label": "Memory Watch Debounce (ms)",
       "help": "Debounce window in milliseconds for coalescing rapid file-watch events before reindex runs. Increase to reduce churn on frequently-written files, or lower for faster freshness.",
       "hasChildren": false
@@ -2741,10 +2496,7 @@
     {
       "path": "agents.defaults.model",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -2758,10 +2510,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models",
-        "reliability"
-      ],
+      "tags": ["models", "reliability"],
       "label": "Model Fallbacks",
       "help": "Ordered fallback models (provider/model). Used when the primary model fails.",
       "hasChildren": true
@@ -2783,9 +2532,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Primary Model",
       "help": "Primary model (provider/model).",
       "hasChildren": false
@@ -2797,9 +2544,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Models",
       "help": "Configured model catalog (keys are full provider/model IDs).",
       "hasChildren": true
@@ -2860,9 +2605,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "PDF Max Size (MB)",
       "help": "Maximum PDF file size in megabytes for the PDF tool (default: 10).",
       "hasChildren": false
@@ -2874,9 +2617,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "PDF Max Pages",
       "help": "Maximum number of PDF pages to process for the PDF tool (default: 20).",
       "hasChildren": false
@@ -2884,10 +2625,7 @@
     {
       "path": "agents.defaults.pdfModel",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -2901,9 +2639,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "reliability"
-      ],
+      "tags": ["reliability"],
       "label": "PDF Model Fallbacks",
       "help": "Ordered fallback PDF models (provider/model).",
       "hasChildren": true
@@ -2925,9 +2661,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "PDF Model",
       "help": "Optional PDF model (provider/model) for the PDF analysis tool. Defaults to imageModel, then session model.",
       "hasChildren": false
@@ -2939,9 +2673,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Repo Root",
       "help": "Optional repository root shown in the system prompt runtime line (overrides auto-detect).",
       "hasChildren": false
@@ -3033,9 +2765,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Sandbox Browser CDP Source Port Range",
       "help": "Optional CIDR allowlist for container-edge CDP ingress (for example 172.21.0.1/32).",
       "hasChildren": false
@@ -3097,9 +2827,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Sandbox Browser Network",
       "help": "Docker network for sandbox browser containers (default: openclaw-sandbox-browser). Avoid bridge if you need stricter isolation.",
       "hasChildren": false
@@ -3211,12 +2939,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "advanced",
-        "security",
-        "storage"
-      ],
+      "tags": ["access", "advanced", "security", "storage"],
       "label": "Sandbox Docker Allow Container Namespace Join",
       "help": "DANGEROUS break-glass override that allows sandbox Docker network mode container:<id>. This joins another container namespace and weakens sandbox isolation.",
       "hasChildren": false
@@ -3314,10 +3037,7 @@
     {
       "path": "agents.defaults.sandbox.docker.memory",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -3327,10 +3047,7 @@
     {
       "path": "agents.defaults.sandbox.docker.memorySwap",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -3419,11 +3136,7 @@
     {
       "path": "agents.defaults.sandbox.docker.ulimits.*",
       "kind": "core",
-      "type": [
-        "number",
-        "object",
-        "string"
-      ],
+      "type": ["number", "object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -3633,10 +3346,7 @@
     {
       "path": "agents.defaults.subagents.model",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -3770,9 +3480,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Workspace",
       "help": "Default workspace path exposed to agent runtime tools for filesystem context and repo-aware behavior. Set this explicitly when running from wrappers so path resolution stays deterministic.",
       "hasChildren": false
@@ -3784,9 +3492,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent List",
       "help": "Explicit list of configured agents with IDs and optional overrides for model, tools, identity, and workspace. Keep IDs stable over time so bindings, approvals, and session routing remain deterministic.",
       "hasChildren": true
@@ -3938,11 +3644,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "automation",
-        "storage"
-      ],
+      "tags": ["access", "automation", "storage"],
       "label": "Heartbeat Direct Policy",
       "help": "Per-agent override for heartbeat direct/DM delivery policy; use \"block\" for agents that should only send heartbeat alerts to non-DM destinations.",
       "hasChildren": false
@@ -4024,9 +3726,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "label": "Agent Heartbeat Suppress Tool Error Warnings",
       "help": "Suppress tool error warning payloads during heartbeat runs.",
       "hasChildren": false
@@ -4038,9 +3738,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "help": "Delivery target (\"last\", \"none\", or a channel id). Known channels: telegram, whatsapp, discord, irc, googlechat, slack, signal, imessage, line, bluebubbles, feishu, matrix, mattermost, msteams, nextcloud-talk, nostr, synology-chat, tlon, twitch, zalo, zalouser.",
       "hasChildren": false
     },
@@ -4121,9 +3819,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Identity Avatar",
       "help": "Agent avatar (workspace-relative path, http(s) URL, or data URI).",
       "hasChildren": false
@@ -4551,17 +4247,11 @@
     {
       "path": "agents.list.*.memorySearch.remote.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "hasChildren": true
     },
     {
@@ -4867,10 +4557,7 @@
     {
       "path": "agents.list.*.model",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -4943,9 +4630,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent Runtime",
       "help": "Optional runtime descriptor for this agent. Use embedded for default OpenClaw execution or acp for external ACP harness defaults.",
       "hasChildren": true
@@ -4957,9 +4642,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent ACP Runtime",
       "help": "ACP runtime defaults for this agent when runtime.type=acp. Binding-level ACP overrides still take precedence per conversation.",
       "hasChildren": true
@@ -4971,9 +4654,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent ACP Harness Agent",
       "help": "Optional ACP harness agent id to use for this OpenClaw agent (for example codex, claude).",
       "hasChildren": false
@@ -4985,9 +4666,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent ACP Backend",
       "help": "Optional ACP backend override for this agent's ACP sessions (falls back to global acp.backend).",
       "hasChildren": false
@@ -4999,9 +4678,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent ACP Working Directory",
       "help": "Optional default working directory for this agent's ACP sessions.",
       "hasChildren": false
@@ -5011,15 +4688,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "persistent",
-        "oneshot"
-      ],
+      "enumValues": ["persistent", "oneshot"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent ACP Mode",
       "help": "Optional ACP session mode default for this agent (persistent or oneshot).",
       "hasChildren": false
@@ -5031,9 +4703,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent Runtime Type",
       "help": "Runtime type for this agent: \"embedded\" (default OpenClaw runtime) or \"acp\" (ACP harness defaults).",
       "hasChildren": false
@@ -5125,9 +4795,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Agent Sandbox Browser CDP Source Port Range",
       "help": "Per-agent override for CDP source CIDR allowlist.",
       "hasChildren": false
@@ -5189,9 +4857,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Agent Sandbox Browser Network",
       "help": "Per-agent override for sandbox browser Docker network.",
       "hasChildren": false
@@ -5303,12 +4969,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "advanced",
-        "security",
-        "storage"
-      ],
+      "tags": ["access", "advanced", "security", "storage"],
       "label": "Agent Sandbox Docker Allow Container Namespace Join",
       "help": "Per-agent DANGEROUS override for container namespace joins in sandbox Docker network mode.",
       "hasChildren": false
@@ -5406,10 +5067,7 @@
     {
       "path": "agents.list.*.sandbox.docker.memory",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -5419,10 +5077,7 @@
     {
       "path": "agents.list.*.sandbox.docker.memorySwap",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -5511,11 +5166,7 @@
     {
       "path": "agents.list.*.sandbox.docker.ulimits.*",
       "kind": "core",
-      "type": [
-        "number",
-        "object",
-        "string"
-      ],
+      "type": ["number", "object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -5659,9 +5310,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent Skill Filter",
       "help": "Optional allowlist of skills for this agent (omit = all skills; empty = no skills).",
       "hasChildren": true
@@ -5709,10 +5358,7 @@
     {
       "path": "agents.list.*.subagents.model",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -5796,9 +5442,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Agent Tool Allowlist Additions",
       "help": "Per-agent additive allowlist for tools on top of global and profile policy. Keep narrow to avoid accidental privilege expansion on specialized agents.",
       "hasChildren": true
@@ -5820,9 +5464,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Agent Tool Policy by Provider",
       "help": "Per-agent provider-specific tool policy overrides for channel-scoped capability control. Use this when a single agent needs tighter restrictions on one provider than others.",
       "hasChildren": true
@@ -5960,10 +5602,7 @@
     {
       "path": "agents.list.*.tools.elevated.allowFrom.*.*",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -6055,11 +5694,7 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "on-miss",
-        "always"
-      ],
+      "enumValues": ["off", "on-miss", "always"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -6090,11 +5725,7 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "sandbox",
-        "gateway",
-        "node"
-      ],
+      "enumValues": ["sandbox", "gateway", "node"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -6275,11 +5906,7 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "deny",
-        "allowlist",
-        "full"
-      ],
+      "enumValues": ["deny", "allowlist", "full"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -6422,9 +6049,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Agent Tool Profile",
       "help": "Per-agent override for tool profile selection when one agent needs a different capability baseline. Use this sparingly so policy differences across agents stay intentional and reviewable.",
       "hasChildren": false
@@ -6526,9 +6151,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Approvals",
       "help": "Approval routing controls for forwarding exec approval requests to chat destinations outside the originating session. Keep this disabled unless operators need explicit out-of-band approval visibility.",
       "hasChildren": true
@@ -6540,9 +6163,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Exec Approval Forwarding",
       "help": "Groups exec-approval forwarding behavior including enablement, routing mode, filters, and explicit targets. Configure here when approval prompts must reach operational channels instead of only the origin thread.",
       "hasChildren": true
@@ -6554,9 +6175,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Approval Agent Filter",
       "help": "Optional allowlist of agent IDs eligible for forwarded approvals, for example `[\"primary\", \"ops-agent\"]`. Use this to limit forwarding blast radius and avoid notifying channels for unrelated agents.",
       "hasChildren": true
@@ -6578,9 +6197,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Forward Exec Approvals",
       "help": "Enables forwarding of exec approval requests to configured delivery destinations (default: false). Keep disabled in low-risk setups and enable only when human approval responders need channel-visible prompts.",
       "hasChildren": false
@@ -6592,9 +6209,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Approval Forwarding Mode",
       "help": "Controls where approval prompts are sent: \"session\" uses origin chat, \"targets\" uses configured targets, and \"both\" sends to both paths. Use \"session\" as baseline and expand only when operational workflow requires redundancy.",
       "hasChildren": false
@@ -6606,9 +6221,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Approval Session Filter",
       "help": "Optional session-key filters matched as substring or regex-style patterns, for example `[\"discord:\", \"^agent:ops:\"]`. Use narrow patterns so only intended approval contexts are forwarded to shared destinations.",
       "hasChildren": true
@@ -6630,9 +6243,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Approval Forwarding Targets",
       "help": "Explicit delivery targets used when forwarding mode includes targets, each with channel and destination details. Keep target lists least-privilege and validate each destination before enabling broad forwarding.",
       "hasChildren": true
@@ -6654,9 +6265,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Approval Target Account ID",
       "help": "Optional account selector for multi-account channel setups when approvals must route through a specific account context. Use this only when the target channel has multiple configured identities.",
       "hasChildren": false
@@ -6668,9 +6277,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Approval Target Channel",
       "help": "Channel/provider ID used for forwarded approval delivery, such as discord, slack, or a plugin channel id. Use valid channel IDs only so approvals do not silently fail due to unknown routes.",
       "hasChildren": false
@@ -6678,16 +6285,11 @@
     {
       "path": "approvals.exec.targets.*.threadId",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Approval Target Thread ID",
       "help": "Optional thread/topic target for channels that support threaded delivery of forwarded approvals. Use this to keep approval traffic contained in operational threads instead of main channels.",
       "hasChildren": false
@@ -6699,9 +6301,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Approval Target Destination",
       "help": "Destination identifier inside the target channel (channel ID, user ID, or thread root depending on provider). Verify semantics per provider because destination format differs across channel integrations.",
       "hasChildren": false
@@ -6713,9 +6313,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Audio",
       "help": "Global audio ingestion settings used before higher-level tools process speech or media content. Configure this when you need deterministic transcription behavior for voice notes and clips.",
       "hasChildren": true
@@ -6727,9 +6325,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Audio Transcription",
       "help": "Command-based transcription settings for converting audio files into text before agent handling. Keep a simple, deterministic command path here so failures are easy to diagnose in logs.",
       "hasChildren": true
@@ -6741,9 +6337,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Audio Transcription Command",
       "help": "Executable + args used to transcribe audio (first token must be a safe binary/path), for example `[\"whisper-cli\", \"--model\", \"small\", \"{input}\"]`. Prefer a pinned command so runtime environments behave consistently.",
       "hasChildren": true
@@ -6765,10 +6359,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance"
-      ],
+      "tags": ["media", "performance"],
       "label": "Audio Transcription Timeout (sec)",
       "help": "Maximum time allowed for the transcription command to finish before it is aborted. Increase this for longer recordings, and keep it tight in latency-sensitive deployments.",
       "hasChildren": false
@@ -6780,9 +6371,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Auth",
       "help": "Authentication profile root used for multi-profile provider credentials and cooldown-based failover ordering. Keep profiles minimal and explicit so automatic failover behavior stays auditable.",
       "hasChildren": true
@@ -6794,10 +6383,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "auth"
-      ],
+      "tags": ["access", "auth"],
       "label": "Auth Cooldowns",
       "help": "Cooldown/backoff controls for temporary profile suppression after billing-related failures and retry windows. Use these to prevent rapid re-selection of profiles that are still blocked.",
       "hasChildren": true
@@ -6809,11 +6395,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "auth",
-        "reliability"
-      ],
+      "tags": ["access", "auth", "reliability"],
       "label": "Billing Backoff (hours)",
       "help": "Base backoff (hours) when a profile fails due to billing/insufficient credits (default: 5).",
       "hasChildren": false
@@ -6825,11 +6407,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "auth",
-        "reliability"
-      ],
+      "tags": ["access", "auth", "reliability"],
       "label": "Billing Backoff Overrides",
       "help": "Optional per-provider overrides for billing backoff (hours).",
       "hasChildren": true
@@ -6851,11 +6429,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "auth",
-        "performance"
-      ],
+      "tags": ["access", "auth", "performance"],
       "label": "Billing Backoff Cap (hours)",
       "help": "Cap (hours) for billing backoff (default: 24).",
       "hasChildren": false
@@ -6867,10 +6441,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "auth"
-      ],
+      "tags": ["access", "auth"],
       "label": "Failover Window (hours)",
       "help": "Failure window (hours) for backoff counters (default: 24).",
       "hasChildren": false
@@ -6882,10 +6453,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "auth"
-      ],
+      "tags": ["access", "auth"],
       "label": "Auth Profile Order",
       "help": "Ordered auth profile IDs per provider (used for automatic failover).",
       "hasChildren": true
@@ -6917,11 +6485,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "auth",
-        "storage"
-      ],
+      "tags": ["access", "auth", "storage"],
       "label": "Auth Profiles",
       "help": "Named auth profiles (provider + mode + optional email).",
       "hasChildren": true
@@ -6973,9 +6537,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Bindings",
       "help": "Top-level binding rules for routing and persistent ACP conversation ownership. Use type=route for normal routing and type=acp for persistent ACP harness bindings.",
       "hasChildren": true
@@ -6997,9 +6559,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Binding Overrides",
       "help": "Optional per-binding ACP overrides for bindings[].type=acp. This layer overrides agents.list[].runtime.acp defaults for the matched conversation.",
       "hasChildren": true
@@ -7011,9 +6571,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Binding Backend",
       "help": "ACP backend override for this binding (falls back to agent runtime ACP backend, then global acp.backend).",
       "hasChildren": false
@@ -7025,9 +6583,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Binding Working Directory",
       "help": "Working directory override for ACP sessions created from this binding.",
       "hasChildren": false
@@ -7039,9 +6595,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Binding Label",
       "help": "Human-friendly label for ACP status/diagnostics in this bound conversation.",
       "hasChildren": false
@@ -7051,15 +6605,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "persistent",
-        "oneshot"
-      ],
+      "enumValues": ["persistent", "oneshot"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACP Binding Mode",
       "help": "ACP session mode override for this binding (persistent or oneshot).",
       "hasChildren": false
@@ -7071,9 +6620,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Agent ID",
       "help": "Target agent ID that receives traffic when the corresponding binding match rule is satisfied. Use valid configured agent IDs only so routing does not fail at runtime.",
       "hasChildren": false
@@ -7095,9 +6642,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Match Rule",
       "help": "Match rule object for deciding when a binding applies, including channel and optional account/peer constraints. Keep rules narrow to avoid accidental agent takeover across contexts.",
       "hasChildren": true
@@ -7109,9 +6654,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Account ID",
       "help": "Optional account selector for multi-account channel setups so the binding applies only to one identity. Use this when account scoping is required for the route and leave unset otherwise.",
       "hasChildren": false
@@ -7123,9 +6666,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Channel",
       "help": "Channel/provider identifier this binding applies to, such as `telegram`, `discord`, or a plugin channel ID. Use the configured channel key exactly so binding evaluation works reliably.",
       "hasChildren": false
@@ -7137,9 +6678,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Guild ID",
       "help": "Optional Discord-style guild/server ID constraint for binding evaluation in multi-server deployments. Use this when the same peer identifiers can appear across different guilds.",
       "hasChildren": false
@@ -7151,9 +6690,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Peer Match",
       "help": "Optional peer matcher for specific conversations including peer kind and peer id. Use this when only one direct/group/channel target should be pinned to an agent.",
       "hasChildren": true
@@ -7165,9 +6702,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Peer ID",
       "help": "Conversation identifier used with peer matching, such as a chat ID, channel ID, or group ID from the provider. Keep this exact to avoid silent non-matches.",
       "hasChildren": false
@@ -7179,9 +6714,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Peer Kind",
       "help": "Peer conversation type: \"direct\", \"group\", \"channel\", or legacy \"dm\" (deprecated alias for direct). Prefer \"direct\" for new configs and keep kind aligned with channel semantics.",
       "hasChildren": false
@@ -7193,9 +6726,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Roles",
       "help": "Optional role-based filter list used by providers that attach roles to chat context. Use this to route privileged or operational role traffic to specialized agents.",
       "hasChildren": true
@@ -7217,9 +6748,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Team ID",
       "help": "Optional team/workspace ID constraint used by providers that scope chats under teams. Add this when you need bindings isolated to one workspace context.",
       "hasChildren": false
@@ -7231,9 +6760,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Binding Type",
       "help": "Binding kind. Use \"route\" (or omit for legacy route entries) for normal routing, and \"acp\" for persistent ACP conversation bindings.",
       "hasChildren": false
@@ -7245,9 +6772,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Broadcast",
       "help": "Broadcast routing map for sending the same outbound message to multiple peer IDs per source conversation. Keep this minimal and audited because one source can fan out to many destinations.",
       "hasChildren": true
@@ -7259,9 +6784,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Broadcast Destination List",
       "help": "Per-source broadcast destination list where each key is a source peer ID and the value is an array of destination peer IDs. Keep lists intentional to avoid accidental message amplification.",
       "hasChildren": true
@@ -7281,15 +6804,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "parallel",
-        "sequential"
-      ],
+      "enumValues": ["parallel", "sequential"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Broadcast Strategy",
       "help": "Delivery order for broadcast fan-out: \"parallel\" sends to all targets concurrently, while \"sequential\" sends one-by-one. Use \"parallel\" for speed and \"sequential\" for stricter ordering/backpressure control.",
       "hasChildren": false
@@ -7301,9 +6819,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser",
       "help": "Browser runtime controls for local or remote CDP attachment, profile routing, and screenshot/snapshot behavior. Keep defaults unless your automation workflow requires custom browser transport settings.",
       "hasChildren": true
@@ -7315,9 +6831,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser Attach-only Mode",
       "help": "Restricts browser mode to attach-only behavior without starting local browser processes. Use this when all browser sessions are externally managed by a remote CDP provider.",
       "hasChildren": false
@@ -7329,9 +6843,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser CDP Port Range Start",
       "help": "Starting local CDP port used for auto-allocated browser profile ports. Increase this when host-level port defaults conflict with other local services.",
       "hasChildren": false
@@ -7343,9 +6855,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser CDP URL",
       "help": "Remote CDP websocket URL used to attach to an externally managed browser instance. Use this for centralized browser hosts and keep URL access restricted to trusted network paths.",
       "hasChildren": false
@@ -7357,9 +6867,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser Accent Color",
       "help": "Default accent color used for browser profile/UI cues where colored identity hints are displayed. Use consistent colors to help operators identify active browser profile context quickly.",
       "hasChildren": false
@@ -7371,9 +6879,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Browser Default Profile",
       "help": "Default browser profile name selected when callers do not explicitly choose a profile. Use a stable low-privilege profile as the default to reduce accidental cross-context state use.",
       "hasChildren": false
@@ -7385,9 +6891,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser Enabled",
       "help": "Enables browser capability wiring in the gateway so browser tools and CDP-driven workflows can run. Disable when browser automation is not needed to reduce surface area and startup work.",
       "hasChildren": false
@@ -7399,9 +6903,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser Evaluate Enabled",
       "help": "Enables browser-side evaluate helpers for runtime script evaluation capabilities where supported. Keep disabled unless your workflows require evaluate semantics beyond snapshots/navigation.",
       "hasChildren": false
@@ -7413,9 +6915,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Browser Executable Path",
       "help": "Explicit browser executable path when auto-discovery is insufficient for your host environment. Use absolute stable paths so launch behavior stays deterministic across restarts.",
       "hasChildren": false
@@ -7447,9 +6947,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser Headless Mode",
       "help": "Forces browser launch in headless mode when the local launcher starts browser instances. Keep headless enabled for server environments and disable only when visible UI debugging is required.",
       "hasChildren": false
@@ -7461,9 +6959,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Browser No-Sandbox Mode",
       "help": "Disables Chromium sandbox isolation flags for environments where sandboxing fails at runtime. Keep this off whenever possible because process isolation protections are reduced.",
       "hasChildren": false
@@ -7475,9 +6971,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Browser Profiles",
       "help": "Named browser profile connection map used for explicit routing to CDP ports or URLs with optional metadata. Keep profile names consistent and avoid overlapping endpoint definitions.",
       "hasChildren": true
@@ -7499,9 +6993,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Browser Profile Attach-only Mode",
       "help": "Per-profile attach-only override that skips local browser launch and only attaches to an existing CDP endpoint. Useful when one profile is externally managed but others are locally launched.",
       "hasChildren": false
@@ -7513,9 +7005,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Browser Profile CDP Port",
       "help": "Per-profile local CDP port used when connecting to browser instances by port instead of URL. Use unique ports per profile to avoid connection collisions.",
       "hasChildren": false
@@ -7527,9 +7017,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Browser Profile CDP URL",
       "help": "Per-profile CDP websocket URL used for explicit remote browser routing by profile name. Use this when profile connections terminate on remote hosts or tunnels.",
       "hasChildren": false
@@ -7541,9 +7029,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Browser Profile Accent Color",
       "help": "Per-profile accent color for visual differentiation in dashboards and browser-related UI hints. Use distinct colors for high-signal operator recognition of active profiles.",
       "hasChildren": false
@@ -7555,9 +7041,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Browser Profile Driver",
       "help": "Per-profile browser driver mode: \"openclaw\" (or legacy \"clawd\") or \"extension\" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.",
       "hasChildren": false
@@ -7569,9 +7053,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser Relay Bind Address",
       "help": "Bind IP address for the Chrome extension relay listener. Leave unset for loopback-only access, or set an explicit non-loopback IP such as 0.0.0.0 only when the relay must be reachable across network namespaces (for example WSL2) and the surrounding network is already trusted.",
       "hasChildren": false
@@ -7583,9 +7065,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Remote CDP Handshake Timeout (ms)",
       "help": "Timeout in milliseconds for post-connect CDP handshake readiness checks against remote browser targets. Raise this for slow-start remote browsers and lower to fail fast in automation loops.",
       "hasChildren": false
@@ -7597,9 +7077,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Remote CDP Timeout (ms)",
       "help": "Timeout in milliseconds for connecting to a remote CDP endpoint before failing the browser attach attempt. Increase for high-latency tunnels, or lower for faster failure detection.",
       "hasChildren": false
@@ -7611,9 +7089,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser Snapshot Defaults",
       "help": "Default snapshot capture configuration used when callers do not provide explicit snapshot options. Tune this for consistent capture behavior across channels and automation paths.",
       "hasChildren": true
@@ -7625,9 +7101,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Browser Snapshot Mode",
       "help": "Default snapshot extraction mode controlling how page content is transformed for agent consumption. Choose the mode that balances readability, fidelity, and token footprint for your workflows.",
       "hasChildren": false
@@ -7639,9 +7113,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Browser SSRF Policy",
       "help": "Server-side request forgery guardrail settings for browser/network fetch paths that could reach internal hosts. Keep restrictive defaults in production and open only explicitly approved targets.",
       "hasChildren": true
@@ -7653,9 +7125,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Browser Allowed Hostnames",
       "help": "Explicit hostname allowlist exceptions for SSRF policy checks on browser/network requests. Keep this list minimal and review entries regularly to avoid stale broad access.",
       "hasChildren": true
@@ -7677,9 +7147,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Browser Allow Private Network",
       "help": "Legacy alias for browser.ssrfPolicy.dangerouslyAllowPrivateNetwork. Prefer the dangerously-named key so risk intent is explicit.",
       "hasChildren": false
@@ -7691,11 +7159,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "advanced",
-        "security"
-      ],
+      "tags": ["access", "advanced", "security"],
       "label": "Browser Dangerously Allow Private Network",
       "help": "Allows access to private-network address ranges from browser tooling. Default is enabled for trusted-network operator setups; disable to enforce strict public-only resolution checks.",
       "hasChildren": false
@@ -7707,9 +7171,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Browser Hostname Allowlist",
       "help": "Legacy/alternate hostname allowlist field used by SSRF policy consumers for explicit host exceptions. Use stable exact hostnames and avoid wildcard-like broad patterns.",
       "hasChildren": true
@@ -7731,9 +7193,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Canvas Host",
       "help": "Canvas host settings for serving canvas assets and local live-reload behavior used by canvas-enabled workflows. Keep disabled unless canvas-hosted assets are actively used.",
       "hasChildren": true
@@ -7745,9 +7205,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Canvas Host Enabled",
       "help": "Enables the canvas host server process and routes for serving canvas files. Keep disabled when canvas workflows are inactive to reduce exposed local services.",
       "hasChildren": false
@@ -7759,9 +7217,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "reliability"
-      ],
+      "tags": ["reliability"],
       "label": "Canvas Host Live Reload",
       "help": "Enables automatic live-reload behavior for canvas assets during development workflows. Keep disabled in production-like environments where deterministic output is preferred.",
       "hasChildren": false
@@ -7773,9 +7229,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Canvas Host Port",
       "help": "TCP port used by the canvas host HTTP server when canvas hosting is enabled. Choose a non-conflicting port and align firewall/proxy policy accordingly.",
       "hasChildren": false
@@ -7787,9 +7241,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Canvas Host Root Directory",
       "help": "Filesystem root directory served by canvas host for canvas content and static assets. Use a dedicated directory and avoid broad repo roots for least-privilege file exposure.",
       "hasChildren": false
@@ -7801,9 +7253,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Channels",
       "help": "Channel provider configurations plus shared defaults that control access policies, heartbeat visibility, and per-surface behavior. Keep defaults centralized and override per provider only where required.",
       "hasChildren": true
@@ -7815,10 +7265,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "BlueBubbles",
       "help": "iMessage via the BlueBubbles mac app + REST API.",
       "hasChildren": true
@@ -7856,10 +7303,7 @@
     {
       "path": "channels.bluebubbles.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -7891,10 +7335,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -7915,12 +7356,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -7949,10 +7385,7 @@
     {
       "path": "channels.bluebubbles.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -7964,11 +7397,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -8099,11 +7528,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -8152,19 +7577,11 @@
     {
       "path": "channels.bluebubbles.accounts.*.password",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -8381,10 +7798,7 @@
     {
       "path": "channels.bluebubbles.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -8416,10 +7830,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -8450,19 +7861,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "BlueBubbles DM Policy",
       "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.bluebubbles.allowFrom=[\"*\"].",
       "hasChildren": false
@@ -8490,10 +7892,7 @@
     {
       "path": "channels.bluebubbles.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -8505,11 +7904,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -8640,11 +8035,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -8693,19 +8084,11 @@
     {
       "path": "channels.bluebubbles.password",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -8785,10 +8168,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord",
       "help": "very well supported right now.",
       "hasChildren": true
@@ -8828,14 +8208,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "group-mentions",
-        "group-all",
-        "direct",
-        "all",
-        "off",
-        "none"
-      ],
+      "enumValues": ["group-mentions", "group-all", "direct", "all", "off", "none"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -9094,10 +8467,7 @@
     {
       "path": "channels.discord.accounts.*.allowBots",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -9117,10 +8487,7 @@
     {
       "path": "channels.discord.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -9272,10 +8639,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -9294,10 +8658,7 @@
     {
       "path": "channels.discord.accounts.*.commands.native",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -9307,10 +8668,7 @@
     {
       "path": "channels.discord.accounts.*.commands.nativeSkills",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -9370,10 +8728,7 @@
     {
       "path": "channels.discord.accounts.*.dm.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -9403,10 +8758,7 @@
     {
       "path": "channels.discord.accounts.*.dm.groupChannels.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -9428,12 +8780,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -9454,12 +8801,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -9628,10 +8970,7 @@
     {
       "path": "channels.discord.accounts.*.execApprovals.approvers.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -9683,11 +9022,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "dm",
-        "channel",
-        "both"
-      ],
+      "enumValues": ["dm", "channel", "both"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -9698,11 +9033,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -9762,17 +9093,9 @@
     {
       "path": "channels.discord.accounts.*.guilds.*.channels.*.autoArchiveDuration",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
-      "enumValues": [
-        "60",
-        "1440",
-        "4320",
-        "10080"
-      ],
+      "enumValues": ["60", "1440", "4320", "10080"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -9841,10 +9164,7 @@
     {
       "path": "channels.discord.accounts.*.guilds.*.channels.*.roles.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -10044,10 +9364,7 @@
     {
       "path": "channels.discord.accounts.*.guilds.*.channels.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -10069,12 +9386,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "own",
-        "all",
-        "allowlist"
-      ],
+      "enumValues": ["off", "own", "all", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -10103,10 +9415,7 @@
     {
       "path": "channels.discord.accounts.*.guilds.*.roles.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -10286,10 +9595,7 @@
     {
       "path": "channels.discord.accounts.*.guilds.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -10431,11 +9737,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -10494,19 +9796,11 @@
     {
       "path": "channels.discord.accounts.*.pluralkit.token",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -10644,12 +9938,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "online",
-        "dnd",
-        "idle",
-        "invisible"
-      ],
+      "enumValues": ["online", "dnd", "idle", "invisible"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -10658,17 +9947,9 @@
     {
       "path": "channels.discord.accounts.*.streaming",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
-      "enumValues": [
-        "off",
-        "partial",
-        "block",
-        "progress"
-      ],
+      "enumValues": ["off", "partial", "block", "progress"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -10679,11 +9960,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "partial",
-        "block",
-        "off"
-      ],
+      "enumValues": ["partial", "block", "off"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -10762,19 +10039,11 @@
     {
       "path": "channels.discord.accounts.*.token",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -10932,12 +10201,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "always",
-        "inbound",
-        "tagged"
-      ],
+      "enumValues": ["off", "always", "inbound", "tagged"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -11066,20 +10330,11 @@
     {
       "path": "channels.discord.accounts.*.voice.tts.elevenlabs.apiKey",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "media",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "media", "network", "security"],
       "hasChildren": true
     },
     {
@@ -11117,11 +10372,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "auto",
-        "on",
-        "off"
-      ],
+      "enumValues": ["auto", "on", "off"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -11262,10 +10513,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "final",
-        "all"
-      ],
+      "enumValues": ["final", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -11374,20 +10622,11 @@
     {
       "path": "channels.discord.accounts.*.voice.tts.openai.apiKey",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "media",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "media", "network", "security"],
       "hasChildren": true
     },
     {
@@ -11485,11 +10724,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "elevenlabs",
-        "openai",
-        "edge"
-      ],
+      "enumValues": ["elevenlabs", "openai", "edge"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -11530,14 +10765,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "group-mentions",
-        "group-all",
-        "direct",
-        "all",
-        "off",
-        "none"
-      ],
+      "enumValues": ["group-mentions", "group-all", "direct", "all", "off", "none"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -11750,10 +10978,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Presence Activity",
       "help": "Discord presence activity text (defaults to custom status).",
       "hasChildren": false
@@ -11765,10 +10990,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Presence Activity Type",
       "help": "Discord presence activity type (0=Playing,1=Streaming,2=Listening,3=Watching,4=Custom,5=Competing).",
       "hasChildren": false
@@ -11780,10 +11002,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Presence Activity URL",
       "help": "Discord presence streaming URL (required for activityType=1).",
       "hasChildren": false
@@ -11811,18 +11030,11 @@
     {
       "path": "channels.discord.allowBots",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "Discord Allow Bot Messages",
       "help": "Allow bot-authored messages to trigger Discord replies (default: false). Set \"mentions\" to only accept bot messages that mention the bot.",
       "hasChildren": false
@@ -11840,10 +11052,7 @@
     {
       "path": "channels.discord.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -11867,10 +11076,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Auto Presence Degraded Text",
       "help": "Optional custom status text while runtime/model availability is degraded or unknown (idle).",
       "hasChildren": false
@@ -11882,10 +11088,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Auto Presence Enabled",
       "help": "Enable automatic Discord bot presence updates based on runtime/model availability signals. When enabled: healthy=>online, degraded/unknown=>idle, exhausted/unavailable=>dnd.",
       "hasChildren": false
@@ -11897,10 +11100,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Auto Presence Exhausted Text",
       "help": "Optional custom status text while runtime detects exhausted/unavailable model quota (dnd). Supports {reason} template placeholder.",
       "hasChildren": false
@@ -11912,11 +11112,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "reliability"
-      ],
+      "tags": ["channels", "network", "reliability"],
       "label": "Discord Auto Presence Healthy Text",
       "help": "Optional custom status text while runtime is healthy (online). If omitted, falls back to static channels.discord.activity when set.",
       "hasChildren": false
@@ -11928,11 +11124,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "Discord Auto Presence Check Interval (ms)",
       "help": "How often to evaluate Discord auto-presence state in milliseconds (default: 30000).",
       "hasChildren": false
@@ -11944,11 +11136,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "Discord Auto Presence Min Update Interval (ms)",
       "help": "Minimum time between actual Discord presence update calls in milliseconds (default: 15000). Prevents status spam on noisy state changes.",
       "hasChildren": false
@@ -12028,10 +11216,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -12050,17 +11235,11 @@
     {
       "path": "channels.discord.commands.native",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Native Commands",
       "help": "Override native commands for Discord (bool or \"auto\").",
       "hasChildren": false
@@ -12068,17 +11247,11 @@
     {
       "path": "channels.discord.commands.nativeSkills",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Native Skill Commands",
       "help": "Override native skill commands for Discord (bool or \"auto\").",
       "hasChildren": false
@@ -12090,10 +11263,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Config Writes",
       "help": "Allow Discord to write config in response to channel events/commands (default: true).",
       "hasChildren": false
@@ -12151,10 +11321,7 @@
     {
       "path": "channels.discord.dm.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -12184,10 +11351,7 @@
     {
       "path": "channels.discord.dm.groupChannels.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -12209,19 +11373,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "Discord DM Policy",
       "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.discord.allowFrom=[\"*\"] (legacy: channels.discord.dm.allowFrom).",
       "hasChildren": false
@@ -12241,19 +11396,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "Discord DM Policy",
       "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.discord.allowFrom=[\"*\"].",
       "hasChildren": false
@@ -12305,10 +11451,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Draft Chunk Break Preference",
       "help": "Preferred breakpoints for Discord draft chunks (paragraph | newline | sentence). Default: paragraph.",
       "hasChildren": false
@@ -12320,11 +11463,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "Discord Draft Chunk Max Chars",
       "help": "Target max size for a Discord stream preview chunk when channels.discord.streaming=\"block\" (default: 800; clamped to channels.discord.textChunkLimit).",
       "hasChildren": false
@@ -12336,10 +11475,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Draft Chunk Min Chars",
       "help": "Minimum chars before emitting a Discord stream preview update when channels.discord.streaming=\"block\" (default: 200).",
       "hasChildren": false
@@ -12371,11 +11507,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "Discord EventQueue Listener Timeout (ms)",
       "help": "Canonical Discord listener timeout control in ms for gateway normalization/enqueue handlers. Default is 120000 in OpenClaw; set per account via channels.discord.accounts.<id>.eventQueue.listenerTimeout.",
       "hasChildren": false
@@ -12387,11 +11519,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "Discord EventQueue Max Concurrency",
       "help": "Optional Discord EventQueue concurrency override (max concurrent handler executions). Set per account via channels.discord.accounts.<id>.eventQueue.maxConcurrency.",
       "hasChildren": false
@@ -12403,11 +11531,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "Discord EventQueue Max Queue Size",
       "help": "Optional Discord EventQueue capacity override (max queued events before backpressure). Set per account via channels.discord.accounts.<id>.eventQueue.maxQueueSize.",
       "hasChildren": false
@@ -12455,10 +11579,7 @@
     {
       "path": "channels.discord.execApprovals.approvers.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -12510,11 +11631,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "dm",
-        "channel",
-        "both"
-      ],
+      "enumValues": ["dm", "channel", "both"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -12525,11 +11642,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -12589,17 +11702,9 @@
     {
       "path": "channels.discord.guilds.*.channels.*.autoArchiveDuration",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
-      "enumValues": [
-        "60",
-        "1440",
-        "4320",
-        "10080"
-      ],
+      "enumValues": ["60", "1440", "4320", "10080"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -12668,10 +11773,7 @@
     {
       "path": "channels.discord.guilds.*.channels.*.roles.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -12871,10 +11973,7 @@
     {
       "path": "channels.discord.guilds.*.channels.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -12896,12 +11995,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "own",
-        "all",
-        "allowlist"
-      ],
+      "enumValues": ["off", "own", "all", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -12930,10 +12024,7 @@
     {
       "path": "channels.discord.guilds.*.roles.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -13113,10 +12204,7 @@
     {
       "path": "channels.discord.guilds.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -13210,11 +12298,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "Discord Inbound Worker Timeout (ms)",
       "help": "Optional queued Discord inbound worker timeout in ms. This is separate from Carbon listener timeouts; defaults to 1800000 and can be disabled with 0. Set per account via channels.discord.accounts.<id>.inboundWorker.runTimeoutMs.",
       "hasChildren": false
@@ -13236,10 +12320,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Guild Members Intent",
       "help": "Enable the Guild Members privileged intent. Must also be enabled in the Discord Developer Portal. Default: false.",
       "hasChildren": false
@@ -13251,10 +12332,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Presence Intent",
       "help": "Enable the Guild Presences privileged intent. Must also be enabled in the Discord Developer Portal. Allows tracking user activities (e.g. Spotify). Default: false.",
       "hasChildren": false
@@ -13274,11 +12352,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -13291,11 +12365,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "Discord Max Lines Per Message",
       "help": "Soft max line count per Discord message (default: 17).",
       "hasChildren": false
@@ -13337,10 +12407,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord PluralKit Enabled",
       "help": "Resolve PluralKit proxied messages and treat system members as distinct senders.",
       "hasChildren": false
@@ -13348,19 +12415,11 @@
     {
       "path": "channels.discord.pluralkit.token",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "label": "Discord PluralKit Token",
       "help": "Optional PluralKit token for resolving private systems or members.",
       "hasChildren": true
@@ -13402,10 +12461,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Proxy URL",
       "help": "Proxy URL for Discord gateway + API requests (app-id lookup and allowlist resolution). Set per account via channels.discord.accounts.<id>.proxy.",
       "hasChildren": false
@@ -13447,11 +12503,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "reliability"
-      ],
+      "tags": ["channels", "network", "reliability"],
       "label": "Discord Retry Attempts",
       "help": "Max retry attempts for outbound Discord API calls (default: 3).",
       "hasChildren": false
@@ -13463,11 +12515,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "reliability"
-      ],
+      "tags": ["channels", "network", "reliability"],
       "label": "Discord Retry Jitter",
       "help": "Jitter factor (0-1) applied to Discord retry delays.",
       "hasChildren": false
@@ -13479,12 +12527,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance",
-        "reliability"
-      ],
+      "tags": ["channels", "network", "performance", "reliability"],
       "label": "Discord Retry Max Delay (ms)",
       "help": "Maximum retry delay cap in ms for Discord outbound calls.",
       "hasChildren": false
@@ -13496,11 +12539,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "reliability"
-      ],
+      "tags": ["channels", "network", "reliability"],
       "label": "Discord Retry Min Delay (ms)",
       "help": "Minimum retry delay in ms for Discord outbound calls.",
       "hasChildren": false
@@ -13530,18 +12569,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "online",
-        "dnd",
-        "idle",
-        "invisible"
-      ],
+      "enumValues": ["online", "dnd", "idle", "invisible"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Presence Status",
       "help": "Discord presence status (online, dnd, idle, invisible).",
       "hasChildren": false
@@ -13549,23 +12580,12 @@
     {
       "path": "channels.discord.streaming",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
-      "enumValues": [
-        "off",
-        "partial",
-        "block",
-        "progress"
-      ],
+      "enumValues": ["off", "partial", "block", "progress"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Streaming Mode",
       "help": "Unified Discord stream preview mode: \"off\" | \"partial\" | \"block\" | \"progress\". \"progress\" maps to \"partial\" on Discord. Legacy boolean/streamMode keys are auto-mapped.",
       "hasChildren": false
@@ -13575,17 +12595,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "partial",
-        "block",
-        "off"
-      ],
+      "enumValues": ["partial", "block", "off"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Stream Mode (Legacy)",
       "help": "Legacy Discord preview mode alias (off | partial | block); auto-migrated to channels.discord.streaming.",
       "hasChildren": false
@@ -13617,11 +12630,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "storage"
-      ],
+      "tags": ["channels", "network", "storage"],
       "label": "Discord Thread Binding Enabled",
       "help": "Enable Discord thread binding features (/focus, bound-thread routing/delivery, and thread-bound subagent sessions). Overrides session.threadBindings.enabled when set.",
       "hasChildren": false
@@ -13633,11 +12642,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "storage"
-      ],
+      "tags": ["channels", "network", "storage"],
       "label": "Discord Thread Binding Idle Timeout (hours)",
       "help": "Inactivity window in hours for Discord thread-bound sessions (/focus and spawned thread sessions). Set 0 to disable idle auto-unfocus (default: 24). Overrides session.threadBindings.idleHours when set.",
       "hasChildren": false
@@ -13649,12 +12654,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance",
-        "storage"
-      ],
+      "tags": ["channels", "network", "performance", "storage"],
       "label": "Discord Thread Binding Max Age (hours)",
       "help": "Optional hard max age in hours for Discord thread-bound sessions. Set 0 to disable hard cap (default: 0). Overrides session.threadBindings.maxAgeHours when set.",
       "hasChildren": false
@@ -13666,11 +12666,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "storage"
-      ],
+      "tags": ["channels", "network", "storage"],
       "label": "Discord Thread-Bound ACP Spawn",
       "help": "Allow /acp spawn to auto-create and bind Discord threads for ACP sessions (default: false; opt-in). Set true to enable thread-bound ACP spawns for this account/channel.",
       "hasChildren": false
@@ -13682,11 +12678,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "storage"
-      ],
+      "tags": ["channels", "network", "storage"],
       "label": "Discord Thread-Bound Subagent Spawn",
       "help": "Allow subagent spawns with thread=true to auto-create and bind Discord threads (default: false; opt-in). Set true to enable thread-bound subagent spawns for this account/channel.",
       "hasChildren": false
@@ -13694,19 +12686,11 @@
     {
       "path": "channels.discord.token",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "label": "Discord Bot Token",
       "help": "Discord bot token used for gateway and REST API authentication for this provider account. Keep this secret out of committed config and rotate immediately after any leak.",
       "hasChildren": true
@@ -13768,10 +12752,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Component Accent Color",
       "help": "Accent color for Discord component containers (hex). Set per account via channels.discord.accounts.<id>.ui.components.accentColor.",
       "hasChildren": false
@@ -13793,10 +12774,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Voice Auto-Join",
       "help": "Voice channels to auto-join on startup (list of guildId/channelId entries).",
       "hasChildren": true
@@ -13838,10 +12816,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Voice DAVE Encryption",
       "help": "Toggle DAVE end-to-end encryption for Discord voice joins (default: true in @discordjs/voice; Discord may require this).",
       "hasChildren": false
@@ -13853,10 +12828,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Voice Decrypt Failure Tolerance",
       "help": "Consecutive decrypt failures before DAVE attempts session recovery (passed to @discordjs/voice; default: 24).",
       "hasChildren": false
@@ -13868,10 +12840,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Discord Voice Enabled",
       "help": "Enable Discord voice channel conversations (default: true). Omit channels.discord.voice to keep voice support disabled for the account.",
       "hasChildren": false
@@ -13883,11 +12852,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "media",
-        "network"
-      ],
+      "tags": ["channels", "media", "network"],
       "label": "Discord Voice Text-to-Speech",
       "help": "Optional TTS overrides for Discord voice playback (merged with messages.tts).",
       "hasChildren": true
@@ -13897,12 +12862,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "always",
-        "inbound",
-        "tagged"
-      ],
+      "enumValues": ["off", "always", "inbound", "tagged"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14031,20 +12991,11 @@
     {
       "path": "channels.discord.voice.tts.elevenlabs.apiKey",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "media",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "media", "network", "security"],
       "hasChildren": true
     },
     {
@@ -14082,11 +13033,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "auto",
-        "on",
-        "off"
-      ],
+      "enumValues": ["auto", "on", "off"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14227,10 +13174,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "final",
-        "all"
-      ],
+      "enumValues": ["final", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14339,20 +13283,11 @@
     {
       "path": "channels.discord.voice.tts.openai.apiKey",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "media",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "media", "network", "security"],
       "hasChildren": true
     },
     {
@@ -14450,11 +13385,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "elevenlabs",
-        "openai",
-        "edge"
-      ],
+      "enumValues": ["elevenlabs", "openai", "edge"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14487,10 +13418,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Feishu",
       "help": "飞书/Lark enterprise messaging.",
       "hasChildren": true
@@ -14548,10 +13476,7 @@
     {
       "path": "channels.feishu.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -14571,10 +13496,7 @@
     {
       "path": "channels.feishu.accounts.*.appSecret",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -14676,10 +13598,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14700,10 +13619,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "websocket",
-        "webhook"
-      ],
+      "enumValues": ["websocket", "webhook"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14724,11 +13640,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "pairing",
-        "allowlist"
-      ],
+      "enumValues": ["open", "pairing", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14779,10 +13691,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "feishu",
-        "lark"
-      ],
+      "enumValues": ["feishu", "lark"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14801,10 +13710,7 @@
     {
       "path": "channels.feishu.accounts.*.encryptKey",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -14854,10 +13760,7 @@
     {
       "path": "channels.feishu.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -14869,11 +13772,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "allowlist",
-        "disabled"
-      ],
+      "enumValues": ["open", "allowlist", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14912,10 +13811,7 @@
     {
       "path": "channels.feishu.accounts.*.groups.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -14937,12 +13833,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "group",
-        "group_sender",
-        "group_topic",
-        "group_topic_sender"
-      ],
+      "enumValues": ["group", "group_sender", "group_topic", "group_topic_sender"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -14953,10 +13844,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "disabled",
-        "enabled"
-      ],
+      "enumValues": ["disabled", "enabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15057,10 +13945,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "disabled",
-        "enabled"
-      ],
+      "enumValues": ["disabled", "enabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15079,10 +13964,7 @@
     {
       "path": "channels.feishu.accounts.*.groupSenderAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -15094,12 +13976,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "group",
-        "group_sender",
-        "group_topic",
-        "group_topic_sender"
-      ],
+      "enumValues": ["group", "group_sender", "group_topic", "group_topic_sender"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15130,10 +14007,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "visible",
-        "hidden"
-      ],
+      "enumValues": ["visible", "hidden"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15174,11 +14048,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "native",
-        "escape",
-        "strip"
-      ],
+      "enumValues": ["native", "escape", "strip"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15189,11 +14059,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "native",
-        "ascii",
-        "simple"
-      ],
+      "enumValues": ["native", "ascii", "simple"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15224,11 +14090,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "own",
-        "all"
-      ],
+      "enumValues": ["off", "own", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15239,11 +14101,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "auto",
-        "raw",
-        "card"
-      ],
+      "enumValues": ["auto", "raw", "card"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15254,10 +14112,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "disabled",
-        "enabled"
-      ],
+      "enumValues": ["disabled", "enabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15378,10 +14233,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "disabled",
-        "enabled"
-      ],
+      "enumValues": ["disabled", "enabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15400,10 +14252,7 @@
     {
       "path": "channels.feishu.accounts.*.verificationToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -15503,10 +14352,7 @@
     {
       "path": "channels.feishu.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -15526,10 +14372,7 @@
     {
       "path": "channels.feishu.appSecret",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -15631,10 +14474,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15655,10 +14495,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "websocket",
-        "webhook"
-      ],
+      "enumValues": ["websocket", "webhook"],
       "defaultValue": "websocket",
       "deprecated": false,
       "sensitive": false,
@@ -15690,11 +14527,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "pairing",
-        "allowlist"
-      ],
+      "enumValues": ["open", "pairing", "allowlist"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -15746,10 +14579,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "feishu",
-        "lark"
-      ],
+      "enumValues": ["feishu", "lark"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15818,10 +14648,7 @@
     {
       "path": "channels.feishu.encryptKey",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -15871,10 +14698,7 @@
     {
       "path": "channels.feishu.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -15886,11 +14710,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "allowlist",
-        "disabled"
-      ],
+      "enumValues": ["open", "allowlist", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15929,10 +14749,7 @@
     {
       "path": "channels.feishu.groups.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -15954,12 +14771,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "group",
-        "group_sender",
-        "group_topic",
-        "group_topic_sender"
-      ],
+      "enumValues": ["group", "group_sender", "group_topic", "group_topic_sender"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -15970,10 +14782,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "disabled",
-        "enabled"
-      ],
+      "enumValues": ["disabled", "enabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16074,10 +14883,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "disabled",
-        "enabled"
-      ],
+      "enumValues": ["disabled", "enabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16096,10 +14902,7 @@
     {
       "path": "channels.feishu.groupSenderAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -16111,12 +14914,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "group",
-        "group_sender",
-        "group_topic",
-        "group_topic_sender"
-      ],
+      "enumValues": ["group", "group_sender", "group_topic", "group_topic_sender"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16147,10 +14945,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "visible",
-        "hidden"
-      ],
+      "enumValues": ["visible", "hidden"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16191,11 +14986,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "native",
-        "escape",
-        "strip"
-      ],
+      "enumValues": ["native", "escape", "strip"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16206,11 +14997,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "native",
-        "ascii",
-        "simple"
-      ],
+      "enumValues": ["native", "ascii", "simple"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16231,11 +15018,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "off",
-        "own",
-        "all"
-      ],
+      "enumValues": ["off", "own", "all"],
       "defaultValue": "own",
       "deprecated": false,
       "sensitive": false,
@@ -16247,11 +15030,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "auto",
-        "raw",
-        "card"
-      ],
+      "enumValues": ["auto", "raw", "card"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16262,10 +15041,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "disabled",
-        "enabled"
-      ],
+      "enumValues": ["disabled", "enabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16388,10 +15164,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "disabled",
-        "enabled"
-      ],
+      "enumValues": ["disabled", "enabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16411,10 +15184,7 @@
     {
       "path": "channels.feishu.verificationToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -16489,10 +15259,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Google Chat",
       "help": "Google Workspace Chat app with HTTP webhook.",
       "hasChildren": true
@@ -16572,10 +15339,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "app-url",
-        "project-number"
-      ],
+      "enumValues": ["app-url", "project-number"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16666,10 +15430,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -16728,10 +15489,7 @@
     {
       "path": "channels.googlechat.accounts.*.dm.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -16753,12 +15511,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -16828,10 +15581,7 @@
     {
       "path": "channels.googlechat.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -16843,11 +15593,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -16927,10 +15673,7 @@
     {
       "path": "channels.googlechat.accounts.*.groups.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -17020,18 +15763,11 @@
     {
       "path": "channels.googlechat.accounts.*.serviceAccount",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -17090,11 +15826,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -17132,11 +15864,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "replace",
-        "status_final",
-        "append"
-      ],
+      "enumValues": ["replace", "status_final", "append"],
       "defaultValue": "replace",
       "deprecated": false,
       "sensitive": false,
@@ -17158,11 +15886,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "none",
-        "message",
-        "reaction"
-      ],
+      "enumValues": ["none", "message", "reaction"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -17243,10 +15967,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "app-url",
-        "project-number"
-      ],
+      "enumValues": ["app-url", "project-number"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -17337,10 +16058,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -17409,10 +16127,7 @@
     {
       "path": "channels.googlechat.dm.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -17434,12 +16149,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -17509,10 +16219,7 @@
     {
       "path": "channels.googlechat.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -17524,11 +16231,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -17608,10 +16311,7 @@
     {
       "path": "channels.googlechat.groups.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -17701,18 +16401,11 @@
     {
       "path": "channels.googlechat.serviceAccount",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -17771,11 +16464,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -17813,11 +16502,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "replace",
-        "status_final",
-        "append"
-      ],
+      "enumValues": ["replace", "status_final", "append"],
       "defaultValue": "replace",
       "deprecated": false,
       "sensitive": false,
@@ -17839,11 +16524,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "none",
-        "message",
-        "reaction"
-      ],
+      "enumValues": ["none", "message", "reaction"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -17876,10 +16557,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "iMessage",
       "help": "this is still a work in progress.",
       "hasChildren": true
@@ -17917,10 +16595,7 @@
     {
       "path": "channels.imessage.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -18022,10 +16697,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -18086,12 +16758,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -18151,10 +16818,7 @@
     {
       "path": "channels.imessage.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -18166,11 +16830,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -18452,11 +17112,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -18565,10 +17221,7 @@
     {
       "path": "channels.imessage.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -18670,10 +17323,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -18686,11 +17336,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "storage"
-      ],
+      "tags": ["channels", "network", "storage"],
       "label": "iMessage CLI Path",
       "help": "Filesystem path to the iMessage bridge CLI binary used for send/receive operations. Set explicitly when the binary is not on PATH in service runtime environments.",
       "hasChildren": false
@@ -18702,10 +17348,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "iMessage Config Writes",
       "help": "Allow iMessage to write config in response to channel events/commands (default: true).",
       "hasChildren": false
@@ -18755,20 +17398,11 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "iMessage DM Policy",
       "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.imessage.allowFrom=[\"*\"].",
       "hasChildren": false
@@ -18826,10 +17460,7 @@
     {
       "path": "channels.imessage.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -18841,11 +17472,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -19127,11 +17754,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -19234,10 +17857,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "IRC",
       "help": "classic IRC networks with DM/channel routing and pairing controls.",
       "hasChildren": true
@@ -19275,10 +17895,7 @@
     {
       "path": "channels.irc.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -19360,10 +17977,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -19394,12 +18008,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -19459,10 +18068,7 @@
     {
       "path": "channels.irc.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -19474,11 +18080,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -19518,10 +18120,7 @@
     {
       "path": "channels.irc.accounts.*.groups.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -19763,11 +18362,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -19850,12 +18445,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": false
     },
     {
@@ -19905,12 +18495,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": false
     },
     {
@@ -19996,10 +18581,7 @@
     {
       "path": "channels.irc.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -20081,10 +18663,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -20125,20 +18704,11 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "IRC DM Policy",
       "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.irc.allowFrom=[\"*\"].",
       "hasChildren": false
@@ -20196,10 +18766,7 @@
     {
       "path": "channels.irc.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -20211,11 +18778,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -20255,10 +18818,7 @@
     {
       "path": "channels.irc.groups.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -20500,11 +19060,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -20577,10 +19133,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "IRC NickServ Enabled",
       "help": "Enable NickServ identify/register after connect (defaults to enabled when password is configured).",
       "hasChildren": false
@@ -20592,12 +19145,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "label": "IRC NickServ Password",
       "help": "NickServ password used for IDENTIFY/REGISTER (sensitive).",
       "hasChildren": false
@@ -20609,13 +19157,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security",
-        "storage"
-      ],
+      "tags": ["auth", "channels", "network", "security", "storage"],
       "label": "IRC NickServ Password File",
       "help": "Optional file path containing NickServ password.",
       "hasChildren": false
@@ -20627,10 +19169,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "IRC NickServ Register",
       "help": "If true, send NickServ REGISTER on every connect. Use once for initial registration, then disable.",
       "hasChildren": false
@@ -20642,10 +19181,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "IRC NickServ Register Email",
       "help": "Email used with NickServ REGISTER (required when register=true).",
       "hasChildren": false
@@ -20657,10 +19193,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "IRC NickServ Service",
       "help": "NickServ service nick (default: NickServ).",
       "hasChildren": false
@@ -20672,12 +19205,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": false
     },
     {
@@ -20757,10 +19285,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "LINE",
       "help": "LINE Messaging API bot for Japan/Taiwan/Thailand markets.",
       "hasChildren": true
@@ -20798,10 +19323,7 @@
     {
       "path": "channels.line.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -20833,12 +19355,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "allowlist",
-        "pairing",
-        "disabled"
-      ],
+      "enumValues": ["open", "allowlist", "pairing", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -20868,10 +19385,7 @@
     {
       "path": "channels.line.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -20883,11 +19397,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "allowlist",
-        "disabled"
-      ],
+      "enumValues": ["open", "allowlist", "disabled"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -20927,10 +19437,7 @@
     {
       "path": "channels.line.accounts.*.groups.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -21060,10 +19567,7 @@
     {
       "path": "channels.line.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -21105,12 +19609,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "allowlist",
-        "pairing",
-        "disabled"
-      ],
+      "enumValues": ["open", "allowlist", "pairing", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -21140,10 +19639,7 @@
     {
       "path": "channels.line.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -21155,11 +19651,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "allowlist",
-        "disabled"
-      ],
+      "enumValues": ["open", "allowlist", "disabled"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -21199,10 +19691,7 @@
     {
       "path": "channels.line.groups.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -21326,10 +19815,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Matrix",
       "help": "open protocol; configure a homeserver + access token.",
       "hasChildren": true
@@ -21438,11 +19924,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "always",
-        "allowlist",
-        "off"
-      ],
+      "enumValues": ["always", "allowlist", "off"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -21461,10 +19943,7 @@
     {
       "path": "channels.matrix.autoJoinAllowlist.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -21476,10 +19955,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -21528,10 +20004,7 @@
     {
       "path": "channels.matrix.dm.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -21553,12 +20026,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -21597,10 +20065,7 @@
     {
       "path": "channels.matrix.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -21612,11 +20077,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -21795,10 +20256,7 @@
     {
       "path": "channels.matrix.groups.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -21840,11 +20298,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -21873,10 +20327,7 @@
     {
       "path": "channels.matrix.password",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -21918,11 +20369,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "first",
-        "all"
-      ],
+      "enumValues": ["off", "first", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -22111,10 +20558,7 @@
     {
       "path": "channels.matrix.rooms.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -22136,11 +20580,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "inbound",
-        "always"
-      ],
+      "enumValues": ["off", "inbound", "always"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -22163,10 +20603,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Mattermost",
       "help": "self-hosted Slack-style chat; install the plugin to enable.",
       "hasChildren": true
@@ -22224,10 +20661,7 @@
     {
       "path": "channels.mattermost.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -22297,10 +20731,7 @@
     {
       "path": "channels.mattermost.accounts.*.botToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -22362,11 +20793,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "oncall",
-        "onmessage",
-        "onchar"
-      ],
+      "enumValues": ["oncall", "onmessage", "onchar"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -22377,10 +20804,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -22419,10 +20843,7 @@
     {
       "path": "channels.mattermost.accounts.*.commands.native",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -22432,10 +20853,7 @@
     {
       "path": "channels.mattermost.accounts.*.commands.nativeSkills",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -22467,12 +20885,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -22502,10 +20915,7 @@
     {
       "path": "channels.mattermost.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -22517,11 +20927,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -22583,11 +20989,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -22628,11 +21030,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "first",
-        "all"
-      ],
+      "enumValues": ["off", "first", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -22701,10 +21099,7 @@
     {
       "path": "channels.mattermost.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -22718,10 +21113,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Mattermost Base URL",
       "help": "Base URL for your Mattermost server (e.g., https://chat.example.com).",
       "hasChildren": false
@@ -22779,19 +21171,11 @@
     {
       "path": "channels.mattermost.botToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "label": "Mattermost Bot Token",
       "help": "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
       "hasChildren": true
@@ -22851,17 +21235,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "oncall",
-        "onmessage",
-        "onchar"
-      ],
+      "enumValues": ["oncall", "onmessage", "onchar"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Mattermost Chat Mode",
       "help": "Reply to channel messages on mention (\"oncall\"), on trigger chars (\">\" or \"!\") (\"onchar\"), or on every message (\"onmessage\").",
       "hasChildren": false
@@ -22871,10 +21248,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -22913,10 +21287,7 @@
     {
       "path": "channels.mattermost.commands.native",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -22926,10 +21297,7 @@
     {
       "path": "channels.mattermost.commands.nativeSkills",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -22943,10 +21311,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Mattermost Config Writes",
       "help": "Allow Mattermost to write config in response to channel events/commands (default: true).",
       "hasChildren": false
@@ -22976,12 +21341,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -23011,10 +21371,7 @@
     {
       "path": "channels.mattermost.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -23026,11 +21383,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -23092,11 +21445,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -23119,10 +21468,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Mattermost Onchar Prefixes",
       "help": "Trigger prefixes for onchar mode (default: [\">\", \"!\"]).",
       "hasChildren": true
@@ -23142,11 +21488,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "first",
-        "all"
-      ],
+      "enumValues": ["off", "first", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -23159,10 +21501,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Mattermost Require Mention",
       "help": "Require @mention in channels before responding (default: true).",
       "hasChildren": false
@@ -23194,10 +21533,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Microsoft Teams",
       "help": "Bot Framework; enterprise support.",
       "hasChildren": true
@@ -23235,19 +21571,11 @@
     {
       "path": "channels.msteams.appPassword",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -23345,10 +21673,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -23361,10 +21686,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "MS Teams Config Writes",
       "help": "Allow Microsoft Teams to write config in response to channel events/commands (default: true).",
       "hasChildren": false
@@ -23404,12 +21726,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -23481,11 +21798,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -23577,11 +21890,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -23642,10 +21951,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "thread",
-        "top-level"
-      ],
+      "enumValues": ["thread", "top-level"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -23726,10 +22032,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "thread",
-        "top-level"
-      ],
+      "enumValues": ["thread", "top-level"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -23900,10 +22203,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "thread",
-        "top-level"
-      ],
+      "enumValues": ["thread", "top-level"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -24126,10 +22426,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Nextcloud Talk",
       "help": "Self-hosted chat via Nextcloud Talk webhook bots.",
       "hasChildren": true
@@ -24177,10 +22474,7 @@
     {
       "path": "channels.nextcloud-talk.accounts.*.apiPassword",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -24300,10 +22594,7 @@
     {
       "path": "channels.nextcloud-talk.accounts.*.botSecret",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -24355,10 +22646,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -24379,12 +22667,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -24456,11 +22739,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -24492,11 +22771,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -24765,10 +23040,7 @@
     {
       "path": "channels.nextcloud-talk.apiPassword",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -24888,10 +23160,7 @@
     {
       "path": "channels.nextcloud-talk.botSecret",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -24943,10 +23212,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -24977,12 +23243,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -25054,11 +23315,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -25090,11 +23347,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -25347,10 +23600,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Nostr",
       "help": "Decentralized DMs via Nostr relays (NIP-04)",
       "hasChildren": true
@@ -25368,10 +23618,7 @@
     {
       "path": "channels.nostr.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -25393,12 +23640,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -25429,11 +23671,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -25576,10 +23814,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Signal",
       "help": "signal-cli linked device; more setup (David Reagans: \"Hop on Discord.\").",
       "hasChildren": true
@@ -25591,10 +23826,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Signal Account",
       "help": "Signal account identifier (phone/number handle) used to bind this channel config to a specific Signal identity. Keep this aligned with your linked device/session state.",
       "hasChildren": false
@@ -25672,10 +23904,7 @@
     {
       "path": "channels.signal.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -25767,10 +23996,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -25821,12 +24047,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -25886,10 +24107,7 @@
     {
       "path": "channels.signal.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -25901,11 +24119,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -26227,11 +24441,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -26270,10 +24480,7 @@
     {
       "path": "channels.signal.accounts.*.reactionAllowlist.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -26285,12 +24492,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "ack",
-        "minimal",
-        "extensive"
-      ],
+      "enumValues": ["off", "ack", "minimal", "extensive"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -26301,12 +24503,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "own",
-        "all",
-        "allowlist"
-      ],
+      "enumValues": ["off", "own", "all", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -26405,10 +24602,7 @@
     {
       "path": "channels.signal.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -26500,10 +24694,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -26526,10 +24717,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Signal Config Writes",
       "help": "Allow Signal to write config in response to channel events/commands (default: true).",
       "hasChildren": false
@@ -26569,20 +24757,11 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "Signal DM Policy",
       "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.signal.allowFrom=[\"*\"].",
       "hasChildren": false
@@ -26640,10 +24819,7 @@
     {
       "path": "channels.signal.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -26655,11 +24831,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -26981,11 +25153,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -27024,10 +25192,7 @@
     {
       "path": "channels.signal.reactionAllowlist.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -27039,12 +25204,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "ack",
-        "minimal",
-        "extensive"
-      ],
+      "enumValues": ["off", "ack", "minimal", "extensive"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -27055,12 +25215,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "own",
-        "all",
-        "allowlist"
-      ],
+      "enumValues": ["off", "own", "all", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -27123,10 +25278,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Slack",
       "help": "supported (Socket Mode).",
       "hasChildren": true
@@ -27274,10 +25426,7 @@
     {
       "path": "channels.slack.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -27287,19 +25436,11 @@
     {
       "path": "channels.slack.accounts.*.appToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -27385,19 +25526,11 @@
     {
       "path": "channels.slack.accounts.*.botToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -27433,10 +25566,7 @@
     {
       "path": "channels.slack.accounts.*.capabilities",
       "kind": "channel",
-      "type": [
-        "array",
-        "object"
-      ],
+      "type": ["array", "object"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -27716,10 +25846,7 @@
     {
       "path": "channels.slack.accounts.*.channels.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -27731,10 +25858,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -27753,10 +25877,7 @@
     {
       "path": "channels.slack.accounts.*.commands.native",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -27766,10 +25887,7 @@
     {
       "path": "channels.slack.accounts.*.commands.nativeSkills",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -27829,10 +25947,7 @@
     {
       "path": "channels.slack.accounts.*.dm.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -27862,10 +25977,7 @@
     {
       "path": "channels.slack.accounts.*.dm.groupChannels.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -27887,12 +25999,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -27923,12 +26030,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -27979,11 +26081,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -28074,11 +26172,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -28099,10 +26193,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "socket",
-        "http"
-      ],
+      "enumValues": ["socket", "http"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -28141,10 +26232,7 @@
     {
       "path": "channels.slack.accounts.*.reactionAllowlist.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -28156,12 +26244,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "own",
-        "all",
-        "allowlist"
-      ],
+      "enumValues": ["off", "own", "all", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -28240,19 +26323,11 @@
     {
       "path": "channels.slack.accounts.*.signingSecret",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -28338,17 +26413,9 @@
     {
       "path": "channels.slack.accounts.*.streaming",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
-      "enumValues": [
-        "off",
-        "partial",
-        "block",
-        "progress"
-      ],
+      "enumValues": ["off", "partial", "block", "progress"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -28359,11 +26426,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "replace",
-        "status_final",
-        "append"
-      ],
+      "enumValues": ["replace", "status_final", "append"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -28394,10 +26457,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "thread",
-        "channel"
-      ],
+      "enumValues": ["thread", "channel"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -28436,19 +26496,11 @@
     {
       "path": "channels.slack.accounts.*.userToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -28609,11 +26661,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "Slack Allow Bot Messages",
       "help": "Allow bot-authored messages to trigger Slack replies (default: false).",
       "hasChildren": false
@@ -28631,10 +26679,7 @@
     {
       "path": "channels.slack.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -28644,19 +26689,11 @@
     {
       "path": "channels.slack.appToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "label": "Slack App Token",
       "help": "Slack app-level token used for Socket Mode connections and event transport when enabled. Use least-privilege app scopes and store this token as a secret.",
       "hasChildren": true
@@ -28744,19 +26781,11 @@
     {
       "path": "channels.slack.botToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "label": "Slack Bot Token",
       "help": "Slack bot token used for standard chat actions in the configured workspace. Keep this credential scoped and rotate if workspace app permissions change.",
       "hasChildren": true
@@ -28794,10 +26823,7 @@
     {
       "path": "channels.slack.capabilities",
       "kind": "channel",
-      "type": [
-        "array",
-        "object"
-      ],
+      "type": ["array", "object"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -28821,10 +26847,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Slack Interactive Replies",
       "help": "Enable agent-authored Slack interactive reply directives (`[[slack_buttons: ...]]`, `[[slack_select: ...]]`). Default: false.",
       "hasChildren": false
@@ -29082,10 +27105,7 @@
     {
       "path": "channels.slack.channels.*.users.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -29097,10 +27117,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -29119,17 +27136,11 @@
     {
       "path": "channels.slack.commands.native",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Slack Native Commands",
       "help": "Override native commands for Slack (bool or \"auto\").",
       "hasChildren": false
@@ -29137,17 +27148,11 @@
     {
       "path": "channels.slack.commands.nativeSkills",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Slack Native Skill Commands",
       "help": "Override native skill commands for Slack (bool or \"auto\").",
       "hasChildren": false
@@ -29159,10 +27164,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Slack Config Writes",
       "help": "Allow Slack to write config in response to channel events/commands (default: true).",
       "hasChildren": false
@@ -29220,10 +27222,7 @@
     {
       "path": "channels.slack.dm.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -29253,10 +27252,7 @@
     {
       "path": "channels.slack.dm.groupChannels.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -29278,19 +27274,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "Slack DM Policy",
       "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.slack.allowFrom=[\"*\"] (legacy: channels.slack.dm.allowFrom).",
       "hasChildren": false
@@ -29320,19 +27307,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "Slack DM Policy",
       "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.slack.allowFrom=[\"*\"].",
       "hasChildren": false
@@ -29382,11 +27360,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -29478,11 +27452,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -29503,10 +27473,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "socket",
-        "http"
-      ],
+      "enumValues": ["socket", "http"],
       "defaultValue": "socket",
       "deprecated": false,
       "sensitive": false,
@@ -29530,10 +27497,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Slack Native Streaming",
       "help": "Enable native Slack text streaming (chat.startStream/chat.appendStream/chat.stopStream) when channels.slack.streaming is partial (default: true).",
       "hasChildren": false
@@ -29551,10 +27515,7 @@
     {
       "path": "channels.slack.reactionAllowlist.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -29566,12 +27527,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "own",
-        "all",
-        "allowlist"
-      ],
+      "enumValues": ["off", "own", "all", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -29650,19 +27606,11 @@
     {
       "path": "channels.slack.signingSecret",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -29748,23 +27696,12 @@
     {
       "path": "channels.slack.streaming",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
-      "enumValues": [
-        "off",
-        "partial",
-        "block",
-        "progress"
-      ],
+      "enumValues": ["off", "partial", "block", "progress"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Slack Streaming Mode",
       "help": "Unified Slack stream preview mode: \"off\" | \"partial\" | \"block\" | \"progress\". Legacy boolean/streamMode keys are auto-mapped.",
       "hasChildren": false
@@ -29774,17 +27711,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "replace",
-        "status_final",
-        "append"
-      ],
+      "enumValues": ["replace", "status_final", "append"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Slack Stream Mode (Legacy)",
       "help": "Legacy Slack preview mode alias (replace | status_final | append); auto-migrated to channels.slack.streaming.",
       "hasChildren": false
@@ -29814,16 +27744,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "thread",
-        "channel"
-      ],
+      "enumValues": ["thread", "channel"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Slack Thread History Scope",
       "help": "Scope for Slack thread history context (\"thread\" isolates per thread; \"channel\" reuses channel history).",
       "hasChildren": false
@@ -29835,10 +27759,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Slack Thread Parent Inheritance",
       "help": "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
       "hasChildren": false
@@ -29850,11 +27771,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "Slack Thread Initial History Limit",
       "help": "Maximum number of existing Slack thread messages to fetch when starting a new thread session (default: 20, set to 0 to disable).",
       "hasChildren": false
@@ -29872,19 +27789,11 @@
     {
       "path": "channels.slack.userToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "label": "Slack User Token",
       "help": "Optional Slack user token for workflows requiring user-context API access beyond bot permissions. Use sparingly and audit scopes because this token can carry broader authority.",
       "hasChildren": true
@@ -29927,12 +27836,7 @@
       "defaultValue": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "label": "Slack User Token Read Only",
       "help": "When true, treat configured Slack user token usage as read-only helper behavior where possible. Keep enabled if you only need supplemental reads without user-context writes.",
       "hasChildren": false
@@ -29955,10 +27859,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Synology Chat",
       "help": "Connect your Synology NAS Chat to OpenClaw",
       "hasChildren": true
@@ -29979,10 +27880,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram",
       "help": "simplest way to get started — register a bot with @BotFather and get going.",
       "hasChildren": true
@@ -30110,10 +28008,7 @@
     {
       "path": "channels.telegram.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -30173,19 +28068,11 @@
     {
       "path": "channels.telegram.accounts.*.botToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -30221,10 +28108,7 @@
     {
       "path": "channels.telegram.accounts.*.capabilities",
       "kind": "channel",
-      "type": [
-        "array",
-        "object"
-      ],
+      "type": ["array", "object"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -30246,13 +28130,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "dm",
-        "group",
-        "all",
-        "allowlist"
-      ],
+      "enumValues": ["off", "dm", "group", "all", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -30263,10 +28141,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -30285,10 +28160,7 @@
     {
       "path": "channels.telegram.accounts.*.commands.native",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -30298,10 +28170,7 @@
     {
       "path": "channels.telegram.accounts.*.commands.nativeSkills",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -30361,10 +28230,7 @@
     {
       "path": "channels.telegram.accounts.*.defaultTo",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -30404,10 +28270,7 @@
     {
       "path": "channels.telegram.accounts.*.direct.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -30419,12 +28282,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -30673,10 +28531,7 @@
     {
       "path": "channels.telegram.accounts.*.direct.*.topics.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -30708,11 +28563,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -30773,12 +28624,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -30908,10 +28754,7 @@
     {
       "path": "channels.telegram.accounts.*.execApprovals.approvers.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -30953,11 +28796,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "dm",
-        "channel",
-        "both"
-      ],
+      "enumValues": ["dm", "channel", "both"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -30976,10 +28815,7 @@
     {
       "path": "channels.telegram.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -30991,11 +28827,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -31035,10 +28867,7 @@
     {
       "path": "channels.telegram.accounts.*.groups.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -31070,11 +28899,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -31313,10 +29138,7 @@
     {
       "path": "channels.telegram.accounts.*.groups.*.topics.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -31348,11 +29170,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -31493,11 +29311,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -31548,10 +29362,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "ipv4first",
-        "verbatim"
-      ],
+      "enumValues": ["ipv4first", "verbatim"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -31572,12 +29383,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "ack",
-        "minimal",
-        "extensive"
-      ],
+      "enumValues": ["off", "ack", "minimal", "extensive"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -31588,11 +29394,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "own",
-        "all"
-      ],
+      "enumValues": ["off", "own", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -31671,17 +29473,9 @@
     {
       "path": "channels.telegram.accounts.*.streaming",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
-      "enumValues": [
-        "off",
-        "partial",
-        "block",
-        "progress"
-      ],
+      "enumValues": ["off", "partial", "block", "progress"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -31692,11 +29486,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "partial",
-        "block"
-      ],
+      "enumValues": ["off", "partial", "block"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -31835,19 +29625,11 @@
     {
       "path": "channels.telegram.accounts.*.webhookSecret",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -31993,10 +29775,7 @@
     {
       "path": "channels.telegram.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -32056,19 +29835,11 @@
     {
       "path": "channels.telegram.botToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "label": "Telegram Bot Token",
       "help": "Telegram bot token used to authenticate Bot API requests for this account/provider config. Use secret/env substitution and rotate tokens if exposure is suspected.",
       "hasChildren": true
@@ -32106,10 +29877,7 @@
     {
       "path": "channels.telegram.capabilities",
       "kind": "channel",
-      "type": [
-        "array",
-        "object"
-      ],
+      "type": ["array", "object"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -32131,19 +29899,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "dm",
-        "group",
-        "all",
-        "allowlist"
-      ],
+      "enumValues": ["off", "dm", "group", "all", "allowlist"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Inline Buttons",
       "help": "Enable Telegram inline button components for supported command and interaction surfaces. Disable if your deployment needs plain-text-only compatibility behavior.",
       "hasChildren": false
@@ -32153,10 +29912,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -32175,17 +29931,11 @@
     {
       "path": "channels.telegram.commands.native",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Native Commands",
       "help": "Override native commands for Telegram (bool or \"auto\").",
       "hasChildren": false
@@ -32193,17 +29943,11 @@
     {
       "path": "channels.telegram.commands.nativeSkills",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Native Skill Commands",
       "help": "Override native skill commands for Telegram (bool or \"auto\").",
       "hasChildren": false
@@ -32215,10 +29959,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Config Writes",
       "help": "Allow Telegram to write config in response to channel events/commands (default: true).",
       "hasChildren": false
@@ -32230,10 +29971,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Custom Commands",
       "help": "Additional Telegram bot menu commands (merged with native; conflicts ignored).",
       "hasChildren": true
@@ -32281,10 +30019,7 @@
     {
       "path": "channels.telegram.defaultTo",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -32324,10 +30059,7 @@
     {
       "path": "channels.telegram.direct.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -32339,12 +30071,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -32593,10 +30320,7 @@
     {
       "path": "channels.telegram.direct.*.topics.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -32628,11 +30352,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -32693,20 +30413,11 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "Telegram DM Policy",
       "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.telegram.allowFrom=[\"*\"].",
       "hasChildren": false
@@ -32798,10 +30509,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Exec Approvals",
       "help": "Telegram-native exec approval routing and approver authorization. Enable this only when Telegram should act as an explicit exec-approval client for the selected bot account.",
       "hasChildren": true
@@ -32813,10 +30521,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Exec Approval Agent Filter",
       "help": "Optional allowlist of agent IDs eligible for Telegram exec approvals, for example `[\"main\", \"ops-agent\"]`. Use this to keep approval prompts scoped to the agents you actually operate from Telegram.",
       "hasChildren": true
@@ -32838,10 +30543,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Exec Approval Approvers",
       "help": "Telegram user IDs allowed to approve exec requests for this bot account. Use numeric Telegram user IDs; prompts are only delivered to these approvers when target includes dm.",
       "hasChildren": true
@@ -32849,10 +30551,7 @@
     {
       "path": "channels.telegram.execApprovals.approvers.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -32866,10 +30565,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Exec Approvals Enabled",
       "help": "Enable Telegram exec approvals for this account. When false or unset, Telegram messages/buttons cannot approve exec requests.",
       "hasChildren": false
@@ -32881,11 +30577,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "storage"
-      ],
+      "tags": ["channels", "network", "storage"],
       "label": "Telegram Exec Approval Session Filter",
       "help": "Optional session-key filters matched as substring or regex-style patterns before Telegram approval routing is used. Use narrow patterns so Telegram approvals only appear for intended sessions.",
       "hasChildren": true
@@ -32905,17 +30597,10 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "dm",
-        "channel",
-        "both"
-      ],
+      "enumValues": ["dm", "channel", "both"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Exec Approval Target",
       "help": "Controls where Telegram approval prompts are sent: \"dm\" sends to approver DMs (default), \"channel\" sends to the originating Telegram chat/topic, and \"both\" sends to both. Channel delivery exposes the command text to the chat, so only use it in trusted groups/topics.",
       "hasChildren": false
@@ -32933,10 +30618,7 @@
     {
       "path": "channels.telegram.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -32948,11 +30630,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -32992,10 +30670,7 @@
     {
       "path": "channels.telegram.groups.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -33027,11 +30702,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -33270,10 +30941,7 @@
     {
       "path": "channels.telegram.groups.*.topics.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -33305,11 +30973,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -33450,11 +31114,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -33497,10 +31157,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram autoSelectFamily",
       "help": "Override Node autoSelectFamily for Telegram (true=enable, false=disable).",
       "hasChildren": false
@@ -33510,10 +31167,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "ipv4first",
-        "verbatim"
-      ],
+      "enumValues": ["ipv4first", "verbatim"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -33534,12 +31188,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "ack",
-        "minimal",
-        "extensive"
-      ],
+      "enumValues": ["off", "ack", "minimal", "extensive"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -33550,11 +31199,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "own",
-        "all"
-      ],
+      "enumValues": ["off", "own", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -33597,11 +31242,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "reliability"
-      ],
+      "tags": ["channels", "network", "reliability"],
       "label": "Telegram Retry Attempts",
       "help": "Max retry attempts for outbound Telegram API calls (default: 3).",
       "hasChildren": false
@@ -33613,11 +31254,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "reliability"
-      ],
+      "tags": ["channels", "network", "reliability"],
       "label": "Telegram Retry Jitter",
       "help": "Jitter factor (0-1) applied to Telegram retry delays.",
       "hasChildren": false
@@ -33629,12 +31266,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance",
-        "reliability"
-      ],
+      "tags": ["channels", "network", "performance", "reliability"],
       "label": "Telegram Retry Max Delay (ms)",
       "help": "Maximum retry delay cap in ms for Telegram outbound calls.",
       "hasChildren": false
@@ -33646,11 +31278,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "reliability"
-      ],
+      "tags": ["channels", "network", "reliability"],
       "label": "Telegram Retry Min Delay (ms)",
       "help": "Minimum retry delay in ms for Telegram outbound calls.",
       "hasChildren": false
@@ -33658,23 +31286,12 @@
     {
       "path": "channels.telegram.streaming",
       "kind": "channel",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
-      "enumValues": [
-        "off",
-        "partial",
-        "block",
-        "progress"
-      ],
+      "enumValues": ["off", "partial", "block", "progress"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Telegram Streaming Mode",
       "help": "Unified Telegram stream preview mode: \"off\" | \"partial\" | \"block\" | \"progress\" (default: \"partial\"). \"progress\" maps to \"partial\" on Telegram. Legacy boolean/streamMode keys are auto-mapped.",
       "hasChildren": false
@@ -33684,11 +31301,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "partial",
-        "block"
-      ],
+      "enumValues": ["off", "partial", "block"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -33721,11 +31334,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "storage"
-      ],
+      "tags": ["channels", "network", "storage"],
       "label": "Telegram Thread Binding Enabled",
       "help": "Enable Telegram conversation binding features (/focus, /unfocus, /agents, and /session idle|max-age). Overrides session.threadBindings.enabled when set.",
       "hasChildren": false
@@ -33737,11 +31346,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "storage"
-      ],
+      "tags": ["channels", "network", "storage"],
       "label": "Telegram Thread Binding Idle Timeout (hours)",
       "help": "Inactivity window in hours for Telegram bound sessions. Set 0 to disable idle auto-unfocus (default: 24). Overrides session.threadBindings.idleHours when set.",
       "hasChildren": false
@@ -33753,12 +31358,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance",
-        "storage"
-      ],
+      "tags": ["channels", "network", "performance", "storage"],
       "label": "Telegram Thread Binding Max Age (hours)",
       "help": "Optional hard max age in hours for Telegram bound sessions. Set 0 to disable hard cap (default: 0). Overrides session.threadBindings.maxAgeHours when set.",
       "hasChildren": false
@@ -33770,11 +31370,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "storage"
-      ],
+      "tags": ["channels", "network", "storage"],
       "label": "Telegram Thread-Bound ACP Spawn",
       "help": "Allow ACP spawns with thread=true to auto-bind Telegram current conversations when supported.",
       "hasChildren": false
@@ -33786,11 +31382,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "storage"
-      ],
+      "tags": ["channels", "network", "storage"],
       "label": "Telegram Thread-Bound Subagent Spawn",
       "help": "Allow subagent spawns with thread=true to auto-bind Telegram current conversations when supported.",
       "hasChildren": false
@@ -33802,11 +31394,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "Telegram API Timeout (seconds)",
       "help": "Max seconds before Telegram API requests are aborted (default: 500 per grammY).",
       "hasChildren": false
@@ -33864,19 +31452,11 @@
     {
       "path": "channels.telegram.webhookSecret",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "channels",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "channels", "network", "security"],
       "hasChildren": true
     },
     {
@@ -33926,10 +31506,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Tlon",
       "help": "Decentralized messaging on Urbit",
       "hasChildren": true
@@ -34179,10 +31756,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "restricted",
-        "open"
-      ],
+      "enumValues": ["restricted", "open"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -34365,10 +31939,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Twitch",
       "help": "Twitch chat integration",
       "hasChildren": true
@@ -34428,13 +31999,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "moderator",
-        "owner",
-        "vip",
-        "subscriber",
-        "all"
-      ],
+      "enumValues": ["moderator", "owner", "vip", "subscriber", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -34503,10 +32068,7 @@
     {
       "path": "channels.twitch.accounts.*.expiresIn",
       "kind": "channel",
-      "type": [
-        "null",
-        "number"
-      ],
+      "type": ["null", "number"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -34578,13 +32140,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "moderator",
-        "owner",
-        "vip",
-        "subscriber",
-        "all"
-      ],
+      "enumValues": ["moderator", "owner", "vip", "subscriber", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -34653,10 +32209,7 @@
     {
       "path": "channels.twitch.expiresIn",
       "kind": "channel",
-      "type": [
-        "null",
-        "number"
-      ],
+      "type": ["null", "number"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -34678,11 +32231,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "bullets",
-        "code",
-        "off"
-      ],
+      "enumValues": ["bullets", "code", "off"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -34755,10 +32304,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "WhatsApp",
       "help": "works with your own number; recommend a separate phone + eSIM.",
       "hasChildren": true
@@ -34819,11 +32365,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "always",
-        "mentions",
-        "never"
-      ],
+      "enumValues": ["always", "mentions", "never"],
       "defaultValue": "mentions",
       "deprecated": false,
       "sensitive": false,
@@ -34935,10 +32477,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -34990,12 +32529,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
@@ -35067,11 +32601,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -35343,11 +32873,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -35459,11 +32985,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "always",
-        "mentions",
-        "never"
-      ],
+      "enumValues": ["always", "mentions", "never"],
       "defaultValue": "mentions",
       "deprecated": false,
       "sensitive": false,
@@ -35605,10 +33127,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "length",
-        "newline"
-      ],
+      "enumValues": ["length", "newline"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -35621,10 +33140,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "WhatsApp Config Writes",
       "help": "Allow WhatsApp to write config in response to channel events/commands (default: true).",
       "hasChildren": false
@@ -35637,11 +33153,7 @@
       "defaultValue": 0,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network",
-        "performance"
-      ],
+      "tags": ["channels", "network", "performance"],
       "label": "WhatsApp Message Debounce (ms)",
       "help": "Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable).",
       "hasChildren": false
@@ -35681,20 +33193,11 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "defaultValue": "pairing",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "channels",
-        "network"
-      ],
+      "tags": ["access", "channels", "network"],
       "label": "WhatsApp DM Policy",
       "help": "Direct message access control (\"pairing\" recommended). \"open\" requires channels.whatsapp.allowFrom=[\"*\"].",
       "hasChildren": false
@@ -35764,11 +33267,7 @@
       "kind": "channel",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "defaultValue": "allowlist",
       "deprecated": false,
       "sensitive": false,
@@ -36040,11 +33539,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -36088,10 +33583,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "WhatsApp Self-Phone Mode",
       "help": "Same-phone setup (bot uses your personal WhatsApp number).",
       "hasChildren": false
@@ -36123,10 +33615,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Zalo",
       "help": "Vietnam-focused messaging platform with Bot API.",
       "hasChildren": true
@@ -36164,10 +33653,7 @@
     {
       "path": "channels.zalo.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -36177,10 +33663,7 @@
     {
       "path": "channels.zalo.accounts.*.botToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -36222,12 +33705,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -36256,10 +33734,7 @@
     {
       "path": "channels.zalo.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -36271,11 +33746,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -36296,11 +33767,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -36369,10 +33836,7 @@
     {
       "path": "channels.zalo.accounts.*.webhookSecret",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -36432,10 +33896,7 @@
     {
       "path": "channels.zalo.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -36445,10 +33906,7 @@
     {
       "path": "channels.zalo.botToken",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -36500,12 +33958,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -36534,10 +33987,7 @@
     {
       "path": "channels.zalo.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -36549,11 +33999,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -36574,11 +34020,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -36647,10 +34089,7 @@
     {
       "path": "channels.zalo.webhookSecret",
       "kind": "channel",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -36704,10 +34143,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "channels",
-        "network"
-      ],
+      "tags": ["channels", "network"],
       "label": "Zalo Personal",
       "help": "Zalo personal account via QR code login.",
       "hasChildren": true
@@ -36745,10 +34181,7 @@
     {
       "path": "channels.zalouser.accounts.*.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -36770,12 +34203,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -36804,10 +34232,7 @@
     {
       "path": "channels.zalouser.accounts.*.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -36819,11 +34244,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -36974,11 +34395,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -37037,10 +34454,7 @@
     {
       "path": "channels.zalouser.allowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -37072,12 +34486,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "pairing",
-        "allowlist",
-        "open",
-        "disabled"
-      ],
+      "enumValues": ["pairing", "allowlist", "open", "disabled"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -37106,10 +34515,7 @@
     {
       "path": "channels.zalouser.groupAllowFrom.*",
       "kind": "channel",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -37121,11 +34527,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "open",
-        "disabled",
-        "allowlist"
-      ],
+      "enumValues": ["open", "disabled", "allowlist"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -37276,11 +34678,7 @@
       "kind": "channel",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "bullets",
-        "code"
-      ],
+      "enumValues": ["off", "bullets", "code"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -37333,9 +34731,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "CLI",
       "help": "CLI presentation controls for local command output behavior such as banner and tagline style. Use this section to keep startup output aligned with operator preference without changing runtime behavior.",
       "hasChildren": true
@@ -37347,9 +34743,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "CLI Banner",
       "help": "CLI startup banner controls for title/version line and tagline style behavior. Keep banner enabled for fast version/context checks, then tune tagline mode to your preferred noise level.",
       "hasChildren": true
@@ -37361,9 +34755,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "CLI Banner Tagline Mode",
       "help": "Controls tagline style in the CLI startup banner: \"random\" (default) picks from the rotating tagline pool, \"default\" always shows the neutral default tagline, and \"off\" hides tagline text while keeping the banner version line.",
       "hasChildren": false
@@ -37381,9 +34773,7 @@
       },
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Commands",
       "help": "Controls chat command surfaces, owner gating, and elevated command access behavior across providers. Keep defaults unless you need stricter operator controls or broader command availability.",
       "hasChildren": true
@@ -37395,9 +34785,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Command Elevated Access Rules",
       "help": "Defines elevated command allow rules by channel and sender for owner-level command surfaces. Use narrow provider-specific identities so privileged commands are not exposed to broad chat audiences.",
       "hasChildren": true
@@ -37415,10 +34803,7 @@
     {
       "path": "commands.allowFrom.*.*",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -37432,9 +34817,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Allow Bash Chat Command",
       "help": "Allow bash chat command (`!`; `/bash` alias) to run host shell commands (default: false; requires tools.elevated).",
       "hasChildren": false
@@ -37446,9 +34829,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Bash Foreground Window (ms)",
       "help": "How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately).",
       "hasChildren": false
@@ -37460,9 +34841,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Allow /config",
       "help": "Allow /config chat command to read/write config on disk (default: false).",
       "hasChildren": false
@@ -37474,9 +34853,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Allow /debug",
       "help": "Allow /debug chat command for runtime-only overrides (default: false).",
       "hasChildren": false
@@ -37484,16 +34861,11 @@
     {
       "path": "commands.native",
       "kind": "core",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Native Commands",
       "help": "Registers native slash/menu commands with channels that support command registration (Discord, Slack, Telegram). Keep enabled for discoverability unless you intentionally run text-only command workflows.",
       "hasChildren": false
@@ -37501,16 +34873,11 @@
     {
       "path": "commands.nativeSkills",
       "kind": "core",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Native Skill Commands",
       "help": "Registers native skill commands so users can invoke skills directly from provider command menus where supported. Keep aligned with your skill policy so exposed commands match what operators expect.",
       "hasChildren": false
@@ -37522,9 +34889,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Command Owners",
       "help": "Explicit owner allowlist for owner-only tools/commands. Use channel-native IDs (optionally prefixed like \"whatsapp:+15551234567\"). '*' is ignored.",
       "hasChildren": true
@@ -37532,10 +34897,7 @@
     {
       "path": "commands.ownerAllowFrom.*",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -37547,16 +34909,11 @@
       "kind": "core",
       "type": "string",
       "required": true,
-      "enumValues": [
-        "raw",
-        "hash"
-      ],
+      "enumValues": ["raw", "hash"],
       "defaultValue": "raw",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Owner ID Display",
       "help": "Controls how owner IDs are rendered in the system prompt. Allowed values: raw, hash. Default: raw.",
       "hasChildren": false
@@ -37568,11 +34925,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "access",
-        "auth",
-        "security"
-      ],
+      "tags": ["access", "auth", "security"],
       "label": "Owner ID Hash Secret",
       "help": "Optional secret used to HMAC hash owner IDs when ownerDisplay=hash. Prefer env substitution.",
       "hasChildren": false
@@ -37585,9 +34938,7 @@
       "defaultValue": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Allow Restart",
       "help": "Allow /restart and gateway restart tool actions (default: true).",
       "hasChildren": false
@@ -37599,9 +34950,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Text Commands",
       "help": "Enables text-command parsing in chat input in addition to native command surfaces where available. Keep this enabled for compatibility across channels that do not support native command registration.",
       "hasChildren": false
@@ -37613,9 +34962,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Use Access Groups",
       "help": "Enforce access-group allowlists/policies for commands.",
       "hasChildren": false
@@ -37627,9 +34974,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "label": "Cron",
       "help": "Global scheduler settings for stored cron jobs, run concurrency, delivery fallback, and run-session retention. Keep defaults unless you are scaling job volume or integrating external webhook receivers.",
       "hasChildren": true
@@ -37641,9 +34986,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "label": "Cron Enabled",
       "help": "Enables cron job execution for stored schedules managed by the gateway. Keep enabled for normal reminder/automation flows, and disable only to pause all cron execution without deleting jobs.",
       "hasChildren": false
@@ -37703,10 +35046,7 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "announce",
-        "webhook"
-      ],
+      "enumValues": ["announce", "webhook"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -37747,10 +35087,7 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "announce",
-        "webhook"
-      ],
+      "enumValues": ["announce", "webhook"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -37773,10 +35110,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "performance"
-      ],
+      "tags": ["automation", "performance"],
       "label": "Cron Max Concurrent Runs",
       "help": "Limits how many cron jobs can execute at the same time when multiple schedules fire together. Use lower values to protect CPU/memory under heavy automation load, or raise carefully for higher throughput.",
       "hasChildren": false
@@ -37788,10 +35122,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "reliability"
-      ],
+      "tags": ["automation", "reliability"],
       "label": "Cron Retry Policy",
       "help": "Overrides the default retry policy for one-shot jobs when they fail with transient errors (rate limit, overloaded, network, server_error). Omit to use defaults: maxAttempts 3, backoffMs [30000, 60000, 300000], retry all transient types.",
       "hasChildren": true
@@ -37803,10 +35134,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "reliability"
-      ],
+      "tags": ["automation", "reliability"],
       "label": "Cron Retry Backoff (ms)",
       "help": "Backoff delays in ms for each retry attempt (default: [30000, 60000, 300000]). Use shorter values for faster retries.",
       "hasChildren": true
@@ -37828,11 +35156,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "performance",
-        "reliability"
-      ],
+      "tags": ["automation", "performance", "reliability"],
       "label": "Cron Retry Max Attempts",
       "help": "Max retries for one-shot jobs on transient errors before permanent disable (default: 3).",
       "hasChildren": false
@@ -37844,10 +35168,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "reliability"
-      ],
+      "tags": ["automation", "reliability"],
       "label": "Cron Retry Error Types",
       "help": "Error types to retry: rate_limit, overloaded, network, timeout, server_error. Use to restrict which errors trigger retries; omit to retry all transient types.",
       "hasChildren": true
@@ -37857,13 +35178,7 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "rate_limit",
-        "overloaded",
-        "network",
-        "timeout",
-        "server_error"
-      ],
+      "enumValues": ["rate_limit", "overloaded", "network", "timeout", "server_error"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -37876,9 +35191,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "label": "Cron Run Log Pruning",
       "help": "Pruning controls for per-job cron run history files under `cron/runs/<jobId>.jsonl`, including size and line retention.",
       "hasChildren": true
@@ -37890,9 +35203,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "label": "Cron Run Log Keep Lines",
       "help": "How many trailing run-log lines to retain when a file exceeds maxBytes (default `2000`). Increase for longer forensic history or lower for smaller disks.",
       "hasChildren": false
@@ -37900,17 +35211,11 @@
     {
       "path": "cron.runLog.maxBytes",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "performance"
-      ],
+      "tags": ["automation", "performance"],
       "label": "Cron Run Log Max Bytes",
       "help": "Maximum bytes per cron run-log file before pruning rewrites to the last keepLines entries (for example `2mb`, default `2000000`).",
       "hasChildren": false
@@ -37918,17 +35223,11 @@
     {
       "path": "cron.sessionRetention",
       "kind": "core",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "storage"
-      ],
+      "tags": ["automation", "storage"],
       "label": "Cron Session Retention",
       "help": "Controls how long completed cron run sessions are kept before pruning (`24h`, `7d`, `1h30m`, or `false` to disable pruning; default: `24h`). Use shorter retention to reduce storage growth on high-frequency schedules.",
       "hasChildren": false
@@ -37940,10 +35239,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "storage"
-      ],
+      "tags": ["automation", "storage"],
       "label": "Cron Store Path",
       "help": "Path to the cron job store file used to persist scheduled jobs across restarts. Set an explicit path only when you need custom storage layout, backups, or mounted volumes.",
       "hasChildren": false
@@ -37955,9 +35251,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "label": "Cron Legacy Webhook (Deprecated)",
       "help": "Deprecated legacy fallback webhook URL used only for old jobs with `notify=true`. Migrate to per-job delivery using `delivery.mode=\"webhook\"` plus `delivery.to`, and avoid relying on this global field.",
       "hasChildren": false
@@ -37965,18 +35259,11 @@
     {
       "path": "cron.webhookToken",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "automation",
-        "security"
-      ],
+      "tags": ["auth", "automation", "security"],
       "label": "Cron Webhook Bearer Token",
       "help": "Bearer token attached to cron webhook POST deliveries when webhook mode is used. Prefer secret/env substitution and rotate this token regularly if shared webhook endpoints are internet-reachable.",
       "hasChildren": true
@@ -38018,9 +35305,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "Diagnostics",
       "help": "Diagnostics controls for targeted tracing, telemetry export, and cache inspection during debugging. Keep baseline diagnostics minimal in production and enable deeper signals only when investigating issues.",
       "hasChildren": true
@@ -38032,10 +35317,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "storage"
-      ],
+      "tags": ["observability", "storage"],
       "label": "Cache Trace",
       "help": "Cache-trace logging settings for observing cache decisions and payload context in embedded runs. Enable this temporarily for debugging and disable afterward to reduce sensitive log footprint.",
       "hasChildren": true
@@ -38047,10 +35329,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "storage"
-      ],
+      "tags": ["observability", "storage"],
       "label": "Cache Trace Enabled",
       "help": "Log cache trace snapshots for embedded agent runs (default: false).",
       "hasChildren": false
@@ -38062,10 +35341,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "storage"
-      ],
+      "tags": ["observability", "storage"],
       "label": "Cache Trace File Path",
       "help": "JSONL output path for cache trace logs (default: $OPENCLAW_STATE_DIR/logs/cache-trace.jsonl).",
       "hasChildren": false
@@ -38077,10 +35353,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "storage"
-      ],
+      "tags": ["observability", "storage"],
       "label": "Cache Trace Include Messages",
       "help": "Include full message payloads in trace output (default: true).",
       "hasChildren": false
@@ -38092,10 +35365,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "storage"
-      ],
+      "tags": ["observability", "storage"],
       "label": "Cache Trace Include Prompt",
       "help": "Include prompt text in trace output (default: true).",
       "hasChildren": false
@@ -38107,10 +35377,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "storage"
-      ],
+      "tags": ["observability", "storage"],
       "label": "Cache Trace Include System",
       "help": "Include system prompt in trace output (default: true).",
       "hasChildren": false
@@ -38122,9 +35389,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "Diagnostics Enabled",
       "help": "Master toggle for diagnostics instrumentation output in logs and telemetry wiring paths. Keep enabled for normal observability, and disable only in tightly constrained environments.",
       "hasChildren": false
@@ -38136,9 +35401,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "Diagnostics Flags",
       "help": "Enable targeted diagnostics logs by flag (e.g. [\"telegram.http\"]). Supports wildcards like \"telegram.*\" or \"*\".",
       "hasChildren": true
@@ -38160,9 +35423,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "OpenTelemetry",
       "help": "OpenTelemetry export settings for traces, metrics, and logs emitted by gateway components. Use this when integrating with centralized observability backends and distributed tracing pipelines.",
       "hasChildren": true
@@ -38174,9 +35435,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "OpenTelemetry Enabled",
       "help": "Enables OpenTelemetry export pipeline for traces, metrics, and logs based on configured endpoint/protocol settings. Keep disabled unless your collector endpoint and auth are fully configured.",
       "hasChildren": false
@@ -38188,9 +35447,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "OpenTelemetry Endpoint",
       "help": "Collector endpoint URL used for OpenTelemetry export transport, including scheme and port. Use a reachable, trusted collector endpoint and monitor ingestion errors after rollout.",
       "hasChildren": false
@@ -38202,10 +35459,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "performance"
-      ],
+      "tags": ["observability", "performance"],
       "label": "OpenTelemetry Flush Interval (ms)",
       "help": "Interval in milliseconds for periodic telemetry flush from buffers to the collector. Increase to reduce export chatter, or lower for faster visibility during active incident response.",
       "hasChildren": false
@@ -38217,9 +35471,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "OpenTelemetry Headers",
       "help": "Additional HTTP/gRPC metadata headers sent with OpenTelemetry export requests, often used for tenant auth or routing. Keep secrets in env-backed values and avoid unnecessary header sprawl.",
       "hasChildren": true
@@ -38241,9 +35493,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "OpenTelemetry Logs Enabled",
       "help": "Enable log signal export through OpenTelemetry in addition to local logging sinks. Use this when centralized log correlation is required across services and agents.",
       "hasChildren": false
@@ -38255,9 +35505,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "OpenTelemetry Metrics Enabled",
       "help": "Enable metrics signal export to the configured OpenTelemetry collector endpoint. Keep enabled for runtime health dashboards, and disable only if metric volume must be minimized.",
       "hasChildren": false
@@ -38269,9 +35517,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "OpenTelemetry Protocol",
       "help": "OTel transport protocol for telemetry export: \"http/protobuf\" or \"grpc\" depending on collector support. Use the protocol your observability backend expects to avoid dropped telemetry payloads.",
       "hasChildren": false
@@ -38283,9 +35529,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "OpenTelemetry Trace Sample Rate",
       "help": "Trace sampling rate (0-1) controlling how much trace traffic is exported to observability backends. Lower rates reduce overhead/cost, while higher rates improve debugging fidelity.",
       "hasChildren": false
@@ -38297,9 +35541,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "OpenTelemetry Service Name",
       "help": "Service name reported in telemetry resource attributes to identify this gateway instance in observability backends. Use stable names so dashboards and alerts remain consistent over deployments.",
       "hasChildren": false
@@ -38311,9 +35553,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "OpenTelemetry Traces Enabled",
       "help": "Enable trace signal export to the configured OpenTelemetry collector endpoint. Keep enabled when latency/debug tracing is needed, and disable if you only want metrics/logs.",
       "hasChildren": false
@@ -38325,10 +35565,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "storage"
-      ],
+      "tags": ["observability", "storage"],
       "label": "Stuck Session Warning Threshold (ms)",
       "help": "Age threshold in milliseconds for emitting stuck-session warnings while a session remains in processing state. Increase for long multi-tool turns to reduce false positives; decrease for faster hang detection.",
       "hasChildren": false
@@ -38340,9 +35577,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Discovery",
       "help": "Service discovery settings for local mDNS advertisement and optional wide-area presence signaling. Keep discovery scoped to expected networks to avoid leaking service metadata.",
       "hasChildren": true
@@ -38354,9 +35589,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "mDNS Discovery",
       "help": "mDNS discovery configuration group for local network advertisement and discovery behavior tuning. Keep minimal mode for routine LAN discovery unless extra metadata is required.",
       "hasChildren": true
@@ -38366,16 +35599,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "minimal",
-        "full"
-      ],
+      "enumValues": ["off", "minimal", "full"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "mDNS Discovery Mode",
       "help": "mDNS broadcast mode (\"minimal\" default, \"full\" includes cliPath/sshPort, \"off\" disables mDNS).",
       "hasChildren": false
@@ -38387,9 +35614,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Wide-area Discovery",
       "help": "Wide-area discovery configuration group for exposing discovery signals beyond local-link scopes. Enable only in deployments that intentionally aggregate gateway presence across sites.",
       "hasChildren": true
@@ -38401,9 +35626,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Wide-area Discovery Domain",
       "help": "Optional unicast DNS-SD domain for wide-area discovery, such as openclaw.internal. Use this when you intentionally publish gateway discovery beyond local mDNS scopes.",
       "hasChildren": false
@@ -38415,9 +35638,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Wide-area Discovery Enabled",
       "help": "Enables wide-area discovery signaling when your environment needs non-local gateway discovery. Keep disabled unless cross-network discovery is operationally required.",
       "hasChildren": false
@@ -38429,9 +35650,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Environment",
       "help": "Environment import and override settings used to supply runtime variables to the gateway process. Use this section to control shell-env loading and explicit variable injection behavior.",
       "hasChildren": true
@@ -38453,9 +35672,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Shell Environment Import",
       "help": "Shell environment import controls for loading variables from your login shell during startup. Keep this enabled when you depend on profile-defined secrets or PATH customizations.",
       "hasChildren": true
@@ -38467,9 +35684,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Shell Environment Import Enabled",
       "help": "Enables loading environment variables from the user shell profile during startup initialization. Keep enabled for developer machines, or disable in locked-down service environments with explicit env management.",
       "hasChildren": false
@@ -38481,9 +35696,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Shell Environment Import Timeout (ms)",
       "help": "Maximum time in milliseconds allowed for shell environment resolution before fallback behavior applies. Use tighter timeouts for faster startup, or increase when shell initialization is heavy.",
       "hasChildren": false
@@ -38495,9 +35708,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Environment Variable Overrides",
       "help": "Explicit key/value environment variable overrides merged into runtime process environment for OpenClaw. Use this for deterministic env configuration instead of relying only on shell profile side effects.",
       "hasChildren": true
@@ -38519,9 +35730,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gateway",
       "help": "Gateway runtime surface for bind mode, auth, control UI, remote transport, and operational safety controls. Keep conservative defaults unless you intentionally expose the gateway beyond trusted local interfaces.",
       "hasChildren": true
@@ -38533,11 +35742,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "network",
-        "reliability"
-      ],
+      "tags": ["access", "network", "reliability"],
       "label": "Gateway Allow x-real-ip Fallback",
       "help": "Enables x-real-ip fallback when x-forwarded-for is missing in proxy scenarios. Keep disabled unless your ingress stack requires this compatibility behavior.",
       "hasChildren": false
@@ -38549,9 +35754,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Auth",
       "help": "Authentication policy for gateway HTTP/WebSocket access including mode, credentials, trusted-proxy behavior, and rate limiting. Keep auth enabled for every non-loopback deployment.",
       "hasChildren": true
@@ -38563,10 +35766,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "network"
-      ],
+      "tags": ["access", "network"],
       "label": "Gateway Auth Allow Tailscale Identity",
       "help": "Allows trusted Tailscale identity paths to satisfy gateway auth checks when configured. Use this only when your tailnet identity posture is strong and operator workflows depend on it.",
       "hasChildren": false
@@ -38578,9 +35778,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Auth Mode",
       "help": "Gateway auth mode: \"none\", \"token\", \"password\", or \"trusted-proxy\" depending on your edge architecture. Use token/password for direct exposure, and trusted-proxy only behind hardened identity-aware proxies.",
       "hasChildren": false
@@ -38588,19 +35786,11 @@
     {
       "path": "gateway.auth.password",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "access",
-        "auth",
-        "network",
-        "security"
-      ],
+      "tags": ["access", "auth", "network", "security"],
       "label": "Gateway Password",
       "help": "Required for Tailscale funnel.",
       "hasChildren": true
@@ -38642,10 +35832,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "performance"
-      ],
+      "tags": ["network", "performance"],
       "label": "Gateway Auth Rate Limit",
       "help": "Login/auth attempt throttling controls to reduce credential brute-force risk at the gateway boundary. Keep enabled in exposed environments and tune thresholds to your traffic baseline.",
       "hasChildren": true
@@ -38693,19 +35880,11 @@
     {
       "path": "gateway.auth.token",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "access",
-        "auth",
-        "network",
-        "security"
-      ],
+      "tags": ["access", "auth", "network", "security"],
       "label": "Gateway Token",
       "help": "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",
       "hasChildren": true
@@ -38747,9 +35926,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Trusted Proxy Auth",
       "help": "Trusted-proxy auth header mapping for upstream identity providers that inject user claims. Use only with known proxy CIDRs and strict header allowlists to prevent spoofed identity headers.",
       "hasChildren": true
@@ -38811,9 +35988,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Bind Mode",
       "help": "Network bind profile: \"auto\", \"lan\", \"loopback\", \"custom\", or \"tailnet\" to control interface exposure. Keep \"loopback\" or \"auto\" for safest local operation unless external clients must connect.",
       "hasChildren": false
@@ -38825,10 +36000,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "reliability"
-      ],
+      "tags": ["network", "reliability"],
       "label": "Gateway Channel Health Check Interval (min)",
       "help": "Interval in minutes for automatic channel health probing and status updates. Use lower intervals for faster detection, or higher intervals to reduce periodic probe noise.",
       "hasChildren": false
@@ -38840,10 +36012,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "performance"
-      ],
+      "tags": ["network", "performance"],
       "label": "Gateway Channel Max Restarts Per Hour",
       "help": "Maximum number of health-monitor-initiated channel restarts allowed within a rolling one-hour window. Once hit, further restarts are skipped until the window expires. Default: 10.",
       "hasChildren": false
@@ -38855,9 +36024,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Channel Stale Event Threshold (min)",
       "help": "How many minutes a connected channel can go without receiving any event before the health monitor treats it as a stale socket and triggers a restart. Default: 30.",
       "hasChildren": false
@@ -38869,9 +36036,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Control UI",
       "help": "Control UI hosting settings including enablement, pathing, and browser-origin/auth hardening behavior. Keep UI exposure minimal and pair with strong auth controls before internet-facing deployments.",
       "hasChildren": true
@@ -38883,10 +36048,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "network"
-      ],
+      "tags": ["access", "network"],
       "label": "Control UI Allowed Origins",
       "help": "Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com). Required for non-loopback Control UI deployments unless dangerous Host-header fallback is explicitly enabled.",
       "hasChildren": true
@@ -38908,12 +36070,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "advanced",
-        "network",
-        "security"
-      ],
+      "tags": ["access", "advanced", "network", "security"],
       "label": "Insecure Control UI Auth Toggle",
       "help": "Loosens strict browser auth checks for Control UI when you must run a non-standard setup. Keep this off unless you trust your network and proxy path, because impersonation risk is higher.",
       "hasChildren": false
@@ -38925,10 +36082,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "storage"
-      ],
+      "tags": ["network", "storage"],
       "label": "Control UI Base Path",
       "help": "Optional URL prefix where the Control UI is served (e.g. /openclaw).",
       "hasChildren": false
@@ -38940,12 +36094,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "advanced",
-        "network",
-        "security"
-      ],
+      "tags": ["access", "advanced", "network", "security"],
       "label": "Dangerously Allow Host-Header Origin Fallback",
       "help": "DANGEROUS toggle that enables Host-header based origin fallback for Control UI/WebChat websocket checks. This mode is supported when your deployment intentionally relies on Host-header origin policy; explicit gateway.controlUi.allowedOrigins remains the recommended hardened default.",
       "hasChildren": false
@@ -38957,12 +36106,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "advanced",
-        "network",
-        "security"
-      ],
+      "tags": ["access", "advanced", "network", "security"],
       "label": "Dangerously Disable Control UI Device Auth",
       "help": "Disables Control UI device identity checks and relies on token/password only. Use only for short-lived debugging on trusted networks, then turn it off immediately.",
       "hasChildren": false
@@ -38974,9 +36118,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Control UI Enabled",
       "help": "Enables serving the gateway Control UI from the gateway HTTP process when true. Keep enabled for local administration, and disable when an external control surface replaces it.",
       "hasChildren": false
@@ -38988,9 +36130,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Control UI Assets Root",
       "help": "Optional filesystem root for Control UI assets (defaults to dist/control-ui).",
       "hasChildren": false
@@ -39002,9 +36142,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Custom Bind Host",
       "help": "Explicit bind host/IP used when gateway.bind is set to custom for manual interface targeting. Use a precise address and avoid wildcard binds unless external exposure is required.",
       "hasChildren": false
@@ -39016,9 +36154,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway HTTP API",
       "help": "Gateway HTTP API configuration grouping endpoint toggles and transport-facing API exposure controls. Keep only required endpoints enabled to reduce attack surface.",
       "hasChildren": true
@@ -39030,9 +36166,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway HTTP Endpoints",
       "help": "HTTP endpoint feature toggles under the gateway API surface for compatibility routes and optional integrations. Enable endpoints intentionally and monitor access patterns after rollout.",
       "hasChildren": true
@@ -39054,9 +36188,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "OpenAI Chat Completions Endpoint",
       "help": "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
       "hasChildren": false
@@ -39068,10 +36200,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "network"
-      ],
+      "tags": ["media", "network"],
       "label": "OpenAI Chat Completions Image Limits",
       "help": "Image fetch/validation controls for OpenAI-compatible `image_url` parts.",
       "hasChildren": true
@@ -39083,11 +36212,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "media",
-        "network"
-      ],
+      "tags": ["access", "media", "network"],
       "label": "OpenAI Chat Completions Image MIME Allowlist",
       "help": "Allowed MIME types for `image_url` parts (case-insensitive list).",
       "hasChildren": true
@@ -39109,11 +36234,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "media",
-        "network"
-      ],
+      "tags": ["access", "media", "network"],
       "label": "OpenAI Chat Completions Allow Image URLs",
       "help": "Allow server-side URL fetches for `image_url` parts (default: false; data URIs remain supported).",
       "hasChildren": false
@@ -39125,11 +36246,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "network",
-        "performance"
-      ],
+      "tags": ["media", "network", "performance"],
       "label": "OpenAI Chat Completions Image Max Bytes",
       "help": "Max bytes per fetched/decoded `image_url` image (default: 10MB).",
       "hasChildren": false
@@ -39141,12 +36258,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "network",
-        "performance",
-        "storage"
-      ],
+      "tags": ["media", "network", "performance", "storage"],
       "label": "OpenAI Chat Completions Image Max Redirects",
       "help": "Max HTTP redirects allowed when fetching `image_url` URLs (default: 3).",
       "hasChildren": false
@@ -39158,11 +36270,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "network",
-        "performance"
-      ],
+      "tags": ["media", "network", "performance"],
       "label": "OpenAI Chat Completions Image Timeout (ms)",
       "help": "Timeout in milliseconds for `image_url` URL fetches (default: 10000).",
       "hasChildren": false
@@ -39174,11 +36282,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "media",
-        "network"
-      ],
+      "tags": ["access", "media", "network"],
       "label": "OpenAI Chat Completions Image URL Allowlist",
       "help": "Optional hostname allowlist for `image_url` URL fetches; supports exact hosts and `*.example.com` wildcards.",
       "hasChildren": true
@@ -39200,10 +36304,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "performance"
-      ],
+      "tags": ["network", "performance"],
       "label": "OpenAI Chat Completions Max Body Bytes",
       "help": "Max request body size in bytes for `/v1/chat/completions` (default: 20MB).",
       "hasChildren": false
@@ -39215,11 +36316,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "network",
-        "performance"
-      ],
+      "tags": ["media", "network", "performance"],
       "label": "OpenAI Chat Completions Max Image Parts",
       "help": "Max number of `image_url` parts accepted from the latest user message (default: 8).",
       "hasChildren": false
@@ -39231,11 +36328,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "network",
-        "performance"
-      ],
+      "tags": ["media", "network", "performance"],
       "label": "OpenAI Chat Completions Max Total Image Bytes",
       "help": "Max cumulative decoded bytes across all `image_url` parts in one request (default: 20MB).",
       "hasChildren": false
@@ -39517,9 +36610,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway HTTP Security Headers",
       "help": "Optional HTTP response security headers applied by the gateway process itself. Prefer setting these at your reverse proxy when TLS terminates there.",
       "hasChildren": true
@@ -39527,16 +36618,11 @@
     {
       "path": "gateway.http.securityHeaders.strictTransportSecurity",
       "kind": "core",
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Strict Transport Security Header",
       "help": "Value for the Strict-Transport-Security response header. Set only on HTTPS origins that you fully control; use false to explicitly disable.",
       "hasChildren": false
@@ -39548,9 +36634,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Mode",
       "help": "Gateway operation mode: \"local\" runs channels and agent runtime on this host, while \"remote\" connects through remote transport. Keep \"local\" unless you intentionally run a split remote gateway topology.",
       "hasChildren": false
@@ -39572,10 +36656,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "network"
-      ],
+      "tags": ["access", "network"],
       "label": "Gateway Node Allowlist (Extra Commands)",
       "help": "Extra node.invoke commands to allow beyond the gateway defaults (array of command strings). Enabling dangerous commands here is a security-sensitive override and is flagged by `openclaw security audit`.",
       "hasChildren": true
@@ -39607,9 +36688,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Node Browser Mode",
       "help": "Node browser routing (\"auto\" = pick single connected browser node, \"manual\" = require node param, \"off\" = disable).",
       "hasChildren": false
@@ -39621,9 +36700,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Node Browser Pin",
       "help": "Pin browser routing to a specific node id or name (optional).",
       "hasChildren": false
@@ -39635,10 +36712,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "network"
-      ],
+      "tags": ["access", "network"],
       "label": "Gateway Node Denylist",
       "help": "Node command names to block even if present in node claims or default allowlist (exact command-name matching only, e.g. `system.run`; does not inspect shell text inside that command).",
       "hasChildren": true
@@ -39660,9 +36734,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Port",
       "help": "TCP port used by the gateway listener for API, control UI, and channel-facing ingress paths. Use a dedicated port and avoid collisions with reverse proxies or local developer services.",
       "hasChildren": false
@@ -39674,9 +36746,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Push Delivery",
       "help": "Push-delivery settings used by the gateway when it needs to wake or notify paired devices. Configure relay-backed APNs here for official iOS builds; direct APNs auth remains env-based for local/manual builds.",
       "hasChildren": true
@@ -39688,9 +36758,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway APNs Delivery",
       "help": "APNs delivery settings for iOS devices paired to this gateway. Use relay settings for official/TestFlight builds that register through the external push relay.",
       "hasChildren": true
@@ -39702,9 +36770,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway APNs Relay",
       "help": "External relay settings for relay-backed APNs sends. The gateway uses this relay for push.test, wake nudges, and reconnect wakes after a paired official iOS build publishes a relay-backed registration.",
       "hasChildren": true
@@ -39716,10 +36782,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "network"
-      ],
+      "tags": ["advanced", "network"],
       "label": "Gateway APNs Relay Base URL",
       "help": "Base HTTPS URL for the external APNs relay service used by official/TestFlight iOS builds. Keep this aligned with the relay URL baked into the iOS build so registration and send traffic hit the same deployment.",
       "hasChildren": false
@@ -39731,10 +36794,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "performance"
-      ],
+      "tags": ["network", "performance"],
       "label": "Gateway APNs Relay Timeout (ms)",
       "help": "Timeout in milliseconds for relay send requests from the gateway to the APNs relay (default: 10000). Increase for slower relays or networks, or lower to fail wake attempts faster.",
       "hasChildren": false
@@ -39746,10 +36806,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "reliability"
-      ],
+      "tags": ["network", "reliability"],
       "label": "Config Reload",
       "help": "Live config-reload policy for how edits are applied and when full restarts are triggered. Keep hybrid behavior for safest operational updates unless debugging reload internals.",
       "hasChildren": true
@@ -39761,11 +36818,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "performance",
-        "reliability"
-      ],
+      "tags": ["network", "performance", "reliability"],
       "label": "Config Reload Debounce (ms)",
       "help": "Debounce window (ms) before applying config changes.",
       "hasChildren": false
@@ -39777,10 +36830,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "reliability"
-      ],
+      "tags": ["network", "reliability"],
       "label": "Config Reload Mode",
       "help": "Controls how config edits are applied: \"off\" ignores live edits, \"restart\" always restarts, \"hot\" applies in-process, and \"hybrid\" tries hot then restarts if required. Keep \"hybrid\" for safest routine updates.",
       "hasChildren": false
@@ -39792,9 +36842,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Remote Gateway",
       "help": "Remote gateway connection settings for direct or SSH transport when this instance proxies to another runtime host. Use remote mode only when split-host operation is intentionally configured.",
       "hasChildren": true
@@ -39802,18 +36850,11 @@
     {
       "path": "gateway.remote.password",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "network", "security"],
       "label": "Remote Gateway Password",
       "help": "Password credential used for remote gateway authentication when password mode is enabled. Keep this secret managed externally and avoid plaintext values in committed config.",
       "hasChildren": true
@@ -39855,9 +36896,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Remote Gateway SSH Identity",
       "help": "Optional SSH identity file path (passed to ssh -i).",
       "hasChildren": false
@@ -39869,9 +36908,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Remote Gateway SSH Target",
       "help": "Remote gateway over SSH (tunnels the gateway port to localhost). Format: user@host or user@host:port.",
       "hasChildren": false
@@ -39883,11 +36920,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "auth",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "network", "security"],
       "label": "Remote Gateway TLS Fingerprint",
       "help": "Expected sha256 TLS fingerprint for the remote gateway (pin to avoid MITM).",
       "hasChildren": false
@@ -39895,18 +36928,11 @@
     {
       "path": "gateway.remote.token",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "network",
-        "security"
-      ],
+      "tags": ["auth", "network", "security"],
       "label": "Remote Gateway Token",
       "help": "Bearer token used to authenticate this client to a remote gateway in token-auth deployments. Store via secret/env substitution and rotate alongside remote gateway auth changes.",
       "hasChildren": true
@@ -39948,9 +36974,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Remote Gateway Transport",
       "help": "Remote connection transport: \"direct\" uses configured URL connectivity, while \"ssh\" tunnels through SSH. Use SSH when you need encrypted tunnel semantics without exposing remote ports.",
       "hasChildren": false
@@ -39962,9 +36986,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Remote Gateway URL",
       "help": "Remote Gateway WebSocket URL (ws:// or wss://).",
       "hasChildren": false
@@ -39976,9 +36998,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Tailscale",
       "help": "Tailscale integration settings for Serve/Funnel exposure and lifecycle handling on gateway start/exit. Keep off unless your deployment intentionally relies on Tailscale ingress.",
       "hasChildren": true
@@ -39990,9 +37010,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Tailscale Mode",
       "help": "Tailscale publish mode: \"off\", \"serve\", or \"funnel\" for private or public exposure paths. Use \"serve\" for tailnet-only access and \"funnel\" only when public internet reachability is required.",
       "hasChildren": false
@@ -40004,9 +37022,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Tailscale Reset on Exit",
       "help": "Resets Tailscale Serve/Funnel state on gateway exit to avoid stale published routes after shutdown. Keep enabled unless another controller manages publish lifecycle outside the gateway.",
       "hasChildren": false
@@ -40018,9 +37034,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway TLS",
       "help": "TLS certificate and key settings for terminating HTTPS directly in the gateway process. Use explicit certificates in production and avoid plaintext exposure on untrusted networks.",
       "hasChildren": true
@@ -40032,9 +37046,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway TLS Auto-Generate Cert",
       "help": "Auto-generates a local TLS certificate/key pair when explicit files are not configured. Use only for local/dev setups and replace with real certificates for production traffic.",
       "hasChildren": false
@@ -40046,10 +37058,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "storage"
-      ],
+      "tags": ["network", "storage"],
       "label": "Gateway TLS CA Path",
       "help": "Optional CA bundle path for client verification or custom trust-chain requirements at the gateway edge. Use this when private PKI or custom certificate chains are part of deployment.",
       "hasChildren": false
@@ -40061,10 +37070,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "storage"
-      ],
+      "tags": ["network", "storage"],
       "label": "Gateway TLS Certificate Path",
       "help": "Filesystem path to the TLS certificate file used by the gateway when TLS is enabled. Use managed certificate paths and keep renewal automation aligned with this location.",
       "hasChildren": false
@@ -40076,9 +37082,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway TLS Enabled",
       "help": "Enables TLS termination at the gateway listener so clients connect over HTTPS/WSS directly. Keep enabled for direct internet exposure or any untrusted network boundary.",
       "hasChildren": false
@@ -40090,10 +37094,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network",
-        "storage"
-      ],
+      "tags": ["network", "storage"],
       "label": "Gateway TLS Key Path",
       "help": "Filesystem path to the TLS private key file used by the gateway when TLS is enabled. Keep this key file permission-restricted and rotate per your security policy.",
       "hasChildren": false
@@ -40105,9 +37106,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Tool Exposure Policy",
       "help": "Gateway-level tool exposure allow/deny policy that can restrict runtime tool availability independent of agent/tool profiles. Use this for coarse emergency controls and production hardening.",
       "hasChildren": true
@@ -40119,10 +37118,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "network"
-      ],
+      "tags": ["access", "network"],
       "label": "Gateway Tool Allowlist",
       "help": "Explicit gateway-level tool allowlist when you want a narrow set of tools available at runtime. Use this for locked-down environments where tool scope must be tightly controlled.",
       "hasChildren": true
@@ -40144,10 +37140,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "network"
-      ],
+      "tags": ["access", "network"],
       "label": "Gateway Tool Denylist",
       "help": "Explicit gateway-level tool denylist to block risky tools even if lower-level policies allow them. Use deny rules for emergency response and defense-in-depth hardening.",
       "hasChildren": true
@@ -40169,9 +37162,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Gateway Trusted Proxy CIDRs",
       "help": "CIDR/IP allowlist of upstream proxies permitted to provide forwarded client identity headers. Keep this list narrow so untrusted hops cannot impersonate users.",
       "hasChildren": true
@@ -40193,9 +37184,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hooks",
       "help": "Inbound webhook automation surface for mapping external events into wake or agent actions in OpenClaw. Keep this locked down with explicit token/session/agent controls before exposing it beyond trusted networks.",
       "hasChildren": true
@@ -40207,9 +37196,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Hooks Allowed Agent IDs",
       "help": "Allowlist of agent IDs that hook mappings are allowed to target when selecting execution agents. Use this to constrain automation events to dedicated service agents.",
       "hasChildren": true
@@ -40231,10 +37218,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Hooks Allowed Session Key Prefixes",
       "help": "Allowlist of accepted session-key prefixes for inbound hook requests when caller-provided keys are enabled. Use narrow prefixes to prevent arbitrary session-key injection.",
       "hasChildren": true
@@ -40256,10 +37240,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Hooks Allow Request Session Key",
       "help": "Allows callers to supply a session key in hook requests when true, enabling caller-controlled routing. Keep false unless trusted integrators explicitly need custom session threading.",
       "hasChildren": false
@@ -40271,9 +37252,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Hooks Default Session Key",
       "help": "Fallback session key used for hook deliveries when a request does not provide one through allowed channels. Use a stable but scoped key to avoid mixing unrelated automation conversations.",
       "hasChildren": false
@@ -40285,9 +37264,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hooks Enabled",
       "help": "Enables the hooks endpoint and mapping execution pipeline for inbound webhook requests. Keep disabled unless you are actively routing external events into the gateway.",
       "hasChildren": false
@@ -40299,9 +37276,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook",
       "help": "Gmail push integration settings used for Pub/Sub notifications and optional local callback serving. Keep this scoped to dedicated Gmail automation accounts where possible.",
       "hasChildren": true
@@ -40313,9 +37288,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Account",
       "help": "Google account identifier used for Gmail watch/subscription operations in this hook integration. Use a dedicated automation mailbox account to isolate operational permissions.",
       "hasChildren": false
@@ -40327,9 +37300,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Gmail Hook Allow Unsafe External Content",
       "help": "Allows less-sanitized external Gmail content to pass into processing when enabled. Keep disabled for safer defaults, and enable only for trusted mail streams with controlled transforms.",
       "hasChildren": false
@@ -40341,9 +37312,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Callback URL",
       "help": "Public callback URL Gmail or intermediaries invoke to deliver notifications into this hook pipeline. Keep this URL protected with token validation and restricted network exposure.",
       "hasChildren": false
@@ -40355,9 +37324,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Include Body",
       "help": "When true, fetch and include email body content for downstream mapping/agent processing. Keep false unless body text is required, because this increases payload size and sensitivity.",
       "hasChildren": false
@@ -40369,9 +37336,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Label",
       "help": "Optional Gmail label filter limiting which labeled messages trigger hook events. Keep filters narrow to avoid flooding automations with unrelated inbox traffic.",
       "hasChildren": false
@@ -40383,9 +37348,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Gmail Hook Max Body Bytes",
       "help": "Maximum Gmail payload bytes processed per event when includeBody is enabled. Keep conservative limits to reduce oversized message processing cost and risk.",
       "hasChildren": false
@@ -40397,9 +37360,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Gmail Hook Model Override",
       "help": "Optional model override for Gmail-triggered runs when mailbox automations should use dedicated model behavior. Keep unset to inherit agent defaults unless mailbox tasks need specialization.",
       "hasChildren": false
@@ -40411,10 +37372,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "label": "Gmail Hook Push Token",
       "help": "Shared secret token required on Gmail push hook callbacks before processing notifications. Use env substitution and rotate if callback endpoints are exposed externally.",
       "hasChildren": false
@@ -40426,9 +37384,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Renew Interval (min)",
       "help": "Renewal cadence in minutes for Gmail watch subscriptions to prevent expiration. Set below provider expiration windows and monitor renew failures in logs.",
       "hasChildren": false
@@ -40440,9 +37396,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Local Server",
       "help": "Local callback server settings block for directly receiving Gmail notifications without a separate ingress layer. Enable only when this process should terminate webhook traffic itself.",
       "hasChildren": true
@@ -40454,9 +37408,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Server Bind Address",
       "help": "Bind address for the local Gmail callback HTTP server used when serving hooks directly. Keep loopback-only unless external ingress is intentionally required.",
       "hasChildren": false
@@ -40468,9 +37420,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Gmail Hook Server Path",
       "help": "HTTP path on the local Gmail callback server where push notifications are accepted. Keep this consistent with subscription configuration to avoid dropped events.",
       "hasChildren": false
@@ -40482,9 +37432,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Server Port",
       "help": "Port for the local Gmail callback HTTP server when serve mode is enabled. Use a dedicated port to avoid collisions with gateway/control interfaces.",
       "hasChildren": false
@@ -40496,9 +37444,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Subscription",
       "help": "Pub/Sub subscription consumed by the gateway to receive Gmail change notifications from the configured topic. Keep subscription ownership clear so multiple consumers do not race unexpectedly.",
       "hasChildren": false
@@ -40510,9 +37456,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Tailscale",
       "help": "Tailscale exposure configuration block for publishing Gmail callbacks through Serve/Funnel routes. Use private tailnet modes before enabling any public ingress path.",
       "hasChildren": true
@@ -40524,9 +37468,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Tailscale Mode",
       "help": "Tailscale exposure mode for Gmail callbacks: \"off\", \"serve\", or \"funnel\". Use \"serve\" for private tailnet delivery and \"funnel\" only when public internet ingress is required.",
       "hasChildren": false
@@ -40538,9 +37480,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Gmail Hook Tailscale Path",
       "help": "Path published by Tailscale Serve/Funnel for Gmail callback forwarding when enabled. Keep it aligned with Gmail webhook config so requests reach the expected handler.",
       "hasChildren": false
@@ -40552,9 +37492,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Tailscale Target",
       "help": "Local service target forwarded by Tailscale Serve/Funnel (for example http://127.0.0.1:8787). Use explicit loopback targets to avoid ambiguous routing.",
       "hasChildren": false
@@ -40566,9 +37504,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Thinking Override",
       "help": "Thinking effort override for Gmail-driven agent runs: \"off\", \"minimal\", \"low\", \"medium\", or \"high\". Keep modest defaults for routine inbox automations to control cost and latency.",
       "hasChildren": false
@@ -40580,9 +37516,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gmail Hook Pub/Sub Topic",
       "help": "Google Pub/Sub topic name used by Gmail watch to publish change notifications for this account. Ensure the topic IAM grants Gmail publish access before enabling watches.",
       "hasChildren": false
@@ -40594,9 +37528,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Internal Hooks",
       "help": "Internal hook runtime settings for bundled/custom event handlers loaded from module paths. Use this for trusted in-process automations and keep handler loading tightly scoped.",
       "hasChildren": true
@@ -40608,9 +37540,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Internal Hooks Enabled",
       "help": "Enables processing for internal hook handlers and configured entries in the internal hook runtime. Keep disabled unless internal hook handlers are intentionally configured.",
       "hasChildren": false
@@ -40622,9 +37552,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Internal Hook Entries",
       "help": "Configured internal hook entry records used to register concrete runtime handlers and metadata. Keep entries explicit and versioned so production behavior is auditable.",
       "hasChildren": true
@@ -40685,9 +37613,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Internal Hook Handlers",
       "help": "List of internal event handlers mapping event names to modules and optional exports. Keep handler definitions explicit so event-to-code routing is auditable.",
       "hasChildren": true
@@ -40709,9 +37635,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Internal Hook Event",
       "help": "Internal event name that triggers this handler module when emitted by the runtime. Use stable event naming conventions to avoid accidental overlap across handlers.",
       "hasChildren": false
@@ -40723,9 +37647,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Internal Hook Export",
       "help": "Optional named export for the internal hook handler function when module default export is not used. Set this when one module ships multiple handler entrypoints.",
       "hasChildren": false
@@ -40737,9 +37659,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Internal Hook Module",
       "help": "Safe relative module path for the internal hook handler implementation loaded at runtime. Keep module files in reviewed directories and avoid dynamic path composition.",
       "hasChildren": false
@@ -40751,9 +37671,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Internal Hook Install Records",
       "help": "Install metadata for internal hook modules, including source and resolved artifacts for repeatable deployments. Use this as operational provenance and avoid manual drift edits.",
       "hasChildren": true
@@ -40915,9 +37833,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Internal Hook Loader",
       "help": "Internal hook loader settings controlling where handler modules are discovered at startup. Use constrained load roots to reduce accidental module conflicts or shadowing.",
       "hasChildren": true
@@ -40929,9 +37845,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Internal Hook Extra Directories",
       "help": "Additional directories searched for internal hook modules beyond default load paths. Keep this minimal and controlled to reduce accidental module shadowing.",
       "hasChildren": true
@@ -40953,9 +37867,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mappings",
       "help": "Ordered mapping rules that match inbound hook requests and choose wake or agent actions with optional delivery routing. Use specific mappings first to avoid broad pattern rules capturing everything.",
       "hasChildren": true
@@ -40977,9 +37889,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Action",
       "help": "Mapping action type: \"wake\" triggers agent wake flow, while \"agent\" sends directly to agent handling. Use \"agent\" for immediate execution and \"wake\" when heartbeat-driven processing is preferred.",
       "hasChildren": false
@@ -40991,9 +37901,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Agent ID",
       "help": "Target agent ID for mapping execution when action routing should not use defaults. Use dedicated automation agents to isolate webhook behavior from interactive operator sessions.",
       "hasChildren": false
@@ -41005,9 +37913,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Hook Mapping Allow Unsafe External Content",
       "help": "When true, mapping content may include less-sanitized external payload data in generated messages. Keep false by default and enable only for trusted sources with reviewed transform logic.",
       "hasChildren": false
@@ -41019,9 +37925,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Delivery Channel",
       "help": "Delivery channel override for mapping outputs (for example \"last\", \"telegram\", \"discord\", \"slack\", \"signal\", \"imessage\", or \"msteams\"). Keep channel overrides explicit to avoid accidental cross-channel sends.",
       "hasChildren": false
@@ -41033,9 +37937,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Deliver Reply",
       "help": "Controls whether mapping execution results are delivered back to a channel destination versus being processed silently. Disable delivery for background automations that should not post user-facing output.",
       "hasChildren": false
@@ -41047,9 +37949,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping ID",
       "help": "Optional stable identifier for a hook mapping entry used for auditing, troubleshooting, and targeted updates. Use unique IDs so logs and config diffs can reference mappings unambiguously.",
       "hasChildren": false
@@ -41061,9 +37961,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Match",
       "help": "Grouping object for mapping match predicates such as path and source before action routing is applied. Keep match criteria specific so unrelated webhook traffic does not trigger automations.",
       "hasChildren": true
@@ -41075,9 +37973,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Hook Mapping Match Path",
       "help": "Path match condition for a hook mapping, usually compared against the inbound request path. Use this to split automation behavior by webhook endpoint path families.",
       "hasChildren": false
@@ -41089,9 +37985,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Match Source",
       "help": "Source match condition for a hook mapping, typically set by trusted upstream metadata or adapter logic. Use stable source identifiers so routing remains deterministic across retries.",
       "hasChildren": false
@@ -41103,9 +37997,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Message Template",
       "help": "Template for synthesizing structured mapping input into the final message content sent to the target action path. Keep templates deterministic so downstream parsing and behavior remain stable.",
       "hasChildren": false
@@ -41117,9 +38009,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Hook Mapping Model Override",
       "help": "Optional model override for mapping-triggered runs when automation should use a different model than agent defaults. Use this sparingly so behavior remains predictable across mapping executions.",
       "hasChildren": false
@@ -41131,9 +38021,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Name",
       "help": "Human-readable mapping display name used in diagnostics and operator-facing config UIs. Keep names concise and descriptive so routing intent is obvious during incident review.",
       "hasChildren": false
@@ -41145,10 +38033,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "security",
-        "storage"
-      ],
+      "tags": ["security", "storage"],
       "label": "Hook Mapping Session Key",
       "help": "Explicit session key override for mapping-delivered messages to control thread continuity. Use stable scoped keys so repeated events correlate without leaking into unrelated conversations.",
       "hasChildren": false
@@ -41160,9 +38045,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Text Template",
       "help": "Text-only fallback template used when rich payload rendering is not desired or not supported. Use this to provide a concise, consistent summary string for chat delivery surfaces.",
       "hasChildren": false
@@ -41174,9 +38057,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Thinking Override",
       "help": "Optional thinking-effort override for mapping-triggered runs to tune latency versus reasoning depth. Keep low or minimal for high-volume hooks unless deeper reasoning is clearly required.",
       "hasChildren": false
@@ -41188,9 +38069,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Hook Mapping Timeout (sec)",
       "help": "Maximum runtime allowed for mapping action execution before timeout handling applies. Use tighter limits for high-volume webhook sources to prevent queue pileups.",
       "hasChildren": false
@@ -41202,9 +38081,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Delivery Destination",
       "help": "Destination identifier inside the selected channel when mapping replies should route to a fixed target. Verify provider-specific destination formats before enabling production mappings.",
       "hasChildren": false
@@ -41216,9 +38093,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Transform",
       "help": "Transform configuration block defining module/export preprocessing before mapping action handling. Use transforms only from reviewed code paths and keep behavior deterministic for repeatable automation.",
       "hasChildren": true
@@ -41230,9 +38105,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Transform Export",
       "help": "Named export to invoke from the transform module; defaults to module default export when omitted. Set this when one file hosts multiple transform handlers.",
       "hasChildren": false
@@ -41244,9 +38117,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Transform Module",
       "help": "Relative transform module path loaded from hooks.transformsDir to rewrite incoming payloads before delivery. Keep modules local, reviewed, and free of path traversal patterns.",
       "hasChildren": false
@@ -41258,9 +38129,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hook Mapping Wake Mode",
       "help": "Wake scheduling mode: \"now\" wakes immediately, while \"next-heartbeat\" defers until the next heartbeat cycle. Use deferred mode for lower-priority automations that can tolerate slight delay.",
       "hasChildren": false
@@ -41272,9 +38141,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Hooks Max Body Bytes",
       "help": "Maximum accepted webhook payload size in bytes before the request is rejected. Keep this bounded to reduce abuse risk and protect memory usage under bursty integrations.",
       "hasChildren": false
@@ -41286,9 +38153,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Hooks Endpoint Path",
       "help": "HTTP path used by the hooks endpoint (for example `/hooks`) on the gateway control server. Use a non-guessable path and combine it with token validation for defense in depth.",
       "hasChildren": false
@@ -41300,9 +38165,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Hooks Presets",
       "help": "Named hook preset bundles applied at load time to seed standard mappings and behavior defaults. Keep preset usage explicit so operators can audit which automations are active.",
       "hasChildren": true
@@ -41324,10 +38187,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "label": "Hooks Auth Token",
       "help": "Shared bearer token checked by hooks ingress for request authentication before mappings run. Use environment substitution and rotate regularly when webhook endpoints are internet-accessible.",
       "hasChildren": false
@@ -41339,9 +38199,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Hooks Transforms Directory",
       "help": "Base directory for hook transform modules referenced by mapping transform.module paths. Use a controlled repo directory so dynamic imports remain reviewable and predictable.",
       "hasChildren": false
@@ -41353,9 +38211,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Logging",
       "help": "Logging behavior controls for severity, output destinations, formatting, and sensitive-data redaction. Keep levels and redaction strict enough for production while preserving useful diagnostics.",
       "hasChildren": true
@@ -41367,9 +38223,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "Console Log Level",
       "help": "Console-specific log threshold: \"silent\", \"fatal\", \"error\", \"warn\", \"info\", \"debug\", or \"trace\" for terminal output control. Use this to keep local console quieter while retaining richer file logging if needed.",
       "hasChildren": false
@@ -41381,9 +38235,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "Console Log Style",
       "help": "Console output format style: \"pretty\", \"compact\", or \"json\" based on operator and ingestion needs. Use json for machine parsing pipelines and pretty/compact for human-first terminal workflows.",
       "hasChildren": false
@@ -41395,10 +38247,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "storage"
-      ],
+      "tags": ["observability", "storage"],
       "label": "Log File Path",
       "help": "Optional file path for persisted log output in addition to or instead of console logging. Use a managed writable path and align retention/rotation with your operational policy.",
       "hasChildren": false
@@ -41410,9 +38259,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "Log Level",
       "help": "Primary log level threshold for runtime logger output: \"silent\", \"fatal\", \"error\", \"warn\", \"info\", \"debug\", or \"trace\". Keep \"info\" or \"warn\" for production, and use debug/trace only during investigation.",
       "hasChildren": false
@@ -41434,10 +38281,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "privacy"
-      ],
+      "tags": ["observability", "privacy"],
       "label": "Custom Redaction Patterns",
       "help": "Additional custom redact regex patterns applied to log output before emission/storage. Use this to mask org-specific tokens and identifiers not covered by built-in redaction rules.",
       "hasChildren": true
@@ -41459,10 +38303,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability",
-        "privacy"
-      ],
+      "tags": ["observability", "privacy"],
       "label": "Sensitive Data Redaction Mode",
       "help": "Sensitive redaction mode: \"off\" disables built-in masking, while \"tools\" redacts sensitive tool/config payload fields. Keep \"tools\" in shared logs unless you have isolated secure log sinks.",
       "hasChildren": false
@@ -41474,9 +38315,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Media",
       "help": "Top-level media behavior shared across providers and tools that handle inbound files. Keep defaults unless you need stable filenames for external processing pipelines or longer-lived inbound media retention.",
       "hasChildren": true
@@ -41488,9 +38327,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Preserve Media Filenames",
       "help": "When enabled, uploaded media keeps its original filename instead of a generated temp-safe name. Turn this on when downstream automations depend on stable names, and leave off to reduce accidental filename leakage.",
       "hasChildren": false
@@ -41502,9 +38339,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Media Retention TTL (hours)",
       "help": "Optional retention window in hours for persisted inbound media cleanup across the full media tree. Leave unset to preserve legacy behavior, or set values like 24 (1 day) or 168 (7 days) when you want automatic cleanup.",
       "hasChildren": false
@@ -41516,9 +38351,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory",
       "help": "Memory backend configuration (global).",
       "hasChildren": true
@@ -41530,9 +38363,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Memory Backend",
       "help": "Selects the global memory engine: \"builtin\" uses OpenClaw memory internals, while \"qmd\" uses the QMD sidecar pipeline. Keep \"builtin\" unless you intentionally operate QMD.",
       "hasChildren": false
@@ -41544,9 +38375,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Memory Citations Mode",
       "help": "Controls citation visibility in replies: \"auto\" shows citations when useful, \"on\" always shows them, and \"off\" hides them. Keep \"auto\" for a balanced signal-to-noise default.",
       "hasChildren": false
@@ -41568,9 +38397,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD Binary",
       "help": "Sets the executable path for the `qmd` binary used by the QMD backend (default: resolved from PATH). Use an explicit absolute path when multiple qmd installs exist or PATH differs across environments.",
       "hasChildren": false
@@ -41582,9 +38409,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD Include Default Memory",
       "help": "Automatically indexes default memory files (MEMORY.md and memory/**/*.md) into QMD collections. Keep enabled unless you want indexing controlled only through explicit custom paths.",
       "hasChildren": false
@@ -41606,10 +38431,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "QMD Max Injected Chars",
       "help": "Caps how much QMD text can be injected into one turn across all hits. Use lower values to control prompt bloat and latency; raise only when context is consistently truncated.",
       "hasChildren": false
@@ -41621,10 +38443,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "QMD Max Results",
       "help": "Limits how many QMD hits are returned into the agent loop for each recall request (default: 6). Increase for broader recall context, or lower to keep prompts tighter and faster.",
       "hasChildren": false
@@ -41636,10 +38455,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "QMD Max Snippet Chars",
       "help": "Caps per-result snippet length extracted from QMD hits in characters (default: 700). Lower this when prompts bloat quickly, and raise only if answers consistently miss key details.",
       "hasChildren": false
@@ -41651,10 +38467,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "QMD Search Timeout (ms)",
       "help": "Sets per-query QMD search timeout in milliseconds (default: 4000). Increase for larger indexes or slower environments, and lower to keep request latency bounded.",
       "hasChildren": false
@@ -41666,9 +38479,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD MCPorter",
       "help": "Routes QMD work through mcporter (MCP runtime) instead of spawning `qmd` for each call. Use this when cold starts are expensive on large models; keep direct process mode for simpler local setups.",
       "hasChildren": true
@@ -41680,9 +38491,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD MCPorter Enabled",
       "help": "Routes QMD through an mcporter daemon instead of spawning qmd per request, reducing cold-start overhead for larger models. Keep disabled unless mcporter is installed and configured.",
       "hasChildren": false
@@ -41694,9 +38503,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD MCPorter Server Name",
       "help": "Names the mcporter server target used for QMD calls (default: qmd). Change only when your mcporter setup uses a custom server name for qmd mcp keep-alive.",
       "hasChildren": false
@@ -41708,9 +38515,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD MCPorter Start Daemon",
       "help": "Automatically starts the mcporter daemon when mcporter-backed QMD mode is enabled (default: true). Keep enabled unless process lifecycle is managed externally by your service supervisor.",
       "hasChildren": false
@@ -41722,9 +38527,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD Extra Paths",
       "help": "Adds custom directories or files to include in QMD indexing, each with an optional name and glob pattern. Use this for project-specific knowledge locations that are outside default memory paths.",
       "hasChildren": true
@@ -41776,9 +38579,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD Surface Scope",
       "help": "Defines which sessions/channels are eligible for QMD recall using session.sendPolicy-style rules. Keep default direct-only scope unless you intentionally want cross-chat memory sharing.",
       "hasChildren": true
@@ -41880,9 +38681,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD Search Mode",
       "help": "Selects the QMD retrieval path: \"query\" uses standard query flow, \"search\" uses search-oriented retrieval, and \"vsearch\" emphasizes vector retrieval. Keep default unless tuning relevance quality.",
       "hasChildren": false
@@ -41904,9 +38703,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD Session Indexing",
       "help": "Indexes session transcripts into QMD so recall can include prior conversation content (experimental, default: false). Enable only when transcript memory is required and you accept larger index churn.",
       "hasChildren": false
@@ -41918,9 +38715,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD Session Export Directory",
       "help": "Overrides where sanitized session exports are written before QMD indexing. Use this when default state storage is constrained or when exports must land on a managed volume.",
       "hasChildren": false
@@ -41932,9 +38727,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD Session Retention (days)",
       "help": "Defines how long exported session files are kept before automatic pruning, in days (default: unlimited). Set a finite value for storage hygiene or compliance retention policies.",
       "hasChildren": false
@@ -41956,10 +38749,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "QMD Command Timeout (ms)",
       "help": "Sets timeout for QMD maintenance commands such as collection list/add in milliseconds (default: 30000). Increase when running on slower disks or remote filesystems that delay command completion.",
       "hasChildren": false
@@ -41971,10 +38761,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "QMD Update Debounce (ms)",
       "help": "Sets the minimum delay between consecutive QMD refresh attempts in milliseconds (default: 15000). Increase this if frequent file changes cause update thrash or unnecessary background load.",
       "hasChildren": false
@@ -41986,10 +38773,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "QMD Embed Interval",
       "help": "Sets how often QMD recomputes embeddings (duration string, default: 60m; set 0 to disable periodic embeds). Lower intervals improve freshness but increase embedding workload and cost.",
       "hasChildren": false
@@ -42001,10 +38785,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "QMD Embed Timeout (ms)",
       "help": "Sets maximum runtime for each `qmd embed` cycle in milliseconds (default: 120000). Increase for heavier embedding workloads or slower hardware, and lower to fail fast under tight SLAs.",
       "hasChildren": false
@@ -42016,10 +38797,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "QMD Update Interval",
       "help": "Sets how often QMD refreshes indexes from source content (duration string, default: 5m). Shorter intervals improve freshness but increase background CPU and I/O.",
       "hasChildren": false
@@ -42031,9 +38809,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD Update on Startup",
       "help": "Runs an initial QMD update once during gateway startup (default: true). Keep enabled so recall starts from a fresh baseline; disable only when startup speed is more important than immediate freshness.",
       "hasChildren": false
@@ -42045,10 +38821,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "QMD Update Timeout (ms)",
       "help": "Sets maximum runtime for each `qmd update` cycle in milliseconds (default: 120000). Raise this for larger collections; lower it when you want quicker failure detection in automation.",
       "hasChildren": false
@@ -42060,9 +38833,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "QMD Wait for Boot Sync",
       "help": "Blocks startup completion until the initial boot-time QMD sync finishes (default: false). Enable when you need fully up-to-date recall before serving traffic, and keep off for faster boot.",
       "hasChildren": false
@@ -42074,9 +38845,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Messages",
       "help": "Message formatting, acknowledgment, queueing, debounce, and status reaction behavior for inbound/outbound chat flows. Use this section when channel responsiveness or message UX needs adjustment.",
       "hasChildren": true
@@ -42088,9 +38857,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Ack Reaction Emoji",
       "help": "Emoji reaction used to acknowledge inbound messages (empty disables).",
       "hasChildren": false
@@ -42100,19 +38867,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "group-mentions",
-        "group-all",
-        "direct",
-        "all",
-        "off",
-        "none"
-      ],
+      "enumValues": ["group-mentions", "group-all", "direct", "all", "off", "none"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Ack Reaction Scope",
       "help": "When to send ack reactions (\"group-mentions\", \"group-all\", \"direct\", \"all\", \"off\", \"none\"). \"off\"/\"none\" disables ack reactions entirely.",
       "hasChildren": false
@@ -42124,9 +38882,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Group Chat Rules",
       "help": "Group-message handling controls including mention triggers and history window sizing. Keep mention patterns narrow so group channels do not trigger on every message.",
       "hasChildren": true
@@ -42138,9 +38894,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Group History Limit",
       "help": "Maximum number of prior group messages loaded as context per turn for group sessions. Use higher values for richer continuity, or lower values for faster and cheaper responses.",
       "hasChildren": false
@@ -42152,9 +38906,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Group Mention Patterns",
       "help": "Safe case-insensitive regex patterns used to detect explicit mentions/trigger phrases in group chats. Use precise patterns to reduce false positives in high-volume channels; invalid or unsafe nested-repetition patterns are ignored.",
       "hasChildren": true
@@ -42176,9 +38928,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Inbound Debounce",
       "help": "Direct inbound debounce settings used before queue/turn processing starts. Configure this for provider-specific rapid message bursts from the same sender.",
       "hasChildren": true
@@ -42190,9 +38940,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Inbound Debounce by Channel (ms)",
       "help": "Per-channel inbound debounce overrides keyed by provider id in milliseconds. Use this where some providers send message fragments more aggressively than others.",
       "hasChildren": true
@@ -42214,9 +38962,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Inbound Message Debounce (ms)",
       "help": "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
       "hasChildren": false
@@ -42228,9 +38974,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Inbound Message Prefix",
       "help": "Prefix text prepended to inbound user messages before they are handed to the agent runtime. Use this sparingly for channel context markers and keep it stable across sessions.",
       "hasChildren": false
@@ -42242,9 +38986,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Inbound Queue",
       "help": "Inbound message queue strategy used to buffer bursts before processing turns. Tune this for busy channels where sequential processing or batching behavior matters.",
       "hasChildren": true
@@ -42256,9 +38998,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Queue Mode by Channel",
       "help": "Per-channel queue mode overrides keyed by provider id (for example telegram, discord, slack). Use this when one channel’s traffic pattern needs different queue behavior than global defaults.",
       "hasChildren": true
@@ -42370,9 +39110,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Queue Capacity",
       "help": "Maximum number of queued inbound items retained before drop policy applies. Keep caps bounded in noisy channels so memory usage remains predictable.",
       "hasChildren": false
@@ -42384,9 +39122,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Queue Debounce (ms)",
       "help": "Global queue debounce window in milliseconds before processing buffered inbound messages. Use higher values to coalesce rapid bursts, or lower values for reduced response latency.",
       "hasChildren": false
@@ -42398,9 +39134,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Queue Debounce by Channel (ms)",
       "help": "Per-channel debounce overrides for queue behavior keyed by provider id. Use this to tune burst handling independently for chat surfaces with different pacing.",
       "hasChildren": true
@@ -42422,9 +39156,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Queue Drop Strategy",
       "help": "Drop strategy when queue cap is exceeded: \"old\", \"new\", or \"summarize\". Use summarize when preserving intent matters, or old/new when deterministic dropping is preferred.",
       "hasChildren": false
@@ -42436,9 +39168,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Queue Mode",
       "help": "Queue behavior mode: \"steer\", \"followup\", \"collect\", \"steer-backlog\", \"steer+backlog\", \"queue\", or \"interrupt\". Keep conservative modes unless you intentionally need aggressive interruption/backlog semantics.",
       "hasChildren": false
@@ -42450,9 +39180,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Remove Ack Reaction After Reply",
       "help": "Removes the acknowledgment reaction after final reply delivery when enabled. Keep enabled for cleaner UX in channels where persistent ack reactions create clutter.",
       "hasChildren": false
@@ -42464,9 +39192,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Outbound Response Prefix",
       "help": "Prefix text prepended to outbound assistant replies before sending to channels. Use for lightweight branding/context tags and avoid long prefixes that reduce content density.",
       "hasChildren": false
@@ -42478,9 +39204,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Status Reactions",
       "help": "Lifecycle status reactions that update the emoji on the trigger message as the agent progresses (queued → thinking → tool → done/error).",
       "hasChildren": true
@@ -42492,9 +39216,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Status Reaction Emojis",
       "help": "Override default status reaction emojis. Keys: thinking, compacting, tool, coding, web, done, error, stallSoft, stallHard. Must be valid Telegram reaction emojis.",
       "hasChildren": true
@@ -42596,9 +39318,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable Status Reactions",
       "help": "Enable lifecycle status reactions for Telegram. When enabled, the ack reaction becomes the initial 'queued' state and progresses through thinking, tool, done/error automatically. Default: false.",
       "hasChildren": false
@@ -42610,9 +39330,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Status Reaction Timing",
       "help": "Override default timing. Keys: debounceMs (700), stallSoftMs (25000), stallHardMs (60000), doneHoldMs (1500), errorHoldMs (2500).",
       "hasChildren": true
@@ -42674,9 +39392,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Suppress Tool Error Warnings",
       "help": "When true, suppress ⚠️ tool-error warnings from being shown to the user. The agent already sees errors in context and can retry. Default: false.",
       "hasChildren": false
@@ -42688,9 +39404,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Message Text-to-Speech",
       "help": "Text-to-speech policy for reading agent replies aloud on supported voice or audio surfaces. Keep disabled unless voice playback is part of your operator/user workflow.",
       "hasChildren": true
@@ -42700,12 +39414,7 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "always",
-        "inbound",
-        "tagged"
-      ],
+      "enumValues": ["off", "always", "inbound", "tagged"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -42834,18 +39543,11 @@
     {
       "path": "messages.tts.elevenlabs.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "media",
-        "security"
-      ],
+      "tags": ["auth", "media", "security"],
       "hasChildren": true
     },
     {
@@ -42883,11 +39585,7 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "auto",
-        "on",
-        "off"
-      ],
+      "enumValues": ["auto", "on", "off"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -43028,10 +39726,7 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "final",
-        "all"
-      ],
+      "enumValues": ["final", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -43140,18 +39835,11 @@
     {
       "path": "messages.tts.openai.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "media",
-        "security"
-      ],
+      "tags": ["auth", "media", "security"],
       "hasChildren": true
     },
     {
@@ -43249,11 +39937,7 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "elevenlabs",
-        "openai",
-        "edge"
-      ],
+      "enumValues": ["elevenlabs", "openai", "edge"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -43286,9 +39970,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Metadata",
       "help": "Metadata fields automatically maintained by OpenClaw to record write/version history for this config file. Keep these values system-managed and avoid manual edits unless debugging migration history.",
       "hasChildren": true
@@ -43300,9 +39982,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Config Last Touched At",
       "help": "ISO timestamp of the last config write (auto-set).",
       "hasChildren": false
@@ -43314,9 +39994,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Config Last Touched Version",
       "help": "Auto-set when OpenClaw writes the config.",
       "hasChildren": false
@@ -43328,9 +40006,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Models",
       "help": "Model catalog root for provider definitions, merge/replace behavior, and optional Bedrock discovery integration. Keep provider definitions explicit and validated before relying on production failover paths.",
       "hasChildren": true
@@ -43342,9 +40018,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Bedrock Model Discovery",
       "help": "Automatic AWS Bedrock model discovery settings used to synthesize provider model entries from account visibility. Keep discovery scoped and refresh intervals conservative to reduce API churn.",
       "hasChildren": true
@@ -43356,9 +40030,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Bedrock Default Context Window",
       "help": "Fallback context-window value applied to discovered models when provider metadata lacks explicit limits. Use realistic defaults to avoid oversized prompts that exceed true provider constraints.",
       "hasChildren": false
@@ -43370,12 +40042,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "auth",
-        "models",
-        "performance",
-        "security"
-      ],
+      "tags": ["auth", "models", "performance", "security"],
       "label": "Bedrock Default Max Tokens",
       "help": "Fallback max-token value applied to discovered models without explicit output token limits. Use conservative defaults to reduce truncation surprises and unexpected token spend.",
       "hasChildren": false
@@ -43387,9 +40054,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Bedrock Discovery Enabled",
       "help": "Enables periodic Bedrock model discovery and catalog refresh for Bedrock-backed providers. Keep disabled unless Bedrock is actively used and IAM permissions are correctly configured.",
       "hasChildren": false
@@ -43401,9 +40066,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Bedrock Discovery Provider Filter",
       "help": "Optional provider allowlist filter for Bedrock discovery so only selected providers are refreshed. Use this to limit discovery scope in multi-provider environments.",
       "hasChildren": true
@@ -43425,10 +40088,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models",
-        "performance"
-      ],
+      "tags": ["models", "performance"],
       "label": "Bedrock Discovery Refresh Interval (s)",
       "help": "Refresh cadence for Bedrock discovery polling in seconds to detect newly available models over time. Use longer intervals in production to reduce API cost and control-plane noise.",
       "hasChildren": false
@@ -43440,9 +40100,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Bedrock Discovery Region",
       "help": "AWS region used for Bedrock discovery calls when discovery is enabled for your deployment. Use the region where your Bedrock models are provisioned to avoid empty discovery results.",
       "hasChildren": false
@@ -43454,9 +40112,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Model Catalog Mode",
       "help": "Controls provider catalog behavior: \"merge\" keeps built-ins and overlays your custom providers, while \"replace\" uses only your configured providers. In \"merge\", matching provider IDs preserve non-empty agent models.json baseUrl values, while apiKey values are preserved only when the provider is not SecretRef-managed in current config/auth-profile context; SecretRef-managed providers refresh apiKey from current source markers, and matching model contextWindow/maxTokens use the higher value between explicit and implicit entries.",
       "hasChildren": false
@@ -43468,9 +40124,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Model Providers",
       "help": "Provider map keyed by provider ID containing connection/auth settings and concrete model definitions. Use stable provider keys so references from agents and tooling remain portable across environments.",
       "hasChildren": true
@@ -43502,9 +40156,7 @@
       ],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Model Provider API Adapter",
       "help": "Provider API adapter selection controlling request/response compatibility handling for model calls. Use the adapter that matches your upstream provider protocol to avoid feature mismatch.",
       "hasChildren": false
@@ -43512,18 +40164,11 @@
     {
       "path": "models.providers.*.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "models",
-        "security"
-      ],
+      "tags": ["auth", "models", "security"],
       "label": "Model Provider API Key",
       "help": "Provider credential used for API-key based authentication when the provider requires direct key auth. Use secret/env substitution and avoid storing real keys in committed config files.",
       "hasChildren": true
@@ -43565,9 +40210,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Model Provider Auth Mode",
       "help": "Selects provider auth style: \"api-key\" for API key auth, \"token\" for bearer token auth, \"oauth\" for OAuth credentials, and \"aws-sdk\" for AWS credential resolution. Match this to your provider requirements.",
       "hasChildren": false
@@ -43579,9 +40222,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Model Provider Authorization Header",
       "help": "When true, credentials are sent via the HTTP Authorization header even if alternate auth is possible. Use this only when your provider or proxy explicitly requires Authorization forwarding.",
       "hasChildren": false
@@ -43593,9 +40234,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Model Provider Base URL",
       "help": "Base URL for the provider endpoint used to serve model requests for that provider entry. Use HTTPS endpoints and keep URLs environment-specific through config templating where needed.",
       "hasChildren": false
@@ -43607,9 +40246,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Model Provider Headers",
       "help": "Static HTTP headers merged into provider requests for tenant routing, proxy auth, or custom gateway requirements. Use this sparingly and keep sensitive header values in secrets.",
       "hasChildren": true
@@ -43617,17 +40254,11 @@
     {
       "path": "models.providers.*.headers.*",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "models",
-        "security"
-      ],
+      "tags": ["models", "security"],
       "hasChildren": true
     },
     {
@@ -43667,9 +40298,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Model Provider Inject num_ctx (OpenAI Compat)",
       "help": "Controls whether OpenClaw injects `options.num_ctx` for Ollama providers configured with the OpenAI-compatible adapter (`openai-completions`). Default is true. Set false only if your proxy/upstream rejects unknown `options` payload fields.",
       "hasChildren": false
@@ -43681,9 +40310,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models"
-      ],
+      "tags": ["models"],
       "label": "Model Provider Model List",
       "help": "Declared model list for a provider including identifiers, metadata, and optional compatibility/cost hints. Keep IDs exact to provider catalog values so selection and fallback resolve correctly.",
       "hasChildren": true
@@ -44005,9 +40632,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Node Host",
       "help": "Node host controls for features exposed from this gateway node to other nodes or clients. Keep defaults unless you intentionally proxy local capabilities across your node network.",
       "hasChildren": true
@@ -44019,9 +40644,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Node Browser Proxy",
       "help": "Groups browser-proxy settings for exposing local browser control through node routing. Enable only when remote node workflows need your local browser profiles.",
       "hasChildren": true
@@ -44033,11 +40656,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "network",
-        "storage"
-      ],
+      "tags": ["access", "network", "storage"],
       "label": "Node Browser Proxy Allowed Profiles",
       "help": "Optional allowlist of browser profile names exposed through node proxy routing. Leave empty to expose all configured profiles, or use a tight list to enforce least-privilege profile access.",
       "hasChildren": true
@@ -44059,9 +40678,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "network"
-      ],
+      "tags": ["network"],
       "label": "Node Browser Proxy Enabled",
       "help": "Expose the local browser control server through node proxy routing so remote clients can use this host's browser capabilities. Keep disabled unless remote automation explicitly depends on it.",
       "hasChildren": false
@@ -44073,9 +40690,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugins",
       "help": "Plugin system controls for enabling extensions, constraining load scope, configuring entries, and tracking installs. Keep plugin policy explicit and least-privilege in production environments.",
       "hasChildren": true
@@ -44087,9 +40702,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Plugin Allowlist",
       "help": "Optional allowlist of plugin IDs; when set, only listed plugins are eligible to load. Use this to enforce approved extension inventories in controlled environments.",
       "hasChildren": true
@@ -44111,9 +40724,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Plugin Denylist",
       "help": "Optional denylist of plugin IDs that are blocked even if allowlists or paths include them. Use deny rules for emergency rollback and hard blocks on risky plugins.",
       "hasChildren": true
@@ -44135,9 +40746,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable Plugins",
       "help": "Enable or disable plugin/extension loading globally during startup and config reload (default: true). Keep enabled only when extension capabilities are required by your deployment.",
       "hasChildren": false
@@ -44149,9 +40758,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Entries",
       "help": "Per-plugin settings keyed by plugin ID including enablement and plugin-specific runtime configuration payloads. Use this for scoped plugin tuning without changing global loader policy.",
       "hasChildren": true
@@ -44173,9 +40780,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Config",
       "help": "Plugin-defined configuration payload interpreted by that plugin's own schema and validation rules. Use only documented fields from the plugin to prevent ignored or invalid settings.",
       "hasChildren": true
@@ -44196,9 +40801,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Enabled",
       "help": "Per-plugin enablement override for a specific entry, applied on top of global plugin policy (restart required). Use this to stage plugin rollout gradually across environments.",
       "hasChildren": false
@@ -44210,9 +40813,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -44224,9 +40825,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -44238,9 +40837,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACPX Runtime",
       "help": "ACP runtime backend powered by acpx with configurable command path and version policy. (plugin: acpx)",
       "hasChildren": true
@@ -44252,9 +40849,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ACPX Runtime Config",
       "help": "Plugin-defined config payload for acpx.",
       "hasChildren": true
@@ -44266,9 +40861,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "acpx Command",
       "help": "Optional path/command override for acpx (for example /home/user/repos/acpx/dist/cli.js). Leave unset to use plugin-local bundled acpx.",
       "hasChildren": false
@@ -44280,9 +40873,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default Working Directory",
       "help": "Default cwd for ACP session operations when not set per session.",
       "hasChildren": false
@@ -44294,9 +40885,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Expected acpx Version",
       "help": "Exact version to enforce (for example 0.1.16) or \"any\" to skip strict version matching.",
       "hasChildren": false
@@ -44308,9 +40897,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "MCP Servers",
       "help": "Named MCP server definitions to inject into ACPX-backed session bootstrap. Each entry needs a command and can include args and env.",
       "hasChildren": true
@@ -44380,15 +40967,10 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "deny",
-        "fail"
-      ],
+      "enumValues": ["deny", "fail"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Non-Interactive Permission Policy",
       "help": "acpx policy when interactive permission prompts are unavailable.",
       "hasChildren": false
@@ -44398,16 +40980,10 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "approve-all",
-        "approve-reads",
-        "deny-all"
-      ],
+      "enumValues": ["approve-all", "approve-reads", "deny-all"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Permission Mode",
       "help": "Default acpx permission policy for runtime prompts.",
       "hasChildren": false
@@ -44419,10 +40995,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "advanced"
-      ],
+      "tags": ["access", "advanced"],
       "label": "Queue Owner TTL Seconds",
       "help": "Idle queue-owner TTL for acpx prompt turns. Keep this short in OpenClaw to avoid delayed completion after each turn.",
       "hasChildren": false
@@ -44434,9 +41007,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Strict Windows cmd Wrapper",
       "help": "Enabled by default. On Windows, reject unresolved .cmd/.bat wrappers instead of shell fallback. Disable only for compatibility with non-standard wrappers.",
       "hasChildren": false
@@ -44448,10 +41019,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "performance"
-      ],
+      "tags": ["advanced", "performance"],
       "label": "Prompt Timeout Seconds",
       "help": "Optional acpx timeout for each runtime turn.",
       "hasChildren": false
@@ -44463,9 +41031,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable ACPX Runtime",
       "hasChildren": false
     },
@@ -44476,9 +41042,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -44490,9 +41054,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -44504,9 +41066,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/bluebubbles",
       "help": "OpenClaw BlueBubbles channel plugin (plugin: bluebubbles)",
       "hasChildren": true
@@ -44518,9 +41078,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/bluebubbles Config",
       "help": "Plugin-defined config payload for bluebubbles.",
       "hasChildren": false
@@ -44532,9 +41090,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/bluebubbles",
       "hasChildren": false
     },
@@ -44545,9 +41101,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -44559,9 +41113,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -44573,9 +41125,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/copilot-proxy",
       "help": "OpenClaw Copilot Proxy provider plugin (plugin: copilot-proxy)",
       "hasChildren": true
@@ -44587,9 +41137,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/copilot-proxy Config",
       "help": "Plugin-defined config payload for copilot-proxy.",
       "hasChildren": false
@@ -44601,9 +41149,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/copilot-proxy",
       "hasChildren": false
     },
@@ -44614,9 +41160,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -44628,9 +41172,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -44642,9 +41184,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Device Pairing",
       "help": "Generate setup codes and approve device pairing requests. (plugin: device-pair)",
       "hasChildren": true
@@ -44656,9 +41196,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Device Pairing Config",
       "help": "Plugin-defined config payload for device-pair.",
       "hasChildren": true
@@ -44670,9 +41208,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Gateway URL",
       "help": "Public WebSocket URL used for /pair setup codes (ws/wss or http/https).",
       "hasChildren": false
@@ -44684,9 +41220,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable Device Pairing",
       "hasChildren": false
     },
@@ -44697,9 +41231,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -44711,9 +41243,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -44725,9 +41255,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "@openclaw/diagnostics-otel",
       "help": "OpenClaw diagnostics OpenTelemetry exporter (plugin: diagnostics-otel)",
       "hasChildren": true
@@ -44739,9 +41267,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "@openclaw/diagnostics-otel Config",
       "help": "Plugin-defined config payload for diagnostics-otel.",
       "hasChildren": false
@@ -44753,9 +41279,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "observability"
-      ],
+      "tags": ["observability"],
       "label": "Enable @openclaw/diagnostics-otel",
       "hasChildren": false
     },
@@ -44766,9 +41290,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -44780,9 +41302,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -44794,9 +41314,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Diffs",
       "help": "Read-only diff viewer and file renderer for agents. (plugin: diffs)",
       "hasChildren": true
@@ -44808,9 +41326,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Diffs Config",
       "help": "Plugin-defined config payload for diffs.",
       "hasChildren": true
@@ -44833,9 +41349,7 @@
       "defaultValue": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default Background Highlights",
       "help": "Show added/removed background highlights by default.",
       "hasChildren": false
@@ -44845,17 +41359,11 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "bars",
-        "classic",
-        "none"
-      ],
+      "enumValues": ["bars", "classic", "none"],
       "defaultValue": "bars",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Diff Indicator Style",
       "help": "Choose added/removed indicators style.",
       "hasChildren": false
@@ -44865,16 +41373,11 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "png",
-        "pdf"
-      ],
+      "enumValues": ["png", "pdf"],
       "defaultValue": "png",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Default File Format",
       "help": "Rendered file format for file mode (PNG or PDF).",
       "hasChildren": false
@@ -44887,10 +41390,7 @@
       "defaultValue": 960,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "Default File Max Width",
       "help": "Maximum file render width in CSS pixels.",
       "hasChildren": false
@@ -44900,17 +41400,11 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "standard",
-        "hq",
-        "print"
-      ],
+      "enumValues": ["standard", "hq", "print"],
       "defaultValue": "standard",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Default File Quality",
       "help": "Quality preset for PNG/PDF rendering.",
       "hasChildren": false
@@ -44923,9 +41417,7 @@
       "defaultValue": 2,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Default File Scale",
       "help": "Device scale factor used while rendering file artifacts.",
       "hasChildren": false
@@ -44938,9 +41430,7 @@
       "defaultValue": "Fira Code",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default Font",
       "help": "Preferred font family name for diff content and headers.",
       "hasChildren": false
@@ -44953,9 +41443,7 @@
       "defaultValue": 15,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default Font Size",
       "help": "Base diff font size in pixels.",
       "hasChildren": false
@@ -44965,10 +41453,7 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "png",
-        "pdf"
-      ],
+      "enumValues": ["png", "pdf"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -44979,10 +41464,7 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "png",
-        "pdf"
-      ],
+      "enumValues": ["png", "pdf"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -45003,11 +41485,7 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "standard",
-        "hq",
-        "print"
-      ],
+      "enumValues": ["standard", "hq", "print"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -45028,16 +41506,11 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "unified",
-        "split"
-      ],
+      "enumValues": ["unified", "split"],
       "defaultValue": "unified",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default Layout",
       "help": "Initial diff layout shown in the viewer.",
       "hasChildren": false
@@ -45050,9 +41523,7 @@
       "defaultValue": 1.6,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default Line Spacing",
       "help": "Line-height multiplier applied to diff rows.",
       "hasChildren": false
@@ -45062,18 +41533,11 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "view",
-        "image",
-        "file",
-        "both"
-      ],
+      "enumValues": ["view", "image", "file", "both"],
       "defaultValue": "both",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default Output Mode",
       "help": "Tool default when mode is omitted. Use view for canvas/gateway viewer, file for PNG/PDF, or both.",
       "hasChildren": false
@@ -45086,9 +41550,7 @@
       "defaultValue": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Show Line Numbers",
       "help": "Show line numbers by default.",
       "hasChildren": false
@@ -45098,16 +41560,11 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "light",
-        "dark"
-      ],
+      "enumValues": ["light", "dark"],
       "defaultValue": "dark",
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default Theme",
       "help": "Initial viewer theme.",
       "hasChildren": false
@@ -45120,9 +41577,7 @@
       "defaultValue": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default Word Wrap",
       "help": "Wrap long lines by default.",
       "hasChildren": false
@@ -45145,9 +41600,7 @@
       "defaultValue": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Remote Viewer",
       "help": "Allow non-loopback access to diff viewer URLs when the token path is known.",
       "hasChildren": false
@@ -45159,9 +41612,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable Diffs",
       "hasChildren": false
     },
@@ -45172,9 +41623,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45186,9 +41635,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45200,9 +41647,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/discord",
       "help": "OpenClaw Discord channel plugin (plugin: discord)",
       "hasChildren": true
@@ -45214,9 +41659,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/discord Config",
       "help": "Plugin-defined config payload for discord.",
       "hasChildren": false
@@ -45228,9 +41671,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/discord",
       "hasChildren": false
     },
@@ -45241,9 +41682,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45255,9 +41694,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45269,9 +41706,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/feishu",
       "help": "OpenClaw Feishu/Lark channel plugin (community maintained by @m1heng) (plugin: feishu)",
       "hasChildren": true
@@ -45283,9 +41718,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/feishu Config",
       "help": "Plugin-defined config payload for feishu.",
       "hasChildren": false
@@ -45297,9 +41730,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/feishu",
       "hasChildren": false
     },
@@ -45310,9 +41741,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45324,9 +41753,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45338,9 +41765,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/google-gemini-cli-auth",
       "help": "OpenClaw Gemini CLI OAuth provider plugin (plugin: google-gemini-cli-auth)",
       "hasChildren": true
@@ -45352,9 +41777,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/google-gemini-cli-auth Config",
       "help": "Plugin-defined config payload for google-gemini-cli-auth.",
       "hasChildren": false
@@ -45366,9 +41789,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/google-gemini-cli-auth",
       "hasChildren": false
     },
@@ -45379,9 +41800,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45393,9 +41812,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45407,9 +41824,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/googlechat",
       "help": "OpenClaw Google Chat channel plugin (plugin: googlechat)",
       "hasChildren": true
@@ -45421,9 +41836,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/googlechat Config",
       "help": "Plugin-defined config payload for googlechat.",
       "hasChildren": false
@@ -45435,9 +41848,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/googlechat",
       "hasChildren": false
     },
@@ -45448,9 +41859,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45462,9 +41871,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45476,9 +41883,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/imessage",
       "help": "OpenClaw iMessage channel plugin (plugin: imessage)",
       "hasChildren": true
@@ -45490,9 +41895,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/imessage Config",
       "help": "Plugin-defined config payload for imessage.",
       "hasChildren": false
@@ -45504,9 +41907,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/imessage",
       "hasChildren": false
     },
@@ -45517,9 +41918,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45531,9 +41930,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45545,9 +41942,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/irc",
       "help": "OpenClaw IRC channel plugin (plugin: irc)",
       "hasChildren": true
@@ -45559,9 +41954,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/irc Config",
       "help": "Plugin-defined config payload for irc.",
       "hasChildren": false
@@ -45573,9 +41966,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/irc",
       "hasChildren": false
     },
@@ -45586,9 +41977,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45600,9 +41989,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45614,9 +42001,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/line",
       "help": "OpenClaw LINE channel plugin (plugin: line)",
       "hasChildren": true
@@ -45628,9 +42013,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/line Config",
       "help": "Plugin-defined config payload for line.",
       "hasChildren": false
@@ -45642,9 +42025,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/line",
       "hasChildren": false
     },
@@ -45655,9 +42036,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45669,9 +42048,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45683,9 +42060,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "LLM Task",
       "help": "Generic JSON-only LLM tool for structured tasks callable from workflows. (plugin: llm-task)",
       "hasChildren": true
@@ -45697,9 +42072,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "LLM Task Config",
       "help": "Plugin-defined config payload for llm-task.",
       "hasChildren": true
@@ -45781,9 +42154,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable LLM Task",
       "hasChildren": false
     },
@@ -45794,9 +42165,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45808,9 +42177,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45822,9 +42189,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Lobster",
       "help": "Typed workflow tool with resumable approvals. (plugin: lobster)",
       "hasChildren": true
@@ -45836,9 +42201,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Lobster Config",
       "help": "Plugin-defined config payload for lobster.",
       "hasChildren": false
@@ -45850,9 +42213,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable Lobster",
       "hasChildren": false
     },
@@ -45863,9 +42224,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45877,9 +42236,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45891,9 +42248,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/matrix",
       "help": "OpenClaw Matrix channel plugin (plugin: matrix)",
       "hasChildren": true
@@ -45905,9 +42260,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/matrix Config",
       "help": "Plugin-defined config payload for matrix.",
       "hasChildren": false
@@ -45919,9 +42272,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/matrix",
       "hasChildren": false
     },
@@ -45932,9 +42283,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -45946,9 +42295,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -45960,9 +42307,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/mattermost",
       "help": "OpenClaw Mattermost channel plugin (plugin: mattermost)",
       "hasChildren": true
@@ -45974,9 +42319,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/mattermost Config",
       "help": "Plugin-defined config payload for mattermost.",
       "hasChildren": false
@@ -45988,9 +42331,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/mattermost",
       "hasChildren": false
     },
@@ -46001,9 +42342,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46015,9 +42354,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46029,9 +42366,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/memory-core",
       "help": "OpenClaw core memory search plugin (plugin: memory-core)",
       "hasChildren": true
@@ -46043,9 +42378,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/memory-core Config",
       "help": "Plugin-defined config payload for memory-core.",
       "hasChildren": false
@@ -46057,9 +42390,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/memory-core",
       "hasChildren": false
     },
@@ -46070,9 +42401,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46084,9 +42413,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46098,9 +42425,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "@openclaw/memory-lancedb",
       "help": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall/capture (plugin: memory-lancedb)",
       "hasChildren": true
@@ -46112,9 +42437,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "@openclaw/memory-lancedb Config",
       "help": "Plugin-defined config payload for memory-lancedb.",
       "hasChildren": true
@@ -46126,9 +42449,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Auto-Capture",
       "help": "Automatically capture important information from conversations",
       "hasChildren": false
@@ -46140,9 +42461,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Auto-Recall",
       "help": "Automatically inject relevant memories into context",
       "hasChildren": false
@@ -46154,11 +42473,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "performance",
-        "storage"
-      ],
+      "tags": ["advanced", "performance", "storage"],
       "label": "Capture Max Chars",
       "help": "Maximum message length eligible for auto-capture",
       "hasChildren": false
@@ -46170,10 +42485,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "storage"
-      ],
+      "tags": ["advanced", "storage"],
       "label": "Database Path",
       "hasChildren": false
     },
@@ -46194,11 +42506,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security",
-        "storage"
-      ],
+      "tags": ["auth", "security", "storage"],
       "label": "OpenAI API Key",
       "help": "API key for OpenAI embeddings (or use ${OPENAI_API_KEY})",
       "hasChildren": false
@@ -46210,10 +42518,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "storage"
-      ],
+      "tags": ["advanced", "storage"],
       "label": "Base URL",
       "help": "Base URL for compatible providers (e.g. http://localhost:11434/v1)",
       "hasChildren": false
@@ -46225,10 +42530,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "storage"
-      ],
+      "tags": ["advanced", "storage"],
       "label": "Dimensions",
       "help": "Vector dimensions for custom models (required for non-standard models)",
       "hasChildren": false
@@ -46240,10 +42542,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models",
-        "storage"
-      ],
+      "tags": ["models", "storage"],
       "label": "Embedding Model",
       "help": "OpenAI embedding model to use",
       "hasChildren": false
@@ -46255,9 +42554,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Enable @openclaw/memory-lancedb",
       "hasChildren": false
     },
@@ -46268,9 +42565,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46282,9 +42577,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46296,9 +42589,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "@openclaw/minimax-portal-auth",
       "help": "OpenClaw MiniMax Portal OAuth provider plugin (plugin: minimax-portal-auth)",
       "hasChildren": true
@@ -46310,9 +42601,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "@openclaw/minimax-portal-auth Config",
       "help": "Plugin-defined config payload for minimax-portal-auth.",
       "hasChildren": false
@@ -46324,9 +42613,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Enable @openclaw/minimax-portal-auth",
       "hasChildren": false
     },
@@ -46337,9 +42624,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46351,9 +42636,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46365,9 +42648,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/msteams",
       "help": "OpenClaw Microsoft Teams channel plugin (plugin: msteams)",
       "hasChildren": true
@@ -46379,9 +42660,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/msteams Config",
       "help": "Plugin-defined config payload for msteams.",
       "hasChildren": false
@@ -46393,9 +42672,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/msteams",
       "hasChildren": false
     },
@@ -46406,9 +42683,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46420,9 +42695,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46434,9 +42707,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/nextcloud-talk",
       "help": "OpenClaw Nextcloud Talk channel plugin (plugin: nextcloud-talk)",
       "hasChildren": true
@@ -46448,9 +42719,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/nextcloud-talk Config",
       "help": "Plugin-defined config payload for nextcloud-talk.",
       "hasChildren": false
@@ -46462,9 +42731,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/nextcloud-talk",
       "hasChildren": false
     },
@@ -46475,9 +42742,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46489,9 +42754,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46503,9 +42766,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/nostr",
       "help": "OpenClaw Nostr channel plugin for NIP-04 encrypted DMs (plugin: nostr)",
       "hasChildren": true
@@ -46517,9 +42778,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/nostr Config",
       "help": "Plugin-defined config payload for nostr.",
       "hasChildren": false
@@ -46531,9 +42790,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/nostr",
       "hasChildren": false
     },
@@ -46544,9 +42801,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46558,9 +42813,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46572,9 +42825,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/ollama-provider",
       "help": "OpenClaw Ollama provider plugin (plugin: ollama)",
       "hasChildren": true
@@ -46586,9 +42837,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/ollama-provider Config",
       "help": "Plugin-defined config payload for ollama.",
       "hasChildren": false
@@ -46600,9 +42849,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/ollama-provider",
       "hasChildren": false
     },
@@ -46613,9 +42860,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46627,9 +42872,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46641,9 +42884,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "OpenProse",
       "help": "OpenProse VM skill pack with a /prose slash command. (plugin: open-prose)",
       "hasChildren": true
@@ -46655,9 +42896,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "OpenProse Config",
       "help": "Plugin-defined config payload for open-prose.",
       "hasChildren": false
@@ -46669,9 +42908,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable OpenProse",
       "hasChildren": false
     },
@@ -46682,9 +42919,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46696,9 +42931,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46710,9 +42943,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Phone Control",
       "help": "Arm/disarm high-risk phone node commands (camera/screen/writes) with an optional auto-expiry. (plugin: phone-control)",
       "hasChildren": true
@@ -46724,9 +42955,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Phone Control Config",
       "help": "Plugin-defined config payload for phone-control.",
       "hasChildren": false
@@ -46738,9 +42967,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable Phone Control",
       "hasChildren": false
     },
@@ -46751,9 +42978,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46765,9 +42990,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46779,9 +43002,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "qwen-portal-auth",
       "help": "Plugin entry for qwen-portal-auth.",
       "hasChildren": true
@@ -46793,9 +43014,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "qwen-portal-auth Config",
       "help": "Plugin-defined config payload for qwen-portal-auth.",
       "hasChildren": false
@@ -46807,9 +43026,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable qwen-portal-auth",
       "hasChildren": false
     },
@@ -46820,9 +43037,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46834,9 +43049,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46848,9 +43061,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/sglang-provider",
       "help": "OpenClaw SGLang provider plugin (plugin: sglang)",
       "hasChildren": true
@@ -46862,9 +43073,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/sglang-provider Config",
       "help": "Plugin-defined config payload for sglang.",
       "hasChildren": false
@@ -46876,9 +43085,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/sglang-provider",
       "hasChildren": false
     },
@@ -46889,9 +43096,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46903,9 +43108,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46917,9 +43120,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/signal",
       "help": "OpenClaw Signal channel plugin (plugin: signal)",
       "hasChildren": true
@@ -46931,9 +43132,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/signal Config",
       "help": "Plugin-defined config payload for signal.",
       "hasChildren": false
@@ -46945,9 +43144,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/signal",
       "hasChildren": false
     },
@@ -46958,9 +43155,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -46972,9 +43167,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -46986,9 +43179,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/slack",
       "help": "OpenClaw Slack channel plugin (plugin: slack)",
       "hasChildren": true
@@ -47000,9 +43191,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/slack Config",
       "help": "Plugin-defined config payload for slack.",
       "hasChildren": false
@@ -47014,9 +43203,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/slack",
       "hasChildren": false
     },
@@ -47027,9 +43214,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -47041,9 +43226,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -47055,9 +43238,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/synology-chat",
       "help": "Synology Chat channel plugin for OpenClaw (plugin: synology-chat)",
       "hasChildren": true
@@ -47069,9 +43250,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/synology-chat Config",
       "help": "Plugin-defined config payload for synology-chat.",
       "hasChildren": false
@@ -47083,9 +43262,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/synology-chat",
       "hasChildren": false
     },
@@ -47096,9 +43273,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -47110,9 +43285,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -47124,9 +43297,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Talk Voice",
       "help": "Manage Talk voice selection (list/set). (plugin: talk-voice)",
       "hasChildren": true
@@ -47138,9 +43309,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Talk Voice Config",
       "help": "Plugin-defined config payload for talk-voice.",
       "hasChildren": false
@@ -47152,9 +43321,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable Talk Voice",
       "hasChildren": false
     },
@@ -47165,9 +43332,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -47179,9 +43344,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -47193,9 +43356,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/telegram",
       "help": "OpenClaw Telegram channel plugin (plugin: telegram)",
       "hasChildren": true
@@ -47207,9 +43368,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/telegram Config",
       "help": "Plugin-defined config payload for telegram.",
       "hasChildren": false
@@ -47221,9 +43380,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/telegram",
       "hasChildren": false
     },
@@ -47234,9 +43391,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -47248,9 +43403,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -47262,9 +43415,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Thread Ownership",
       "help": "Prevents multiple agents from responding in the same Slack thread. Uses HTTP calls to the slack-forwarder ownership API. (plugin: thread-ownership)",
       "hasChildren": true
@@ -47276,9 +43427,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Thread Ownership Config",
       "help": "Plugin-defined config payload for thread-ownership.",
       "hasChildren": true
@@ -47290,9 +43439,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "A/B Test Channels",
       "help": "Slack channel IDs where thread ownership is enforced",
       "hasChildren": true
@@ -47314,9 +43461,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Forwarder URL",
       "help": "Base URL of the slack-forwarder ownership API (default: http://slack-forwarder:8750)",
       "hasChildren": false
@@ -47328,9 +43473,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Enable Thread Ownership",
       "hasChildren": false
     },
@@ -47341,9 +43484,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -47355,9 +43496,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -47369,9 +43508,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/tlon",
       "help": "OpenClaw Tlon/Urbit channel plugin (plugin: tlon)",
       "hasChildren": true
@@ -47383,9 +43520,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/tlon Config",
       "help": "Plugin-defined config payload for tlon.",
       "hasChildren": false
@@ -47397,9 +43532,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/tlon",
       "hasChildren": false
     },
@@ -47410,9 +43543,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -47424,9 +43555,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -47438,9 +43567,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/twitch",
       "help": "OpenClaw Twitch channel plugin (plugin: twitch)",
       "hasChildren": true
@@ -47452,9 +43579,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/twitch Config",
       "help": "Plugin-defined config payload for twitch.",
       "hasChildren": false
@@ -47466,9 +43591,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/twitch",
       "hasChildren": false
     },
@@ -47479,9 +43602,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -47493,9 +43614,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -47507,9 +43626,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/vllm-provider",
       "help": "OpenClaw vLLM provider plugin (plugin: vllm)",
       "hasChildren": true
@@ -47521,9 +43638,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/vllm-provider Config",
       "help": "Plugin-defined config payload for vllm.",
       "hasChildren": false
@@ -47535,9 +43650,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/vllm-provider",
       "hasChildren": false
     },
@@ -47548,9 +43661,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -47562,9 +43673,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -47576,9 +43685,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/voice-call",
       "help": "OpenClaw voice-call plugin (plugin: voice-call)",
       "hasChildren": true
@@ -47590,9 +43697,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/voice-call Config",
       "help": "Plugin-defined config payload for voice-call.",
       "hasChildren": true
@@ -47604,9 +43709,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Inbound Allowlist",
       "hasChildren": true
     },
@@ -47637,9 +43740,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "From Number",
       "hasChildren": false
     },
@@ -47650,9 +43751,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Inbound Greeting",
       "hasChildren": false
     },
@@ -47661,17 +43760,10 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "disabled",
-        "allowlist",
-        "pairing",
-        "open"
-      ],
+      "enumValues": ["disabled", "allowlist", "pairing", "open"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Inbound Policy",
       "hasChildren": false
     },
@@ -47710,15 +43802,10 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "notify",
-        "conversation"
-      ],
+      "enumValues": ["notify", "conversation"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default Call Mode",
       "hasChildren": false
     },
@@ -47729,9 +43816,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Notify Hangup Delay (sec)",
       "hasChildren": false
     },
@@ -47770,17 +43855,10 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "telnyx",
-        "twilio",
-        "plivo",
-        "mock"
-      ],
+      "enumValues": ["telnyx", "twilio", "plivo", "mock"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Provider",
       "help": "Use twilio, telnyx, or mock for dev/no-network.",
       "hasChildren": false
@@ -47792,9 +43870,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Public Webhook URL",
       "hasChildren": false
     },
@@ -47805,9 +43881,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Response Model",
       "hasChildren": false
     },
@@ -47818,9 +43892,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Response System Prompt",
       "hasChildren": false
     },
@@ -47831,10 +43903,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "performance"
-      ],
+      "tags": ["advanced", "performance"],
       "label": "Response Timeout (ms)",
       "hasChildren": false
     },
@@ -47865,9 +43934,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Webhook Bind",
       "hasChildren": false
     },
@@ -47878,9 +43945,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Webhook Path",
       "hasChildren": false
     },
@@ -47891,9 +43956,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Webhook Port",
       "hasChildren": false
     },
@@ -47914,9 +43977,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Skip Signature Verification",
       "hasChildren": false
     },
@@ -47937,10 +43998,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "storage"
-      ],
+      "tags": ["advanced", "storage"],
       "label": "Call Log Store Path",
       "hasChildren": false
     },
@@ -47961,9 +44019,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable Streaming",
       "hasChildren": false
     },
@@ -48004,11 +44060,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "advanced",
-        "auth",
-        "security"
-      ],
+      "tags": ["advanced", "auth", "security"],
       "label": "OpenAI Realtime API Key",
       "hasChildren": false
     },
@@ -48039,10 +44091,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "storage"
-      ],
+      "tags": ["advanced", "storage"],
       "label": "Media Stream Path",
       "hasChildren": false
     },
@@ -48053,10 +44102,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "media"
-      ],
+      "tags": ["advanced", "media"],
       "label": "Realtime STT Model",
       "hasChildren": false
     },
@@ -48065,9 +44111,7 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "openai-realtime"
-      ],
+      "enumValues": ["openai-realtime"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -48108,9 +44152,7 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "openai"
-      ],
+      "enumValues": ["openai"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -48131,16 +44173,10 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "serve",
-        "funnel"
-      ],
+      "enumValues": ["off", "serve", "funnel"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Tailscale Mode",
       "hasChildren": false
     },
@@ -48151,10 +44187,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "storage"
-      ],
+      "tags": ["advanced", "storage"],
       "label": "Tailscale Path",
       "hasChildren": false
     },
@@ -48175,10 +44208,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "label": "Telnyx API Key",
       "hasChildren": false
     },
@@ -48189,9 +44219,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Telnyx Connection ID",
       "hasChildren": false
     },
@@ -48202,9 +44230,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "security"
-      ],
+      "tags": ["security"],
       "label": "Telnyx Public Key",
       "hasChildren": false
     },
@@ -48215,9 +44241,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Default To Number",
       "hasChildren": false
     },
@@ -48246,12 +44270,7 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "always",
-        "inbound",
-        "tagged"
-      ],
+      "enumValues": ["off", "always", "inbound", "tagged"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -48384,12 +44403,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "advanced",
-        "auth",
-        "media",
-        "security"
-      ],
+      "tags": ["advanced", "auth", "media", "security"],
       "label": "ElevenLabs API Key",
       "hasChildren": false
     },
@@ -48398,11 +44412,7 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "auto",
-        "on",
-        "off"
-      ],
+      "enumValues": ["auto", "on", "off"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -48415,10 +44425,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "media"
-      ],
+      "tags": ["advanced", "media"],
       "label": "ElevenLabs Base URL",
       "hasChildren": false
     },
@@ -48439,11 +44446,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "media",
-        "models"
-      ],
+      "tags": ["advanced", "media", "models"],
       "label": "ElevenLabs Model ID",
       "hasChildren": false
     },
@@ -48464,10 +44467,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "media"
-      ],
+      "tags": ["advanced", "media"],
       "label": "ElevenLabs Voice ID",
       "hasChildren": false
     },
@@ -48556,10 +44556,7 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "final",
-        "all"
-      ],
+      "enumValues": ["final", "all"],
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -48672,12 +44669,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "advanced",
-        "auth",
-        "media",
-        "security"
-      ],
+      "tags": ["advanced", "auth", "media", "security"],
       "label": "OpenAI API Key",
       "hasChildren": false
     },
@@ -48708,11 +44700,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "media",
-        "models"
-      ],
+      "tags": ["advanced", "media", "models"],
       "label": "OpenAI TTS Model",
       "hasChildren": false
     },
@@ -48733,10 +44721,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "media"
-      ],
+      "tags": ["advanced", "media"],
       "label": "OpenAI TTS Voice",
       "hasChildren": false
     },
@@ -48755,17 +44740,10 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "openai",
-        "elevenlabs",
-        "edge"
-      ],
+      "enumValues": ["openai", "elevenlabs", "edge"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced",
-        "media"
-      ],
+      "tags": ["advanced", "media"],
       "label": "TTS Provider Override",
       "help": "Deep-merges with messages.tts (Edge is ignored for calls).",
       "hasChildren": false
@@ -48807,10 +44785,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "advanced"
-      ],
+      "tags": ["access", "advanced"],
       "label": "Allow ngrok Free Tier (Loopback Bypass)",
       "hasChildren": false
     },
@@ -48821,11 +44796,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "advanced",
-        "auth",
-        "security"
-      ],
+      "tags": ["advanced", "auth", "security"],
       "label": "ngrok Auth Token",
       "hasChildren": false
     },
@@ -48836,9 +44807,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "ngrok Domain",
       "hasChildren": false
     },
@@ -48847,17 +44816,10 @@
       "kind": "plugin",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "none",
-        "ngrok",
-        "tailscale-serve",
-        "tailscale-funnel"
-      ],
+      "enumValues": ["none", "ngrok", "tailscale-serve", "tailscale-funnel"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Tunnel Provider",
       "hasChildren": false
     },
@@ -48878,9 +44840,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Twilio Account SID",
       "hasChildren": false
     },
@@ -48891,10 +44851,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "label": "Twilio Auth Token",
       "hasChildren": false
     },
@@ -48965,9 +44922,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/voice-call",
       "hasChildren": false
     },
@@ -48978,9 +44933,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -48992,9 +44945,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -49006,9 +44957,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/whatsapp",
       "help": "OpenClaw WhatsApp channel plugin (plugin: whatsapp)",
       "hasChildren": true
@@ -49020,9 +44969,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/whatsapp Config",
       "help": "Plugin-defined config payload for whatsapp.",
       "hasChildren": false
@@ -49034,9 +44981,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/whatsapp",
       "hasChildren": false
     },
@@ -49047,9 +44992,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -49061,9 +45004,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -49075,9 +45016,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/zalo",
       "help": "OpenClaw Zalo channel plugin (plugin: zalo)",
       "hasChildren": true
@@ -49089,9 +45028,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/zalo Config",
       "help": "Plugin-defined config payload for zalo.",
       "hasChildren": false
@@ -49103,9 +45040,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/zalo",
       "hasChildren": false
     },
@@ -49116,9 +45051,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -49130,9 +45063,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -49144,9 +45075,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/zalouser",
       "help": "OpenClaw Zalo Personal Account plugin via native zca-js integration (plugin: zalouser)",
       "hasChildren": true
@@ -49158,9 +45087,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "@openclaw/zalouser Config",
       "help": "Plugin-defined config payload for zalouser.",
       "hasChildren": false
@@ -49172,9 +45099,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Enable @openclaw/zalouser",
       "hasChildren": false
     },
@@ -49185,9 +45110,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Hook Policy",
       "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
       "hasChildren": true
@@ -49199,9 +45122,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access"
-      ],
+      "tags": ["access"],
       "label": "Allow Prompt Injection Hooks",
       "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
       "hasChildren": false
@@ -49213,9 +45134,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Install Records",
       "help": "CLI-managed install metadata (used by `openclaw plugins update` to locate install sources).",
       "hasChildren": true
@@ -49237,9 +45156,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Install Time",
       "help": "ISO timestamp of last install/update.",
       "hasChildren": false
@@ -49251,9 +45168,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Plugin Install Path",
       "help": "Resolved install directory (usually ~/.openclaw/extensions/<id>).",
       "hasChildren": false
@@ -49265,9 +45180,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Resolved Integrity",
       "help": "Resolved npm dist integrity hash for the fetched artifact (if reported by npm).",
       "hasChildren": false
@@ -49279,9 +45192,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Resolution Time",
       "help": "ISO timestamp when npm package metadata was last resolved for this install record.",
       "hasChildren": false
@@ -49293,9 +45204,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Resolved Package Name",
       "help": "Resolved npm package name from the fetched artifact.",
       "hasChildren": false
@@ -49307,9 +45216,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Resolved Package Spec",
       "help": "Resolved exact npm spec (<name>@<version>) from the fetched artifact.",
       "hasChildren": false
@@ -49321,9 +45228,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Resolved Package Version",
       "help": "Resolved npm package version from the fetched artifact (useful for non-pinned specs).",
       "hasChildren": false
@@ -49335,9 +45240,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Resolved Shasum",
       "help": "Resolved npm dist shasum for the fetched artifact (if reported by npm).",
       "hasChildren": false
@@ -49349,9 +45252,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Install Source",
       "help": "Install source (\"npm\", \"archive\", or \"path\").",
       "hasChildren": false
@@ -49363,9 +45264,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Plugin Install Source Path",
       "help": "Original archive/path used for install (if any).",
       "hasChildren": false
@@ -49377,9 +45276,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Install Spec",
       "help": "Original npm spec used for install (if source is npm).",
       "hasChildren": false
@@ -49391,9 +45288,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Install Version",
       "help": "Version recorded at install time (if available).",
       "hasChildren": false
@@ -49405,9 +45300,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Loader",
       "help": "Plugin loader configuration group for specifying filesystem paths where plugins are discovered. Keep load paths explicit and reviewed to avoid accidental untrusted extension loading.",
       "hasChildren": true
@@ -49419,9 +45312,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Plugin Load Paths",
       "help": "Additional plugin files or directories scanned by the loader beyond built-in defaults. Use dedicated extension directories and avoid broad paths with unrelated executable content.",
       "hasChildren": true
@@ -49443,9 +45334,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Plugin Slots",
       "help": "Selects which plugins own exclusive runtime slots such as memory so only one plugin provides that capability. Use explicit slot ownership to avoid overlapping providers with conflicting behavior.",
       "hasChildren": true
@@ -49457,9 +45346,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Context Engine Plugin",
       "help": "Selects the active context engine plugin by id so one plugin provides context orchestration behavior.",
       "hasChildren": false
@@ -49471,9 +45358,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Memory Plugin",
       "help": "Select the active memory plugin by id, or \"none\" to disable memory plugins.",
       "hasChildren": false
@@ -49805,9 +45690,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session",
       "help": "Global session routing, reset, delivery policy, and maintenance controls for conversation history behavior. Keep defaults unless you need stricter isolation, retention, or delivery constraints.",
       "hasChildren": true
@@ -49819,9 +45702,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Agent-to-Agent",
       "help": "Groups controls for inter-agent session exchanges, including loop prevention limits on reply chaining. Keep defaults unless you run advanced agent-to-agent automation with strict turn caps.",
       "hasChildren": true
@@ -49833,10 +45714,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "Agent-to-Agent Ping-Pong Turns",
       "help": "Max reply-back turns between requester and target agents during agent-to-agent exchanges (0-5). Use lower values to hard-limit chatter loops and preserve predictable run completion.",
       "hasChildren": false
@@ -49848,9 +45726,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "DM Session Scope",
       "help": "DM session scoping: \"main\" keeps continuity, while \"per-peer\", \"per-channel-peer\", and \"per-account-channel-peer\" increase isolation. Use isolated modes for shared inboxes or multi-account deployments.",
       "hasChildren": false
@@ -49862,9 +45738,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Identity Links",
       "help": "Maps canonical identities to provider-prefixed peer IDs so equivalent users resolve to one DM thread (example: telegram:123456). Use this when the same human appears across multiple channels or accounts.",
       "hasChildren": true
@@ -49896,9 +45770,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Idle Minutes",
       "help": "Applies a legacy idle reset window in minutes for session reuse behavior across inactivity gaps. Use this only for compatibility and prefer structured reset policies under session.reset/session.resetByType.",
       "hasChildren": false
@@ -49910,9 +45782,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Main Key",
       "help": "Overrides the canonical main session key used for continuity when dmScope or routing logic points to \"main\". Use a stable value only if you intentionally need custom session anchoring.",
       "hasChildren": false
@@ -49924,9 +45794,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Maintenance",
       "help": "Automatic session-store maintenance controls for pruning age, entry caps, and file rotation behavior. Start in warn mode to observe impact, then enforce once thresholds are tuned.",
       "hasChildren": true
@@ -49934,16 +45802,11 @@
     {
       "path": "session.maintenance.highWaterBytes",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Disk High-water Target",
       "help": "Target size after disk-budget cleanup (high-water mark). Defaults to 80% of maxDiskBytes; set explicitly for tighter reclaim behavior on constrained disks.",
       "hasChildren": false
@@ -49951,17 +45814,11 @@
     {
       "path": "session.maintenance.maxDiskBytes",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "Session Max Disk Budget",
       "help": "Optional per-agent sessions-directory disk budget (for example `500mb`). Use this to cap session storage per agent; when exceeded, warn mode reports pressure and enforce mode performs oldest-first cleanup.",
       "hasChildren": false
@@ -49973,10 +45830,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "Session Max Entries",
       "help": "Caps total session entry count retained in the store to prevent unbounded growth over time. Use lower limits for constrained environments, or higher limits when longer history is required.",
       "hasChildren": false
@@ -49986,15 +45840,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "enforce",
-        "warn"
-      ],
+      "enumValues": ["enforce", "warn"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Maintenance Mode",
       "help": "Determines whether maintenance policies are only reported (\"warn\") or actively applied (\"enforce\"). Keep \"warn\" during rollout and switch to \"enforce\" after validating safe thresholds.",
       "hasChildren": false
@@ -50002,16 +45851,11 @@
     {
       "path": "session.maintenance.pruneAfter",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Prune After",
       "help": "Removes entries older than this duration (for example `30d` or `12h`) during maintenance passes. Use this as the primary age-retention control and align it with data retention policy.",
       "hasChildren": false
@@ -50023,9 +45867,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Prune Days (Deprecated)",
       "help": "Deprecated age-retention field kept for compatibility with legacy configs using day counts. Use session.maintenance.pruneAfter instead so duration syntax and behavior are consistent.",
       "hasChildren": false
@@ -50033,17 +45875,11 @@
     {
       "path": "session.maintenance.resetArchiveRetention",
       "kind": "core",
-      "type": [
-        "boolean",
-        "number",
-        "string"
-      ],
+      "type": ["boolean", "number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset Archive Retention",
       "help": "Retention for reset transcript archives (`*.reset.<timestamp>`). Accepts a duration (for example `30d`), or `false` to disable cleanup. Defaults to pruneAfter so reset artifacts do not grow forever.",
       "hasChildren": false
@@ -50051,16 +45887,11 @@
     {
       "path": "session.maintenance.rotateBytes",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Rotate Size",
       "help": "Rotates the session store when file size exceeds a threshold such as `10mb` or `1gb`. Use this to bound single-file growth and keep backup/restore operations manageable.",
       "hasChildren": false
@@ -50072,12 +45903,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "auth",
-        "performance",
-        "security",
-        "storage"
-      ],
+      "tags": ["auth", "performance", "security", "storage"],
       "label": "Session Parent Fork Max Tokens",
       "help": "Maximum parent-session token count allowed for thread/session inheritance forking. If the parent exceeds this, OpenClaw starts a fresh thread session instead of forking; set 0 to disable this protection.",
       "hasChildren": false
@@ -50089,9 +45915,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset Policy",
       "help": "Defines the default reset policy object used when no type-specific or channel-specific override applies. Set this first, then layer resetByType or resetByChannel only where behavior must differ.",
       "hasChildren": true
@@ -50103,9 +45927,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Daily Reset Hour",
       "help": "Sets local-hour boundary (0-23) for daily reset mode so sessions roll over at predictable times. Use with mode=daily and align to operator timezone expectations for human-readable behavior.",
       "hasChildren": false
@@ -50117,9 +45939,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset Idle Minutes",
       "help": "Sets inactivity window before reset for idle mode and can also act as secondary guard with daily mode. Use larger values to preserve continuity or smaller values for fresher short-lived threads.",
       "hasChildren": false
@@ -50131,9 +45951,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset Mode",
       "help": "Selects reset strategy: \"daily\" resets at a configured hour and \"idle\" resets after inactivity windows. Keep one clear mode per policy to avoid surprising context turnover patterns.",
       "hasChildren": false
@@ -50145,9 +45963,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset by Channel",
       "help": "Provides channel-specific reset overrides keyed by provider/channel id for fine-grained behavior control. Use this only when one channel needs exceptional reset behavior beyond type-level policies.",
       "hasChildren": true
@@ -50199,9 +46015,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset by Chat Type",
       "help": "Overrides reset behavior by chat type (direct, group, thread) when defaults are not sufficient. Use this when group/thread traffic needs different reset cadence than direct messages.",
       "hasChildren": true
@@ -50213,9 +46027,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset (Direct)",
       "help": "Defines reset policy for direct chats and supersedes the base session.reset configuration for that type. Use this as the canonical direct-message override instead of the legacy dm alias.",
       "hasChildren": true
@@ -50257,9 +46069,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset (DM Deprecated Alias)",
       "help": "Deprecated alias for direct reset behavior kept for backward compatibility with older configs. Use session.resetByType.direct instead so future tooling and validation remain consistent.",
       "hasChildren": true
@@ -50301,9 +46111,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset (Group)",
       "help": "Defines reset policy for group chat sessions where continuity and noise patterns differ from DMs. Use shorter idle windows for busy groups if context drift becomes a problem.",
       "hasChildren": true
@@ -50345,9 +46153,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset (Thread)",
       "help": "Defines reset policy for thread-scoped sessions, including focused channel thread workflows. Use this when thread sessions should expire faster or slower than other chat types.",
       "hasChildren": true
@@ -50389,9 +46195,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Reset Triggers",
       "help": "Lists message triggers that force a session reset when matched in inbound content. Use sparingly for explicit reset phrases so context is not dropped unexpectedly during normal conversation.",
       "hasChildren": true
@@ -50413,9 +46217,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Scope",
       "help": "Sets base session grouping strategy: \"per-sender\" isolates by sender and \"global\" shares one session per channel context. Keep \"per-sender\" for safer multi-user behavior unless deliberate shared context is required.",
       "hasChildren": false
@@ -50427,10 +46229,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Session Send Policy",
       "help": "Controls cross-session send permissions using allow/deny rules evaluated against channel, chatType, and key prefixes. Use this to fence where session tools can deliver messages in complex environments.",
       "hasChildren": true
@@ -50442,10 +46241,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Session Send Policy Default Action",
       "help": "Sets fallback action when no sendPolicy rule matches: \"allow\" or \"deny\". Keep \"allow\" for simpler setups, or choose \"deny\" when you require explicit allow rules for every destination.",
       "hasChildren": false
@@ -50457,10 +46253,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Session Send Policy Rules",
       "help": "Ordered allow/deny rules evaluated before the default action, for example `{ action: \"deny\", match: { channel: \"discord\" } }`. Put most specific rules first so broad rules do not shadow exceptions.",
       "hasChildren": true
@@ -50482,10 +46275,7 @@
       "required": true,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Session Send Rule Action",
       "help": "Defines rule decision as \"allow\" or \"deny\" when the corresponding match criteria are satisfied. Use deny-first ordering when enforcing strict boundaries with explicit allow exceptions.",
       "hasChildren": false
@@ -50497,10 +46287,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Session Send Rule Match",
       "help": "Defines optional rule match conditions that can combine channel, chatType, and key-prefix constraints. Keep matches narrow so policy intent stays readable and debugging remains straightforward.",
       "hasChildren": true
@@ -50512,10 +46299,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Session Send Rule Channel",
       "help": "Matches rule application to a specific channel/provider id (for example discord, telegram, slack). Use this when one channel should permit or deny delivery independently of others.",
       "hasChildren": false
@@ -50527,10 +46311,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Session Send Rule Chat Type",
       "help": "Matches rule application to chat type (direct, group, thread) so behavior varies by conversation form. Use this when DM and group destinations require different safety boundaries.",
       "hasChildren": false
@@ -50542,10 +46323,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Session Send Rule Key Prefix",
       "help": "Matches a normalized session-key prefix after internal key normalization steps in policy consumers. Use this for general prefix controls, and prefer rawKeyPrefix when exact full-key matching is required.",
       "hasChildren": false
@@ -50557,10 +46335,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "storage"
-      ],
+      "tags": ["access", "storage"],
       "label": "Session Send Rule Raw Key Prefix",
       "help": "Matches the raw, unnormalized session-key prefix for exact full-key policy targeting. Use this when normalized keyPrefix is too broad and you need agent-prefixed or transport-specific precision.",
       "hasChildren": false
@@ -50572,9 +46347,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Store Path",
       "help": "Sets the session storage file path used to persist session records across restarts. Use an explicit path only when you need custom disk layout, backup routing, or mounted-volume storage.",
       "hasChildren": false
@@ -50586,9 +46359,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Thread Bindings",
       "help": "Shared defaults for thread-bound session routing behavior across providers that support thread focus workflows. Configure global defaults here and override per channel only when behavior differs.",
       "hasChildren": true
@@ -50600,9 +46371,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Thread Binding Enabled",
       "help": "Global master switch for thread-bound session routing features and focused thread delivery behavior. Keep enabled for modern thread workflows unless you need to disable thread binding globally.",
       "hasChildren": false
@@ -50614,9 +46383,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Thread Binding Idle Timeout (hours)",
       "help": "Default inactivity window in hours for thread-bound sessions across providers/channels (0 disables idle auto-unfocus). Default: 24.",
       "hasChildren": false
@@ -50628,10 +46395,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "Thread Binding Max Age (hours)",
       "help": "Optional hard max age in hours for thread-bound sessions across providers/channels (0 disables hard cap). Default: 0.",
       "hasChildren": false
@@ -50643,10 +46407,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage"
-      ],
+      "tags": ["performance", "storage"],
       "label": "Session Typing Interval (seconds)",
       "help": "Controls interval for repeated typing indicators while replies are being prepared in typing-capable channels. Increase to reduce chatty updates or decrease for more active typing feedback.",
       "hasChildren": false
@@ -50658,9 +46419,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage"
-      ],
+      "tags": ["storage"],
       "label": "Session Typing Mode",
       "help": "Controls typing behavior timing: \"never\", \"instant\", \"thinking\", or \"message\" based emission points. Keep conservative modes in high-volume channels to avoid unnecessary typing noise.",
       "hasChildren": false
@@ -50672,9 +46431,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Skills",
       "hasChildren": true
     },
@@ -50721,17 +46478,11 @@
     {
       "path": "skills.entries.*.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security"
-      ],
+      "tags": ["auth", "security"],
       "hasChildren": true
     },
     {
@@ -50940,9 +46691,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Watch Skills",
       "help": "Enable filesystem watching for skill-definition changes so updates can be applied without full process restart. Keep enabled in development workflows and disable in immutable production images.",
       "hasChildren": false
@@ -50954,10 +46703,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation",
-        "performance"
-      ],
+      "tags": ["automation", "performance"],
       "label": "Skills Watch Debounce (ms)",
       "help": "Debounce window in milliseconds for coalescing rapid skill file changes before reload logic runs. Increase to reduce reload churn on frequent writes, or lower for faster edit feedback.",
       "hasChildren": false
@@ -50969,9 +46715,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Talk",
       "help": "Talk-mode voice synthesis settings for voice identity, model selection, output format, and interruption behavior. Use this section to tune human-facing voice UX while controlling latency and cost.",
       "hasChildren": true
@@ -50979,18 +46723,11 @@
     {
       "path": "talk.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "media",
-        "security"
-      ],
+      "tags": ["auth", "media", "security"],
       "label": "Talk API Key",
       "help": "Use this legacy ElevenLabs API key for Talk mode only during migration, and keep secrets in env-backed storage. Prefer talk.providers.elevenlabs.apiKey (fallback: ELEVENLABS_API_KEY).",
       "hasChildren": true
@@ -51032,9 +46769,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Talk Interrupt on Speech",
       "help": "If true (default), stop assistant speech when the user starts speaking in Talk mode. Keep enabled for conversational turn-taking.",
       "hasChildren": false
@@ -51046,10 +46781,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "models"
-      ],
+      "tags": ["media", "models"],
       "label": "Talk Model ID",
       "help": "Legacy ElevenLabs model ID for Talk mode (default: eleven_v3). Prefer talk.providers.elevenlabs.modelId.",
       "hasChildren": false
@@ -51061,9 +46793,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Talk Output Format",
       "help": "Use this legacy ElevenLabs output format for Talk mode (for example pcm_44100 or mp3_44100_128) only during migration. Prefer talk.providers.elevenlabs.outputFormat.",
       "hasChildren": false
@@ -51075,9 +46805,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Talk Active Provider",
       "help": "Active Talk provider id (for example \"elevenlabs\").",
       "hasChildren": false
@@ -51089,9 +46817,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Talk Provider Settings",
       "help": "Provider-specific Talk settings keyed by provider id. During migration, prefer this over legacy talk.* keys.",
       "hasChildren": true
@@ -51118,18 +46844,11 @@
     {
       "path": "talk.providers.*.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "media",
-        "security"
-      ],
+      "tags": ["auth", "media", "security"],
       "label": "Talk Provider API Key",
       "help": "Provider API key for Talk mode.",
       "hasChildren": true
@@ -51171,10 +46890,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "models"
-      ],
+      "tags": ["media", "models"],
       "label": "Talk Provider Model ID",
       "help": "Provider default model ID for Talk mode.",
       "hasChildren": false
@@ -51186,9 +46902,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Talk Provider Output Format",
       "help": "Provider default output format for Talk mode.",
       "hasChildren": false
@@ -51200,9 +46914,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Talk Provider Voice Aliases",
       "help": "Optional provider voice alias map for Talk directives.",
       "hasChildren": true
@@ -51224,9 +46936,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Talk Provider Voice ID",
       "help": "Provider default voice ID for Talk mode.",
       "hasChildren": false
@@ -51238,10 +46948,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance"
-      ],
+      "tags": ["media", "performance"],
       "label": "Talk Silence Timeout (ms)",
       "help": "Milliseconds of user silence before Talk mode finalizes and sends the current transcript. Leave unset to keep the platform default pause window (700 ms on macOS and Android, 900 ms on iOS).",
       "hasChildren": false
@@ -51253,9 +46960,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Talk Voice Aliases",
       "help": "Use this legacy ElevenLabs voice alias map (for example {\"Clawd\":\"EXAVITQu4vr4xnSDxMaL\"}) only during migration. Prefer talk.providers.elevenlabs.voiceAliases.",
       "hasChildren": true
@@ -51277,9 +46982,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media"
-      ],
+      "tags": ["media"],
       "label": "Talk Voice ID",
       "help": "Legacy ElevenLabs default voice ID for Talk mode. Prefer talk.providers.elevenlabs.voiceId.",
       "hasChildren": false
@@ -51291,9 +46994,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Tools",
       "help": "Global tool access policy and capability configuration across web, exec, media, messaging, and elevated surfaces. Use this section to constrain risky capabilities before broad rollout.",
       "hasChildren": true
@@ -51305,9 +47006,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Agent-to-Agent Tool Access",
       "help": "Policy for allowing agent-to-agent tool calls and constraining which target agents can be reached. Keep disabled or tightly scoped unless cross-agent orchestration is intentionally enabled.",
       "hasChildren": true
@@ -51319,10 +47018,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "tools"
-      ],
+      "tags": ["access", "tools"],
       "label": "Agent-to-Agent Target Allowlist",
       "help": "Allowlist of target agent IDs permitted for agent_to_agent calls when orchestration is enabled. Use explicit allowlists to avoid uncontrolled cross-agent call graphs.",
       "hasChildren": true
@@ -51344,9 +47040,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Enable Agent-to-Agent Tool",
       "help": "Enables the agent_to_agent tool surface so one agent can invoke another agent at runtime. Keep off in simple deployments and enable only when orchestration value outweighs complexity.",
       "hasChildren": false
@@ -51358,10 +47052,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "tools"
-      ],
+      "tags": ["access", "tools"],
       "label": "Tool Allowlist",
       "help": "Absolute tool allowlist that replaces profile-derived defaults for strict environments. Use this only when you intentionally run a tightly curated subset of tool capabilities.",
       "hasChildren": true
@@ -51383,10 +47074,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "tools"
-      ],
+      "tags": ["access", "tools"],
       "label": "Tool Allowlist Additions",
       "help": "Extra tool allowlist entries merged on top of the selected tool profile and default policy. Keep this list small and explicit so audits can quickly identify intentional policy exceptions.",
       "hasChildren": true
@@ -51408,9 +47096,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Tool Policy by Provider",
       "help": "Per-provider tool allow/deny overrides keyed by channel/provider ID to tailor capabilities by surface. Use this when one provider needs stricter controls than global tool policy.",
       "hasChildren": true
@@ -51502,10 +47188,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "tools"
-      ],
+      "tags": ["access", "tools"],
       "label": "Tool Denylist",
       "help": "Global tool denylist that blocks listed tools even when profile or provider rules would allow them. Use deny rules for emergency lockouts and long-term defense-in-depth.",
       "hasChildren": true
@@ -51527,9 +47210,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Elevated Tool Access",
       "help": "Elevated tool access controls for privileged command surfaces that should only be reachable from trusted senders. Keep disabled unless operator workflows explicitly require elevated actions.",
       "hasChildren": true
@@ -51541,10 +47222,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "tools"
-      ],
+      "tags": ["access", "tools"],
       "label": "Elevated Tool Allow Rules",
       "help": "Sender allow rules for elevated tools, usually keyed by channel/provider identity formats. Use narrow, explicit identities so elevated commands cannot be triggered by unintended users.",
       "hasChildren": true
@@ -51562,10 +47240,7 @@
     {
       "path": "tools.elevated.allowFrom.*.*",
       "kind": "core",
-      "type": [
-        "number",
-        "string"
-      ],
+      "type": ["number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -51579,9 +47254,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Enable Elevated Tool Access",
       "help": "Enables elevated tool execution path when sender and policy checks pass. Keep disabled in public/shared channels and enable only for trusted owner-operated contexts.",
       "hasChildren": false
@@ -51593,9 +47266,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Exec Tool",
       "help": "Exec-tool policy grouping for shell execution host, security mode, approval behavior, and runtime bindings. Keep conservative defaults in production and tighten elevated execution paths.",
       "hasChildren": true
@@ -51617,10 +47288,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "tools"
-      ],
+      "tags": ["access", "tools"],
       "label": "apply_patch Model Allowlist",
       "help": "Optional allowlist of model ids (e.g. \"gpt-5.2\" or \"openai/gpt-5.2\").",
       "hasChildren": true
@@ -51642,9 +47310,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Enable apply_patch",
       "help": "Experimental. Enables apply_patch for OpenAI models when allowed by tool policy.",
       "hasChildren": false
@@ -51656,12 +47322,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "advanced",
-        "security",
-        "tools"
-      ],
+      "tags": ["access", "advanced", "security", "tools"],
       "label": "apply_patch Workspace-Only",
       "help": "Restrict apply_patch paths to the workspace directory (default: true). Set false to allow writing outside the workspace (dangerous).",
       "hasChildren": false
@@ -51671,16 +47332,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "off",
-        "on-miss",
-        "always"
-      ],
+      "enumValues": ["off", "on-miss", "always"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Exec Ask",
       "help": "Approval strategy for when exec commands require human confirmation before running. Use stricter ask behavior in shared channels and lower-friction settings in private operator contexts.",
       "hasChildren": false
@@ -51710,16 +47365,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "sandbox",
-        "gateway",
-        "node"
-      ],
+      "enumValues": ["sandbox", "gateway", "node"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Exec Host",
       "help": "Selects execution host strategy for shell commands, typically controlling local vs delegated execution environment. Use the safest host mode that still satisfies your automation requirements.",
       "hasChildren": false
@@ -51731,9 +47380,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Exec Node Binding",
       "help": "Node binding configuration for exec tooling when command execution is delegated through connected nodes. Use explicit node binding only when multi-node routing is required.",
       "hasChildren": false
@@ -51745,9 +47392,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Exec Notify On Exit",
       "help": "When true (default), backgrounded exec sessions on exit and node exec lifecycle events enqueue a system event and request a heartbeat.",
       "hasChildren": false
@@ -51759,9 +47404,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Exec Notify On Empty Success",
       "help": "When true, successful backgrounded exec exits with empty output still enqueue a completion system event (default: false).",
       "hasChildren": false
@@ -51773,10 +47416,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage",
-        "tools"
-      ],
+      "tags": ["storage", "tools"],
       "label": "Exec PATH Prepend",
       "help": "Directories to prepend to PATH for exec runs (gateway/sandbox).",
       "hasChildren": true
@@ -51798,10 +47438,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage",
-        "tools"
-      ],
+      "tags": ["storage", "tools"],
       "label": "Exec Safe Bin Profiles",
       "help": "Optional per-binary safe-bin profiles (positional limits + allowed/denied flags).",
       "hasChildren": true
@@ -51883,9 +47520,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Exec Safe Bins",
       "help": "Allow stdin-only safe binaries to run without explicit allowlist entries.",
       "hasChildren": true
@@ -51907,10 +47542,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage",
-        "tools"
-      ],
+      "tags": ["storage", "tools"],
       "label": "Exec Safe Bin Trusted Dirs",
       "help": "Additional explicit directories trusted for safe-bin path checks (PATH entries are never auto-trusted).",
       "hasChildren": true
@@ -51930,16 +47562,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "deny",
-        "allowlist",
-        "full"
-      ],
+      "enumValues": ["deny", "allowlist", "full"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Exec Security",
       "help": "Execution security posture selector controlling sandbox/approval expectations for command execution. Keep strict security mode for untrusted prompts and relax only for trusted operator workflows.",
       "hasChildren": false
@@ -51971,9 +47597,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Workspace-only FS tools",
       "help": "Restrict filesystem tools (read/write/edit/apply_patch) to the workspace directory (default: false).",
       "hasChildren": false
@@ -51995,9 +47619,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Enable Link Understanding",
       "help": "Enable automatic link understanding pre-processing so URLs can be summarized before agent reasoning. Keep enabled for richer context, and disable when strict minimal processing is required.",
       "hasChildren": false
@@ -52009,10 +47631,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "tools"
-      ],
+      "tags": ["performance", "tools"],
       "label": "Link Understanding Max Links",
       "help": "Maximum number of links expanded per turn during link understanding. Use lower values to control latency/cost in chatty threads and higher values when multi-link context is critical.",
       "hasChildren": false
@@ -52024,10 +47643,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models",
-        "tools"
-      ],
+      "tags": ["models", "tools"],
       "label": "Link Understanding Models",
       "help": "Preferred model list for link understanding tasks, evaluated in order as fallbacks when supported. Use lightweight models first for routine summarization and heavier models only when needed.",
       "hasChildren": true
@@ -52099,9 +47715,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Link Understanding Scope",
       "help": "Controls when link understanding runs relative to conversation context and message type. Keep scope conservative to avoid unnecessary fetches on messages where links are not actionable.",
       "hasChildren": true
@@ -52203,10 +47817,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "tools"
-      ],
+      "tags": ["performance", "tools"],
       "label": "Link Understanding Timeout (sec)",
       "help": "Per-link understanding timeout budget in seconds before unresolved links are skipped. Keep this bounded to avoid long stalls when external sites are slow or unreachable.",
       "hasChildren": false
@@ -52228,9 +47839,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Tool-loop Critical Threshold",
       "help": "Critical threshold for repetitive patterns when detector is enabled (default: 20).",
       "hasChildren": false
@@ -52252,9 +47861,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Tool-loop Generic Repeat Detection",
       "help": "Enable generic repeated same-tool/same-params loop detection (default: true).",
       "hasChildren": false
@@ -52266,9 +47873,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Tool-loop Poll No-Progress Detection",
       "help": "Enable known poll tool no-progress loop detection (default: true).",
       "hasChildren": false
@@ -52280,9 +47885,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Tool-loop Ping-Pong Detection",
       "help": "Enable ping-pong loop detection (default: true).",
       "hasChildren": false
@@ -52294,9 +47897,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Tool-loop Detection",
       "help": "Enable repetitive tool-call loop detection and backoff safety checks (default: false).",
       "hasChildren": false
@@ -52308,10 +47909,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "reliability",
-        "tools"
-      ],
+      "tags": ["reliability", "tools"],
       "label": "Tool-loop Global Circuit Breaker Threshold",
       "help": "Global no-progress breaker threshold (default: 30).",
       "hasChildren": false
@@ -52323,9 +47921,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Tool-loop History Size",
       "help": "Tool history window size for loop detection (default: 30).",
       "hasChildren": false
@@ -52337,9 +47933,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Tool-loop Warning Threshold",
       "help": "Warning threshold for repetitive patterns when detector is enabled (default: 10).",
       "hasChildren": false
@@ -52371,10 +47965,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Audio Understanding Attachment Policy",
       "help": "Attachment policy for audio inputs indicating which uploaded files are eligible for audio processing. Keep restrictive defaults in mixed-content channels to avoid unintended audio workloads.",
       "hasChildren": true
@@ -52466,10 +48057,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Transcript Echo Format",
       "help": "Format string for the echoed transcript message. Use `{transcript}` as a placeholder for the transcribed text. Default: '📝 \"{transcript}\"'.",
       "hasChildren": false
@@ -52481,10 +48069,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Echo Transcript to Chat",
       "help": "Echo the audio transcript back to the originating chat before agent processing. When enabled, users immediately see what was heard from their voice note, helping them verify transcription accuracy before the agent acts on it. Default: false.",
       "hasChildren": false
@@ -52496,10 +48081,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Enable Audio Understanding",
       "help": "Enable audio understanding so voice notes or audio clips can be transcribed/summarized for agent context. Disable when audio ingestion is outside policy or unnecessary for your workflows.",
       "hasChildren": false
@@ -52531,10 +48113,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Audio Understanding Language",
       "help": "Preferred language hint for audio understanding/transcription when provider support is available. Set this to improve recognition accuracy for known primary languages.",
       "hasChildren": false
@@ -52546,11 +48125,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance",
-        "tools"
-      ],
+      "tags": ["media", "performance", "tools"],
       "label": "Audio Understanding Max Bytes",
       "help": "Maximum accepted audio payload size in bytes before processing is rejected or clipped by policy. Set this based on expected recording length and upstream provider limits.",
       "hasChildren": false
@@ -52562,11 +48137,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance",
-        "tools"
-      ],
+      "tags": ["media", "performance", "tools"],
       "label": "Audio Understanding Max Chars",
       "help": "Maximum characters retained from audio understanding output to prevent oversized transcript injection. Increase for long-form dictation, or lower to keep conversational turns compact.",
       "hasChildren": false
@@ -52578,11 +48149,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "models",
-        "tools"
-      ],
+      "tags": ["media", "models", "tools"],
       "label": "Audio Understanding Models",
       "help": "Ordered model preferences specifically for audio understanding, used before shared media model fallback. Choose models optimized for transcription quality in your primary language/domain.",
       "hasChildren": true
@@ -52820,11 +48387,7 @@
     {
       "path": "tools.media.audio.models.*.providerOptions.*.*",
       "kind": "core",
-      "type": [
-        "boolean",
-        "number",
-        "string"
-      ],
+      "type": ["boolean", "number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -52858,10 +48421,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Audio Understanding Prompt",
       "help": "Instruction template guiding audio understanding output style, such as concise summary versus near-verbatim transcript. Keep wording consistent so downstream automations can rely on output format.",
       "hasChildren": false
@@ -52889,11 +48449,7 @@
     {
       "path": "tools.media.audio.providerOptions.*.*",
       "kind": "core",
-      "type": [
-        "boolean",
-        "number",
-        "string"
-      ],
+      "type": ["boolean", "number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -52907,10 +48463,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Audio Understanding Scope",
       "help": "Scope selector for when audio understanding runs across inbound messages and attachments. Keep focused scopes in high-volume channels to reduce cost and avoid accidental transcription.",
       "hasChildren": true
@@ -53012,11 +48565,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance",
-        "tools"
-      ],
+      "tags": ["media", "performance", "tools"],
       "label": "Audio Understanding Timeout (sec)",
       "help": "Timeout in seconds for audio understanding execution before the operation is cancelled. Use longer timeouts for long recordings and tighter ones for interactive chat responsiveness.",
       "hasChildren": false
@@ -53028,11 +48577,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance",
-        "tools"
-      ],
+      "tags": ["media", "performance", "tools"],
       "label": "Media Understanding Concurrency",
       "help": "Maximum number of concurrent media understanding operations per turn across image, audio, and video tasks. Lower this in resource-constrained deployments to prevent CPU/network saturation.",
       "hasChildren": false
@@ -53054,10 +48599,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Image Understanding Attachment Policy",
       "help": "Attachment handling policy for image inputs, including which message attachments qualify for image analysis. Use restrictive settings in untrusted channels to reduce unexpected processing.",
       "hasChildren": true
@@ -53169,10 +48711,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Enable Image Understanding",
       "help": "Enable image understanding so attached or referenced images can be interpreted into textual context. Disable if you need text-only operation or want to avoid image-processing cost.",
       "hasChildren": false
@@ -53214,11 +48753,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance",
-        "tools"
-      ],
+      "tags": ["media", "performance", "tools"],
       "label": "Image Understanding Max Bytes",
       "help": "Maximum accepted image payload size in bytes before the item is skipped or truncated by policy. Keep limits realistic for your provider caps and infrastructure bandwidth.",
       "hasChildren": false
@@ -53230,11 +48765,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance",
-        "tools"
-      ],
+      "tags": ["media", "performance", "tools"],
       "label": "Image Understanding Max Chars",
       "help": "Maximum characters returned from image understanding output after model response normalization. Use tighter limits to reduce prompt bloat and larger limits for detail-heavy OCR tasks.",
       "hasChildren": false
@@ -53246,11 +48777,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "models",
-        "tools"
-      ],
+      "tags": ["media", "models", "tools"],
       "label": "Image Understanding Models",
       "help": "Ordered model preferences specifically for image understanding when you want to override shared media models. Put the most reliable multimodal model first to reduce fallback attempts.",
       "hasChildren": true
@@ -53488,11 +49015,7 @@
     {
       "path": "tools.media.image.models.*.providerOptions.*.*",
       "kind": "core",
-      "type": [
-        "boolean",
-        "number",
-        "string"
-      ],
+      "type": ["boolean", "number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -53526,10 +49049,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Image Understanding Prompt",
       "help": "Instruction template used for image understanding requests to shape extraction style and detail level. Keep prompts deterministic so outputs stay consistent across turns and channels.",
       "hasChildren": false
@@ -53557,11 +49077,7 @@
     {
       "path": "tools.media.image.providerOptions.*.*",
       "kind": "core",
-      "type": [
-        "boolean",
-        "number",
-        "string"
-      ],
+      "type": ["boolean", "number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -53575,10 +49091,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Image Understanding Scope",
       "help": "Scope selector for when image understanding is attempted (for example only explicit requests versus broader auto-detection). Keep narrow scope in busy channels to control token and API spend.",
       "hasChildren": true
@@ -53680,11 +49193,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance",
-        "tools"
-      ],
+      "tags": ["media", "performance", "tools"],
       "label": "Image Understanding Timeout (sec)",
       "help": "Timeout in seconds for each image understanding request before it is aborted. Increase for high-resolution analysis and lower it for latency-sensitive operator workflows.",
       "hasChildren": false
@@ -53696,11 +49205,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "models",
-        "tools"
-      ],
+      "tags": ["media", "models", "tools"],
       "label": "Media Understanding Shared Models",
       "help": "Shared fallback model list used by media understanding tools when modality-specific model lists are not set. Keep this aligned with available multimodal providers to avoid runtime fallback churn.",
       "hasChildren": true
@@ -53938,11 +49443,7 @@
     {
       "path": "tools.media.models.*.providerOptions.*.*",
       "kind": "core",
-      "type": [
-        "boolean",
-        "number",
-        "string"
-      ],
+      "type": ["boolean", "number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -53986,10 +49487,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Video Understanding Attachment Policy",
       "help": "Attachment eligibility policy for video analysis, defining which message files can trigger video processing. Keep this explicit in shared channels to prevent accidental large media workloads.",
       "hasChildren": true
@@ -54101,10 +49599,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Enable Video Understanding",
       "help": "Enable video understanding so clips can be summarized into text for downstream reasoning and responses. Disable when processing video is out of policy or too expensive for your deployment.",
       "hasChildren": false
@@ -54146,11 +49641,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance",
-        "tools"
-      ],
+      "tags": ["media", "performance", "tools"],
       "label": "Video Understanding Max Bytes",
       "help": "Maximum accepted video payload size in bytes before policy rejection or trimming occurs. Tune this to provider and infrastructure limits to avoid repeated timeout/failure loops.",
       "hasChildren": false
@@ -54162,11 +49653,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance",
-        "tools"
-      ],
+      "tags": ["media", "performance", "tools"],
       "label": "Video Understanding Max Chars",
       "help": "Maximum characters retained from video understanding output to control prompt growth. Raise for dense scene descriptions and lower when concise summaries are preferred.",
       "hasChildren": false
@@ -54178,11 +49665,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "models",
-        "tools"
-      ],
+      "tags": ["media", "models", "tools"],
       "label": "Video Understanding Models",
       "help": "Ordered model preferences specifically for video understanding before shared media fallback applies. Prioritize models with strong multimodal video support to minimize degraded summaries.",
       "hasChildren": true
@@ -54420,11 +49903,7 @@
     {
       "path": "tools.media.video.models.*.providerOptions.*.*",
       "kind": "core",
-      "type": [
-        "boolean",
-        "number",
-        "string"
-      ],
+      "type": ["boolean", "number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -54458,10 +49937,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Video Understanding Prompt",
       "help": "Instruction template for video understanding describing desired summary granularity and focus areas. Keep this stable so output quality remains predictable across model/provider fallbacks.",
       "hasChildren": false
@@ -54489,11 +49965,7 @@
     {
       "path": "tools.media.video.providerOptions.*.*",
       "kind": "core",
-      "type": [
-        "boolean",
-        "number",
-        "string"
-      ],
+      "type": ["boolean", "number", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -54507,10 +49979,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "tools"
-      ],
+      "tags": ["media", "tools"],
       "label": "Video Understanding Scope",
       "help": "Scope selector controlling when video understanding is attempted across incoming events. Narrow scope in noisy channels, and broaden only where video interpretation is core to workflow.",
       "hasChildren": true
@@ -54612,11 +50081,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "media",
-        "performance",
-        "tools"
-      ],
+      "tags": ["media", "performance", "tools"],
       "label": "Video Understanding Timeout (sec)",
       "help": "Timeout in seconds for each video understanding request before cancellation. Use conservative values in interactive channels and longer values for offline or batch-heavy processing.",
       "hasChildren": false
@@ -54638,10 +50103,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "tools"
-      ],
+      "tags": ["access", "tools"],
       "label": "Allow Cross-Context Messaging",
       "help": "Legacy override: allow cross-context sends across all providers.",
       "hasChildren": false
@@ -54663,9 +50125,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Enable Message Broadcast",
       "help": "Enable broadcast action (default: true).",
       "hasChildren": false
@@ -54687,10 +50147,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "tools"
-      ],
+      "tags": ["access", "tools"],
       "label": "Allow Cross-Context (Across Providers)",
       "help": "Allow sends across different providers (default: false).",
       "hasChildren": false
@@ -54702,10 +50159,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "access",
-        "tools"
-      ],
+      "tags": ["access", "tools"],
       "label": "Allow Cross-Context (Same Provider)",
       "help": "Allow sends to other channels within the same provider (default: true).",
       "hasChildren": false
@@ -54727,9 +50181,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Cross-Context Marker",
       "help": "Add a visible origin marker when sending cross-context (default: true).",
       "hasChildren": false
@@ -54741,9 +50193,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Cross-Context Marker Prefix",
       "help": "Text prefix for cross-context markers (supports \"{channel}\").",
       "hasChildren": false
@@ -54755,9 +50205,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Cross-Context Marker Suffix",
       "help": "Text suffix for cross-context markers (supports \"{channel}\").",
       "hasChildren": false
@@ -54769,10 +50217,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage",
-        "tools"
-      ],
+      "tags": ["storage", "tools"],
       "label": "Tool Profile",
       "help": "Global tool profile name used to select a predefined tool policy baseline before applying allow/deny overrides. Use this for consistent environment posture across agents and keep profile names stable.",
       "hasChildren": false
@@ -54784,10 +50229,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage",
-        "tools"
-      ],
+      "tags": ["storage", "tools"],
       "label": "Sandbox Tool Policy",
       "help": "Tool policy wrapper for sandboxed agent executions so sandbox runs can have distinct capability boundaries. Use this to enforce stronger safety in sandbox contexts.",
       "hasChildren": true
@@ -54799,10 +50241,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage",
-        "tools"
-      ],
+      "tags": ["storage", "tools"],
       "label": "Sandbox Tool Allow/Deny Policy",
       "help": "Allow/deny tool policy applied when agents run in sandboxed execution environments. Keep policies minimal so sandbox tasks cannot escalate into unnecessary external actions.",
       "hasChildren": true
@@ -54952,18 +50391,10 @@
       "kind": "core",
       "type": "string",
       "required": false,
-      "enumValues": [
-        "self",
-        "tree",
-        "agent",
-        "all"
-      ],
+      "enumValues": ["self", "tree", "agent", "all"],
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "storage",
-        "tools"
-      ],
+      "tags": ["storage", "tools"],
       "label": "Session Tools Visibility",
       "help": "Controls which sessions can be targeted by sessions_list/sessions_history/sessions_send. (\"tree\" default = current session + spawned subagent sessions; \"self\" = only current; \"agent\" = any session in the current agent id; \"all\" = any session; cross-agent still requires tools.agentToAgent).",
       "hasChildren": false
@@ -54975,9 +50406,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Subagent Tool Policy",
       "help": "Tool policy wrapper for spawned subagents to restrict or expand tool availability compared to parent defaults. Use this to keep delegated agent capabilities scoped to task intent.",
       "hasChildren": true
@@ -54989,9 +50418,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Subagent Tool Allow/Deny Policy",
       "help": "Allow/deny tool policy applied to spawned subagent runtimes for per-subagent hardening. Keep this narrower than parent scope when subagents run semi-autonomous workflows.",
       "hasChildren": true
@@ -55063,9 +50490,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Web Tools",
       "help": "Web-tool policy grouping for search/fetch providers, limits, and fallback behavior tuning. Keep enabled settings aligned with API key availability and outbound networking policy.",
       "hasChildren": true
@@ -55087,11 +50512,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage",
-        "tools"
-      ],
+      "tags": ["performance", "storage", "tools"],
       "label": "Web Fetch Cache TTL (min)",
       "help": "Cache TTL in minutes for web_fetch results.",
       "hasChildren": false
@@ -55103,9 +50524,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Enable Web Fetch Tool",
       "help": "Enable the web_fetch tool (lightweight HTTP fetch).",
       "hasChildren": false
@@ -55123,18 +50542,11 @@
     {
       "path": "tools.web.fetch.firecrawl.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security",
-        "tools"
-      ],
+      "tags": ["auth", "security", "tools"],
       "label": "Firecrawl API Key",
       "help": "Firecrawl API key (fallback: FIRECRAWL_API_KEY env var).",
       "hasChildren": true
@@ -55176,9 +50588,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Firecrawl Base URL",
       "help": "Firecrawl base URL (e.g. https://api.firecrawl.dev or custom endpoint).",
       "hasChildren": false
@@ -55190,9 +50600,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Enable Firecrawl Fallback",
       "help": "Enable Firecrawl fallback for web_fetch (if configured).",
       "hasChildren": false
@@ -55204,10 +50612,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "tools"
-      ],
+      "tags": ["performance", "tools"],
       "label": "Firecrawl Cache Max Age (ms)",
       "help": "Firecrawl maxAge (ms) for cached results when supported by the API.",
       "hasChildren": false
@@ -55219,9 +50624,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Firecrawl Main Content Only",
       "help": "When true, Firecrawl returns only the main content (default: true).",
       "hasChildren": false
@@ -55233,10 +50636,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "tools"
-      ],
+      "tags": ["performance", "tools"],
       "label": "Firecrawl Timeout (sec)",
       "help": "Timeout in seconds for Firecrawl requests.",
       "hasChildren": false
@@ -55248,10 +50648,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "tools"
-      ],
+      "tags": ["performance", "tools"],
       "label": "Web Fetch Max Chars",
       "help": "Max characters returned by web_fetch (truncated).",
       "hasChildren": false
@@ -55263,10 +50660,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "tools"
-      ],
+      "tags": ["performance", "tools"],
       "label": "Web Fetch Hard Max Chars",
       "help": "Hard cap for web_fetch maxChars (applies to config and tool calls).",
       "hasChildren": false
@@ -55278,11 +50672,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage",
-        "tools"
-      ],
+      "tags": ["performance", "storage", "tools"],
       "label": "Web Fetch Max Redirects",
       "help": "Maximum redirects allowed for web_fetch (default: 3).",
       "hasChildren": false
@@ -55294,9 +50684,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Web Fetch Readability Extraction",
       "help": "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
       "hasChildren": false
@@ -55308,10 +50696,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "tools"
-      ],
+      "tags": ["performance", "tools"],
       "label": "Web Fetch Timeout (sec)",
       "help": "Timeout in seconds for web_fetch requests.",
       "hasChildren": false
@@ -55323,9 +50708,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Web Fetch User-Agent",
       "help": "Override User-Agent header for web_fetch requests.",
       "hasChildren": false
@@ -55343,18 +50726,11 @@
     {
       "path": "tools.web.search.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security",
-        "tools"
-      ],
+      "tags": ["auth", "security", "tools"],
       "label": "Brave Search API Key",
       "help": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
       "hasChildren": true
@@ -55406,9 +50782,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Brave Search Mode",
       "help": "Brave Search mode: \"web\" (URL results) or \"llm-context\" (pre-extracted page content for LLM grounding).",
       "hasChildren": false
@@ -55420,11 +50794,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "storage",
-        "tools"
-      ],
+      "tags": ["performance", "storage", "tools"],
       "label": "Web Search Cache TTL (min)",
       "help": "Cache TTL in minutes for web_search results.",
       "hasChildren": false
@@ -55436,9 +50806,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Enable Web Search Tool",
       "help": "Enable the web_search tool (requires a provider API key).",
       "hasChildren": false
@@ -55456,18 +50824,11 @@
     {
       "path": "tools.web.search.gemini.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security",
-        "tools"
-      ],
+      "tags": ["auth", "security", "tools"],
       "label": "Gemini Search API Key",
       "help": "Gemini API key for Google Search grounding (fallback: GEMINI_API_KEY env var).",
       "hasChildren": true
@@ -55509,10 +50870,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models",
-        "tools"
-      ],
+      "tags": ["models", "tools"],
       "label": "Gemini Search Model",
       "help": "Gemini model override (default: \"gemini-2.5-flash\").",
       "hasChildren": false
@@ -55530,18 +50888,11 @@
     {
       "path": "tools.web.search.grok.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security",
-        "tools"
-      ],
+      "tags": ["auth", "security", "tools"],
       "label": "Grok Search API Key",
       "help": "Grok (xAI) API key (fallback: XAI_API_KEY env var).",
       "hasChildren": true
@@ -55593,10 +50944,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models",
-        "tools"
-      ],
+      "tags": ["models", "tools"],
       "label": "Grok Search Model",
       "help": "Grok model override (default: \"grok-4-1-fast\").",
       "hasChildren": false
@@ -55614,18 +50962,11 @@
     {
       "path": "tools.web.search.kimi.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security",
-        "tools"
-      ],
+      "tags": ["auth", "security", "tools"],
       "label": "Kimi Search API Key",
       "help": "Moonshot/Kimi API key (fallback: KIMI_API_KEY or MOONSHOT_API_KEY env var).",
       "hasChildren": true
@@ -55667,9 +51008,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Kimi Search Base URL",
       "help": "Kimi base URL override (default: \"https://api.moonshot.ai/v1\").",
       "hasChildren": false
@@ -55681,10 +51020,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models",
-        "tools"
-      ],
+      "tags": ["models", "tools"],
       "label": "Kimi Search Model",
       "help": "Kimi model override (default: \"moonshot-v1-128k\").",
       "hasChildren": false
@@ -55696,10 +51032,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "tools"
-      ],
+      "tags": ["performance", "tools"],
       "label": "Web Search Max Results",
       "help": "Number of results to return (1-10).",
       "hasChildren": false
@@ -55717,18 +51050,11 @@
     {
       "path": "tools.web.search.perplexity.apiKey",
       "kind": "core",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": ["object", "string"],
       "required": false,
       "deprecated": false,
       "sensitive": true,
-      "tags": [
-        "auth",
-        "security",
-        "tools"
-      ],
+      "tags": ["auth", "security", "tools"],
       "label": "Perplexity API Key",
       "help": "Perplexity or OpenRouter API key (fallback: PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var). Direct Perplexity keys default to the Search API; OpenRouter keys use Sonar chat completions.",
       "hasChildren": true
@@ -55770,9 +51096,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Perplexity Base URL",
       "help": "Optional Perplexity/OpenRouter chat-completions base URL override. Setting this opts Perplexity into the legacy Sonar/OpenRouter compatibility path.",
       "hasChildren": false
@@ -55784,10 +51108,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "models",
-        "tools"
-      ],
+      "tags": ["models", "tools"],
       "label": "Perplexity Model",
       "help": "Optional Sonar/OpenRouter model override (default: \"perplexity/sonar-pro\"). Setting this opts Perplexity into the legacy chat-completions compatibility path.",
       "hasChildren": false
@@ -55799,9 +51120,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "tools"
-      ],
+      "tags": ["tools"],
       "label": "Web Search Provider",
       "help": "Search provider (\"brave\", \"gemini\", \"grok\", \"kimi\", or \"perplexity\"). Auto-detected from available API keys if omitted.",
       "hasChildren": false
@@ -55813,10 +51132,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance",
-        "tools"
-      ],
+      "tags": ["performance", "tools"],
       "label": "Web Search Timeout (sec)",
       "help": "Timeout in seconds for web_search requests.",
       "hasChildren": false
@@ -55828,9 +51144,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "UI",
       "help": "UI presentation settings for accenting and assistant identity shown in control surfaces. Use this for branding and readability customization without changing runtime behavior.",
       "hasChildren": true
@@ -55842,9 +51156,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Assistant Appearance",
       "help": "Assistant display identity settings for name and avatar shown in UI surfaces. Keep these values aligned with your operator-facing persona and support expectations.",
       "hasChildren": true
@@ -55856,9 +51168,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Assistant Avatar",
       "help": "Assistant avatar image source used in UI surfaces (URL, path, or data URI depending on runtime support). Use trusted assets and consistent branding dimensions for clean rendering.",
       "hasChildren": false
@@ -55870,9 +51180,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Assistant Name",
       "help": "Display name shown for the assistant in UI views, chat chrome, and status contexts. Keep this stable so operators can reliably identify which assistant persona is active.",
       "hasChildren": false
@@ -55884,9 +51192,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Accent Color",
       "help": "Primary accent/seam color used by UI surfaces for emphasis, badges, and visual identity cues. Use high-contrast values that remain readable across light/dark themes.",
       "hasChildren": false
@@ -55898,9 +51204,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Updates",
       "help": "Update-channel and startup-check behavior for keeping OpenClaw runtime versions current. Use conservative channels in production and more experimental channels only in controlled environments.",
       "hasChildren": true
@@ -55922,9 +51226,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Auto Update Beta Check Interval (hours)",
       "help": "How often beta-channel checks run in hours (default: 1).",
       "hasChildren": false
@@ -55936,9 +51238,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Auto Update Enabled",
       "help": "Enable background auto-update for package installs (default: false).",
       "hasChildren": false
@@ -55950,9 +51250,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Auto Update Stable Delay (hours)",
       "help": "Minimum delay before stable-channel auto-apply starts (default: 6).",
       "hasChildren": false
@@ -55964,9 +51262,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Auto Update Stable Jitter (hours)",
       "help": "Extra stable-channel rollout spread window in hours (default: 12).",
       "hasChildren": false
@@ -55978,9 +51274,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Update Channel",
       "help": "Update channel for git + npm installs (\"stable\", \"beta\", or \"dev\").",
       "hasChildren": false
@@ -55992,9 +51286,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "label": "Update Check on Start",
       "help": "Check for npm updates when the gateway starts (default: true).",
       "hasChildren": false
@@ -56006,9 +51298,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Web Channel",
       "help": "Web channel runtime settings for heartbeat and reconnect behavior when operating web-based chat surfaces. Use reconnect values tuned to your network reliability profile and expected uptime needs.",
       "hasChildren": true
@@ -56020,9 +51310,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Web Channel Enabled",
       "help": "Enables the web channel runtime and related websocket lifecycle behavior. Keep disabled when web chat is unused to reduce active connection management overhead.",
       "hasChildren": false
@@ -56034,9 +51322,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "automation"
-      ],
+      "tags": ["automation"],
       "label": "Web Channel Heartbeat Interval (sec)",
       "help": "Heartbeat interval in seconds for web channel connectivity and liveness maintenance. Use shorter intervals for faster detection, or longer intervals to reduce keepalive chatter.",
       "hasChildren": false
@@ -56048,9 +51334,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Web Channel Reconnect Policy",
       "help": "Reconnect backoff policy for web channel reconnect attempts after transport failure. Keep bounded retries and jitter tuned to avoid thundering-herd reconnect behavior.",
       "hasChildren": true
@@ -56062,9 +51346,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Web Reconnect Backoff Factor",
       "help": "Exponential backoff multiplier used between reconnect attempts in web channel retry loops. Keep factor above 1 and tune with jitter for stable large-fleet reconnect behavior.",
       "hasChildren": false
@@ -56076,9 +51358,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Web Reconnect Initial Delay (ms)",
       "help": "Initial reconnect delay in milliseconds before the first retry after disconnection. Use modest delays to recover quickly without immediate retry storms.",
       "hasChildren": false
@@ -56090,9 +51370,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Web Reconnect Jitter",
       "help": "Randomization factor (0-1) applied to reconnect delays to desynchronize clients after outage events. Keep non-zero jitter in multi-client deployments to reduce synchronized spikes.",
       "hasChildren": false
@@ -56104,9 +51382,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Web Reconnect Max Attempts",
       "help": "Maximum reconnect attempts before giving up for the current failure sequence (0 means no retries). Use finite caps for controlled failure handling in automation-sensitive environments.",
       "hasChildren": false
@@ -56118,9 +51394,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "performance"
-      ],
+      "tags": ["performance"],
       "label": "Web Reconnect Max Delay (ms)",
       "help": "Maximum reconnect backoff cap in milliseconds to bound retry delay growth over repeated failures. Use a reasonable cap so recovery remains timely after prolonged outages.",
       "hasChildren": false
@@ -56132,9 +51406,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Setup Wizard State",
       "help": "Setup wizard state tracking fields that record the most recent guided onboarding run details. Keep these fields for observability and troubleshooting of setup flows across upgrades.",
       "hasChildren": true
@@ -56146,9 +51418,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Wizard Last Run Timestamp",
       "help": "ISO timestamp for when the setup wizard most recently completed on this host. Use this to confirm onboarding recency during support and operational audits.",
       "hasChildren": false
@@ -56160,9 +51430,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Wizard Last Run Command",
       "help": "Command invocation recorded for the latest wizard run to preserve execution context. Use this to reproduce onboarding steps when verifying setup regressions.",
       "hasChildren": false
@@ -56174,9 +51442,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Wizard Last Run Commit",
       "help": "Source commit identifier recorded for the last wizard execution in development builds. Use this to correlate onboarding behavior with exact source state during debugging.",
       "hasChildren": false
@@ -56188,9 +51454,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Wizard Last Run Mode",
       "help": "Wizard execution mode recorded as \"local\" or \"remote\" for the most recent onboarding flow. Use this to understand whether setup targeted direct local runtime or remote gateway topology.",
       "hasChildren": false
@@ -56202,9 +51466,7 @@
       "required": false,
       "deprecated": false,
       "sensitive": false,
-      "tags": [
-        "advanced"
-      ],
+      "tags": ["advanced"],
       "label": "Wizard Last Run Version",
       "help": "OpenClaw version recorded at the time of the most recent wizard run on this config. Use this when diagnosing behavior differences across version-to-version onboarding changes.",
       "hasChildren": false

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -47,8 +47,17 @@ export async function resolveAnnounceTarget(params: {
     const accountId =
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined);
+    const rawThreadId =
+      (typeof deliveryContext?.threadId === "string" ||
+      typeof deliveryContext?.threadId === "number"
+        ? deliveryContext.threadId
+        : undefined) ??
+      (typeof match?.lastThreadId === "string" || typeof match?.lastThreadId === "number"
+        ? match.lastThreadId
+        : undefined);
+    const threadId = rawThreadId != null ? String(rawThreadId) : undefined;
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, threadId };
     }
   } catch {
     // ignore

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -44,6 +44,7 @@ export type SessionListDeliveryContext = {
   channel?: string;
   to?: string;
   accountId?: string;
+  threadId?: string | number;
 };
 
 export type SessionListRow = {
@@ -66,6 +67,7 @@ export type SessionListRow = {
   lastChannel?: string;
   lastTo?: string;
   lastAccountId?: string;
+  lastThreadId?: string | number;
   transcriptPath?: string;
   messages?: unknown[];
 };

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -24,7 +24,7 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
     return null;
   }
   const [channelRaw, kind, ...rest] = parts;
-  if (kind !== "group" && kind !== "channel") {
+  if (kind !== "group" && kind !== "channel" && kind !== "thread") {
     return null;
   }
 
@@ -38,10 +38,16 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
 
   if (match) {
     threadId = match[1]; // Keep as string to match AgentCommandOpts.threadId
+  } else if (kind === "thread" && rest.length >= 2) {
+    // agent:<id>:<channel>:thread:<chatId>:<topicId>
+    threadId = String(rest[1] ?? "").trim() || undefined;
   }
 
   // Remove :topic:N or :thread:N suffix from ID for target
-  const id = match ? restJoined.replace(/:(topic|thread):\d+$/, "") : restJoined.trim();
+  let id = match ? restJoined.replace(/:(topic|thread):\d+$/, "") : restJoined.trim();
+  if (!match && kind === "thread" && rest.length >= 1) {
+    id = String(rest[0] ?? "").trim();
+  }
 
   if (!id) {
     return null;

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -127,6 +127,7 @@ export async function runSessionsSendA2AFlow(params: {
             message: announceReply.trim(),
             channel: announceTarget.channel,
             accountId: announceTarget.accountId,
+            threadId: announceTarget.threadId,
             idempotencyKey: crypto.randomUUID(),
           },
           timeoutMs: 10_000,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -226,6 +226,19 @@ describe("resolveAnnounceTarget", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
+  it("derives thread announce target from channel-thread session key", async () => {
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:telegram:thread:-1003173393372:463",
+      displayKey: "agent:main:telegram:thread:-1003173393372:463",
+    });
+    expect(target).toEqual({
+      channel: "telegram",
+      to: "group:-1003173393372",
+      threadId: "463",
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it("hydrates WhatsApp accountId from sessions.list when available", async () => {
     callGatewayMock.mockResolvedValueOnce({
       sessions: [
@@ -253,6 +266,35 @@ describe("resolveAnnounceTarget", () => {
     const first = callGatewayMock.mock.calls[0]?.[0] as { method?: string } | undefined;
     expect(first).toBeDefined();
     expect(first?.method).toBe("sessions.list");
+  });
+
+  it("hydrates announce threadId from deliveryContext for thread sessions", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:thread:-1003173393372:463",
+          deliveryContext: {
+            channel: "telegram",
+            to: "group:-1003173393372",
+            accountId: "bot-main",
+            threadId: 463,
+          },
+          lastThreadId: 463,
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:thread:-1003173393372:463",
+      displayKey: "agent:main:thread:-1003173393372:463",
+    });
+
+    expect(target).toEqual({
+      channel: "telegram",
+      to: "group:-1003173393372",
+      accountId: "bot-main",
+      threadId: "463",
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #47515

## Summary
- Preserve `threadId` when resolving announce target from `sessions.list` delivery context.
- Pass `threadId` through the `sessions_send` announce `send` call.
- Extend key parsing to accept `:thread:` session kind and extract `threadId` from channel-thread session keys.
- Add/extend tests in `sessions.test.ts` for thread-target resolution and delivery-context hydration.

## Notes
- `threadId` is normalized to string for compatibility with gateway send request parsing.
- Non-thread sessions remain unaffected.