### PR TITLE
Auto-reply: allow message tool for non-text content

### DIFF
--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -133,7 +133,7 @@ export function buildGroupChatContext(params: { sessionCtx: TemplateContext }): 
     lines.push(`Participants: ${members}.`);
   }
   lines.push(
-    "Your replies are automatically sent to this group chat. Reply normally, and only use the message tool when you need to send non-text content.",
+    "Your replies are automatically sent to this group chat. Reply normally, and only use the message tool to send attachments, images, audio, video, or files.",
   );
   return lines.join(" ");
 }

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -133,7 +133,7 @@ export function buildGroupChatContext(params: { sessionCtx: TemplateContext }): 
     lines.push(`Participants: ${members}.`);
   }
   lines.push(
-    "Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group — just reply normally.",
+    "Your replies are automatically sent to this group chat. Reply normally, and only use the message tool when you need to send non-text content.",
   );
   return lines.join(" ");
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: 群聊系统提示语禁止使用 message tool，导致附件/非文本内容无法发送。
- Why it matters: 群聊场景需要允许发送附件或非纯文本内容。
- What changed: 放宽提示语，允许在发送非文本内容时使用 message tool。
- What did NOT change (scope boundary): 业务逻辑与发送流程未改动，仅提示语文本变更。

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

群聊提示语改为：默认直接回复，仅在需要发送非文本内容时使用 message tool。

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: 未记录
- Runtime/container: 未记录
- Model/provider: 未记录
- Integration/channel (if any): 未记录
- Relevant config (redacted): 未记录

### Steps

1. 不适用
2. 不适用
3. 不适用

### Expected

- 允许在发送非文本内容时使用 message tool。

### Actual

- 与期望一致。

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: 未手动验证
- Edge cases checked: 未手动验证
- What you did **not** verify: 未进行运行时验证或端到端验证

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: 回滚该提交即可恢复旧提示语。
- Files/config to restore: src/auto-reply/reply/groups.ts
- Known bad symptoms reviewers should watch for: 群聊中再次无法发送附件。

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: 模型误解“非文本内容”的范围。
  - Mitigation: 如需更严格限定，进一步明确“附件/图片/文件”等具体类型。
