### PR TITLE
Fix logfile rotation: resolve file path at write time

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -138,16 +138,33 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
     return logger;
   }
 
-  fs.mkdirSync(path.dirname(settings.file), { recursive: true });
+  const isRolling = isRollingPath(settings.file);
+  const configuredFile = isRolling ? null : settings.file;
+
+  // Resolve the current target file at write time so rolling logs switch
+  // to the new dated file automatically when the date changes.
+  const resolveTargetFile = (): string => configuredFile ?? defaultRollingPathForToday();
+
+  fs.mkdirSync(path.dirname(resolveTargetFile()), { recursive: true });
   // Clean up stale rolling logs when using a dated log filename.
-  if (isRollingPath(settings.file)) {
-    pruneOldRollingLogs(path.dirname(settings.file));
+  if (isRolling) {
+    pruneOldRollingLogs(path.dirname(resolveTargetFile()));
   }
-  let currentFileBytes = getCurrentLogFileBytes(settings.file);
+  let currentFile = resolveTargetFile();
+  let currentFileBytes = getCurrentLogFileBytes(currentFile);
   let warnedAboutSizeCap = false;
 
   logger.attachTransport((logObj: LogObj) => {
     try {
+      // Check if the rolling file has changed (date rollover).
+      const targetFile = resolveTargetFile();
+      if (targetFile !== currentFile) {
+        currentFile = targetFile;
+        currentFileBytes = getCurrentLogFileBytes(currentFile);
+        warnedAboutSizeCap = false;
+        fs.mkdirSync(path.dirname(currentFile), { recursive: true });
+      }
+
       const time = formatLocalIsoWithOffset(logObj.date ?? new Date());
       const line = JSON.stringify({ ...logObj, time });
       const payload = `${line}\n`;
@@ -160,16 +177,16 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
             time: formatLocalIsoWithOffset(new Date()),
             level: "warn",
             subsystem: "logging",
-            message: `log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}`,
+            message: `log file size cap reached; suppressing writes file=${currentFile} maxFileBytes=${settings.maxFileBytes}`,
           });
-          appendLogLine(settings.file, `${warningLine}\n`);
+          appendLogLine(currentFile, `${warningLine}\n`);
           process.stderr.write(
-            `[openclaw] log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}\n`,
+            `[openclaw] log file size cap reached; suppressing writes file=${currentFile} maxFileBytes=${settings.maxFileBytes}\n`,
           );
         }
         return;
       }
-      if (appendLogLine(settings.file, payload)) {
+      if (appendLogLine(currentFile, payload)) {
         currentFileBytes = nextBytes;
       }
     } catch {


### PR DESCRIPTION
## Summary

- Fix log transport capturing `settings.file` at creation time, causing logs to continue writing to the old dated file after midnight
- Transport now resolves the target file path dynamically on each write for rolling logs
- Non-rolling (user-configured) file paths remain static as before

Fixes #47280