### PR TITLE
CI: restore secret scan and agent doc links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,9 @@ jobs:
       - name: Detect committed private keys
         run: pre-commit run --all-files detect-private-key
 
+      - name: Detect committed secrets against baseline
+        run: pre-commit run --all-files detect-secrets
+
       - name: Audit changed GitHub workflows with zizmor
         run: |
           set -euo pipefail

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -1163,10 +1163,13 @@ If your AI does something bad:
 
 ## Secret Scanning (detect-secrets)
 
-CI runs the `detect-secrets` pre-commit hook in the `secrets` job.
-Pushes to `main` always run an all-files scan. Pull requests use a changed-file
-fast path when a base commit is available, and fall back to an all-files scan
-otherwise. If it fails, there are new candidates not yet in the baseline.
+CI runs both secret-focused checks in the `secrets` job:
+
+- `detect-private-key` for committed private key material
+- `detect-secrets` for baseline-backed secret candidate scanning
+
+The `detect-secrets` hook runs as an all-files scan in CI. If it fails, there
+are new candidates not yet reflected in `.secrets.baseline`.
 
 ### If CI fails
 
@@ -1177,6 +1180,7 @@ otherwise. If it fails, there are new candidates not yet in the baseline.
    ```
 
 2. Understand the tools:
+   - `detect-private-key` is a narrow hard fail for committed private key material.
    - `detect-secrets` in pre-commit runs `detect-secrets-hook` with the repo's
      baseline and excludes.
    - `detect-secrets audit` opens an interactive review to mark each baseline

--- a/docs/reference/templates/CLAUDE.md
+++ b/docs/reference/templates/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/zh-CN/CLAUDE.md
+++ b/docs/zh-CN/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/zh-CN/reference/templates/CLAUDE.md
+++ b/docs/zh-CN/reference/templates/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -198,16 +198,6 @@ function appendCronDeliveryInstruction(params: {
   return `${params.commandBody}\n\nReturn your summary as plain text; it will be delivered automatically. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`.trim();
 }
 
-function resolveCronEmbeddedAgentLane(lane?: string) {
-  const trimmed = lane?.trim();
-  // Cron jobs already execute inside the cron command lane. Reusing that same
-  // lane for the nested embedded-agent run deadlocks: the outer cron task holds
-  // the lane while the inner run waits to reacquire it.
-  if (!trimmed || trimmed === "cron") {
-    return CommandLane.Nested;
-  }
-  return trimmed;
-}
 export async function runCronIsolatedAgentTurn(params: {
   cfg: OpenClawConfig;
   deps: CliDeps;


### PR DESCRIPTION
## Summary
- restore `detect-secrets` in the CI `secrets` job
- align the security docs with the actual CI secret-scanning behavior
- add missing `CLAUDE.md` symlinks next to existing `AGENTS.md` files in template and zh-CN doc paths
- remove unused cron dead code uncovered during validation

## Verification
- `corepack pnpm install`
- `pnpm check`
