### PR TITLE
feat(msteams): add DefaultAzureCredential auth type for passwordless Teams auth

### DIFF
--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -4,6 +4,7 @@
   "description": "OpenClaw Microsoft Teams channel plugin",
   "type": "module",
   "dependencies": {
+    "@azure/identity": "^4.9.1",
     "@microsoft/agents-hosting": "^1.3.1",
     "express": "^5.2.1"
   },
@@ -31,6 +32,7 @@
     },
     "releaseChecks": {
       "rootDependencyMirrorAllowlist": [
+        "@azure/identity",
         "@microsoft/agents-hosting"
       ]
     }

--- a/extensions/msteams/src/errors.test.ts
+++ b/extensions/msteams/src/errors.test.ts
@@ -41,6 +41,8 @@ describe("msteams errors", () => {
 
   it("provides actionable hints for common cases", () => {
     expect(formatMSTeamsSendErrorHint({ kind: "auth" })).toContain("msteams");
+    expect(formatMSTeamsSendErrorHint({ kind: "auth" })).toContain("MSTEAMS_APP_ID");
+    expect(formatMSTeamsSendErrorHint({ kind: "auth" })).toContain("MSTEAMS_TENANT_ID");
     expect(formatMSTeamsSendErrorHint({ kind: "throttled" })).toContain("throttled");
   });
 

--- a/extensions/msteams/src/errors.ts
+++ b/extensions/msteams/src/errors.ts
@@ -193,7 +193,7 @@ export function formatMSTeamsSendErrorHint(
   classification: MSTeamsSendErrorClassification,
 ): string | undefined {
   if (classification.kind === "auth") {
-    return "check msteams appId/tenantId and auth config (appPassword, certificate, or federated credential)";
+    return "check msteams appId/tenantId (or env MSTEAMS_APP_ID/MSTEAMS_TENANT_ID) and auth config (appPassword, certificate, or federated credential)";
   }
   if (classification.kind === "throttled") {
     return "Teams throttled the bot; backing off may help";

--- a/extensions/msteams/src/errors.ts
+++ b/extensions/msteams/src/errors.ts
@@ -193,7 +193,7 @@ export function formatMSTeamsSendErrorHint(
   classification: MSTeamsSendErrorClassification,
 ): string | undefined {
   if (classification.kind === "auth") {
-    return "check msteams appId/appPassword/tenantId (or env vars MSTEAMS_APP_ID/MSTEAMS_APP_PASSWORD/MSTEAMS_TENANT_ID)";
+    return "check msteams appId/tenantId and auth config (appPassword, certificate, or federated credential)";
   }
   if (classification.kind === "throttled") {
     return "Teams throttled the bot; backing off may help";

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -1,6 +1,6 @@
 import type { MSTeamsConfig } from "openclaw/plugin-sdk/msteams";
 import { GRAPH_ROOT } from "./attachments/shared.js";
-import { loadMSTeamsSdkWithAuth } from "./sdk.js";
+import { createTokenProvider, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { readAccessToken } from "./token-response.js";
 import { resolveMSTeamsCredentials } from "./token.js";
 
@@ -57,7 +57,7 @@ export async function resolveGraphToken(cfg: unknown): Promise<string> {
     throw new Error("MS Teams credentials missing");
   }
   const { sdk, authConfig } = await loadMSTeamsSdkWithAuth(creds);
-  const tokenProvider = new sdk.MsalTokenProvider(authConfig);
+  const tokenProvider = createTokenProvider(creds, authConfig, sdk);
   const token = await tokenProvider.getAccessToken("https://graph.microsoft.com");
   const accessToken = readAccessToken(token);
   if (!accessToken) {

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -112,6 +112,7 @@ vi.mock("./resolve-allowlist.js", () => ({
 
 vi.mock("./sdk.js", () => ({
   createMSTeamsAdapter: () => createMSTeamsAdapter(),
+  createTokenProvider: () => ({ getAccessToken: vi.fn(async () => "mock-token") }),
   loadMSTeamsSdkWithAuth: () => loadMSTeamsSdkWithAuth(),
 }));
 

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -19,7 +19,7 @@ import {
   resolveMSTeamsUserAllowlist,
 } from "./resolve-allowlist.js";
 import { getMSTeamsRuntime } from "./runtime.js";
-import { createMSTeamsAdapter, loadMSTeamsSdkWithAuth } from "./sdk.js";
+import { createMSTeamsAdapter, createTokenProvider, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { resolveMSTeamsCredentials } from "./token.js";
 
 export type MonitorMSTeamsOpts = {
@@ -248,10 +248,10 @@ export async function monitorMSTeamsProvider(
   const express = await import("express");
 
   const { sdk, authConfig } = await loadMSTeamsSdkWithAuth(creds);
-  const { ActivityHandler, MsalTokenProvider, authorizeJWT } = sdk;
+  const { ActivityHandler, authorizeJWT } = sdk;
 
   // Auth configuration - create early so adapter is available for deliverReplies
-  const tokenProvider = new MsalTokenProvider(authConfig);
+  const tokenProvider = createTokenProvider(creds, authConfig, sdk);
   const adapter = createMSTeamsAdapter(authConfig, sdk);
 
   const handler = registerMSTeamsHandlers(new ActivityHandler() as MSTeamsActivityHandler, {

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -4,7 +4,7 @@ import {
   type MSTeamsConfig,
 } from "openclaw/plugin-sdk/msteams";
 import { formatUnknownError } from "./errors.js";
-import { loadMSTeamsSdkWithAuth } from "./sdk.js";
+import { createTokenProvider, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { readAccessToken } from "./token-response.js";
 import { resolveMSTeamsCredentials } from "./token.js";
 
@@ -66,7 +66,7 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
 
   try {
     const { sdk, authConfig } = await loadMSTeamsSdkWithAuth(creds);
-    const tokenProvider = new sdk.MsalTokenProvider(authConfig);
+    const tokenProvider = createTokenProvider(creds, authConfig, sdk);
     await tokenProvider.getAccessToken("https://api.botframework.com");
     let graph:
       | {

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -60,7 +60,7 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
     return {
       ok: false,
       error:
-        "missing credentials (appId, tenantId, and one of: appPassword, certificate, or federated credential)",
+        "missing credentials (appId, tenantId — or env MSTEAMS_APP_ID/MSTEAMS_TENANT_ID — and one of: appPassword, certificate, or federated credential)",
     };
   }
 

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -59,7 +59,8 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
   if (!creds) {
     return {
       ok: false,
-      error: "missing credentials (appId, appPassword, tenantId)",
+      error:
+        "missing credentials (appId, tenantId, and one of: appPassword, certificate, or federated credential)",
     };
   }
 

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -4,6 +4,52 @@ import type { MSTeamsCredentials } from "./token.js";
 export type MSTeamsSdk = typeof import("@microsoft/agents-hosting");
 export type MSTeamsAuthConfig = ReturnType<MSTeamsSdk["getAuthConfigWithDefaults"]>;
 
+/**
+ * Token provider that wraps @azure/identity's DefaultAzureCredential.
+ * Implements the same getAccessToken(scope) interface as MsalTokenProvider
+ * so it can be used as a drop-in replacement throughout the plugin.
+ *
+ * Accepts appId (clientId) and tenantId so the credential targets the
+ * correct bot identity — required for workload identity and user-assigned
+ * managed identity where multiple identities may be available.
+ */
+export class DefaultAzureCredentialTokenProvider {
+  private credential: import("@azure/identity").DefaultAzureCredential | undefined;
+  private readonly clientId: string;
+  private readonly tenantId: string;
+
+  constructor(clientId: string, tenantId: string) {
+    this.clientId = clientId;
+    this.tenantId = tenantId;
+  }
+
+  /**
+   * Acquire a token for the given resource. Callers pass resource URIs
+   * (e.g. "https://graph.microsoft.com"), which are normalized to AAD
+   * scopes ("https://graph.microsoft.com/.default") as required by
+   * @azure/identity's getToken().
+   */
+  async getAccessToken(resource: string) {
+    if (!this.credential) {
+      const { DefaultAzureCredential } = await import("@azure/identity");
+      this.credential = new DefaultAzureCredential({
+        managedIdentityClientId: this.clientId,
+        workloadIdentityClientId: this.clientId,
+        tenantId: this.tenantId,
+      });
+    }
+    // Normalize resource URI to AAD scope — MsalTokenProvider accepts bare
+    // resource URIs but DefaultAzureCredential.getToken() requires scopes.
+    const scope = resource.endsWith("/.default")
+      ? resource
+      : `${resource.replace(/\/+$/, "")}/.default`;
+    const token = await this.credential.getToken(scope);
+    if (!token)
+      throw new Error(`DefaultAzureCredential: failed to acquire token for scope ${scope}`);
+    return token.token;
+  }
+}
+
 export async function loadMSTeamsSdk(): Promise<MSTeamsSdk> {
   return await import("@microsoft/agents-hosting");
 }
@@ -27,6 +73,10 @@ export function buildMSTeamsAuthConfig(
       if (creds.ficClientId) base.FICClientId = creds.ficClientId;
       if (creds.widAssertionFile) base.WIDAssertionFile = creds.widAssertionFile;
       break;
+    case "defaultAzureCredential":
+      // No additional fields needed — DAC handles credential discovery.
+      // The SDK still needs clientId/tenantId for audience validation.
+      break;
     case "clientSecret":
     default:
       if (creds.appPassword) base.clientSecret = creds.appPassword;
@@ -34,6 +84,21 @@ export function buildMSTeamsAuthConfig(
   }
 
   return sdk.getAuthConfigWithDefaults(base);
+}
+
+/**
+ * Create the appropriate token provider based on auth type.
+ * For defaultAzureCredential, returns our DAC wrapper instead of MsalTokenProvider.
+ */
+export function createTokenProvider(
+  creds: MSTeamsCredentials,
+  authConfig: MSTeamsAuthConfig,
+  sdk: MSTeamsSdk,
+) {
+  if (creds.authType === "defaultAzureCredential") {
+    return new DefaultAzureCredentialTokenProvider(creds.appId, creds.tenantId);
+  }
+  return new sdk.MsalTokenProvider(authConfig);
 }
 
 export function createMSTeamsAdapter(
@@ -46,5 +111,5 @@ export function createMSTeamsAdapter(
 export async function loadMSTeamsSdkWithAuth(creds: MSTeamsCredentials) {
   const sdk = await loadMSTeamsSdk();
   const authConfig = buildMSTeamsAuthConfig(creds, sdk);
-  return { sdk, authConfig };
+  return { sdk, authConfig, creds };
 }

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -12,11 +12,28 @@ export function buildMSTeamsAuthConfig(
   creds: MSTeamsCredentials,
   sdk: MSTeamsSdk,
 ): MSTeamsAuthConfig {
-  return sdk.getAuthConfigWithDefaults({
+  const base: Parameters<MSTeamsSdk["getAuthConfigWithDefaults"]>[0] = {
     clientId: creds.appId,
-    clientSecret: creds.appPassword,
     tenantId: creds.tenantId,
-  });
+  };
+
+  switch (creds.authType) {
+    case "certificate":
+      base.certPemFile = creds.certPemFile;
+      base.certKeyFile = creds.certKeyFile;
+      if (creds.sendX5C != null) base.sendX5C = creds.sendX5C;
+      break;
+    case "federatedCredential":
+      if (creds.ficClientId) base.FICClientId = creds.ficClientId;
+      if (creds.widAssertionFile) base.WIDAssertionFile = creds.widAssertionFile;
+      break;
+    case "clientSecret":
+    default:
+      base.clientSecret = creds.appPassword;
+      break;
+  }
+
+  return sdk.getAuthConfigWithDefaults(base);
 }
 
 export function createMSTeamsAdapter(

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -19,8 +19,8 @@ export function buildMSTeamsAuthConfig(
 
   switch (creds.authType) {
     case "certificate":
-      base.certPemFile = creds.certPemFile;
-      base.certKeyFile = creds.certKeyFile;
+      if (creds.certPemFile) base.certPemFile = creds.certPemFile;
+      if (creds.certKeyFile) base.certKeyFile = creds.certKeyFile;
       if (creds.sendX5C != null) base.sendX5C = creds.sendX5C;
       break;
     case "federatedCredential":

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -29,7 +29,7 @@ export function buildMSTeamsAuthConfig(
       break;
     case "clientSecret":
     default:
-      base.clientSecret = creds.appPassword;
+      if (creds.appPassword) base.clientSecret = creds.appPassword;
       break;
   }
 

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -73,10 +73,15 @@ export function buildMSTeamsAuthConfig(
       if (creds.ficClientId) base.FICClientId = creds.ficClientId;
       if (creds.widAssertionFile) base.WIDAssertionFile = creds.widAssertionFile;
       break;
-    case "defaultAzureCredential":
-      // No additional fields needed — DAC handles credential discovery.
-      // The SDK still needs clientId/tenantId for audience validation.
+    case "defaultAzureCredential": {
+      // Detect AKS workload identity and pass through to SDK's native WID support.
+      // AZURE_FEDERATED_TOKEN_FILE is injected by the Azure Workload Identity webhook.
+      const widAssertionFile = process.env.AZURE_FEDERATED_TOKEN_FILE;
+      if (widAssertionFile) {
+        base.WIDAssertionFile = widAssertionFile;
+      }
       break;
+    }
     case "clientSecret":
     default:
       if (creds.appPassword) base.clientSecret = creds.appPassword;
@@ -96,6 +101,13 @@ export function createTokenProvider(
   sdk: MSTeamsSdk,
 ) {
   if (creds.authType === "defaultAzureCredential") {
+    // When WIDAssertionFile is set (AKS workload identity), the SDK's native
+    // MsalTokenProvider handles token acquisition via client assertion.
+    // Fall back to @azure/identity DefaultAzureCredential for other environments
+    // (local dev with az cli, managed identity without federation, etc.).
+    if (authConfig.WIDAssertionFile) {
+      return new sdk.MsalTokenProvider(authConfig);
+    }
     return new DefaultAzureCredentialTokenProvider(creds.appId, creds.tenantId);
   }
   return new sdk.MsalTokenProvider(authConfig);

--- a/extensions/msteams/src/send-context.ts
+++ b/extensions/msteams/src/send-context.ts
@@ -11,7 +11,7 @@ import type {
 } from "./conversation-store.js";
 import type { MSTeamsAdapter } from "./messenger.js";
 import { getMSTeamsRuntime } from "./runtime.js";
-import { createMSTeamsAdapter, loadMSTeamsSdkWithAuth } from "./sdk.js";
+import { createMSTeamsAdapter, createTokenProvider, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { resolveMSTeamsCredentials } from "./token.js";
 
 export type MSTeamsConversationType = "personal" | "groupChat" | "channel";
@@ -127,7 +127,7 @@ export async function resolveMSTeamsSendContext(params: {
   const adapter = createMSTeamsAdapter(authConfig, sdk);
 
   // Create token provider for Graph API / OneDrive operations
-  const tokenProvider = new sdk.MsalTokenProvider(authConfig) as MSTeamsAccessTokenProvider;
+  const tokenProvider = createTokenProvider(creds, authConfig, sdk) as MSTeamsAccessTokenProvider;
 
   // Determine conversation type from stored reference
   const storedConversationType = ref.conversation?.conversationType?.toLowerCase() ?? "";

--- a/extensions/msteams/src/setup-surface.ts
+++ b/extensions/msteams/src/setup-surface.ts
@@ -374,6 +374,14 @@ export const msteamsSetupWizard: ChannelSetupWizard = {
             appId,
             appPassword,
             tenantId,
+            // Reset auth type and related fields when re-entering credentials
+            // as client secret — otherwise the old authType takes precedence.
+            authType: "clientSecret",
+            certPemFile: undefined,
+            certKeyFile: undefined,
+            sendX5C: undefined,
+            ficClientId: undefined,
+            widAssertionFile: undefined,
           },
         },
       };

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -37,7 +37,77 @@ describe("resolveMSTeamsCredentials", () => {
       appId: "app-id",
       appPassword: "app-password", // pragma: allowlist secret
       tenantId: "tenant-id",
+      authType: "clientSecret",
     });
+  });
+
+  it("defaults to clientSecret when authType is not specified", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      appPassword: "secret",
+      tenantId: "tenant-id",
+    });
+
+    expect(resolved?.authType).toBe("clientSecret");
+  });
+
+  it("resolves certificate credentials", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "certificate",
+      certPemFile: "/path/to/cert.pem",
+      certKeyFile: "/path/to/key.pem",
+    });
+
+    expect(resolved?.authType).toBe("certificate");
+    expect(resolved?.certPemFile).toBe("/path/to/cert.pem");
+    expect(resolved?.certKeyFile).toBe("/path/to/key.pem");
+  });
+
+  it("returns undefined for certificate auth missing certKeyFile", () => {
+    expect(
+      resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+        certPemFile: "/path/to/cert.pem",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("resolves federated credentials with ficClientId", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "federatedCredential",
+      ficClientId: "fic-client-id",
+    });
+
+    expect(resolved?.authType).toBe("federatedCredential");
+    expect(resolved?.ficClientId).toBe("fic-client-id");
+  });
+
+  it("resolves federated credentials with widAssertionFile", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "federatedCredential",
+      widAssertionFile: "/var/run/secrets/azure/tokens/azure-identity-token",
+    });
+
+    expect(resolved?.authType).toBe("federatedCredential");
+    expect(resolved?.widAssertionFile).toBe("/var/run/secrets/azure/tokens/azure-identity-token");
+  });
+
+  it("returns undefined for federated auth with neither ficClientId nor widAssertionFile", () => {
+    expect(
+      resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "federatedCredential",
+      }),
+    ).toBeUndefined();
   });
 
   it("throws when appPassword remains an unresolved SecretRef object", () => {
@@ -68,5 +138,48 @@ describe("hasConfiguredMSTeamsCredentials", () => {
     });
 
     expect(configured).toBe(true);
+  });
+
+  it("detects certificate auth as configured", () => {
+    expect(
+      hasConfiguredMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+        certPemFile: "/path/to/cert.pem",
+        certKeyFile: "/path/to/key.pem",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects certificate auth missing cert files", () => {
+    expect(
+      hasConfiguredMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+      }),
+    ).toBe(false);
+  });
+
+  it("detects federated credential auth as configured", () => {
+    expect(
+      hasConfiguredMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "federatedCredential",
+        ficClientId: "fic-client-id",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects federated auth with no credential source", () => {
+    expect(
+      hasConfiguredMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "federatedCredential",
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -66,16 +66,48 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.appPassword).toBeUndefined();
   });
 
-  it("resolves certificate auth without config cert fields (SDK env fallback)", () => {
-    const resolved = resolveMSTeamsCredentials({
-      appId: "app-id",
-      tenantId: "tenant-id",
-      authType: "certificate",
-    });
+  it("resolves certificate auth via SDK plain env vars", () => {
+    process.env.certPemFile = "/env/cert.pem";
+    process.env.certKeyFile = "/env/key.pem";
+    try {
+      const resolved = resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+      });
 
-    expect(resolved?.authType).toBe("certificate");
-    expect(resolved?.certPemFile).toBeUndefined();
-    expect(resolved?.certKeyFile).toBeUndefined();
+      expect(resolved?.authType).toBe("certificate");
+    } finally {
+      delete process.env.certPemFile;
+      delete process.env.certKeyFile;
+    }
+  });
+
+  it("resolves certificate auth with mixed config/env sources", () => {
+    process.env.certKeyFile = "/env/key.pem";
+    try {
+      const resolved = resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+        certPemFile: "/config/cert.pem",
+      });
+
+      expect(resolved?.authType).toBe("certificate");
+      expect(resolved?.certPemFile).toBe("/config/cert.pem");
+    } finally {
+      delete process.env.certKeyFile;
+    }
+  });
+
+  it("returns undefined for certificate auth with no auth material anywhere", () => {
+    expect(
+      resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "certificate",
+      }),
+    ).toBeUndefined();
   });
 
   it("resolves federated credentials with ficClientId", () => {
@@ -103,16 +135,29 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.widAssertionFile).toBe("/var/run/secrets/azure/tokens/azure-identity-token");
   });
 
-  it("resolves federated auth without config fields (SDK env fallback)", () => {
-    const resolved = resolveMSTeamsCredentials({
-      appId: "app-id",
-      tenantId: "tenant-id",
-      authType: "federatedCredential",
-    });
+  it("resolves federated auth via SDK plain env vars", () => {
+    process.env.FICClientId = "env-fic-id";
+    try {
+      const resolved = resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "federatedCredential",
+      });
 
-    expect(resolved?.authType).toBe("federatedCredential");
-    expect(resolved?.ficClientId).toBeUndefined();
-    expect(resolved?.widAssertionFile).toBeUndefined();
+      expect(resolved?.authType).toBe("federatedCredential");
+    } finally {
+      delete process.env.FICClientId;
+    }
+  });
+
+  it("returns undefined for federated auth with no auth material anywhere", () => {
+    expect(
+      resolveMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "federatedCredential",
+      }),
+    ).toBeUndefined();
   });
 
   it("throws when appPassword remains an unresolved SecretRef object", () => {
@@ -157,14 +202,31 @@ describe("hasConfiguredMSTeamsCredentials", () => {
     ).toBe(true);
   });
 
-  it("treats certificate auth as configured even without cert files (SDK env fallback)", () => {
+  it("detects certificate auth via SDK plain env vars", () => {
+    process.env.certPemFile = "/env/cert.pem";
+    process.env.certKeyFile = "/env/key.pem";
+    try {
+      expect(
+        hasConfiguredMSTeamsCredentials({
+          appId: "app-id",
+          tenantId: "tenant-id",
+          authType: "certificate",
+        }),
+      ).toBe(true);
+    } finally {
+      delete process.env.certPemFile;
+      delete process.env.certKeyFile;
+    }
+  });
+
+  it("rejects certificate auth with no auth material anywhere", () => {
     expect(
       hasConfiguredMSTeamsCredentials({
         appId: "app-id",
         tenantId: "tenant-id",
         authType: "certificate",
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("detects federated credential auth as configured", () => {
@@ -178,13 +240,28 @@ describe("hasConfiguredMSTeamsCredentials", () => {
     ).toBe(true);
   });
 
-  it("treats federated auth as configured even without config fields (SDK env fallback)", () => {
+  it("detects federated auth via SDK plain env vars", () => {
+    process.env.WIDAssertionFile = "/var/run/token";
+    try {
+      expect(
+        hasConfiguredMSTeamsCredentials({
+          appId: "app-id",
+          tenantId: "tenant-id",
+          authType: "federatedCredential",
+        }),
+      ).toBe(true);
+    } finally {
+      delete process.env.WIDAssertionFile;
+    }
+  });
+
+  it("rejects federated auth with no auth material anywhere", () => {
     expect(
       hasConfiguredMSTeamsCredentials({
         appId: "app-id",
         tenantId: "tenant-id",
         authType: "federatedCredential",
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -66,15 +66,16 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.appPassword).toBeUndefined();
   });
 
-  it("returns undefined for certificate auth missing certKeyFile", () => {
-    expect(
-      resolveMSTeamsCredentials({
-        appId: "app-id",
-        tenantId: "tenant-id",
-        authType: "certificate",
-        certPemFile: "/path/to/cert.pem",
-      }),
-    ).toBeUndefined();
+  it("resolves certificate auth without config cert fields (SDK env fallback)", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "certificate",
+    });
+
+    expect(resolved?.authType).toBe("certificate");
+    expect(resolved?.certPemFile).toBeUndefined();
+    expect(resolved?.certKeyFile).toBeUndefined();
   });
 
   it("resolves federated credentials with ficClientId", () => {
@@ -102,14 +103,16 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.widAssertionFile).toBe("/var/run/secrets/azure/tokens/azure-identity-token");
   });
 
-  it("returns undefined for federated auth with neither ficClientId nor widAssertionFile", () => {
-    expect(
-      resolveMSTeamsCredentials({
-        appId: "app-id",
-        tenantId: "tenant-id",
-        authType: "federatedCredential",
-      }),
-    ).toBeUndefined();
+  it("resolves federated auth without config fields (SDK env fallback)", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "federatedCredential",
+    });
+
+    expect(resolved?.authType).toBe("federatedCredential");
+    expect(resolved?.ficClientId).toBeUndefined();
+    expect(resolved?.widAssertionFile).toBeUndefined();
   });
 
   it("throws when appPassword remains an unresolved SecretRef object", () => {
@@ -154,14 +157,14 @@ describe("hasConfiguredMSTeamsCredentials", () => {
     ).toBe(true);
   });
 
-  it("rejects certificate auth missing cert files", () => {
+  it("treats certificate auth as configured even without cert files (SDK env fallback)", () => {
     expect(
       hasConfiguredMSTeamsCredentials({
         appId: "app-id",
         tenantId: "tenant-id",
         authType: "certificate",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("detects federated credential auth as configured", () => {
@@ -175,13 +178,13 @@ describe("hasConfiguredMSTeamsCredentials", () => {
     ).toBe(true);
   });
 
-  it("rejects federated auth with no credential source", () => {
+  it("treats federated auth as configured even without config fields (SDK env fallback)", () => {
     expect(
       hasConfiguredMSTeamsCredentials({
         appId: "app-id",
         tenantId: "tenant-id",
         authType: "federatedCredential",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -164,6 +164,19 @@ describe("resolveMSTeamsCredentials", () => {
     ).toBeUndefined();
   });
 
+  it("resolves defaultAzureCredential with only appId and tenantId", () => {
+    const resolved = resolveMSTeamsCredentials({
+      appId: "app-id",
+      tenantId: "tenant-id",
+      authType: "defaultAzureCredential",
+    });
+
+    expect(resolved?.authType).toBe("defaultAzureCredential");
+    expect(resolved?.appId).toBe("app-id");
+    expect(resolved?.tenantId).toBe("tenant-id");
+    expect(resolved?.appPassword).toBeUndefined();
+  });
+
   it("throws when appPassword remains an unresolved SecretRef object", () => {
     expect(() =>
       resolveMSTeamsCredentials({
@@ -267,5 +280,15 @@ describe("hasConfiguredMSTeamsCredentials", () => {
         authType: "federatedCredential",
       }),
     ).toBe(false);
+  });
+
+  it("detects defaultAzureCredential as configured with only appId and tenantId", () => {
+    expect(
+      hasConfiguredMSTeamsCredentials({
+        appId: "app-id",
+        tenantId: "tenant-id",
+        authType: "defaultAzureCredential",
+      }),
+    ).toBe(true);
   });
 });

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -77,6 +77,10 @@ describe("resolveMSTeamsCredentials", () => {
       });
 
       expect(resolved?.authType).toBe("certificate");
+      // Env-only cert paths are not forwarded in credentials — the SDK
+      // merges them from env at runtime via getAuthConfigWithDefaults().
+      expect(resolved?.certPemFile).toBeUndefined();
+      expect(resolved?.certKeyFile).toBeUndefined();
     } finally {
       delete process.env.certPemFile;
       delete process.env.certKeyFile;

--- a/extensions/msteams/src/token.test.ts
+++ b/extensions/msteams/src/token.test.ts
@@ -51,7 +51,7 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.authType).toBe("clientSecret");
   });
 
-  it("resolves certificate credentials", () => {
+  it("resolves certificate credentials without appPassword", () => {
     const resolved = resolveMSTeamsCredentials({
       appId: "app-id",
       tenantId: "tenant-id",
@@ -63,6 +63,7 @@ describe("resolveMSTeamsCredentials", () => {
     expect(resolved?.authType).toBe("certificate");
     expect(resolved?.certPemFile).toBe("/path/to/cert.pem");
     expect(resolved?.certKeyFile).toBe("/path/to/key.pem");
+    expect(resolved?.appPassword).toBeUndefined();
   });
 
   it("returns undefined for certificate auth missing certKeyFile", () => {
@@ -86,6 +87,7 @@ describe("resolveMSTeamsCredentials", () => {
 
     expect(resolved?.authType).toBe("federatedCredential");
     expect(resolved?.ficClientId).toBe("fic-client-id");
+    expect(resolved?.appPassword).toBeUndefined();
   });
 
   it("resolves federated credentials with widAssertionFile", () => {

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -5,7 +5,8 @@ import {
   normalizeSecretInputString,
 } from "./secret-input.js";
 
-export type MSTeamsAuthType = "clientSecret" | "certificate" | "federatedCredential";
+/** Derived from MSTeamsConfig.authType to keep a single source of truth. */
+export type MSTeamsAuthType = NonNullable<MSTeamsConfig["authType"]>;
 
 export type MSTeamsCredentials = {
   appId: string;

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -9,7 +9,7 @@ export type MSTeamsAuthType = "clientSecret" | "certificate" | "federatedCredent
 
 export type MSTeamsCredentials = {
   appId: string;
-  appPassword: string;
+  appPassword?: string;
   tenantId: string;
   authType: MSTeamsAuthType;
   certPemFile?: string;
@@ -58,7 +58,6 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
       if (!certPemFile || !certKeyFile) return undefined;
       return {
         appId,
-        appPassword: "", // not used for certificate auth
         tenantId,
         authType,
         certPemFile,
@@ -72,7 +71,6 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
       if (!ficClientId && !widAssertionFile) return undefined;
       return {
         appId,
-        appPassword: "", // not used for federated auth
         tenantId,
         authType,
         ficClientId,

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -5,36 +5,89 @@ import {
   normalizeSecretInputString,
 } from "./secret-input.js";
 
+export type MSTeamsAuthType = "clientSecret" | "certificate" | "federatedCredential";
+
 export type MSTeamsCredentials = {
   appId: string;
   appPassword: string;
   tenantId: string;
+  authType: MSTeamsAuthType;
+  certPemFile?: string;
+  certKeyFile?: string;
+  sendX5C?: boolean;
+  ficClientId?: string;
+  widAssertionFile?: string;
 };
 
 export function hasConfiguredMSTeamsCredentials(cfg?: MSTeamsConfig): boolean {
-  return Boolean(
-    normalizeSecretInputString(cfg?.appId) &&
-    hasConfiguredSecretInput(cfg?.appPassword) &&
-    normalizeSecretInputString(cfg?.tenantId),
-  );
+  const appId = normalizeSecretInputString(cfg?.appId);
+  const tenantId = normalizeSecretInputString(cfg?.tenantId);
+  if (!appId || !tenantId) return false;
+
+  const authType = cfg?.authType ?? "clientSecret";
+
+  switch (authType) {
+    case "certificate":
+      return Boolean(cfg?.certPemFile && cfg?.certKeyFile);
+    case "federatedCredential":
+      return Boolean(cfg?.ficClientId || cfg?.widAssertionFile);
+    case "clientSecret":
+    default:
+      return Boolean(hasConfiguredSecretInput(cfg?.appPassword));
+  }
 }
 
 export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentials | undefined {
   const appId =
     normalizeSecretInputString(cfg?.appId) ||
     normalizeSecretInputString(process.env.MSTEAMS_APP_ID);
-  const appPassword =
-    normalizeResolvedSecretInputString({
-      value: cfg?.appPassword,
-      path: "channels.msteams.appPassword",
-    }) || normalizeSecretInputString(process.env.MSTEAMS_APP_PASSWORD);
   const tenantId =
     normalizeSecretInputString(cfg?.tenantId) ||
     normalizeSecretInputString(process.env.MSTEAMS_TENANT_ID);
 
-  if (!appId || !appPassword || !tenantId) {
+  if (!appId || !tenantId) {
     return undefined;
   }
 
-  return { appId, appPassword, tenantId };
+  const authType: MSTeamsAuthType = cfg?.authType ?? "clientSecret";
+
+  switch (authType) {
+    case "certificate": {
+      const certPemFile = cfg?.certPemFile;
+      const certKeyFile = cfg?.certKeyFile;
+      if (!certPemFile || !certKeyFile) return undefined;
+      return {
+        appId,
+        appPassword: "", // not used for certificate auth
+        tenantId,
+        authType,
+        certPemFile,
+        certKeyFile,
+        sendX5C: cfg?.sendX5C,
+      };
+    }
+    case "federatedCredential": {
+      const ficClientId = cfg?.ficClientId;
+      const widAssertionFile = cfg?.widAssertionFile;
+      if (!ficClientId && !widAssertionFile) return undefined;
+      return {
+        appId,
+        appPassword: "", // not used for federated auth
+        tenantId,
+        authType,
+        ficClientId,
+        widAssertionFile,
+      };
+    }
+    case "clientSecret":
+    default: {
+      const appPassword =
+        normalizeResolvedSecretInputString({
+          value: cfg?.appPassword,
+          path: "channels.msteams.appPassword",
+        }) || normalizeSecretInputString(process.env.MSTEAMS_APP_PASSWORD);
+      if (!appPassword) return undefined;
+      return { appId, appPassword, tenantId, authType: "clientSecret" };
+    }
+  }
 }

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -30,12 +30,18 @@ export type MSTeamsCredentials = {
  * belong to an unrelated Agents SDK connection and cannot be reliably
  * attributed to the Teams channel.
  */
+/** Return trimmed value if non-blank, otherwise undefined. */
+function trimPresence(value: string | undefined | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
 function hasCertificateAuthMaterial(
   cfg?: MSTeamsConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  const hasPem = Boolean(cfg?.certPemFile || env.certPemFile);
-  const hasKey = Boolean(cfg?.certKeyFile || env.certKeyFile);
+  const hasPem = Boolean(trimPresence(cfg?.certPemFile) || trimPresence(env.certPemFile));
+  const hasKey = Boolean(trimPresence(cfg?.certKeyFile) || trimPresence(env.certKeyFile));
   return hasPem && hasKey;
 }
 
@@ -52,7 +58,10 @@ function hasFederatedAuthMaterial(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   return Boolean(
-    cfg?.ficClientId || env.FICClientId || cfg?.widAssertionFile || env.WIDAssertionFile,
+    trimPresence(cfg?.ficClientId) ||
+    trimPresence(env.FICClientId) ||
+    trimPresence(cfg?.widAssertionFile) ||
+    trimPresence(env.WIDAssertionFile),
   );
 }
 
@@ -95,8 +104,8 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
         appId,
         tenantId,
         authType,
-        certPemFile: cfg?.certPemFile,
-        certKeyFile: cfg?.certKeyFile,
+        certPemFile: trimPresence(cfg?.certPemFile),
+        certKeyFile: trimPresence(cfg?.certKeyFile),
         sendX5C: cfg?.sendX5C,
       };
     }
@@ -106,8 +115,8 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
         appId,
         tenantId,
         authType,
-        ficClientId: cfg?.ficClientId,
-        widAssertionFile: cfg?.widAssertionFile,
+        ficClientId: trimPresence(cfg?.ficClientId),
+        widAssertionFile: trimPresence(cfg?.widAssertionFile),
       };
     }
     case "clientSecret":

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -20,6 +20,42 @@ export type MSTeamsCredentials = {
   widAssertionFile?: string;
 };
 
+/**
+ * Check whether certificate auth material is present in typed config
+ * or the SDK's plain env vars. Each field is checked independently so
+ * mixed-source configs (e.g. certPemFile in config, certKeyFile in env)
+ * are accepted — the SDK merges them field-by-field at runtime.
+ *
+ * Does not check connections__*__settings__* env vars because those may
+ * belong to an unrelated Agents SDK connection and cannot be reliably
+ * attributed to the Teams channel.
+ */
+function hasCertificateAuthMaterial(
+  cfg?: MSTeamsConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const hasPem = Boolean(cfg?.certPemFile || env.certPemFile);
+  const hasKey = Boolean(cfg?.certKeyFile || env.certKeyFile);
+  return hasPem && hasKey;
+}
+
+/**
+ * Check whether federated credential auth material is present in typed
+ * config or the SDK's plain env vars. Either FICClientId or
+ * WIDAssertionFile is sufficient.
+ *
+ * Does not check connections__*__settings__* env vars because those may
+ * belong to an unrelated Agents SDK connection.
+ */
+function hasFederatedAuthMaterial(
+  cfg?: MSTeamsConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return Boolean(
+    cfg?.ficClientId || env.FICClientId || cfg?.widAssertionFile || env.WIDAssertionFile,
+  );
+}
+
 export function hasConfiguredMSTeamsCredentials(cfg?: MSTeamsConfig): boolean {
   const appId = normalizeSecretInputString(cfg?.appId);
   const tenantId = normalizeSecretInputString(cfg?.tenantId);
@@ -29,9 +65,9 @@ export function hasConfiguredMSTeamsCredentials(cfg?: MSTeamsConfig): boolean {
 
   switch (authType) {
     case "certificate":
+      return hasCertificateAuthMaterial(cfg);
     case "federatedCredential":
-      // Auth type explicitly set — detail fields may come from SDK env fallbacks.
-      return true;
+      return hasFederatedAuthMaterial(cfg);
     case "clientSecret":
     default:
       return Boolean(hasConfiguredSecretInput(cfg?.appPassword));
@@ -54,8 +90,7 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
 
   switch (authType) {
     case "certificate": {
-      // Config fields are optional — the SDK's getAuthConfigWithDefaults()
-      // can also source certPemFile/certKeyFile from environment variables.
+      if (!hasCertificateAuthMaterial(cfg)) return undefined;
       return {
         appId,
         tenantId,
@@ -66,8 +101,7 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
       };
     }
     case "federatedCredential": {
-      // Config fields are optional — the SDK's getAuthConfigWithDefaults()
-      // can also source ficClientId/widAssertionFile from environment variables.
+      if (!hasFederatedAuthMaterial(cfg)) return undefined;
       return {
         appId,
         tenantId,

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -29,9 +29,9 @@ export function hasConfiguredMSTeamsCredentials(cfg?: MSTeamsConfig): boolean {
 
   switch (authType) {
     case "certificate":
-      return Boolean(cfg?.certPemFile && cfg?.certKeyFile);
     case "federatedCredential":
-      return Boolean(cfg?.ficClientId || cfg?.widAssertionFile);
+      // Auth type explicitly set — detail fields may come from SDK env fallbacks.
+      return true;
     case "clientSecret":
     default:
       return Boolean(hasConfiguredSecretInput(cfg?.appPassword));
@@ -54,28 +54,26 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
 
   switch (authType) {
     case "certificate": {
-      const certPemFile = cfg?.certPemFile;
-      const certKeyFile = cfg?.certKeyFile;
-      if (!certPemFile || !certKeyFile) return undefined;
+      // Config fields are optional — the SDK's getAuthConfigWithDefaults()
+      // can also source certPemFile/certKeyFile from environment variables.
       return {
         appId,
         tenantId,
         authType,
-        certPemFile,
-        certKeyFile,
+        certPemFile: cfg?.certPemFile,
+        certKeyFile: cfg?.certKeyFile,
         sendX5C: cfg?.sendX5C,
       };
     }
     case "federatedCredential": {
-      const ficClientId = cfg?.ficClientId;
-      const widAssertionFile = cfg?.widAssertionFile;
-      if (!ficClientId && !widAssertionFile) return undefined;
+      // Config fields are optional — the SDK's getAuthConfigWithDefaults()
+      // can also source ficClientId/widAssertionFile from environment variables.
       return {
         appId,
         tenantId,
         authType,
-        ficClientId,
-        widAssertionFile,
+        ficClientId: cfg?.ficClientId,
+        widAssertionFile: cfg?.widAssertionFile,
       };
     }
     case "clientSecret":

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -77,6 +77,9 @@ export function hasConfiguredMSTeamsCredentials(cfg?: MSTeamsConfig): boolean {
       return hasCertificateAuthMaterial(cfg);
     case "federatedCredential":
       return hasFederatedAuthMaterial(cfg);
+    case "defaultAzureCredential":
+      // DAC handles its own credential discovery — appId + tenantId is sufficient.
+      return true;
     case "clientSecret":
     default:
       return Boolean(hasConfiguredSecretInput(cfg?.appPassword));
@@ -118,6 +121,11 @@ export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentia
         ficClientId: trimPresence(cfg?.ficClientId),
         widAssertionFile: trimPresence(cfg?.widAssertionFile),
       };
+    }
+    case "defaultAzureCredential": {
+      // DAC defers credential selection to @azure/identity at runtime.
+      // Only appId + tenantId are required from config.
+      return { appId, tenantId, authType };
     }
     case "clientSecret":
     default: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,9 @@ importers:
 
   extensions/msteams:
     dependencies:
+      '@azure/identity':
+        specifier: ^4.9.1
+        version: 4.13.0
       '@microsoft/agents-hosting':
         specifier: ^1.3.1
         version: 1.3.1
@@ -990,13 +993,45 @@ packages:
     resolution: {integrity: sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==}
     engines: {node: '>=20.0.0'}
 
+  '@azure/core-client@1.10.1':
+    resolution: {integrity: sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-rest-pipeline@1.23.0':
+    resolution: {integrity: sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-tracing@1.3.1':
+    resolution: {integrity: sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==}
+    engines: {node: '>=20.0.0'}
+
   '@azure/core-util@1.13.1':
     resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
     engines: {node: '>=20.0.0'}
 
+  '@azure/identity@4.13.0':
+    resolution: {integrity: sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/logger@1.3.0':
+    resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/msal-browser@4.29.1':
+    resolution: {integrity: sha512-1Vrt27du1cl4QHkzLc6L4aeXqliPIDIs5l/1I4hWWMXkXccY/EznJT1+pBdoVze0azTAI8sCyq5B4cBVYG1t9w==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@15.16.1':
+    resolution: {integrity: sha512-qxUG9TCl+TVSSX58onVDHDWrvT5CE0+NeeUAbkQqaESpSm79u5IePLnPWMMjCUnUR2zJd4+Bt9vioVRzLmJb2g==}
+    engines: {node: '>=0.8.0'}
+
   '@azure/msal-common@16.1.0':
     resolution: {integrity: sha512-uiX0ChrRFbreXlPlDR8LwHKmZpJudDAr124iNWJKJ+b7MJUWXmvVU3idSi/c5lk1FwLVZeMxhQir3BGdV09I+g==}
     engines: {node: '>=0.8.0'}
+
+  '@azure/msal-node@3.8.9':
+    resolution: {integrity: sha512-jZ0pw/BbdEUWGhomCaAiVDfXRI/9K56m5hTNqB/CzcbZEYhXm5qpK1cDngN1iXfwSfmUMorOUQ2FC0dyuQ9uRg==}
+    engines: {node: '>=16'}
 
   '@azure/msal-node@5.0.5':
     resolution: {integrity: sha512-CxUYSZgFiviUC3d8Hc+tT7uxre6QkPEWYEHWXmyEBzaO6tfFY4hs5KbXWU6s4q9Zv1NP/04qiR3mcujYLRuYuw==}
@@ -3549,6 +3584,10 @@ packages:
     resolution: {integrity: sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==}
     engines: {node: '>=20.0.0'}
 
+  '@typespec/ts-http-runtime@0.3.4':
+    resolution: {integrity: sha512-CI0NhTrz4EBaa0U+HaaUZrJhPoso8sG7ZFya8uQoBA57fjzrjRSv87ekCjLZOFExN+gXE/z0xuN2QfH4H2HrLQ==}
+    engines: {node: '>=20.0.0'}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -3965,6 +4004,10 @@ packages:
   bun-types@1.3.9:
     resolution: {integrity: sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg==}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -4231,6 +4274,18 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -4858,6 +4913,11 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
@@ -4879,6 +4939,11 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
@@ -4915,6 +4980,10 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -5564,6 +5633,10 @@ packages:
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
     hasBin: true
@@ -6082,6 +6155,10 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -6822,6 +6899,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -7802,6 +7883,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@azure/core-client@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-rest-pipeline@1.23.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@typespec/ts-http-runtime': 0.3.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-tracing@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@azure/core-util@1.13.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
@@ -7810,7 +7919,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@azure/identity@4.13.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@azure/msal-browser': 4.29.1
+      '@azure/msal-node': 3.8.9
+      open: 10.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/logger@1.3.0':
+    dependencies:
+      '@typespec/ts-http-runtime': 0.3.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/msal-browser@4.29.1':
+    dependencies:
+      '@azure/msal-common': 15.16.1
+
+  '@azure/msal-common@15.16.1': {}
+
   '@azure/msal-common@16.1.0': {}
+
+  '@azure/msal-node@3.8.9':
+    dependencies:
+      '@azure/msal-common': 15.16.1
+      jsonwebtoken: 9.0.3
+      uuid: 8.3.2
 
   '@azure/msal-node@5.0.5':
     dependencies:
@@ -10608,6 +10752,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typespec/ts-http-runtime@0.3.4':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@urbit/aura@3.0.0': {}
@@ -11098,6 +11250,10 @@ snapshots:
       '@types/node': 25.5.0
     optional: true
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   bytes@3.1.2: {}
 
   cac@7.0.0: {}
@@ -11345,6 +11501,15 @@ snapshots:
   deep-extend@0.6.0: {}
 
   deepmerge@4.3.1: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
 
   defu@6.1.4: {}
 
@@ -12121,6 +12286,8 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  is-docker@3.0.0: {}
+
   is-electron@2.2.2: {}
 
   is-expression@4.0.0:
@@ -12139,6 +12306,10 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-interactive@2.0.0: {}
 
@@ -12164,6 +12335,10 @@ snapshots:
   is-typedarray@1.0.0: {}
 
   is-unicode-supported@2.1.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isarray@1.0.0: {}
 
@@ -12861,6 +13036,13 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
   openai@6.26.0(ws@8.19.0)(zod@4.3.6):
     optionalDependencies:
       ws: 8.19.0
@@ -13532,6 +13714,8 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -14296,6 +14480,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   xml-name-validator@5.0.0: {}
 

--- a/src/config/types.msteams.ts
+++ b/src/config/types.msteams.ts
@@ -64,6 +64,31 @@ export type MSTeamsConfig = {
   appId?: string;
   /** Azure Bot App Password / Client Secret. */
   appPassword?: SecretInput;
+  /**
+   * Authentication type for the bot.
+   * - "clientSecret" (default): Uses appPassword (client secret).
+   * - "certificate": Uses certPemFile + certKeyFile for certificate-based auth.
+   * - "federatedCredential": Uses FIC (First-party Integration Channel) client ID
+   *   with workload identity federation (no secret needed).
+   */
+  authType?: "clientSecret" | "certificate" | "federatedCredential";
+  /** Path to the certificate PEM file (used when authType is "certificate"). */
+  certPemFile?: string;
+  /** Path to the certificate key file (used when authType is "certificate"). */
+  certKeyFile?: string;
+  /** Whether to send the X5C param for SNI authentication (used with certificate auth). */
+  sendX5C?: boolean;
+  /**
+   * The FIC (First-party Integration Channel) client ID for federated credential auth.
+   * This is the client ID of a user-assigned managed identity with a federated credential
+   * configured on the App Registration.
+   */
+  ficClientId?: string;
+  /**
+   * Path to the workload identity assertion file (e.g., K8s service account token).
+   * Used with federated credential auth when running in Kubernetes or similar environments.
+   */
+  widAssertionFile?: string;
   /** Azure AD Tenant ID (for single-tenant bots). */
   tenantId?: string;
   /** Webhook server configuration. */

--- a/src/config/types.msteams.ts
+++ b/src/config/types.msteams.ts
@@ -70,8 +70,11 @@ export type MSTeamsConfig = {
    * - "certificate": Uses certPemFile + certKeyFile for certificate-based auth.
    * - "federatedCredential": Uses FIC (First-party Integration Channel) client ID
    *   with workload identity federation (no secret needed).
+   * - "defaultAzureCredential": Defers credential selection to @azure/identity's
+   *   DefaultAzureCredential, which tries env vars, workload identity, managed
+   *   identity, az cli, and other sources automatically.
    */
-  authType?: "clientSecret" | "certificate" | "federatedCredential";
+  authType?: "clientSecret" | "certificate" | "federatedCredential" | "defaultAzureCredential";
   /** Path to the certificate PEM file (used when authType is "certificate"). */
   certPemFile?: string;
   /** Path to the certificate key file (used when authType is "certificate"). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1483,7 +1483,9 @@ export const MSTeamsConfigSchema = z
     configWrites: z.boolean().optional(),
     appId: z.string().optional(),
     appPassword: SecretInputSchema.optional().register(sensitive),
-    authType: z.enum(["clientSecret", "certificate", "federatedCredential"]).optional(),
+    authType: z
+      .enum(["clientSecret", "certificate", "federatedCredential", "defaultAzureCredential"])
+      .optional(),
     certPemFile: z.string().optional(),
     certKeyFile: z.string().optional(),
     sendX5C: z.boolean().optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1483,6 +1483,12 @@ export const MSTeamsConfigSchema = z
     configWrites: z.boolean().optional(),
     appId: z.string().optional(),
     appPassword: SecretInputSchema.optional().register(sensitive),
+    authType: z.enum(["clientSecret", "certificate", "federatedCredential"]).optional(),
+    certPemFile: z.string().optional(),
+    certKeyFile: z.string().optional(),
+    sendX5C: z.boolean().optional(),
+    ficClientId: z.string().optional(),
+    widAssertionFile: z.string().optional(),
     tenantId: z.string().optional(),
     webhook: z
       .object({


### PR DESCRIPTION
## Context

Issue #40855 requested passwordless authentication for the MS Teams channel. PR #40884 added certificate and federated credential support. PR #47934 addressed review feedback on that work — fixing schema validation, type design, env var hints, and SDK env fallback handling.

This PR builds on both to add `defaultAzureCredential` as a fourth auth type, completing the passwordless auth story for enterprise deployments.

## Problem

Certificate and federated credential auth modes require operators to explicitly configure credential material (cert paths, FIC client IDs, workload identity assertion files). In Kubernetes deployments with Azure Workload Identity, and in local development with `az login`, these details are already available in the environment — but the operator still has to know which mode to select and which fields to set.

`DefaultAzureCredential` from `@azure/identity` solves this by automatically discovering credentials from the environment: workload identity, managed identity, Azure CLI, environment variables, and other sources. The operator only needs to provide `appId` and `tenantId`.

## Changes

**New auth type: `defaultAzureCredential`**

```json
{
  "channels": {
    "msteams": {
      "enabled": true,
      "appId": "<app-registration-id>",
      "tenantId": "<tenant-id>",
      "authType": "defaultAzureCredential"
    }
  }
}
```

**`DefaultAzureCredentialTokenProvider`** (`extensions/msteams/src/sdk.ts`)
- Wraps `@azure/identity`'s `DefaultAzureCredential` with the same `getAccessToken(scope)` interface as `MsalTokenProvider`
- Passes `appId` as `managedIdentityClientId` and `workloadIdentityClientId` so the credential targets the correct bot identity
- Normalizes resource URIs to AAD scopes (`https://graph.microsoft.com` → `https://graph.microsoft.com/.default`) since `DefaultAzureCredential.getToken()` requires scope format, not bare resource URIs

**`createTokenProvider()` factory** (`extensions/msteams/src/sdk.ts`)
- Returns DAC or MSAL provider based on `authType`
- Used by all 4 token acquisition sites: `probe.ts`, `monitor.ts`, `send-context.ts`, `graph.ts`

**Setup surface fix** (`extensions/msteams/src/setup-surface.ts`)
- When re-entering credentials as client secret via the setup wizard, `authType` and related fields (`certPemFile`, `certKeyFile`, `ficClientId`, `widAssertionFile`) are now reset. Previously, re-running setup on a non-client-secret config would preserve the old `authType`, causing `resolveMSTeamsCredentials()` to ignore the newly entered secret.

**Release checks** (`extensions/msteams/package.json`)
- Added `@azure/identity` to `rootDependencyMirrorAllowlist` so `scripts/release-check.ts` does not report bundled extension dependency drift.

**Config schema + types**
- `authType` union extended with `"defaultAzureCredential"` in both `types.msteams.ts` and `zod-schema.providers-core.ts`

## Use cases

**AKS with Workload Identity** — the pod's service account has a federated credential. `DefaultAzureCredential` picks it up automatically. No secrets, no cert files, no Vault.

**Local development** — `az login` and go. Same config works everywhere.

**Azure VMs / App Service** — managed identity. Same config.

## Dependencies

- `@azure/identity` ^4.9.1 added as a dependency of the msteams extension (not root `package.json`, per plugin guidelines)

## AI Disclosure

- [x] AI-assisted (Claude Code + Codex review — multiple review cycles)
- [x] Fully tested — 246/246 msteams tests passing
- [x] `pnpm build && pnpm check && pnpm test` green (pre-existing `normalizeAgentId` tsgo error on main excluded)
- [x] Authors understand what the code does
- [x] Codex review addressed: scope normalization, identity pinning, setup surface reset, release checks allowlist

Fixes #40855
Related: #40884, #47934