### PR TITLE
fix(memory): return relevant snippets instead of file beginning in search results

### DIFF
--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -46,15 +46,21 @@ function extractRelevantSnippet(
     }
   }
 
-  // If no match found, return the full chunk text rather than truncating to
-  // the beginning.  Semantic/vector matches often don't share literal keywords
-  // with the query, so trimming from the start would discard the relevant
-  // section when it appears later in the chunk.
+  // No keyword anchor found — semantic/vector matches may not share literal
+  // tokens with the query.  Return a tail window of the chunk capped at
+  // maxChars so the snippet stays within the payload budget while still
+  // capturing content that appears later in the chunk (the common case for
+  // purely semantic hits).
   if (matchIndex === -1) {
+    const tailStart = Math.max(0, text.length - maxChars);
+    const tailText = tailStart === 0 ? text : text.substring(tailStart);
+    const cappedSnippet = truncateUtf16Safe(tailText, maxChars);
+    const offsetLines =
+      tailStart > 0 ? (text.substring(0, tailStart).match(/\n/g) || []).length : 0;
     return {
-      snippet: text,
-      offsetLines: 0,
-      snippetLines: (text.match(/\n/g) || []).length,
+      snippet: cappedSnippet,
+      offsetLines,
+      snippetLines: (cappedSnippet.match(/\n/g) || []).length,
       anchorFound: false,
     };
   }

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -178,6 +178,7 @@ export async function searchVector(params: {
   vectorTable: string;
   providerModel: string;
   queryVec: number[];
+  queryText: string;
   limit: number;
   snippetMaxChars: number;
   ensureVectorReady: (dimensions: number) => Promise<boolean>;

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -264,12 +264,14 @@ export async function searchVector(params: {
       // that are not contiguous, so applying a text-based offset can produce
       // synthetic line numbers that don't exist.  Keep original range for sessions.
       const isSessionSource = row.source === "sessions";
-      const adjustedStart = isSessionSource
-        ? row.start_line
-        : Math.min(row.start_line + offsetLines, row.end_line);
       // When no anchor was found the snippet is a fallback window; preserve
-      // the chunk's full line span so semantic matches later in the text are
-      // not excluded.  Always clamp to the chunk's original end_line to
+      // the chunk's original line span so follow-up memory_get reads don't
+      // skip earlier content that may contain the semantic match.
+      const adjustedStart =
+        isSessionSource || !anchorFound
+          ? row.start_line
+          : Math.min(row.start_line + offsetLines, row.end_line);
+      // Always clamp to the chunk's original end_line to
       // guard against synthetic newlines inflating the count.
       const endLine =
         !isSessionSource && anchorFound
@@ -309,9 +311,10 @@ export async function searchVector(params: {
       );
       // Session chunks use sparse remapped line numbers; skip offset adjustment.
       const isSessionSource = entry.chunk.source === "sessions";
-      const adjustedStart = isSessionSource
-        ? entry.chunk.startLine
-        : Math.min(entry.chunk.startLine + offsetLines, entry.chunk.endLine);
+      const adjustedStart =
+        isSessionSource || !anchorFound
+          ? entry.chunk.startLine
+          : Math.min(entry.chunk.startLine + offsetLines, entry.chunk.endLine);
       const endLine =
         !isSessionSource && anchorFound
           ? Math.min(adjustedStart + snippetLines, entry.chunk.endLine)
@@ -447,9 +450,10 @@ export async function searchKeyword(params: {
     );
     // Session chunks use sparse remapped line numbers; skip offset adjustment.
     const isSessionSource = row.source === "sessions";
-    const adjustedStart = isSessionSource
-      ? row.start_line
-      : Math.min(row.start_line + offsetLines, row.end_line);
+    const adjustedStart =
+      isSessionSource || !anchorFound
+        ? row.start_line
+        : Math.min(row.start_line + offsetLines, row.end_line);
     const endLine =
       !isSessionSource && anchorFound
         ? Math.min(adjustedStart + snippetLines, row.end_line)

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -230,14 +230,19 @@ export async function searchVector(params: {
         params.queryText,
         params.snippetMaxChars,
       );
-      const adjustedStart = row.start_line + offsetLines;
+      // Session chunks use sparse remapped line numbers (from JSONL lineMap)
+      // that are not contiguous, so applying a text-based offset can produce
+      // synthetic line numbers that don't exist.  Keep original range for sessions.
+      const isSessionSource = row.source === "sessions";
+      const adjustedStart = isSessionSource ? row.start_line : row.start_line + offsetLines;
       // When no anchor was found the snippet is a fallback window; preserve
       // the chunk's full line span so semantic matches later in the text are
       // not excluded.  Always clamp to the chunk's original end_line to
       // guard against synthetic newlines inflating the count.
-      const endLine = anchorFound
-        ? Math.min(adjustedStart + snippetLines, row.end_line)
-        : row.end_line;
+      const endLine =
+        !isSessionSource && anchorFound
+          ? Math.min(adjustedStart + snippetLines, row.end_line)
+          : row.end_line;
       return {
         id: row.id,
         path: row.path,
@@ -270,10 +275,15 @@ export async function searchVector(params: {
         params.queryText,
         params.snippetMaxChars,
       );
-      const adjustedStart = entry.chunk.startLine + offsetLines;
-      const endLine = anchorFound
-        ? Math.min(adjustedStart + snippetLines, entry.chunk.endLine)
-        : entry.chunk.endLine;
+      // Session chunks use sparse remapped line numbers; skip offset adjustment.
+      const isSessionSource = entry.chunk.source === "sessions";
+      const adjustedStart = isSessionSource
+        ? entry.chunk.startLine
+        : entry.chunk.startLine + offsetLines;
+      const endLine =
+        !isSessionSource && anchorFound
+          ? Math.min(adjustedStart + snippetLines, entry.chunk.endLine)
+          : entry.chunk.endLine;
       return {
         id: entry.chunk.id,
         path: entry.chunk.path,
@@ -402,10 +412,13 @@ export async function searchKeyword(params: {
       params.query,
       params.snippetMaxChars,
     );
-    const adjustedStart = row.start_line + offsetLines;
-    const endLine = anchorFound
-      ? Math.min(adjustedStart + snippetLines, row.end_line)
-      : row.end_line;
+    // Session chunks use sparse remapped line numbers; skip offset adjustment.
+    const isSessionSource = row.source === "sessions";
+    const adjustedStart = isSessionSource ? row.start_line : row.start_line + offsetLines;
+    const endLine =
+      !isSessionSource && anchorFound
+        ? Math.min(adjustedStart + snippetLines, row.end_line)
+        : row.end_line;
     return {
       id: row.id,
       path: row.path,

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -10,6 +10,72 @@ const vectorToBlob = (embedding: number[]): Buffer =>
 const FTS_QUERY_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
 const SHORT_CJK_TRIGRAM_RE = /[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af\u3131-\u3163]/u;
 
+/**
+ * Extract a relevant snippet window around the query match in the text.
+ * If the query is found, returns a window centered on the match.
+ * Otherwise falls back to the beginning of the text.
+ */
+function extractRelevantSnippet(
+  text: string,
+  query: string,
+  maxChars: number,
+): { snippet: string; offsetLines: number } {
+  if (text.length <= maxChars) {
+    return { snippet: text, offsetLines: 0 };
+  }
+
+  // Try to find the query (case-insensitive) in the text
+  const lowerText = text.toLowerCase();
+  const queryTerms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((term) => term.length > 2);
+
+  let matchIndex = -1;
+
+  // Find the first matching term
+  for (const term of queryTerms) {
+    const idx = lowerText.indexOf(term);
+    if (idx !== -1) {
+      matchIndex = idx;
+      break;
+    }
+  }
+
+  // If no match found, fall back to beginning
+  if (matchIndex === -1) {
+    return { snippet: truncateUtf16Safe(text, maxChars), offsetLines: 0 };
+  }
+
+  // Calculate window start, trying to center the match
+  const halfWindow = Math.floor(maxChars / 2);
+  let windowStart = Math.max(0, matchIndex - halfWindow);
+  let windowEnd = Math.min(text.length, windowStart + maxChars);
+
+  // Adjust if we're near the end
+  if (windowEnd === text.length && windowEnd - windowStart < maxChars) {
+    windowStart = Math.max(0, windowEnd - maxChars);
+  }
+
+  // Try to start at a line boundary for cleaner output
+  if (windowStart > 0) {
+    const lineStart = text.lastIndexOf("\n", windowStart);
+    if (lineStart !== -1 && windowStart - lineStart < 100) {
+      windowStart = lineStart + 1;
+      // Recalculate windowEnd to maintain maxChars length after snap
+      windowEnd = Math.min(text.length, windowStart + maxChars);
+    }
+  }
+
+  // Count lines before the window to adjust startLine/endLine display
+  const textBeforeWindow = text.substring(0, windowStart);
+  const offsetLines = (textBeforeWindow.match(/\n/g) || []).length;
+
+  const snippet = text.substring(windowStart, windowEnd);
+  return { snippet: truncateUtf16Safe(snippet, maxChars), offsetLines };
+}
+
+
 export type SearchSource = string;
 
 export type SearchRowResult = {

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -61,9 +61,35 @@ function extractRelevantSnippet(
 
   // Normalize text for diacritic-insensitive matching (mirrors SQLite
   // unicode61 tokenizer folding: résumé → resume, café → cafe).
-  const foldDiacritics = (s: string): string =>
-    s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  const foldDiacritics = (s: string): string => s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
   const normalizedText = foldDiacritics(lowerText);
+
+  // Build a mapping from normalized-string offsets to original-string offsets.
+  // NFD normalization + combining mark removal can make the normalized string
+  // shorter than the original (e.g. precomposed "é" [1 char] decomposes to
+  // "e\u0301" [2 chars] in NFD, then stripping the mark yields "e" [1 char]).
+  // normToOrig[i] gives the lowerText index for normalizedText[i].
+  const normToOrig: number[] = [];
+  {
+    const nfd = lowerText.normalize("NFD");
+    // First map every NFD position back to the lowerText position it came from.
+    const nfdToOrig: number[] = Array.from({ length: nfd.length });
+    let nfdIdx = 0;
+    for (let origIdx = 0; origIdx < lowerText.length; origIdx++) {
+      const decomposed = lowerText[origIdx].normalize("NFD");
+      for (let j = 0; j < decomposed.length; j++) {
+        nfdToOrig[nfdIdx++] = origIdx;
+      }
+    }
+    // Now walk the NFD string, skip combining marks (which were stripped to
+    // produce normalizedText), and carry through the original position.
+    for (let ni = 0; ni < nfd.length; ni++) {
+      if (/[\u0300-\u036f]/.test(nfd[ni])) {
+        continue;
+      }
+      normToOrig.push(nfdToOrig[ni]);
+    }
+  }
 
   // Find the first matching term — try both raw indexOf and
   // diacritic-folded indexOf so FTS unicode61 normalized matches
@@ -72,7 +98,11 @@ function extractRelevantSnippet(
   for (const term of queryTerms) {
     let idx = lowerText.indexOf(term);
     if (idx === -1) {
-      idx = normalizedText.indexOf(foldDiacritics(term));
+      const normIdx = normalizedText.indexOf(foldDiacritics(term));
+      if (normIdx !== -1) {
+        // Map the normalized-string offset back to the original string.
+        idx = normIdx < normToOrig.length ? normToOrig[normIdx] : lowerText.length;
+      }
     }
     if (idx !== -1) {
       matchIndex = idx;

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -59,9 +59,21 @@ function extractRelevantSnippet(
 
   let matchIndex = -1;
 
-  // Find the first matching term
+  // Normalize text for diacritic-insensitive matching (mirrors SQLite
+  // unicode61 tokenizer folding: résumé → resume, café → cafe).
+  const foldDiacritics = (s: string): string =>
+    s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  const normalizedText = foldDiacritics(lowerText);
+
+  // Find the first matching term — try both raw indexOf and
+  // diacritic-folded indexOf so FTS unicode61 normalized matches
+  // (e.g. query "resume" matching stored "résumé") still anchor
+  // the snippet at the correct position.
   for (const term of queryTerms) {
-    const idx = lowerText.indexOf(term);
+    let idx = lowerText.indexOf(term);
+    if (idx === -1) {
+      idx = normalizedText.indexOf(foldDiacritics(term));
+    }
     if (idx !== -1) {
       matchIndex = idx;
       break;

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -20,6 +20,7 @@ function extractRelevantSnippet(
   text: string,
   query: string,
   maxChars: number,
+  ftsTokenizer?: "unicode61" | "trigram",
 ): { snippet: string; offsetLines: number; snippetLines: number; anchorFound: boolean } {
   if (text.length <= maxChars) {
     return {
@@ -34,6 +35,17 @@ function extractRelevantSnippet(
   // conversational queries produce correct anchor terms.
   const lowerText = text.toLowerCase();
   let queryTerms = extractKeywords(query).toSorted((a, b) => b.length - a.length);
+
+  // When the FTS index uses trigram tokenization, the full query string is a
+  // valid match token (e.g. CJK "北京市" is indexed as-is).  Prepend it so
+  // snippet anchoring tries the trigram-matched term before the shorter pieces
+  // that extractKeywords may produce.
+  if (ftsTokenizer === "trigram") {
+    const full = query.trim().toLowerCase();
+    if (full.length > 0 && !queryTerms.includes(full)) {
+      queryTerms = [full, ...queryTerms];
+    }
+  }
 
   // extractKeywords drops pure-numeric tokens (e.g. "404", "2024").
   // Fall back to raw alphanumeric tokens so numeric queries still anchor.
@@ -431,6 +443,7 @@ export async function searchKeyword(params: {
       row.text,
       params.query,
       params.snippetMaxChars,
+      params.ftsTokenizer,
     );
     // Session chunks use sparse remapped line numbers; skip offset adjustment.
     const isSessionSource = row.source === "sessions";

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -20,9 +20,14 @@ function extractRelevantSnippet(
   text: string,
   query: string,
   maxChars: number,
-): { snippet: string; offsetLines: number; snippetLines: number } {
+): { snippet: string; offsetLines: number; snippetLines: number; anchorFound: boolean } {
   if (text.length <= maxChars) {
-    return { snippet: text, offsetLines: 0, snippetLines: (text.match(/\n/g) || []).length };
+    return {
+      snippet: text,
+      offsetLines: 0,
+      snippetLines: (text.match(/\n/g) || []).length,
+      anchorFound: true,
+    };
   }
 
   // Use the same tokenizer as the search engine so CJK terms and
@@ -48,6 +53,7 @@ function extractRelevantSnippet(
       snippet: fallback,
       offsetLines: 0,
       snippetLines: (fallback.match(/\n/g) || []).length,
+      anchorFound: false,
     };
   }
 
@@ -77,7 +83,7 @@ function extractRelevantSnippet(
 
   const snippet = truncateUtf16Safe(text.substring(windowStart, windowEnd), maxChars);
   const snippetLines = (snippet.match(/\n/g) || []).length;
-  return { snippet, offsetLines, snippetLines };
+  return { snippet, offsetLines, snippetLines, anchorFound: true };
 }
 
 export type SearchSource = string;
@@ -219,17 +225,24 @@ export async function searchVector(params: {
       dist: number;
     }>;
     return rows.map((row) => {
-      const { snippet, offsetLines, snippetLines } = extractRelevantSnippet(
+      const { snippet, offsetLines, snippetLines, anchorFound } = extractRelevantSnippet(
         row.text,
         params.queryText,
         params.snippetMaxChars,
       );
       const adjustedStart = row.start_line + offsetLines;
+      // When no anchor was found the snippet is a fallback window; preserve
+      // the chunk's full line span so semantic matches later in the text are
+      // not excluded.  Always clamp to the chunk's original end_line to
+      // guard against synthetic newlines inflating the count.
+      const endLine = anchorFound
+        ? Math.min(adjustedStart + snippetLines, row.end_line)
+        : row.end_line;
       return {
         id: row.id,
         path: row.path,
         startLine: adjustedStart,
-        endLine: adjustedStart + snippetLines,
+        endLine,
         score: 1 - row.dist,
         snippet,
         source: row.source,
@@ -252,17 +265,20 @@ export async function searchVector(params: {
     .toSorted((a, b) => b.score - a.score)
     .slice(0, params.limit)
     .map((entry) => {
-      const { snippet, offsetLines, snippetLines } = extractRelevantSnippet(
+      const { snippet, offsetLines, snippetLines, anchorFound } = extractRelevantSnippet(
         entry.chunk.text,
         params.queryText,
         params.snippetMaxChars,
       );
       const adjustedStart = entry.chunk.startLine + offsetLines;
+      const endLine = anchorFound
+        ? Math.min(adjustedStart + snippetLines, entry.chunk.endLine)
+        : entry.chunk.endLine;
       return {
         id: entry.chunk.id,
         path: entry.chunk.path,
         startLine: adjustedStart,
-        endLine: adjustedStart + snippetLines,
+        endLine,
         score: entry.score,
         snippet,
         source: entry.chunk.source,
@@ -381,17 +397,20 @@ export async function searchKeyword(params: {
           ftsScore: textScore,
         })
       : textScore;
-    const { snippet, offsetLines, snippetLines } = extractRelevantSnippet(
+    const { snippet, offsetLines, snippetLines, anchorFound } = extractRelevantSnippet(
       row.text,
       params.query,
       params.snippetMaxChars,
     );
     const adjustedStart = row.start_line + offsetLines;
+    const endLine = anchorFound
+      ? Math.min(adjustedStart + snippetLines, row.end_line)
+      : row.end_line;
     return {
       id: row.id,
       path: row.path,
       startLine: adjustedStart,
-      endLine: adjustedStart + snippetLines,
+      endLine,
       score,
       textScore,
       snippet,

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -69,7 +69,7 @@ function extractRelevantSnippet(
     const segments = full
       .split(/\s+/)
       .filter((s) => s.length > 0)
-      .sort((a, b) => b.length - a.length);
+      .toSorted((a, b) => b.length - a.length);
     if (segments.length > 1) {
       for (const seg of segments) {
         if (!queryTerms.includes(seg)) {

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -62,12 +62,12 @@ function extractRelevantSnippet(
     if (full.length > 0 && !queryTerms.includes(full)) {
       queryTerms = [full, ...queryTerms];
     }
-    // For multi-term trigram queries (e.g. "成语接龙 游戏"), the full query
-    // with whitespace may not match verbatim in stored text that lacks the
-    // separator.  Add each individual segment as an anchor candidate so
-    // partial matches can still anchor the snippet.
+    // For multi-term trigram queries (e.g. "成语接龙 游戏" or "成语接龙,游戏"),
+    // the full query with separators may not match verbatim in stored text.
+    // Split on both whitespace and punctuation (matching FTS_QUERY_TOKEN_RE
+    // token boundaries) so each segment can anchor the snippet independently.
     const segments = full
-      .split(/\s+/)
+      .split(/[^\p{L}\p{N}_]+/u)
       .filter((s) => s.length > 0)
       .toSorted((a, b) => b.length - a.length);
     if (segments.length > 1) {

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -34,6 +34,23 @@ function extractRelevantSnippet(
   // Use the same tokenizer as the search engine so CJK terms and
   // conversational queries produce correct anchor terms.
   const lowerText = text.toLowerCase();
+
+  // Build a mapping from lowerText offsets back to original text offsets.
+  // Unicode lowercasing is not always length-preserving (e.g. Turkish İ
+  // [U+0130, 1 code unit] lowercases to i̇ [U+0069 + U+0307, 2 code units]).
+  // Without this mapping, indexOf results from lowerText would drift forward
+  // when used to window the original text.
+  const lowerToOrig: number[] = [];
+  {
+    let lowerIdx = 0;
+    for (let origIdx = 0; origIdx < text.length; origIdx++) {
+      const lc = text[origIdx].toLowerCase();
+      for (let j = 0; j < lc.length; j++) {
+        lowerToOrig[lowerIdx++] = origIdx;
+      }
+    }
+  }
+
   let queryTerms = extractKeywords(query).toSorted((a, b) => b.length - a.length);
 
   // When the FTS index uses trigram tokenization, the full query string is a
@@ -97,15 +114,18 @@ function extractRelevantSnippet(
   // the snippet at the correct position.
   for (const term of queryTerms) {
     let idx = lowerText.indexOf(term);
-    if (idx === -1) {
-      const normIdx = normalizedText.indexOf(foldDiacritics(term));
-      if (normIdx !== -1) {
-        // Map the normalized-string offset back to the original string.
-        idx = normIdx < normToOrig.length ? normToOrig[normIdx] : lowerText.length;
-      }
-    }
     if (idx !== -1) {
-      matchIndex = idx;
+      // Map lowerText offset back to original text offset in case
+      // toLowerCase() changed the string length.
+      matchIndex = idx < lowerToOrig.length ? lowerToOrig[idx] : text.length;
+      break;
+    }
+    // Fallback: try diacritic-folded matching.
+    const normIdx = normalizedText.indexOf(foldDiacritics(term));
+    if (normIdx !== -1) {
+      // Map normalized-string offset → lowerText offset → original text offset.
+      const lowerIdx = normIdx < normToOrig.length ? normToOrig[normIdx] : lowerText.length;
+      matchIndex = lowerIdx < lowerToOrig.length ? lowerToOrig[lowerIdx] : text.length;
       break;
     }
   }

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { extractKeywords } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import {
   cosineSimilarity,
   parseEmbedding,
@@ -24,12 +25,10 @@ function extractRelevantSnippet(
     return { snippet: text, offsetLines: 0 };
   }
 
-  // Try to find the query (case-insensitive) in the text
+  // Use the same tokenizer as the search engine so CJK terms and
+  // conversational queries produce correct anchor terms.
   const lowerText = text.toLowerCase();
-  const queryTerms = query
-    .toLowerCase()
-    .split(/\s+/)
-    .filter((term) => term.length > 2);
+  const queryTerms = extractKeywords(query).sort((a, b) => b.length - a.length);
 
   let matchIndex = -1;
 

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -20,9 +20,9 @@ function extractRelevantSnippet(
   text: string,
   query: string,
   maxChars: number,
-): { snippet: string; offsetLines: number } {
+): { snippet: string; offsetLines: number; snippetLines: number } {
   if (text.length <= maxChars) {
-    return { snippet: text, offsetLines: 0 };
+    return { snippet: text, offsetLines: 0, snippetLines: (text.match(/\n/g) || []).length };
   }
 
   // Use the same tokenizer as the search engine so CJK terms and
@@ -43,7 +43,12 @@ function extractRelevantSnippet(
 
   // If no match found, fall back to beginning
   if (matchIndex === -1) {
-    return { snippet: truncateUtf16Safe(text, maxChars), offsetLines: 0 };
+    const fallback = truncateUtf16Safe(text, maxChars);
+    return {
+      snippet: fallback,
+      offsetLines: 0,
+      snippetLines: (fallback.match(/\n/g) || []).length,
+    };
   }
 
   // Calculate window start, trying to center the match
@@ -70,10 +75,10 @@ function extractRelevantSnippet(
   const textBeforeWindow = text.substring(0, windowStart);
   const offsetLines = (textBeforeWindow.match(/\n/g) || []).length;
 
-  const snippet = text.substring(windowStart, windowEnd);
-  return { snippet: truncateUtf16Safe(snippet, maxChars), offsetLines };
+  const snippet = truncateUtf16Safe(text.substring(windowStart, windowEnd), maxChars);
+  const snippetLines = (snippet.match(/\n/g) || []).length;
+  return { snippet, offsetLines, snippetLines };
 }
-
 
 export type SearchSource = string;
 
@@ -214,12 +219,17 @@ export async function searchVector(params: {
       dist: number;
     }>;
     return rows.map((row) => {
-      const { snippet, offsetLines } = extractRelevantSnippet(row.text, params.queryText, params.snippetMaxChars);
+      const { snippet, offsetLines, snippetLines } = extractRelevantSnippet(
+        row.text,
+        params.queryText,
+        params.snippetMaxChars,
+      );
+      const adjustedStart = row.start_line + offsetLines;
       return {
         id: row.id,
         path: row.path,
-        startLine: row.start_line + offsetLines,
-        endLine: row.end_line,
+        startLine: adjustedStart,
+        endLine: adjustedStart + snippetLines,
         score: 1 - row.dist,
         snippet,
         source: row.source,
@@ -242,16 +252,17 @@ export async function searchVector(params: {
     .toSorted((a, b) => b.score - a.score)
     .slice(0, params.limit)
     .map((entry) => {
-      const { snippet, offsetLines } = extractRelevantSnippet(
+      const { snippet, offsetLines, snippetLines } = extractRelevantSnippet(
         entry.chunk.text,
         params.queryText,
         params.snippetMaxChars,
       );
+      const adjustedStart = entry.chunk.startLine + offsetLines;
       return {
         id: entry.chunk.id,
         path: entry.chunk.path,
-        startLine: entry.chunk.startLine + offsetLines,
-        endLine: entry.chunk.endLine,
+        startLine: adjustedStart,
+        endLine: adjustedStart + snippetLines,
         score: entry.score,
         snippet,
         source: entry.chunk.source,
@@ -370,12 +381,17 @@ export async function searchKeyword(params: {
           ftsScore: textScore,
         })
       : textScore;
-    const { snippet, offsetLines } = extractRelevantSnippet(row.text, params.query, params.snippetMaxChars);
+    const { snippet, offsetLines, snippetLines } = extractRelevantSnippet(
+      row.text,
+      params.query,
+      params.snippetMaxChars,
+    );
+    const adjustedStart = row.start_line + offsetLines;
     return {
       id: row.id,
       path: row.path,
-      startLine: row.start_line + offsetLines,
-      endLine: row.end_line,
+      startLine: adjustedStart,
+      endLine: adjustedStart + snippetLines,
       score,
       textScore,
       snippet,

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -65,13 +65,22 @@ function extractRelevantSnippet(
   }
 
   // extractKeywords drops pure-numeric tokens (e.g. "404", "2024").
-  // Fall back to raw alphanumeric tokens so numeric queries still anchor.
-  if (queryTerms.length === 0) {
-    queryTerms = query
+  // For mixed queries like "error 404", append numeric tokens that
+  // extractKeywords removed so they can still anchor the snippet.
+  {
+    const rawTokens = query
       .toLowerCase()
       .split(/[^a-z0-9]+/i)
-      .filter((t) => t.length >= 2)
-      .toSorted((a, b) => b.length - a.length);
+      .filter((t) => t.length >= 2);
+    const numericTokens = rawTokens.filter((t) => /^\d+$/.test(t) && !queryTerms.includes(t));
+    if (queryTerms.length === 0) {
+      // Entirely numeric query — use all raw tokens.
+      queryTerms = rawTokens.toSorted((a, b) => b.length - a.length);
+    } else if (numericTokens.length > 0) {
+      // Mixed query — append missing numeric tokens so anchoring
+      // considers them alongside the keyword-extracted terms.
+      queryTerms = [...queryTerms, ...numericTokens.toSorted((a, b) => b.length - a.length)];
+    }
   }
 
   let matchIndex = -1;

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -33,7 +33,17 @@ function extractRelevantSnippet(
   // Use the same tokenizer as the search engine so CJK terms and
   // conversational queries produce correct anchor terms.
   const lowerText = text.toLowerCase();
-  const queryTerms = extractKeywords(query).toSorted((a, b) => b.length - a.length);
+  let queryTerms = extractKeywords(query).toSorted((a, b) => b.length - a.length);
+
+  // extractKeywords drops pure-numeric tokens (e.g. "404", "2024").
+  // Fall back to raw alphanumeric tokens so numeric queries still anchor.
+  if (queryTerms.length === 0) {
+    queryTerms = query
+      .toLowerCase()
+      .split(/[^a-z0-9]+/i)
+      .filter((t) => t.length >= 2)
+      .toSorted((a, b) => b.length - a.length);
+  }
 
   let matchIndex = -1;
 

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -221,6 +221,7 @@ export async function searchVector(params: {
   queryText: string;
   limit: number;
   snippetMaxChars: number;
+  ftsTokenizer?: "unicode61" | "trigram";
   ensureVectorReady: (dimensions: number) => Promise<boolean>;
   sourceFilterVec: { sql: string; params: SearchSource[] };
   sourceFilterChunks: { sql: string; params: SearchSource[] };
@@ -259,6 +260,7 @@ export async function searchVector(params: {
         row.text,
         params.queryText,
         params.snippetMaxChars,
+        params.ftsTokenizer,
       );
       // Session chunks use sparse remapped line numbers (from JSONL lineMap)
       // that are not contiguous, so applying a text-based offset can produce
@@ -308,6 +310,7 @@ export async function searchVector(params: {
         entry.chunk.text,
         params.queryText,
         params.snippetMaxChars,
+        params.ftsTokenizer,
       );
       // Session chunks use sparse remapped line numbers; skip offset adjustment.
       const isSessionSource = entry.chunk.source === "sessions";

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -33,7 +33,7 @@ function extractRelevantSnippet(
   // Use the same tokenizer as the search engine so CJK terms and
   // conversational queries produce correct anchor terms.
   const lowerText = text.toLowerCase();
-  const queryTerms = extractKeywords(query).sort((a, b) => b.length - a.length);
+  const queryTerms = extractKeywords(query).toSorted((a, b) => b.length - a.length);
 
   let matchIndex = -1;
 
@@ -46,13 +46,15 @@ function extractRelevantSnippet(
     }
   }
 
-  // If no match found, fall back to beginning
+  // If no match found, return the full chunk text rather than truncating to
+  // the beginning.  Semantic/vector matches often don't share literal keywords
+  // with the query, so trimming from the start would discard the relevant
+  // section when it appears later in the chunk.
   if (matchIndex === -1) {
-    const fallback = truncateUtf16Safe(text, maxChars);
     return {
-      snippet: fallback,
+      snippet: text,
       offsetLines: 0,
-      snippetLines: (fallback.match(/\n/g) || []).length,
+      snippetLines: (text.match(/\n/g) || []).length,
       anchorFound: false,
     };
   }

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -62,6 +62,21 @@ function extractRelevantSnippet(
     if (full.length > 0 && !queryTerms.includes(full)) {
       queryTerms = [full, ...queryTerms];
     }
+    // For multi-term trigram queries (e.g. "成语接龙 游戏"), the full query
+    // with whitespace may not match verbatim in stored text that lacks the
+    // separator.  Add each individual segment as an anchor candidate so
+    // partial matches can still anchor the snippet.
+    const segments = full
+      .split(/\s+/)
+      .filter((s) => s.length > 0)
+      .sort((a, b) => b.length - a.length);
+    if (segments.length > 1) {
+      for (const seg of segments) {
+        if (!queryTerms.includes(seg)) {
+          queryTerms.push(seg);
+        }
+      }
+    }
   }
 
   // extractKeywords drops pure-numeric tokens (e.g. "404", "2024").

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -234,7 +234,9 @@ export async function searchVector(params: {
       // that are not contiguous, so applying a text-based offset can produce
       // synthetic line numbers that don't exist.  Keep original range for sessions.
       const isSessionSource = row.source === "sessions";
-      const adjustedStart = isSessionSource ? row.start_line : row.start_line + offsetLines;
+      const adjustedStart = isSessionSource
+        ? row.start_line
+        : Math.min(row.start_line + offsetLines, row.end_line);
       // When no anchor was found the snippet is a fallback window; preserve
       // the chunk's full line span so semantic matches later in the text are
       // not excluded.  Always clamp to the chunk's original end_line to
@@ -279,7 +281,7 @@ export async function searchVector(params: {
       const isSessionSource = entry.chunk.source === "sessions";
       const adjustedStart = isSessionSource
         ? entry.chunk.startLine
-        : entry.chunk.startLine + offsetLines;
+        : Math.min(entry.chunk.startLine + offsetLines, entry.chunk.endLine);
       const endLine =
         !isSessionSource && anchorFound
           ? Math.min(adjustedStart + snippetLines, entry.chunk.endLine)
@@ -414,7 +416,9 @@ export async function searchKeyword(params: {
     );
     // Session chunks use sparse remapped line numbers; skip offset adjustment.
     const isSessionSource = row.source === "sessions";
-    const adjustedStart = isSessionSource ? row.start_line : row.start_line + offsetLines;
+    const adjustedStart = isSessionSource
+      ? row.start_line
+      : Math.min(row.start_line + offsetLines, row.end_line);
     const endLine =
       !isSessionSource && anchorFound
         ? Math.min(adjustedStart + snippetLines, row.end_line)

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -147,15 +147,18 @@ export async function searchVector(params: {
       source: SearchSource;
       dist: number;
     }>;
-    return rows.map((row) => ({
-      id: row.id,
-      path: row.path,
-      startLine: row.start_line,
-      endLine: row.end_line,
-      score: 1 - row.dist,
-      snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
-      source: row.source,
-    }));
+    return rows.map((row) => {
+      const { snippet, offsetLines } = extractRelevantSnippet(row.text, params.queryText, params.snippetMaxChars);
+      return {
+        id: row.id,
+        path: row.path,
+        startLine: row.start_line + offsetLines,
+        endLine: row.end_line,
+        score: 1 - row.dist,
+        snippet,
+        source: row.source,
+      };
+    });
   }
 
   const candidates = listChunks({
@@ -172,15 +175,22 @@ export async function searchVector(params: {
   return scored
     .toSorted((a, b) => b.score - a.score)
     .slice(0, params.limit)
-    .map((entry) => ({
-      id: entry.chunk.id,
-      path: entry.chunk.path,
-      startLine: entry.chunk.startLine,
-      endLine: entry.chunk.endLine,
-      score: entry.score,
-      snippet: truncateUtf16Safe(entry.chunk.text, params.snippetMaxChars),
-      source: entry.chunk.source,
-    }));
+    .map((entry) => {
+      const { snippet, offsetLines } = extractRelevantSnippet(
+        entry.chunk.text,
+        params.queryText,
+        params.snippetMaxChars,
+      );
+      return {
+        id: entry.chunk.id,
+        path: entry.chunk.path,
+        startLine: entry.chunk.startLine + offsetLines,
+        endLine: entry.chunk.endLine,
+        score: entry.score,
+        snippet,
+        source: entry.chunk.source,
+      };
+    });
 }
 
 export function listChunks(params: {
@@ -294,14 +304,15 @@ export async function searchKeyword(params: {
           ftsScore: textScore,
         })
       : textScore;
+    const { snippet, offsetLines } = extractRelevantSnippet(row.text, params.query, params.snippetMaxChars);
     return {
       id: row.id,
       path: row.path,
-      startLine: row.start_line,
+      startLine: row.start_line + offsetLines,
       endLine: row.end_line,
       score,
       textScore,
-      snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
+      snippet,
       source: row.source,
     };
   });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -397,7 +397,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     const queryVec = await this.embedQueryWithTimeout(cleaned);
     const hasVector = queryVec.some((v) => v !== 0);
     const vectorResults = hasVector
-      ? await this.searchVector(queryVec, candidates).catch(() => [])
+      ? await this.searchVector(queryVec, cleaned, candidates).catch(() => [])
       : [];
 
     if (!hybrid.enabled || !this.fts.enabled || !this.fts.available) {
@@ -472,6 +472,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
   private async searchVector(
     queryVec: number[],
+    queryText: string,
     limit: number,
   ): Promise<Array<MemorySearchResult & { id: string }>> {
     // This method should never be called without a provider
@@ -483,6 +484,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       vectorTable: VECTOR_TABLE,
       providerModel: this.provider.model,
       queryVec,
+      queryText,
       limit,
       snippetMaxChars: SNIPPET_MAX_CHARS,
       ensureVectorReady: async (dimensions) => await this.ensureVectorReady(dimensions),

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -487,6 +487,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       queryText,
       limit,
       snippetMaxChars: SNIPPET_MAX_CHARS,
+      ftsTokenizer: this.settings.store.fts.tokenizer,
       ensureVectorReady: async (dimensions) => await this.ensureVectorReady(dimensions),
       sourceFilterVec: this.buildSourceFilter("c"),
       sourceFilterChunks: this.buildSourceFilter(),


### PR DESCRIPTION
## Summary
- Fix memory search to show relevant snippet window around matched query terms instead of always showing the file beginning
- When a chunk contains matching content deep in its text, the snippet now extracts a window centered on the match
- Add regression test to verify correct snippet extraction for content at line 50+ in a file

## Changes
- `src/memory/manager-search.ts`: Add `extractRelevantSnippet()` helper that finds query terms and extracts a centered window
- `src/memory/manager.ts`: Pass query text to searchVector for snippet extraction
- `src/memory/index.test.ts`: Add regression test for #47730

## Test plan
- [x] New regression test passes: searches for "UniqueDeepContentMarker" on line 50 and verifies snippet contains the marker
- [x] All existing memory tests pass
- [x] oxlint passes on changed files

Fixes #47730