### PR TITLE
fix: set Nested lane concurrency to prevent sessions_send serialization

### DIFF
--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -7,4 +7,8 @@ export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) 
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  setCommandLaneConcurrency(
+    CommandLane.Nested,
+    Math.max(resolveAgentMaxConcurrent(cfg), resolveSubagentMaxConcurrent(cfg)),
+  );
 }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -156,7 +156,6 @@ export function createGatewayReloadHandlers(params: {
       Math.max(resolveAgentMaxConcurrent(nextConfig), resolveSubagentMaxConcurrent(nextConfig)),
     );
 
-
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);
     } else if (plan.noopPaths.length > 0) {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -151,6 +151,11 @@ export function createGatewayReloadHandlers(params: {
     setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
+    setCommandLaneConcurrency(
+      CommandLane.Nested,
+      Math.max(resolveAgentMaxConcurrent(nextConfig), resolveSubagentMaxConcurrent(nextConfig)),
+    );
+
 
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);


### PR DESCRIPTION
## Problem

The `Nested` command lane (used by `sessions_send` for inter-agent messaging) is never assigned an explicit concurrency value in `applyGatewayLaneConcurrency()` or the hot-reload handler. It defaults to `maxConcurrent: 1`, which means **all `sessions_send` calls execute sequentially** — even when multiple calls are fired in the same tool call block with `timeoutSeconds: 0`.

For a team of 13 agents, this turns a ~30-second parallel dispatch into a ~6.5-minute sequential crawl.

## Root Cause

In `src/gateway/server-lanes.ts`, concurrency is set for `Cron`, `Main`, and `Subagent` lanes, but `Nested` is missing:

```typescript
// Before (server-lanes.ts)
setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
// Nested lane: missing → defaults to 1
```

Same issue in `src/gateway/server-reload-handlers.ts` (hot-reload path).

## Fix

Add `CommandLane.Nested` concurrency in both locations, set to `Math.max(agentMaxConcurrent, subagentMaxConcurrent)`:

```typescript
setCommandLaneConcurrency(
  CommandLane.Nested,
  Math.max(resolveAgentMaxConcurrent(cfg), resolveSubagentMaxConcurrent(cfg)),
);
```

This ensures the nested lane can handle at least as many concurrent inter-agent messages as there are agent/subagent slots.

## Changes

- `src/gateway/server-lanes.ts` — add Nested lane concurrency in `applyGatewayLaneConcurrency()`
- `src/gateway/server-reload-handlers.ts` — add Nested lane concurrency in hot-reload handler

## Testing

Verified with a 13-agent team on Discord:
- **Before:** 13 `sessions_send` calls with `timeoutSeconds: 0` take ~6.5 minutes (sequential)
- **After:** Same 13 calls complete in ~30 seconds (parallel)

Fixes #45165