### PR TITLE
fix(doctor): show update step progress during pre-doctor git update

### DIFF
--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -1,4 +1,5 @@
 import { formatCliCommand } from "../cli/command-format.js";
+import { createUpdateProgress } from "../cli/update-cli/progress.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { runGatewayUpdate } from "../infra/update-runner.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -52,10 +53,14 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
       return { updated: false };
     }
     note("Running update (fetch/rebase/build/ui:build/doctor)…", "Update");
+    const progressController = createUpdateProgress(
+      Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    );
     const result = await runGatewayUpdate({
       cwd: params.root,
       argv1: process.argv[1],
-    });
+      progress: progressController.progress,
+    }).finally(() => progressController.stop());
     note(
       [
         `Status: ${result.status}`,


### PR DESCRIPTION
## Summary

- Problem:
when running `openclaw doctor` with a git checkout and choosing Yes for “Update OpenClaw from git before running doctor?”, the CLI only shows a static line (Running update (fetch/rebase/build/ui:build/doctor)…) for a multi-minute process, which makes it seem hung.

- Why it matters:
Just a quality of life change, doesn't really matter
- What changed:
added in the pre-existing progress controller.
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

When `openclaw doctor` offers a git update and the user selects **Yes**, the CLI now shows live per-step update progress (same progress controller as `openclaw update`) instead of only a static “Running update...” line.

## Security Impact (required)

  - New permissions/capabilities? (`No`)
  - Secrets/tokens handling changed? (`No`)
  - New/changed network calls? (`No`)
  - Command/tool execution surface changed? (`No`)
  - Data access scope changed? (`No`)
  - If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

  1. Run `openclaw doctor`.
  2. At “Update OpenClaw from git before running doctor?”, select `Yes`.
  3. Observe update output while git update is running.

### Expected
  - CLI should show ongoing step progress (not appear stuck on a single static line).

### Actual
  - CLI now shows step updates (for example, `✓ Working directory is clean (...)`, followed by subsequent steps when applicable)

## Evidence

Attach at least one:
- [x] Trace/log snippets
```
$ time openclaw doctor

🦞 OpenClaw 2026.3.14 (14137be)
   If you're lost, run doctor; if you're brave, run prod; if you're wise, run tests.

                  🦞 OPENCLAW 🦞

┌  OpenClaw doctor
│
◇  Update OpenClaw from git before running doctor?
│  Yes
│
◇  Update ───────────────────────────────────────────────╮
│                                                        │
│  Running update (fetch/rebase/build/ui:build/doctor)…  │
│                                                        │
├────────────────────────────────────────────────────────╯
│
◇  Update result ─────────────╮
│                             │
│  Status: ok                 │
│  Mode: git                  │
│  Root: /home/john/openclaw  │
│                             │
├─────────────────────────────╯
│
└  Update completed (doctor already ran as part of the update).


real	1m54.278s
user	3m51.651s
sys	0m24.597s
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I tested it with a local build
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

  - Backward compatible? (`Yes`)
  - Config/env changes? (`No`)
  - Migration needed? (`No`)
  - If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: just revert it
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: N/A

## Risks and Mitigations
None