### PR TITLE
memory: preserve keyword fallback hits after merge-time scoring

### DIFF
--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -194,7 +194,13 @@ describe("memory index", () => {
     vectorEnabled?: boolean;
     cacheEnabled?: boolean;
     minScore?: number;
-    hybrid?: { enabled: boolean; vectorWeight?: number; textWeight?: number };
+    hybrid?: {
+      enabled: boolean;
+      vectorWeight?: number;
+      textWeight?: number;
+      temporalDecay?: { enabled: boolean; halfLifeDays: number };
+      mmr?: { enabled: boolean; lambda: number };
+    };
   }): TestCfg {
     return {
       agents: {

--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -1066,6 +1066,48 @@ describe("memory index", () => {
     );
   });
 
+  it("preserves multi-token keyword-only hybrid hits when bm25 textScore stays below 1", async () => {
+    await fs.writeFile(
+      path.join(memoryDir, "2026-01-13.md"),
+      "# Log\nWindows hosted Ollama bridge recovery line.",
+    );
+    const manager = await getPersistentManager(
+      createCfg({
+        storePath: indexMainPath,
+        minScore: 0.35,
+        hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
+      }),
+    );
+    await manager.sync({ reason: "test" });
+
+    const results = await manager.search("Windows-hosted Ollama bridge");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.path).toContain("memory/2026-01-13.md");
+  });
+
+  it("preserves keyword fallback hits after temporal decay lowers merged score below minScore", async () => {
+    const memoryPath = path.join(memoryDir, "2026-01-14.md");
+    await fs.writeFile(
+      memoryPath,
+      "# Log\nCurrent evidence from the Windows host includes gpt-oss 20b llama3 2 3b on 11434.",
+    );
+    const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+    await fs.utimes(memoryPath, ninetyDaysAgo, ninetyDaysAgo);
+
+    const manager = await getPersistentManager(
+      createCfg({
+        storePath: indexMainPath,
+        minScore: 0.35,
+        hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
+      }),
+    );
+    await manager.sync({ reason: "test" });
+
+    const results = await manager.search("gpt-oss 20b llama3.2 3b 11434");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.path).toContain("memory/2026-01-14.md");
+  });
+
   it("reports vector availability after probe", async () => {
     const cfg = createCfg({ storePath: indexVectorPath, vectorEnabled: true });
     const manager = await getPersistentManager(cfg);

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -347,21 +347,18 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return strict.slice(0, maxResults);
     }
 
-    // Hybrid defaults can produce keyword-only matches with max score equal to
-    // textWeight (for example 0.3). If minScore is higher (for example 0.35),
-    // these exact lexical hits get filtered out even when they are the only
-    // relevant results.
-    const relaxedMinScore = Math.min(minScore, hybrid.textWeight);
+    // If strict hybrid results are empty but keyword matches exist, fall back to
+    // the keyword-backed subset directly. Applying another merged-score floor
+    // here can still drop exact lexical hits after temporal decay / MMR even
+    // though keyword search already found them.
     const keywordKeys = new Set(
       keywordResults.map(
         (entry) => `${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`,
       ),
     );
     return merged
-      .filter(
-        (entry) =>
-          keywordKeys.has(`${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`) &&
-          entry.score >= relaxedMinScore,
+      .filter((entry) =>
+        keywordKeys.has(`${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`),
       )
       .slice(0, maxResults);
   }

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -348,18 +348,25 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
 
     // If strict hybrid results are empty but keyword matches exist, fall back to
-    // the keyword-backed subset directly. Applying another merged-score floor
-    // here can still drop exact lexical hits after temporal decay / MMR even
-    // though keyword search already found them.
+    // the keyword-backed subset. Derive the relaxed threshold from the already-
+    // merged post-decay/MMR scores so we preserve the best lexical hits without
+    // ignoring minScore entirely.
     const keywordKeys = new Set(
       keywordResults.map(
         (entry) => `${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`,
       ),
     );
-    return merged
-      .filter((entry) =>
-        keywordKeys.has(`${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`),
-      )
+    const keywordOnlyEntries = merged.filter((entry) =>
+      keywordKeys.has(`${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`),
+    );
+    const relaxedMinScore = Math.min(
+      minScore,
+      keywordOnlyEntries.length > 0
+        ? Math.max(...keywordOnlyEntries.map((entry) => entry.score))
+        : 0,
+    );
+    return keywordOnlyEntries
+      .filter((entry) => entry.score >= relaxedMinScore)
       .slice(0, maxResults);
   }
 


### PR DESCRIPTION
## Summary

- Problem: hybrid search can still return an empty result set even when keyword search found exact lexical hits.
- Why it matters: the previous fallback path could still drop those hits because the merged score used for filtering is affected by post-merge steps such as temporal decay and MMR.
- What changed: when strict hybrid results are empty, fallback now derives its relaxed threshold from the already-merged keyword-backed entries (`entry.score` after temporal decay / MMR) instead of using a raw or theoretical keyword ceiling.
- Tests: regression coverage exercises both the keyword-only BM25 `< 1.0` case and the temporal-decay case that previously dropped exact lexical hits.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Memory / storage
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25183
- Related #29485

## User-visible / Behavior Changes

`memory_search` can now preserve exact/strong keyword-backed results when strict hybrid ranking returns nothing, even if post-merge scoring effects (like temporal decay) would otherwise push those entries below the default `minScore`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (local)
- Runtime/container: Node.js + vitest workspace tests
- Model/provider: mocked embedding providers in memory tests; live symptom reproduced separately against local memory index
- Relevant config: hybrid search defaults / `minScore=0.35`, `vectorWeight=0.7`, `textWeight=0.3`, temporal decay enabled

### Steps

1. Reproduce the live symptom where SQLite FTS matches a recent memory chunk but `memory_search` returns no result.
2. Inspect hybrid fallback logic in `src/memory/manager.ts`.
3. Run targeted tests:
   - `npx vitest run src/memory/index.test.ts src/memory/hybrid.test.ts`
4. Run the memory suite:
   - `npx vitest run src/memory/*.test.ts`
5. Verify the live query path against the installed runtime.

### Expected

- When strict hybrid results are empty but keyword-backed merged entries exist, fallback should preserve the best lexical hits instead of returning nothing.

### Actual

- Pass.
- Regression coverage includes:
  - `preserves multi-token keyword-only hybrid hits when bm25 textScore stays below 1`
  - `preserves keyword fallback hits after temporal decay lowers merged score below minScore`

## Evidence

- [x] Failing reasoning/repro before + passing tests after
- [x] Regression test added
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified the live symptom chain locally: SQLite FTS could match the fresh memory fact while `memory_search` still dropped it.
- Verified the refined fix with:
  - `npx vitest run src/memory/index.test.ts src/memory/hybrid.test.ts`
  - `npx vitest run src/memory/*.test.ts`
- Result: `39 files / 313 tests passed`

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert this PR commit(s).
- Watch for unexpected score shifts in hybrid searches where only keyword-backed results are available.

## Risks and Mitigations

- Risk: fallback may still surface keyword-backed results when strict hybrid ranking is empty.
- Mitigation: the relaxed threshold is now derived from the already-merged keyword-backed entries, so fallback remains bounded by the actual post-merge score landscape rather than bypassing scoring altogether.
