### PR TITLE
fix(embedded): prevent requiresThinkingAsText unshift crash

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -9,6 +9,7 @@ import {
   composeSystemPromptWithHookContext,
   persistSessionsYieldContextMessage,
   isOllamaCompatProvider,
+  modelRequiresThinkingAsText,
   prependSystemPromptAddition,
   queueSessionsYieldInterruptMessage,
   resolveAttemptFsWorkspaceOnly,
@@ -1664,6 +1665,49 @@ describe("resolveOllamaBaseUrlForRun", () => {
 
   it("falls back to native default when neither baseUrl is configured", () => {
     expect(resolveOllamaBaseUrlForRun({})).toBe("http://127.0.0.1:11434");
+  });
+});
+
+describe("modelRequiresThinkingAsText", () => {
+  it("returns true only for openai-completions with strict boolean compat flag", () => {
+    expect(
+      modelRequiresThinkingAsText({
+        api: "openai-completions",
+        compat: { requiresThinkingAsText: true },
+      }),
+    ).toBe(true);
+    expect(
+      modelRequiresThinkingAsText({
+        api: "openai-completions",
+        compat: { requiresThinkingAsText: 1 },
+      }),
+    ).toBe(false);
+    expect(
+      modelRequiresThinkingAsText({
+        api: "openai-completions",
+        compat: { requiresThinkingAsText: "true" },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for missing compat or non-openai-completions api", () => {
+    expect(
+      modelRequiresThinkingAsText({
+        api: "openai-completions",
+      }),
+    ).toBe(false);
+    expect(
+      modelRequiresThinkingAsText({
+        api: "openai-completions",
+        compat: null,
+      }),
+    ).toBe(false);
+    expect(
+      modelRequiresThinkingAsText({
+        api: "openai-responses",
+        compat: { requiresThinkingAsText: true },
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -133,7 +133,7 @@ import {
   buildEmbeddedSystemPrompt,
   createSystemPromptOverride,
 } from "../system-prompt.js";
-import { dropThinkingBlocks } from "../thinking.js";
+import { convertThinkingBlocksToText, dropThinkingBlocks } from "../thinking.js";
 import { collectAllowedToolNames } from "../tool-name-allowlist.js";
 import { installToolResultContextGuard } from "../tool-result-context-guard.js";
 import { splitSdkTools } from "../tool-split.js";
@@ -482,6 +482,19 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         return options?.onPayload?.(payload, model);
       },
     });
+}
+
+function modelRequiresThinkingAsText(model: { api?: unknown; compat?: unknown }): boolean {
+  if (model.api !== "openai-completions") {
+    return false;
+  }
+  if (!model.compat || typeof model.compat !== "object") {
+    return false;
+  }
+  if (!("requiresThinkingAsText" in model.compat)) {
+    return false;
+  }
+  return (model.compat as { requiresThinkingAsText?: unknown }).requiresThinkingAsText === true;
 }
 
 function resolveCaseInsensitiveAllowedToolName(
@@ -2312,6 +2325,28 @@ export async function runEmbeddedAttempt(
             return inner(model, context, options);
           }
           const sanitized = dropThinkingBlocks(messages as unknown as AgentMessage[]) as unknown;
+          if (sanitized === messages) {
+            return inner(model, context, options);
+          }
+          const nextContext = {
+            ...(context as unknown as Record<string, unknown>),
+            messages: sanitized,
+          } as unknown;
+          return inner(model, nextContext as typeof context, options);
+        };
+      }
+
+      // Work around openai-completions adapter paths that can convert assistant
+      // content to a string and then `unshift` thinking-as-text into it.
+      if (modelRequiresThinkingAsText(params.model)) {
+        const inner = activeSession.agent.streamFn;
+        activeSession.agent.streamFn = (model, context, options) => {
+          const ctx = context as unknown as { messages?: unknown };
+          const messages = ctx?.messages;
+          if (!Array.isArray(messages)) {
+            return inner(model, context, options);
+          }
+          const sanitized = convertThinkingBlocksToText(messages as unknown as AgentMessage[]);
           if (sanitized === messages) {
             return inner(model, context, options);
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -484,7 +484,7 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
     });
 }
 
-function modelRequiresThinkingAsText(model: { api?: unknown; compat?: unknown }): boolean {
+export function modelRequiresThinkingAsText(model: { api?: unknown; compat?: unknown }): boolean {
   if (model.api !== "openai-completions") {
     return false;
   }

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -1,7 +1,11 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
-import { dropThinkingBlocks, isAssistantMessageWithContent } from "./thinking.js";
+import {
+  convertThinkingBlocksToText,
+  dropThinkingBlocks,
+  isAssistantMessageWithContent,
+} from "./thinking.js";
 
 function dropSingleAssistantContent(content: Array<Record<string, unknown>>) {
   const messages: AgentMessage[] = [
@@ -59,5 +63,69 @@ describe("dropThinkingBlocks", () => {
       { type: "thinking", thinking: "internal-only" },
     ]);
     expect(assistant.content).toEqual([{ type: "text", text: "" }]);
+  });
+});
+
+describe("convertThinkingBlocksToText", () => {
+  it("returns the original reference when no thinking blocks are present", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "hello" }),
+      castAgentMessage({ role: "assistant", content: [{ type: "text", text: "world" }] }),
+    ];
+
+    const result = convertThinkingBlocksToText(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("prepends joined thinking text and removes thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "first thought" },
+          { type: "text", text: "final answer" },
+          { type: "thinking", thinking: "second thought" },
+        ],
+      }),
+    ];
+
+    const result = convertThinkingBlocksToText(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(result).not.toBe(messages);
+    expect(assistant.content).toEqual([
+      { type: "text", text: "first thought\n\nsecond thought" },
+      { type: "text", text: "final answer" },
+    ]);
+  });
+
+  it("keeps assistant turn structure when thinking was the only content", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "internal-only" }],
+      }),
+    ];
+
+    const result = convertThinkingBlocksToText(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "internal-only" }]);
+  });
+
+  it("drops empty thinking blocks and preserves non-thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "   " },
+          { type: "toolCall", id: "c1", name: "read", arguments: {} },
+        ],
+      }),
+    ];
+
+    const result = convertThinkingBlocksToText(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([
+      { type: "toolCall", id: "c1", name: "read", arguments: {} },
+    ]);
   });
 });

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -56,6 +56,10 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
  * For providers that require "thinking as text", convert assistant thinking
  * blocks into a leading text block and remove the original thinking blocks.
  *
