### PR TITLE
gateway: suppress colon-ending narration flush before tool calls

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -605,6 +605,109 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
+  it("suppresses pre-tool flush when buffered text ends with a colon", () => {
+    let now = 12_500;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, toolEventRecipients, handler } =
+      createHarness({
+        resolveSessionKeyForRun: () => "session-colon",
+      });
+
+    chatRunState.registry.add("run-colon", {
+      sessionKey: "session-colon",
+      clientRunId: "client-colon",
+    });
+    registerAgentRunContext("run-colon", {
+      sessionKey: "session-colon",
+      verboseLevel: "off",
+    });
+    toolEventRecipients.add("run-colon", "conn-1");
+
+    // Buffer text ending with colon (incomplete narration before tool call).
+    handler({
+      runId: "run-colon",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Let me check:" },
+    });
+
+    // Tool start should NOT flush the colon-ending text.
+    now = 12_550;
+    handler({
+      runId: "run-colon",
+      seq: 2,
+      stream: "tool",
+      ts: Date.now(),
+      data: { phase: "start", name: "read", toolCallId: "tool-colon-1" },
+    });
+
+    // Only the initial delta should have been broadcast, not a pre-tool flush.
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(1);
+    const payload = chatCalls[0]?.[1] as { state?: string } | undefined;
+    expect(payload?.state).toBe("delta");
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    nowSpy.mockRestore();
+    resetAgentRunContextForTest();
+  });
+
+  it("still flushes pre-tool text that ends with a period", () => {
+    let now = 13_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, chatRunState, toolEventRecipients, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-period",
+    });
+
+    chatRunState.registry.add("run-period", {
+      sessionKey: "session-period",
+      clientRunId: "client-period",
+    });
+    registerAgentRunContext("run-period", {
+      sessionKey: "session-period",
+      verboseLevel: "off",
+    });
+    toolEventRecipients.add("run-period", "conn-1");
+
+    handler({
+      runId: "run-period",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Let me check." },
+    });
+
+    // Throttled update within 150ms.
+    now = 13_050;
+    handler({
+      runId: "run-period",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Let me check this for you." },
+    });
+
+    handler({
+      runId: "run-period",
+      seq: 3,
+      stream: "tool",
+      ts: Date.now(),
+      data: { phase: "start", name: "read", toolCallId: "tool-period-1" },
+    });
+
+    // Should flush: initial delta + pre-tool flush = 2 chat broadcasts.
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(2);
+    const flushedPayload = chatCalls[1]?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(flushedPayload.state).toBe("delta");
+    expect(flushedPayload.message?.content?.[0]?.text).toBe("Let me check this for you.");
+    nowSpy.mockRestore();
+    resetAgentRunContextForTest();
+  });
+
   it("routes tool events only to registered recipients when verbose is enabled", () => {
     const { broadcast, broadcastToConnIds, toolEventRecipients, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-1",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -598,6 +598,7 @@ export function createAgentEventHandler({
     clientRunId: string,
     sourceRunId: string,
     seq: number,
+    opts?: { suppressIncompleteNarration?: boolean },
   ) => {
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId);
     const shouldSuppressSilentLeadFragment = isSilentReplyLeadFragment(text);
@@ -605,11 +606,15 @@ export function createAgentEventHandler({
       clientRunId,
       sourceRunId,
     );
+    // Skip colon-ending narration so it merges with subsequent tool output
+    // instead of being flushed as an orphaned fragment before the tool card.
+    const isIncompleteNarration = opts?.suppressIncompleteNarration && text.endsWith(":");
     if (
       !text ||
       shouldSuppressSilent ||
       shouldSuppressSilentLeadFragment ||
-      shouldSuppressHeartbeatStreaming
+      shouldSuppressHeartbeatStreaming ||
+      isIncompleteNarration
     ) {
       return;
     }
@@ -756,7 +761,9 @@ export function createAgentEventHandler({
       // Flush pending assistant text before tool-start events so clients can
       // render complete pre-tool text above tool cards (not truncated by delta throttle).
       if (toolPhase === "start" && isControlUiVisible && sessionKey && !isAborted) {
-        flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq);
+        flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq, {
+          suppressIncompleteNarration: true,
+        });
       }
       // Always broadcast tool events to registered WS recipients with
       // tool-events capability, regardless of verboseLevel. The verbose


### PR DESCRIPTION
## Summary

- Problem: Agent narration ending with a colon (e.g. "Let me check:") is flushed as a standalone message before tool execution, delivering incomplete/orphan messages to users.
- Why it matters: Users on Discord (and other channels) receive content-free messages with no follow-up, breaking conversation flow.
- What changed: `flushBufferedChatDeltaIfNeeded` now skips the flush when buffered text ends with `:`. The text stays buffered and merges with subsequent tool output or the final message.
- What did NOT change (scope boundary): Final message delivery (`emitChatFinal`) is untouched; colon-ending text is never lost, only deferred.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #47675

## User-visible / Behavior Changes

Agent narration ending with a colon before a tool call is no longer delivered as an orphan message. It merges with subsequent content.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: anthropic/claude-sonnet-4-6
- Integration/channel (if any): Discord

### Steps

1. Send a message to agent that requires a tool call
2. Agent generates narration like "Let me check:" before calling the tool
3. Observe the message delivered to the user

### Expected

- Colon-ending narration is not flushed as a standalone message; it merges with tool output

### Actual (before fix)

- "Let me check:" delivered as an orphan message with no follow-up content

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Two new tests added:
- `suppresses pre-tool flush when buffered text ends with a colon` — verifies colon-ending text is NOT flushed before tool start
- `still flushes pre-tool text that ends with a period` — verifies normal text still flushes correctly (no regression)

## Human Verification (required)

- Verified scenarios: colon-ending text suppressed, period-ending text still flushed, all 25 existing tests pass
- Edge cases checked: text ending with period (still flushes), empty text (still suppressed), silent reply tokens (still suppressed)
- What you did **not** verify: live Discord end-to-end (no local OpenClaw instance with Discord configured)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single guard condition in `flushBufferedChatDeltaIfNeeded`
- Files/config to restore: `src/gateway/server-chat.ts`
- Known bad symptoms reviewers should watch for: Pre-tool narration text not appearing at all (would indicate the guard is too aggressive)

## Risks and Mitigations

- Risk: Legitimate colon-ending text (e.g. code snippets) could be delayed
  - Mitigation: Only affects the pre-tool flush path; text still delivers via `emitChatFinal`. Mid-text colons are unaffected since `endsWith(":")` only matches trailing colons.