### PR TITLE
fix(telegram): preserve sticky IPv4 fallback across polling restarts

### DIFF
--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -54,6 +54,8 @@ export type TelegramBotOptions = {
   mediaMaxMb?: number;
   replyToMode?: ReplyToMode;
   proxyFetch?: typeof fetch;
+  /** Pre-resolved fetch to reuse across bot recreations (preserves sticky IPv4 fallback state). */
+  resolvedFetch?: typeof fetch;
   config?: OpenClawConfig;
   /** Signal to abort in-flight Telegram API fetch requests (e.g. getUpdates) on shutdown. */
   fetchAbortSignal?: AbortSignal;
@@ -132,9 +134,13 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     : null;
   const telegramCfg = account.config;
 
-  const fetchImpl = resolveTelegramFetch(opts.proxyFetch, {
-    network: telegramCfg.network,
-  }) as unknown as ApiClientOptions["fetch"];
+  // Reuse pre-resolved fetch when provided to preserve sticky IPv4 fallback state
+  // across polling restarts. Without this, each bot recreation resets the sticky dispatcher,
+  // causing repeated IPv6 connect timeouts on hosts with unstable IPv6 routes.
+  const fetchImpl = (opts.resolvedFetch ??
+    resolveTelegramFetch(opts.proxyFetch, {
+      network: telegramCfg.network,
+    })) as unknown as ApiClientOptions["fetch"];
   const shouldProvideFetch = Boolean(fetchImpl);
   // grammY's ApiClientOptions types still track `node-fetch` types; Node 22+ global fetch
   // (undici) is structurally compatible at runtime but not assignable in TS.

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -184,6 +184,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       accountId: account.accountId,
       runtime: opts.runtime,
       proxyFetch,
+      network: account.config.network,
       abortSignal: opts.abortSignal,
       runnerOptions: createTelegramRunnerOptions(cfg),
       getLastUpdateId: () => lastUpdateId,

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -1,9 +1,11 @@
 import { type RunOptions, run } from "@grammyjs/runner";
+import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
+import { resolveTelegramFetch } from "./fetch.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 
 const TELEGRAM_POLL_RESTART_POLICY = {
@@ -42,6 +44,8 @@ type TelegramPollingSessionOpts = {
   accountId: string;
   runtime: Parameters<typeof createTelegramBot>[0]["runtime"];
   proxyFetch: Parameters<typeof createTelegramBot>[0]["proxyFetch"];
+  /** Telegram account network config; used to resolve transport once for the session. */
+  network?: TelegramNetworkConfig;
   abortSignal?: AbortSignal;
   runnerOptions: RunOptions<unknown>;
   getLastUpdateId: () => number | null;
@@ -55,8 +59,14 @@ export class TelegramPollingSession {
   #forceRestarted = false;
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
+  // Resolve fetch once so sticky IPv4 fallback state survives polling restarts.
+  #sharedFetch: typeof fetch;
 
-  constructor(private readonly opts: TelegramPollingSessionOpts) {}
+  constructor(private readonly opts: TelegramPollingSessionOpts) {
+    this.#sharedFetch = resolveTelegramFetch(opts.proxyFetch, {
+      network: opts.network,
+    });
+  }
 
   get activeRunner() {
     return this.#activeRunner;
@@ -128,6 +138,7 @@ export class TelegramPollingSession {
         token: this.opts.token,
         runtime: this.opts.runtime,
         proxyFetch: this.opts.proxyFetch,
+        resolvedFetch: this.#sharedFetch,
         config: this.opts.config,
         accountId: this.opts.accountId,
         fetchAbortSignal: fetchAbortController.signal,


### PR DESCRIPTION
## Summary

- Resolve `resolveTelegramFetch()` once in `TelegramPollingSession` constructor and reuse across bot recreations via new `resolvedFetch` option
- The sticky IPv4 fallback state (closure variable `stickyIpv4FallbackEnabled`) now survives the full polling session lifetime instead of resetting on every restart
- Pass account `network` config to polling session so transport is resolved with correct settings

## Problem

When `autoSelectFamily=true` (Node 22+ default) and the host has unstable IPv6 routes to `api.telegram.org`, the fetch layer correctly detects failures and enables a sticky IPv4-only dispatcher. However, each polling restart calls `createTelegramBot()` → `resolveTelegramFetch()`, creating a new fetch closure with `stickyIpv4FallbackEnabled = false`. This causes a repeating cycle:

```
IPv6 timeout → sticky IPv4 fallback → works → polling stall (~90s)
→ restart → new transport → sticky lost → IPv6 timeout again
```

Observed: **47 polling stalls in 20 hours** on a host with residential ISP (unstable IPv6 to Telegram).

## Fix

`TelegramPollingSession` now resolves the fetch function once in its constructor and passes it to each `createTelegramBot()` call via `opts.resolvedFetch`. The bot uses the pre-resolved fetch (preserving sticky state) when available, falling back to `resolveTelegramFetch()` for non-polling callers.

## Test plan

- [ ] Existing `fetch.test.ts` and `polling-session.test.ts` still pass
- [ ] On a host with unstable IPv6: verify `autoSelectFamily=true (default-node22)` is logged only once per session (not after each restart)
- [ ] On a host with unstable IPv6: verify polling stalls no longer trigger repeated IPv6 timeouts
- [ ] Non-polling bot creation (webhook mode, one-shot) is unaffected (no `resolvedFetch` passed)

Fixes #48177