### PR TITLE
feat: Telegram频道同步优化 + Cron配置指南

### DIFF
--- a/docs/cron-job-configuration.md
+++ b/docs/cron-job-configuration.md
@@ -1,0 +1,281 @@
+# OpenClaw Cron Job 配置完全指南
+
+## 快速选择表
+
+| 场景 | Session类型 | Payload类型 | 示例 |
+|------|------------|-------------|------|
+| 简单通知/提醒 | main | systemEvent | 心跳检测、定时提醒 |
+| 复杂任务/需AI处理 | isolated | agentTurn | 数据分析、内容生成 |
+| 需指定模型 | isolated | agentTurn + model | 特定模型任务 |
+
+---
+
+## 两种Session类型详解
+
+### 1. Main Session
+
+**特点**:
+- 使用现有的agent session
+- 轻量级，快速执行
+- **限制**: 只能用 `systemEvent`
+
+**适用场景**:
+- 系统状态通知
+- 简单的心跳检测
+- 不需要AI处理的纯通知
+
+**配置示例**:
+```json
+{
+  "sessionTarget": "main",
+  "payload": {
+    "kind": "systemEvent",
+    "text": "[自动任务] 备份完成"
+  }
+}
+```
+
+**常见错误**:
+```
+Error: main cron jobs require payload.kind="systemEvent"
+```
+**原因**: 在main session中使用了 `agentTurn`
+**解决**: 改为 `systemEvent` 或切换到 `isolated` session
+
+---
+
+### 2. Isolated Session
+
+**特点**:
+- 创建独立的session
+- 可以指定model
+- 可以执行复杂任务
+- 超时控制更灵活
+
+**适用场景**:
+- 需要AI分析的任务
+- 需要指定特定模型
+- 耗时较长的任务
+- 需要隔离环境的任务
+
+**配置示例**:
+```json
+{
+  "sessionTarget": "isolated",
+  "payload": {
+    "kind": "agentTurn",
+    "message": "分析今日数据并生成报告",
+    "model": "kimi-coding/kimi-for-coding",
+    "timeoutSeconds": 300
+  }
+}
+```
+
+---
+
+## 完整配置模板
+
+### Template 1: 简单系统通知 (Main + systemEvent)
+```json
+{
+  "name": "heartbeat-check",
+  "schedule": {
+    "kind": "every",
+    "everyMs": 3600000
+  },
+  "sessionTarget": "main",
+  "payload": {
+    "kind": "systemEvent",
+    "text": "系统心跳正常"
+  },
+  "delivery": {
+    "mode": "announce"
+  }
+}
+```
+
+### Template 2: AI数据分析 (Isolated + agentTurn)
+```json
+{
+  "name": "daily-analysis",
+  "schedule": {
+    "kind": "cron",
+    "expr": "0 9 * * *",
+    "tz": "Asia/Shanghai"
+  },
+  "sessionTarget": "isolated",
+  "payload": {
+    "kind": "agentTurn",
+    "message": "分析昨日数据，生成摘要报告",
+    "model": "my_api/claude-opus-4-6",
+    "timeoutSeconds": 600
+  },
+  "delivery": {
+    "mode": "announce",
+    "channel": "telegram"
+  }
+}
+```
+
+### Template 3: 指定Kimi模型的任务
+```json
+{
+  "name": "kimi-task",
+  "schedule": {
+    "kind": "every",
+    "everyMs": 7200000
+  },
+  "sessionTarget": "isolated",
+  "payload": {
+    "kind": "agentTurn",
+    "message": "执行需要Kimi处理的任务",
+    "model": "kimi-coding/kimi-for-coding",
+    "timeoutSeconds": 300
+  }
+}
+```
+
+---
+
+## 常见错误与解决方案
+
+### Error 1: JSON解析错误
+```
+Unexpected non-whitespace character after JSON at position X
+```
+
+**原因**: message中包含特殊字符或未转义的引号
+
+**解决**:
+- 避免在message中使用复杂的JSON或代码块
+- 使用简单的纯文本指令
+- 如需复杂内容，让agent读取文件而非直接放在message中
+
+---
+
+### Error 2: Main session限制
+```
+main cron jobs require payload.kind="systemEvent"
+```
+
+**原因**: 在main session中使用了agentTurn
+
+**解决**:
+```json
+// 错误
+{
+  "sessionTarget": "main",
+  "payload": {
+    "kind": "agentTurn",  // ❌ main不能用这个
+    "message": "..."
+  }
+}
+
+// 正确 - 方案1: 改为systemEvent
+{
+  "sessionTarget": "main",
+  "payload": {
+    "kind": "systemEvent",  // ✅
+    "text": "..."
+  }
+}
+
+// 正确 - 方案2: 改为isolated
+{
+  "sessionTarget": "isolated",  // ✅
+  "payload": {
+    "kind": "agentTurn",
+    "message": "..."
+  }
+}
+```
+
+---
+
+### Error 3: 超时
+```
+cron: job execution timed out
+```
+
+**原因**: 任务执行时间超过timeoutSeconds
+
+**解决**:
+- 增加 `timeoutSeconds` (最大通常600秒)
+- 优化任务，减少执行时间
+- 将大任务拆分为多个小任务
+
+---
+
+## 最佳实践
+
+### 1. 超时设置建议
+| 任务类型 | 建议超时 |
+|---------|---------|
+| 简单通知 | 30s |
+| 数据查询 | 120s |
+| AI生成内容 | 300s |
+| 复杂分析 | 600s |
+
+### 2. 模型选择建议
+| 场景 | 推荐模型 |
+|------|---------|
+| 代码相关 | kimi-coding/kimi-for-coding |
+| 分析/总结 | my_api/claude-opus-4-6 |
+| 中文内容 | kimi-coding/kimi-for-coding |
+| 长文本处理 | my_api/claude-opus-4-6 |
+
+### 3. 交付设置
+```json
+// 只通知自己
+{
+  "delivery": {
+    "mode": "announce"
+  }
+}
+
+// 发送到特定频道
+{
+  "delivery": {
+    "mode": "announce",
+    "channel": "telegram",
+    "to": "-1001234567890"
+  }
+}
+
+// 静默执行（不通知）
+{
+  "delivery": {
+    "mode": "none"
+  }
+}
+```
+
+---
+
+## 调试技巧
+
+### 1. 手动触发测试
+```bash
+openclaw cron run <job-id>
+```
+
+### 2. 查看执行历史
+```bash
+openclaw cron runs <job-id>
+```
+
+### 3. 检查错误详情
+```bash
+openclaw cron list
+# 查看 lastError 字段
+```
+
+---
+
+## 贡献者
+
+- huangpi1030-tech: 本文档编写
+
+---
+
+如有问题，欢迎在 OpenClaw Discussion 中讨论。

