### PR TITLE
fix: skills snapshot not invalidated after gateway restart - AI assisted

### DIFF
--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -24,7 +24,12 @@ const log = createSubsystemLogger("gateway/skills");
 const listeners = new Set<(event: SkillsChangeEvent) => void>();
 const workspaceVersions = new Map<string, number>();
 const watchers = new Map<string, SkillsWatchState>();
-let globalVersion = 0;
+// Initialize to Date.now() so each process restart produces a unique starting version.
+// This ensures any snapshot that was cached in a previous run (version = previousStartupTime)
+// is always considered stale after a restart and gets rebuilt on the next agent turn.
+// Without this, globalVersion resets to 0 after every restart and snapshots built with
+// version=0 would never be invalidated (shouldRefresh would see 0 === 0 and skip the rebuild).
+let globalVersion = Date.now();
 
 export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.git([\\/]|$)/,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -210,22 +210,28 @@ export async function ensureSkillSnapshot(params: {
     systemSent = true;
   }
 
-  const skillsSnapshot = shouldRefreshSnapshot
-    ? buildWorkspaceSkillSnapshot(workspaceDir, {
-        config: cfg,
-        skillFilter,
-        eligibility: { remote: remoteEligibility },
-        snapshotVersion,
-      })
-    : (nextEntry?.skillsSnapshot ??
-      (isFirstTurnInSession
-        ? undefined
-        : buildWorkspaceSkillSnapshot(workspaceDir, {
+  // When shouldRefreshSnapshot is true, we need a fresh snapshot. But if the first-turn
+  // block above already built one with the current snapshotVersion (detectable via version
+  // equality), reuse it to avoid scanning the skills directory twice per first turn.
+  const skillsSnapshot =
+    shouldRefreshSnapshot && nextEntry?.skillsSnapshot?.version === snapshotVersion
+      ? nextEntry.skillsSnapshot
+      : shouldRefreshSnapshot
+        ? buildWorkspaceSkillSnapshot(workspaceDir, {
             config: cfg,
             skillFilter,
             eligibility: { remote: remoteEligibility },
             snapshotVersion,
-          })));
+          })
+        : (nextEntry?.skillsSnapshot ??
+          (isFirstTurnInSession
+            ? undefined
+            : buildWorkspaceSkillSnapshot(workspaceDir, {
+                config: cfg,
+                skillFilter,
+                eligibility: { remote: remoteEligibility },
+                snapshotVersion,
+              })));
   if (
     skillsSnapshot &&
     sessionStore &&

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -877,7 +877,7 @@ async function agentCommandInternal(
     const needsSkillsSnapshot =
       isNewSession ||
       !sessionEntry?.skillsSnapshot ||
-      sessionEntry.skillsSnapshot.version !== skillsSnapshotVersion;
+      sessionEntry.skillsSnapshot.version < skillsSnapshotVersion;
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -873,8 +873,11 @@ async function agentCommandInternal(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+    const needsSkillsSnapshot =
+      isNewSession ||
+      !sessionEntry?.skillsSnapshot ||
+      sessionEntry.skillsSnapshot.version !== skillsSnapshotVersion;
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {


### PR DESCRIPTION
…skills in agent context (#1)

* Initial plan

* fix: invalidate stale skills snapshots after gateway restart

Initialize globalVersion to Date.now() in refresh.ts so each process restart produces a unique starting version. Previously, globalVersion reset to 0 on every restart causing cached snapshots (also version=0) to appear current and never be refreshed, hiding skills added between restarts.

Also fix a double-build in session-updates.ts: when shouldRefreshSnapshot is true but the first-turn block already built a fresh snapshot with the current snapshotVersion, reuse it instead of scanning the filesystem twice.

Also fix needsSkillsSnapshot in commands/agent.ts to check version staleness (not just whether a snapshot exists), applying the same consistency on the CLI agent path.

Fixes openclaw/openclaw#43735



---------

## Summary

Describe the problem and fix in 2–5 bullets:

See issue - https://github.com/openclaw/openclaw/issues/43735

## Change Type (select all)

- [X ] Bug fix - 
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [X ] Gateway / orchestration
- [X ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #

https://github.com/openclaw/openclaw/issues/43735

- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  

None

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) - N
- Secrets/tokens handling changed? (`Yes/No`) - N
- New/changed network calls? (`Yes/No`) - N
- Command/tool execution surface changed? (`Yes/No`) - N
- Data access scope changed? (`Yes/No`) - N
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

See issue.


### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify: hard to reproduce on demand

## Review Conversations

- [X ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) - N
- Config/env changes? (`Yes/No`) - N
- Migration needed? (`Yes/No`) - N
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

None