### PR TITLE
fix(ui): polish code block copy button styling

### DIFF
--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -84,9 +84,95 @@
   overflow-x: auto;
 }
 
+.chat-text :where(.code-block-wrapper) {
+  margin-top: 0.75em;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--secondary) 55%, transparent);
+}
+
+.chat-text :where(.code-block-header) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--panel) 85%, transparent);
+}
+
+.chat-text :where(.code-block-lang) {
+  min-width: 0;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.chat-text :where(.code-block-copy) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 72px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel) 70%, transparent);
+  color: var(--muted-strong);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.chat-text :where(.code-block-copy:hover) {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  background: color-mix(in srgb, var(--accent) 12%, var(--panel));
+  color: var(--text);
+}
+
+.chat-text :where(.code-block-copy:focus-visible) {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.chat-text :where(.code-block-copy__done) {
+  display: none;
+}
+
+.chat-text :where(.code-block-copy.copied) {
+  border-color: color-mix(in srgb, var(--success, #22c55e) 55%, var(--border));
+  background: color-mix(in srgb, var(--success, #22c55e) 12%, var(--panel));
+  color: var(--text);
+}
+
+.chat-text :where(.code-block-copy.copied .code-block-copy__idle) {
+  display: none;
+}
+
+.chat-text :where(.code-block-copy.copied .code-block-copy__done) {
+  display: inline;
+}
+
 .chat-text :where(pre code) {
   background: none;
   padding: 0;
+}
+
+.chat-text :where(.code-block-wrapper pre) {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .chat-text :where(blockquote) {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -218,6 +218,11 @@
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
+:root[data-theme-mode="light"] .chat-text .code-block-wrapper pre {
+  background: transparent;
+  border: 0;
+}
+
 .chat-text :where(hr) {
   border: none;
   border-top: 1px solid var(--border);

--- a/ui/src/ui/markdown.browser.test.ts
+++ b/ui/src/ui/markdown.browser.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+import "../styles.css";
+import { toSanitizedMarkdownHtml } from "./markdown.ts";
+
+describe("markdown code block copy button styles", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows a single copy label state at a time", async () => {
+    const container = document.createElement("div");
+    container.className = "chat-text";
+    container.innerHTML = toSanitizedMarkdownHtml(["```bash", "echo hello", "```"].join("\n"));
+    document.body.append(container);
+
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const button = container.querySelector<HTMLButtonElement>(".code-block-copy");
+    const idle = container.querySelector<HTMLElement>(".code-block-copy__idle");
+    const done = container.querySelector<HTMLElement>(".code-block-copy__done");
+
+    expect(button).not.toBeNull();
+    expect(idle).not.toBeNull();
+    expect(done).not.toBeNull();
+    if (!button || !idle || !done) {
+      return;
+    }
+
+    expect(getComputedStyle(button).display).toMatch(/flex/);
+    expect(getComputedStyle(idle).display).not.toBe("none");
+    expect(getComputedStyle(done).display).toBe("none");
+
+    button.classList.add("copied");
+
+    expect(getComputedStyle(idle).display).toBe("none");
+    expect(getComputedStyle(done).display).not.toBe("none");
+  });
+});

--- a/ui/src/ui/markdown.browser.test.ts
+++ b/ui/src/ui/markdown.browser.test.ts
@@ -5,6 +5,7 @@ import { toSanitizedMarkdownHtml } from "./markdown.ts";
 describe("markdown code block copy button styles", () => {
   afterEach(() => {
     document.body.innerHTML = "";
+    delete document.documentElement.dataset.themeMode;
   });
 
   it("shows a single copy label state at a time", async () => {
@@ -34,5 +35,26 @@ describe("markdown code block copy button styles", () => {
 
     expect(getComputedStyle(idle).display).toBe("none");
     expect(getComputedStyle(done).display).not.toBe("none");
+  });
+
+  it("keeps wrapped code blocks borderless in light mode", async () => {
+    document.documentElement.dataset.themeMode = "light";
+
+    const container = document.createElement("div");
+    container.className = "chat-text";
+    container.innerHTML = toSanitizedMarkdownHtml(["```bash", "echo hello", "```"].join("\n"));
+    document.body.append(container);
+
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const pre = container.querySelector<HTMLElement>(".code-block-wrapper pre");
+    expect(pre).not.toBeNull();
+    if (!pre) {
+      return;
+    }
+
+    const preStyle = getComputedStyle(pre);
+    expect(preStyle.backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    expect(preStyle.borderTopWidth).toBe("0px");
   });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The WebUI/Control UI code-block copy control had no dedicated styling, so headers rendered with cramped raw text like `CopyCopied!` beside the language label.
- Why it matters: The copy action looked visually broken and distracted from code snippets even though clipboard behavior still worked.
- What changed: Added scoped code-block wrapper/header/copy-button styles in `ui/src/styles/chat/text.css` and added a browser regression test that checks the copy control shows only one label state at a time.
- What did NOT change (scope boundary): Clipboard behavior, markdown parsing, and non-code-block chat rendering were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #47851
- Related #

## User-visible / Behavior Changes

- Code blocks now render with a styled header and a pill-shaped copy button instead of showing crowded `CopyCopied!` text.
- The copied state swaps labels cleanly instead of showing both at once.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local dev container
- Model/provider: N/A
- Integration/channel (if any): WebUI / Control UI chat markdown rendering
- Relevant config (redacted): default UI test setup

### Steps

1. Open a chat/code view containing a fenced code block such as ```bash```.
2. Inspect the code-block header before clicking copy.
3. Click the copy control and inspect the copied state.

### Expected

- The language label and copy control are visually separated and styled.
- Only one copy label state is visible at a time.

### Actual

- After the change, the copy control renders as a styled button and switches cleanly between `Copy` and `Copied!`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran the focused unit and browser tests for markdown/code-block rendering and reviewed the CSS diff for the code-block copy control.
- Edge cases checked: Verified the copied state hides the idle label and shows the success label without affecting markdown rendering for code blocks.
- What you did **not** verify: I did not manually inspect the running WebUI in a full app session.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the code-block styling/test commit.
- Files/config to restore: `ui/src/styles/chat/text.css`, `ui/src/ui/markdown.browser.test.ts`
- Known bad symptoms reviewers should watch for: Code-block headers revert to unstyled text, the copy control shows both labels at once, or copied-state styling stops toggling correctly.

## Risks and Mitigations

- Risk: Styling changes could slightly alter code-block header spacing in themes or viewports not covered by the focused tests.
  - Mitigation: The CSS is narrowly scoped to `.chat-text` code-block classes and the browser regression test locks the label-state behavior.