### PR TITLE
docs: add AARI Execution Firewall to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **AARI Execution Firewall** — Pre-execution firewall for OpenClaw agents with ALLOW / WARN / BLOCK policy enforcement and audit trail.
+  npm: `@aari/aari-firewall`
+  repo: `https://github.com/aari-ai/openclaw-aari`
+  install: `openclaw plugins install @aari/aari-firewall`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,12 +45,12 @@ Use this format when adding entries:
 
 ## Listed plugins
 
-- **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
-  npm: `@icesword760/openclaw-wechat`
-  repo: `https://github.com/icesword0760/openclaw-wechat`
-  install: `openclaw plugins install @icesword760/openclaw-wechat`
-
 - **AARI Execution Firewall** — Pre-execution firewall for OpenClaw agents with ALLOW / WARN / BLOCK policy enforcement and audit trail.
   npm: `@aari/aari-firewall`
   repo: `https://github.com/aari-ai/openclaw-aari`
   install: `openclaw plugins install @aari/aari-firewall`
+
+- **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
+  npm: `@icesword760/openclaw-wechat`
+  repo: `https://github.com/icesword0760/openclaw-wechat`
+  install: `openclaw plugins install @icesword760/openclaw-wechat`


### PR DESCRIPTION
## Summary

Adds the AARI Execution Firewall plugin to the community plugins list.

**Plugin:** AARI Execution Firewall
**npm:** `@aari/aari-firewall`
**repo:** https://github.com/aari-ai/openclaw-aari
**install:** `openclaw plugins install @aari/aari-firewall`

## What it does

Pre-execution firewall for OpenClaw agents. Intercepts every tool call before execution via the `before_tool_call` hook, calls the AARI control plane for a risk score (0–100) and policy decision, and enforces ALLOW / WARN / BLOCK before anything runs.

- BLOCK returns a clean stop signal — tool does not execute
- Full audit trail via `after_tool_call` hook
- Fail-closed: high-risk action types blocked locally if server is unreachable

## Validation status

Already validated on a live OpenClaw runtime:
- `exec` ALLOW and BLOCK (destructive shell commands blocked by policy)
- `message` → Telegram ALLOW and BLOCK

## Meets listing requirements

- Published on npm: https://www.npmjs.com/package/@aari/aari-firewall
- Source on GitHub: https://github.com/aari-ai/openclaw-aari (public)
- README with setup docs and validation scenarios
- Issue tracker: https://github.com/aari-ai/openclaw-aari/issues
