### PR TITLE
fix: language dropdown shows wrong value on page refresh

### DIFF
--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -190,7 +190,7 @@ export function renderOverview(props: OverviewProps) {
     `;
   })();
 
-  const currentLocale = i18n.getLocale();
+  const currentLocale = props.settings.locale || i18n.getLocale();
 
   return html`
     <section class="grid">


### PR DESCRIPTION
Issue #48015

## Problem
Race condition between i18n loading and Lit rendering causes the language dropdown to show "English" after page refresh, even when a different language was selected.

When the page loads, `i18n.getLocale()` may return the default locale "en" before the translations are fully loaded, causing the `<select>` value to be set incorrectly.

## Fix
Use `props.settings.locale` as the primary source (persisted from previous session) before falling back to `i18n.getLocale()`.

```typescript
// Before
const currentLocale = i18n.getLocale();

// After  
const currentLocale = props.settings.locale || i18n.getLocale();
```

The settings locale is loaded from localStorage synchronously and represents the user's actual saved preference, making it a more reliable source during initial render.