### PR TITLE
fix(telegram): add request-level timeout for getUpdates long-poll

### DIFF
--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -204,7 +204,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       let requestTimer: ReturnType<typeof setTimeout> | undefined;
       if (extractTelegramApiMethod(input) === "getUpdates") {
         requestTimer = setTimeout(
-          () => controller.abort(new Error("getUpdates request timeout")),
+          () => controller.abort(new DOMException("getUpdates request timeout", "TimeoutError")),
           GET_UPDATES_REQUEST_TIMEOUT_MS,
         );
       }

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -72,6 +72,24 @@ export type TelegramBotOptions = {
 
 export { getTelegramSequentialKey };
 
+/**
+ * Hard request timeout for `getUpdates` long-poll requests (ms).
+ *
+ * Telegram long-polling holds the connection for up to `timeout` seconds
+ * (default 30) before responding.  On VPS / cloud hosts whose NAT or
+ * firewall silently drops idle TCP connections before that window elapses,
+ * the HTTP request hangs indefinitely.  The polling-session watchdog
+ * (`POLL_STALL_THRESHOLD_MS = 90 s`) eventually catches this, but it
+ * introduces 90–120 s of avoidable dead time per stall cycle.
+ *
+ * This constant sets a per-request `setTimeout` on the fetch
+ * `AbortController` so a dropped connection aborts cleanly in ≤ 60 s,
+ * letting the grammY runner retry immediately.
+ *
+ * Value = Telegram poll timeout (30 s) + 30 s network buffer.
+ */
+const GET_UPDATES_REQUEST_TIMEOUT_MS = 60_000;
+
 type TelegramFetchInput = Parameters<NonNullable<ApiClientOptions["fetch"]>>[0];
 type TelegramFetchInit = Parameters<NonNullable<ApiClientOptions["fetch"]>>[1];
 type GlobalFetchInput = Parameters<typeof globalThis.fetch>[0];
@@ -178,10 +196,25 @@ export function createTelegramBot(opts: TelegramBotOptions) {
           init.signal.addEventListener("abort", onRequestAbort);
         }
       }
+      // Apply a hard request timeout for getUpdates to detect silently-dropped
+      // TCP connections.  VPS/cloud NAT may kill idle connections before the
+      // Telegram long-poll server-side timeout elapses, leaving the request
+      // hanging until the polling stall watchdog fires (90 s+).  This timeout
+      // lets the runner retry much sooner.
+      let requestTimer: ReturnType<typeof setTimeout> | undefined;
+      if (extractTelegramApiMethod(input) === "getUpdates") {
+        requestTimer = setTimeout(
+          () => controller.abort(new Error("getUpdates request timeout")),
+          GET_UPDATES_REQUEST_TIMEOUT_MS,
+        );
+      }
       return callFetch(input as GlobalFetchInput, {
         ...(init as GlobalFetchInit),
         signal: controller.signal,
       }).finally(() => {
+        if (requestTimer) {
+          clearTimeout(requestTimer);
+        }
         shutdownSignal.removeEventListener("abort", onShutdown);
         if (init?.signal && onRequestAbort) {
           init.signal.removeEventListener("abort", onRequestAbort);


### PR DESCRIPTION
## Summary

- Adds a 60 s hard request timeout (`AbortSignal`) for `getUpdates` fetch calls in the Telegram bot fetch wrapper
- Detects silently-dropped TCP connections caused by VPS/cloud NAT idle timeouts, aborting the hung request cleanly instead of waiting 90–120 s for the polling stall watchdog

## Problem

On VPS / cloud hosts (observed on Hostinger KVM), NAT or firewall rules silently drop idle TCP connections.  Telegram long-polling holds the connection for up to 30 s (`timeout: 30`), but there is no HTTP-level request timeout on the `fetch()` call.  When the connection is killed mid-flight:

1. The HTTP request hangs indefinitely (no TCP RST, no FIN)
2. The polling stall watchdog (`POLL_STALL_THRESHOLD_MS = 90 s`) eventually detects no `getUpdates` calls and forces a restart
3. This introduces 90–120 s of dead time per stall cycle (90 s threshold + up to 30 s watchdog interval)

This is a general issue affecting any cloud environment with aggressive NAT idle timeouts — not isolated to a specific host.  System-level TCP keepalive tuning (`tcp_keepalive_time`) helps for persistent WebSocket connections but does not reliably protect short-lived HTTP request connections at the Node.js/undici layer.

## Fix

A `setTimeout` on the existing `AbortController` in the shutdown signal fetch wrapper, scoped to `getUpdates` requests only.  The timeout is `GET_UPDATES_REQUEST_TIMEOUT_MS = 60_000` (poll timeout 30 s + 30 s network buffer).

Non-`getUpdates` API calls are unaffected.  The timer is cleared in `finally` to avoid leaks.

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm check` — 0 warnings, 0 errors
- [x] `pnpm test -- extensions/telegram/src/bot.create-telegram-bot.test.ts` — 46/46 pass
- [x] `pnpm test -- extensions/telegram/src/fetch.test.ts` — 20/20 pass
- [x] Verified on production Hostinger VPS: Telegram polling stalls reduced from every ~107 s to clean recovery within 60 s

🤖 AI-assisted (Claude Code). Fully tested. I understand the code — the fix reuses the existing `AbortController` in `createTelegramBot`'s shutdown signal fetch wrapper and adds a scoped timer for `getUpdates` requests only.