### PR TITLE
fix(telegram): restore native draft streaming for DM answer lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/Web: pass explicit Baileys socket timings into every WhatsApp Web socket and expose `web.whatsapp.*` keepalive, connect, and query timeout settings so unstable networks can avoid repeated 408 disconnect and opening-handshake timeout loops. Fixes #56365. (#73580) Thanks @velvet-shark.
 - Channels/Telegram: persist native command metadata on target sessions so topic, helper, and ACP-bound slash commands keep their session metadata attached to the routed conversation. (#57548) Thanks @GaosCode.
 - Channels/native commands: keep validated native slash command replies visible in group chats while preserving explicit owner allowlists for command authorization. (#73672) Thanks @obviyus.
+- Channels/Telegram: restore native draft streaming for DM answer previews while retaining ambiguous final materializations instead of sending duplicate fallback replies. (#47631; refs #42479) Thanks @XanderLuciano and @XXcipherX.
 - Auto-reply/session: carry the tail of user/assistant turns into the freshly-rotated transcript on silent in-reply session resets (compaction failure, role-ordering conflict) so direct-chat continuity survives the rebind. Fixes #70853. (#70898) Thanks @neeravmakwana.
 
 ## 2026.4.27

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2437,7 +2437,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     },
   );
 
-  it("uses message preview transport for all DM lanes when streaming is active", async () => {
+  it("uses native draft answer transport and message reasoning transport for DM lanes", async () => {
     setupDraftStreams({ answerMessageId: 999, reasoningMessageId: 111 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
@@ -2453,12 +2453,14 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "partial" });
 
     expect(createTelegramDraftStream).toHaveBeenCalledTimes(2);
+    // Answer lane uses auto (defaults to draft for DMs) for smooth streaming
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "message",
+        previewTransport: "auto",
       }),
     );
+    // Reasoning lane uses message transport to avoid conflicts
     expect(createTelegramDraftStream.mock.calls[1]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
@@ -2467,7 +2469,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("finalizes DM answer preview in place without materializing or sending a duplicate", async () => {
+  it("finalizes DM answer preview using native draft transport", async () => {
     const answerDraftStream = createDraftStream(321);
     const reasoningDraftStream = createDraftStream(111);
     createTelegramDraftStream
@@ -2484,10 +2486,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createContext(), streamMode: "partial" });
 
+    // Answer lane uses auto (draft transport for DMs)
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "message",
+        previewTransport: "auto",
       }),
     );
     expect(answerDraftStream.materialize).not.toHaveBeenCalled();

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2470,7 +2470,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   it("finalizes DM answer preview using native draft transport", async () => {
-    const answerDraftStream = createDraftStream(321);
+    const answerDraftStream = createTestDraftStream({ messageId: 321, previewMode: "draft" });
     const reasoningDraftStream = createDraftStream(111);
     createTelegramDraftStream
       .mockImplementationOnce(() => answerDraftStream)
@@ -2493,14 +2493,36 @@ describe("dispatchTelegramMessage draft streaming", () => {
         previewTransport: "auto",
       }),
     );
-    expect(answerDraftStream.materialize).not.toHaveBeenCalled();
+    expect(answerDraftStream.materialize).toHaveBeenCalledTimes(1);
     expect(deliverReplies).not.toHaveBeenCalled();
-    expect(editMessageTelegram).toHaveBeenCalledWith(
-      123,
-      321,
-      "Checking the directory...",
-      expect.any(Object),
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+  });
+
+  it("retains ambiguous DM draft answer materialize outcomes without duplicate fallback", async () => {
+    const answerDraftStream = createTestDraftStream({ previewMode: "draft" });
+    answerDraftStream.materialize.mockResolvedValue(undefined);
+    answerDraftStream.sendMayHaveLanded.mockReturnValue(true);
+    const reasoningDraftStream = createDraftStream(111);
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Checking the directory..." });
+        await dispatcherOptions.deliver({ text: "Checking the directory..." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
     );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(answerDraftStream.materialize).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.sendMayHaveLanded).toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
   });
 
   it("keeps reasoning and answer streaming in separate preview lanes", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2437,7 +2437,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     },
   );
 
-  it("uses native draft answer transport and message reasoning transport for DM lanes", async () => {
+  it("uses auto transport for DM answer lane and message transport for DM reasoning lane when streaming is active", async () => {
     setupDraftStreams({ answerMessageId: 999, reasoningMessageId: 111 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -405,10 +405,11 @@ export const dispatchTelegramMessage = async ({
       ? (replyQuoteMessageId ?? msg.message_id)
       : undefined;
   const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;
-  // Bot API 9.5 (March 2026) made sendMessageDraft available to all bots without
-  // requiring topics. Use native draft transport for DM answer lanes to enable
-  // smooth character-by-character streaming. Keep reasoning lane on message
-  // transport to avoid preview conflicts.
+  // The 3.8 "message" transport workaround was a hedge against a duplicate-flash
+  // bug caused by the draft→message materialize hop at finalize time. Bot API 9.5
+  // (March 2026) appears to have resolved this — no flash observed in testing.
+  // Use native draft transport for DM answer lanes to restore smooth streaming.
+  // Keep reasoning lane on message transport to avoid preview conflicts.
   const useMessagePreviewTransportForDmReasoning =
     threadSpec?.scope === "dm" && canStreamAnswerDraft;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -405,19 +405,27 @@ export const dispatchTelegramMessage = async ({
       ? (replyQuoteMessageId ?? msg.message_id)
       : undefined;
   const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;
-  // DM draft previews still duplicate briefly at materialize time.
-  const useMessagePreviewTransportForDm = threadSpec?.scope === "dm" && canStreamAnswerDraft;
+  // Bot API 9.5 (March 2026) made sendMessageDraft available to all bots without
+  // requiring topics. Use native draft transport for DM answer lanes to enable
+  // smooth character-by-character streaming. Keep reasoning lane on message
+  // transport to avoid preview conflicts.
+  const useMessagePreviewTransportForDmReasoning =
+    threadSpec?.scope === "dm" && canStreamAnswerDraft;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
+    // Only use message transport for reasoning lane in DMs; answer lane uses auto
+    // (which defaults to draft transport for DMs) for smooth streaming.
+    const useMessageTransport =
+      laneName === "reasoning" && useMessagePreviewTransportForDmReasoning;
     const stream = enabled
       ? (telegramDeps.createTelegramDraftStream ?? createTelegramDraftStream)({
           api: bot.api,
           chatId,
           maxChars: draftMaxChars,
           thread: threadSpec,
-          previewTransport: useMessagePreviewTransportForDm ? "message" : "auto",
+          previewTransport: useMessageTransport ? "message" : "auto",
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -331,6 +331,28 @@ describe("createTelegramDraftStream", () => {
     );
   });
 
+  it("marks sendMayHaveLanded after an ambiguous materialize send failure", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage.mockRejectedValueOnce(new Error("timeout after Telegram accepted send"));
+    const warn = vi.fn();
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "draft",
+      warn,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    const materializedId = await stream.materialize?.();
+
+    expect(materializedId).toBeUndefined();
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 42 });
+    expect(stream.sendMayHaveLanded?.()).toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream preview materialize failed: timeout after Telegram accepted send",
+    );
+  });
+
   it("returns existing preview id when materializing message transport", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -106,7 +106,7 @@ export type TelegramDraftStream = {
   materialize?: () => Promise<number | undefined>;
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
-  /** True when a preview sendMessage was attempted but the response was lost. */
+  /** True when a preview/materialize sendMessage was attempted but the response was lost. */
   sendMayHaveLanded?: () => boolean;
 };
 
@@ -438,6 +438,7 @@ export function createTelegramDraftStream(params: {
       return undefined;
     }
     const renderedParseMode = lastSentText ? lastSentParseMode : undefined;
+    messageSendAttempted = true;
     try {
       const { sent, usedThreadParams } = await sendRenderedMessageWithThreadFallback({
         renderedText,
@@ -462,6 +463,9 @@ export function createTelegramDraftStream(params: {
         return streamMessageId;
       }
     } catch (err) {
+      if (isSafeToRetrySendError(err) || isTelegramClientRejection(err)) {
+        messageSendAttempted = false;
+      }
       params.warn?.(`telegram stream preview materialize failed: ${formatErrorMessage(err)}`);
     }
     return undefined;

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -120,6 +120,7 @@ type TryUpdatePreviewParams = {
 };
 
 type PreviewEditResult = "edited" | "retained" | "regressive-skipped" | "fallback";
+type DraftMaterializeResult = { kind: "materialized"; messageId: number } | { kind: "retained" };
 
 type ConsumeArchivedAnswerPreviewParams = {
   lane: DraftLaneState;
@@ -236,7 +237,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     lane: DraftLaneState;
     laneName: LaneName;
     text: string;
-  }): Promise<number | undefined> => {
+  }): Promise<DraftMaterializeResult | undefined> => {
     const stream = args.lane.stream;
     if (!stream || !isDraftPreviewLane(args.lane)) {
       return undefined;
@@ -254,7 +255,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           `telegram: ${args.laneName} draft materialize may have landed despite missing message id; retaining to avoid duplicate`,
         );
         params.markDelivered();
-        return true;
+        args.lane.lastPartialText = args.text;
+        return { kind: "retained" };
       }
       params.log(
         `telegram: ${args.laneName} draft preview materialize produced no message id; falling back to standard send`,
@@ -263,7 +265,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
     args.lane.lastPartialText = args.text;
     params.markDelivered();
-    return materializedMessageId;
+    return { kind: "materialized", messageId: materializedMessageId };
   };
 
   const tryEditPreviewMessage = async (args: {
@@ -589,17 +591,21 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           }
         }
         if (canMaterializeDraftFinal(lane, previewButtons)) {
-          const materializedMessageId = await tryMaterializeDraftPreviewForFinal({
+          const materialized = await tryMaterializeDraftPreviewForFinal({
             lane,
             laneName,
             text,
           });
-          if (typeof materializedMessageId === "number") {
+          if (materialized?.kind === "materialized") {
             markActivePreviewComplete(laneName);
             return result("preview-finalized", {
               content: text,
-              messageId: materializedMessageId,
+              messageId: materialized.messageId,
             });
+          }
+          if (materialized?.kind === "retained") {
+            markActivePreviewComplete(laneName);
+            return result("preview-retained");
           }
         }
         if (shouldUseFreshFinalForLane(lane)) {

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -246,6 +246,16 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     stream.update(args.text);
     const materializedMessageId = await stream.materialize?.();
     if (typeof materializedMessageId !== "number") {
+      // Guard against ambiguous failures: if a send was attempted but the
+      // response was lost (network timeout), the message may have landed.
+      // Retain instead of falling back to avoid duplicate final messages.
+      if (stream.sendMayHaveLanded?.()) {
+        params.log(
+          `telegram: ${args.laneName} draft materialize may have landed despite missing message id; retaining to avoid duplicate`,
+        );
+        params.markDelivered();
+        return true;
+      }
       params.log(
         `telegram: ${args.laneName} draft preview materialize produced no message id; falling back to standard send`,
       );


### PR DESCRIPTION
## What

This restores `sendMessageDraft` for the answer lane in Telegram DMs, bringing back the smooth character-by-character streaming that was disabled in 3.8.

## Why

The 3.8 change (`d4ab731`) switched all DM lanes to message transport (`sendMessage` + `editMessageText`) to fix a "duplicate flash" bug at finalization. But this killed the smooth streaming experience — messages now come through in choppy blocks instead of flowing naturally.

I bisected between 3.7 and 3.8 to find the regression, and confirmed that on 3.7 with native draft streaming:
- Streaming is noticeably smoother
- The "duplicate flash" bug does not reproduce (possibly fixed by Bot API 9.5, which made `sendMessageDraft` available to all bots on March 1, 2026)

## Changes

- Answer lane now uses `"auto"` transport (defaults to native draft for DMs)
- Reasoning lane stays on `"message"` transport to avoid preview conflicts
- Updated tests to match

## Testing

Tested on OpenClaw 2026.3.7 with `streaming: "partial"` configured. No duplicate flash observed at message finalization. Streaming feels significantly smoother compared to 3.8+.

## Related Issues

Fixes #32469
Addresses #31061
Addresses #32148
Addresses #32180