### PR TITLE
fix(daemon): accept 'Last Result' schtasks key variant on Windows (#47726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/watch mode: restart on bundled-plugin package and manifest metadata changes, rebuild `dist` for extension source and `tsdown.config.ts` changes, and still ignore extension docs. (#47571) thanks @gumadeiras.
 - Gateway/watch mode: recreate bundled plugin runtime metadata after clean or stale `dist` states, so `pnpm gateway:watch` no longer fails on missing `dist/extensions/*/openclaw.plugin.json` manifests after a rebuild. Thanks @gumadeiras.
 - Plugins/context engines: enforce owner-aware context-engine registration on both loader and public SDK paths so plugins cannot spoof privileged ownership, claim the core `legacy` engine id, or overwrite an existing engine id through direct SDK imports. (#47595) Thanks @vincentkoc.
+- Windows/gateway status: accept `schtasks` `Last Result` output as an alias for `Last Run Result`, so running scheduled-task installs no longer show `Runtime: unknown`. (#47844) Thanks @MoerAI.
 
 ## 2026.3.13
 

--- a/src/cli/program.smoke.test.ts
+++ b/src/cli/program.smoke.test.ts
@@ -4,10 +4,10 @@ import {
   ensureConfigReady,
   installBaseProgramMocks,
   installSmokeProgramMocks,
-  onboardCommand,
   runTui,
   runtime,
   setupCommand,
+  setupWizardCommand,
 } from "./program.test-mocks.js";
 
 installBaseProgramMocks();
@@ -68,6 +68,6 @@ describe("cli program (smoke)", () => {
     await runProgram(["setup", "--remote-url", "ws://example"]);
 
     expect(setupCommand).not.toHaveBeenCalled();
-    expect(onboardCommand).toHaveBeenCalledTimes(1);
+    expect(setupWizardCommand).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cli/program.test-mocks.ts
+++ b/src/cli/program.test-mocks.ts
@@ -2,34 +2,39 @@ import { vi, type Mock } from "vitest";
 
 type AnyMock = Mock<(...args: unknown[]) => unknown>;
 
-const programMocks = vi.hoisted(() => ({
-  messageCommand: vi.fn(),
-  statusCommand: vi.fn(),
-  configureCommand: vi.fn(),
-  configureCommandWithSections: vi.fn(),
-  setupCommand: vi.fn(),
-  onboardCommand: vi.fn(),
-  callGateway: vi.fn(),
-  runChannelLogin: vi.fn(),
-  runChannelLogout: vi.fn(),
-  runTui: vi.fn(),
-  loadAndMaybeMigrateDoctorConfig: vi.fn(),
-  ensureConfigReady: vi.fn(),
-  ensurePluginRegistryLoaded: vi.fn(),
-  runtime: {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(() => {
-      throw new Error("exit");
-    }),
-  },
-}));
+const programMocks = vi.hoisted(() => {
+  const setupWizardCommand = vi.fn();
+  return {
+    messageCommand: vi.fn(),
+    statusCommand: vi.fn(),
+    configureCommand: vi.fn(),
+    configureCommandWithSections: vi.fn(),
+    setupCommand: vi.fn(),
+    setupWizardCommand,
+    onboardCommand: setupWizardCommand,
+    callGateway: vi.fn(),
+    runChannelLogin: vi.fn(),
+    runChannelLogout: vi.fn(),
+    runTui: vi.fn(),
+    loadAndMaybeMigrateDoctorConfig: vi.fn(),
+    ensureConfigReady: vi.fn(),
+    ensurePluginRegistryLoaded: vi.fn(),
+    runtime: {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(() => {
+        throw new Error("exit");
+      }),
+    },
+  };
+});
 
 export const messageCommand = programMocks.messageCommand as AnyMock;
 export const statusCommand = programMocks.statusCommand as AnyMock;
 export const configureCommand = programMocks.configureCommand as AnyMock;
 export const configureCommandWithSections = programMocks.configureCommandWithSections as AnyMock;
 export const setupCommand = programMocks.setupCommand as AnyMock;
+export const setupWizardCommand = programMocks.setupWizardCommand as AnyMock;
 export const onboardCommand = programMocks.onboardCommand as AnyMock;
 export const callGateway = programMocks.callGateway as AnyMock;
 export const runChannelLogin = programMocks.runChannelLogin as AnyMock;
@@ -71,7 +76,10 @@ vi.mock("../commands/configure.js", () => ({
   },
 }));
 vi.mock("../commands/setup.js", () => ({ setupCommand: programMocks.setupCommand }));
-vi.mock("../commands/onboard.js", () => ({ onboardCommand: programMocks.onboardCommand }));
+vi.mock("../commands/onboard.js", () => ({
+  onboardCommand: programMocks.onboardCommand,
+  setupWizardCommand: programMocks.setupWizardCommand,
+}));
 vi.mock("../runtime.js", () => ({ defaultRuntime: programMocks.runtime }));
 vi.mock("./channel-auth.js", () => ({
   runChannelLogin: programMocks.runChannelLogin,

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -23,6 +23,20 @@ describe("schtasks runtime parsing", () => {
       lastRunResult: "0x0",
     });
   });
+
+  it("parses 'Last Result' key variant (without 'Run') (#47726)", () => {
+    const output = [
+      "TaskName: \\OpenClaw Gateway",
+      "Status: Running",
+      "Last Run Time: 2026/3/16 8:34:15",
+      "Last Result: 267009",
+    ].join("\r\n");
+    expect(parseSchtasksQuery(output)).toEqual({
+      status: "Running",
+      lastRunTime: "2026/3/16 8:34:15",
+      lastRunResult: "267009",
+    });
+  });
 });
 
 describe("scheduled task runtime derivation", () => {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -178,7 +178,9 @@ export function parseSchtasksQuery(output: string): ScheduledTaskInfo {
   if (lastRunTime) {
     info.lastRunTime = lastRunTime;
   }
-  const lastRunResult = entries["last run result"];
+  // Some Windows locales/versions emit "Last Result" instead of "Last Run Result".
+  // Accept both so gateway status is not falsely reported as "unknown" (#47726).
+  const lastRunResult = entries["last run result"] ?? entries["last result"];
   if (lastRunResult) {
     info.lastRunResult = lastRunResult;
   }


### PR DESCRIPTION
## Summary
- Fix `Runtime: unknown` on Windows when `schtasks /Query` outputs `Last Result` instead of `Last Run Result`
- Some Windows locales/versions emit the shorter key name, causing `parseSchtasksQuery` to miss the result code
- Falls back to `entries["last result"]` when `entries["last run result"]` is absent

## Changes
- `src/daemon/schtasks.ts`: Accept both `Last Run Result` and `Last Result` key variants
- `src/daemon/schtasks.test.ts`: Add regression test for the shorter key variant

Closes #47726