### PR TITLE
Fix stale TTS summarizeText mock for resolveModelAsync

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -2,7 +2,7 @@ import { completeSimple, type AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
 import { getApiKeyForModel } from "../agents/model-auth.js";
-import { resolveModel } from "../agents/pi-embedded-runner/model.js";
+import { resolveModelAsync } from "../agents/pi-embedded-runner/model.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { withEnv } from "../test-utils/env.js";
 import * as tts from "./tts.js";
@@ -21,7 +21,7 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
 }));
 
 vi.mock("../agents/pi-embedded-runner/model.js", () => ({
-  resolveModel: vi.fn((provider: string, modelId: string) => ({
+  resolveModelAsync: vi.fn(async (provider: string, modelId: string) => ({
     model: {
       provider,
       id: modelId,
@@ -411,11 +411,11 @@ describe("tts", () => {
         timeoutMs: 30_000,
       });
 
-      expect(resolveModel).toHaveBeenCalledWith("openai", "gpt-4.1-mini", undefined, cfg);
+      expect(resolveModelAsync).toHaveBeenCalledWith("openai", "gpt-4.1-mini", undefined, cfg);
     });
 
     it("registers the Ollama api before direct summarization", async () => {
-      vi.mocked(resolveModel).mockReturnValue({
+      vi.mocked(resolveModelAsync).mockResolvedValue({
         model: {
           provider: "ollama",
           id: "qwen3:8b",


### PR DESCRIPTION
## Summary

Update the `src/tts/tts.test.ts` mock to match the current `summarizeText` implementation.

## Problem

`src/tts/tts-core.ts` now resolves the summary model via `resolveModelAsync(...)`, but `src/tts/tts.test.ts` was still mocking and asserting against `resolveModel(...)`.

That causes the Windows CI shard to fail with:

```text
[vitest] No "resolveModelAsync" export is defined on the "../agents/pi-embedded-runner/model.js" mock.
```

## Change

- mock `resolveModelAsync` instead of `resolveModel`
- update the `summarizeText` assertions to expect the async resolver
- keep the fix scoped to the test layer only

## Verification

```bash
npx pnpm@10.23.0 exec vitest run src/tts/tts.test.ts
```

Independent of #47073.
