### PR TITLE
fix(status): fall back to transcript-derived token count when provider reports zero (fixes #48206)

### DIFF
--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -1,4 +1,7 @@
+import fs from "node:fs";
+import readline from "node:readline";
 import { setCliSessionId } from "../../agents/cli-session.js";
+import { estimateMessagesTokens } from "../../agents/compaction.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -6,6 +9,7 @@ import { deriveSessionTotalTokens, hasNonzeroUsage } from "../../agents/usage.js
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   mergeSessionEntry,
+  resolveSessionTranscriptPath,
   setSessionRuntimeModel,
   type SessionEntry,
   updateSessionStore,
@@ -14,6 +18,61 @@ import {
 type RunResult = Awaited<
   ReturnType<(typeof import("../../agents/pi-embedded.js"))["runEmbeddedPiAgent"]>
 >;
+
+/**
+ * Fallback function to estimate token count from session transcript when provider doesn't report usage.
+ * Reads the JSONL session file and estimates tokens from message content.
+ */
+async function estimateTokensFromSessionTranscript(params: {
+  sessionId: string;
+  sessionKey: string;
+  agentId?: string;
+}): Promise<number | undefined> {
+  try {
+    // Resolve transcript path
+    const transcriptPath = resolveSessionTranscriptPath(params.sessionId, params.agentId);
+
+    // Check if transcript file exists
+    if (!fs.existsSync(transcriptPath)) {
+      return undefined;
+    }
+
+    // Read and parse JSONL file to extract messages
+    const messages: any[] = [];
+    const fileStream = fs.createReadStream(transcriptPath, { encoding: "utf-8" });
+    const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+    try {
+      for await (const line of rl) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        try {
+          const parsed = JSON.parse(trimmed);
+          // Extract message objects that have role/content
+          if (parsed?.message?.role && (parsed.message.content || parsed.message.tool_calls)) {
+            messages.push(parsed.message);
+          }
+        } catch {
+          // Skip malformed lines
+        }
+      }
+    } finally {
+      rl.close();
+      fileStream.destroy();
+    }
+
+    // If we have messages, estimate tokens using the existing function
+    if (messages.length > 0) {
+      return estimateMessagesTokens(messages);
+    }
+
+    return undefined;
+  } catch {
+    // If anything fails, return undefined so the system doesn't break
+    return undefined;
+  }
+}
 
 export async function updateSessionStoreAfterAgentRun(params: {
   cfg: OpenClawConfig;
@@ -98,6 +157,34 @@ export async function updateSessionStoreAfterAgentRun(params: {
     }
     next.cacheRead = usage.cacheRead ?? 0;
     next.cacheWrite = usage.cacheWrite ?? 0;
+  } else {
+    // Fallback: when provider doesn't report usage (e.g., MiniMax via Cloudflare AI Gateway),
+    // estimate token count from the session transcript content
+    try {
+      const estimatedTokens = await estimateTokensFromSessionTranscript({
+        sessionId,
+        sessionKey,
+        agentId: cfg.agentId ?? "main",
+      });
+
+      if (typeof estimatedTokens === "number" && estimatedTokens > 0) {
+        next.totalTokens = estimatedTokens;
+        next.totalTokensFresh = true;
+        // Set input/output to 0 since we don't have breakdown, but have estimated total
+        next.inputTokens = 0;
+        next.outputTokens = 0;
+        next.cacheRead = 0;
+        next.cacheWrite = 0;
+      } else {
+        // If estimation also fails, keep the old behavior
+        next.totalTokens = undefined;
+        next.totalTokensFresh = false;
+      }
+    } catch {
+      // If fallback estimation fails, don't break - just use the old behavior
+      next.totalTokens = undefined;
+      next.totalTokensFresh = false;
+    }
   }
   if (compactionsThisRun > 0) {
     next.compactionCount = (entry.compactionCount ?? 0) + compactionsThisRun;


### PR DESCRIPTION
## Summary

When a provider does not return usage data, `/status` now estimates token count from the session transcript instead of showing 0.

## Problem

Some providers (e.g. MiniMax via Cloudflare AI Gateway) do not include `usage` in their API responses. OpenClaw records 0 tokens, so `/status` shows `Context: 0/200k` even when the session has ~97k tokens of actual content.

## Fix

Add `estimateTokensFromSessionTranscript()` in `session-store.ts`:
- Reads the JSONL session transcript
- Extracts messages with role/content
- Uses the existing `estimateMessagesTokens()` from the compaction module
- Only called as fallback when provider-reported usage is 0

This gives users an accurate context gauge regardless of provider behavior.

AI-assisted (Claude). Fixes #48206