### PR TITLE
fix(gateway): keep long-running clients alive across reconnect delays

### DIFF
--- a/src/gateway/client.reconnect-keepalive.test.ts
+++ b/src/gateway/client.reconnect-keepalive.test.ts
@@ -1,0 +1,197 @@
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import { once } from "node:events";
+import type { Readable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer, type WebSocket } from "ws";
+
+type ReconnectChildProcess = ChildProcessByStdio<null, Readable, Readable>;
+
+async function listenWebSocketServer(port = 0): Promise<WebSocketServer> {
+  return await new Promise((resolve, reject) => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port });
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+async function closeWebSocketServer(server: WebSocketServer | null): Promise<void> {
+  if (!server) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function waitForConnection(server: WebSocketServer, timeoutMs: number): Promise<WebSocket> {
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`timed out waiting for websocket connection after ${timeoutMs}ms`));
+    }, timeoutMs);
+    server.once("connection", (socket) => {
+      clearTimeout(timeout);
+      resolve(socket);
+    });
+    server.once("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+function startReconnectChild(url: string): {
+  child: ReconnectChildProcess;
+  stdout: string[];
+  stderr: string[];
+} {
+  const clientModuleUrl = new URL("./client.ts", import.meta.url).href;
+  const script = `
+    import { GatewayClient } from ${JSON.stringify(clientModuleUrl)};
+    const url = process.argv[1]?.trim();
+    if (!url) {
+      throw new Error("missing gateway url");
+    }
+    const client = new GatewayClient({
+      url,
+      onConnectError: (err) => {
+        console.error(\`connect-error:\${err.message}\`);
+      },
+      onClose: (code, reason) => {
+        console.error(\`close:\${code}:\${reason}\`);
+      },
+    });
+    client.start();
+    // Match the long-running node-host lifecycle: the GatewayClient owns reconnect behavior.
+    await new Promise(() => {});
+  `;
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "-e", script, url],
+    {
+      cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: string) => stderr.push(chunk));
+  return { child, stdout, stderr };
+}
+
+async function stopChildProcess(child: ReconnectChildProcess | null): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode) {
+    return;
+  }
+  child.kill("SIGTERM");
+  await once(child, "exit");
+}
+
+async function waitForReconnectConnection(params: {
+  server: WebSocketServer;
+  child: ReconnectChildProcess;
+  stderr: string[];
+  timeoutMs: number;
+}): Promise<WebSocket> {
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          [
+            `timed out waiting for reconnect after ${params.timeoutMs}ms`,
+            params.stderr.join("").trim() ? `stderr:\n${params.stderr.join("")}` : "",
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        ),
+      );
+    }, params.timeoutMs);
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          [
+            `child exited before reconnect (code=${code ?? "null"}, signal=${signal ?? "null"})`,
+            params.stderr.join("").trim() ? `stderr:\n${params.stderr.join("")}` : "",
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        ),
+      );
+    };
+
+    const onConnection = (socket: WebSocket) => {
+      cleanup();
+      resolve(socket);
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      params.child.off("exit", onExit);
+      params.server.off("connection", onConnection);
+    };
+
+    params.child.once("exit", onExit);
+    params.server.once("connection", onConnection);
+    params.server.once("error", (err) => {
+      cleanup();
+      reject(err);
+    });
+  });
+}
+
+const activeServers = new Set<WebSocketServer>();
+const activeChildren = new Set<ReconnectChildProcess>();
+
+afterEach(async () => {
+  await Promise.all([...activeServers].map(async (server) => await closeWebSocketServer(server)));
+  activeServers.clear();
+  await Promise.all([...activeChildren].map(async (child) => await stopChildProcess(child)));
+  activeChildren.clear();
+});
+
+describe("GatewayClient reconnect keepalive", () => {
+  it("keeps a long-running client alive long enough to reconnect after close", async () => {
+    const firstServer = await listenWebSocketServer();
+    activeServers.add(firstServer);
+    const address = firstServer.address();
+    const port =
+      typeof address === "object" && address
+        ? address.port
+        : (() => {
+            throw new Error("missing websocket server address");
+          })();
+
+    // Use a real child process so an unref'd reconnect timer can let the event loop fall out.
+    const { child, stderr } = startReconnectChild(`ws://127.0.0.1:${port}`);
+    activeChildren.add(child);
+
+    const firstSocket = await waitForConnection(firstServer, 4_000);
+    firstSocket.close(1012, "service restart");
+    await once(firstSocket, "close");
+    await closeWebSocketServer(firstServer);
+    activeServers.delete(firstServer);
+
+    const secondServer = await listenWebSocketServer(port);
+    activeServers.add(secondServer);
+    const secondSocket = await waitForReconnectConnection({
+      server: secondServer,
+      child,
+      stderr,
+      timeoutMs: 4_000,
+    });
+
+    expect(child.exitCode).toBeNull();
+    secondSocket.close(1000, "test complete");
+  });
+});

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -363,6 +363,28 @@ describe("GatewayClient close handling", () => {
     }
   });
 
