### PR TITLE
fix(msteams): address review feedback on #40884 — schema, types, env validation

### DIFF
--- a/extensions/msteams/src/errors.test.ts
+++ b/extensions/msteams/src/errors.test.ts
@@ -41,6 +41,8 @@ describe("msteams errors", () => {
 
   it("provides actionable hints for common cases", () => {
     expect(formatMSTeamsSendErrorHint({ kind: "auth" })).toContain("msteams");
+    expect(formatMSTeamsSendErrorHint({ kind: "auth" })).toContain("MSTEAMS_APP_ID");
+    expect(formatMSTeamsSendErrorHint({ kind: "auth" })).toContain("MSTEAMS_TENANT_ID");
     expect(formatMSTeamsSendErrorHint({ kind: "throttled" })).toContain("throttled");
   });
 

--- a/extensions/msteams/src/errors.ts
+++ b/extensions/msteams/src/errors.ts
@@ -193,7 +193,7 @@ export function formatMSTeamsSendErrorHint(
   classification: MSTeamsSendErrorClassification,
 ): string | undefined {
   if (classification.kind === "auth") {
-    return "check msteams appId/tenantId and auth config (appPassword, certificate, or federated credential)";
+    return "check msteams appId/tenantId (or env MSTEAMS_APP_ID/MSTEAMS_TENANT_ID) and auth config (appPassword, certificate, or federated credential)";
   }
   if (classification.kind === "throttled") {
     return "Teams throttled the bot; backing off may help";

--- a/extensions/msteams/src/errors.ts
+++ b/extensions/msteams/src/errors.ts
@@ -193,7 +193,7 @@ export function formatMSTeamsSendErrorHint(
   classification: MSTeamsSendErrorClassification,
 ): string | undefined {
   if (classification.kind === "auth") {
-    return "check msteams appId/appPassword/tenantId (or env vars MSTEAMS_APP_ID/MSTEAMS_APP_PASSWORD/MSTEAMS_TENANT_ID)";
+    return "check msteams appId/tenantId and auth config (appPassword, certificate, or federated credential)";
   }
   if (classification.kind === "throttled") {
     return "Teams throttled the bot; backing off may help";

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -60,7 +60,7 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
     return {
       ok: false,
       error:
-        "missing credentials (appId, tenantId, and one of: appPassword, certificate, or federated credential)",
+        "missing credentials (appId, tenantId — or env MSTEAMS_APP_ID/MSTEAMS_TENANT_ID — and one of: appPassword, certificate, or federated credential)",
     };
   }
 

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -59,7 +59,8 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
   if (!creds) {
     return {
       ok: false,
-      error: "missing credentials (appId, appPassword, tenantId)",
+      error:
+        "missing credentials (appId, tenantId, and one of: appPassword, certificate, or federated credential)",
     };
   }
 

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -12,11 +12,28 @@ export function buildMSTeamsAuthConfig(
   creds: MSTeamsCredentials,
   sdk: MSTeamsSdk,
 ): MSTeamsAuthConfig {
-  return sdk.getAuthConfigWithDefaults({
+  const base: Parameters<MSTeamsSdk["getAuthConfigWithDefaults"]>[0] = {
     clientId: creds.appId,
-    clientSecret: creds.appPassword,
     tenantId: creds.tenantId,
-  });
+  };
+
+  switch (creds.authType) {
+    case "certificate":
+      base.certPemFile = creds.certPemFile;
+      base.certKeyFile = creds.certKeyFile;
+      if (creds.sendX5C != null) base.sendX5C = creds.sendX5C;
+      break;
+    case "federatedCredential":
+      if (creds.ficClientId) base.FICClientId = creds.ficClientId;
+      if (creds.widAssertionFile) base.WIDAssertionFile = creds.widAssertionFile;
+      break;
+    case "clientSecret":
+    default:
+      base.clientSecret = creds.appPassword;
+      break;
+  }
+
+  return sdk.getAuthConfigWithDefaults(base);
 }
 
 export function createMSTeamsAdapter(

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -19,8 +19,8 @@ export function buildMSTeamsAuthConfig(
 
   switch (creds.authType) {
     case "certificate":
-      base.certPemFile = creds.certPemFile;
-      base.certKeyFile = creds.certKeyFile;
+      if (creds.certPemFile) base.certPemFile = creds.certPemFile;
+      if (creds.certKeyFile) base.certKeyFile = creds.certKeyFile;
       if (creds.sendX5C != null) base.sendX5C = creds.sendX5C;
       break;
     case "federatedCredential":

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -29,7 +29,7 @@ export function buildMSTeamsAuthConfig(
       break;
     case "clientSecret":
     default:
-      base.clientSecret = creds.appPassword;
+      if (creds.appPassword) base.clientSecret = creds.appPassword;
       break;
   }
 

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -37,7 +37,77 @@ describe("resolveMSTeamsCredentials", () => {
       appId: "app-id",
       appPassword: "app-password", // pragma: allowlist secret
       tenantId: "tenant-id",
+      authType: "clientSecret",
     });
+  });
+
+  it("defaults to clientSecret when authType is not specified", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      appPassword: "secret",
+      tenantId: "tenant-id",
+    });
+
+    expect(resolved?.authType).toBe("clientSecret");
+  });
+
+  it("resolves certificate credentials", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "certificate",
+      certPemFile: "/path/to/cert.pem",
+      certKeyFile: "/path/to/key.pem",
+    });
+
+    expect(resolved?.authType).toBe("certificate");
+    expect(resolved?.certPemFile).toBe("/path/to/cert.pem");
+    expect(resolved?.certKeyFile).toBe("/path/to/key.pem");
+  });
+
+  it("returns undefined for certificate auth missing certKeyFile", () => {
+    expect(
+      resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+        certPemFile: "/path/to/cert.pem",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("resolves federated credentials with ficClientId", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "federatedCredential",
+      ficClientId: "fic-client-id",
+    });
+
+    expect(resolved?.authType).toBe("federatedCredential");
+    expect(resolved?.ficClientId).toBe("fic-client-id");
+  });
+
+  it("resolves federated credentials with widAssertionFile", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "federatedCredential",
+      widAssertionFile: "/var/run/secrets/azure/tokens/azure-identity-token",
+    });
+
+    expect(resolved?.authType).toBe("federatedCredential");
+    expect(resolved?.widAssertionFile).toBe("/var/run/secrets/azure/tokens/azure-identity-token");
+  });
+
+  it("returns undefined for federated auth with neither ficClientId nor widAssertionFile", () => {
+    expect(
+      resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "federatedCredential",
+      }),
+    ).toBeUndefined();
   });
 
   it("throws when appPassword remains an unresolved SecretRef object", () => {
@@ -68,5 +138,48 @@ describe("hasConfiguredMSTeamsCredentials", () => {
     });
 
     expect(configured).toBe(true);
+  });
+
+  it("detects certificate auth as configured", () => {
+    expect(
+      hasConfiguredMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+        certPemFile: "/path/to/cert.pem",
+        certKeyFile: "/path/to/key.pem",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects certificate auth missing cert files", () => {
+    expect(
+      hasConfiguredMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+      }),
+    ).toBe(false);
+  });
+
+  it("detects federated credential auth as configured", () => {
+    expect(
+      hasConfiguredMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "federatedCredential",
+        ficClientId: "fic-client-id",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects federated auth with no credential source", () => {
+    expect(
+      hasConfiguredMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "federatedCredential",
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -66,16 +66,48 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.appPassword).toBeUndefined();
   });
 
-  it("resolves certificate auth without config cert fields (SDK env fallback)", () => {
-    const resolved = resolveMSTeamsCredentials({
-      appId: "app-id",
-      tenantId: "tenant-id",
-      authType: "certificate",
-    });
+  it("resolves certificate auth via SDK plain env vars", () => {
+    process.env.certPemFile = "/env/cert.pem";
+    process.env.certKeyFile = "/env/key.pem";
+    try {
+      const resolved = resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+      });
 
-    expect(resolved?.authType).toBe("certificate");
-    expect(resolved?.certPemFile).toBeUndefined();
-    expect(resolved?.certKeyFile).toBeUndefined();
+      expect(resolved?.authType).toBe("certificate");
+    } finally {
+      delete process.env.certPemFile;
+      delete process.env.certKeyFile;
+    }
+  });
+
+  it("resolves certificate auth with mixed config/env sources", () => {
+    process.env.certKeyFile = "/env/key.pem";
+    try {
+      const resolved = resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+        certPemFile: "/config/cert.pem",
+      });
+
+      expect(resolved?.authType).toBe("certificate");
+      expect(resolved?.certPemFile).toBe("/config/cert.pem");
+    } finally {
+      delete process.env.certKeyFile;
+    }
+  });
+
+  it("returns undefined for certificate auth with no auth material anywhere", () => {
+    expect(
+      resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+      }),
+    ).toBeUndefined();
   });
 
   it("resolves federated credentials with ficClientId", () => {
@@ -103,16 +135,29 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.widAssertionFile).toBe("/var/run/secrets/azure/tokens/azure-identity-token");
   });
 
