### PR TITLE
fix(web-fetch): restore strict-first fetch with narrow env-proxy retry

### DIFF
--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -4,7 +4,7 @@ import { type FetchMock, withFetchPreconnect } from "../../test-utils/fetch-mock
 import { makeFetchHeaders } from "./web-fetch.test-harness.js";
 
 const lookupMock = vi.fn();
-const resolvePinnedHostname = ssrf.resolvePinnedHostname;
+const resolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
 
 function redirectResponse(location: string): Response {
   return {
@@ -62,14 +62,15 @@ describe("web_fetch SSRF protection", () => {
   const priorFetch = global.fetch;
 
   beforeEach(() => {
-    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation((hostname) =>
-      resolvePinnedHostname(hostname, lookupMock),
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation((hostname, params = {}) =>
+      resolvePinnedHostnameWithPolicy(hostname, { ...params, lookupFn: lookupMock }),
     );
   });
 
   afterEach(() => {
     global.fetch = priorFetch;
     lookupMock.mockClear();
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -109,6 +110,45 @@ describe("web_fetch SSRF protection", () => {
 
     await expectBlockedUrl(tool, "https://private.test/resource", /private|internal|blocked/i);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks RFC2544 fake-IP DNS answers without trusted proxy transport context", async () => {
+    lookupMock.mockResolvedValue([{ address: "198.18.0.153", family: 4 }]);
+
+    const fetchSpy = setMockFetch();
+    const tool = await createWebFetchToolForTest();
+
+    await expectBlockedUrl(
+      tool,
+      "https://proxy-fake-ip.test/resource",
+      /private|internal|blocked/i,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows RFC2544 fake-IP DNS answers when trusted proxy transport context is enabled", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    lookupMock.mockResolvedValue([{ address: "198.18.0.153", family: 4 }]);
+
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("ok"));
+    const tool = await createWebFetchToolForTest();
+
+    const result = await tool?.execute?.("call", { url: "https://proxy-fake-ip.test/resource" });
+    expect(result?.details).toMatchObject({
+      status: 200,
+      extractor: "raw",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps literal RFC2544 IP targets blocked even in proxy-aware mode", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const fetchSpy = setMockFetch();
+    const tool = await createWebFetchToolForTest();
+
+    await expectBlockedUrl(tool, "https://198.18.0.153/resource", /private|internal|blocked/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(lookupMock).not.toHaveBeenCalled();
   });
 
   it("blocks redirects to private hosts", async () => {

--- a/src/agents/tools/web-fetch.transport-retry.test.ts
+++ b/src/agents/tools/web-fetch.transport-retry.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SsrFBlockedError } from "../../infra/net/ssrf.js";
+import * as webGuardedFetch from "./web-guarded-fetch.js";
+import { createWebFetchTool } from "./web-tools.js";
+
+function createTool() {
+  return createWebFetchTool({
+    config: {
+      tools: {
+        web: {
+          fetch: {
+            cacheTtlMinutes: 0,
+            firecrawl: { enabled: false },
+          },
+        },
+      },
+    },
+  });
+}
+
+function createCachingTool() {
+  return createWebFetchTool({
+    config: {
+      tools: {
+        web: {
+          fetch: {
+            cacheTtlMinutes: 10,
+            firecrawl: { enabled: false },
+          },
+        },
+      },
+    },
+  });
+}
+
+describe("web_fetch transport retry", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("uses strict transport by default for normal requests", async () => {
+    const fetchSpy = vi.spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard").mockResolvedValue({
+      response: new Response("ok", {
+        status: 200,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      }),
+      finalUrl: "https://example.com/ok",
+      release: async () => {},
+    });
+
+    const tool = createTool();
+    await tool?.execute?.("call", { url: "https://example.com/ok" });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        useEnvProxy: false,
+      }),
+    );
+  });
+
+  it("retries with env-proxy only after strict SSRF block on hostname when proxy env is set", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const fetchSpy = vi
+      .spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard")
+      .mockRejectedValueOnce(
+        new SsrFBlockedError("Blocked: resolves to private/internal/special-use IP address"),
+      )
+      .mockResolvedValueOnce({
+        response: new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        }),
+        finalUrl: "https://proxy-fake-ip.test/resource",
+        release: async () => {},
+      });
+
+    const tool = createTool();
+    const result = await tool?.execute?.("call", { url: "https://proxy-fake-ip.test/resource" });
+
+    expect(result?.details).toMatchObject({ status: 200 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ useEnvProxy: false }));
+    expect(fetchSpy.mock.calls[1]?.[0]).toEqual(expect.objectContaining({ useEnvProxy: true }));
+  });
+
+  it("does not retry literal IP targets even when proxy env is set", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const fetchSpy = vi
+      .spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard")
+      .mockRejectedValue(
+        new SsrFBlockedError("Blocked hostname or private/internal/special-use IP address"),
+      );
+
+    const tool = createTool();
+    await expect(tool?.execute?.("call", { url: "https://198.18.0.153/resource" })).rejects.toThrow(
+      /blocked|private|internal/i,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ useEnvProxy: false }));
+  });
+
+  it("does not retry strict SSRF block when proxy env is not configured", async () => {
+    const fetchSpy = vi
+      .spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard")
+      .mockRejectedValue(
+        new SsrFBlockedError("Blocked: resolves to private/internal/special-use IP address"),
+      );
+
+    const tool = createTool();
+    await expect(
+      tool?.execute?.("call", { url: "https://proxy-fake-ip.test/resource" }),
+    ).rejects.toThrow(/blocked|private|internal/i);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ useEnvProxy: false }));
+  });
+
+  it("does not retry when only ALL_PROXY is configured", async () => {
+    vi.stubEnv("ALL_PROXY", "socks5://127.0.0.1:1080");
+    const fetchSpy = vi
+      .spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard")
+      .mockRejectedValue(
+        new SsrFBlockedError("Blocked: resolves to private/internal/special-use IP address"),
+      );
+
+    const tool = createTool();
+    await expect(
+      tool?.execute?.("call", { url: "https://proxy-fake-ip.test/resource" }),
+    ).rejects.toThrow(/blocked|private|internal/i);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ useEnvProxy: false }));
+  });
+
+  it("does not retry when NO_PROXY bypasses env proxy for the hostname", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("NO_PROXY", "proxy-fake-ip.test");
+    const fetchSpy = vi
+      .spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard")
+      .mockRejectedValue(
+        new SsrFBlockedError("Blocked: resolves to private/internal/special-use IP address"),
+      );
+
+    const tool = createTool();
+    await expect(
+      tool?.execute?.("call", { url: "https://proxy-fake-ip.test/resource" }),
+    ).rejects.toThrow(/blocked|private|internal/i);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ useEnvProxy: false }));
+  });
+
+  it("does not reuse cached proxy-route results after NO_PROXY state changes", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const fetchSpy = vi
+      .spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard")
+      .mockRejectedValueOnce(
+        new SsrFBlockedError("Blocked: resolves to private/internal/special-use IP address"),
+      )
+      .mockResolvedValueOnce({
+        response: new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        }),
+        finalUrl: "https://proxy-cache-state.test/resource",
+        release: async () => {},
+      })
+      .mockRejectedValueOnce(
+        new SsrFBlockedError("Blocked: resolves to private/internal/special-use IP address"),
+      );
+
+    const tool = createCachingTool();
+    const url = "https://proxy-cache-state.test/resource";
+
+    const first = await tool?.execute?.("call", { url });
+    expect(first?.details).toMatchObject({ status: 200 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    vi.stubEnv("NO_PROXY", "proxy-cache-state.test");
+    await expect(tool?.execute?.("call", { url })).rejects.toThrow(/blocked|private|internal/i);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(fetchSpy.mock.calls[2]?.[0]).toEqual(expect.objectContaining({ useEnvProxy: false }));
+  });
+
+  it("invalidates cache when NO_PROXY changes only for a redirected hop host", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const fetchSpy = vi
+      .spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard")
+      .mockResolvedValueOnce({
+        response: new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        }),
+        finalUrl: "https://redirected-proxy-hop.test/resource",
+        release: async () => {},
+      })
+      .mockRejectedValueOnce(new Error("should refetch after NO_PROXY change"));
+
+    const tool = createCachingTool();
+    const url = "https://entry-proxy-hop.test/resource";
+
+    const first = await tool?.execute?.("call", { url });
+    expect(first?.details).toMatchObject({ status: 200 });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    vi.stubEnv("NO_PROXY", "redirected-proxy-hop.test");
+    await expect(tool?.execute?.("call", { url })).rejects.toThrow(
+      /should refetch after NO_PROXY change/i,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,10 +1,17 @@
+import crypto from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
-import { SsrFBlockedError } from "../../infra/net/ssrf.js";
-import { logDebug } from "../../logger.js";
+import { hasEnvHttpProxyRouteForUrl } from "../../infra/net/proxy-env.js";
+import { type SsrFPolicy, SsrFBlockedError } from "../../infra/net/ssrf.js";
+import { logDebug, logInfo } from "../../logger.js";
 import type { RuntimeWebFetchFirecrawlMetadata } from "../../secrets/runtime-web-tools.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
+import {
+  isCanonicalDottedDecimalIPv4,
+  isLegacyIpv4Literal,
+  parseCanonicalIpAddress,
+} from "../../shared/net/ip.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { stringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
@@ -45,6 +52,7 @@ const DEFAULT_FIRECRAWL_BASE_URL = "https://api.firecrawl.dev";
 const DEFAULT_FIRECRAWL_MAX_AGE_MS = 172_800_000;
 const DEFAULT_FETCH_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+const WEB_FETCH_INTERNAL_SSRF_POLICY: SsrFPolicy = { allowRfc2544BenchmarkRange: true };
 
 const FETCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 
@@ -207,6 +215,28 @@ function resolveMaxRedirects(value: unknown, fallback: number): number {
   return Math.max(0, Math.floor(parsed));
 }
 
+function looksLikeUnsupportedIpv4Literal(hostname: string): boolean {
+  const parts = hostname.split(".");
+  if (parts.length === 0 || parts.length > 4) {
+    return false;
+  }
+  if (parts.some((part) => part.length === 0)) {
+    return true;
+  }
+  return parts.every((part) => /^[0-9]+$/.test(part) || /^0x/i.test(part));
+}
+
+function isLiteralIpHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  if (parseCanonicalIpAddress(normalized)) {
+    return true;
+  }
+  if (!isCanonicalDottedDecimalIPv4(normalized) && isLegacyIpv4Literal(normalized)) {
+    return true;
+  }
+  return looksLikeUnsupportedIpv4Literal(normalized);
+}
+
 function looksLikeHtml(value: string): boolean {
   const trimmed = value.trimStart();
   if (!trimmed) {
@@ -250,6 +280,22 @@ const WEB_FETCH_WRAPPER_NO_WARNING_OVERHEAD = wrapExternalContent("", {
   source: "web_fetch",
   includeWarning: false,
 }).length;
+const ENV_PROXY_ROUTE_FINGERPRINT_KEYS = [
+  "http_proxy",
+  "HTTP_PROXY",
+  "https_proxy",
+  "HTTPS_PROXY",
+  "no_proxy",
+  "NO_PROXY",
+] as const;
+
+function resolveEnvProxyRouteFingerprint(env: NodeJS.ProcessEnv = process.env): string {
+  const payload = ENV_PROXY_ROUTE_FINGERPRINT_KEYS.map((key) => {
+    const raw = env[key];
+    return `${key}=${typeof raw === "string" ? raw : "<unset>"}`;
+  }).join("\n");
+  return crypto.createHash("sha256").update(payload).digest("hex").slice(0, 16);
+}
 
 function wrapWebFetchContent(
   value: string,
@@ -458,6 +504,7 @@ type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   cacheTtlMs: number;
   userAgent: string;
   readabilityEnabled: boolean;
+  ssrfPolicy: SsrFPolicy;
 };
 
 function toFirecrawlContentParams(
@@ -512,14 +559,6 @@ async function maybeFetchFirecrawlWebFetchPayload(
 }
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
-  const cacheKey = normalizeCacheKey(
-    `fetch:${params.url}:${params.extractMode}:${params.maxChars}`,
-  );
-  const cached = readCache(FETCH_CACHE, cacheKey);
-  if (cached) {
-    return { ...cached.value, cached: true };
-  }
-
   let parsedUrl: URL;
   try {
     parsedUrl = new URL(params.url);
@@ -529,27 +568,70 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   if (!["http:", "https:"].includes(parsedUrl.protocol)) {
     throw new Error("Invalid URL: must be http or https");
   }
+  const hasTrustedEnvProxyRoute = hasEnvHttpProxyRouteForUrl(parsedUrl);
+  const envProxyRouteFingerprint = resolveEnvProxyRouteFingerprint();
+  const cacheKey = normalizeCacheKey(
+    `fetch:${params.url}:${params.extractMode}:${params.maxChars}:proxy-aware-rfc2544:env-proxy-route-${hasTrustedEnvProxyRoute ? "on" : "off"}:env-proxy-route-state-${envProxyRouteFingerprint}`,
+  );
+  const cached = readCache(FETCH_CACHE, cacheKey);
+  if (cached) {
+    return { ...cached.value, cached: true };
+  }
 
   const start = Date.now();
   let res: Response;
   let release: (() => Promise<void>) | null = null;
   let finalUrl = params.url;
+  const requestInit: RequestInit = {
+    headers: {
+      Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
+      "User-Agent": params.userAgent,
+      "Accept-Language": "en-US,en;q=0.9",
+    },
+  };
   try {
-    const result = await fetchWithWebToolsNetworkGuard({
-      url: params.url,
-      maxRedirects: params.maxRedirects,
-      timeoutSeconds: params.timeoutSeconds,
-      init: {
-        headers: {
-          Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
-          "User-Agent": params.userAgent,
-          "Accept-Language": "en-US,en;q=0.9",
-        },
-      },
-    });
-    res = result.response;
-    finalUrl = result.finalUrl;
-    release = result.release;
+    try {
+      // Keep the initial attempt on strict SSRF defaults; fake-IP continuation is
+      // only considered in the narrow trusted env-proxy retry branch below.
+      const result = await fetchWithWebToolsNetworkGuard({
+        url: params.url,
+        maxRedirects: params.maxRedirects,
+        timeoutSeconds: params.timeoutSeconds,
+        useEnvProxy: false,
+        init: requestInit,
+      });
+      res = result.response;
+      finalUrl = result.finalUrl;
+      release = result.release;
+    } catch (error) {
+      const shouldRetryViaEnvProxy =
+        error instanceof SsrFBlockedError &&
+        hasTrustedEnvProxyRoute &&
+        !isLiteralIpHostname(parsedUrl.hostname);
+      if (!shouldRetryViaEnvProxy) {
+        throw error;
+      }
+      logInfo(
+        "[web-fetch] strict SSRF blocked initial URL fetch; retrying hostname target via trusted env-proxy",
+      );
+      let retryResult: Awaited<ReturnType<typeof fetchWithWebToolsNetworkGuard>>;
+      try {
+        retryResult = await fetchWithWebToolsNetworkGuard({
+          url: params.url,
+          maxRedirects: params.maxRedirects,
+          timeoutSeconds: params.timeoutSeconds,
+          policy: params.ssrfPolicy,
+          useEnvProxy: true,
+          init: requestInit,
+        });
+      } catch (retryError) {
+        logDebug("[web-fetch] trusted env-proxy retry failed after strict SSRF block");
+        throw retryError;
+      }
+      res = retryResult.response;
+      finalUrl = retryResult.finalUrl;
+      release = retryResult.release;
+    }
 
     // Cloudflare Markdown for Agents — log token budget hint when present
     const markdownTokens = res.headers.get("x-markdown-tokens");
@@ -741,6 +823,9 @@ export function createWebFetchTool(options?: {
     return null;
   }
   const readabilityEnabled = resolveFetchReadabilityEnabled(fetch);
+  // Internal-only policy signal: continuation stays transport-aware and never
+  // becomes a user-configurable SSRF bypass surface.
+  const ssrfPolicy = WEB_FETCH_INTERNAL_SSRF_POLICY;
   const firecrawl = resolveFirecrawlConfig(fetch);
   const runtimeFirecrawlActive = options?.runtimeFirecrawl?.active;
   const shouldResolveFirecrawlApiKey =
@@ -787,6 +872,7 @@ export function createWebFetchTool(options?: {
         cacheTtlMs: resolveCacheTtlMs(fetch?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         userAgent,
         readabilityEnabled,
+        ssrfPolicy,
         firecrawlEnabled,
         firecrawlApiKey,
         firecrawlBaseUrl,

--- a/src/agents/tools/web-guarded-fetch.test.ts
+++ b/src/agents/tools/web-guarded-fetch.test.ts
@@ -1,33 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "../../infra/net/fetch-guard.js";
+import * as fetchGuard from "../../infra/net/fetch-guard.js";
 import { withStrictWebToolsEndpoint, withTrustedWebToolsEndpoint } from "./web-guarded-fetch.js";
-
-vi.mock("../../infra/net/fetch-guard.js", () => {
-  const GUARDED_FETCH_MODE = {
-    STRICT: "strict",
-    TRUSTED_ENV_PROXY: "trusted_env_proxy",
-  } as const;
-  return {
-    GUARDED_FETCH_MODE,
-    fetchWithSsrFGuard: vi.fn(),
-    withStrictGuardedFetchMode: (params: Record<string, unknown>) => ({
-      ...params,
-      mode: GUARDED_FETCH_MODE.STRICT,
-    }),
-    withTrustedEnvProxyGuardedFetchMode: (params: Record<string, unknown>) => ({
-      ...params,
-      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
-    }),
-  };
-});
 
 describe("web-guarded-fetch", () => {
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it("uses trusted SSRF policy for trusted web tools endpoints", async () => {
-    vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+    const fetchWithSsrFGuardSpy = vi.spyOn(fetchGuard, "fetchWithSsrFGuard").mockResolvedValue({
       response: new Response("ok", { status: 200 }),
       finalUrl: "https://example.com",
       release: async () => {},
@@ -35,20 +16,20 @@ describe("web-guarded-fetch", () => {
 
     await withTrustedWebToolsEndpoint({ url: "https://example.com" }, async () => undefined);
 
-    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+    expect(fetchWithSsrFGuardSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://example.com",
         policy: expect.objectContaining({
           dangerouslyAllowPrivateNetwork: true,
           allowRfc2544BenchmarkRange: true,
         }),
-        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+        mode: fetchGuard.GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
       }),
     );
   });
 
   it("keeps strict endpoint policy unchanged", async () => {
-    vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+    const fetchWithSsrFGuardSpy = vi.spyOn(fetchGuard, "fetchWithSsrFGuard").mockResolvedValue({
       response: new Response("ok", { status: 200 }),
       finalUrl: "https://example.com",
       release: async () => {},
@@ -56,13 +37,13 @@ describe("web-guarded-fetch", () => {
 
     await withStrictWebToolsEndpoint({ url: "https://example.com" }, async () => undefined);
 
-    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+    expect(fetchWithSsrFGuardSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://example.com",
       }),
     );
-    const call = vi.mocked(fetchWithSsrFGuard).mock.calls[0]?.[0];
+    const call = fetchWithSsrFGuardSpy.mock.calls[0]?.[0];
     expect(call?.policy).toBeUndefined();
-    expect(call?.mode).toBe(GUARDED_FETCH_MODE.STRICT);
+    expect(call?.mode).toBe(fetchGuard.GUARDED_FETCH_MODE.STRICT);
   });
 });

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -6,6 +6,7 @@ import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import { __testing as webFetchTesting } from "./web-fetch.js";
 import { makeFetchHeaders } from "./web-fetch.test-harness.js";
 import { createWebFetchTool } from "./web-tools.js";
+const resolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
 
 type MockResponse = {
   ok: boolean;
@@ -147,15 +148,20 @@ describe("web_fetch extraction fallbacks", () => {
   const priorFetch = global.fetch;
 
   beforeEach(() => {
-    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation(async (hostname) => {
-      const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
-      const addresses = ["93.184.216.34", "93.184.216.35"];
-      return {
-        hostname: normalized,
-        addresses,
-        lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses }),
-      };
-    });
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(
+      async (hostname, params = {}) => {
+        const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+        const addresses = ["93.184.216.34", "93.184.216.35"];
+        return await resolvePinnedHostnameWithPolicy(normalized, {
+          ...params,
+          lookupFn: (async () =>
+            addresses.map((address) => ({
+              address,
+              family: address.includes(":") ? 6 : 4,
+            }))) as unknown as ssrf.LookupFn,
+        });
+      },
+    );
   });
 
   afterEach(() => {

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -130,14 +130,96 @@ describe("fetchWithSsrFGuard hardening", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("allows RFC2544 benchmark range IPv4 literal URLs when explicitly opted in", async () => {
+  it("allows fake-IP DNS continuation in strict mode when explicitly allowed by policy", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "198.18.0.153", family: 4 },
+    ]) as unknown as LookupFn;
     const fetchImpl = vi.fn().mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
     const result = await fetchWithSsrFGuard({
-      url: "http://198.18.0.153/file",
+      url: "https://proxy.fake.test/file",
       fetchImpl,
+      lookupFn,
       policy: { allowRfc2544BenchmarkRange: true },
     });
+
     expect(result.response.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    await result.release();
+  });
+
+  it("allows fake-IP DNS continuation only in trusted proxy transport mode", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const lookupFn = vi.fn(async () => [
+      { address: "198.18.0.153", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn().mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://proxy.fake.test/file",
+      fetchImpl,
+      lookupFn,
+      policy: { allowRfc2544BenchmarkRange: true },
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+    });
+
+    expect(result.response.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    await result.release();
+  });
+
+  it("blocks fake-IP continuation when only ALL_PROXY is set in trusted env-proxy mode", async () => {
+    vi.stubEnv("ALL_PROXY", "socks5://127.0.0.1:1080");
+    const lookupFn = vi.fn(async () => [
+      { address: "198.18.0.153", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://proxy.fake.test/file",
+        fetchImpl,
+        lookupFn,
+        policy: { allowRfc2544BenchmarkRange: true },
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("blocks fake-IP continuation when NO_PROXY bypasses env proxy for target", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("NO_PROXY", "proxy.fake.test");
+    const lookupFn = vi.fn(async () => [
+      { address: "198.18.0.153", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://proxy.fake.test/file",
+        fetchImpl,
+        lookupFn,
+        policy: { allowRfc2544BenchmarkRange: true },
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("never allows literal RFC2544 IP targets even in trusted proxy mode", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://198.18.0.153/file",
+        fetchImpl,
+        policy: { allowRfc2544BenchmarkRange: true },
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it("fails closed for plain HTTP targets when explicit proxy mode requires pinned DNS", async () => {
@@ -163,6 +245,33 @@ describe("fetchWithSsrFGuard hardening", () => {
       expectedError: /private|internal|blocked/i,
       lookupFn,
     });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks fake-IP continuation on redirect hops when NO_PROXY bypasses trusted env-proxy routing", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("NO_PROXY", "redirected.proxy.fake.test");
+    const lookupFn = vi.fn(async (hostname: string) => {
+      if (hostname === "entry.proxy.fake.test" || hostname === "redirected.proxy.fake.test") {
+        return [{ address: "198.18.0.153", family: 4 }];
+      }
+      return [{ address: "93.184.216.34", family: 4 }];
+    }) as unknown as LookupFn;
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse("https://redirected.proxy.fake.test/file"));
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://entry.proxy.fake.test/start",
+        fetchImpl,
+        lookupFn,
+        policy: { allowRfc2544BenchmarkRange: true },
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+
+    // First hop is fetched, redirect hop is blocked before fetch when NO_PROXY bypasses env proxy.
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -1,13 +1,14 @@
 import type { Dispatcher } from "undici";
 import { logWarn } from "../../logger.js";
 import { bindAbortRelay } from "../../utils/fetch-timeout.js";
-import { hasProxyEnvConfigured } from "./proxy-env.js";
+import { hasEnvHttpProxyRouteForUrl } from "./proxy-env.js";
 import {
   closeDispatcher,
   createPinnedDispatcher,
   resolvePinnedHostnameWithPolicy,
   type LookupFn,
   type PinnedDispatcherPolicy,
+  type SsrFTransportContext,
   SsrFBlockedError,
   type SsrFPolicy,
 } from "./ssrf.js";
@@ -89,6 +90,40 @@ function resolveGuardedFetchMode(params: GuardedFetchOptions): GuardedFetchMode 
     return GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY;
   }
   return GUARDED_FETCH_MODE.STRICT;
+}
+
+function resolveSsrFTransportContext(params: {
+  mode: GuardedFetchMode;
+  hasEnvProxyRoute: boolean;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+}): SsrFTransportContext {
+  if (params.dispatcherPolicy?.mode === "explicit-proxy") {
+    return { mode: "trusted-proxy", proxy: "explicit-proxy" };
+  }
+  if (params.dispatcherPolicy?.mode === "env-proxy") {
+    return { mode: "trusted-proxy", proxy: "env-proxy" };
+  }
+  if (params.mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && params.hasEnvProxyRoute) {
+    return { mode: "trusted-proxy", proxy: "env-proxy" };
+  }
+  return { mode: "direct" };
+}
+
+function resolveHopSsrFPolicy(params: {
+  mode: GuardedFetchMode;
+  canUseTrustedEnvProxy: boolean;
+  policy?: SsrFPolicy;
+}): SsrFPolicy | undefined {
+  if (
+    params.mode !== GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY ||
+    params.canUseTrustedEnvProxy ||
+    params.policy?.allowRfc2544BenchmarkRange !== true
+  ) {
+    return params.policy;
+  }
+
+  const { allowRfc2544BenchmarkRange: _discard, ...rest } = params.policy;
+  return Object.keys(rest).length > 0 ? rest : undefined;
 }
 
 function assertExplicitProxySupportsPinnedDns(
@@ -207,17 +242,34 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
     let dispatcher: Dispatcher | null = null;
     try {
       assertExplicitProxySupportsPinnedDns(parsedUrl, params.dispatcherPolicy, params.pinDns);
-      const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
-        lookupFn: params.lookupFn,
+      const hasEnvProxyRoute = hasEnvHttpProxyRouteForUrl(parsedUrl);
+      const canUseTrustedEnvProxy =
+        mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasEnvProxyRoute;
+      const hopPolicy = resolveHopSsrFPolicy({
+        mode,
+        canUseTrustedEnvProxy,
         policy: params.policy,
       });
-      const canUseTrustedEnvProxy =
-        mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
+      const transportContext = resolveSsrFTransportContext({
+        mode,
+        hasEnvProxyRoute,
+        dispatcherPolicy: params.dispatcherPolicy,
+      });
+      const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+        lookupFn: params.lookupFn,
+        policy: hopPolicy,
+        transportContext,
+      });
       if (canUseTrustedEnvProxy) {
         const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
         dispatcher = new EnvHttpProxyAgent();
       } else if (params.pinDns !== false) {
-        dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy, params.policy);
+        dispatcher = createPinnedDispatcher(
+          pinned,
+          params.dispatcherPolicy,
+          hopPolicy,
+          transportContext,
+        );
       }
 
       const init: RequestInit & { dispatcher?: Dispatcher } = {

--- a/src/infra/net/proxy-env.test.ts
+++ b/src/infra/net/proxy-env.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  hasEnvHttpProxyRouteForUrl,
   hasEnvHttpProxyConfigured,
   hasProxyEnvConfigured,
   resolveEnvHttpProxyUrl,
@@ -84,5 +85,63 @@ describe("resolveEnvHttpProxyUrl", () => {
     } as NodeJS.ProcessEnv;
 
     expect(resolveEnvHttpProxyUrl("http", env)).toBe("http://lower-http.test:8080");
+  });
+});
+
+describe("hasEnvHttpProxyRouteForUrl", () => {
+  it("returns true when HTTPS env proxy is configured and target is not bypassed", () => {
+    const env = {
+      HTTPS_PROXY: "http://proxy.test:8080",
+    } as NodeJS.ProcessEnv;
+    expect(hasEnvHttpProxyRouteForUrl("https://public.example/resource", env)).toBe(true);
+  });
+
+  it("returns false when only ALL_PROXY is configured", () => {
+    const env = {
+      ALL_PROXY: "http://proxy.test:8080",
+    } as NodeJS.ProcessEnv;
+    expect(hasEnvHttpProxyRouteForUrl("https://public.example/resource", env)).toBe(false);
+  });
+
+  it("returns false when NO_PROXY bypasses the target hostname", () => {
+    const env = {
+      HTTPS_PROXY: "http://proxy.test:8080",
+      NO_PROXY: "public.example",
+    } as NodeJS.ProcessEnv;
+    expect(hasEnvHttpProxyRouteForUrl("https://public.example/resource", env)).toBe(false);
+  });
+
+  it("treats lower-case no_proxy as authoritative over upper-case NO_PROXY", () => {
+    const env = {
+      HTTPS_PROXY: "http://proxy.test:8080",
+      no_proxy: "",
+      NO_PROXY: "public.example",
+    } as NodeJS.ProcessEnv;
+    expect(hasEnvHttpProxyRouteForUrl("https://public.example/resource", env)).toBe(true);
+  });
+
+  it("honors NO_PROXY host:port entries", () => {
+    const env = {
+      HTTPS_PROXY: "http://proxy.test:8080",
+      NO_PROXY: "public.example:8443",
+    } as NodeJS.ProcessEnv;
+    expect(hasEnvHttpProxyRouteForUrl("https://public.example/resource", env)).toBe(true);
+    expect(hasEnvHttpProxyRouteForUrl("https://public.example:8443/resource", env)).toBe(false);
+  });
+
+  it("does not treat URL-shaped NO_PROXY tokens as hostname bypass entries", () => {
+    const env = {
+      HTTPS_PROXY: "http://proxy.test:8080",
+      NO_PROXY: "https://public.example",
+    } as NodeJS.ProcessEnv;
+    expect(hasEnvHttpProxyRouteForUrl("https://public.example/resource", env)).toBe(true);
+  });
+
+  it("treats wildcard bypass as global only when NO_PROXY is exactly '*'", () => {
+    const env = {
+      HTTPS_PROXY: "http://proxy.test:8080",
+      NO_PROXY: "*,public.example",
+    } as NodeJS.ProcessEnv;
+    expect(hasEnvHttpProxyRouteForUrl("https://unrelated.example/resource", env)).toBe(true);
   });
 });

--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -53,3 +53,126 @@ export function hasEnvHttpProxyConfigured(
 ): boolean {
   return resolveEnvHttpProxyUrl(protocol, env) !== undefined;
 }
+
+function resolveNoProxyEnvValue(env: NodeJS.ProcessEnv): string {
+  const lowerNoProxy = normalizeProxyEnvValue(env.no_proxy);
+  if (lowerNoProxy !== undefined) {
+    return lowerNoProxy ?? "";
+  }
+  const upperNoProxy = normalizeProxyEnvValue(env.NO_PROXY);
+  return upperNoProxy ?? "";
+}
+
+function resolveUrlDefaultPort(protocol: string): number | null {
+  if (protocol === "http:") {
+    return 80;
+  }
+  if (protocol === "https:") {
+    return 443;
+  }
+  return null;
+}
+
+function resolveUrlPort(url: URL): number | null {
+  if (url.port) {
+    const parsed = Number.parseInt(url.port, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return resolveUrlDefaultPort(url.protocol);
+}
+
+function normalizeNoProxyHostname(value: string): string {
+  let normalized = value.trim().toLowerCase();
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    normalized = normalized.slice(1, -1);
+  }
+  normalized = normalized.replace(/^\*?\./, "");
+  return normalized;
+}
+
+function parseNoProxyEntry(entry: string): { hostname: string; port?: number } | null {
+  const trimmed = entry.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed === "*") {
+    return { hostname: "*" };
+  }
+
+  let hostname = trimmed;
+  let port: number | undefined;
+  if (trimmed.startsWith("[")) {
+    const ipv6Match = trimmed.match(/^\[([^\]]+)\](?::(\d+))?$/);
+    if (ipv6Match) {
+      hostname = ipv6Match[1] ?? trimmed;
+      if (ipv6Match[2]) {
+        const parsedPort = Number.parseInt(ipv6Match[2], 10);
+        if (Number.isFinite(parsedPort)) {
+          port = parsedPort;
+        }
+      }
+    }
+  } else if (trimmed.indexOf(":") === trimmed.lastIndexOf(":")) {
+    const hostPortMatch = trimmed.match(/^(.+):(\d+)$/);
+    if (hostPortMatch) {
+      hostname = hostPortMatch[1] ?? trimmed;
+      const parsedPort = Number.parseInt(hostPortMatch[2], 10);
+      if (Number.isFinite(parsedPort)) {
+        port = parsedPort;
+      }
+    }
+  }
+
+  const normalizedHostname = normalizeNoProxyHostname(hostname);
+  if (!normalizedHostname) {
+    return null;
+  }
+  return port ? { hostname: normalizedHostname, port } : { hostname: normalizedHostname };
+}
+
+function noProxyBypassesUrl(url: URL, env: NodeJS.ProcessEnv): boolean {
+  const noProxyValue = resolveNoProxyEnvValue(env);
+  if (!noProxyValue) {
+    return false;
+  }
+  if (noProxyValue === "*") {
+    return true;
+  }
+
+  const targetHostname = normalizeNoProxyHostname(url.hostname);
+  const targetPort = resolveUrlPort(url);
+  if (!targetHostname) {
+    return false;
+  }
+
+  const entries = noProxyValue.split(/[,\s]+/);
+  for (const entry of entries) {
+    const parsed = parseNoProxyEntry(entry);
+    if (!parsed) {
+      continue;
+    }
+    if (parsed.port !== undefined && targetPort !== null && parsed.port !== targetPort) {
+      continue;
+    }
+    if (targetHostname === parsed.hostname || targetHostname.endsWith(`.${parsed.hostname}`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasEnvHttpProxyRouteForUrl(
+  url: URL | string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const parsedUrl = typeof url === "string" ? new URL(url) : url;
+  const protocol =
+    parsedUrl.protocol === "http:" ? "http" : parsedUrl.protocol === "https:" ? "https" : null;
+  if (!protocol) {
+    return false;
+  }
+  if (!hasEnvHttpProxyConfigured(protocol, env)) {
+    return false;
+  }
+  return !noProxyBypassesUrl(parsedUrl, env);
+}

--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -58,7 +58,7 @@ describe("ssrf pinning", () => {
     await expect(resolvePinnedHostname("example.com", lookup)).rejects.toThrow(/private|internal/i);
   });
 
-  it("allows RFC2544 benchmark range addresses only when policy explicitly opts in", async () => {
+  it("allows RFC2544 benchmark range DNS answers when explicitly allowed by policy", async () => {
     const lookup = vi.fn(async () => [
       { address: "198.18.0.153", family: 4 },
     ]) as unknown as LookupFn;
@@ -67,11 +67,33 @@ describe("ssrf pinning", () => {
       /private|internal/i,
     );
 
-    const pinned = await resolvePinnedHostnameWithPolicy("api.telegram.org", {
+    const directPinned = await resolvePinnedHostnameWithPolicy("api.telegram.org", {
       lookupFn: lookup,
       policy: { allowRfc2544BenchmarkRange: true },
     });
+    expect(directPinned.addresses).toContain("198.18.0.153");
+
+    const pinned = await resolvePinnedHostnameWithPolicy("api.telegram.org", {
+      lookupFn: lookup,
+      policy: { allowRfc2544BenchmarkRange: true },
+      transportContext: { mode: "trusted-proxy", proxy: "env-proxy" },
+    });
     expect(pinned.addresses).toContain("198.18.0.153");
+  });
+
+  it("never allows literal RFC2544 IP targets even with trusted proxy transport context", async () => {
+    const lookup = vi.fn(async () => [
+      { address: "198.18.0.153", family: 4 },
+    ]) as unknown as LookupFn;
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("198.18.0.153", {
+        lookupFn: lookup,
+        policy: { allowRfc2544BenchmarkRange: true },
+        transportContext: { mode: "trusted-proxy", proxy: "env-proxy" },
+      }),
+    ).rejects.toThrow(/private|internal/i);
+    expect(lookup).not.toHaveBeenCalled();
   });
 
   it("falls back for non-matching hostnames", async () => {

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -30,6 +30,10 @@ export class SsrFBlockedError extends Error {
 
 export type LookupFn = typeof dnsLookup;
 
+export type SsrFTransportContext =
+  | { mode: "direct" }
+  | { mode: "trusted-proxy"; proxy: "env-proxy" | "explicit-proxy" };
+
 export type SsrFPolicy = {
   allowPrivateNetwork?: boolean;
   dangerouslyAllowPrivateNetwork?: boolean;
@@ -81,6 +85,23 @@ function resolveIpv4SpecialUseBlockOptions(policy?: SsrFPolicy): Ipv4SpecialUseB
   };
 }
 
+function isRfc2544ContinuationRequested(policy?: SsrFPolicy): boolean {
+  return policy?.allowRfc2544BenchmarkRange === true;
+}
+
+function withEffectiveRfc2544Policy(
+  policy: SsrFPolicy | undefined,
+  allowRfc2544BenchmarkRange: boolean,
+): SsrFPolicy | undefined {
+  if (!policy) {
+    return allowRfc2544BenchmarkRange ? { allowRfc2544BenchmarkRange: true } : undefined;
+  }
+  return {
+    ...policy,
+    allowRfc2544BenchmarkRange,
+  };
+}
+
 function isHostnameAllowedByPattern(hostname: string, pattern: string): boolean {
   if (pattern.startsWith("*.")) {
     const suffix = pattern.slice(2);
@@ -110,6 +131,26 @@ function looksLikeUnsupportedIpv4Literal(address: string): boolean {
   // Tighten only "ipv4-ish" literals (numbers + optional 0x prefix). Hostnames like
   // "example.com" must stay in hostname policy handling and not be treated as malformed IPs.
   return parts.every((part) => /^[0-9]+$/.test(part) || /^0x/i.test(part));
+}
+
+function isIpLiteralInputHost(hostname: string): boolean {
+  if (parseCanonicalIpAddress(hostname)) {
+    return true;
+  }
+  if (hostname.includes(":")) {
+    return false;
+  }
+  if (!isCanonicalDottedDecimalIPv4(hostname) && isLegacyIpv4Literal(hostname)) {
+    return true;
+  }
+  return looksLikeUnsupportedIpv4Literal(hostname);
+}
+
+function shouldAllowRfc2544OnDnsResults(params: {
+  hostname: string;
+  policy?: SsrFPolicy;
+}): boolean {
+  return isRfc2544ContinuationRequested(params.policy) && !isIpLiteralInputHost(params.hostname);
 }
 
 // Returns true for private/internal and special-use non-global addresses.
@@ -310,7 +351,11 @@ function dedupeAndPreferIpv4(results: readonly LookupAddress[]): string[] {
 
 export async function resolvePinnedHostnameWithPolicy(
   hostname: string,
-  params: { lookupFn?: LookupFn; policy?: SsrFPolicy } = {},
+  params: {
+    lookupFn?: LookupFn;
+    policy?: SsrFPolicy;
+    transportContext?: SsrFTransportContext;
+  } = {},
 ): Promise<PinnedHostname> {
   const normalized = normalizeHostname(hostname);
   if (!normalized) {
@@ -319,6 +364,16 @@ export async function resolvePinnedHostnameWithPolicy(
 
   const hostnameAllowlist = normalizeHostnameAllowlist(params.policy?.hostnameAllowlist);
   const skipPrivateNetworkChecks = shouldSkipPrivateNetworkChecks(normalized, params.policy);
+  // Keep input-host checks strict. RFC2544 continuation is only considered
+  // for DNS answers from hostname targets (never literal-IP input hosts).
+  const hostPolicy = withEffectiveRfc2544Policy(params.policy, false);
+  const dnsResolvedPolicy = withEffectiveRfc2544Policy(
+    params.policy,
+    shouldAllowRfc2544OnDnsResults({
+      hostname: normalized,
+      policy: params.policy,
+    }),
+  );
 
   if (!matchesHostnameAllowlist(normalized, hostnameAllowlist)) {
     throw new SsrFBlockedError(`Blocked hostname (not in allowlist): ${hostname}`);
@@ -326,7 +381,7 @@ export async function resolvePinnedHostnameWithPolicy(
 
   if (!skipPrivateNetworkChecks) {
     // Phase 1: fail fast for literal hosts/IPs before any DNS lookup side-effects.
-    assertAllowedHostOrIpOrThrow(normalized, params.policy);
+    assertAllowedHostOrIpOrThrow(normalized, hostPolicy);
   }
 
   const lookupFn = params.lookupFn ?? dnsLookup;
@@ -337,7 +392,7 @@ export async function resolvePinnedHostnameWithPolicy(
 
   if (!skipPrivateNetworkChecks) {
     // Phase 2: re-check DNS answers so public hostnames cannot pivot to private targets.
-    assertAllowedResolvedAddressesOrThrow(results, params.policy);
+    assertAllowedResolvedAddressesOrThrow(results, dnsResolvedPolicy);
   }
 
   // Prefer addresses returned as IPv4 by DNS family metadata before other
@@ -372,7 +427,9 @@ function resolvePinnedDispatcherLookup(
   pinned: PinnedHostname,
   override?: PinnedHostnameOverride,
   policy?: SsrFPolicy,
+  transportContext?: SsrFTransportContext,
 ): PinnedHostname["lookup"] {
+  void transportContext;
   if (!override) {
     return pinned.lookup;
   }
@@ -386,8 +443,15 @@ function resolvePinnedDispatcherLookup(
     address,
     family: address.includes(":") ? 6 : 4,
   }));
+  const overridePolicy = withEffectiveRfc2544Policy(
+    policy,
+    shouldAllowRfc2544OnDnsResults({
+      hostname: pinned.hostname,
+      policy,
+    }),
+  );
   if (!shouldSkipPrivateNetworkChecks(pinned.hostname, policy)) {
-    assertAllowedResolvedAddressesOrThrow(records, policy);
+    assertAllowedResolvedAddressesOrThrow(records, overridePolicy);
   }
   return createPinnedLookup({
     hostname: pinned.hostname,
@@ -400,9 +464,15 @@ export function createPinnedDispatcher(
   pinned: PinnedHostname,
   policy?: PinnedDispatcherPolicy,
   ssrfPolicy?: SsrFPolicy,
+  transportContext?: SsrFTransportContext,
 ): Dispatcher {
   const { Agent, EnvHttpProxyAgent, ProxyAgent } = loadUndiciRuntimeDeps();
-  const lookup = resolvePinnedDispatcherLookup(pinned, policy?.pinnedHostname, ssrfPolicy);
+  const lookup = resolvePinnedDispatcherLookup(
+    pinned,
+    policy?.pinnedHostname,
+    ssrfPolicy,
+    transportContext,
+  );
 
   if (!policy || policy.mode === "direct") {
     return new Agent({


### PR DESCRIPTION
## Summary

Problem: `web_fetch` started failing in proxy setups that resolve public hostnames into the RFC2544 fake-IP range (`198.18.0.0/15`), which is common with Clash/Surge/mihomo `fake-ip` mode.

Why it matters: in these environments, `web_fetch` can become effectively unusable for normal public URLs even though the target is not actually private or internal.

What changed:
- Fixed `web_fetch` in fake-IP proxy environments where hostname DNS answers may fall into RFC2544 (`198.18.0.0/15`) and trigger strict SSRF blocking.
- Preserved strict-first behavior for `web_fetch`: the initial attempt stays on the normal strict path.
- Added a narrow conditional retry via trusted env-proxy only after an initial `SsrFBlockedError`, only for hostname targets, and only when an effective env-proxy route exists.
- Refined trusted env-proxy detection to be route-aware (including `NO_PROXY` bypass and excluding `ALL_PROXY`-only false positives).
- Kept shared `fetch-guard` / `ssrf` as the enforcement layer.
- Kept RFC2544 continuation scoped to hostname DNS-answer handling; literal IP targets remain blocked.

What did NOT change (scope boundary):
- `web_fetch` does not skip or disable strict SSRF checks; strict validation still runs first.
- No general private-network allowance was added: RFC1918, loopback, link-local, metadata, and other internal/private targets remain blocked.
- Literal IP targets do not get the env-proxy retry path.
- No unconditional proxy routing was introduced for all `web_fetch` requests.
- Shared `fetch-guard` / `ssrf` enforcement was preserved.
- No broad SSRF bypass mechanism was introduced.
- Requests bypassed by `NO_PROXY` (or `ALL_PROXY`-only env) are not treated as trusted env-proxy transport.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

Issues:
- #25215
- #49377
- #44527
- and more...

PRs:
- #51407

## User-visible / Behavior Changes

- `web_fetch` remains strict-first by default.
- If the initial strict fetch is blocked by SSRF, `web_fetch` retries via trusted env-proxy only when:
  - the target is a hostname (not a literal IP), and
  - an effective env-proxy route exists for that URL.
- Effective env-proxy routing is `NO_PROXY`-aware and does not treat `ALL_PROXY`-only env as trusted env-proxy transport.
- This restores compatibility in fake-IP proxy environments without making ordinary requests default to proxy routing.
- Literal IP targets are not retried and remain blocked.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes`
  - Notes: Adds a conditional second attempt only after strict SSRF blocking, only for hostname targets, and only when proxy env is configured; no broadening of private/internal target access.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

Notes:
- Strict SSRF enforcement remains in shared infra.
- The retry path is narrow and transport-aware; it is not a general bypass.
- Trusted env-proxy context is derived from effective route eligibility, not mere proxy-env presence.

## Repro + Verification

### Environment

- OS: macOS 26.3.1 arm64
- Runtime/container: local OpenClaw CLI / gateway
- Model/provider: `grok-4`
- Integration/channel (if any): None
- Relevant setup: Clash/Surge/mihomo-style fake-IP environment; proxy env configured for the process when testing the retry path

### Steps

1. Run Clash/Surge/mihomo or other proxy software with `fake-ip` mode so a normal public hostname resolves into `198.18.0.0/15`.
2. Try `web_fetch` on a normal public URL such as `https://www.google.com`.
3. Compare behavior before and after this change.
4. To exercise the retry path, configure proxy env for the OpenClaw process (for example via shell env or `openclaw.json` env config).

### Expected

- `web_fetch` should remain strict by default.
- In fake-IP proxy environments, hostname requests should be able to continue only through the narrow trusted env-proxy retry path after strict SSRF blocking.
- Private/internal targets and literal IP targets should remain blocked.

### Actual

#### Before

User Input:
```text
Use web fetch test www.google.com
```

Bot:
```text
The `web_fetch` tool blocked the request to `https://www.google.com`, saying it resolves to a private/internal/special-use IP address (which seems odd for Google). Want to try a different URL or debug this?
```

Log:
```text
15:25:15 [security] blocked URL fetch (url-fetch) target=https://www.google.com/ reason=Blocked: resolves to private/internal/special-use IP address
15:25:15 [tools] web_fetch failed: Blocked: resolves to private/internal/special-use IP address
```

#### After

User Input:
```text
Use web fetch test www.google.com
```

Bot:
```text
Fetched https://www.google.com once more – the content is unchanged from the last pulls. If you're testing for variations or something else, let me know; otherwise, here's the same markdown extract for reference:
AboutStore
Gmail
Images
Sign in
AdvertisingBusinessHow Search works
Applying AI towards science and the environment
PrivacyTermsSettings
(As always, external untrusted content.) What next?
```

Log:
```text
15:54:48 [security] blocked URL fetch (url-fetch) target=https://www.google.com/ reason=Blocked: resolves to private/internal/special-use IP address
15:54:48 [web-fetch] strict SSRF blocked initial URL fetch; retrying hostname target via trusted env-proxy
```

## Evidence

- [x] Failing behavior before + passing behavior after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Confirmed ordinary `web_fetch` requests remain strict-first by default.
  - Confirmed hostname requests in fake-IP proxy environments can proceed through the narrow env-proxy retry path.
  - Confirmed literal IP targets do not use this continuation path.
  - Confirmed shared `fetch-guard` / `ssrf` enforcement remains intact.
  - Ran targeted tests for strict-first behavior, transport-aware retry behavior, and SSRF pinning behavior.
- Edge cases checked:
  - No effective env-proxy route: no retry
  - `ALL_PROXY`-only env: no trusted env-proxy retry/path
  - `NO_PROXY` bypass for target hostname: no trusted env-proxy retry/path
- What I did **not** verify:
  - Full end-to-end validation across every proxy implementation and operating system combination

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

Notes:
  - No user-facing config or migration is required.
  - The retry path is conditional and transport-aware, not a general SSRF bypass.
  - To exercise this path in fake-IP environments, proxy env must already be configured for the OpenClaw process.

## Failure Recovery (if this breaks)

- Revert this PR if needed.
- Known bad symptoms reviewers should watch for:
  - ordinary `web_fetch` requests unexpectedly defaulting to env-proxy again
  - literal IP targets accidentally retrying
  - fake-IP hostname requests still failing even when proxy env is configured

## Risks and Mitigations

- Risk: a broader env-proxy behavior could accidentally change ordinary request routing.
- Mitigation: this patch restores strict-first behavior and limits env-proxy use to a narrow retry path after strict SSRF blocking.

- Risk: the retry path could be mistaken for a general SSRF bypass.
- Mitigation: shared SSRF enforcement remains intact; private/internal targets still remain blocked; literal IP targets do not continue; no public bypass toggle is exposed.