### PR TITLE
Fix status cache hit rate denominator

### DIFF
--- a/src/commands/status.format.test.ts
+++ b/src/commands/status.format.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { formatTokensCompact } from "./status.format.js";
+
+describe("formatTokensCompact", () => {
+  it("computes cache percentage from prompt tokens instead of total session tokens", () => {
+    expect(
+      formatTokensCompact({
+        inputTokens: 2_000,
+        cacheRead: 400_000,
+        cacheWrite: 1_000,
+        totalTokens: 2_500,
+        contextTokens: 1_000_000,
+        percentUsed: 0,
+      }),
+    ).toContain("99% cached");
+  });
+
+  it("keeps the existing cache ratio for normal sessions", () => {
+    expect(
+      formatTokensCompact({
+        inputTokens: 2_000,
+        cacheRead: 2_000,
+        cacheWrite: 1_000,
+        totalTokens: 5_000,
+        contextTokens: 10_000,
+        percentUsed: 50,
+      }),
+    ).toContain("40% cached");
+  });
+});

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -16,13 +16,19 @@ export const formatDuration = (ms: number | null | undefined) => {
 export const formatTokensCompact = (
   sess: Pick<
     SessionStatus,
-    "totalTokens" | "contextTokens" | "percentUsed" | "cacheRead" | "cacheWrite"
+    | "totalTokens"
+    | "contextTokens"
+    | "percentUsed"
+    | "cacheRead"
+    | "cacheWrite"
+    | "inputTokens"
   >,
 ) => {
   const used = sess.totalTokens;
   const ctx = sess.contextTokens;
   const cacheRead = sess.cacheRead;
   const cacheWrite = sess.cacheWrite;
+  const inputTokens = sess.inputTokens;
 
   let result = "";
   if (used == null) {
@@ -36,11 +42,11 @@ export const formatTokensCompact = (
 
   // Add cache hit rate if there are cached reads
   if (typeof cacheRead === "number" && cacheRead > 0) {
-    const total =
-      typeof used === "number"
-        ? used
-        : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
-    const hitRate = Math.round((cacheRead / total) * 100);
+    const totalPromptTokens =
+      cacheRead +
+      (typeof cacheWrite === "number" ? cacheWrite : 0) +
+      (typeof inputTokens === "number" ? inputTokens : 0);
+    const hitRate = totalPromptTokens > 0 ? Math.round((cacheRead / totalPromptTokens) * 100) : 0;
     result += ` · 🗄️ ${hitRate}% cached`;
   }
 


### PR DESCRIPTION
## Summary
- compute the compact status cache percentage from prompt-side tokens (fresh input + cache read + cache write) instead of total session tokens
- keep the existing compact status display unchanged for normal sessions
- add a regression test covering cache-heavy sessions so the compact status no longer reports impossible values above 100%

## Testing
- node_modules\\.bin\\vitest.cmd run src/commands/status.format.test.ts

Closes #48148