### PR TITLE
fix: auto-split long messages at channel limits instead of silent failure

### DIFF
--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -1,3 +1,4 @@
+import { chunkText } from "../../../src/auto-reply/chunk.js";
 import {
   resolvePayloadMediaUrls,
   sendPayloadMediaSequence,
@@ -72,16 +73,25 @@ async function maybeSendDiscordWebhookText(params: {
     identity: params.identity,
     binding,
   });
-  const result = await sendWebhookMessageDiscord(params.text, {
-    webhookId: binding.webhookId,
-    webhookToken: binding.webhookToken,
-    accountId: binding.accountId,
-    threadId: binding.threadId,
-    cfg: params.cfg,
-    replyTo: params.replyToId ?? undefined,
-    username: persona.username,
-    avatarUrl: persona.avatarUrl,
-  });
+  // Auto-split long text for webhook sends to avoid Discord 2000-char API rejection.
+  // See: https://github.com/openclaw/openclaw/issues/47909
+  const chunks =
+    params.text.length > DISCORD_TEXT_CHUNK_LIMIT
+      ? chunkText(params.text, DISCORD_TEXT_CHUNK_LIMIT)
+      : [params.text];
+  let result: { messageId: string; channelId: string } | null = null;
+  for (const chunk of chunks) {
+    result = await sendWebhookMessageDiscord(chunk, {
+      webhookId: binding.webhookId,
+      webhookToken: binding.webhookToken,
+      accountId: binding.accountId,
+      threadId: binding.threadId,
+      cfg: params.cfg,
+      replyTo: params.replyToId ?? undefined,
+      username: persona.username,
+      avatarUrl: persona.avatarUrl,
+    });
+  }
   return result;
 }
 

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1,6 +1,7 @@
 import {
   chunkByParagraph,
   chunkMarkdownTextWithMode,
+  chunkText,
   resolveChunkMode,
   resolveTextChunkLimit,
 } from "../../auto-reply/chunk.js";
@@ -564,22 +565,32 @@ async function deliverOutboundPayloadsCore(
     silent: params.silent,
     mediaLocalRoots,
   });
-  const configuredTextLimit = handler.chunker
-    ? resolveTextChunkLimit(cfg, channel, accountId, {
-        fallbackLimit: handler.textChunkLimit,
-      })
-    : undefined;
+  // Always resolve the text chunk limit when the channel declares one, even without
+  // a custom chunker.  This ensures messages that exceed the channel's character cap
+  // are auto-split using a default chunker instead of being sent as-is (which causes
+  // silent failures on Telegram, Discord, etc.).
+  // See: https://github.com/openclaw/openclaw/issues/47909
+  const configuredTextLimit =
+    handler.chunker || handler.textChunkLimit
+      ? resolveTextChunkLimit(cfg, channel, accountId, {
+          fallbackLimit: handler.textChunkLimit,
+        })
+      : undefined;
   const textLimit = handler.resolveEffectiveTextChunkLimit
     ? handler.resolveEffectiveTextChunkLimit(configuredTextLimit)
     : configuredTextLimit;
   const chunkMode = handler.chunker ? resolveChunkMode(cfg, channel, accountId) : "length";
+  // Use the channel's chunker when available, otherwise fall back to a plain
+  // length-aware text chunker so every channel gets auto-splitting.
+  const effectiveChunker: Chunker | null =
+    handler.chunker ?? (textLimit !== undefined ? chunkText : null);
 
   const sendTextChunks = async (
     text: string,
     overrides?: { replyToId?: string | null; threadId?: string | number | null },
   ) => {
     throwIfAborted(abortSignal);
-    if (!handler.chunker || textLimit === undefined) {
+    if (!effectiveChunker || textLimit === undefined) {
       results.push(await handler.sendText(text, overrides));
       return;
     }
@@ -594,7 +605,7 @@ async function deliverOutboundPayloadsCore(
         blockChunks.push(text);
       }
       for (const blockChunk of blockChunks) {
-        const chunks = handler.chunker(blockChunk, textLimit);
+        const chunks = effectiveChunker(blockChunk, textLimit);
         if (!chunks.length && blockChunk) {
           chunks.push(blockChunk);
         }
@@ -605,7 +616,7 @@ async function deliverOutboundPayloadsCore(
       }
       return;
     }
-    const chunks = handler.chunker(text, textLimit);
+    const chunks = effectiveChunker(text, textLimit);
     for (const chunk of chunks) {
       throwIfAborted(abortSignal);
       results.push(await handler.sendText(chunk, overrides));


### PR DESCRIPTION
## Problem

When an agent sends a message exceeding the channel's character limit (Telegram 4096, Discord 2000), the message silently fails — the user sees nothing, no error, no partial message.

From logs:
```
[telegram] message failed: Call to 'sendMessage' failed! (400: Bad Request: message is too long)
[tools] message failed: Call to 'sendMessage' failed! (400: Bad Request: message is too long)
```

## Root Cause

The core delivery layer (`deliverOutboundPayloadsCore`) only resolves `textChunkLimit` and applies chunking when the channel's outbound adapter provides a custom `chunker`. Channels that set `chunker: null` but still declare a `textChunkLimit` (like Discord) skip the chunking step entirely in the delivery layer.

Additionally, Discord's webhook send path (`maybeSendDiscordWebhookText`) sends the full text as-is without any splitting.

## Fix

1. **`src/infra/outbound/deliver.ts`**: Always resolve `configuredTextLimit` when either `chunker` or `textChunkLimit` is set. Introduce an `effectiveChunker` that falls back to the generic `chunkText()` utility when no custom chunker is provided but a limit exists.

2. **`extensions/discord/src/outbound-adapter.ts`**: Add auto-splitting for the webhook send path using `chunkText()` to split text exceeding the 2000-char Discord limit before sending.

## Testing

- All 43 deliver.test.ts tests pass ✅
- All 447 outbound tests pass ✅  
- All 31 chunk tests pass ✅
- TypeScript compilation clean ✅
- ESLint clean ✅

Fixes #47909