### PR TITLE
feat(agents): emit reasoning stream to gateway clients without channel callback

### DIFF
--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -45,7 +45,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     reasoningMode,
     includeReasoning: reasoningMode === "on",
     shouldEmitPartialReplies: !(reasoningMode === "on" && !params.onBlockReply),
-    streamReasoning: reasoningMode === "stream" && typeof params.onReasoningStream === "function",
+    streamReasoning: reasoningMode === "stream",
     deltaBuffer: "",
     blockBuffer: "",
     // Track if a streamed chunk opened a <think> block (stateful across chunks).
@@ -554,7 +554,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   };
 
   const emitReasoningStream = (text: string) => {
-    if (!state.streamReasoning || !params.onReasoningStream) {
+    if (!state.streamReasoning) {
       return;
     }
     const formatted = formatReasoningMessage(text);
@@ -570,7 +570,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     const delta = formatted.startsWith(prior) ? formatted.slice(prior.length) : formatted;
     state.lastStreamedReasoning = formatted;
 
-    // Broadcast thinking event to WebSocket clients in real-time
+    // Broadcast thinking event to all gateway clients (WebSocket, node
+    // subscribers, etc.) regardless of whether a channel-specific callback
+    // exists.  This allows webchat and other gateway-connected clients to
+    // display live reasoning content during agent turns.
     emitAgentEvent({
       runId: params.runId,
       stream: "thinking",
@@ -580,9 +583,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       },
     });
 
-    void params.onReasoningStream({
-      text: formatted,
-    });
+    if (params.onReasoningStream) {
+      void params.onReasoningStream({
+        text: formatted,
+      });
+    }
   };
 
   const resetForCompactionRetry = () => {


### PR DESCRIPTION
## Summary

- Decouple `emitAgentEvent({ stream: "thinking" })` from the `onReasoningStream` callback in `emitReasoningStream()`
- `streamReasoning` is now `true` whenever `reasoningMode === "stream"`, regardless of whether an `onReasoningStream` callback is provided
- Agent events with `stream: "thinking"` are broadcast to all gateway-connected clients (WebSocket, node subscribers) even when no channel-specific callback exists

## Problem

Gateway-connected clients (webchat, WebSocket) never receive `stream: "thinking"` agent events because:

1. `streamReasoning` requires **both** `reasoningMode === "stream"` AND `typeof params.onReasoningStream === "function"` (line 48)
2. The gateway does not provide an `onReasoningStream` callback — only channel integrations like Telegram do
3. This means `emitAgentEvent()` (the gateway broadcast) never fires for webchat, even though the gateway's `createAgentEventHandler` already broadcasts all non-tool events to connected clients

## Fix

Two minimal changes in `src/agents/pi-embedded-subscribe.ts`:

1. **Line 48**: Remove the `onReasoningStream` callback requirement from `streamReasoning` — it should only depend on `reasoningMode === "stream"`
2. **Lines 556-586**: Make `emitAgentEvent()` fire unconditionally when `streamReasoning` is true, and make the `onReasoningStream` callback optional (still called when provided)

## Impact

- **Webchat/WebSocket clients**: Will now receive `stream: "thinking"` agent events when `reasoningLevel: "stream"` is set via `sessions.patch`
- **Telegram/existing channels**: No behavior change — `onReasoningStream` callback is still invoked when provided
- **No breaking changes**: The `onReasoningStream` callback remains optional as defined in `SubscribeEmbeddedPiSessionParams`

## Test plan

- [ ] Existing reasoning stream tests pass (they provide `onReasoningStream`, so behavior unchanged)
- [ ] WebSocket gateway client receives `stream: "thinking"` events when session has `reasoningLevel: "stream"`
- [ ] Telegram reasoning stream still works as before

Closes #5086

🤖 Generated with [Claude Code](https://claude.com/claude-code)