### PR TITLE
fix(windows): handle 'Last Result' key variant in schtasks output

### DIFF
--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -23,6 +23,20 @@ describe("schtasks runtime parsing", () => {
       lastRunResult: "0x0",
     });
   });
+
+  it("parses 'Last Result' key variant (some Windows versions omit 'Run')", () => {
+    const output = [
+      "TaskName: \\OpenClaw Gateway",
+      "Status: Running",
+      "Last Run Time: 2026/3/16 8:34:15",
+      "Last Result: 267009",
+    ].join("\r\n");
+    expect(parseSchtasksQuery(output)).toEqual({
+      status: "Running",
+      lastRunTime: "2026/3/16 8:34:15",
+      lastRunResult: "267009",
+    });
+  });
 });
 
 describe("scheduled task runtime derivation", () => {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -178,7 +178,7 @@ export function parseSchtasksQuery(output: string): ScheduledTaskInfo {
   if (lastRunTime) {
     info.lastRunTime = lastRunTime;
   }
-  const lastRunResult = entries["last run result"];
+  const lastRunResult = entries["last run result"] ?? entries["last result"];
   if (lastRunResult) {
     info.lastRunResult = lastRunResult;
   }


### PR DESCRIPTION
## Summary

Fixes #47726.

On some Windows versions, `schtasks /Query /V /FO LIST` outputs the key `Last Result` instead of `Last Run Result`. The `parseSchtasksQuery` function only looked for `last run result`, causing `lastRunResult` to be `undefined`, which propagated through `normalizeTaskResultCode(undefined)` → `null` → `deriveScheduledTaskRuntimeStatus` returning `{ status: 'unknown' }` even when the gateway was running normally.

## Change

```ts
// Before
const lastRunResult = entries["last run result"];

// After
const lastRunResult = entries["last run result"] ?? entries["last result"];
```

## Testing

Added a test case in `schtasks.test.ts` for the `Last Result` key variant. All 23 schtasks unit tests pass.