### PR TITLE
feat(android): add System Assistant (VoiceInteractionService) support

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -54,6 +54,29 @@
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
         </service>
+        <service
+            android:name=".assistant.AssistantService"
+            android:exported="true"
+            android:permission="android.permission.BIND_VOICE_INTERACTION">
+            <intent-filter>
+                <action android:name="android.service.voice.VoiceInteractionService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.voice_interaction"
+                android:resource="@xml/voice_interaction_service" />
+        </service>
+        <service
+            android:name=".assistant.AssistantSessionService"
+            android:exported="true"
+            android:permission="android.permission.BIND_VOICE_INTERACTION" />
+        <service
+            android:name=".assistant.AssistantRecognitionService"
+            android:exported="true"
+            android:permission="android.permission.BIND_RECOGNITION_SERVICE">
+            <intent-filter>
+                <action android:name="android.speech.RecognitionService" />
+            </intent-filter>
+        </service>
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"
@@ -66,11 +89,20 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|uiMode|density|keyboard|keyboardHidden|navigation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.ASSIST" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VOICE_ASSIST" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
     </application>

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -49,6 +50,21 @@ class MainActivity : ComponentActivity() {
 
     // Keep startup path lean: start foreground service after first frame.
     window.decorView.post { NodeForegroundService.start(this) }
+
+    handleAssistantIntent(intent)
+  }
+
+  override fun onNewIntent(intent: Intent) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+    handleAssistantIntent(intent)
+  }
+
+  private fun handleAssistantIntent(intent: Intent?) {
+    if (intent?.getBooleanExtra("auto_listen", false) == true) {
+      viewModel.navigateToVoiceTab()
+      viewModel.setMicEnabled(true)
+    }
   }
 
   override fun onStart() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -8,7 +8,9 @@ import ai.openclaw.app.node.CameraCaptureManager
 import ai.openclaw.app.node.CanvasController
 import ai.openclaw.app.node.SmsManager
 import ai.openclaw.app.voice.VoiceConversationEntry
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class MainViewModel(app: Application) : AndroidViewModel(app) {
   private val runtime: NodeRuntime = (app as NodeApp).runtime
@@ -71,6 +73,15 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val chatPendingToolCalls = runtime.chatPendingToolCalls
   val chatSessions = runtime.chatSessions
   val pendingRunCount: StateFlow<Int> = runtime.pendingRunCount
+
+  // One-shot event: incremented each time the System Assistant triggers voice launch.
+  // PostOnboardingTabs observes this to navigate to the Voice tab.
+  private val _navigateToVoiceTabEvent = MutableStateFlow(0L)
+  val navigateToVoiceTabEvent: StateFlow<Long> = _navigateToVoiceTabEvent.asStateFlow()
+
+  fun navigateToVoiceTab() {
+    _navigateToVoiceTabEvent.value = _navigateToVoiceTabEvent.value + 1L
+  }
 
   fun setForeground(value: Boolean) {
     runtime.setForeground(value)

--- a/apps/android/app/src/main/java/ai/openclaw/app/assistant/AssistantRecognitionService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/assistant/AssistantRecognitionService.kt
@@ -1,0 +1,14 @@
+package ai.openclaw.app.assistant
+
+import android.os.Bundle
+import android.speech.RecognitionService
+
+/**
+ * Stub RecognitionService required by VoiceInteractionService to be considered
+ * "qualified" by the Android system. OpenClaw handles speech capture internally.
+ */
+class AssistantRecognitionService : RecognitionService() {
+  override fun onStartListening(recognizerIntent: android.content.Intent, listener: Callback) {}
+  override fun onCancel(listener: Callback) {}
+  override fun onStopListening(listener: Callback) {}
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/assistant/AssistantService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/assistant/AssistantService.kt
@@ -1,0 +1,16 @@
+package ai.openclaw.app.assistant
+
+import android.service.voice.VoiceInteractionService
+
+/**
+ * Registers OpenClaw as an Android System Assistant (digital assistant).
+ *
+ * Users can select this via: Settings → Apps → Default apps → Digital assistant app.
+ * Once set, pressing and holding the home button (or the assistant gesture on Android 16+)
+ * will trigger [AssistantSession.onShow], which launches MainActivity in voice mode.
+ */
+class AssistantService : VoiceInteractionService() {
+  override fun onReady() {
+    super.onReady()
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/assistant/AssistantSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/assistant/AssistantSession.kt
@@ -1,0 +1,19 @@
+package ai.openclaw.app.assistant
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.service.voice.VoiceInteractionSession
+import ai.openclaw.app.MainActivity
+
+class AssistantSession(context: Context) : VoiceInteractionSession(context) {
+  override fun onShow(args: Bundle?, showFlags: Int) {
+    super.onShow(args, showFlags)
+    val intent = Intent(context, MainActivity::class.java).apply {
+      putExtra("auto_listen", true)
+      addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+    }
+    context.startActivity(intent)
+    hide()
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/assistant/AssistantSessionService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/assistant/AssistantSessionService.kt
@@ -1,0 +1,11 @@
+package ai.openclaw.app.assistant
+
+import android.os.Bundle
+import android.service.voice.VoiceInteractionSession
+import android.service.voice.VoiceInteractionSessionService
+
+class AssistantSessionService : VoiceInteractionSessionService() {
+  override fun onNewSession(args: Bundle?): VoiceInteractionSession {
+    return AssistantSession(this)
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/PostOnboardingTabs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/PostOnboardingTabs.kt
@@ -69,6 +69,14 @@ private enum class StatusVisual {
 fun PostOnboardingTabs(viewModel: MainViewModel, modifier: Modifier = Modifier) {
   var activeTab by rememberSaveable { mutableStateOf(HomeTab.Connect) }
 
+  // Navigate to Voice tab when triggered by System Assistant
+  val navigateToVoiceTabEvent by viewModel.navigateToVoiceTabEvent.collectAsState()
+  LaunchedEffect(navigateToVoiceTabEvent) {
+    if (navigateToVoiceTabEvent > 0L) {
+      activeTab = HomeTab.Voice
+    }
+  }
+
   // Stop TTS when user navigates away from voice tab
   LaunchedEffect(activeTab) {
     viewModel.setVoiceScreenActive(activeTab == HomeTab.Voice)

--- a/apps/android/app/src/main/res/xml/voice_interaction_service.xml
+++ b/apps/android/app/src/main/res/xml/voice_interaction_service.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<voice-interaction-service
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:sessionService="ai.openclaw.app.assistant.AssistantSessionService"
+    android:recognitionService="ai.openclaw.app.assistant.AssistantRecognitionService"
+    android:settingsActivity="ai.openclaw.app.MainActivity"
+    android:supportsAssist="true"
+    android:supportsLaunchVoiceAssistFromKeyguard="true"
+    android:supportsLocalInteraction="true" />


### PR DESCRIPTION
## Summary

Registers the OpenClaw Android app as an Android **System Assistant** (digital assistant), allowing users to invoke it via the power button hold, home button long-press, or assistant gesture on Android 8+.

## How to use

1. Open **Settings → Apps → Default apps → Digital assistant app**
2. Select **OpenClaw**
3. Press and hold the power button (or use the assistant gesture on Android 16+)
4. OpenClaw launches automatically and starts listening

## How it works

- **`AssistantService`** (`VoiceInteractionService`) is the entry point the system binds when OpenClaw is the default assistant.
- **`AssistantSession`** (`VoiceInteractionSession`) handles the trigger: on `onShow()` it launches `MainActivity` with `auto_listen=true` and immediately hides the session overlay.
- **`AssistantRecognitionService`** is a required no-op stub — the system needs a declared `RecognitionService` to consider an assistant "qualified". Speech capture is handled entirely by the existing `MicCaptureManager`.
- **`MainActivity`** reads the `auto_listen` extra in both `onCreate` and `onNewIntent` (for singleTop redelivery) and signals the ViewModel.
- **`MainViewModel`** exposes a `navigateToVoiceTabEvent` counter flow; **`PostOnboardingTabs`** observes it to switch to the Voice tab.

## Changes

| File | Change |
|------|--------|
| `assistant/AssistantService.kt` | New — `VoiceInteractionService` stub |
| `assistant/AssistantSessionService.kt` | New — creates `AssistantSession` |
| `assistant/AssistantSession.kt` | New — launches app in voice mode |
| `assistant/AssistantRecognitionService.kt` | New — required `RecognitionService` stub |
| `res/xml/voice_interaction_service.xml` | New — service config with capability flags |
| `AndroidManifest.xml` | Registers services, adds ASSIST intent filters, singleTop launchMode |
| `MainActivity.kt` | Handles `auto_listen` extra + `onNewIntent` |
| `MainViewModel.kt` | Adds `navigateToVoiceTab()` signal |
| `PostOnboardingTabs.kt` | Observes tab navigation event |

## Non-breaking

This is entirely opt-in — the assistant is only active if the user explicitly sets OpenClaw as their default digital assistant in system settings. No changes to existing functionality or startup behavior.

## Tested on

- Pixel 10 Pro XL, Android 16