### PR TITLE
feat(acpx): add Cursor CLI as built-in ACP agent

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -444,6 +444,7 @@ Current acpx built-in harness aliases:
 - `pi`
 - `claude`
 - `codex`
+- `cursor`
 - `opencode`
 - `gemini`
 - `kimi`
@@ -464,7 +465,7 @@ Core ACP baseline:
     dispatch: { enabled: true },
     backend: "acpx",
     defaultAgent: "codex",
-    allowedAgents: ["pi", "claude", "codex", "opencode", "gemini", "kimi"],
+    allowedAgents: ["pi", "claude", "codex", "cursor", "opencode", "gemini", "kimi"],
     maxConcurrentSessions: 8,
     stream: {
       coalesceIdleMs: 300,

--- a/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-agent-command.ts
@@ -5,6 +5,7 @@ import { spawnAndCollect, type SpawnCommandOptions } from "./process.js";
 const ACPX_BUILTIN_AGENT_COMMANDS: Record<string, string> = {
   codex: "npx @zed-industries/codex-acp",
   claude: "npx -y @zed-industries/claude-agent-acp",
+  cursor: "cursor-agent acp",
   gemini: "gemini",
   opencode: "npx -y opencode-ai acp",
   pi: "npx pi-acp",


### PR DESCRIPTION
## Summary

Adds Cursor CLI (`cursor-agent`) as a built-in ACP harness alias in the acpx plugin.

## What

- Added `cursor: "cursor-agent acp"` to `ACPX_BUILTIN_AGENT_COMMANDS` in the acpx plugin
- Updated `acp-agents.md` docs to include cursor in the harness list and `allowedAgents` example

## Why

Cursor CLI ships with a native `acp` subcommand (`cursor-agent acp`) that implements the Agent Client Protocol over stdio. This means users with a Cursor subscription can leverage it as an ACP coding agent directly through OpenClaw — no external adapter package required.

The upstream acpx repo (`openclaw/acpx`) already includes cursor in its agent registry. This PR brings the bundled OpenClaw acpx plugin in sync.

## Testing

Tested end-to-end on a live OpenClaw instance:
1. Installed Cursor CLI (`curl https://cursor.com/install -fsS | bash`)
2. Authenticated (`cursor-agent login`)
3. Enabled ACP with `acp.defaultAgent: "cursor"`
4. Verified the full pipeline: `OpenClaw → acpx → cursor-agent acp → Cursor API`
5. Prompt/response ✅, tool calls (file creation) ✅, streaming ✅, session management ✅

## Notes

- Cursor CLI must be installed and authenticated separately (`cursor-agent login`)
- Uses Cursor's own subscription/API — very economical for users who already pay for Cursor
- Matches the upstream acpx registry entry: `cursor: "cursor-agent acp"`