### PR TITLE
fix: resolveAnnounceTarget drops threadId for thread-based sessions

### DIFF
--- a/src/agents/tools/sessions-announce-target.test.ts
+++ b/src/agents/tools/sessions-announce-target.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveAnnounceTarget } from "./sessions-announce-target.js";
+import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
+
+const callGatewayMock = vi.fn();
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+describe("sessions regression tests", () => {
+  describe("resolveAnnounceTargetFromKey", () => {
+    it("should return null for 'main' channel internal keys even if kind is 'thread'", () => {
+      const key = "agent:main:main:thread:9999";
+      const target = resolveAnnounceTargetFromKey(key);
+      expect(target).toBeNull();
+    });
+
+    it("should still resolve for external channels", () => {
+      const key = "agent:main:telegram:thread:1234:5678";
+      const target = resolveAnnounceTargetFromKey(key);
+      expect(target).toEqual({
+        channel: "telegram",
+        to: "group:1234",
+        threadId: "5678",
+      });
+    });
+  });
+
+  describe("resolveAnnounceTarget", () => {
+    it("should accept numeric threadId from deliveryContext and convert to string", async () => {
+      callGatewayMock.mockResolvedValueOnce({
+        sessions: [
+          {
+            key: "agent:main:session1",
+            deliveryContext: {
+              channel: "telegram",
+              to: "12345",
+              threadId: 9999, // Numeric threadId
+            },
+          },
+        ],
+      });
+
+      const target = await resolveAnnounceTarget({
+        sessionKey: "agent:main:session1",
+        displayKey: "session1",
+      });
+
+      expect(target).toEqual({
+        channel: "telegram",
+        to: "12345",
+        accountId: undefined,
+        threadId: "9999", // Should be string
+      });
+    });
+
+    it("should accept numeric lastThreadId from match and convert to string", async () => {
+      callGatewayMock.mockResolvedValueOnce({
+        sessions: [
+          {
+            key: "agent:main:session2",
+            lastChannel: "discord",
+            lastTo: "67890",
+            lastThreadId: 8888, // Numeric lastThreadId
+          },
+        ],
+      });
+
+      const target = await resolveAnnounceTarget({
+        sessionKey: "agent:main:session2",
+        displayKey: "session2",
+      });
+
+      expect(target).toEqual({
+        channel: "discord",
+        to: "67890",
+        accountId: undefined,
+        threadId: "8888", // Should be string
+      });
+    });
+  });
+});

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -47,8 +47,11 @@ export async function resolveAnnounceTarget(params: {
     const accountId =
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined);
+    const threadId =
+      (typeof deliveryContext?.threadId === "string" ? deliveryContext.threadId : undefined) ??
+      (typeof match?.lastThreadId === "string" ? match.lastThreadId : undefined);
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, threadId };
     }
   } catch {
     // ignore

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -48,8 +48,13 @@ export async function resolveAnnounceTarget(params: {
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined);
     const threadId =
-      (typeof deliveryContext?.threadId === "string" ? deliveryContext.threadId : undefined) ??
-      (typeof match?.lastThreadId === "string" ? match.lastThreadId : undefined);
+      (typeof deliveryContext?.threadId === "string" ||
+      typeof deliveryContext?.threadId === "number"
+        ? String(deliveryContext.threadId)
+        : undefined) ??
+      (typeof match?.lastThreadId === "string" || typeof match?.lastThreadId === "number"
+        ? String(match.lastThreadId)
+        : undefined);
     if (channel && to) {
       return { channel, to, accountId, threadId };
     }

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -44,6 +44,7 @@ export type SessionListDeliveryContext = {
   channel?: string;
   to?: string;
   accountId?: string;
+  threadId?: string;
 };
 
 export type SessionListRow = {
@@ -66,6 +67,7 @@ export type SessionListRow = {
   lastChannel?: string;
   lastTo?: string;
   lastAccountId?: string;
+  lastThreadId?: string;
   transcriptPath?: string;
   messages?: unknown[];
 };

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -24,7 +24,7 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
     return null;
   }
   const [channelRaw, kind, ...rest] = parts;
-  if (kind !== "group" && kind !== "channel") {
+  if (kind !== "group" && kind !== "channel" && kind !== "thread") {
     return null;
   }
 
@@ -38,10 +38,16 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
 
   if (match) {
     threadId = match[1]; // Keep as string to match AgentCommandOpts.threadId
+  } else if (kind === "thread" && rest.length >= 2) {
+    threadId = rest[rest.length - 1];
   }
 
   // Remove :topic:N or :thread:N suffix from ID for target
-  const id = match ? restJoined.replace(/:(topic|thread):\d+$/, "") : restJoined.trim();
+  const id = match
+    ? restJoined.replace(/:(topic|thread):\d+$/, "")
+    : kind === "thread" && rest.length >= 2
+      ? rest.slice(0, -1).join(":")
+      : restJoined.trim();
 
   if (!id) {
     return null;

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -24,7 +24,7 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
     return null;
   }
   const [channelRaw, kind, ...rest] = parts;
-  if (kind !== "group" && kind !== "channel" && kind !== "thread") {
+  if (channelRaw === "main" || (kind !== "group" && kind !== "channel" && kind !== "thread")) {
     return null;
   }
 

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -127,6 +127,7 @@ export async function runSessionsSendA2AFlow(params: {
             message: announceReply.trim(),
             channel: announceTarget.channel,
             accountId: announceTarget.accountId,
+            threadId: announceTarget.threadId,
             idempotencyKey: crypto.randomUUID(),
           },
           timeoutMs: 10_000,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -254,6 +254,46 @@ describe("resolveAnnounceTarget", () => {
     expect(first).toBeDefined();
     expect(first?.method).toBe("sessions.list");
   });
+
+  it("extracts threadId from kind:thread keys (fixes #47971)", async () => {
+    // This tests resolveAnnounceTargetFromKey via resolveAnnounceTarget fallback
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:cody:discord:thread:12345:67890",
+      displayKey: "agent:cody:discord:thread:12345:67890",
+    });
+    expect(target).toEqual({
+      channel: "discord",
+      to: "channel:12345",
+      threadId: "67890",
+    });
+  });
+
+  it("propagates threadId from session store (fixes #47971)", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:whatsapp:group:123@g.us",
+          deliveryContext: {
+            channel: "whatsapp",
+            to: "123@g.us",
+            accountId: "work",
+            threadId: "456",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      displayKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    expect(target).toEqual({
+      channel: "whatsapp",
+      to: "123@g.us",
+      accountId: "work",
+      threadId: "456",
+    });
+  });
 });
 
 describe("sessions_list gating", () => {

--- a/src/channels/plugins/contracts/suites.ts
+++ b/src/channels/plugins/contracts/suites.ts
@@ -1,13 +1,23 @@
-import { expect, it } from "vitest";
+import { expect, it, type Mock } from "vitest";
+import type { MsgContext } from "../../../auto-reply/templating.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import type {
+  ResolveProviderRuntimeGroupPolicyParams,
+  RuntimeGroupPolicyResolution,
+} from "../../../config/runtime-group-policy.js";
+import { normalizeChatType } from "../../chat-type.js";
+import { resolveConversationLabel } from "../../conversation-label.js";
+import { validateSenderIdentity } from "../../sender-identity.js";
 import type {
   ChannelAccountSnapshot,
   ChannelAccountState,
-  ChannelMessageCapability,
   ChannelSetupInput,
 } from "../types.core.js";
-import type { ChannelPlugin } from "../types.js";
-import type { ChannelMessageActionName } from "../types.js";
+import type {
+  ChannelMessageActionName,
+  ChannelMessageCapability,
+  ChannelPlugin,
+} from "../types.js";
 
 function sortStrings(values: readonly string[]) {
   return [...values].toSorted((left, right) => left.localeCompare(right));
@@ -80,6 +90,142 @@ export function installChannelActionsContractSuite(params: {
       }
     });
   }
+}
+
+export function installChannelSurfaceContractSuite(params: {
+  plugin: Pick<
+    ChannelPlugin,
+    | "id"
+    | "actions"
+    | "setup"
+    | "status"
+    | "outbound"
+    | "messaging"
+    | "threading"
+    | "directory"
+    | "gateway"
+  >;
+  surface:
+    | "actions"
+    | "setup"
+    | "status"
+    | "outbound"
+    | "messaging"
+    | "threading"
+    | "directory"
+    | "gateway";
+}) {
+  const { plugin, surface } = params;
+
+  it(`exposes the ${surface} surface contract`, () => {
+    if (surface === "actions") {
+      expect(plugin.actions).toBeDefined();
+      expect(typeof plugin.actions?.listActions).toBe("function");
+      return;
+    }
+
+    if (surface === "setup") {
+      expect(plugin.setup).toBeDefined();
+      expect(typeof plugin.setup?.applyAccountConfig).toBe("function");
+      return;
+    }
+
+    if (surface === "status") {
+      expect(plugin.status).toBeDefined();
+      expect(typeof plugin.status?.buildAccountSnapshot).toBe("function");
+      return;
+    }
+
+    if (surface === "outbound") {
+      const outbound = plugin.outbound;
+      expect(outbound).toBeDefined();
+      expect(["direct", "gateway", "hybrid"]).toContain(outbound?.deliveryMode);
+      expect(
+        [
+          outbound?.sendPayload,
+          outbound?.sendFormattedText,
+          outbound?.sendFormattedMedia,
+          outbound?.sendText,
+          outbound?.sendMedia,
+          outbound?.sendPoll,
+        ].some((value) => typeof value === "function"),
+      ).toBe(true);
+      return;
+    }
+
+    if (surface === "messaging") {
+      const messaging = plugin.messaging;
+      expect(messaging).toBeDefined();
+      expect(
+        [
+          messaging?.normalizeTarget,
+          messaging?.parseExplicitTarget,
+          messaging?.inferTargetChatType,
+          messaging?.buildCrossContextComponents,
+          messaging?.enableInteractiveReplies,
+          messaging?.hasStructuredReplyPayload,
+          messaging?.formatTargetDisplay,
+          messaging?.resolveOutboundSessionRoute,
+        ].some((value) => typeof value === "function"),
+      ).toBe(true);
+      if (messaging?.targetResolver) {
+        if (messaging.targetResolver.looksLikeId) {
+          expect(typeof messaging.targetResolver.looksLikeId).toBe("function");
+        }
+        if (messaging.targetResolver.hint !== undefined) {
+          expect(typeof messaging.targetResolver.hint).toBe("string");
+          expect(messaging.targetResolver.hint.trim()).not.toBe("");
+        }
+        if (messaging.targetResolver.resolveTarget) {
+          expect(typeof messaging.targetResolver.resolveTarget).toBe("function");
+        }
+      }
+      return;
+    }
+
+    if (surface === "threading") {
+      const threading = plugin.threading;
+      expect(threading).toBeDefined();
+      expect(
+        [
+          threading?.resolveReplyToMode,
+          threading?.buildToolContext,
+          threading?.resolveAutoThreadId,
+          threading?.resolveReplyTransport,
+          threading?.resolveFocusedBinding,
+        ].some((value) => typeof value === "function"),
+      ).toBe(true);
+      return;
+    }
+
+    if (surface === "directory") {
+      const directory = plugin.directory;
+      expect(directory).toBeDefined();
+      expect(
+        [
+          directory?.self,
+          directory?.listPeers,
+          directory?.listPeersLive,
+          directory?.listGroups,
+          directory?.listGroupsLive,
+          directory?.listGroupMembers,
+        ].some((value) => typeof value === "function"),
+      ).toBe(true);
+      return;
+    }
+
+    const gateway = plugin.gateway;
+    expect(gateway).toBeDefined();
+    expect(
+      [
+        gateway?.startAccount,
+        gateway?.stopAccount,
+        gateway?.loginWithQrStart,
+        gateway?.loginWithQrWait,
+        gateway?.logoutAccount,
+      ].some((value) => typeof value === "function"),
+    ).toBe(true);
+  });
 }
 
 type ChannelSetupContractCase<ResolvedAccount> = {
@@ -210,5 +356,193 @@ export function installChannelStatusContractSuite<ResolvedAccount, Probe = unkno
         expect(state).toBe(testCase.expectedState);
       }
     });
