### PR TITLE
fix(agent): drop thinking blocks for non-native anthropic-messages proxies

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -169,4 +169,57 @@ describe("resolveTranscriptPolicy", () => {
       includeCamelCase: true,
     });
   });
+
+  // Third-party proxies that front-end the Anthropic API cannot reliably pass
+  // thinking signatures through byte-for-byte. They must drop thinking blocks
+  // before replay to prevent 400 "thinking blocks cannot be modified" errors.
+  // See: https://github.com/openclaw/openclaw/issues/<TBD>
+  it.each([
+    {
+      title: "brconnector proxy (e.g. shannon-auto)",
+      provider: "brconnector",
+      modelId: "shannon-auto",
+    },
+    {
+      title: "litellm proxy with claude model alias",
+      provider: "litellm",
+      modelId: "my-claude-alias",
+    },
+    {
+      title: "custom anthropic-messages proxy with non-claude model id",
+      provider: "my-company-proxy",
+      modelId: "assistant-v2",
+    },
+  ])(
+    "drops thinking blocks for $title using anthropic-messages API (#proxy-thinking-blocks)",
+    ({ provider, modelId }) => {
+      const policy = resolveTranscriptPolicy({
+        provider,
+        modelId,
+        modelApi: "anthropic-messages",
+      });
+      expect(policy.dropThinkingBlocks).toBe(true);
+    },
+  );
+
+  it("does not drop thinking blocks for native anthropic provider (signatures preserved)", () => {
+    // The native anthropic provider passes signatures byte-for-byte; dropping is
+    // handled separately via dropThinkingBlockModelHints: ["claude"].
+    const policy = resolveTranscriptPolicy({
+      provider: "anthropic",
+      modelId: "claude-opus-4",
+      modelApi: "anthropic-messages",
+    });
+    // Already dropped via model hint "claude" — test the combined result is true
+    expect(policy.dropThinkingBlocks).toBe(true);
+  });
+
+  it("does not drop thinking blocks for non-anthropic-messages providers regardless of provider name", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "brconnector",
+      modelId: "some-openai-model",
+      modelApi: "openai-completions",
+    });
+    expect(policy.dropThinkingBlocks).toBe(false);
+  });
 });

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -86,7 +86,18 @@ export function resolveTranscriptPolicy(params: {
   // Anthropic Claude endpoints can reject replayed `thinking` blocks unless the
   // original signatures are preserved byte-for-byte. Drop them at send-time to
   // keep persisted sessions usable across follow-up turns.
-  const dropThinkingBlocks = shouldDropThinkingBlocksForModel({ provider, modelId });
+  //
+  // Third-party proxies (brconnector, litellm, openrouter, etc.) that front-end
+  // the Anthropic API via `anthropic-messages` cannot reliably preserve thinking
+  // signatures — the proxy may mangle or strip the `thinkingSignature` field,
+  // causing a 400 "thinking blocks cannot be modified" error on the next turn.
+  // Only the native "anthropic" provider (direct API access) can be trusted to
+  // pass signatures through byte-for-byte; any other provider using the
+  // anthropic-messages API should drop thinking blocks before replay.
+  const isNativeAnthropicProvider = provider === "anthropic";
+  const dropThinkingBlocks =
+    shouldDropThinkingBlocksForModel({ provider, modelId }) ||
+    (isAnthropic && !isNativeAnthropicProvider);
 
   const needsNonImageSanitize =
     isGoogle || isAnthropic || isMistral || shouldSanitizeGeminiThoughtSignaturesForProvider;


### PR DESCRIPTION
## Problem

Third-party proxies (brconnector, litellm, openrouter, etc.) configured with `api: "anthropic-messages"` cannot reliably preserve Anthropic thinking block signatures byte-for-byte. When the proxy mangles or strips the `thinkingSignature` field, the next API call fails with:

```
HTTP 400: thinking or redacted_thinking blocks in the latest assistant
message cannot be modified. These blocks must remain as they were in
the original response.
```

## Root Cause

In `resolveTranscriptPolicy`, `dropThinkingBlocks` was only set when the **model ID** matched an entry in `dropThinkingBlockModelHints` (e.g. `"claude"`). Proxy providers often expose custom model aliases (`shannon-auto`, `my-claude-v2`, etc.) that don't match any hint — so thinking blocks were replayed with potentially corrupted signatures.

## Fix

Treat the native `anthropic` provider as the **only** endpoint that can be trusted to preserve thinking signatures end-to-end. Any other provider using the `anthropic-messages` API (i.e. a proxy) now drops thinking blocks before replay, matching the safe behavior already applied to `amazon-bedrock`.

```ts
// Before
const dropThinkingBlocks = shouldDropThinkingBlocksForModel({ provider, modelId });

// After
const isNativeAnthropicProvider = provider === "anthropic";
const dropThinkingBlocks =
  shouldDropThinkingBlocksForModel({ provider, modelId }) ||
  (isAnthropic && !isNativeAnthropicProvider);
```

## Affected Providers

Any custom proxy configured with `api: "anthropic-messages"`, for example:
- brconnector (e.g. model alias `shannon-auto`)
- litellm proxies fronting Claude
- Any internal gateway using the Anthropic Messages API format

## Tests

Added cases to `transcript-policy.test.ts` covering:
- Proxy providers drop thinking blocks ✅
- Native `anthropic` provider is unaffected ✅  
- Non-anthropic-messages providers are unaffected ✅