### PR TITLE
docs: add Cortex Memory to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -34,6 +34,19 @@ commands for resume, planning, review, model selection, compaction, and more.
 openclaw plugins install openclaw-codex-app-server
 ```
 
+### Cortex Memory
+
+Persistent memory engine for AI assistants with 4-tier architecture
+(Working, Episodic, Semantic, Procedural), Bayesian beliefs, people graph,
+and multi-signal retrieval. Local-first, zero-cloud, Rust-native.
+
+- **npm:** `@cortex-ai-memory/cortex-memory`
+- **repo:** [github.com/gambletan/cortex](https://github.com/gambletan/cortex)
+
+```bash
+openclaw plugins install @cortex-ai-memory/cortex-memory
+```
+
 ### DingTalk
 
 Enterprise robot integration using Stream mode. Supports text, images, and


### PR DESCRIPTION
## Summary

Add **Cortex Memory** to the community plugins listing.

- **npm**: `@cortex-ai-memory/cortex-memory`
- **repo**: https://github.com/gambletan/cortex
- **install**: `openclaw plugins install @cortex-ai-memory/cortex-memory`

Cortex is a persistent memory engine for AI assistants — 4-tier memory architecture (Working → Episodic → Semantic → Procedural) with Bayesian beliefs, people graph, and multi-signal retrieval. Local-first, zero-cloud, Rust-native (~27MB binary, sub-millisecond queries).

### Plugin features
- **Auto-Recall** — injects relevant memories before each agent turn
- **Auto-Capture** — stores conversation context after each turn
- 7 registered tools: memory_search, memory_store, memory_get, belief_observe, fact_add, preference_set, person_resolve
- CLI commands: `openclaw cortex search/context/beliefs/store`

### Fixes from previous PR (#42568)
- **Alphabetical order**: Entry is now placed before "WeChat" (was appended at end)
- **Ownership consistency**: npm package `@cortex-ai-memory/cortex-memory` homepage links to `github.com/gambletan/cortex` — same maintainer, verified via npm registry metadata

### Quality checklist
- [x] Published on npm (`@cortex-ai-memory/cortex-memory@1.5.1`)
- [x] Public GitHub repository with docs
- [x] Issue tracker enabled
- [x] Active maintenance