-  it("resolves federated auth without config fields (SDK env fallback)", () => {
-    const resolved = resolveMSTeamsCredentials({
-      appId: "app-id",
-      tenantId: "tenant-id",
-      authType: "federatedCredential",
-    });
+  it("resolves federated auth via SDK plain env vars", () => {
+    process.env.FICClientId = "env-fic-id";
+    try {
+      const resolved = resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "federatedCredential",
+      });
 
-    expect(resolved?.authType).toBe("federatedCredential");
-    expect(resolved?.ficClientId).toBeUndefined();
-    expect(resolved?.widAssertionFile).toBeUndefined();
+      expect(resolved?.authType).toBe("federatedCredential");
+    } finally {
+      delete process.env.FICClientId;
+    }
+  });
+
+  it("returns undefined for federated auth with no auth material anywhere", () => {
+    expect(
+      resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "federatedCredential",
+      }),
+    ).toBeUndefined();
   });
 
   it("throws when appPassword remains an unresolved SecretRef object", () => {
@@ -157,14 +202,31 @@ describe("hasConfiguredMSTeamsCredentials", () => {
     ).toBe(true);
   });
 
-  it("treats certificate auth as configured even without cert files (SDK env fallback)", () => {
+  it("detects certificate auth via SDK plain env vars", () => {
+    process.env.certPemFile = "/env/cert.pem";
+    process.env.certKeyFile = "/env/key.pem";
+    try {
+      expect(
+        hasConfiguredMSTeamsCredentials({
+          appId: "app-id",
+          tenantId: "tenant-id",
+          authType: "certificate",
+        }),
+      ).toBe(true);
+    } finally {
+      delete process.env.certPemFile;
+      delete process.env.certKeyFile;
+    }
+  });
+
+  it("rejects certificate auth with no auth material anywhere", () => {
     expect(
       hasConfiguredMSTeamsCredentials({
         appId: "app-id",
         tenantId: "tenant-id",
         authType: "certificate",
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("detects federated credential auth as configured", () => {
@@ -178,13 +240,28 @@ describe("hasConfiguredMSTeamsCredentials", () => {
     ).toBe(true);
   });
 
-  it("treats federated auth as configured even without config fields (SDK env fallback)", () => {
+  it("detects federated auth via SDK plain env vars", () => {
+    process.env.WIDAssertionFile = "/var/run/token";
+    try {
+      expect(
+        hasConfiguredMSTeamsCredentials({
+          appId: "app-id",
+          tenantId: "tenant-id",
+          authType: "federatedCredential",
+        }),
+      ).toBe(true);
+    } finally {
+      delete process.env.WIDAssertionFile;
+    }
+  });
+
+  it("rejects federated auth with no auth material anywhere", () => {
     expect(
       hasConfiguredMSTeamsCredentials({
         appId: "app-id",
         tenantId: "tenant-id",
         authType: "federatedCredential",
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -66,15 +66,16 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.appPassword).toBeUndefined();
   });
 
-  it("returns undefined for certificate auth missing certKeyFile", () => {
-    expect(
-      resolveMSTeamsCredentials({
-        appId: "app-id",
-        tenantId: "tenant-id",
-        authType: "certificate",
-        certPemFile: "/path/to/cert.pem",
-      }),
-    ).toBeUndefined();
+  it("resolves certificate auth without config cert fields (SDK env fallback)", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "certificate",
+    });
+
+    expect(resolved?.authType).toBe("certificate");
+    expect(resolved?.certPemFile).toBeUndefined();
+    expect(resolved?.certKeyFile).toBeUndefined();
   });
 
   it("resolves federated credentials with ficClientId", () => {
@@ -102,14 +103,16 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.widAssertionFile).toBe("/var/run/secrets/azure/tokens/azure-identity-token");
   });
 
-  it("returns undefined for federated auth with neither ficClientId nor widAssertionFile", () => {
-    expect(
-      resolveMSTeamsCredentials({
-        appId: "app-id",
-        tenantId: "tenant-id",
-        authType: "federatedCredential",
-      }),
-    ).toBeUndefined();
+  it("resolves federated auth without config fields (SDK env fallback)", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "federatedCredential",
+    });
+
+    expect(resolved?.authType).toBe("federatedCredential");
+    expect(resolved?.ficClientId).toBeUndefined();
+    expect(resolved?.widAssertionFile).toBeUndefined();
   });
 
   it("throws when appPassword remains an unresolved SecretRef object", () => {
@@ -154,14 +157,14 @@ describe("hasConfiguredMSTeamsCredentials", () => {
     ).toBe(true);
   });
 
-  it("rejects certificate auth missing cert files", () => {
+  it("treats certificate auth as configured even without cert files (SDK env fallback)", () => {
     expect(
       hasConfiguredMSTeamsCredentials({
         appId: "app-id",
         tenantId: "tenant-id",
         authType: "certificate",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("detects federated credential auth as configured", () => {
@@ -175,13 +178,13 @@ describe("hasConfiguredMSTeamsCredentials", () => {
     ).toBe(true);
   });
 
-  it("rejects federated auth with no credential source", () => {
+  it("treats federated auth as configured even without config fields (SDK env fallback)", () => {
     expect(
       hasConfiguredMSTeamsCredentials({
         appId: "app-id",
         tenantId: "tenant-id",
         authType: "federatedCredential",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -77,6 +77,10 @@ describe("resolveMSTeamsCredentials", () => {
       });
 
       expect(resolved?.authType).toBe("certificate");
+      // Env-only cert paths are not forwarded in credentials — the SDK
+      // merges them from env at runtime via getAuthConfigWithDefaults().
+      expect(resolved?.certPemFile).toBeUndefined();
+      expect(resolved?.certKeyFile).toBeUndefined();
     } finally {
       delete process.env.certPemFile;
       delete process.env.certKeyFile;

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -51,7 +51,7 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.authType).toBe("clientSecret");
   });
 
-  it("resolves certificate credentials", () => {
+  it("resolves certificate credentials without appPassword", () => {
     const resolved = resolveMSTeamsCredentials({
       appId: "app-id",
       tenantId: "tenant-id",
@@ -63,6 +63,7 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.authType).toBe("certificate");
     expect(resolved?.certPemFile).toBe("/path/to/cert.pem");
     expect(resolved?.certKeyFile).toBe("/path/to/key.pem");
+    expect(resolved?.appPassword).toBeUndefined();
   });
 
   it("returns undefined for certificate auth missing certKeyFile", () => {
@@ -86,6 +87,7 @@ describe("resolveMSTeamsCredentials", () => {
 
     expect(resolved?.authType).toBe("federatedCredential");
     expect(resolved?.ficClientId).toBe("fic-client-id");
+    expect(resolved?.appPassword).toBeUndefined();
   });
 
   it("resolves federated credentials with widAssertionFile", () => {

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -5,7 +5,8 @@ import {
   normalizeSecretInputString,
 } from "./secret-input.js";
 
-export type MSTeamsAuthType = "clientSecret" | "certificate" | "federatedCredential";
+/** Derived from MSTeamsConfig.authType to keep a single source of truth. */
+export type MSTeamsAuthType = NonNullable<MSTeamsConfig["authType"]>;
 
 export type MSTeamsCredentials = {
   appId: string;

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -9,7 +9,7 @@ export type MSTeamsAuthType = "clientSecret" | "certificate" | "federatedCredent
 
 export type MSTeamsCredentials = {
   appId: string;
-  appPassword: string;
+  appPassword?: string;
   tenantId: string;
   authType: MSTeamsAuthType;
   certPemFile?: string;
@@ -58,7 +58,6 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
       if (!certPemFile || !certKeyFile) return undefined;
       return {
         appId,
-        appPassword: "", // not used for certificate auth
         tenantId,
         authType,
         certPemFile,
@@ -72,7 +71,6 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
       if (!ficClientId && !widAssertionFile) return undefined;
       return {
         appId,
-        appPassword: "", // not used for federated auth
         tenantId,
         authType,
         ficClientId,

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -5,36 +5,89 @@ import {
   normalizeSecretInputString,
 } from "./secret-input.js";
 
+export type MSTeamsAuthType = "clientSecret" | "certificate" | "federatedCredential";
+
 export type MSTeamsCredentials = {
   appId: string;
   appPassword: string;
   tenantId: string;
+  authType: MSTeamsAuthType;
+  certPemFile?: string;
+  certKeyFile?: string;
+  sendX5C?: boolean;
+  ficClientId?: string;
+  widAssertionFile?: string;
 };
 
 export function hasConfiguredMSTeamsCredentials(cfg?: MSTeamsConfig): boolean {
-  return Boolean(
-    normalizeSecretInputString(cfg?.appId) &&
-    hasConfiguredSecretInput(cfg?.appPassword) &&
-    normalizeSecretInputString(cfg?.tenantId),
-  );
+  const appId = normalizeSecretInputString(cfg?.appId);
+  const tenantId = normalizeSecretInputString(cfg?.tenantId);
+  if (!appId || !tenantId) return false;
+
+  const authType = cfg?.authType ?? "clientSecret";
+
+  switch (authType) {
+    case "certificate":
+      return Boolean(cfg?.certPemFile && cfg?.certKeyFile);
+    case "federatedCredential":
+      return Boolean(cfg?.ficClientId || cfg?.widAssertionFile);
+    case "clientSecret":
+    default:
+      return Boolean(hasConfiguredSecretInput(cfg?.appPassword));
+  }
 }
 
 export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentials | undefined {
   const appId =
     normalizeSecretInputString(cfg?.appId) ||
     normalizeSecretInputString(process.env.MSTEAMS_APP_ID);
-  const appPassword =
-    normalizeResolvedSecretInputString({
-      value: cfg?.appPassword,
-      path: "channels.msteams.appPassword",
-    }) || normalizeSecretInputString(process.env.MSTEAMS_APP_PASSWORD);
   const tenantId =
     normalizeSecretInputString(cfg?.tenantId) ||
     normalizeSecretInputString(process.env.MSTEAMS_TENANT_ID);
 
-  if (!appId || !appPassword || !tenantId) {
+  if (!appId || !tenantId) {
     return undefined;
   }
 
-  return { appId, appPassword, tenantId };
+  const authType: MSTeamsAuthType = cfg?.authType ?? "clientSecret";
+
+  switch (authType) {
+    case "certificate": {
+      const certPemFile = cfg?.certPemFile;
+      const certKeyFile = cfg?.certKeyFile;
+      if (!certPemFile || !certKeyFile) return undefined;
+      return {
+        appId,
+        appPassword: "", // not used for certificate auth
+        tenantId,
+        authType,
+        certPemFile,
+        certKeyFile,
+        sendX5C: cfg?.sendX5C,
+      };
+    }
+    case "federatedCredential": {
+      const ficClientId = cfg?.ficClientId;
+      const widAssertionFile = cfg?.widAssertionFile;
+      if (!ficClientId && !widAssertionFile) return undefined;
+      return {
+        appId,
+        appPassword: "", // not used for federated auth
+        tenantId,
+        authType,
+        ficClientId,
+        widAssertionFile,
+      };
+    }
+    case "clientSecret":
+    default: {
+      const appPassword =
+        normalizeResolvedSecretInputString({
+          value: cfg?.appPassword,
+          path: "channels.msteams.appPassword",
+        }) || normalizeSecretInputString(process.env.MSTEAMS_APP_PASSWORD);
+      if (!appPassword) return undefined;
+      return { appId, appPassword, tenantId, authType: "clientSecret" };
+    }
+  }
 }

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -30,12 +30,18 @@ export type MSTeamsCredentials = {
  * belong to an unrelated Agents SDK connection and cannot be reliably
  * attributed to the Teams channel.
  */
+/** Return trimmed value if non-blank, otherwise undefined. */
+function trimPresence(value: string | undefined | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
 function hasCertificateAuthMaterial(
   cfg?: MSTeamsConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  const hasPem = Boolean(cfg?.certPemFile || env.certPemFile);
-  const hasKey = Boolean(cfg?.certKeyFile || env.certKeyFile);
+  const hasPem = Boolean(trimPresence(cfg?.certPemFile) || trimPresence(env.certPemFile));
+  const hasKey = Boolean(trimPresence(cfg?.certKeyFile) || trimPresence(env.certKeyFile));
   return hasPem && hasKey;
 }
 
@@ -52,7 +58,10 @@ function hasFederatedAuthMaterial(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   return Boolean(
-    cfg?.ficClientId || env.FICClientId || cfg?.widAssertionFile || env.WIDAssertionFile,
+    trimPresence(cfg?.ficClientId) ||
+    trimPresence(env.FICClientId) ||
+    trimPresence(cfg?.widAssertionFile) ||
+    trimPresence(env.WIDAssertionFile),
   );
 }
 
@@ -95,8 +104,8 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
         appId,
         tenantId,
         authType,
-        certPemFile: cfg?.certPemFile,
-        certKeyFile: cfg?.certKeyFile,
+        certPemFile: trimPresence(cfg?.certPemFile),
+        certKeyFile: trimPresence(cfg?.certKeyFile),
         sendX5C: cfg?.sendX5C,
       };
     }
@@ -106,8 +115,8 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
         appId,
         tenantId,
         authType,
-        ficClientId: cfg?.ficClientId,
-        widAssertionFile: cfg?.widAssertionFile,
+        ficClientId: trimPresence(cfg?.ficClientId),
+        widAssertionFile: trimPresence(cfg?.widAssertionFile),
       };
     }
     case "clientSecret":

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -20,6 +20,42 @@ export type MSTeamsCredentials = {
   widAssertionFile?: string;
 };
 
+/**
+ * Check whether certificate auth material is present in typed config
+ * or the SDK's plain env vars. Each field is checked independently so
+ * mixed-source configs (e.g. certPemFile in config, certKeyFile in env)
+ * are accepted — the SDK merges them field-by-field at runtime.
+ *
+ * Does not check connections__*__settings__* env vars because those may
+ * belong to an unrelated Agents SDK connection and cannot be reliably
+ * attributed to the Teams channel.
+ */
+function hasCertificateAuthMaterial(
+  cfg?: MSTeamsConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const hasPem = Boolean(cfg?.certPemFile || env.certPemFile);
+  const hasKey = Boolean(cfg?.certKeyFile || env.certKeyFile);
+  return hasPem && hasKey;
+}
+
+/**
+ * Check whether federated credential auth material is present in typed
+ * config or the SDK's plain env vars. Either FICClientId or
+ * WIDAssertionFile is sufficient.
+ *
+ * Does not check connections__*__settings__* env vars because those may
+ * belong to an unrelated Agents SDK connection.
+ */
+function hasFederatedAuthMaterial(
+  cfg?: MSTeamsConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return Boolean(
+    cfg?.ficClientId || env.FICClientId || cfg?.widAssertionFile || env.WIDAssertionFile,
+  );
+}
+
 export function hasConfiguredMSTeamsCredentials(cfg?: MSTeamsConfig): boolean {
   const appId = normalizeSecretInputString(cfg?.appId);
   const tenantId = normalizeSecretInputString(cfg?.tenantId);
@@ -29,9 +65,9 @@ export function hasConfiguredMSTeamsCredentials(cfg?: MSTeamsConfig): boolean {
 
   switch (authType) {
     case "certificate":
+      return hasCertificateAuthMaterial(cfg);
     case "federatedCredential":
-      // Auth type explicitly set — detail fields may come from SDK env fallbacks.
-      return true;
+      return hasFederatedAuthMaterial(cfg);
     case "clientSecret":
     default:
       return Boolean(hasConfiguredSecretInput(cfg?.appPassword));
@@ -54,8 +90,7 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
 
   switch (authType) {
     case "certificate": {
-      // Config fields are optional — the SDK's getAuthConfigWithDefaults()
-      // can also source certPemFile/certKeyFile from environment variables.
+      if (!hasCertificateAuthMaterial(cfg)) return undefined;
       return {
         appId,
         tenantId,
@@ -66,8 +101,7 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
       };
     }
     case "federatedCredential": {
-      // Config fields are optional — the SDK's getAuthConfigWithDefaults()
-      // can also source ficClientId/widAssertionFile from environment variables.
+      if (!hasFederatedAuthMaterial(cfg)) return undefined;
       return {
         appId,
         tenantId,

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -29,9 +29,9 @@ export function hasConfiguredMSTeamsCredentials(cfg?: MSTeamsConfig): boolean {
 
   switch (authType) {
     case "certificate":
-      return Boolean(cfg?.certPemFile && cfg?.certKeyFile);
     case "federatedCredential":
-      return Boolean(cfg?.ficClientId || cfg?.widAssertionFile);
+      // Auth type explicitly set — detail fields may come from SDK env fallbacks.
+      return true;
     case "clientSecret":
     default:
       return Boolean(hasConfiguredSecretInput(cfg?.appPassword));
@@ -54,28 +54,26 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
 
   switch (authType) {
     case "certificate": {
-      const certPemFile = cfg?.certPemFile;
-      const certKeyFile = cfg?.certKeyFile;
-      if (!certPemFile || !certKeyFile) return undefined;
+      // Config fields are optional — the SDK's getAuthConfigWithDefaults()
+      // can also source certPemFile/certKeyFile from environment variables.
       return {
         appId,
         tenantId,
         authType,
-        certPemFile,
-        certKeyFile,
+        certPemFile: cfg?.certPemFile,
+        certKeyFile: cfg?.certKeyFile,
         sendX5C: cfg?.sendX5C,
       };
     }
     case "federatedCredential": {
-      const ficClientId = cfg?.ficClientId;
-      const widAssertionFile = cfg?.widAssertionFile;
-      if (!ficClientId && !widAssertionFile) return undefined;
+      // Config fields are optional — the SDK's getAuthConfigWithDefaults()
+      // can also source ficClientId/widAssertionFile from environment variables.
       return {
         appId,
         tenantId,
         authType,
-        ficClientId,
-        widAssertionFile,
+        ficClientId: cfg?.ficClientId,
+        widAssertionFile: cfg?.widAssertionFile,
       };
     }
     case "clientSecret":

--- a/src/config/types.msteams.ts
+++ b/src/config/types.msteams.ts
@@ -64,6 +64,31 @@ export type MSTeamsConfig = {
   appId?: string;
   /** Azure Bot App Password / Client Secret. */
   appPassword?: SecretInput;
+  /**
+   * Authentication type for the bot.
+   * - "clientSecret" (default): Uses appPassword (client secret).
+   * - "certificate": Uses certPemFile + certKeyFile for certificate-based auth.
+   * - "federatedCredential": Uses FIC (First-party Integration Channel) client ID
+   *   with workload identity federation (no secret needed).
+   */
+  authType?: "clientSecret" | "certificate" | "federatedCredential";
+  /** Path to the certificate PEM file (used when authType is "certificate"). */
+  certPemFile?: string;
+  /** Path to the certificate key file (used when authType is "certificate"). */
+  certKeyFile?: string;
+  /** Whether to send the X5C param for SNI authentication (used with certificate auth). */
+  sendX5C?: boolean;
+  /**
+   * The FIC (First-party Integration Channel) client ID for federated credential auth.
+   * This is the client ID of a user-assigned managed identity with a federated credential
+   * configured on the App Registration.
+   */
+  ficClientId?: string;
+  /**
+   * Path to the workload identity assertion file (e.g., K8s service account token).
+   * Used with federated credential auth when running in Kubernetes or similar environments.
+   */
+  widAssertionFile?: string;
   /** Azure AD Tenant ID (for single-tenant bots). */
   tenantId?: string;
   /** Webhook server configuration. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1483,6 +1483,12 @@ export const MSTeamsConfigSchema = z
     configWrites: z.boolean().optional(),
     appId: z.string().optional(),
     appPassword: SecretInputSchema.optional().register(sensitive),
+    authType: z.enum(["clientSecret", "certificate", "federatedCredential"]).optional(),
+    certPemFile: z.string().optional(),
+    certKeyFile: z.string().optional(),
+    sendX5C: z.boolean().optional(),
+    ficClientId: z.string().optional(),
+    widAssertionFile: z.string().optional(),
     tenantId: z.string().optional(),
     webhook: z
       .object({


### PR DESCRIPTION
## Summary

Builds on #40884 (federated credentials and certificate auth support) to fix review issues and add env-backed auth validation:

- **Make `appPassword` optional** — was required but set to empty string for non-secret auth; now optional in `MSTeamsCredentials`
- **Deduplicate `MSTeamsAuthType`** — derived from `MSTeamsConfig["authType"]` instead of a standalone union in two files
- **Add Zod schema fields** — `authType`, `certPemFile`, `certKeyFile`, `sendX5C`, `ficClientId`, `widAssertionFile` added to `MSTeamsConfigSchema` (P1 blocker — configs using these fields were rejected)
- **Restore env var hints** — error messages now include `MSTEAMS_APP_ID`/`MSTEAMS_TENANT_ID` alongside new auth type guidance
- **Validate auth material across sources** — presence helpers check typed config + SDK plain env vars; rejects empty configs that would silently fall through to managed identity auth; accepts mixed-source configs (e.g. certPemFile in config, certKeyFile in env)

## No regressions from prior state

None of the known limitations below are regressions — they are pre-existing gaps in the original feature (#40884). This PR strictly improves the state: adds missing schema validation, fixes type design, restores dropped error hints, and adds auth material presence checks that did not exist before.

## Known limitations (addressed in follow-up PR)

- `authType` is not auto-inferred from environment — if `authType` is omitted, `resolveMSTeamsCredentials` defaults to `clientSecret` even when certificate/federated env vars are present. Requires a unified auth-source resolution helper.
- `hasConfiguredMSTeamsCredentials` does not check `MSTEAMS_APP_ID`/`MSTEAMS_TENANT_ID` env vars — env-only deployments may appear unconfigured in onboarding.
- `connections__serviceConnection__settings__*` env vars are not checked in presence validation — cannot reliably attribute them to the Teams channel vs other Agents SDK connections. The SDK merges them at runtime.
- Integration tests for the SDK env merge path are deferred to the follow-up.

These will be resolved in a follow-up PR that introduces a shared `readTeamsAuthPresence` helper and `DefaultAzureCredential` support.

## AI Disclosure

- [x] AI-assisted (Claude Code + Codex review)
- [x] Fully tested — 233/233 msteams tests passing
- [x] `pnpm build && pnpm check && pnpm test` green
- [x] Authors understand what the code does

Fixes #40855
Related: #40884