### PR TITLE
fix: child logger inherits parent minLevel when no override given

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -227,7 +227,7 @@ export function getChildLogger(
   const name = bindings ? JSON.stringify(bindings) : undefined;
   return base.getSubLogger({
     name,
-    minLevel,
+    ...(minLevel !== undefined ? { minLevel } : {}),
     prefix: bindings ? [name ?? ""] : [],
   });
 }


### PR DESCRIPTION
Fixes #40465

## Root Cause

`getChildLogger` passes `minLevel: undefined` to tslog's `getSubLogger` when no level override is given. Inside tslog's constructor, `undefined` is treated as `settings?.minLevel ?? 0`, which resets the child logger to level 0 (trace/silly), ignoring the parent's configured `minLevel`. This causes DEBUG-level logs (e.g. cron timer logs) to appear even when `logging.level` is set to `"info"`.

## Fix

Only spread `minLevel` into the sub-logger settings when it is explicitly provided. When `undefined`, omit it entirely so tslog inherits the parent's `minLevel`:

```diff
  return base.getSubLogger({
    name,
-   minLevel,
+   ...(minLevel !== undefined ? { minLevel } : {}),
    prefix: bindings ? [name ?? ""] : [],
  });
```

## Testing

- All 68 logging tests pass
- All 521 cron tests pass
- Lint clean