### PR TITLE
fix: respect OPENCLAW_PROFILE in gateway lifecycle commands

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -303,4 +303,55 @@ describe("runDaemonRestart health checks", () => {
 
     expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
   });
+
+  it("uses OPENCLAW_PROFILE to resolve target profile's service port", async () => {
+    const originalEnv = process.env.OPENCLAW_PROFILE;
+    try {
+      process.env.OPENCLAW_PROFILE = "rescue";
+      service.readCommand.mockResolvedValue({
+        programArguments: ["openclaw", "gateway", "--port", "18790"],
+        environment: { OPENCLAW_PROFILE: "rescue", OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.rescue" },
+      });
+
+      const { runDaemonRestart } = await import("./lifecycle.js");
+      mockUnmanagedRestart({ runPostRestartCheck: true });
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+
+      await runDaemonRestart({ json: true });
+
+      // Verify service.readCommand was called with profile-specific environment
+      expect(service.readCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          OPENCLAW_PROFILE: "rescue",
+          OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.rescue",
+        }),
+      );
+      expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18790);
+    } finally {
+      process.env.OPENCLAW_PROFILE = originalEnv;
+    }
+  });
+
+  it("falls back to current process env when OPENCLAW_PROFILE is not set", async () => {
+    const originalEnv = process.env.OPENCLAW_PROFILE;
+    try {
+      delete process.env.OPENCLAW_PROFILE;
+      service.readCommand.mockResolvedValue({
+        programArguments: ["openclaw", "gateway", "--port", "18789"],
+        environment: {},
+      });
+
+      const { runDaemonRestart } = await import("./lifecycle.js");
+      mockUnmanagedRestart({ runPostRestartCheck: true });
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+
+      await runDaemonRestart({ json: true });
+
+      // Verify service.readCommand was called with current process.env
+      expect(service.readCommand).toHaveBeenCalledWith(process.env);
+      expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
+    } finally {
+      process.env.OPENCLAW_PROFILE = originalEnv;
+    }
+  });
 });

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -328,7 +328,11 @@ describe("runDaemonRestart health checks", () => {
       );
       expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18790);
     } finally {
-      process.env.OPENCLAW_PROFILE = originalEnv;
+      if (originalEnv === undefined) {
+        delete process.env.OPENCLAW_PROFILE;
+      } else {
+        process.env.OPENCLAW_PROFILE = originalEnv;
+      }
     }
   });
 
@@ -351,7 +355,11 @@ describe("runDaemonRestart health checks", () => {
       expect(service.readCommand).toHaveBeenCalledWith(process.env);
       expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
     } finally {
-      process.env.OPENCLAW_PROFILE = originalEnv;
+      if (originalEnv === undefined) {
+        delete process.env.OPENCLAW_PROFILE;
+      } else {
+        process.env.OPENCLAW_PROFILE = originalEnv;
+      }
     }
   });
 });

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -1,5 +1,6 @@
 import { isRestartEnabled } from "../../config/commands.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
+import { resolveGatewayLaunchAgentLabel } from "../../daemon/constants.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { probeGateway } from "../../gateway/probe.js";
 import {
@@ -32,6 +33,35 @@ const POST_RESTART_HEALTH_ATTEMPTS = DEFAULT_RESTART_HEALTH_ATTEMPTS;
 const POST_RESTART_HEALTH_DELAY_MS = DEFAULT_RESTART_HEALTH_DELAY_MS;
 
 async function resolveGatewayLifecyclePort(service = resolveGatewayService()) {
+  // Priority: use OPENCLAW_PROFILE from CLI to determine which profile's service to operate on
+  const profile = process.env.OPENCLAW_PROFILE?.trim();
+  
+  if (profile) {
+    // Build service-specific environment for the target profile
+    const label = resolveGatewayLaunchAgentLabel(profile);
+    const targetEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      OPENCLAW_PROFILE: profile,
+      OPENCLAW_LAUNCHD_LABEL: label,
+    };
+    
+    // Read the target profile's service configuration
+    const command = await service.readCommand(targetEnv).catch(() => null);
+    const serviceEnv = command?.environment ?? undefined;
+    const mergedEnv = {
+      ...targetEnv,
+      ...(serviceEnv ?? undefined),
+    } as NodeJS.ProcessEnv;
+
+    const portFromArgs = parsePortFromArgs(command?.programArguments);
+    if (portFromArgs !== null) {
+      return portFromArgs;
+    }
+    // Fall through to config-based resolution if port not found in service command
+    return resolveGatewayPort(await readBestEffortConfig(), mergedEnv);
+  }
+
+  // Fallback: use current process environment (backward compatible)
   const command = await service.readCommand(process.env).catch(() => null);
   const serviceEnv = command?.environment ?? undefined;
   const mergedEnv = {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -35,16 +35,18 @@ const POST_RESTART_HEALTH_DELAY_MS = DEFAULT_RESTART_HEALTH_DELAY_MS;
 async function resolveGatewayLifecyclePort(service = resolveGatewayService()) {
   // Priority: use OPENCLAW_PROFILE from CLI to determine which profile's service to operate on
   const profile = process.env.OPENCLAW_PROFILE?.trim();
-  
+
   if (profile) {
     // Build service-specific environment for the target profile
+    // When --profile is explicitly specified, derive label from profile
+    // (this takes precedence over any existing OPENCLAW_LAUNCHD_LABEL)
     const label = resolveGatewayLaunchAgentLabel(profile);
     const targetEnv: NodeJS.ProcessEnv = {
       ...process.env,
       OPENCLAW_PROFILE: profile,
       OPENCLAW_LAUNCHD_LABEL: label,
     };
-    
+
     // Read the target profile's service configuration
     const command = await service.readCommand(targetEnv).catch(() => null);
     const serviceEnv = command?.environment ?? undefined;


### PR DESCRIPTION
Fixes #47555

## Problem

When executing `openclaw --profile <profile-name> gateway restart` from within an agent session, the `--profile` flag was silently ignored. The command operated on the current session's gateway instead of the specified profile.

## Root Cause

The `resolveGatewayLifecyclePort` function in `src/cli/daemon-cli/lifecycle.ts` was reading service configuration from the current process environment, ignoring the `OPENCLAW_PROFILE` environment variable set by the CLI parser.

## Solution

Modified `resolveGatewayLifecyclePort` to:
1. Check for `OPENCLAW_PROFILE` environment variable first
2. If present, build target profile's service environment and read that profile's service configuration
3. Fall back to current process environment for backward compatibility

## Changes

- `src/cli/daemon-cli/lifecycle.ts`: Updated `resolveGatewayLifecyclePort` to respect `OPENCLAW_PROFILE`
- `src/cli/daemon-cli/lifecycle.test.ts`: Added unit tests for profile-specific and fallback behavior

## Impact

This fix affects all gateway lifecycle commands:
- `openclaw gateway restart`
- `openclaw gateway start`
- `openclaw gateway stop`
- `openclaw gateway status`

All commands now correctly operate on the profile specified by `--profile` flag.

## Testing

- Added unit tests for profile-specific port resolution
- Backward compatibility maintained when `--profile` is not specified