### PR TITLE
fix(ui): refresh avatar when switching agents (#48121)

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1434,6 +1434,7 @@ export function renderApp(state: AppViewState) {
                   state.chatMessages = [];
                   void loadChatHistory(state);
                   void state.loadAssistantIdentity();
+                  void refreshChatAvatar(state);
                 },
                 showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
                 onScrollToBottom: () => state.scrollToBottom(),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1423,6 +1423,7 @@ export function renderApp(state: AppViewState) {
                   });
                   void loadChatHistory(state);
                   void state.loadAssistantIdentity();
+                  void refreshChatAvatar(state);
                 },
                 onNavigateToAgent: () => {
                   state.agentsSelectedId = resolvedAgentId;


### PR DESCRIPTION
## Summary

Fixes #48121 - Switching agents does not update avatar until manual refresh

## Changes

- Added `refreshChatAvatar(state)` call in the `onAgentChange` callback in `ui/src/ui/app-render.ts`
- Avatar now updates immediately when switching between agents, without requiring manual page refresh

## Testing

✅ Docker sandbox test passed - verified the fix is correctly placed in the onAgentChange callback

The fix ensures that when a user switches agents in the Control UI:
1. The session key is updated
2. Chat history is loaded
3. Assistant identity is loaded
4. **Avatar is refreshed** ← This was missing

The `refreshChatAvatar` function was already imported and used in other places (session reset, session select), but was missing from the agent switch flow.

## Impact

- Minimal change (1 line added + verification doc)
- No breaking changes
- Improves UX by eliminating the need for manual refresh when switching agents

## Verification

- ✅ Syntax check passed
- ✅ Docker sandbox test passed
- ✅ Code follows existing patterns in the codebase