### PR TITLE
fix(ui): show agent name in session dropdown for multi-agent setups (#47744)

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -811,14 +811,12 @@ export function resolveSessionOptionGroups(
     seenKeys.add(key);
     const row = byKey.get(key);
     const parsed = parseAgentSessionKey(key);
+    const agentGroupLabel = parsed ? resolveAgentGroupLabel(state, parsed.agentId) : undefined;
     const group = parsed
-      ? ensureGroup(
-          `agent:${parsed.agentId.toLowerCase()}`,
-          resolveAgentGroupLabel(state, parsed.agentId),
-        )
+      ? ensureGroup(`agent:${parsed.agentId.toLowerCase()}`, agentGroupLabel ?? parsed.agentId)
       : ensureGroup("other", "Other Sessions");
     const scopeLabel = parsed?.rest?.trim() || key;
-    const label = resolveSessionScopedOptionLabel(key, row, parsed?.rest);
+    const label = resolveSessionScopedOptionLabel(key, row, parsed?.rest, agentGroupLabel);
     group.options.push({
       key,
       label,
@@ -875,10 +873,11 @@ function resolveSessionScopedOptionLabel(
   key: string,
   row?: SessionsListResult["sessions"][number],
   rest?: string,
+  agentGroupLabel?: string,
 ) {
   const base = rest?.trim() || key;
   if (!row) {
-    return base;
+    return agentGroupLabel ? `${agentGroupLabel} / ${base}` : base;
   }
 
   const label = row.label?.trim() || "";
@@ -887,7 +886,7 @@ function resolveSessionScopedOptionLabel(
     return resolveSessionDisplayName(key, row);
   }
 
-  return base;
+  return agentGroupLabel ? `${agentGroupLabel} / ${base}` : base;
 }
 
 type ThemeOption = { id: ThemeName; label: string; icon: string };

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -842,8 +842,10 @@ export function resolveSessionOptionGroups(
       counts.set(option.label, (counts.get(option.label) ?? 0) + 1);
     }
     for (const option of group.options) {
-      if ((counts.get(option.label) ?? 0) > 1 && option.scopeLabel !== option.label) {
-        option.label = `${option.label} · ${option.scopeLabel}`;
+      if ((counts.get(option.label) ?? 0) > 1) {
+        // Use scopeLabel when not already in label (e.g. "agent / main" has scopeLabel "main"); else use full key
+        const suffix = option.label.includes(option.scopeLabel) ? option.title : option.scopeLabel;
+        option.label = `${option.label} · ${suffix}`;
       }
     }
   }
@@ -883,7 +885,8 @@ function resolveSessionScopedOptionLabel(
   const label = row.label?.trim() || "";
   const displayName = row.displayName?.trim() || "";
   if ((label && label !== key) || (displayName && displayName !== key)) {
-    return resolveSessionDisplayName(key, row);
+    const customLabel = resolveSessionDisplayName(key, row);
+    return agentGroupLabel ? `${agentGroupLabel} / ${customLabel}` : customLabel;
   }
 
   return agentGroupLabel ? `${agentGroupLabel} / ${base}` : base;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -676,7 +676,7 @@ describe("chat view", () => {
       option.textContent?.trim(),
     );
 
-    expect(labels).toContain("Subagent: cron-config-check");
+    expect(labels).toContain("main / Subagent: cron-config-check");
     expect(labels).not.toContain(state.sessionKey);
     expect(labels).not.toContain(
       "subagent:4f2146de-887b-4176-9abe-91140082959b · webchat:g-agent-main-subagent-4f2146de-887b-4176-9abe-91140082959b",
@@ -695,7 +695,7 @@ describe("chat view", () => {
       option.textContent?.trim(),
     );
 
-    expect(labels).toContain("subagent:4f2146de-887b-4176-9abe-91140082959b");
+    expect(labels).toContain("main / subagent:4f2146de-887b-4176-9abe-91140082959b");
     expect(labels).not.toContain("Subagent:");
   });
 
@@ -724,7 +724,7 @@ describe("chat view", () => {
       option.textContent?.trim(),
     );
 
-    expect(labels).toContain("subagent:4f2146de-887b-4176-9abe-91140082959b");
+    expect(labels).toContain("main / subagent:4f2146de-887b-4176-9abe-91140082959b");
     expect(labels).not.toContain("Subagent:");
   });
 
@@ -761,11 +761,11 @@ describe("chat view", () => {
     );
 
     expect(labels).toContain(
-      "Subagent: cron-config-check · subagent:4f2146de-887b-4176-9abe-91140082959b",
+      "main / Subagent: cron-config-check · subagent:4f2146de-887b-4176-9abe-91140082959b",
     );
     expect(labels).toContain(
-      "Subagent: cron-config-check · subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
+      "main / Subagent: cron-config-check · subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
     );
-    expect(labels).not.toContain("Subagent: cron-config-check");
+    expect(labels).not.toContain("main / Subagent: cron-config-check");
   });
 });


### PR DESCRIPTION
## Summary

- **Problem:** When multiple agents are configured, the Session dropdown shows all sessions as "main", making it impossible to distinguish which agent each session belongs to.
- **Why it matters:** Users with multi-agent setups cannot tell which agent session they are selecting, causing confusion.
- **What changed:** Session option labels now use `{agentName} / {sessionName}` format (e.g. `深度对话 / main`, `coding / main`) so each option is self-descriptive.
- **What did NOT change:** Optgroup structure, session switching logic, or other UI behavior.

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Linked Issue/PR

- Closes #47744

## User-visible / Behavior Changes

Session dropdown options for agent sessions now display as `{agentName} / {sessionName}` instead of just the session name (e.g. `main`). This applies to both desktop and mobile chat controls.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No