### PR TITLE
fix: wrap bunx with cmd shim on Windows

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -79,7 +79,7 @@ function resolveNpmArgvForWindows(argv: string[]): string[] | null {
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
     command,
-    cmdCommands: ["pnpm", "yarn"],
+    cmdCommands: ["pnpm", "yarn", "bunx"],
   });
 }
 

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -111,4 +111,28 @@ describe("windows command wrapper behavior", () => {
       platformSpy.mockRestore();
     }
   });
+
+  it("wraps bunx via cmd.exe in runCommandWithTimeout on Windows", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+
+    spawnMock.mockImplementation(
+      (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
+    );
+
+    try {
+      const result = await runCommandWithTimeout(["bunx", "--version"], { timeoutMs: 1000 });
+      expect(result.code).toBe(0);
+      const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
+      if (!captured) {
+        throw new Error("expected command wrapper to be called");
+      }
+      expect(captured[0]).toBe(expectedComSpec);
+      expect(captured[1].slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+      expect(captured[1][3]).toContain("bunx.cmd --version");
+      expect(captured[2].windowsVerbatimArguments).toBe(true);
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary\n- add  to the Windows command shim list in \n- ensure  wraps  via  with \n- add a Windows-focused regression test for the  path\n\n## Why\nIssue #47748 reports Windows update failures caused by batch-command spawning behavior. The Feishu onboarding import is already fixed in the current tree, but the Windows command wrapper still only special-cased  and . Extending the same shim handling to  keeps Windows package-manager launches on the safe  wrapper path and avoids another  spawn failure class.\n\nFixes #47748\n