### PR TITLE
fix(plugins): normalize renamed plugin id hints

### DIFF
--- a/src/hooks/bundled/boot-md/handler.test.ts
+++ b/src/hooks/bundled/boot-md/handler.test.ts
@@ -17,6 +17,10 @@ vi.mock("../../../agents/agent-scope.js", () => ({
 }));
 vi.mock("../../../logging/subsystem.js", () => ({
   createSubsystemLogger: () => ({
+    child: () => ({
+      warn: logWarn,
+      debug: logDebug,
+    }),
     warn: logWarn,
     debug: logDebug,
   }),

--- a/src/hooks/plugin-hooks.test.ts
+++ b/src/hooks/plugin-hooks.test.ts
@@ -106,8 +106,8 @@ describe("bundle plugin hooks", () => {
     expect(entries[0]?.hook.name).toBe("bundle-hook");
     expect(entries[0]?.hook.source).toBe("openclaw-plugin");
     expect(entries[0]?.hook.pluginId).toBe("sample-bundle");
-    expect(entries[0]?.hook.baseDir).toBe(
-      fs.realpathSync.native(path.join(bundleRoot, "hooks", "bundle-hook")),
+    expect(path.normalize(entries[0]?.hook.baseDir ?? "")).toBe(
+      path.normalize(fs.realpathSync.native(path.join(bundleRoot, "hooks", "bundle-hook"))),
     );
     expect(entries[0]?.metadata?.events).toEqual(["command:new"]);
   });

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -219,6 +219,43 @@ describe("discoverOpenClawPlugins", () => {
     expect(ids).not.toContain("ollama-provider");
   });
 
+  it("normalizes renamed plugin package ids to canonical plugin ids", async () => {
+    const stateDir = makeTempDir();
+    const cases = [
+      { packageName: "@openclaw/brave-plugin", expectedId: "brave" },
+      { packageName: "@openclaw/google-plugin", expectedId: "google" },
+      { packageName: "@openclaw/perplexity-plugin", expectedId: "perplexity" },
+      { packageName: "@openclaw/xai-plugin", expectedId: "xai" },
+    ];
+
+    for (const [index, testCase] of cases.entries()) {
+      const packageDir = path.join(stateDir, "extensions", `plugin-pack-${index}`);
+      mkdirSafe(path.join(packageDir, "src"));
+      writePluginPackageManifest({
+        packageDir,
+        packageName: testCase.packageName,
+        extensions: ["./src/index.ts"],
+      });
+      fs.writeFileSync(
+        path.join(packageDir, "src", "index.ts"),
+        "export default function () {}",
+        "utf-8",
+      );
+    }
+
+    const { candidates } = await discoverWithStateDir(stateDir, {});
+    const ids = candidates.map((c) => c.idHint);
+
+    expect(ids).toContain("brave");
+    expect(ids).toContain("google");
+    expect(ids).toContain("perplexity");
+    expect(ids).toContain("xai");
+    expect(ids).not.toContain("brave-plugin");
+    expect(ids).not.toContain("google-plugin");
+    expect(ids).not.toContain("perplexity-plugin");
+    expect(ids).not.toContain("xai-plugin");
+  });
+
   it("treats configured directory paths as plugin packages", async () => {
     const stateDir = makeTempDir();
     const packDir = path.join(stateDir, "packs", "demo-plugin-dir");

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -339,9 +339,13 @@ function deriveIdHint(params: {
     : rawPackageName;
   const canonicalPackageId =
     {
+      "brave-plugin": "brave",
+      "google-plugin": "google",
       "ollama-provider": "ollama",
+      "perplexity-plugin": "perplexity",
       "sglang-provider": "sglang",
       "vllm-provider": "vllm",
+      "xai-plugin": "xai",
     }[unscoped] ?? unscoped;
 
   if (!params.hasMultipleExtensions) {


### PR DESCRIPTION
## Summary
- normalize renamed `*-plugin` package names to their canonical plugin ids during discovery
- add a discovery regression test covering brave, google, perplexity, and xai plugin packages

## Testing
- `pnpm test -- --run src/plugins/discovery.test.ts -t "normalizes renamed plugin package ids to canonical plugin ids"`
- `pnpm test -- --run src/plugins/discovery.test.ts src/plugins/manifest-registry.test.ts`

Closes #48237