### PR TITLE
fix(tools): enforce agent tool profile restrictions correctly

### DIFF
--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -293,4 +293,76 @@ describe("resolveEffectiveToolPolicy", () => {
     const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "coder" });
     expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
   });
+
+  it("does not implicitly expose global exec when agent has explicit alsoAllow without it", () => {
+    // Regression test for #47487: tool profile restrictions not enforced
+    const cfg = {
+      tools: {
+        exec: { security: "full", ask: "off" },
+      },
+      agents: {
+        list: [
+          {
+            id: "messenger",
+            tools: {
+              profile: "messaging",
+              alsoAllow: ["web_search"],
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "messenger" });
+    expect(result.profileAlsoAllow).toEqual(["web_search"]);
+    expect(result.profileAlsoAllow).not.toContain("exec");
+    expect(result.profileAlsoAllow).not.toContain("process");
+  });
+
+  it("does not implicitly expose global fs when agent has explicit empty alsoAllow", () => {
+    const cfg = {
+      tools: {
+        fs: { workspaceOnly: false },
+      },
+      agents: {
+        list: [
+          {
+            id: "restricted",
+            tools: {
+              profile: "messaging",
+              alsoAllow: [],
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "restricted" });
+    // Empty array is returned (not undefined) when explicit alsoAllow is set
+    expect(result.profileAlsoAllow).toEqual([]);
+    expect(result.profileAlsoAllow).not.toContain("read");
+    expect(result.profileAlsoAllow).not.toContain("write");
+    expect(result.profileAlsoAllow).not.toContain("edit");
+  });
+
+  it("still uses agent-level exec section for implicit exposure even with explicit alsoAllow", () => {
+    const cfg = {
+      tools: {
+        profile: "messaging",
+      },
+      agents: {
+        list: [
+          {
+            id: "coder",
+            tools: {
+              alsoAllow: ["web_search"],
+              exec: { host: "sandbox" },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "coder" });
+    expect(result.profileAlsoAllow).toContain("web_search");
+    expect(result.profileAlsoAllow).toContain("exec");
+    expect(result.profileAlsoAllow).toContain("process");
+  });
 });

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -277,18 +277,25 @@ function hasExplicitToolSection(section: unknown): boolean {
 function resolveImplicitProfileAlsoAllow(params: {
   globalTools?: OpenClawConfig["tools"];
   agentTools?: AgentToolsConfig;
+  /** When agent has explicit alsoAllow, skip global tool sections for implicit exposure. */
+  agentHasExplicitAlsoAllow?: boolean;
 }): string[] | undefined {
   const implicit = new Set<string>();
+  // When agent has explicit alsoAllow set, only agent-level tool sections should
+  // trigger implicit exposure. Global tool sections should not override agent's
+  // explicit restriction. This prevents tools.exec at global level from bypassing
+  // an agent's profile + alsoAllow restriction.
+  const useGlobalSections = !params.agentHasExplicitAlsoAllow;
   if (
     hasExplicitToolSection(params.agentTools?.exec) ||
-    hasExplicitToolSection(params.globalTools?.exec)
+    (useGlobalSections && hasExplicitToolSection(params.globalTools?.exec))
   ) {
     implicit.add("exec");
     implicit.add("process");
   }
   if (
     hasExplicitToolSection(params.agentTools?.fs) ||
-    hasExplicitToolSection(params.globalTools?.fs)
+    (useGlobalSections && hasExplicitToolSection(params.globalTools?.fs))
   ) {
     implicit.add("read");
     implicit.add("write");
@@ -327,9 +334,14 @@ export function resolveEffectiveToolPolicy(params: {
     modelProvider: params.modelProvider,
     modelId: params.modelId,
   });
+  const agentExplicitAlsoAllow = resolveExplicitProfileAlsoAllow(agentTools);
   const explicitProfileAlsoAllow =
-    resolveExplicitProfileAlsoAllow(agentTools) ?? resolveExplicitProfileAlsoAllow(globalTools);
-  const implicitProfileAlsoAllow = resolveImplicitProfileAlsoAllow({ globalTools, agentTools });
+    agentExplicitAlsoAllow ?? resolveExplicitProfileAlsoAllow(globalTools);
+  const implicitProfileAlsoAllow = resolveImplicitProfileAlsoAllow({
+    globalTools,
+    agentTools,
+    agentHasExplicitAlsoAllow: agentExplicitAlsoAllow !== undefined,
+  });
   const profileAlsoAllow =
     explicitProfileAlsoAllow || implicitProfileAlsoAllow
       ? Array.from(

--- a/src/agents/tool-fs-policy.test.ts
+++ b/src/agents/tool-fs-policy.test.ts
@@ -140,6 +140,52 @@ describe("resolveEffectiveToolFsRootExpansionAllowed", () => {
     expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "messenger" })).toBe(false);
   });
 
+  it("blocks global fs expansion when agent has explicit alsoAllow restriction", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        profile: "messaging",
+        fs: { workspaceOnly: false },
+      },
+      agents: {
+        list: [
+          {
+            id: "restricted",
+            tools: {
+              alsoAllow: [],
+            },
+          },
+        ],
+      },
+    };
+
+    // Agent explicitly set alsoAllow:[] — global tools.fs should not grant
+    // implicit read/write/edit for this agent's media path.
+    expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "restricted" })).toBe(false);
+  });
+
+  it("allows agent fs expansion when agent has own fs config with explicit alsoAllow", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        profile: "messaging",
+      },
+      agents: {
+        list: [
+          {
+            id: "mixed",
+            tools: {
+              alsoAllow: [],
+              fs: { workspaceOnly: false },
+            },
+          },
+        ],
+      },
+    };
+
+    // Agent has explicit alsoAllow:[] but also its own fs config — agent-level
+    // fs should still grant implicit read/write/edit.
+    expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "mixed" })).toBe(true);
+  });
+
   it("honors agent workspaceOnly overrides over global fs opt-in", () => {
     const cfg: OpenClawConfig = {
       tools: {

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -46,7 +46,13 @@ export function resolveEffectiveToolFsRootExpansionAllowed(params: {
   const profile = agentTools?.profile ?? globalTools?.profile;
   const profileAlsoAllow = new Set(agentTools?.alsoAllow ?? globalTools?.alsoAllow ?? []);
   const fsConfig = resolveToolFsConfig(params);
-  const hasExplicitFsConfig = agentTools?.fs !== undefined || globalTools?.fs !== undefined;
+  // When agent has explicit alsoAllow, global fs config should not grant
+  // implicit read/write/edit — only agent-level fs config should. This
+  // prevents the media read path from bypassing agent tool restrictions.
+  const agentHasExplicitAlsoAllow = agentTools?.alsoAllow !== undefined;
+  const hasExplicitFsConfig =
+    agentTools?.fs !== undefined ||
+    (globalTools?.fs !== undefined && !agentHasExplicitAlsoAllow);
   if (fsConfig.workspaceOnly === true) {
     return false;
   }


### PR DESCRIPTION
## Summary

- When an agent has an explicit `tools.alsoAllow` list, global tool sections (`tools.exec`, `tools.fs`) no longer implicitly expose those tools
- This prevents a security boundary violation where `exec` could be used despite being excluded from the agent's profile + alsoAllow configuration
- Agent-level tool sections still trigger implicit exposure as expected

## Root cause

`resolveImplicitProfileAlsoAllow()` was checking if EITHER global OR agent had a `tools.exec` section and adding `exec` to the implicit allow list. When an agent explicitly set `alsoAllow` without `exec`, the global `tools.exec` config was still overriding the agent's restriction.

## Test plan

- [x] Added regression test: agent with `tools.profile: "messaging"` and explicit `alsoAllow: ["web_search"]` does not get `exec` exposed from global `tools.exec`
- [x] Added test: agent with empty `alsoAllow: []` blocks global `tools.fs` implicit exposure
- [x] Added test: agent with explicit `alsoAllow` AND agent-level `tools.exec` section still gets `exec` implicitly exposed (agent-level behavior preserved)
- [x] All existing tool policy tests pass

Fixes #47487