+  }
+}
+
+type PayloadLike = {
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  text?: string;
+};
+
+type SendResultLike = {
+  messageId: string;
+  [key: string]: unknown;
+};
+
+type ChunkingMode =
+  | {
+      longTextLength: number;
+      maxChunkLength: number;
+      mode: "split";
+    }
+  | {
+      longTextLength: number;
+      mode: "passthrough";
+    };
+
+export function installChannelOutboundPayloadContractSuite(params: {
+  channel: string;
+  chunking: ChunkingMode;
+  createHarness: (params: { payload: PayloadLike; sendResults?: SendResultLike[] }) => {
+    run: () => Promise<Record<string, unknown>>;
+    sendMock: Mock;
+    to: string;
+  };
+}) {
+  it("text-only delegates to sendText", async () => {
+    const { run, sendMock, to } = params.createHarness({
+      payload: { text: "hello" },
+    });
+    const result = await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith(to, "hello", expect.any(Object));
+    expect(result).toMatchObject({ channel: params.channel });
+  });
+
+  it("single media delegates to sendMedia", async () => {
+    const { run, sendMock, to } = params.createHarness({
+      payload: { text: "cap", mediaUrl: "https://example.com/a.jpg" },
+    });
+    const result = await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith(
+      to,
+      "cap",
+      expect.objectContaining({ mediaUrl: "https://example.com/a.jpg" }),
+    );
+    expect(result).toMatchObject({ channel: params.channel });
+  });
+
+  it("multi-media iterates URLs with caption on first", async () => {
+    const { run, sendMock, to } = params.createHarness({
+      payload: {
+        text: "caption",
+        mediaUrls: ["https://example.com/1.jpg", "https://example.com/2.jpg"],
+      },
+      sendResults: [{ messageId: "m-1" }, { messageId: "m-2" }],
+    });
+    const result = await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock).toHaveBeenNthCalledWith(
+      1,
+      to,
+      "caption",
+      expect.objectContaining({ mediaUrl: "https://example.com/1.jpg" }),
+    );
+    expect(sendMock).toHaveBeenNthCalledWith(
+      2,
+      to,
+      "",
+      expect.objectContaining({ mediaUrl: "https://example.com/2.jpg" }),
+    );
+    expect(result).toMatchObject({ channel: params.channel, messageId: "m-2" });
+  });
+
+  it("empty payload returns no-op", async () => {
+    const { run, sendMock } = params.createHarness({ payload: {} });
+    const result = await run();
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: params.channel, messageId: "" });
+  });
+
+  if (params.chunking.mode === "passthrough") {
+    it("text exceeding chunk limit is sent as-is when chunker is null", async () => {
+      const text = "a".repeat(params.chunking.longTextLength);
+      const { run, sendMock, to } = params.createHarness({ payload: { text } });
+      const result = await run();
+
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      expect(sendMock).toHaveBeenCalledWith(to, text, expect.any(Object));
+      expect(result).toMatchObject({ channel: params.channel });
+    });
+    return;
+  }
+
+  const chunking = params.chunking;
+
+  it("chunking splits long text", async () => {
+    const text = "a".repeat(chunking.longTextLength);
+    const { run, sendMock } = params.createHarness({
+      payload: { text },
+      sendResults: [{ messageId: "c-1" }, { messageId: "c-2" }],
+    });
+    const result = await run();
+
+    expect(sendMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    for (const call of sendMock.mock.calls) {
+      expect((call[1] as string).length).toBeLessThanOrEqual(chunking.maxChunkLength);
+    }
+    expect(result).toMatchObject({ channel: params.channel });
+  });
+}
+
+export function primeChannelOutboundSendMock(
+  sendMock: Mock,
+  fallbackResult: Record<string, unknown>,
+  sendResults: SendResultLike[] = [],
+) {
+  sendMock.mockReset();
+  if (sendResults.length === 0) {
+    sendMock.mockResolvedValue(fallbackResult);
+    return;
+  }
+  for (const result of sendResults) {
+    sendMock.mockResolvedValueOnce(result);
+  }
+}
+
+type RuntimeGroupPolicyResolver = (
+  params: ResolveProviderRuntimeGroupPolicyParams,
+) => RuntimeGroupPolicyResolution;
+
+export function installChannelRuntimeGroupPolicyFallbackSuite(params: {
+  configuredLabel: string;
+  defaultGroupPolicyUnderTest: "allowlist" | "disabled" | "open";
+  missingConfigLabel: string;
+  missingDefaultLabel: string;
+  resolve: RuntimeGroupPolicyResolver;
+}) {
+  it(params.missingConfigLabel, () => {
+    const resolved = params.resolve({
+      providerConfigPresent: false,
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+
+  it(params.configuredLabel, () => {
+    const resolved = params.resolve({
+      providerConfigPresent: true,
+    });
+    expect(resolved.groupPolicy).toBe("open");
+    expect(resolved.providerMissingFallbackApplied).toBe(false);
+  });
+
+  it(params.missingDefaultLabel, () => {
+    const resolved = params.resolve({
+      providerConfigPresent: false,
+      defaultGroupPolicy: params.defaultGroupPolicyUnderTest,
+    });
+    expect(resolved.groupPolicy).toBe("allowlist");
+    expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+}
+
+export function expectChannelInboundContextContract(ctx: MsgContext) {
+  expect(validateSenderIdentity(ctx)).toEqual([]);
+
+  expect(ctx.Body).toBeTypeOf("string");
+  expect(ctx.BodyForAgent).toBeTypeOf("string");
+  expect(ctx.BodyForCommands).toBeTypeOf("string");
+
+  const chatType = normalizeChatType(ctx.ChatType);
+  if (chatType && chatType !== "direct") {
+    const label = ctx.ConversationLabel?.trim() || resolveConversationLabel(ctx);
+    expect(label).toBeTruthy();
   }
 }

--- a/src/cron/isolated-agent.test-setup.ts
+++ b/src/cron/isolated-agent.test-setup.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
-import { signalOutbound, telegramOutbound } from "../../test/channel-outbounds.js";
 import { parseTelegramTarget } from "../../extensions/telegram/src/targets.js";
+import { signalOutbound, telegramOutbound } from "../../test/channel-outbounds.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -194,7 +194,10 @@ export function loadSettings(): UiSettings {
   try {
     // First check for legacy key (no scope), then check for scoped key
     const scopedKey = settingsKeyForGateway(defaults.gatewayUrl);
-    const raw = storage?.getItem(scopedKey) ?? storage?.getItem(SETTINGS_KEY_PREFIX + "default") ?? storage?.getItem("openclaw.control.settings.v1");
+    const raw =
+      storage?.getItem(scopedKey) ??
+      storage?.getItem(SETTINGS_KEY_PREFIX + "default") ??
+      storage?.getItem("openclaw.control.settings.v1");
     if (!raw) {
       return defaults;
     }
@@ -266,7 +269,10 @@ function persistSettings(next: UiSettings) {
   let existingSessionsByGateway: Record<string, ScopedSessionSelection> = {};
   try {
     // Try to migrate from legacy key or other scopes
-    const raw = storage?.getItem(scopedKey) ?? storage?.getItem(SETTINGS_KEY_PREFIX + "default") ?? storage?.getItem("openclaw.control.settings.v1");
+    const raw =
+      storage?.getItem(scopedKey) ??
+      storage?.getItem(SETTINGS_KEY_PREFIX + "default") ??
+      storage?.getItem("openclaw.control.settings.v1");
     if (raw) {
       const parsed = JSON.parse(raw) as PersistedUiSettings;
       if (parsed.sessionsByGateway && typeof parsed.sessionsByGateway === "object") {


### PR DESCRIPTION
Fixes openclaw/openclaw#47971

This PR ensures that `threadId` is propagated during the `sessions_send` announce flow, specifically for thread-based sessions.

Changes:
- `resolveAnnounceTargetFromKey`: Added support for `kind === "thread"` and improved `threadId` extraction from session keys.
- `resolveAnnounceTarget`: Now includes `threadId` when fetching session details from the gateway.
- `runSessionsSendA2AFlow`: Passes `threadId` to the final `callGateway({ method: "send" })` call.

Verified with new tests in `src/agents/tools/sessions.test.ts`.