### PR TITLE
fix(agent): inherit per-agent model override in embedded/subagent runs (fixes #48255)

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -401,7 +401,6 @@ export function resolveSubagentSpawnModelSelection(params: {
       cfg: params.cfg,
       agentId: params.agentId,
     }) ??
-    normalizeModelSelection(resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model)) ??
     `${runtimeDefault.provider}/${runtimeDefault.model}`
   );
 }


### PR DESCRIPTION
## Summary

Subagent and embedded runs now properly inherit the parent agent per-agent model override instead of falling back to global defaults.

## Problem

When an agent has a per-agent model override in `agents.list[].model.primary`, embedded and subagent runs ignored it and fell back to `agents.defaults.model.primary`. This caused cascading errors when the global default provider was rate-limited or unavailable.

## Root Cause

`resolveSubagentSpawnModelSelection()` had a redundant fallback to `agents.defaults.model.primary` that bypassed the already-computed `runtimeDefault` (which includes per-agent overrides via `resolveDefaultModelForAgent`).

## Fix

Removed 1 line. The fallback chain is now:
1. Explicit model override from caller
2. Subagent-specific config
3. Parent agent model via `runtimeDefault` (resolves per-agent overrides -> global defaults -> provider defaults)

`runtimeDefault` already handles the full resolution chain.

AI-assisted (Claude). Fixes #48255