+ * Thinking blocks are intentionally collapsed regardless of their original
+ * position (for example `[thinking, text, thinking]` becomes
+ * `[combined-thinking-text, text]`) to match provider-compat replay behavior.
+ *
  * This avoids downstream adapter paths that assume `assistant.content` is an
  * array and call `unshift` on it, even when provider compat can force string
  * content in the outgoing payload.
@@ -82,6 +86,7 @@ export function convertThinkingBlocksToText(messages: AgentMessage[]): AgentMess
       nextContent.push(block);
     }
     if (thinkingTexts.length > 0) {
+      // Keep replay deterministic by emitting one canonical leading text block.
       nextContent.unshift({
         type: "text",
         text: thinkingTexts.join("\n\n"),

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -51,3 +51,49 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
   }
   return touched ? out : messages;
 }
+
+/**
+ * For providers that require "thinking as text", convert assistant thinking
+ * blocks into a leading text block and remove the original thinking blocks.
+ *
+ * This avoids downstream adapter paths that assume `assistant.content` is an
+ * array and call `unshift` on it, even when provider compat can force string
+ * content in the outgoing payload.
+ */
+export function convertThinkingBlocksToText(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (!isAssistantMessageWithContent(msg)) {
+      out.push(msg);
+      continue;
+    }
+    const thinkingTexts: string[] = [];
+    const nextContent: AssistantContentBlock[] = [];
+    for (const block of msg.content) {
+      if (block && typeof block === "object" && (block as { type?: unknown }).type === "thinking") {
+        touched = true;
+        const thinkingValue = (block as { thinking?: unknown }).thinking;
+        if (typeof thinkingValue === "string" && thinkingValue.trim().length > 0) {
+          thinkingTexts.push(thinkingValue);
+        }
+        continue;
+      }
+      nextContent.push(block);
+    }
+    if (thinkingTexts.length > 0) {
+      nextContent.unshift({
+        type: "text",
+        text: thinkingTexts.join("\n\n"),
+      } as AssistantContentBlock);
+    }
+    if (nextContent.length === msg.content.length && thinkingTexts.length === 0) {
+      out.push(msg);
+      continue;
+    }
+    const content =
+      nextContent.length > 0 ? nextContent : [{ type: "text", text: "" } as AssistantContentBlock];
+    out.push({ ...msg, content });
+  }
+  return touched ? out : messages;
+}

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,6 +1157,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "google-gemini-cli-auth",
+    idHint: "google-gemini-cli-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/google-gemini-cli-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "google-gemini-cli-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["google-gemini-cli"],
+    },
+  },
+  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1859,6 +1882,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
+    },
+  },
+  {
+    dirName: "minimax-portal-auth",
+    idHint: "minimax-portal-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/minimax-portal-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "minimax-portal-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["minimax-portal"],
     },
   },
   {

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,29 +1157,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
-    dirName: "google-gemini-cli-auth",
-    idHint: "google-gemini-cli-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/google-gemini-cli-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "google-gemini-cli-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["google-gemini-cli"],
-    },
-  },
-  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1882,29 +1859,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
-    },
-  },
-  {
-    dirName: "minimax-portal-auth",
-    idHint: "minimax-portal-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/minimax-portal-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "minimax-portal-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["minimax-portal"],
     },
   },
   {


### PR DESCRIPTION
## Summary

- Problem: embedded runs can fail with `textContent.unshift is not a function` when using `openai-completions` models that set `compat.requiresThinkingAsText`.
- Why it matters: this crashes a normal turn even though the model response is otherwise recoverable, causing user-visible run failures.
- What changed: added a session-history sanitizer that converts assistant `thinking` blocks into a leading `text` block before stream dispatch, and wired it into `run/attempt.ts` only for `openai-completions` + `requiresThinkingAsText`.
- What did NOT change (scope boundary): no dependency patching in `@mariozechner/pi-ai`, no changes to non-`requiresThinkingAsText` model flows.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #47548
- Related #35952
- Related #35997
- Related #36112
- Related #43864

## User-visible / Behavior Changes

Embedded runs no longer crash on this thinking-as-text conversion edge case; the turn proceeds with thinking content represented as text.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: local macOS dev host
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: openai-completions path with `compat.requiresThinkingAsText`
- Integration/channel (if any): embedded runner
- Relevant config (redacted): model compat includes `requiresThinkingAsText: true`

### Steps

1. Create assistant history containing `thinking` blocks and replay through embedded run.
2. Use openai-completions model compat requiring thinking-as-text.
3. Observe transform path before stream call.

### Expected

- Thinking should be represented as text without crashing.

### Actual

- Before fix, downstream adapter can call `unshift` on string content and throw `textContent.unshift is not a function`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local checks run:
- `pnpm test -- src/agents/pi-embedded-runner/thinking.test.ts`
- `pnpm test -- src/agents/pi-embedded-runner/run/attempt.test.ts -t "wrapOllamaCompatNumCtx"`
- `pnpm build`
- `pnpm check`

## Human Verification (required)

- Verified scenarios: thinking-only assistant history; mixed thinking+text assistant history; no-thinking baseline path.
- Edge cases checked: empty thinking blocks; non-assistant messages unchanged; unchanged array reference when no thinking blocks exist.
- What you did **not** verify: live provider/channel end-to-end run on external infrastructure.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`, `src/agents/pi-embedded-runner/thinking.ts`.
- Known bad symptoms reviewers should watch for: assistant replay ordering changes for thinking blocks.

## Risks and Mitigations

- Risk: converting thinking blocks to text can alter exact replay formatting.
  - Mitigation: conversion is gated to `openai-completions` with `requiresThinkingAsText` only, and covered by targeted tests.
