### PR TITLE
fix(ui): lazy-evaluate fs.constants in tmp-openclaw-dir (#48062)

### DIFF
--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -3,7 +3,9 @@ import os from "node:os";
 import path from "node:path";
 
 export const POSIX_OPENCLAW_TMP_DIR = "/tmp/openclaw";
-const TMP_DIR_ACCESS_MODE = fs.constants.W_OK | fs.constants.X_OK;
+function getTmpDirAccessMode(): number {
+  return fs.constants.W_OK | fs.constants.X_OK;
+}
 
 type ResolvePreferredOpenClawTmpDirOptions = {
   accessSync?: (path: string, mode?: number) => void;
@@ -86,7 +88,7 @@ export function resolvePreferredOpenClawTmpDir(
       if (!isTrustedTmpDir(candidate)) {
         return "invalid";
       }
-      accessSync(candidatePath, TMP_DIR_ACCESS_MODE);
+      accessSync(candidatePath, getTmpDirAccessMode());
       return "available";
     } catch (err) {
       if (isNodeErrorWithCode(err, "ENOENT")) {
@@ -152,7 +154,7 @@ export function resolvePreferredOpenClawTmpDir(
   }
 
   try {
-    accessSync("/tmp", TMP_DIR_ACCESS_MODE);
+    accessSync("/tmp", getTmpDirAccessMode());
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_OPENCLAW_TMP_DIR, { recursive: true, mode: 0o700 });
     chmodSync(POSIX_OPENCLAW_TMP_DIR, 0o700);


### PR DESCRIPTION
## Summary

Fix Control UI blank screen caused by `fs.constants.W_OK` being evaluated at module scope, which crashes when Vite bundles the file for the browser.

## Problem

`src/infra/tmp-openclaw-dir.ts` line 6:
```typescript
const TMP_DIR_ACCESS_MODE = fs.constants.W_OK | fs.constants.X_OK;
```

This evaluates at **import time**. Vite externalizes `node:fs` to `undefined` for browser targets, so the Control UI crashes with:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'W_OK')
```

Import chain:
```
ui/src/main.ts → ... → src/logging/logger.ts → src/infra/tmp-openclaw-dir.ts
```

## Fix

Replace top-level constant with a lazy function:

```diff
-const TMP_DIR_ACCESS_MODE = fs.constants.W_OK | fs.constants.X_OK;
+function getTmpDirAccessMode(): number {
+  return fs.constants.W_OK | fs.constants.X_OK;
+}
```

Two call sites updated. Zero behavior change for server-side code.

Fixes #48062