### PR TITLE
fix(feishu): isolate per-account credential resolution to prevent full plugin crash

### DIFF
--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -239,6 +239,18 @@ export function resolveFeishuAccount(params: {
  */
 export function listEnabledFeishuAccounts(cfg: ClawdbotConfig): ResolvedFeishuAccount[] {
   return listFeishuAccountIds(cfg)
-    .map((accountId) => resolveFeishuAccount({ cfg, accountId }))
-    .filter((account) => account.enabled && account.configured);
+    .map((accountId) => {
+      try {
+        return resolveFeishuAccount({ cfg, accountId });
+      } catch (err) {
+        console.warn(
+          `feishu: skipping account "${accountId}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return null;
+      }
+    })
+    .filter(
+      (account): account is ResolvedFeishuAccount =>
+        account !== null && account.enabled && account.configured,
+    );
 }

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -245,6 +245,7 @@ export function listEnabledFeishuAccounts(cfg: ClawdbotConfig): ResolvedFeishuAc
       } catch (err) {
         console.warn(
           `feishu: skipping account "${accountId}": ${err instanceof Error ? err.message : String(err)}`,
+          err,
         );
         return null;
       }


### PR DESCRIPTION
## Summary

Prevents a single Feishu account's unresolvable SecretRef from crashing the entire feishu plugin and taking all accounts offline.

## Root Cause

`listEnabledFeishuAccounts()` in `accounts.ts` uses `.map()` to call `resolveFeishuAccount()` for each configured account. When an account uses a file-source SecretRef (e.g. `file:filemain:/channels/feishu2/appSecret`), this ref is not resolvable during plugin re-registration (~3 minutes after startup when config reload triggers). The unhandled exception propagates through `.map()`, causing `recordPluginError` to mark the entire feishu plugin as failed — all accounts go offline.

## Fix

Wrap `resolveFeishuAccount()` in a per-account try-catch inside the `.map()` callback. On failure, log a warning with the account ID and error message, return `null`, and filter it out. Other accounts continue operating normally.

## Changes

- `extensions/feishu/src/accounts.ts`: 14 lines added, 2 removed

## Testing

- `pnpm build` passes

Fixes #47436