### PR TITLE
fix(tui): resolve per-agent model override in status bar defaults

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -10,6 +10,7 @@ import {
   capArrayByJsonBytes,
   classifySessionKey,
   deriveSessionTitle,
+  getSessionDefaults,
   listAgentsForGateway,
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
@@ -871,4 +872,25 @@ describe("loadCombinedSessionStoreForGateway includes disk-only agents (#32804)"
       expect(store["agent:codex:acp-task"]).toBeDefined();
     });
   });
+});
+
+test("getSessionDefaults uses per-agent model override when agentId is provided", () => {
+  const cfg: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: { primary: "anthropic/claude-sonnet-4-6" },
+      },
+      list: [
+        {
+          id: "main",
+          model: { primary: "anthropic/claude-opus-4-6" },
+        },
+      ],
+    },
+  };
+  const globalDefaults = getSessionDefaults(cfg);
+  expect(globalDefaults.model).toBe("claude-sonnet-4-6");
+
+  const agentDefaults = getSessionDefaults(cfg, "main");
+  expect(agentDefaults.model).toBe("claude-opus-4-6");
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -735,12 +735,14 @@ export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
   return { storePath, store: combined };
 }
 
-export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults {
-  const resolved = resolveConfiguredModelRef({
-    cfg,
-    defaultProvider: DEFAULT_PROVIDER,
-    defaultModel: DEFAULT_MODEL,
-  });
+export function getSessionDefaults(cfg: OpenClawConfig, agentId?: string): GatewaySessionsDefaults {
+  const resolved = agentId
+    ? resolveDefaultModelForAgent({ cfg, agentId })
+    : resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      });
   const contextTokens =
     cfg.agents?.defaults?.contextTokens ??
     lookupContextTokens(resolved.model) ??
@@ -1022,7 +1024,7 @@ export function listSessionsFromStore(params: {
     ts: now,
     path: storePath,
     count: finalSessions.length,
-    defaults: getSessionDefaults(cfg),
+    defaults: getSessionDefaults(cfg, agentId || undefined),
     sessions: finalSessions,
   };
 }


### PR DESCRIPTION
## Summary

- **Problem:** TUI status bar displays `agents.defaults.model.primary` instead of the resolved per-agent model override, showing the wrong model when agents have explicit model configurations.
- **Root cause:** `getSessionDefaults()` always called `resolveConfiguredModelRef()` without an `agentId`, returning the global default. The TUI falls back to these defaults when no runtime model is recorded on the session entry.
- **Fix:** `getSessionDefaults()` now accepts an optional `agentId` parameter and uses `resolveDefaultModelForAgent()` (which respects per-agent overrides) when provided. The `listSessionsFromStore()` call site passes the already-available `agentId` through.

Closes #48067

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX
- [x] Gateway / orchestration

## User-visible / Behavior Changes

- TUI status bar now correctly displays the per-agent model (e.g. `anthropic/claude-opus-4-6`) when the active agent has a model override, instead of always showing the global default.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Evidence

- Unit test added: verifies `getSessionDefaults(cfg, "main")` returns per-agent model while `getSessionDefaults(cfg)` returns global default
- All 48 session-utils tests pass

## Human Verification (required)

- Verified: `getSessionDefaults` resolves per-agent model via `resolveDefaultModelForAgent` when `agentId` is provided
- Verified: fallback to global defaults when no `agentId` is given (backward compatible)
- Not verified: visual TUI rendering (requires running gateway with multi-agent config)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — `agentId` parameter is optional, existing callers unaffected
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; status bar reverts to showing global defaults
- Known bad symptoms: None — worst case is the previous behavior (wrong model displayed)

## Risks and Mitigations

None — minimal change, additive optional parameter, existing behavior preserved when `agentId` is omitted.