### PR TITLE
feat(feishu): send delayed acknowledgment for slow direct messages

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -388,6 +388,127 @@ describe("handleFeishuMessage ACP routing", () => {
   });
 });
 
+describe("handleFeishuMessage delayed ack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockResolveConfiguredAcpRoute.mockReset().mockImplementation(
+      ({ route }) =>
+        ({
+          configuredBinding: null,
+          route,
+        }) as any,
+    );
+    mockEnsureConfiguredAcpRouteReady.mockReset().mockResolvedValue({ ok: true });
+    mockResolveBoundConversation.mockReset().mockReturnValue(null);
+    mockTouchBinding.mockReset();
+    mockResolveAgentRoute.mockReset().mockReturnValue({
+      agentId: "main",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:main:feishu:direct:ou_sender_1",
+      mainSessionKey: "agent:main:main",
+      matchedBy: "default",
+    });
+    mockSendMessageFeishu.mockReset().mockResolvedValue({ messageId: "ack-msg", chatId: "oc_dm" });
+    mockCreateFeishuReplyDispatcher.mockReset().mockReturnValue({
+      dispatcher: {
+        sendToolResult: vi.fn(),
+        sendBlockReply: vi.fn(),
+        sendFinalReply: vi.fn(),
+        waitForIdle: vi.fn(),
+        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        markComplete: vi.fn(),
+      } as any,
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+    });
+
+    const slowDispatchReplyFromConfig = vi.fn(
+      () =>
+        new Promise<{ queuedFinal: boolean; counts: { final: number } }>((resolve) => {
+          setTimeout(() => resolve({ queuedFinal: false, counts: { final: 1 } }), 9_000);
+        }),
+    );
+
+    setFeishuRuntime(
+      createPluginRuntimeMock({
+        channel: {
+          routing: {
+            resolveAgentRoute:
+              mockResolveAgentRoute as unknown as PluginRuntime["channel"]["routing"]["resolveAgentRoute"],
+          },
+          session: {
+            readSessionUpdatedAt:
+              mockReadSessionUpdatedAt as unknown as PluginRuntime["channel"]["session"]["readSessionUpdatedAt"],
+            resolveStorePath:
+              mockResolveStorePath as unknown as PluginRuntime["channel"]["session"]["resolveStorePath"],
+          },
+          reply: {
+            resolveEnvelopeFormatOptions: vi.fn(
+              () => ({}),
+            ) as unknown as PluginRuntime["channel"]["reply"]["resolveEnvelopeFormatOptions"],
+            formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+            finalizeInboundContext: ((ctx: unknown) =>
+              ctx) as unknown as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
+            dispatchReplyFromConfig: slowDispatchReplyFromConfig,
+            withReplyDispatcher: vi.fn(
+              async ({
+                run,
+              }: Parameters<PluginRuntime["channel"]["reply"]["withReplyDispatcher"]>[0]) =>
+                await run(),
+            ) as unknown as PluginRuntime["channel"]["reply"]["withReplyDispatcher"],
+          },
+          commands: {
+            shouldComputeCommandAuthorized: vi.fn(() => false),
+            resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+          },
+          pairing: {
+            readAllowFromStore: vi.fn().mockResolvedValue(["ou_sender_1"]),
+            upsertPairingRequest: vi.fn(),
+            buildPairingReply: vi.fn(),
+          },
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends a delayed acknowledgment for slow direct-message dispatches", async () => {
+    const pending = dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-slow",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "run something slow" }),
+        },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(8_000);
+
+    expect(mockSendMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "oc_dm",
+        text: "已收到，开始处理；如果需要较长时间，我会在完成后继续反馈结果。",
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await pending;
+  });
+});
+
 describe("handleFeishuMessage command authorization", () => {
   const mockFinalizeInboundContext = vi.fn((ctx: unknown) => ctx);
   const mockDispatchReplyFromConfig = vi

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -454,9 +454,16 @@ describe("handleFeishuMessage delayed ack", () => {
             dispatchReplyFromConfig: slowDispatchReplyFromConfig,
             withReplyDispatcher: vi.fn(
               async ({
+                onSettled,
                 run,
               }: Parameters<PluginRuntime["channel"]["reply"]["withReplyDispatcher"]>[0]) =>
-                await run(),
+                {
+                  try {
+                    return await run();
+                  } finally {
+                    await onSettled?.();
+                  }
+                },
             ) as unknown as PluginRuntime["channel"]["reply"]["withReplyDispatcher"],
           },
           commands: {
@@ -506,6 +513,73 @@ describe("handleFeishuMessage delayed ack", () => {
 
     await vi.advanceTimersByTimeAsync(1_000);
     await pending;
+  });
+
+  it("does not send a delayed acknowledgment for fast direct-message dispatches", async () => {
+    const pending = dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-fast",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "run something fast" }),
+        },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(7_999);
+    await pending;
+
+    expect(mockSendMessageFeishu).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "已收到，开始处理；如果需要较长时间，我会在完成后继续反馈结果。",
+      }),
+    );
+  });
+
+  it("does not send a delayed acknowledgment for group chats", async () => {
+    const pending = dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            groups: {
+              oc_group_chat: {
+                allow: true,
+                requireMention: false,
+              },
+            },
+          },
+        },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-group",
+          chat_id: "oc_group_chat",
+          chat_type: "group",
+          message_type: "text",
+          content: JSON.stringify({ text: "run something slow in group" }),
+        },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(9_000);
+    await pending;
+
+    expect(mockSendMessageFeishu).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "已收到，开始处理；如果需要较长时间，我会在完成后继续反馈结果。",
+      }),
+    );
   });
 });
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -106,6 +106,8 @@ function extractPermissionError(err: unknown): PermissionError | null {
 // Cache display names by sender id (open_id/user_id) to avoid an API call on every message.
 const SENDER_NAME_TTL_MS = 10 * 60 * 1000;
 const senderNameCache = new Map<string, { name: string; expireAt: number }>();
+const LONG_TASK_ACK_DELAY_MS = 8_000;
+const LONG_TASK_ACK_TEXT = "已收到，开始处理；如果需要较长时间，我会在完成后继续反馈结果。";
 
 // Cache permission errors to avoid spamming the user with repeated notifications.
 // Key: appId or "default", Value: timestamp of last notification
@@ -181,6 +183,52 @@ async function resolveFeishuSenderName(params: {
     log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${String(err)}`);
     return {};
   }
+}
+
+function scheduleDelayedAck(params: {
+  enabled: boolean;
+  cfg: ClawdbotConfig;
+  chatId: string;
+  accountId: string;
+  replyToMessageId?: string;
+  replyInThread?: boolean;
+  log: (...args: any[]) => void;
+}) {
+  if (!params.enabled) {
+    return { cancel: async () => {} };
+  }
+
+  let cancelled = false;
+  let sendPromise: Promise<void> | null = null;
+  const timer = setTimeout(() => {
+    if (cancelled) {
+      return;
+    }
+    sendPromise = sendMessageFeishu({
+      cfg: params.cfg,
+      to: params.chatId,
+      text: LONG_TASK_ACK_TEXT,
+      accountId: params.accountId,
+      replyToMessageId: params.replyToMessageId,
+      replyInThread: params.replyInThread,
+    })
+      .then(() => {
+        params.log(`feishu[${params.accountId}]: delayed ack sent`);
+      })
+      .catch((err) => {
+        params.log(`feishu[${params.accountId}]: delayed ack failed: ${String(err)}`);
+      });
+  }, LONG_TASK_ACK_DELAY_MS);
+
+  return {
+    cancel: async () => {
+      cancelled = true;
+      clearTimeout(timer);
+      if (sendPromise) {
+        await sendPromise;
+      }
+    },
+  };
 }
 
 export type FeishuMessageEvent = {
@@ -1782,19 +1830,34 @@ export async function handleFeishuMessage(params: {
       });
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
-      const { queuedFinal, counts } = await core.channel.reply.withReplyDispatcher({
-        dispatcher,
-        onSettled: () => {
-          markDispatchIdle();
-        },
-        run: () =>
-          core.channel.reply.dispatchReplyFromConfig({
-            ctx: ctxPayload,
-            cfg,
-            dispatcher,
-            replyOptions,
-          }),
+      const delayedAck = scheduleDelayedAck({
+        enabled: ctx.chatType === "p2p" || ctx.chatType === "private",
+        cfg,
+        chatId: ctx.chatId,
+        accountId: account.accountId,
+        replyToMessageId: replyTargetMessageId,
+        replyInThread,
+        log,
       });
+      let queuedFinal;
+      let counts;
+      try {
+        ({ queuedFinal, counts } = await core.channel.reply.withReplyDispatcher({
+          dispatcher,
+          onSettled: () => {
+            markDispatchIdle();
+          },
+          run: () =>
+            core.channel.reply.dispatchReplyFromConfig({
+              ctx: ctxPayload,
+              cfg,
+              dispatcher,
+              replyOptions,
+            }),
+        }));
+      } finally {
+        await delayedAck.cancel();
+      }
 
       if (isGroup && historyKey && chatHistories) {
         clearHistoryEntriesIfEnabled({

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -224,6 +224,8 @@ function scheduleDelayedAck(params: {
     cancel: async () => {
       cancelled = true;
       clearTimeout(timer);
+      // sendPromise is always safe to await here because the timer callback
+      // attaches its own .catch() and converts failures into log entries.
       if (sendPromise) {
         await sendPromise;
       }


### PR DESCRIPTION
## Summary

Adds a delayed acknowledgment for slow Feishu direct-message dispatches.

If a Feishu DM/private message has been accepted for processing but no user-visible reply has been produced within 8 seconds, OpenClaw sends a lightweight acknowledgment and then continues with the normal final reply flow.

## Problem

Long-running Feishu tasks can already be executing tool actions, but users may still receive no textual confirmation if the main reply path is slow or times out before a final response is delivered.

## Changes

- add a delayed acknowledgment timer in `extensions/feishu/src/bot.ts`
- limit the behavior to `p2p/private` chats
- cancel the timer when dispatch settles
- add test coverage in `extensions/feishu/src/bot.test.ts`

## Notes

- this keeps the change intentionally small and localized to the Feishu bot dispatch path
- I was not able to run the full test suite in the local workspace used for preparing this patch because the repository was provided as a zip checkout without installed dependencies
