### PR TITLE
acpx: add Kiro CLI as built-in ACP agent

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -444,6 +444,7 @@ Current acpx built-in harness aliases:
 - `pi`
 - `claude`
 - `codex`
+- `kiro`
 - `opencode`
 - `gemini`
 - `kimi`
@@ -464,7 +465,7 @@ Core ACP baseline:
     dispatch: { enabled: true },
     backend: "acpx",
     defaultAgent: "codex",
-    allowedAgents: ["pi", "claude", "codex", "opencode", "gemini", "kimi"],
+    allowedAgents: ["pi", "claude", "codex", "kiro", "opencode", "gemini", "kimi"],
     maxConcurrentSessions: 8,
     stream: {
       coalesceIdleMs: 300,

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -1,5 +1,5 @@
 ---
-summary: "Use ACP runtime sessions for Pi, Claude Code, Codex, OpenCode, Gemini CLI, and other harness agents"
+summary: "Use ACP runtime sessions for Pi, Claude Code, Codex, Kiro, OpenCode, Gemini CLI, and other harness agents"
 read_when:
   - Running coding harnesses through ACP
   - Setting up thread-bound ACP sessions on thread-capable channels
@@ -11,7 +11,7 @@ title: "ACP Agents"
 
 # ACP agents
 
-[Agent Client Protocol (ACP)](https://agentclientprotocol.com/) sessions let OpenClaw run external coding harnesses (for example Pi, Claude Code, Codex, OpenCode, and Gemini CLI) through an ACP backend plugin.
+[Agent Client Protocol (ACP)](https://agentclientprotocol.com/) sessions let OpenClaw run external coding harnesses (for example Pi, Claude Code, Codex, Kiro, OpenCode, and Gemini CLI) through an ACP backend plugin.
 
 If you ask OpenClaw in plain language to "run this in Codex" or "start Claude Code in a thread", OpenClaw should route that request to the ACP runtime (not the native sub-agent runtime).
 

--- a/extensions/acpx/skills/acp-router/SKILL.md
+++ b/extensions/acpx/skills/acp-router/SKILL.md
@@ -89,7 +89,7 @@ Call:
 
 ## Thread spawn recovery policy
 
-When the user asks to start a coding harness in a thread (for example "start a codex/claude/pi/kimi thread"), treat that as an ACP runtime request and try to satisfy it end-to-end.
+When the user asks to start a coding harness in a thread (for example "start a codex/claude/pi/kiro/kimi thread"), treat that as an ACP runtime request and try to satisfy it end-to-end.
 
 Required behavior when ACP backend is unavailable:
 
@@ -183,6 +183,7 @@ ${ACPX_CMD} codex sessions close oc-codex-<conversationId>
 - `pi`
 - `claude`
 - `codex`
+- `kiro`
 - `opencode`
 - `gemini`
 - `kimi`
@@ -194,6 +195,7 @@ Defaults are:
 - `pi -> npx pi-acp`
 - `claude -> npx -y @zed-industries/claude-agent-acp`
 - `codex -> npx @zed-industries/codex-acp`
+- `kiro -> kiro-cli acp`
 - `opencode -> npx -y opencode-ai acp`
 - `gemini -> gemini`
 - `kimi -> kimi acp`

--- a/extensions/acpx/skills/acp-router/SKILL.md
+++ b/extensions/acpx/skills/acp-router/SKILL.md
@@ -1,25 +1,25 @@
 ---
 name: acp-router
-description: Route plain-language requests for Pi, Claude Code, Codex, OpenCode, Gemini CLI, or ACP harness work into either OpenClaw ACP runtime sessions or direct acpx-driven sessions ("telephone game" flow). For coding-agent thread requests, read this skill first, then use only `sessions_spawn` for thread creation.
+description: Route plain-language requests for Pi, Claude Code, Codex, Kiro, OpenCode, Gemini CLI, or ACP harness work into either OpenClaw ACP runtime sessions or direct acpx-driven sessions ("telephone game" flow). For coding-agent thread requests, read this skill first, then use only `sessions_spawn` for thread creation.
 user-invocable: false
 ---
 
 # ACP Harness Router
 
-When user intent is "run this in Pi/Claude Code/Codex/OpenCode/Gemini/Kimi (ACP harness)", do not use subagent runtime or PTY scraping. Route through ACP-aware flows.
+When user intent is "run this in Pi/Claude Code/Codex/Kiro/OpenCode/Gemini/Kimi (ACP harness)", do not use subagent runtime or PTY scraping. Route through ACP-aware flows.
 
 ## Intent detection
 
 Trigger this skill when the user asks OpenClaw to:
 
-- run something in Pi / Claude Code / Codex / OpenCode / Gemini
+- run something in Pi / Claude Code / Codex / Kiro / OpenCode / Gemini
 - continue existing harness work
 - relay instructions to an external coding harness
 - keep an external harness conversation in a thread-like conversation
 
 Mandatory preflight for coding-agent thread requests:
 
-- Before creating any thread for Pi/Claude/Codex/OpenCode/Gemini work, read this skill first in the same turn.
+- Before creating any thread for Pi/Claude/Codex/Kiro/OpenCode/Gemini work, read this skill first in the same turn.
 - After reading, follow `OpenClaw ACP runtime path` below; do not use `message(action="thread-create")` for ACP harness thread spawn.
 
 ## Mode selection
@@ -39,7 +39,7 @@ Do not use:
 
 - `subagents` runtime for harness control
 - `/acp` command delegation as a requirement for the user
-- PTY scraping of pi/claude/codex/opencode/gemini/kimi CLIs when `acpx` is available
+- PTY scraping of pi/claude/codex/kiro/opencode/gemini/kimi CLIs when `acpx` is available
 
 ## AgentId mapping
 
@@ -48,6 +48,7 @@ Use these defaults when user names a harness directly:
 - "pi" -> `agentId: "pi"`
 - "claude" or "claude code" -> `agentId: "claude"`
 - "codex" -> `agentId: "codex"`
+- "kiro" or "kiro cli" -> `agentId: "kiro"`
 - "opencode" -> `agentId: "opencode"`
 - "gemini" or "gemini cli" -> `agentId: "gemini"`
 - "kimi" or "kimi cli" -> `agentId: "kimi"`

--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
@@ -6,6 +6,7 @@ const ACPX_BUILTIN_AGENT_COMMANDS: Record<string, string> = {
   codex: "npx @zed-industries/codex-acp",
   claude: "npx -y @zed-industries/claude-agent-acp",
   gemini: "gemini",
+  kiro: "kiro-cli acp",
   opencode: "npx -y opencode-ai acp",
   pi: "npx pi-acp",
 };

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -5,7 +5,7 @@ import { listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { readJsonBodyWithLimit, requestBodyErrorToText } from "../infra/http-body.js";
-import { parseAgentSessionKey } from "../routing/session-key.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { type HookMappingResolved, resolveHookMappings } from "./hooks-mapping.js";
 import { resolveAllowedAgentIds } from "./hooks-policy.js";


### PR DESCRIPTION
Adds Kiro CLI (`kiro-cli acp`) to the built-in ACP agent commands list.

Kiro CLI implements the [Agent Client Protocol](https://kiro.dev/docs/cli/acp/) and can be invoked as `kiro-cli acp` over stdio JSON-RPC.

### Changes
- `extensions/acpx/src/runtime-internals/mcp-agent-command.ts`: add `kiro: "kiro-cli acp"` to `ACPX_BUILTIN_AGENT_COMMANDS`
- `docs/tools/acp-agents.md`: mention Kiro in the ACP agents doc
- `extensions/acpx/skills/acp-router/SKILL.md`: add Kiro to intent detection, agent ID mapping, and preflight lists
