### PR TITLE
feat(agents): add minimal Context Book bootstrap pipeline

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -114,6 +114,59 @@ describe("resolveBootstrapContextForRun", () => {
     expect(files.every((file) => file.name === "HEARTBEAT.md")).toBe(true);
   });
 
+  it("includes always-on Context Book entries for normal sessions", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.mkdir(path.join(workspaceDir, "context-books"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "context-books", "coding.yaml"),
+      [
+        "entries:",
+        "  - name: Repo rules",
+        "    enabled: true",
+        "    alwaysActive: true",
+        "    order: 5",
+        "    content: |",
+        "      Use pnpm",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await resolveBootstrapContextForRun({ workspaceDir });
+    const contextBookFile = result.bootstrapFiles.find(
+      (file) => file.name === "CONTEXT_BOOK:Repo rules",
+    );
+    const injected = result.contextFiles.find((file) =>
+      file.path.includes("coding.yaml#repo-rules"),
+    );
+
+    expect(contextBookFile?.content).toBe("Use pnpm");
+    expect(injected?.content).toBe("Use pnpm");
+  });
+
+  it("skips Context Book entries for subagent sessions", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.mkdir(path.join(workspaceDir, "context-books"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "context-books", "coding.yaml"),
+      [
+        "entries:",
+        "  - name: Repo rules",
+        "    enabled: true",
+        "    alwaysActive: true",
+        "    content: |",
+        "      Use pnpm",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:default:subagent:task-1",
+    });
+
+    expect(files.some((file) => file.name.startsWith("CONTEXT_BOOK:"))).toBe(false);
+  });
+
   it("keeps bootstrap context empty in lightweight cron mode", async () => {
     const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
     await fs.writeFile(path.join(workspaceDir, "HEARTBEAT.md"), "check inbox", "utf8");

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
+import { loadContextBookBootstrapFiles } from "./context-books.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import {
   buildBootstrapContextFiles,
@@ -83,9 +84,17 @@ export async function resolveBootstrapFilesForRun(params: {
     contextMode: params.contextMode,
     runKind: params.runKind,
   });
+  const contextBookFiles = await loadContextBookBootstrapFiles({
+    workspaceDir: params.workspaceDir,
+    sessionKey,
+    contextMode: params.contextMode,
+    runKind: params.runKind,
+    warn: params.warn,
+  });
+  const mergedBootstrapFiles = [...bootstrapFiles, ...contextBookFiles];
 
   const updated = await applyBootstrapHookOverrides({
-    files: bootstrapFiles,
+    files: mergedBootstrapFiles,
     workspaceDir: params.workspaceDir,
     config: params.config,
     sessionKey: params.sessionKey,

--- a/src/agents/context-books.test.ts
+++ b/src/agents/context-books.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { makeTempWorkspace } from "../test-helpers/workspace.js";
+import { CONTEXT_BOOKS_DIRNAME, loadContextBookBootstrapFiles } from "./context-books.js";
+
+describe("loadContextBookBootstrapFiles", () => {
+  it("loads enabled always-on entries from YAML and JSON files in descending order", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-context-books-");
+    const contextBooksDir = path.join(workspaceDir, CONTEXT_BOOKS_DIRNAME);
+    await fs.mkdir(contextBooksDir, { recursive: true });
+    await fs.writeFile(
+      path.join(contextBooksDir, "alpha.yaml"),
+      [
+        "entries:",
+        "  - name: Low priority",
+        "    enabled: true",
+        "    alwaysActive: true",
+        "    order: 1",
+        "    content: |",
+        "      low",
+        "  - name: Triggered only",
+        "    enabled: true",
+        "    keywords: [vite]",
+        "    content: |",
+        "      skipped",
+      ].join("\n"),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(contextBooksDir, "beta.json"),
+      JSON.stringify({
+        entries: [
+          {
+            name: "High priority",
+            enabled: true,
+            alwaysActive: true,
+            order: 10,
+            content: "high",
+          },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const files = await loadContextBookBootstrapFiles({ workspaceDir });
+
+    expect(files.map((file) => file.name)).toEqual([
+      "CONTEXT_BOOK:High priority",
+      "CONTEXT_BOOK:Low priority",
+    ]);
+    expect(files.map((file) => file.content)).toEqual(["high", "low"]);
+    expect(files[0]?.path).toContain("beta.json#high-priority");
+  });
+
+  it("warns and skips entries with unsupported non-bootstrap positions", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-context-books-");
+    const contextBooksDir = path.join(workspaceDir, CONTEXT_BOOKS_DIRNAME);
+    await fs.mkdir(contextBooksDir, { recursive: true });
+    await fs.writeFile(
+      path.join(contextBooksDir, "depth.yaml"),
+      [
+        "entries:",
+        "  - name: Tail reminder",
+        "    enabled: true",
+        "    alwaysActive: true",
+        "    position: tail_reminder",
+        "    content: |",
+        "      do the thing",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const warnings: string[] = [];
+    const files = await loadContextBookBootstrapFiles({
+      workspaceDir,
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(files).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("unsupported position");
+  });
+});

--- a/src/agents/context-books.ts
+++ b/src/agents/context-books.ts
@@ -1,0 +1,260 @@
+import syncFs from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import YAML from "yaml";
+import { openBoundaryFile } from "../infra/boundary-file-read.js";
+import { isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
+import { resolveUserPath } from "../utils.js";
+import type { BootstrapContextMode, BootstrapContextRunKind } from "./bootstrap-files.js";
+import type { WorkspaceBootstrapFile } from "./workspace.js";
+
+export const CONTEXT_BOOKS_DIRNAME = "context-books";
+
+const CONTEXT_BOOK_EXTENSIONS = new Set([".json", ".yaml", ".yml"]);
+const CONTEXT_BOOK_MAX_FILE_BYTES = 512 * 1024;
+const SUPPORTED_BOOTSTRAP_POSITIONS = new Set(["before_context", "after_context"]);
+
+type RawContextBookDocument =
+  | {
+      entries?: unknown;
+    }
+  | unknown[];
+
+type NormalizedContextBookEntry = {
+  syntheticName: string;
+  syntheticPath: string;
+  content: string;
+  order: number;
+  sourcePath: string;
+  sourceIndex: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function parseOrder(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 0;
+}
+
+function normalizeEntryName(rawName: unknown, sourcePath: string, index: number): string {
+  const trimmed = typeof rawName === "string" ? rawName.trim() : "";
+  if (trimmed) {
+    return trimmed;
+  }
+  return `${path.basename(sourcePath)}#${index + 1}`;
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "entry";
+}
+
+function parseContextBookDocument(raw: string, sourcePath: string): RawContextBookDocument | null {
+  const extension = path.extname(sourcePath).toLowerCase();
+  try {
+    const parsed =
+      extension === ".json"
+        ? (JSON.parse(raw) as unknown)
+        : (YAML.parse(raw, { schema: "core" }) as unknown);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+    if (isRecord(parsed)) {
+      return parsed as RawContextBookDocument;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function extractEntries(
+  document: RawContextBookDocument,
+  sourcePath: string,
+  warn?: (message: string) => void,
+): NormalizedContextBookEntry[] {
+  const rawEntries = Array.isArray(document)
+    ? document
+    : Array.isArray(document.entries)
+      ? document.entries
+      : [];
+  if (!rawEntries.length) {
+    return [];
+  }
+
+  const normalized: NormalizedContextBookEntry[] = [];
+  for (const [index, rawEntry] of rawEntries.entries()) {
+    if (!isRecord(rawEntry)) {
+      warn?.(`skipping context book entry ${sourcePath}#${index + 1} - entry must be an object`);
+      continue;
+    }
+
+    const enabled = parseBoolean(rawEntry.enabled, true);
+    const alwaysActive = parseBoolean(rawEntry.alwaysActive, false);
+    if (!enabled || !alwaysActive) {
+      continue;
+    }
+
+    const content = typeof rawEntry.content === "string" ? rawEntry.content.trim() : "";
+    if (!content) {
+      warn?.(`skipping context book entry ${sourcePath}#${index + 1} - missing content`);
+      continue;
+    }
+
+    const positionValue =
+      typeof rawEntry.position === "string" ? rawEntry.position.trim().toLowerCase() : "";
+    const position = positionValue || "after_context";
+    if (!SUPPORTED_BOOTSTRAP_POSITIONS.has(position)) {
+      warn?.(
+        `skipping context book entry ${sourcePath}#${index + 1} - unsupported position "${position}" in bootstrap-backed Context Book v1`,
+      );
+      continue;
+    }
+
+    const entryName = normalizeEntryName(rawEntry.name, sourcePath, index);
+    normalized.push({
+      syntheticName: `CONTEXT_BOOK:${entryName}`,
+      syntheticPath: `${sourcePath}#${slugify(entryName)}`,
+      content,
+      order: parseOrder(rawEntry.order),
+      sourcePath,
+      sourceIndex: index,
+    });
+  }
+
+  normalized.sort((a, b) => {
+    if (a.order !== b.order) {
+      return b.order - a.order;
+    }
+    if (a.sourcePath !== b.sourcePath) {
+      return a.sourcePath.localeCompare(b.sourcePath);
+    }
+    return a.sourceIndex - b.sourceIndex;
+  });
+  return normalized;
+}
+
+async function readContextBookFile(params: {
+  workspaceDir: string;
+  filePath: string;
+  warn?: (message: string) => void;
+}): Promise<string | undefined> {
+  const opened = await openBoundaryFile({
+    absolutePath: params.filePath,
+    rootPath: params.workspaceDir,
+    boundaryLabel: "workspace root",
+    maxBytes: CONTEXT_BOOK_MAX_FILE_BYTES,
+  });
+  if (!opened.ok) {
+    params.warn?.(
+      `skipping context book ${params.filePath} - ${opened.reason === "validation" ? "invalid file" : opened.reason}`,
+    );
+    return undefined;
+  }
+
+  try {
+    return syncFs.readFileSync(opened.fd, "utf-8");
+  } catch {
+    params.warn?.(`skipping context book ${params.filePath} - failed to read file`);
+    return undefined;
+  } finally {
+    syncFs.closeSync(opened.fd);
+  }
+}
+
+function shouldSkipContextBooks(params: {
+  sessionKey?: string;
+  contextMode?: BootstrapContextMode;
+  runKind?: BootstrapContextRunKind;
+}): boolean {
+  if (params.contextMode === "lightweight") {
+    return true;
+  }
+  if (params.runKind === "heartbeat" || params.runKind === "cron") {
+    return true;
+  }
+  const sessionKey = params.sessionKey;
+  if (!sessionKey) {
+    return false;
+  }
+  // Keep current prompt minimization behavior for cron/subagent sessions until
+  // sessionKinds-aware Context Book routing lands.
+  return isSubagentSessionKey(sessionKey) || isCronSessionKey(sessionKey);
+}
+
+export async function loadContextBookBootstrapFiles(params: {
+  workspaceDir: string;
+  sessionKey?: string;
+  contextMode?: BootstrapContextMode;
+  runKind?: BootstrapContextRunKind;
+  warn?: (message: string) => void;
+}): Promise<WorkspaceBootstrapFile[]> {
+  if (shouldSkipContextBooks(params)) {
+    return [];
+  }
+
+  const workspaceDir = resolveUserPath(params.workspaceDir);
+  const contextBooksDir = path.join(workspaceDir, CONTEXT_BOOKS_DIRNAME);
+  let entries: Awaited<ReturnType<typeof fs.readdir>>;
+  try {
+    entries = await fs.readdir(contextBooksDir, { withFileTypes: true });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return [];
+    }
+    params.warn?.(`failed to read context-books directory: ${contextBooksDir}`);
+    return [];
+  }
+
+  const files = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => CONTEXT_BOOK_EXTENSIONS.has(path.extname(name).toLowerCase()))
+    .toSorted((a, b) => a.localeCompare(b));
+
+  const normalizedEntries: NormalizedContextBookEntry[] = [];
+  for (const fileName of files) {
+    const filePath = path.join(contextBooksDir, fileName);
+    const raw = await readContextBookFile({
+      workspaceDir,
+      filePath,
+      warn: params.warn,
+    });
+    if (!raw) {
+      continue;
+    }
+    const parsed = parseContextBookDocument(raw, filePath);
+    if (!parsed) {
+      params.warn?.(`skipping context book ${filePath} - invalid YAML/JSON document`);
+      continue;
+    }
+    normalizedEntries.push(...extractEntries(parsed, filePath, params.warn));
+  }
+
+  normalizedEntries.sort((a, b) => {
+    if (a.order !== b.order) {
+      return b.order - a.order;
+    }
+    if (a.sourcePath !== b.sourcePath) {
+      return a.sourcePath.localeCompare(b.sourcePath);
+    }
+    return a.sourceIndex - b.sourceIndex;
+  });
+
+  return normalizedEntries.map((entry) => ({
+    name: entry.syntheticName,
+    path: entry.syntheticPath,
+    content: entry.content,
+    missing: false,
+  }));
+}

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -141,7 +141,7 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_MEMORY_ALT_FILENAME;
 
 export type WorkspaceBootstrapFile = {
-  name: WorkspaceBootstrapFileName;
+  name: WorkspaceBootstrapFileName | (string & {});
   path: string;
   content?: string;
   missing: boolean;


### PR DESCRIPTION
## Summary

- Add a minimal **Context Book** pipeline that loads `context-books/*.yaml|yml|json` from the workspace directory and compiles always-on entries into synthetic bootstrap prompt content
- Support `enabled`, `alwaysActive`, `order`, `name`, `content`, and `position` (before_context / after_context) fields with validation
- Skip Context Book injection for lightweight, heartbeat, cron, and subagent sessions to preserve existing minimal-context strategies
- Widen `WorkspaceBootstrapFile.name` type to accept synthetic `CONTEXT_BOOK:*` names alongside built-in bootstrap filenames

## Test plan

- [x] `vitest run src/agents/context-books.test.ts` — loads YAML/JSON, respects order/enabled/alwaysActive, warns on unsupported positions
- [x] `vitest run src/agents/bootstrap-files.test.ts` — Context Book entries included for normal sessions, skipped for subagent sessions, empty in lightweight cron mode
- [ ] Manual: create `~/.openclaw/workspace/context-books/coding.yaml` with an always-on entry, run `/context detail` in a main session, verify `CONTEXT_BOOK:*` appears in injected context

🤖 Generated with [Claude Code](https://claude.com/claude-code)