### PR TITLE
feat(skills): add `openclaw skills install <name>` CLI command

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -46,6 +46,8 @@ export type SkillStatusEntry = {
   missing: Requirements;
   configChecks: SkillStatusConfigCheck[];
   install: SkillInstallOption[];
+  /** True when the skill defines at least one install spec, even if none apply to the current OS. */
+  hasInstallSpecs: boolean;
 };
 
 export type SkillStatusReport = {
@@ -221,6 +223,7 @@ function buildSkillStatus(
     missing,
     configChecks,
     install: normalizeInstallOptions(entry, prefs ?? resolveSkillsInstallPreferences(config)),
+    hasInstallSpecs: (entry.metadata?.install ?? []).length > 0,
   };
 }
 

--- a/src/cli/requirements-test-fixtures.ts
+++ b/src/cli/requirements-test-fixtures.ts
@@ -14,5 +14,6 @@ export function createEmptyInstallChecks() {
     missing: createEmptyRequirements(),
     configChecks: [],
     install: [],
+    hasInstallSpecs: false,
   };
 }

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -1,10 +1,10 @@
-import { spinner } from "@clack/prompts";
 import type { Command } from "commander";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
+import { withProgress } from "./progress.js";
 import { formatSkillInfo, formatSkillsCheck, formatSkillsList } from "./skills-cli.format.js";
 
 export type {
@@ -99,24 +99,20 @@ export function registerSkillsCli(program: Command) {
         const { installSkill } = await import("../agents/skills-install.js");
         let anyFailed = false;
         for (const option of skill.install) {
-          const spin = spinner();
-          spin.start(theme.accent(`Installing ${name} (${option.label})…`));
-          const result = await installSkill({
-            workspaceDir,
-            skillName: name,
-            installId: option.id,
-            config,
-          });
+          const result = await withProgress(
+            { label: theme.accent(`Installing ${name} (${option.label})…`), indeterminate: true },
+            () => installSkill({ workspaceDir, skillName: name, installId: option.id, config }),
+          );
           const warnings = result.warnings ?? [];
           if (result.ok) {
-            spin.stop(
+            defaultRuntime.log(
               warnings.length > 0
                 ? `Installed ${name} (${option.label}) — with warnings`
                 : `Installed ${name} (${option.label})`,
             );
           } else {
             const code = result.code == null ? "" : ` (exit ${result.code})`;
-            spin.stop(theme.error(`Failed: ${name} (${option.label})${code} — ${result.message}`));
+            defaultRuntime.error(`Failed: ${name} (${option.label})${code} — ${result.message}`);
             if (result.stderr) {
               defaultRuntime.log(result.stderr.trim());
             } else if (result.stdout) {
@@ -129,9 +125,7 @@ export function registerSkillsCli(program: Command) {
           }
         }
         if (anyFailed) {
-          defaultRuntime.log(
-            `Tip: run \`openclaw doctor\` to review skills + requirements.`,
-          );
+          defaultRuntime.log(`Tip: run \`openclaw doctor\` to review skills + requirements.`);
           defaultRuntime.exit(1);
         }
       } catch (err) {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -92,8 +92,16 @@ export function registerSkillsCli(program: Command) {
           return;
         }
         if (skill.install.length === 0) {
-          defaultRuntime.log(`No install specs for skill: ${name}`);
-          defaultRuntime.exit(0);
+          if (skill.hasInstallSpecs) {
+            // Install specs exist but were filtered out (e.g. unsupported OS).
+            defaultRuntime.error(
+              `No installers available for skill: ${name} on this platform (${process.platform})`,
+            );
+            defaultRuntime.exit(1);
+          } else {
+            defaultRuntime.log(`No install specs for skill: ${name}`);
+            defaultRuntime.exit(0);
+          }
           return;
         }
         const { installSkill } = await import("../agents/skills-install.js");

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -1,3 +1,4 @@
+import { spinner } from "@clack/prompts";
 import type { Command } from "commander";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
@@ -72,6 +73,71 @@ export function registerSkillsCli(program: Command) {
     .option("--json", "Output as JSON", false)
     .action(async (opts) => {
       await runSkillsAction((report) => formatSkillsCheck(report, opts));
+    });
+
+  skills
+    .command("install")
+    .description("Install dependencies for a skill")
+    .argument("<name>", "Skill name")
+    .action(async (name: string) => {
+      try {
+        const config = loadConfig();
+        const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+        const { buildWorkspaceSkillStatus } = await import("../agents/skills-status.js");
+        const report = buildWorkspaceSkillStatus(workspaceDir, { config });
+        const skill = report.skills.find((s) => s.name === name);
+        if (!skill) {
+          defaultRuntime.error(`Skill not found: ${name}`);
+          defaultRuntime.exit(1);
+          return;
+        }
+        if (skill.install.length === 0) {
+          defaultRuntime.log(`No install specs for skill: ${name}`);
+          defaultRuntime.exit(0);
+          return;
+        }
+        const { installSkill } = await import("../agents/skills-install.js");
+        let anyFailed = false;
+        for (const option of skill.install) {
+          const spin = spinner();
+          spin.start(theme.accent(`Installing ${name} (${option.label})…`));
+          const result = await installSkill({
+            workspaceDir,
+            skillName: name,
+            installId: option.id,
+            config,
+          });
+          const warnings = result.warnings ?? [];
+          if (result.ok) {
+            spin.stop(
+              warnings.length > 0
+                ? `Installed ${name} (${option.label}) — with warnings`
+                : `Installed ${name} (${option.label})`,
+            );
+          } else {
+            const code = result.code == null ? "" : ` (exit ${result.code})`;
+            spin.stop(theme.error(`Failed: ${name} (${option.label})${code} — ${result.message}`));
+            if (result.stderr) {
+              defaultRuntime.log(result.stderr.trim());
+            } else if (result.stdout) {
+              defaultRuntime.log(result.stdout.trim());
+            }
+            anyFailed = true;
+          }
+          for (const warning of warnings) {
+            defaultRuntime.log(warning);
+          }
+        }
+        if (anyFailed) {
+          defaultRuntime.log(
+            `Tip: run \`openclaw doctor\` to review skills + requirements.`,
+          );
+          defaultRuntime.exit(1);
+        }
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
     });
 
   // Default action (no subcommand) - show list


### PR DESCRIPTION
## Summary

- Adds `openclaw skills install <name>` subcommand to the existing `skills` CLI group
- Calls the existing `installSkill()` function (already used by onboarding and exposed via gateway RPC `skills.install`) for each install option on the skill
- Shows a `@clack/prompts` spinner per dependency, prints warnings, and exits non-zero on any failure with a `openclaw doctor` tip

## Changes

- `src/cli/skills-cli.ts`: add `skills install <name>` subcommand; import `spinner` from `@clack/prompts`

## Test plan

- [ ] `openclaw skills install <skill-with-deps>` — spinner shows, dependency installs, exits 0
- [ ] `openclaw skills install <unknown-skill>` — prints "Skill not found" and exits 1
- [ ] `openclaw skills install <skill-with-no-install-specs>` — prints "No install specs" and exits 0
- [ ] `openclaw skills install <skill-with-failing-dep>` — prints failure message + `openclaw doctor` tip, exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)