### PR TITLE
Add common-pitfalls.md reference documentation

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -370,3 +370,7 @@ After testing the skill, users may request improvements. Often this happens righ
 2. Notice struggles or inefficiencies
 3. Identify how SKILL.md or bundled resources should be updated
 4. Implement changes and test again
+
+## Common Issues
+
+If your skill isn't loading or behaving unexpectedly, see [references/common-pitfalls.md](references/common-pitfalls.md).

--- a/skills/skill-creator/references/common-pitfalls.md
+++ b/skills/skill-creator/references/common-pitfalls.md
@@ -1,0 +1,104 @@
+# Common Pitfalls in Skill Development
+
+This document catalogs common issues that developers encounter when creating skills for OpenClaw.
+
+## YAML Frontmatter Issues
+
+### Unquoted Colons in Description Field
+
+**Problem:** Skills with unquoted colons in the `description` field fail to load silently due to YAML parser errors.
+
+**Error Message:**
+```
+Nested mappings are not allowed in compact mappings
+```
+
+**Root Cause:** YAML treats unquoted colons as key-value separators. The colon (`:`) is interpreted as a delimiter, not as part of the string.
+
+**Broken Example:**
+```yaml
+---
+name: my-skill
+description: Use when you need to: do something important
+---
+```
+
+**Fixed Example:**
+```yaml
+---
+name: my-skill
+description: "Use when you need to: do something important"
+---
+```
+
+**Detection Difficulty:**
+- `package_skill.py` validates and packages successfully
+- Skills appear in workspace directory
+- No runtime errors visible to user
+- Skills simply don't appear in loaded skills list
+- Required OpenClaw restart + new session to test
+
+**Best Practice:** Always quote strings in YAML frontmatter that contain:
+- Colons (`:`)
+- Special characters (`*`, `#`, `|`, `>`)
+- Strings starting/ending with spaces
+
+---
+
+## SKILL.md Body Issues
+
+### Excessive Verbosity
+
+**Problem:** SKILL.md files that are too long consume excessive context window.
+
+**Solution:** Use the progressive disclosure pattern:
+- Keep SKILL.md body under 500 lines
+- Move detailed reference material to `references/` directory
+- Link to reference files from SKILL.md body
+
+### Missing Trigger Examples
+
+**Problem:** Skills with vague descriptions don't get triggered appropriately.
+
+**Solution:** Include specific phrases in the `description` field:
+```yaml
+description: "Create, edit, or improve AgentSkills. Triggers on: create a skill, improve this skill, tidy up skill, audit skill"
+```
+
+---
+
+## Bundle Resource Issues
+
+### Large Reference Files
+
+**Problem:** Loading large reference files into context unnecessarily.
+
+**Solution:** For files over 10k words, include grep search patterns in SKILL.md to help Codex find relevant sections.
+
+### Missing Script Executability
+
+**Problem:** Scripts in `scripts/` directory not being executed properly.
+
+**Solution:** Ensure scripts have proper shebang (`#!/bin/bash`, `#!/usr/bin/env python3`) and execute permissions.
+
+---
+
+## Testing Issues
+
+### Skills Not Appearing After Restart
+
+**Common Causes:**
+1. YAML frontmatter parsing errors (see: Unquoted Colons)
+2. Invalid YAML syntax
+3. Missing required fields (`name`, `description`)
+4. File in wrong location (must be in `skills/<skill-name>/SKILL.md`)
+
+**Debugging Steps:**
+1. Check OpenClaw logs for YAML parsing errors
+2. Validate YAML with `python3 -c "import yaml; yaml.safe_load(open('SKILL.md'))"`
+3. Verify skill directory structure matches specification
+4. Ensure no symlinks (security restriction)
+
+---
+
+*Last updated: 2026-03-15*


### PR DESCRIPTION
## Summary

Adds a new `references/common-pitfalls.md` file to the skill-creator skill that documents common issues developers encounter when creating skills.

## Changes

1. **New file**: `skills/skill-creator/references/common-pitfalls.md`
   - Documents YAML frontmatter issues (unquoted colons)
   - Documents SKILL.md body issues (excessive verbosity, missing triggers)
   - Documents bundle resource issues
   - Documents testing/debugging issues

2. **Updated**: `skills/skill-creator/SKILL.md`
   - Added reference link to common-pitfalls.md in a new "Common Issues" section

## Why This Helps

When creating skills, developers often encounter silent failures due to YAML parsing errors with unquoted colons in descriptions. This documentation:
- Provides progressive disclosure (only loaded when needed)
- Is extensible (easy to add more pitfalls over time)
- Is searchable (developers can grep for specific errors)
- Travels with the skill

## Addresses

- Fixes #47612

---

*Contributed by Flocky (haroldfabla2-hue)*