### PR TITLE
fix: correct LINE plugin webhook route path case to fix 404 on Windows

### DIFF
--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -285,7 +285,7 @@ export async function monitorLineProvider(
   });
 
   // Register HTTP webhook handler
-  const normalizedPath = normalizePluginHttpPath(webhookPath, "/line/webhook") ?? "/line/webhook";
+  const normalizedPath = (normalizePluginHttpPath(webhookPath, "/line/webhook") ?? "/line/webhook").toLowerCase();
   const unregisterHttp = registerPluginHttpRoute({
     path: normalizedPath,
     auth: "plugin",


### PR DESCRIPTION
## Summary

Fix case sensitivity issue in LINE plugin webhook route registration, which was causing 404 errors on Windows (Windows file paths are case-insensitive, but HTTP routes are case-sensitive). Aligns the registered path with the expected /line/webhook endpoint.

## Changes

- Convert webhook route path to lowercase when registering to ensure consistent casing regardless of OS or configuration
- No other functional changes

## Testing

Verified route path is correctly registered as lowercase /line/webhook, works on both case-sensitive and case-insensitive OSes.

Fixes openclaw/openclaw#48079