### PR TITLE
fix(windows): add windowsHide to all Windows spawn resolution paths

### DIFF
--- a/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
@@ -56,6 +56,7 @@ rl.on("close", () => process.exit(0));
     const child = spawn(process.execPath, [proxyPath, "--payload", payload], {
       stdio: ["pipe", "pipe", "inherit"],
       cwd: process.cwd(),
+      windowsHide: true,
     });
 
     let stdout = "";

--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -133,6 +133,27 @@ describe("resolveSpawnCommand", () => {
     });
   });
 
+  it("sets windowsHide on direct exe resolution on windows", async () => {
+    const dir = await createTempDir();
+    const exePath = path.join(dir, "acpx.exe");
+    await writeFile(exePath, "", "utf8");
+
+    const resolved = resolveSpawnCommand(
+      {
+        command: exePath,
+        args: ["--help"],
+      },
+      undefined,
+      winRuntime({}),
+    );
+
+    expect(resolved).toEqual({
+      command: exePath,
+      args: ["--help"],
+      windowsHide: true,
+    });
+  });
+
   it("falls back to shell mode when wrapper cannot be safely unwrapped", async () => {
     const dir = await createTempDir();
     const wrapperPath = path.join(dir, "custom-wrapper.cmd");
@@ -151,6 +172,7 @@ describe("resolveSpawnCommand", () => {
       command: wrapperPath,
       args: ["--arg", "value"],
       shell: true,
+      windowsHide: true,
     });
   });
 
@@ -237,6 +259,7 @@ describe("waitForExit", () => {
   it("resolves when the child already exited before waiting starts", async () => {
     const child = spawn(process.execPath, ["-e", "process.exit(0)"], {
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     await new Promise<void>((resolve, reject) => {

--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -249,6 +249,7 @@ export function resolveWindowsSpawnProgramCandidate(
     command: resolvedCommand,
     leadingArgv: [],
     resolution: "direct",
+    windowsHide: true,
   };
 }
 
@@ -271,6 +272,7 @@ export function applyWindowsSpawnProgramPolicy(params: {
       leadingArgv: [],
       resolution: "shell-fallback",
       shell: true,
+      windowsHide: true,
     };
   }
   throw new Error(


### PR DESCRIPTION
## Summary
- Adds `windowsHide: true` to the `direct` and `shell-fallback` resolution paths in `src/plugin-sdk/windows-spawn.ts`
- These were the only two Windows-path resolutions missing the flag — all other paths (`node-entrypoint`, `exe-entrypoint`) already set it
- All downstream spawn call sites (acpx runtime, lobster, ACP client) correctly forward `windowsHide` from the resolution, so the fix propagates automatically
- Adds test coverage for direct `.exe` resolution asserting `windowsHide: true`
- Updates shell-fallback test expectation to include `windowsHide: true`
- Adds `windowsHide: true` to raw `spawn()` calls in test files to prevent console flash during test runs on Windows

## Root Cause
`resolveWindowsSpawnProgramCandidate()` only set `windowsHide: true` for `node-entrypoint` and `exe-entrypoint` resolutions. The `direct` path (e.g. `.exe` files resolved on Windows) and the `shell-fallback` path (unresolved `.cmd` wrappers) left `windowsHide` as `undefined`, causing every ACP spawn to flash a visible `cmd.exe` console window.

## Test plan
- [x] `pnpm vitest run extensions/acpx/src/runtime-internals/process.test.ts` — 15/15 passing
- [x] New test: `sets windowsHide on direct exe resolution on windows`
- [x] Updated test: `falls back to shell mode` now asserts `windowsHide: true`
- [x] No-op on macOS/Linux — `windowsHide` is ignored on non-Windows platforms

Closes #40340

🤖 Generated with [Claude Code](https://claude.com/claude-code)