--- a/examples/telegram-channel-sync/README.md
+++ b/examples/telegram-channel-sync/README.md
@@ -1,0 +1,25 @@
+# Telegram 频道同步示例
+
+此示例展示了如何使用 Telethon 库同步 Telegram 频道消息到本地文件。
+
+## 特性
+
+- ✅ 超时保护 (180秒)
+- ✅ 消息数量限制 (单次100条)
+- ✅ Telegram 限流处理
+- ✅ 详细日志输出
+- ✅ 连接复用
+
+## 使用方法
+
+1. 安装依赖: `pip install telethon`
+2. 配置 API_ID 和 API_HASH
+3. 运行脚本: `python3 sync_new_messages.py`
+
+## 文件说明
+
+- `sync_new_messages.py` - 通用频道同步脚本模板
+
+## 贡献者
+
+- huangpi1030-tech

--- a/examples/telegram-channel-sync/sync_new_messages.py
+++ b/examples/telegram-channel-sync/sync_new_messages.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+journey_of_someone 频道新消息同步脚本（增强版）
+- 添加超时保护
+- 添加连接复用
+- 添加详细日志
+"""
+import asyncio
+import os
+import sys
+import signal
+from telethon import TelegramClient
+from telethon.errors import FloodWaitError, RPCError
+from datetime import datetime
+
+# 配置
+API_ID = 34417503
+API_HASH = "44ffd372b38f182f6145eab6bf060377"
+CHANNEL = "journey_of_someone"
+SESSION_FILE = "/root/.openclaw/workspace/tg-channel-note/BensonTradingDesk/benson_scraper"
+NEW_MSG_FILE = "/root/.openclaw/workspace/tg-channel-note/journey_of_someone/journey_of_someone_new_messages.md"
+LAST_ID_FILE = "/root/.openclaw/workspace/tg-channel-note/journey_of_someone/last_synced_message_id.txt"
+TIMEOUT_SECONDS = 180  # 3分钟超时
+
+class TimeoutError(Exception):
+    pass
+
+def timeout_handler(signum, frame):
+    raise TimeoutError(f"脚本执行超过 {TIMEOUT_SECONDS} 秒")
+
+async def sync_new_messages():
+    start_time = datetime.now()
+    print(f"[{start_time.strftime('%Y-%m-%d %H:%M:%S')}] 🚀 开始同步 journey_of_someone 频道消息")
+    
+    # 设置超时信号
+    signal.signal(signal.SIGALRM, timeout_handler)
+    signal.alarm(TIMEOUT_SECONDS)
+    
+    try:
+        # 读取上次同步的最后消息ID
+        last_id = 0
+        if os.path.exists(LAST_ID_FILE):
+            with open(LAST_ID_FILE, 'r') as f:
+                content = f.read().strip()
+                if content.isdigit():
+                    last_id = int(content)
+        
+        print(f"📌 上次同步到消息ID: {last_id}")
+        
+        # 创建客户端（复用 session）
+        client = TelegramClient(SESSION_FILE, API_ID, API_HASH)
+        
+        try:
+            await client.connect()
+            
+            if not await client.is_user_authorized():
+                print("❌ 未授权，请先完成登录")
+                return 1
+            
+            print("✅ 已登录 Telegram")
+            
+            # 获取频道实体
+            try:
+                channel = await client.get_entity(CHANNEL)
+                print(f"✅ 找到频道: {channel.title}")
+            except RPCError as e:
+                print(f"❌ 获取频道失败: {e}")
+                return 1
+            
+            # 抓取新消息（限制最多100条，防止超时）
+            new_messages = []
+            msg_count = 0
+            max_messages = 100  # 限制单次同步数量
+            
+            async for message in client.iter_messages(channel, min_id=last_id, limit=max_messages):
+                if message.text:
+                    new_messages.append({
+                        'id': message.id,
+                        'date': message.date.strftime('%Y-%m-%d %H:%M:%S'),
+                        'text': message.text,
+                        'views': message.views or 0
+                    })
+                    msg_count += 1
+                    if msg_count >= max_messages:
+                        print(f"⚠️ 达到单次同步上限 ({max_messages} 条)，剩余消息下次同步")
+                        break
+            
+            if not new_messages:
+                print("✅ 没有新消息，无需更新")
+                return 0
+            
+            # 按时间正序排列
+            new_messages.sort(key=lambda x: x['id'])
+            print(f"🆕 发现 {len(new_messages)} 条新消息，开始写入...")
+            
+            # 初始化文件（如果不存在）
+            if not os.path.exists(NEW_MSG_FILE):
+                os.makedirs(os.path.dirname(NEW_MSG_FILE), exist_ok=True)
+                with open(NEW_MSG_FILE, 'w', encoding='utf-8') as f:
+                    f.write("# journey_of_someone 新消息记录\n\n")
+                    f.write("**频道**: https://t.me/journey_of_someone\n")
+                    f.write("**说明**: 本文件记录历史抓取后的所有新消息\n\n")
+                    f.write("---\n\n")
+            
+            # 追加写入新消息
+            with open(NEW_MSG_FILE, 'a', encoding='utf-8') as f:
+                f.write(f"\n## 同步时间: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n")
+                for msg in new_messages:
+                    f.write(f"### 消息 #{msg['id']}\n\n")
+                    f.write(f"**时间**: {msg['date']}\n")
+                    f.write(f"**浏览量**: {msg['views']}\n\n")
+                    f.write(f"{msg['text']}\n\n")
+                    f.write("---\n\n")
+            
+            # 更新最新消息ID
+            latest_id = new_messages[-1]['id']
+            with open(LAST_ID_FILE, 'w') as f:
+                f.write(str(latest_id))
+            
+            elapsed = (datetime.now() - start_time).total_seconds()
+            print(f"✅ 已写入 {len(new_messages)} 条新消息")
+            print(f"📌 更新最新消息ID: {latest_id}")
+            print(f"📁 文件: {NEW_MSG_FILE}")
+            print(f"⏱️ 耗时: {elapsed:.1f} 秒")
+            return 0
+            
+        except FloodWaitError as e:
+            print(f"❌ 触发 Telegram 速率限制，需要等待 {e.seconds} 秒")
+            return 1
+        except TimeoutError:
+            print(f"❌ 执行超时（>{TIMEOUT_SECONDS}秒），请检查网络或稍后重试")
+            return 1
+        finally:
+            signal.alarm(0)  # 取消超时
+            await client.disconnect()
+            
+    except Exception as e:
+        print(f"❌ 未预期错误: {type(e).__name__}: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(sync_new_messages())
+    sys.exit(exit_code)


### PR DESCRIPTION
## 贡献内容

### 1. Telegram 频道同步示例 (examples/telegram-channel-sync/)

**问题**: 原脚本在频道消息量大时容易超时，无错误处理

**改进**:
- ✅ 180秒信号超时保护
- ✅ 单次最多100条消息限制
- ✅ FloodWaitError 处理
- ✅ 详细日志（时间戳、进度、耗时）

**测试**: 优化前经常超时(>300s)，优化后2-3秒完成

### 2. Cron Job 配置指南 (docs/cron-job-configuration.md)

**问题**: main vs isolated session 的区别没有明确文档

**内容**:
- 两种session类型详细对比
- 常见错误和解决方案
- 3种场景的配置模板
- 调试技巧

## 贡献者

- @huangpi1030-tech
- 使用OpenClaw 2个月+，日常用于频道监控和知识库自动化

## 验证

- [x] 代码已实际使用并验证
- [x] 文档经过多轮修订
- [x] 愿意根据反馈持续改进

---

期待反馈！