### PR TITLE
fix(agent): prevent fallback model from permanently overwriting agent config

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1100,8 +1100,23 @@ async function agentCommandInternal(
           }
         }
       }
-      const isFromFallback =
+      // A fallback occurred if the fallback resolution settled on a different
+      // model than the user intended.  However, in embedded runs hook selection
+      // can rewrite the effective model (agentMeta), so the model actually
+      // persisted may differ from both the fallback candidate and the intended
+      // target.  Only mark the session as "from fallback" when the persisted
+      // runtime model still matches the fallback candidate — if hooks rewrote
+      // it, the stored model is not "sticky fallback" and should not be
+      // suppressed during later resolution.
+      const fallbackOccurred =
         fallbackProvider !== intendedProvider || fallbackModel !== intendedModel;
+      const runtimeModel = result.meta.agentMeta?.model;
+      const runtimeProvider = result.meta.agentMeta?.provider;
+      const isFromFallback =
+        fallbackOccurred &&
+        (!runtimeModel ||
+          (runtimeModel === fallbackModel &&
+            (runtimeProvider ?? fallbackProvider) === fallbackProvider));
       await updateSessionStoreAfterAgentRun({
         cfg,
         contextTokensOverride: agentCfg?.contextTokens,

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -969,7 +969,7 @@ async function agentCommandInternal(
         result = fallbackResult.result;
         fallbackProvider = fallbackResult.provider;
         fallbackModel = fallbackResult.model;
-        fallbackAttempts = fallbackResult.attempts;
+        fallbackAttempts = fallbackResult.attempts ?? [];
         if (!lifecycleEnded) {
           const stopReason = result.meta.stopReason;
           if (stopReason && stopReason !== "end_turn") {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1097,7 +1097,6 @@ async function agentCommandInternal(
           if (match) {
             intendedProvider = match[1];
             intendedModel = match[2];
-            break;
           }
         }
       }

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1081,6 +1081,8 @@ async function agentCommandInternal(
     // Update token+model fields in the session store.
     if (sessionStore && sessionKey) {
       const { updateSessionStoreAfterAgentRun } = await loadSessionStoreRuntime();
+      // Model is from fallback if the successfully-used provider/model differs from the primary.
+      const isFromFallback = fallbackProvider !== provider || fallbackModel !== model;
       await updateSessionStoreAfterAgentRun({
         cfg,
         contextTokensOverride: agentCfg?.contextTokens,
@@ -1092,6 +1094,7 @@ async function agentCommandInternal(
         defaultModel: model,
         fallbackProvider,
         fallbackModel,
+        isFromFallback,
         result,
         touchInteraction:
           opts.bootstrapContextRunKind !== "cron" &&

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -896,6 +896,7 @@ async function agentCommandInternal(
     let result: Awaited<ReturnType<AttemptExecutionRuntime["runAgentAttempt"]>>;
     let fallbackProvider = provider;
     let fallbackModel = model;
+    let fallbackAttempts: { error: string }[] = [];
     const MAX_LIVE_SWITCH_RETRIES = 5;
     let liveSwitchRetries = 0;
     for (;;) {
@@ -968,6 +969,7 @@ async function agentCommandInternal(
         result = fallbackResult.result;
         fallbackProvider = fallbackResult.provider;
         fallbackModel = fallbackResult.model;
+        fallbackAttempts = fallbackResult.attempts;
         if (!lifecycleEnded) {
           const stopReason = result.meta.stopReason;
           if (stopReason && stopReason !== "end_turn") {
@@ -1081,8 +1083,26 @@ async function agentCommandInternal(
     // Update token+model fields in the session store.
     if (sessionStore && sessionKey) {
       const { updateSessionStoreAfterAgentRun } = await loadSessionStoreRuntime();
-      // Model is from fallback if the successfully-used provider/model differs from the primary.
-      const isFromFallback = fallbackProvider !== provider || fallbackModel !== model;
+      // Determine the intended model target for fallback detection.
+      // When a LiveSessionModelSwitchError is handled inside the fallback chain
+      // (model-fallback.ts), the switch target becomes the user's intended model
+      // but provider/model still reflect the original primary. Use the switch
+      // target as the baseline so the successful switch isn't mislabelled as
+      // a fallback.
+      let intendedProvider = provider;
+      let intendedModel = model;
+      if (fallbackAttempts.length) {
+        for (const attempt of fallbackAttempts) {
+          const match = attempt.error?.match(/^Live session model switch requested: (.+?)\/(.+)/);
+          if (match) {
+            intendedProvider = match[1];
+            intendedModel = match[2];
+            break;
+          }
+        }
+      }
+      const isFromFallback =
+        fallbackProvider !== intendedProvider || fallbackModel !== intendedModel;
       await updateSessionStoreAfterAgentRun({
         cfg,
         contextTokensOverride: agentCfg?.contextTokens,

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -48,6 +48,8 @@ export async function updateSessionStoreAfterAgentRun(params: {
   defaultModel: string;
   fallbackProvider?: string;
   fallbackModel?: string;
+  /** True when the model was selected by the fallback chain rather than being the primary. */
+  isFromFallback?: boolean;
   result: RunResult;
   touchInteraction?: boolean;
 }) {
@@ -102,6 +104,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   setSessionRuntimeModel(next, {
     provider: providerUsed,
     model: modelUsed,
+    isFromFallback: params.isFromFallback ?? false,
   });
   if (agentHarnessId) {
     next.agentHarnessId = agentHarnessId;

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -43,10 +43,15 @@ export function resolveLiveSessionModelSelection(params: {
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
   });
+  // Skip session-stored runtime model when it came from the fallback chain,
+  // so the live-switch resolver sees the configured default rather than a
+  // stale fallback identity.  Mirrors the guard in session-utils.ts.  #47705
+  const isFromFallback =
+    entry && "modelIsFromFallback" in entry && entry.modelIsFromFallback === true;
   const persisted = resolvePersistedSelectedModelRef({
     defaultProvider: defaultModelRef.provider,
-    runtimeProvider: entry?.modelProvider,
-    runtimeModel: entry?.model,
+    runtimeProvider: isFromFallback ? undefined : entry?.modelProvider,
+    runtimeModel: isFromFallback ? undefined : entry?.model,
     overrideProvider: normalizedSelection.providerOverride,
     overrideModel: normalizedSelection.modelOverride,
   });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1298,8 +1298,25 @@ export async function runReplyAgent(params: {
       }) ??
       DEFAULT_CONTEXT_TOKENS;
 
-    // Model is from fallback if the successfully-used provider/model differs from the primary.
-    const isFromFallback = providerUsed !== selectedProvider || modelUsed !== selectedModel;
+    // Determine the intended model target for fallback detection.
+    // When a LiveSessionModelSwitchError is handled inside the fallback chain
+    // (model-fallback.ts), the switch target becomes the user's intended model
+    // but selectedProvider/selectedModel still reflect the original primary.
+    // Use the switch target as the baseline so the successful switch isn't
+    // mislabelled as a fallback.
+    let intendedProvider = selectedProvider;
+    let intendedModel = selectedModel;
+    if (fallbackAttempts?.length) {
+      for (const attempt of fallbackAttempts) {
+        const match = attempt.error?.match(/^Live session model switch requested: (.+?)\/(.+)/);
+        if (match) {
+          intendedProvider = match[1];
+          intendedModel = match[2];
+          break;
+        }
+      }
+    }
+    const isFromFallback = providerUsed !== intendedProvider || modelUsed !== intendedModel;
     await persistRunSessionUsage({
       storePath,
       sessionKey,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1298,6 +1298,8 @@ export async function runReplyAgent(params: {
       }) ??
       DEFAULT_CONTEXT_TOKENS;
 
+    // Model is from fallback if the successfully-used provider/model differs from the primary.
+    const isFromFallback = providerUsed !== selectedProvider || modelUsed !== selectedModel;
     await persistRunSessionUsage({
       storePath,
       sessionKey,
@@ -1307,6 +1309,7 @@ export async function runReplyAgent(params: {
       promptTokens,
       modelUsed,
       providerUsed,
+      isFromFallback,
       contextTokensUsed,
       systemPromptReport: runResult.meta?.systemPromptReport,
       cliSessionId,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1312,7 +1312,6 @@ export async function runReplyAgent(params: {
         if (match) {
           intendedProvider = match[1];
           intendedModel = match[2];
-          break;
         }
       }
     }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1315,7 +1315,23 @@ export async function runReplyAgent(params: {
         }
       }
     }
-    const isFromFallback = providerUsed !== intendedProvider || modelUsed !== intendedModel;
+    // A fallback occurred if the fallback resolution settled on a different
+    // model than the user intended.  However, in embedded runs hook selection
+    // can rewrite the effective model (agentMeta), so the model actually
+    // persisted may differ from both the fallback candidate and the intended
+    // target.  Only mark the session as "from fallback" when the persisted
+    // runtime model still matches the fallback candidate — if hooks rewrote
+    // it, the stored model is not "sticky fallback" and should not be
+    // suppressed during later resolution.
+    const fallbackOccurred =
+      fallbackProvider !== intendedProvider || fallbackModel !== intendedModel;
+    const runtimeModel = runResult.meta?.agentMeta?.model;
+    const runtimeProvider = runResult.meta?.agentMeta?.provider;
+    const isFromFallback =
+      fallbackOccurred &&
+      (!runtimeModel ||
+        (runtimeModel === fallbackModel &&
+          (runtimeProvider ?? fallbackProvider) === fallbackProvider));
     await persistRunSessionUsage({
       storePath,
       sessionKey,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -371,7 +371,7 @@ export function createFollowupRunner(params: {
         runResult = fallbackResult.result;
         fallbackProvider = fallbackResult.provider;
         fallbackModel = fallbackResult.model;
-        fallbackAttempts = fallbackResult.attempts;
+        fallbackAttempts = fallbackResult.attempts ?? [];
       } catch (err) {
         const message = formatErrorMessage(err);
         replyOperation.fail("run_failed", err);

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -409,7 +409,6 @@ export function createFollowupRunner(params: {
             if (match) {
               intendedProvider = match[1];
               intendedModel = match[2];
-              break;
             }
           }
         }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -241,6 +241,7 @@ export function createFollowupRunner(params: {
       let runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
       let fallbackProvider = run.provider;
       let fallbackModel = run.model;
+      let fallbackAttempts: { error: string }[] = [];
       let activeSessionEntry =
         (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;
       activeSessionEntry = await runPreflightCompactionIfNeeded({
@@ -370,6 +371,7 @@ export function createFollowupRunner(params: {
         runResult = fallbackResult.result;
         fallbackProvider = fallbackResult.provider;
         fallbackModel = fallbackResult.model;
+        fallbackAttempts = fallbackResult.attempts;
       } catch (err) {
         const message = formatErrorMessage(err);
         replyOperation.fail("run_failed", err);
@@ -393,9 +395,26 @@ export function createFollowupRunner(params: {
         }) ?? DEFAULT_CONTEXT_TOKENS;
 
       if (storePath && sessionKey) {
-        // Model is from fallback if the successfully-used provider/model differs from the primary.
+        // Determine the intended model target for fallback detection.
+        // When a LiveSessionModelSwitchError is handled inside the fallback chain
+        // (model-fallback.ts), the switch target becomes the user's intended model
+        // but queued.run.provider/model still reflect the original primary. Use
+        // the switch target as the baseline so the successful switch isn't
+        // mislabelled as a fallback.
+        let intendedProvider = queued.run.provider;
+        let intendedModel = queued.run.model;
+        if (fallbackAttempts.length) {
+          for (const attempt of fallbackAttempts) {
+            const match = attempt.error?.match(/^Live session model switch requested: (.+?)\/(.+)/);
+            if (match) {
+              intendedProvider = match[1];
+              intendedModel = match[2];
+              break;
+            }
+          }
+        }
         const isFromFallback =
-          fallbackProvider !== queued.run.provider || fallbackModel !== queued.run.model;
+          fallbackProvider !== intendedProvider || fallbackModel !== intendedModel;
         await persistRunSessionUsage({
           storePath,
           sessionKey,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -412,8 +412,23 @@ export function createFollowupRunner(params: {
             }
           }
         }
-        const isFromFallback =
+        // A fallback occurred if the fallback resolution settled on a
+        // different model than the user intended.  However, in embedded runs
+        // hook selection can rewrite the effective model (agentMeta), so the
+        // model actually persisted may differ from both the fallback candidate
+        // and the intended target.  Only mark the session as "from fallback"
+        // when the persisted runtime model still matches the fallback
+        // candidate — if hooks rewrote it, the stored model is not "sticky
+        // fallback" and should not be suppressed during later resolution.
+        const fallbackOccurred =
           fallbackProvider !== intendedProvider || fallbackModel !== intendedModel;
+        const runtimeModel = runResult.meta?.agentMeta?.model;
+        const runtimeProvider = runResult.meta?.agentMeta?.provider;
+        const isFromFallback =
+          fallbackOccurred &&
+          (!runtimeModel ||
+            (runtimeModel === fallbackModel &&
+              (runtimeProvider ?? fallbackProvider) === fallbackProvider));
         await persistRunSessionUsage({
           storePath,
           sessionKey,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -393,6 +393,9 @@ export function createFollowupRunner(params: {
         }) ?? DEFAULT_CONTEXT_TOKENS;
 
       if (storePath && sessionKey) {
+        // Model is from fallback if the successfully-used provider/model differs from the primary.
+        const isFromFallback =
+          fallbackProvider !== queued.run.provider || fallbackModel !== queued.run.model;
         await persistRunSessionUsage({
           storePath,
           sessionKey,
@@ -402,6 +405,7 @@ export function createFollowupRunner(params: {
           promptTokens,
           modelUsed,
           providerUsed,
+          isFromFallback,
           contextTokensUsed,
           systemPromptReport: runResult.meta?.systemPromptReport,
           cliSessionBinding: runResult.meta?.agentMeta?.cliSessionBinding,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -82,6 +82,8 @@ export async function persistSessionUsageUpdate(params: {
   lastCallUsage?: NormalizedUsage;
   modelUsed?: string;
   providerUsed?: string;
+  /** True when the model was selected by the fallback chain rather than being the primary. */
+  isFromFallback?: boolean;
   contextTokensUsed?: number;
   promptTokens?: number;
   usageIsContextSnapshot?: boolean;
@@ -135,6 +137,7 @@ export async function persistSessionUsageUpdate(params: {
           const patch: Partial<SessionEntry> = {
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,
+            modelIsFromFallback: params.isFromFallback ?? false,
             contextTokens: resolvedContextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
@@ -176,6 +179,7 @@ export async function persistSessionUsageUpdate(params: {
           const patch: Partial<SessionEntry> = {
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,
+            modelIsFromFallback: params.isFromFallback ?? false,
             contextTokens: params.contextTokensUsed ?? entry.contextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -137,7 +137,7 @@ export async function persistSessionUsageUpdate(params: {
           const patch: Partial<SessionEntry> = {
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,
-            modelIsFromFallback: params.isFromFallback ?? false,
+            modelIsFromFallback: params.isFromFallback ?? entry.modelIsFromFallback,
             contextTokens: resolvedContextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
@@ -179,7 +179,7 @@ export async function persistSessionUsageUpdate(params: {
           const patch: Partial<SessionEntry> = {
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,
-            modelIsFromFallback: params.isFromFallback ?? false,
+            modelIsFromFallback: params.isFromFallback ?? entry.modelIsFromFallback,
             contextTokens: params.contextTokensUsed ?? entry.contextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),

--- a/src/commands/sessions-display-model.ts
+++ b/src/commands/sessions-display-model.ts
@@ -80,10 +80,10 @@ export function resolveSessionDisplayDefaults(
   };
 }
 
-export function resolveSessionDisplayModel(
+export function resolveSessionDisplayModelRef(
   cfg: OpenClawConfig,
   row: SessionDisplayModelRow,
-): string {
+): { provider: string; model: string } {
   const agentId = row.key.startsWith("agent:") ? row.key.split(":")[1] : undefined;
   const defaultRef = resolveDefaultModelRef(cfg, agentId);
   const normalizedOverride = normalizeStoredOverrideModel({
@@ -95,10 +95,17 @@ export function resolveSessionDisplayModel(
     return parseModelRef(
       normalizedOverride.modelOverride,
       normalizedOverride.providerOverride ?? defaultRef.provider,
-    ).model;
+    );
   }
   if (row.model && !row.modelIsFromFallback) {
-    return parseModelRef(row.model, row.modelProvider ?? defaultRef.provider).model;
+    return parseModelRef(row.model, row.modelProvider ?? defaultRef.provider);
   }
-  return defaultRef.model;
+  return defaultRef;
+}
+
+export function resolveSessionDisplayModel(
+  cfg: OpenClawConfig,
+  row: SessionDisplayModelRow,
+): string {
+  return resolveSessionDisplayModelRef(cfg, row).model;
 }

--- a/src/commands/sessions-display-model.ts
+++ b/src/commands/sessions-display-model.ts
@@ -8,6 +8,7 @@ type SessionDisplayModelRow = {
   modelProvider?: string;
   modelOverride?: string;
   providerOverride?: string;
+  modelIsFromFallback?: boolean;
 };
 
 type SessionDisplayDefaults = {
@@ -96,7 +97,7 @@ export function resolveSessionDisplayModel(
       normalizedOverride.providerOverride ?? defaultRef.provider,
     ).model;
   }
-  if (row.model) {
+  if (row.model && !row.modelIsFromFallback) {
     return parseModelRef(row.model, row.modelProvider ?? defaultRef.provider).model;
   }
   return defaultRef.model;

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -24,6 +24,7 @@ export type SessionDisplayRow = {
   modelProvider?: string;
   providerOverride?: string;
   modelOverride?: string;
+  modelIsFromFallback?: boolean;
   contextTokens?: number;
 };
 
@@ -57,11 +58,13 @@ export function toSessionDisplayRows(store: Record<string, SessionEntry>): Sessi
         modelProvider: entry?.modelProvider,
         providerOverride: entry?.providerOverride,
         modelOverride: entry?.modelOverride,
+        modelIsFromFallback: entry?.modelIsFromFallback,
         contextTokens: entry?.contextTokens,
       } satisfies SessionDisplayRow;
     })
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
 }
+
 
 function truncateSessionKey(key: string): string {
   if (key.length <= SESSION_KEY_PAD) {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -9,6 +9,7 @@ import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
 import {
   resolveSessionDisplayDefaults,
   resolveSessionDisplayModel,
+  resolveSessionDisplayModelRef,
 } from "./sessions-display-model.js";
 import {
   formatSessionAgeCell,
@@ -180,7 +181,8 @@ export async function sessionsCommand(
       activeMinutes: activeMinutes ?? null,
       sessions: await Promise.all(
         rows.map(async (r) => {
-          const model = resolveSessionDisplayModel(cfg, r);
+          const ref = resolveSessionDisplayModelRef(cfg, r);
+          const model = ref.model;
           return {
             ...r,
             totalTokens: resolveSessionTotalTokens(r) ?? null,
@@ -193,6 +195,7 @@ export async function sessionsCommand(
               configContextTokens ??
               null,
             model,
+            ...(r.modelIsFromFallback ? { modelProvider: ref.provider } : undefined),
           };
         }),
       ),

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -232,8 +232,12 @@ export async function sessionsCommand(
 
   for (const row of rows) {
     const model = resolveSessionDisplayModel(cfg, row);
+    // When the last run used a fallback model, ignore its stored context
+    // window — compute from the displayed (primary/override) model instead.
+    // See #47705.
+    const storedContextTokens = row.modelIsFromFallback ? undefined : row.contextTokens;
     const contextTokens =
-      row.contextTokens ??
+      storedContextTokens ??
       configuredContextTokens ??
       (await lookupContextTokensForDisplay(model)) ??
       configContextTokens;

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -187,7 +187,7 @@ export async function sessionsCommand(
             totalTokensFresh:
               typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
             contextTokens:
-              r.contextTokens ??
+              (r.modelIsFromFallback ? undefined : r.contextTokens) ??
               configuredContextTokens ??
               (await lookupContextTokensForDisplay(model)) ??
               configContextTokens ??

--- a/src/commands/status.summary.runtime.test.ts
+++ b/src/commands/status.summary.runtime.test.ts
@@ -106,4 +106,32 @@ describe("statusSummaryRuntime.resolveSessionModelRef", () => {
       model: "gpt-5.4",
     });
   });
+
+  it("ignores runtime model/provider when modelIsFromFallback is true", () => {
+    expect(
+      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+        modelProvider: "amazon-bedrock",
+        model: "minimax.minimax-m2.5",
+        modelIsFromFallback: true,
+      } as never),
+    ).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+  });
+
+  it("still honours explicit overrides even when modelIsFromFallback is true", () => {
+    expect(
+      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.4",
+        modelProvider: "amazon-bedrock",
+        model: "minimax.minimax-m2.5",
+        modelIsFromFallback: true,
+      } as never),
+    ).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+    });
+  });
 });

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -151,11 +151,16 @@ function resolveSessionModelRef(
     defaultModel: DEFAULT_MODEL,
     agentId,
   });
+  // Skip session-stored runtime model if it came from the fallback chain,
+  // mirroring the logic in session-utils.ts. See #47705.
+  const isFromFallback =
+    entry && "modelIsFromFallback" in entry && entry.modelIsFromFallback === true;
+
   return (
     resolvePersistedSelectedModelRef({
       defaultProvider: resolved.provider || DEFAULT_PROVIDER,
-      runtimeProvider: entry?.modelProvider,
-      runtimeModel: entry?.model,
+      runtimeProvider: isFromFallback ? undefined : entry?.modelProvider,
+      runtimeModel: isFromFallback ? undefined : entry?.model,
       overrideProvider: entry?.providerOverride,
       overrideModel: entry?.modelOverride,
       allowPluginNormalization: false,

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -203,7 +203,11 @@ export async function getStatusSummary(
             cfg,
             provider: resolvedModel.provider,
             model,
-            contextTokensOverride: entry?.contextTokens,
+            // When the last run used a fallback model, ignore its stored
+            // context window so utilization is computed against the displayed
+            // (primary/override) model's window. See #47705.
+            contextTokensOverride:
+              entry && entry.modelIsFromFallback ? undefined : entry?.contextTokens,
             fallbackContextTokens: configContextTokens ?? undefined,
             allowAsyncLoad: false,
           }) ?? null;

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -6,6 +6,7 @@ import { upsertAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import * as jsonFiles from "../../infra/json-files.js";
 import { createSuiteTempRootTracker, withTempDirSync } from "../../test-helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config.js";
+
 import type { SessionConfig } from "../types.base.js";
 import { resolveSessionLifecycleTimestamps } from "./lifecycle.js";
 import {
@@ -18,7 +19,7 @@ import { evaluateSessionFreshness, resolveSessionResetPolicy } from "./reset.js"
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { clearSessionStoreCacheForTest, loadSessionStore, updateSessionStore } from "./store.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
-import { mergeSessionEntry, type SessionEntry } from "./types.js";
+import { mergeSessionEntry, setSessionRuntimeModel, type SessionEntry } from "./types.js";
 
 describe("session path safety", () => {
   it("rejects unsafe session IDs", () => {
@@ -529,5 +530,73 @@ describe("resolveAndPersistSessionFile", () => {
 
     const saved = loadSessionStore(fixture.storePath(), { skipCache: true });
     expect(saved[sessionKey]?.sessionFile).toBe(expectedNextSessionFile);
+  });
+});
+
+describe("setSessionRuntimeModel", () => {
+  it("sets model and provider on session entry", () => {
+    const entry: SessionEntry = { sessionId: "s1", updatedAt: Date.now() };
+
+    const result = setSessionRuntimeModel(entry, {
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    expect(result).toBe(true);
+    expect(entry.modelProvider).toBe("anthropic");
+    expect(entry.model).toBe("claude-opus-4-6");
+    expect(entry.modelIsFromFallback).toBe(false);
+  });
+
+  it("sets modelIsFromFallback when isFromFallback is true (#47705)", () => {
+    const entry: SessionEntry = { sessionId: "s1", updatedAt: Date.now() };
+
+    setSessionRuntimeModel(entry, {
+      provider: "xai",
+      model: "grok-4-1-fast-reasoning",
+      isFromFallback: true,
+    });
+
+    expect(entry.modelIsFromFallback).toBe(true);
+  });
+
+  it("clears modelIsFromFallback when isFromFallback is false", () => {
+    const entry: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      modelIsFromFallback: true,
+    };
+
+    setSessionRuntimeModel(entry, {
+      provider: "openai-codex",
+      model: "gpt-5.3-codex",
+      isFromFallback: false,
+    });
+
+    expect(entry.modelIsFromFallback).toBe(false);
+  });
+
+  it("returns false for empty provider", () => {
+    const entry: SessionEntry = { sessionId: "s1", updatedAt: Date.now() };
+
+    const result = setSessionRuntimeModel(entry, {
+      provider: "",
+      model: "claude-opus-4-6",
+    });
+
+    expect(result).toBe(false);
+    expect(entry.model).toBeUndefined();
+  });
+
+  it("returns false for empty model", () => {
+    const entry: SessionEntry = { sessionId: "s1", updatedAt: Date.now() };
+
+    const result = setSessionRuntimeModel(entry, {
+      provider: "anthropic",
+      model: "",
+    });
+
+    expect(result).toBe(false);
+    expect(entry.modelProvider).toBeUndefined();
   });
 });

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -240,6 +240,13 @@ export type SessionEntry = {
    */
   agentHarnessId?: string;
   /**
+   * True when the session's runtime model was selected by the fallback chain
+   * rather than being the configured primary. Used to prevent fallback models
+   * from being persisted back to agent config and to ensure the primary model
+   * is retried on subsequent requests.
+   */
+  modelIsFromFallback?: boolean;
+  /**
    * Last selected/runtime model pair for which a fallback notice was emitted.
    * Used to avoid repeating the same fallback notice every turn.
    */
@@ -353,7 +360,7 @@ export function normalizeSessionRuntimeModelFields(entry: SessionEntry): Session
 
 export function setSessionRuntimeModel(
   entry: SessionEntry,
-  runtime: { provider: string; model: string },
+  runtime: { provider: string; model: string; isFromFallback?: boolean },
 ): boolean {
   const provider = runtime.provider.trim();
   const model = runtime.model.trim();
@@ -362,6 +369,7 @@ export function setSessionRuntimeModel(
   }
   entry.modelProvider = provider;
   entry.model = model;
+  entry.modelIsFromFallback = runtime.isFromFallback ?? false;
   return true;
 }
 

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -1,3 +1,4 @@
+import type { FallbackAttempt } from "../../agents/model-fallback.types.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
@@ -55,6 +56,8 @@ export type CronExecutionResult = {
   configuredProvider: string;
   /** Model from config/model-selection before any fallback. Updated on LiveSessionModelSwitchError. */
   configuredModel: string;
+  /** Fallback attempts from the last runWithModelFallback call. */
+  fallbackAttempts: FallbackAttempt[];
   runStartedAt: number;
   runEndedAt: number;
   liveSelection: CronLiveSelection;
@@ -107,6 +110,7 @@ export function createCronPromptExecutor(params: {
   let runResult: CronPromptRunResult | undefined;
   let fallbackProvider = params.liveSelection.provider;
   let fallbackModel = params.liveSelection.model;
+  let fallbackAttempts: FallbackAttempt[] = [];
   let runEndedAt = Date.now();
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.cronSession.sessionEntry.systemPromptReport,
@@ -229,6 +233,7 @@ export function createCronPromptExecutor(params: {
     runResult = fallbackResult.result;
     fallbackProvider = fallbackResult.provider;
     fallbackModel = fallbackResult.model;
+    fallbackAttempts = fallbackResult.attempts;
     params.liveSelection.provider = fallbackResult.provider;
     params.liveSelection.model = fallbackResult.model;
     runEndedAt = Date.now();
@@ -240,6 +245,7 @@ export function createCronPromptExecutor(params: {
       runResult,
       fallbackProvider,
       fallbackModel,
+      fallbackAttempts,
       runEndedAt,
       liveSelection: params.liveSelection,
     }),
@@ -362,7 +368,8 @@ export async function executeCronRun(params: {
     }
   }
 
-  let { runResult, fallbackProvider, fallbackModel, runEndedAt } = executor.getState();
+  let { runResult, fallbackProvider, fallbackModel, fallbackAttempts, runEndedAt } =
+    executor.getState();
   if (!runResult) {
     throw new Error("cron isolated run returned no result");
   }
@@ -409,7 +416,8 @@ export async function executeCronRun(params: {
         "Use tools when needed, including sessions_spawn for parallel subtasks, wait for spawned subagents to finish, then return only the final summary.",
       ].join(" ");
       await executor.runPrompt(continuationPrompt);
-      ({ runResult, fallbackProvider, fallbackModel, runEndedAt } = executor.getState());
+      ({ runResult, fallbackProvider, fallbackModel, fallbackAttempts, runEndedAt } =
+        executor.getState());
     }
   }
 
@@ -420,6 +428,7 @@ export async function executeCronRun(params: {
     runResult,
     fallbackProvider,
     fallbackModel,
+    fallbackAttempts,
     configuredProvider,
     configuredModel,
     runStartedAt,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -233,7 +233,7 @@ export function createCronPromptExecutor(params: {
     runResult = fallbackResult.result;
     fallbackProvider = fallbackResult.provider;
     fallbackModel = fallbackResult.model;
-    fallbackAttempts = [...fallbackAttempts, ...fallbackResult.attempts];
+    fallbackAttempts = [...fallbackAttempts, ...(fallbackResult.attempts ?? [])];
     params.liveSelection.provider = fallbackResult.provider;
     params.liveSelection.model = fallbackResult.model;
     runEndedAt = Date.now();

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -51,6 +51,10 @@ export type CronExecutionResult = {
   runResult: CronPromptRunResult;
   fallbackProvider: string;
   fallbackModel: string;
+  /** Provider from config/model-selection before any fallback. Updated on LiveSessionModelSwitchError. */
+  configuredProvider: string;
+  /** Model from config/model-selection before any fallback. Updated on LiveSessionModelSwitchError. */
+  configuredModel: string;
   runStartedAt: number;
   runEndedAt: number;
   liveSelection: CronLiveSelection;
@@ -312,6 +316,11 @@ export async function executeCronRun(params: {
   });
 
   const runStartedAt = params.runStartedAt ?? Date.now();
+  // Snapshot the configured provider/model before the retry loop so we can
+  // detect fallback usage later. Updated on LiveSessionModelSwitchError
+  // (model switch = new configured target, not a fallback).
+  let configuredProvider = params.liveSelection.provider;
+  let configuredModel = params.liveSelection.model;
   const MAX_MODEL_SWITCH_RETRIES = 2;
   let modelSwitchRetries = 0;
   while (true) {
@@ -335,6 +344,9 @@ export async function executeCronRun(params: {
       params.liveSelection.authProfileIdSource = err.authProfileId
         ? err.authProfileIdSource
         : undefined;
+      // A model switch changes the configured target, not a fallback.
+      configuredProvider = err.provider;
+      configuredModel = err.model;
       syncCronSessionLiveSelection({
         entry: params.cronSession.sessionEntry,
         liveSelection: params.liveSelection,
@@ -408,6 +420,8 @@ export async function executeCronRun(params: {
     runResult,
     fallbackProvider,
     fallbackModel,
+    configuredProvider,
+    configuredModel,
     runStartedAt,
     runEndedAt,
     liveSelection: params.liveSelection,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -233,7 +233,7 @@ export function createCronPromptExecutor(params: {
     runResult = fallbackResult.result;
     fallbackProvider = fallbackResult.provider;
     fallbackModel = fallbackResult.model;
-    fallbackAttempts = fallbackResult.attempts;
+    fallbackAttempts = [...fallbackAttempts, ...fallbackResult.attempts];
     params.liveSelection.provider = fallbackResult.provider;
     params.liveSelection.model = fallbackResult.model;
     runEndedAt = Date.now();

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -74,6 +74,7 @@ export function syncCronSessionLiveSelection(params: {
 }) {
   params.entry.modelProvider = params.liveSelection.provider;
   params.entry.model = params.liveSelection.model;
+  params.entry.modelIsFromFallback = false;
   if (params.liveSelection.authProfileId) {
     params.entry.authProfileOverride = params.liveSelection.authProfileId;
     params.entry.authProfileOverrideSource = params.liveSelection.authProfileIdSource;

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -64,6 +64,7 @@ export function markCronSessionPreRun(params: {
 }) {
   params.entry.modelProvider = params.provider;
   params.entry.model = params.model;
+  params.entry.modelIsFromFallback = false;
   params.entry.systemSent = true;
 }
 

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -267,6 +267,7 @@ function makeDefaultModelFallbackResult() {
     },
     provider: "openai",
     model: "gpt-5.4",
+    attempts: [],
   };
 }
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -765,8 +765,22 @@ async function finalizeCronRun(params: {
   // Model is from fallback if the successfully-used provider/model differs
   // from the configured target. LiveSessionModelSwitchError updates the
   // configured snapshot so model switches are not treated as fallbacks.
-  const isFromFallback =
-    providerUsed !== execution.configuredProvider || modelUsed !== execution.configuredModel;
+  // When runWithModelFallback consumes a LiveSessionModelSwitchError internally
+  // (without it reaching the outer retry loop in executeCronRun), the configured
+  // snapshot is not updated. Check fallbackAttempts for switch requests to
+  // derive the actual intended target so live switches aren't mislabelled.
+  let intendedProvider = execution.configuredProvider;
+  let intendedModel = execution.configuredModel;
+  if (execution.fallbackAttempts?.length) {
+    for (const attempt of execution.fallbackAttempts) {
+      const match = attempt.error?.match(/^Live session model switch requested: (.+?)\/(.+)/);
+      if (match) {
+        intendedProvider = match[1];
+        intendedModel = match[2];
+      }
+    }
+  }
+  const isFromFallback = providerUsed !== intendedProvider || modelUsed !== intendedModel;
   setSessionRuntimeModel(prepared.cronSession.sessionEntry, {
     provider: providerUsed,
     model: modelUsed,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -780,7 +780,23 @@ async function finalizeCronRun(params: {
       }
     }
   }
-  const isFromFallback = providerUsed !== intendedProvider || modelUsed !== intendedModel;
+  // A fallback occurred if the fallback resolution settled on a different
+  // model than the user intended.  However, in embedded runs hook selection
+  // can rewrite the effective model (agentMeta), so the model actually
+  // persisted may differ from both the fallback candidate and the intended
+  // target.  Only mark the session as "from fallback" when the persisted
+  // runtime model still matches the fallback candidate — if hooks rewrote
+  // it, the stored model is not "sticky fallback" and should not be
+  // suppressed during later resolution.
+  const fallbackOccurred =
+    execution.fallbackProvider !== intendedProvider || execution.fallbackModel !== intendedModel;
+  const runtimeModel = finalRunResult.meta?.agentMeta?.model;
+  const runtimeProvider = finalRunResult.meta?.agentMeta?.provider;
+  const isFromFallback =
+    fallbackOccurred &&
+    (!runtimeModel ||
+      (runtimeModel === execution.fallbackModel &&
+        (runtimeProvider ?? execution.fallbackProvider) === execution.fallbackProvider));
   setSessionRuntimeModel(prepared.cronSession.sessionEntry, {
     provider: providerUsed,
     model: modelUsed,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -762,9 +762,15 @@ async function finalizeCronRun(params: {
     resolvePositiveContextTokens(prepared.cronSession.sessionEntry.contextTokens) ??
     DEFAULT_CONTEXT_TOKENS;
 
+  // Model is from fallback if the successfully-used provider/model differs
+  // from the configured target. LiveSessionModelSwitchError updates the
+  // configured snapshot so model switches are not treated as fallbacks.
+  const isFromFallback =
+    providerUsed !== execution.configuredProvider || modelUsed !== execution.configuredModel;
   setSessionRuntimeModel(prepared.cronSession.sessionEntry, {
     provider: providerUsed,
     model: modelUsed,
+    isFromFallback,
   });
   prepared.cronSession.sessionEntry.contextTokens = contextTokens;
   if (isCliProvider(providerUsed, prepared.cfgWithAgentDefaults)) {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -879,6 +879,58 @@ describe("resolveSessionModelRef", () => {
 
     expect(resolved).toEqual({ provider: "anthropic", model: "claude-sonnet-4-6" });
   });
+
+  test("ignores session-stored model when modelIsFromFallback is true (#47705)", () => {
+    // When a fallback model is stored in the session, resolveSessionModelRef should
+    // skip it and return the configured primary model instead, so the primary is
+    // retried on subsequent requests.
+    const cfg = createModelDefaultsConfig({
+      primary: "openai-codex/gpt-5.3-codex",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "fallback-session",
+      updatedAt: Date.now(),
+      modelProvider: "xai",
+      model: "grok-4-1-fast-reasoning",
+      modelIsFromFallback: true,
+    });
+
+    expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.3-codex" });
+  });
+
+  test("uses session-stored model when modelIsFromFallback is false", () => {
+    // When the model was explicitly set (not from fallback), it should be used.
+    const cfg = createModelDefaultsConfig({
+      primary: "openai-codex/gpt-5.3-codex",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "explicit-session",
+      updatedAt: Date.now(),
+      modelProvider: "anthropic",
+      model: "claude-opus-4-6",
+      modelIsFromFallback: false,
+    });
+
+    expect(resolved).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+  });
+
+  test("uses session-stored model when modelIsFromFallback is undefined (legacy)", () => {
+    // Legacy sessions without the flag should still work as before.
+    const cfg = createModelDefaultsConfig({
+      primary: "openai-codex/gpt-5.3-codex",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "legacy-session",
+      updatedAt: Date.now(),
+      modelProvider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    expect(resolved).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+  });
 });
 
 describe("listSessionsFromStore selected model display", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -931,6 +931,26 @@ describe("resolveSessionModelRef", () => {
 
     expect(resolved).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
   });
+
+  test("honours model override even when modelIsFromFallback is true", () => {
+    // When a fallback model is stored but an explicit override was set via
+    // sessions.patch, the override should still be used.
+    const cfg = createModelDefaultsConfig({
+      primary: "openai-codex/gpt-5.3-codex",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "override-fallback-session",
+      updatedAt: Date.now(),
+      modelProvider: "xai",
+      model: "grok-4-1-fast-reasoning",
+      modelIsFromFallback: true,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6",
+    });
+
+    expect(resolved).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+  });
 });
 
 describe("listSessionsFromStore selected model display", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1066,7 +1066,10 @@ export function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
     | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
+    | Pick<
+        SessionEntry,
+        "model" | "modelProvider" | "modelOverride" | "providerOverride" | "modelIsFromFallback"
+      >,
   agentId?: string,
 ): { provider: string; model: string } {
   const resolved = agentId
@@ -1082,13 +1085,21 @@ export function resolveSessionModelRef(
     modelOverride: entry?.modelOverride,
   });
 
-  const persisted = resolvePersistedSelectedModelRef({
-    defaultProvider: resolved.provider || DEFAULT_PROVIDER,
-    runtimeProvider: entry?.modelProvider,
-    runtimeModel: entry?.model,
-    overrideProvider: normalizedOverride.providerOverride,
-    overrideModel: normalizedOverride.modelOverride,
-  });
+  // Skip session-stored runtime model if it came from the fallback chain.
+  // This ensures the primary model is retried on subsequent requests rather
+  // than permanently sticking with the fallback. See #47705.
+  const isFromFallback =
+    entry && "modelIsFromFallback" in entry && entry.modelIsFromFallback === true;
+
+  const persisted = isFromFallback
+    ? null
+    : resolvePersistedSelectedModelRef({
+        defaultProvider: resolved.provider || DEFAULT_PROVIDER,
+        runtimeProvider: entry?.modelProvider,
+        runtimeModel: entry?.model,
+        overrideProvider: normalizedOverride.providerOverride,
+        overrideModel: normalizedOverride.modelOverride,
+      });
   if (persisted) {
     return persisted;
   }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1181,7 +1181,10 @@ export function resolveSessionModelIdentityRef(
   cfg: OpenClawConfig,
   entry?:
     | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride" | "modelIsFromFallback">,
+    | Pick<
+        SessionEntry,
+        "model" | "modelProvider" | "modelOverride" | "providerOverride" | "modelIsFromFallback"
+      >,
   agentId?: string,
   fallbackModelRef?: string,
 ): { provider?: string; model: string } {
@@ -1379,8 +1382,9 @@ export function buildGatewaySessionRow(params: {
       model,
       entry,
     }) ?? resolveNonNegativeNumber(transcriptUsage?.estimatedCostUsd);
+  const isEntryFromFallback = entry && "modelIsFromFallback" in entry && entry.modelIsFromFallback;
   const contextTokens =
-    resolvePositiveNumber(entry?.contextTokens) ??
+    (!isEntryFromFallback ? resolvePositiveNumber(entry?.contextTokens) : undefined) ??
     resolvePositiveNumber(transcriptUsage?.contextTokens) ??
     resolvePositiveNumber(
       resolveContextTokensForModel({

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1091,15 +1091,15 @@ export function resolveSessionModelRef(
   const isFromFallback =
     entry && "modelIsFromFallback" in entry && entry.modelIsFromFallback === true;
 
-  const persisted = isFromFallback
-    ? null
-    : resolvePersistedSelectedModelRef({
-        defaultProvider: resolved.provider || DEFAULT_PROVIDER,
-        runtimeProvider: entry?.modelProvider,
-        runtimeModel: entry?.model,
-        overrideProvider: normalizedOverride.providerOverride,
-        overrideModel: normalizedOverride.modelOverride,
-      });
+  const persisted = resolvePersistedSelectedModelRef({
+    defaultProvider: resolved.provider || DEFAULT_PROVIDER,
+    // Skip session-stored runtime model when it came from the fallback chain,
+    // but still honour explicit model overrides set via sessions.patch.
+    runtimeProvider: isFromFallback ? undefined : entry?.modelProvider,
+    runtimeModel: isFromFallback ? undefined : entry?.model,
+    overrideProvider: normalizedOverride.providerOverride,
+    overrideModel: normalizedOverride.modelOverride,
+  });
   if (persisted) {
     return persisted;
   }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1181,12 +1181,13 @@ export function resolveSessionModelIdentityRef(
   cfg: OpenClawConfig,
   entry?:
     | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
+    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride" | "modelIsFromFallback">,
   agentId?: string,
   fallbackModelRef?: string,
 ): { provider?: string; model: string } {
-  const runtimeModel = entry?.model?.trim();
-  const runtimeProvider = entry?.modelProvider?.trim();
+  const isFromFallback = entry && "modelIsFromFallback" in entry && entry.modelIsFromFallback;
+  const runtimeModel = isFromFallback ? undefined : entry?.model?.trim();
+  const runtimeProvider = isFromFallback ? undefined : entry?.modelProvider?.trim();
   if (runtimeModel) {
     if (runtimeProvider) {
       return { provider: runtimeProvider, model: runtimeModel };

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1395,6 +1395,7 @@ export function buildGatewaySessionRow(params: {
         cfg,
         provider: modelProvider,
         model,
+        contextTokensOverride: cfg.agents?.defaults?.contextTokens,
         // Gateway/session listing is read-only; don't start async model discovery.
         allowAsyncLoad: false,
       }),

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1349,10 +1349,12 @@ export function buildGatewaySessionRow(params: {
           fallbackModel: resolvedModel.model ?? DEFAULT_MODEL,
         })
       : null;
+  const isEntryFromFallback = entry && "modelIsFromFallback" in entry && entry.modelIsFromFallback;
   const preferLiveSubagentModelIdentity =
     Boolean(subagentRun?.model?.trim()) && subagentStatus === "running";
   const shouldUseTranscriptModelIdentity =
     runtimeModelPresent &&
+    !isEntryFromFallback &&
     !preferLiveSubagentModelIdentity &&
     (needsTranscriptTotalTokens || needsTranscriptContextTokens);
   const resolvedModelIdentity = {
@@ -1382,7 +1384,6 @@ export function buildGatewaySessionRow(params: {
       model,
       entry,
     }) ?? resolveNonNegativeNumber(transcriptUsage?.estimatedCostUsd);
-  const isEntryFromFallback = entry && "modelIsFromFallback" in entry && entry.modelIsFromFallback;
   // When the entry is from a fallback run, skip both the stored entry
   // context tokens and transcript-derived context tokens — both reflect the
   // fallback model's context window rather than the resolved primary model.

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1383,9 +1383,12 @@ export function buildGatewaySessionRow(params: {
       entry,
     }) ?? resolveNonNegativeNumber(transcriptUsage?.estimatedCostUsd);
   const isEntryFromFallback = entry && "modelIsFromFallback" in entry && entry.modelIsFromFallback;
+  // When the entry is from a fallback run, skip both the stored entry
+  // context tokens and transcript-derived context tokens — both reflect the
+  // fallback model's context window rather than the resolved primary model.
   const contextTokens =
     (!isEntryFromFallback ? resolvePositiveNumber(entry?.contextTokens) : undefined) ??
-    resolvePositiveNumber(transcriptUsage?.contextTokens) ??
+    (!isEntryFromFallback ? resolvePositiveNumber(transcriptUsage?.contextTokens) : undefined) ??
     resolvePositiveNumber(
       resolveContextTokensForModel({
         cfg,


### PR DESCRIPTION
## Summary

- Adds `modelIsFromFallback` flag to track when session's runtime model was selected by fallback chain
- Updates `resolveSessionModelRef` to skip session-stored model when from fallback, ensuring primary is retried
- Updates all callers (`agent.ts`, `session-store.ts`, `agent-runner.ts`, `followup-runner.ts`, `cron/run.ts`) to pass the flag

## Test plan

- [x] Added unit tests for `setSessionRuntimeModel` with `isFromFallback` flag
- [x] Added unit tests for `resolveSessionModelRef` to verify fallback models are skipped
- [x] Verified existing tests still pass

Fixes #47705