+  it("cancels a pending reconnect when stop is called", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new GatewayClient({
+        url: "ws://127.0.0.1:18789",
+      });
+
+      client.start();
+      getLatestWs().emitClose(1012, "service restart");
+      expect(vi.getTimerCount()).toBe(1);
+
+      // A stopped client should not keep retrying in the background.
+      client.stop();
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(wsInstances).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not clear persisted device auth when explicit shared token is provided", () => {
     const onClose = vi.fn();
     const identity: DeviceIdentity = {

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -385,6 +385,31 @@ describe("GatewayClient close handling", () => {
     }
   });
 
+  it("cancels a pending reconnect when start is called during backoff", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new GatewayClient({
+        url: "ws://127.0.0.1:18789",
+      });
+
+      client.start();
+      getLatestWs().emitClose(1012, "service restart");
+      expect(vi.getTimerCount()).toBe(1);
+
+      // A manual restart should replace the delayed retry instead of racing it later.
+      client.start();
+      expect(vi.getTimerCount()).toBe(0);
+      expect(wsInstances).toHaveLength(2);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(wsInstances).toHaveLength(2);
+      client.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not clear persisted device auth when explicit shared token is provided", () => {
     const onClose = vi.fn();
     const identity: DeviceIdentity = {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -138,6 +138,7 @@ export class GatewayClient {
   private connectNonce: string | null = null;
   private connectSent = false;
   private connectTimer: NodeJS.Timeout | null = null;
+  private reconnectTimer: NodeJS.Timeout | null = null;
   private pendingDeviceTokenRetry = false;
   private deviceTokenRetryBudgetUsed = false;
   private pendingConnectErrorDetailCode: string | null = null;
@@ -166,6 +167,8 @@ export class GatewayClient {
     if (this.closed) {
       return;
     }
+    // A fired reconnect timer hands control back to start(); drop the stale handle first.
+    this.reconnectTimer = null;
     const url = this.opts.url ?? "ws://127.0.0.1:18789";
     if (this.opts.tlsFingerprint && !url.startsWith("wss://")) {
       this.opts.onConnectError?.(new Error("gateway tls fingerprint requires wss:// gateway url"));
@@ -323,6 +326,11 @@ export class GatewayClient {
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
     this.pendingConnectErrorDetailCode = null;
+    // Prompt shutdown requires cancelling any pending retry timers.
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     if (this.tickTimer) {
       clearInterval(this.tickTimer);
       this.tickTimer = null;
@@ -720,10 +728,16 @@ export class GatewayClient {
       clearInterval(this.tickTimer);
       this.tickTimer = null;
     }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+    }
     const delay = this.backoffMs;
     this.backoffMs = Math.min(this.backoffMs * 2, 30_000);
     // Keep reconnect timers ref'd so long-running clients stay alive between disconnect and retry.
-    setTimeout(() => this.start(), delay);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.start();
+    }, delay);
   }
 
   private flushPendingErrors(err: Error) {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -722,7 +722,8 @@ export class GatewayClient {
     }
     const delay = this.backoffMs;
     this.backoffMs = Math.min(this.backoffMs * 2, 30_000);
-    setTimeout(() => this.start(), delay).unref();
+    // Keep reconnect timers ref'd so long-running clients stay alive between disconnect and retry.
+    setTimeout(() => this.start(), delay);
   }
 
   private flushPendingErrors(err: Error) {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -163,12 +163,20 @@ export class GatewayClient {
         : 30_000;
   }
 
+  private clearReconnectTimer() {
+    if (!this.reconnectTimer) {
+      return;
+    }
+    // Manual reconnects and shutdown should cancel delayed retries, not just drop the handle.
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+  }
+
   start() {
     if (this.closed) {
       return;
     }
-    // A fired reconnect timer hands control back to start(); drop the stale handle first.
-    this.reconnectTimer = null;
+    this.clearReconnectTimer();
     const url = this.opts.url ?? "ws://127.0.0.1:18789";
     if (this.opts.tlsFingerprint && !url.startsWith("wss://")) {
       this.opts.onConnectError?.(new Error("gateway tls fingerprint requires wss:// gateway url"));
@@ -327,10 +335,7 @@ export class GatewayClient {
     this.deviceTokenRetryBudgetUsed = false;
     this.pendingConnectErrorDetailCode = null;
     // Prompt shutdown requires cancelling any pending retry timers.
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
+    this.clearReconnectTimer();
     if (this.tickTimer) {
       clearInterval(this.tickTimer);
       this.tickTimer = null;
@@ -728,9 +733,7 @@ export class GatewayClient {
       clearInterval(this.tickTimer);
       this.tickTimer = null;
     }
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-    }
+    this.clearReconnectTimer();
     const delay = this.backoffMs;
     this.backoffMs = Math.min(this.backoffMs * 2, 30_000);
     // Keep reconnect timers ref'd so long-running clients stay alive between disconnect and retry.


### PR DESCRIPTION
## Summary

- Problem: Long-running `GatewayClient` can exit after a websocket disconnect before the scheduled reconnect attempt runs.
- Why it matters: Daemon-like clients such as node-host can churn during gateway restarts or brief outages instead of retrying in-place.
- What changed: Keep the reconnect timer ref'd in `GatewayClient.scheduleReconnect()` and add a process-level regression test that exercises the real event-loop lifecycle.
- What did NOT change (scope boundary): No auth/protocol behavior changed, no new config/env flags were added, and no node-host call sites or APIs were modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48032 

## User-visible / Behavior Changes

Long-running gateway clients now stay alive across reconnect delays after a websocket close instead of allowing the process to exit between disconnect and retry.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS host; reproduced against Linux-style long-running node-host behavior
- Runtime/container: Node.js via local source checkout
- Model/provider: N/A
- Integration/channel (if any): Gateway websocket client / node-host style reconnect path
- Relevant config (redacted): none required beyond a normal websocket gateway URL

### Steps

1. Start a websocket server and connect a long-running `GatewayClient`-based process to it.
2. Close the websocket from the server side so the client schedules a reconnect.
3. Bring the server back and observe whether the same process reconnects or exits before the retry fires.

### Expected

- The long-running client process stays alive and reconnects after the delay.

### Actual

- Before this patch, the reconnect timer was scheduled with `.unref()`, so the process would exit before the retry ever fired.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```sh
CI=true NPM_CONFIG_CACHE=/tmp/openclaw-npm-cache pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/client.reconnect-keepalive.test.ts src/gateway/client.test.ts

Result:

- 2 files passed
- 21 tests passed
```

I also verified the broader build gate:

```
pnpm build
```

Note: broader repo gates at current main were not clean in my checkout for unrelated upstream issues outside this patch (for example existing pnpm check failures in extensions/slack, src/infra/bonjour.ts, src/infra/gaxios-fetch-compat.ts, and unrelated test timeouts in other suites).

## Human Verification (required)

- Verified scenarios:
    - A real child process running GatewayClient stays alive after server-side close and reconnects when the websocket server returns.
    - Existing focused GatewayClient tests still pass alongside the new regression.
- Edge cases checked:
    - The regression uses a real child process instead of mocked timers/handles, so it exercises the actual event-loop exit behavior.
    - I tested a straight restart, stopping/starting the running gateway, and deploying a new gateway container image to ECS
- What you did not verify:
    - I did not get a clean full-repo pnpm check / pnpm test pass because current upstream HEAD had unrelated baseline failures in other areas.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
    - Revert this PR.
- Files/config to restore:
    - Restore src/gateway/client.ts
    - Remove src/gateway/client.reconnect-keepalive.test.ts
- Known bad symptoms reviewers should watch for:
    - Unexpected reconnect behavior changes in short-lived GatewayClient consumers
    - Reconnect attempts continuing longer than expected after disconnect

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

 - Risk:
    - Keeping reconnect timers ref'd changes process-lifecycle behavior for all GatewayClient callers, not just node-host.
    - Mitigation:
        - The change is intentionally minimal.
        - The main target is long-running clients, which are the callers most affected by the bug.
        - The PR includes a process-level regression test that proves the intended lifecycle behavior directly.