### PR TITLE
feat: retain last N images in history for better context

### DIFF
--- a/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
@@ -2,12 +2,21 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
-import { PRUNED_HISTORY_IMAGE_MARKER, pruneProcessedHistoryImages } from "./history-image-prune.js";
+import {
+  DEFAULT_KEEP_LAST_IMAGES,
+  PRUNED_HISTORY_IMAGE_MARKER,
+  pruneProcessedHistoryImages,
+} from "./history-image-prune.js";
 
 describe("pruneProcessedHistoryImages", () => {
   const image: ImageContent = { type: "image", data: "abc", mimeType: "image/png" };
+  const makeImage = (id: string): ImageContent => ({
+    type: "image",
+    data: id,
+    mimeType: "image/png",
+  });
 
-  it("prunes image blocks from user messages that already have assistant replies", () => {
+  it("prunes image blocks when keepLastN is 0", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({
         role: "user",
@@ -19,7 +28,7 @@ describe("pruneProcessedHistoryImages", () => {
       }),
     ];
 
-    const didMutate = pruneProcessedHistoryImages(messages);
+    const didMutate = pruneProcessedHistoryImages(messages, 0);
 
     expect(didMutate).toBe(true);
     const firstUser = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
@@ -28,6 +37,66 @@ describe("pruneProcessedHistoryImages", () => {
     expect(content).toHaveLength(2);
     expect(content[0]?.type).toBe("text");
     expect(content[1]).toMatchObject({ type: "text", text: PRUNED_HISTORY_IMAGE_MARKER });
+  });
+
+  it("does not prune when image count is within keepLastN limit", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "user",
+        content: [{ type: "text", text: "See images" }, makeImage("img1"), makeImage("img2")],
+      }),
+      castAgentMessage({
+        role: "assistant",
+        content: "got it",
+      }),
+    ];
+
+    const didMutate = pruneProcessedHistoryImages(messages, 5);
+
+    expect(didMutate).toBe(false);
+    const firstUser = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
+    const content = firstUser?.content as Array<{ type: string; data?: string }>;
+    expect(content[1]).toMatchObject({ type: "image", data: "img1" });
+    expect(content[2]).toMatchObject({ type: "image", data: "img2" });
+  });
+
+  it("retains the last N images and prunes older ones", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "user",
+        content: [makeImage("old1"), makeImage("old2")],
+      }),
+      castAgentMessage({
+        role: "assistant",
+        content: "first reply",
+      }),
+      castAgentMessage({
+        role: "user",
+        content: [makeImage("new1"), makeImage("new2")],
+      }),
+      castAgentMessage({
+        role: "assistant",
+        content: "second reply",
+      }),
+    ];
+
+    const didMutate = pruneProcessedHistoryImages(messages, 2);
+
+    expect(didMutate).toBe(true);
+    // Old images should be pruned
+    const firstUser = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
+    const firstContent = firstUser?.content as Array<{
+      type: string;
+      text?: string;
+      data?: string;
+    }>;
+    expect(firstContent[0]).toMatchObject({ type: "text", text: PRUNED_HISTORY_IMAGE_MARKER });
+    expect(firstContent[1]).toMatchObject({ type: "text", text: PRUNED_HISTORY_IMAGE_MARKER });
+    // Recent images should be retained
+    const thirdUser = messages[2] as Extract<AgentMessage, { role: "user" }> | undefined;
+    const thirdContent = thirdUser?.content as Array<{ type: string; data?: string }>;
+    expect(thirdContent[0]).toMatchObject({ type: "image", data: "new1" });
+    expect(thirdContent[1]).toMatchObject({ type: "image", data: "new2" });
   });
 
   it("does not prune latest user message when no assistant response exists yet", () => {
@@ -49,7 +118,7 @@ describe("pruneProcessedHistoryImages", () => {
     expect(first.content[1]).toMatchObject({ type: "image", data: "abc" });
   });
 
-  it("prunes image blocks from toolResult messages that already have assistant replies", () => {
+  it("prunes toolResult image blocks when exceeding keepLastN", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({
         role: "toolResult",
@@ -62,7 +131,7 @@ describe("pruneProcessedHistoryImages", () => {
       }),
     ];
 
-    const didMutate = pruneProcessedHistoryImages(messages);
+    const didMutate = pruneProcessedHistoryImages(messages, 0);
 
     expect(didMutate).toBe(true);
     const firstTool = messages[0] as Extract<AgentMessage, { role: "toolResult" }> | undefined;
@@ -86,5 +155,9 @@ describe("pruneProcessedHistoryImages", () => {
     expect(didMutate).toBe(false);
     const firstUser = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
     expect(firstUser?.content).toBe("noop");
+  });
+
+  it("uses DEFAULT_KEEP_LAST_IMAGES as the default value", () => {
+    expect(DEFAULT_KEEP_LAST_IMAGES).toBe(5);
   });
 });

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -2,11 +2,24 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 export const PRUNED_HISTORY_IMAGE_MARKER = "[image data removed - already processed by model]";
 
+/** Default number of recent images to retain in history. */
+export const DEFAULT_KEEP_LAST_IMAGES = 5;
+
+/** Location of an image block in the message array. */
+interface ImageLocation {
+  messageIndex: number;
+  blockIndex: number;
+}
+
 /**
- * Idempotent cleanup for legacy sessions that persisted image blocks in history.
- * Called each run; mutates only user turns that already have an assistant reply.
+ * Idempotent cleanup for sessions that persisted image blocks in history.
+ * Called each run; mutates only user/toolResult turns that already have an assistant reply.
+ * Retains the most recent `keepLastN` images to preserve context for follow-up questions.
  */
-export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
+export function pruneProcessedHistoryImages(
+  messages: AgentMessage[],
+  keepLastN: number = DEFAULT_KEEP_LAST_IMAGES,
+): boolean {
   let lastAssistantIndex = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i]?.role === "assistant") {
@@ -18,7 +31,8 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
     return false;
   }
 
-  let didMutate = false;
+  // Collect all image locations before lastAssistantIndex
+  const imageLocations: ImageLocation[] = [];
   for (let i = 0; i < lastAssistantIndex; i++) {
     const message = messages[i];
     if (
@@ -33,15 +47,38 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
       if (!block || typeof block !== "object") {
         continue;
       }
-      if ((block as { type?: string }).type !== "image") {
-        continue;
+      if ((block as { type?: string }).type === "image") {
+        imageLocations.push({ messageIndex: i, blockIndex: j });
       }
-      message.content[j] = {
-        type: "text",
-        text: PRUNED_HISTORY_IMAGE_MARKER,
-      } as (typeof message.content)[number];
-      didMutate = true;
     }
+  }
+
+  // Keep the last N images, only prune older ones
+  const pruneCount = Math.max(0, imageLocations.length - keepLastN);
+  if (pruneCount === 0) {
+    return false;
+  }
+
+  let didMutate = false;
+  // Prune only the oldest images (first `pruneCount` in the array)
+  for (let k = 0; k < pruneCount; k++) {
+    const loc = imageLocations[k];
+    if (!loc) {
+      continue;
+    }
+    const message = messages[loc.messageIndex];
+    if (
+      !message ||
+      (message.role !== "user" && message.role !== "toolResult") ||
+      !Array.isArray(message.content)
+    ) {
+      continue;
+    }
+    message.content[loc.blockIndex] = {
+      type: "text",
+      text: PRUNED_HISTORY_IMAGE_MARKER,
+    } as (typeof message.content)[number];
+    didMutate = true;
   }
 
   return didMutate;


### PR DESCRIPTION
## Summary

- Add `keepLastN` parameter to `pruneProcessedHistoryImages` (default: 5)
- Only prune images beyond the retention threshold, keeping recent images for context
- Enable multi-turn conversations about images without losing context

Closes #48145

## Test plan

- [x] Existing tests updated to verify new behavior
- [x] New test: images within `keepLastN` limit are not pruned
- [x] New test: older images are pruned while recent ones are retained
- [x] New test: `DEFAULT_KEEP_LAST_IMAGES` constant is exported and equals 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)