### PR TITLE
fix: gateway agent method bypasses session daily/idle reset

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -15,6 +15,10 @@ import {
   resolveAgentMainSessionKey,
   type SessionEntry,
   updateSessionStore,
+  evaluateSessionFreshness,
+  resolveSessionResetPolicy,
+  resolveSessionResetType,
+  resolveChannelResetConfig,
 } from "../../config/sessions.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import {
@@ -351,7 +355,29 @@ export const agentHandlers: GatewayRequestHandlers = {
       const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(requestedSessionKey);
       cfgForAgent = cfg;
       const now = Date.now();
-      const sessionId = entry?.sessionId ?? randomUUID();
+
+      // Evaluate session freshness before reusing the existing sessionId.
+      // Without this, the pre-resolved sessionId is passed to resolveSession()
+      // which skips its own freshness check when opts.sessionId is provided,
+      // preventing daily/idle session resets from ever firing.
+      let sessionId: string;
+      if (entry?.sessionId && entry.updatedAt != null) {
+        const sessionCfg = cfg.session;
+        const resetType = resolveSessionResetType({ sessionKey: canonicalKey });
+        const resetOverride = resolveChannelResetConfig({
+          sessionCfg,
+          channel: entry.lastChannel ?? entry.channel,
+        });
+        const policy = resolveSessionResetPolicy({ sessionCfg, resetType, resetOverride });
+        const { fresh } = evaluateSessionFreshness({
+          updatedAt: entry.updatedAt,
+          now,
+          policy,
+        });
+        sessionId = fresh ? entry.sessionId : randomUUID();
+      } else {
+        sessionId = entry?.sessionId ?? randomUUID();
+      }
       const labelValue = request.label?.trim() || entry?.label;
       const sessionAgent = resolveAgentIdFromSessionKey(canonicalKey);
       spawnedByValue = canonicalizeSpawnedByForAgent(cfg, sessionAgent, entry?.spawnedBy);


### PR DESCRIPTION
## Summary

The gateway `agent` RPC method handler in `src/gateway/server-methods/agent.ts` pre-resolves the `sessionId` from the session store entry without evaluating session freshness. This `sessionId` is then passed explicitly to `resolveSession()` in `src/commands/agent/session.ts`, which skips its own freshness check when `opts.sessionId` is provided.

**Impact:** Sessions that receive periodic `callGateway({ method: "agent" })` calls — most commonly via **cron announce delivery** — will never reset through the daily or idle timeout mechanism. The cron delivery also refreshes `updatedAt` on each invocation, preventing any subsequent freshness check from detecting staleness.

## Root Cause

In `src/gateway/server-methods/agent.ts` (line 354):

```typescript
const sessionId = entry?.sessionId ?? randomUUID();
```

This unconditionally reuses the stored session ID. Later, `resolvedSessionId = sessionId` passes it to `agentCommandFromIngress`, where `resolveSession()` has:

```typescript
const sessionId =
  opts.sessionId?.trim() ||           // takes priority, skips freshness
  (fresh ? sessionEntry?.sessionId : undefined) ||
  crypto.randomUUID();
```

Since `opts.sessionId` is already set, the `fresh` evaluation is bypassed entirely.

## Fix

Evaluate session freshness using the existing reset policy pipeline (`resolveSessionResetType` -> `resolveChannelResetConfig` -> `resolveSessionResetPolicy` -> `evaluateSessionFreshness`) **before** deciding whether to reuse the existing `sessionId` or mint a new UUID.

## Reproduction

1. Configure a cron job with `sessionTarget: "isolated"` delivering via announce to a Telegram group
2. Default session config: `reset.mode: "daily"`, `atHour: 4`
3. Cron fires at 9 AM daily (after the 4 AM reset window)
4. Observe the group session retains the same `sessionId` indefinitely -- daily reset never triggers
5. Session transcript grows unbounded with compactions accumulating

## Testing

- AI-assisted: the bug was identified by tracing the source code path from cron delivery through the gateway agent handler to `resolveSession()`
- Verified the freshness math: `resolveDailyResetAtMs` correctly computes 4 AM local time, and `evaluateSessionFreshness` correctly returns `fresh: false` for sessions with overnight gaps crossing the reset hour
- The fix reuses the exact same freshness evaluation pipeline used by `resolveSession()` and `dispatchInboundMessage()`

AI-assisted (Claude Code)
