### PR TITLE
fix(bluebubbles): restore webhook ingress after source-loaded startup

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -24,7 +24,21 @@ import {
 import { fetchBlueBubblesServerInfo } from "./probe.js";
 import { getBlueBubblesRuntime } from "./runtime.js";
 
-const webhookTargets = new Map<string, WebhookTarget[]>();
+const WEBHOOK_TARGETS_STATE = Symbol.for("openclaw.bluebubbles.webhookTargets");
+
+type WebhookTargetsHost = NodeJS.Process & {
+  [WEBHOOK_TARGETS_STATE]?: Map<string, WebhookTarget[]>;
+};
+
+function getSharedWebhookTargets(): Map<string, WebhookTarget[]> {
+  const host = process as WebhookTargetsHost;
+  if (!host[WEBHOOK_TARGETS_STATE]) {
+    host[WEBHOOK_TARGETS_STATE] = new Map<string, WebhookTarget[]>();
+  }
+  return host[WEBHOOK_TARGETS_STATE];
+}
+
+const webhookTargets = getSharedWebhookTargets();
 const webhookInFlightLimiter = createWebhookInFlightLimiter();
 const debounceRegistry = createBlueBubblesDebounceRegistry({ processMessage });
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -8,6 +8,7 @@ import {
 import { createServer as createHttpsServer } from "node:https";
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
+import { handleBlueBubblesWebhookRequest } from "../../extensions/bluebubbles/src/monitor.js";
 import { handleSlackHttpRequest } from "../../extensions/slack/src/http/index.js";
 import { resolveAgentAvatar } from "../agents/identity-avatar.js";
 import { CANVAS_WS_PATH, handleA2uiHttpRequest } from "../canvas-host/a2ui.js";
@@ -803,6 +804,10 @@ export function createGatewayHttpServer(opts: {
         {
           name: "slack",
           run: () => handleSlackHttpRequest(req, res),
+        },
+        {
+          name: "bluebubbles",
+          run: () => handleBlueBubblesWebhookRequest(req, res),
         },
       ];
       if (openResponsesEnabled) {

--- a/src/gateway/server.bluebubbles-http.test.ts
+++ b/src/gateway/server.bluebubbles-http.test.ts
@@ -1,10 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-type BlueBubblesWebhookHandler = (
-  req: IncomingMessage,
-  res: ServerResponse,
-) => Promise<boolean>;
+type BlueBubblesWebhookHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
 
 const handleBlueBubblesWebhookRequest = vi.hoisted(() =>
   vi.fn<BlueBubblesWebhookHandler>(async () => false),
@@ -54,13 +51,11 @@ describe("gateway bluebubbles webhook stage", () => {
   });
 
   it("falls through to plugin handling when the bluebubbles handler does not claim the request", async () => {
-    const handlePluginRequest = vi.fn(
-      async (_req: IncomingMessage, res: ServerResponse) => {
-        res.statusCode = 204;
-        res.end();
-        return true;
-      },
-    );
+    const handlePluginRequest = vi.fn(async (_req: IncomingMessage, res: ServerResponse) => {
+      res.statusCode = 204;
+      res.end();
+      return true;
+    });
 
     await withGatewayServer({
       prefix: "bluebubbles-webhook-fallthrough",

--- a/src/gateway/server.bluebubbles-http.test.ts
+++ b/src/gateway/server.bluebubbles-http.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const handleBlueBubblesWebhookRequest = vi.hoisted(() => vi.fn(async () => false));
+
+vi.mock("../../extensions/bluebubbles/src/monitor.js", () => ({
+  handleBlueBubblesWebhookRequest,
+}));
+
+import { AUTH_NONE, sendRequest, withGatewayServer } from "./server-http.test-harness.js";
+
+describe("gateway bluebubbles webhook stage", () => {
+  beforeEach(() => {
+    handleBlueBubblesWebhookRequest.mockReset();
+    handleBlueBubblesWebhookRequest.mockResolvedValue(false);
+  });
+
+  it("handles bluebubbles webhooks before plugin http fallthrough", async () => {
+    handleBlueBubblesWebhookRequest.mockImplementation(async (req, res) => {
+      const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+      if (req.method !== "POST" || pathname !== "/bluebubbles-webhook") {
+        return false;
+      }
+      res.statusCode = 202;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("bluebubbles-handled");
+      return true;
+    });
+
+    const handlePluginRequest = vi.fn(async () => false);
+
+    await withGatewayServer({
+      prefix: "bluebubbles-webhook-stage",
+      resolvedAuth: AUTH_NONE,
+      overrides: { handlePluginRequest },
+      run: async (server) => {
+        const response = await sendRequest(server, {
+          path: "/bluebubbles-webhook",
+          method: "POST",
+        });
+
+        expect(response.res.statusCode).toBe(202);
+        expect(response.getBody()).toBe("bluebubbles-handled");
+        expect(handlePluginRequest).not.toHaveBeenCalled();
+      },
+    });
+  });
+});

--- a/src/gateway/server.bluebubbles-http.test.ts
+++ b/src/gateway/server.bluebubbles-http.test.ts
@@ -1,6 +1,14 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const handleBlueBubblesWebhookRequest = vi.hoisted(() => vi.fn(async () => false));
+type BlueBubblesWebhookHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => Promise<boolean>;
+
+const handleBlueBubblesWebhookRequest = vi.hoisted(() =>
+  vi.fn<BlueBubblesWebhookHandler>(async () => false),
+);
 
 vi.mock("../../extensions/bluebubbles/src/monitor.js", () => ({
   handleBlueBubblesWebhookRequest,
@@ -41,6 +49,31 @@ describe("gateway bluebubbles webhook stage", () => {
         expect(response.res.statusCode).toBe(202);
         expect(response.getBody()).toBe("bluebubbles-handled");
         expect(handlePluginRequest).not.toHaveBeenCalled();
+      },
+    });
+  });
+
+  it("falls through to plugin handling when the bluebubbles handler does not claim the request", async () => {
+    const handlePluginRequest = vi.fn(
+      async (_req: IncomingMessage, res: ServerResponse) => {
+        res.statusCode = 204;
+        res.end();
+        return true;
+      },
+    );
+
+    await withGatewayServer({
+      prefix: "bluebubbles-webhook-fallthrough",
+      resolvedAuth: AUTH_NONE,
+      overrides: { handlePluginRequest },
+      run: async (server) => {
+        const response = await sendRequest(server, {
+          path: "/not-bluebubbles",
+          method: "POST",
+        });
+
+        expect(response.res.statusCode).toBe(204);
+        expect(handlePluginRequest).toHaveBeenCalledTimes(1);
       },
     });
   });


### PR DESCRIPTION
## Summary
- keep BlueBubbles webhook targets in process-shared state so registrations survive source-loaded startup paths
- run the BlueBubbles HTTP handler before plugin request fallthrough in the gateway
- add a regression test for `POST /bluebubbles-webhook` so the route cannot silently regress back to `404`

## Testing
- `corepack pnpm vitest run src/gateway/server.bluebubbles-http.test.ts extensions/bluebubbles/src/monitor.webhook-route.test.ts`
- `corepack pnpm build`