### PR TITLE
feat(cron): support additionalTargets for multi-channel delivery

### DIFF
--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -8,7 +8,7 @@ import { resolveAgentOutboundIdentity } from "../infra/outbound/identity.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { getChildLogger } from "../logging.js";
 import { resolveDeliveryTarget } from "./isolated-agent/delivery-target.js";
-import type { CronDelivery, CronDeliveryMode, CronJob, CronMessageChannel } from "./types.js";
+import type { CronDelivery, CronDeliveryMode, CronDeliveryTarget, CronJob, CronMessageChannel } from "./types.js";
 
 export type CronDeliveryPlan = {
   mode: CronDeliveryMode;
@@ -17,7 +17,7 @@ export type CronDeliveryPlan = {
   /** Explicit channel account id from the delivery config, if set. */
   accountId?: string;
   /** Additional delivery targets for multi-channel delivery */
-  additionalTargets?: Array<{ channel?: CronMessageChannel; to?: string; accountId?: string }>;
+  additionalTargets?: CronDeliveryTarget[];
   source: "delivery" | "payload";
   requested: boolean;
 };
@@ -79,12 +79,17 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   );
   if (hasDelivery) {
     const resolvedMode = mode ?? "announce";
-    // Extract additionalTargets from delivery config
+    // Extract and normalize additionalTargets from delivery config
     const deliveryAdditionalTargets = (delivery as { additionalTargets?: unknown })?.additionalTargets;
     const additionalTargets = Array.isArray(deliveryAdditionalTargets)
-      ? deliveryAdditionalTargets.filter((t): t is { channel?: CronMessageChannel; to?: string; accountId?: string } =>
-          t && typeof t === "object"
-        )
+      ? deliveryAdditionalTargets
+        .filter((t): t is Record<string, unknown> => t != null && typeof t === "object")
+        .map((t) => ({
+          channel: normalizeChannel(t.channel),
+          to: normalizeTo(t.to),
+          accountId: normalizeAccountId(t.accountId),
+        }))
+        .filter((t) => t.channel !== undefined || t.to !== undefined || t.accountId !== undefined)
       : undefined;
     return {
       mode: resolvedMode,

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -16,6 +16,8 @@ export type CronDeliveryPlan = {
   to?: string;
   /** Explicit channel account id from the delivery config, if set. */
   accountId?: string;
+  /** Additional delivery targets for multi-channel delivery */
+  additionalTargets?: Array<{ channel?: CronMessageChannel; to?: string; accountId?: string }>;
   source: "delivery" | "payload";
   requested: boolean;
 };
@@ -77,11 +79,19 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   );
   if (hasDelivery) {
     const resolvedMode = mode ?? "announce";
+    // Extract additionalTargets from delivery config
+    const deliveryAdditionalTargets = (delivery as { additionalTargets?: unknown })?.additionalTargets;
+    const additionalTargets = Array.isArray(deliveryAdditionalTargets)
+      ? deliveryAdditionalTargets.filter((t): t is { channel?: CronMessageChannel; to?: string; accountId?: string } =>
+          t && typeof t === "object"
+        )
+      : undefined;
     return {
       mode: resolvedMode,
       channel: resolvedMode === "announce" ? channel : undefined,
       to,
       accountId: deliveryAccountId,
+      additionalTargets,
       source: "delivery",
       requested: resolvedMode === "announce",
     };

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -177,10 +177,25 @@ async function resolveCronDeliveryContext(params: {
     accountId: deliveryPlan.accountId,
     sessionKey: params.job.sessionKey,
   });
+  // Resolve additional targets if present
+  const resolvedAdditionalTargets = deliveryPlan.additionalTargets
+    ? await Promise.all(
+        deliveryPlan.additionalTargets.map(async (target) => ({
+          target,
+          resolved: await resolveDeliveryTarget(params.cfg, params.agentId, {
+            channel: target.channel ?? "last",
+            to: target.to,
+            accountId: target.accountId,
+            sessionKey: params.job.sessionKey,
+          }),
+        }))
+      )
+    : undefined;
   return {
     deliveryPlan,
     deliveryRequested: deliveryPlan.requested,
     resolvedDelivery,
+    resolvedAdditionalTargets,
     toolPolicy: resolveCronToolPolicy({
       deliveryRequested: deliveryPlan.requested,
       resolvedDelivery,

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -203,11 +203,27 @@ function coerceDelivery(delivery: UnknownRecord) {
   } else if ("accountId" in next && typeof next.accountId !== "string") {
     delete next.accountId;
   }
-  // Handle additionalTargets array
+  // Handle additionalTargets array with normalization
   if (Array.isArray(delivery.additionalTargets)) {
-    next.additionalTargets = delivery.additionalTargets.filter(
-      (target) => target && typeof target === "object"
-    );
+    next.additionalTargets = delivery.additionalTargets
+      .filter((target) => target && typeof target === "object")
+      .map((target) => {
+        const normalized: UnknownRecord = {};
+        if (typeof target.channel === "string") {
+          const trimmed = target.channel.trim().toLowerCase();
+          if (trimmed) normalized.channel = trimmed;
+        }
+        if (typeof target.to === "string") {
+          const trimmed = target.to.trim();
+          if (trimmed) normalized.to = trimmed;
+        }
+        if (typeof target.accountId === "string") {
+          const trimmed = target.accountId.trim();
+          if (trimmed) normalized.accountId = trimmed;
+        }
+        return normalized;
+      })
+      .filter((t) => t.channel || t.to || t.accountId);
   }
   return next;
 }

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -203,6 +203,12 @@ function coerceDelivery(delivery: UnknownRecord) {
   } else if ("accountId" in next && typeof next.accountId !== "string") {
     delete next.accountId;
   }
+  // Handle additionalTargets array
+  if (Array.isArray(delivery.additionalTargets)) {
+    next.additionalTargets = delivery.additionalTargets.filter(
+      (target) => target && typeof target === "object"
+    );
+  }
   return next;
 }
 

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -20,6 +20,12 @@ export type CronMessageChannel = ChannelId | "last";
 
 export type CronDeliveryMode = "none" | "announce" | "webhook";
 
+export type CronDeliveryTarget = {
+  channel?: CronMessageChannel;
+  to?: string;
+  accountId?: string;
+};
+
 export type CronDelivery = {
   mode: CronDeliveryMode;
   channel?: CronMessageChannel;
@@ -29,6 +35,8 @@ export type CronDelivery = {
   bestEffort?: boolean;
   /** Separate destination for failure notifications. */
   failureDestination?: CronFailureDestination;
+  /** Additional delivery targets for multi-channel delivery */
+  additionalTargets?: CronDeliveryTarget[];
 };
 
 export type CronFailureDestination = {

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -174,11 +174,21 @@ export const CronFailureDestinationSchema = Type.Object(
   { additionalProperties: false },
 );
 
+const CronDeliveryTargetSchema = Type.Object(
+  {
+    channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
+    to: Type.Optional(Type.String()),
+    accountId: Type.Optional(NonEmptyString),
+  },
+  { additionalProperties: false },
+);
+
 const CronDeliverySharedProperties = {
   channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
   accountId: Type.Optional(NonEmptyString),
   bestEffort: Type.Optional(Type.Boolean()),
   failureDestination: Type.Optional(CronFailureDestinationSchema),
+  additionalTargets: Type.Optional(Type.Array(CronDeliveryTargetSchema)),
 };
 
 const CronDeliveryNoopSchema = Type.Object(


### PR DESCRIPTION
## Summary

Add support for additional delivery targets in Cron jobs, allowing notifications to be sent to multiple channels.

## Changes

- Add `CronDeliveryTarget` type for additional delivery targets
- Add `additionalTargets` field to `CronDelivery` type
- Add schema validation for `additionalTargets` in cron.ts
- Add coercion logic for `additionalTargets` in normalize.ts
- Extend `CronDeliveryPlan` to include additionalTargets

Closes #48026