### PR TITLE
Extensions: add gateway-probe for compact gateway event review

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -198,6 +198,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/diagnostics-otel/**"
+"extensions: gateway-probe":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/gateway-probe/**"
 "extensions: llm-task":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/gateway-probe/EVENT_CATALOG.md
+++ b/extensions/gateway-probe/EVENT_CATALOG.md
@@ -1,0 +1,54 @@
+# Gateway Probe Event Catalog
+
+`gateway-probe` emits a single normalized event envelope with:
+
+- `probeId`, `probeName`, `labels`
+- `eventType`, `source`, `severity`, `occurredAt`
+- optional `agentId`, `sessionId`, `sessionKey`, `traceId`, `spanId`
+- a redacted `payload`
+
+The plugin intentionally avoids streaming or delta-style events. It keeps only
+terminal or abnormal events so that one conversation turn produces a small,
+reviewable number of records.
+
+## Session events
+
+- `audit.session.started`
+- `audit.session.ended`
+- `audit.gateway.started`
+- `audit.gateway.stopped`
+
+Source: `session_hook`
+
+## Tool and model events
+
+- `audit.tool.call.finished`
+- `audit.model.response.usage`
+- `realtime.trace.action_span` (terminal model-response companion span only)
+
+Source: `session_hook`
+
+## Log-derived abnormal events
+
+- `ops.subsystem.error`
+- `security.ws.unauthorized`
+- `security.http.tool_invoke.failed`
+- `security.http.malformed_or_reset`
+- `security.device.role_escalation`
+
+Source: `app_log`
+
+## Diagnostic abnormal / terminal events
+
+- `realtime.message.processed`
+- `realtime.webhook.error`
+- `realtime.session.stuck`
+- `realtime.tool.loop`
+
+Source: `diagnostic`
+
+## Privacy notes
+
+- string payload fields are passed through `redactSensitiveText`
+- nested payloads are truncated for size and depth
+- host IPs are not attached automatically; add them explicitly through `labels` if needed

--- a/extensions/gateway-probe/README.md
+++ b/extensions/gateway-probe/README.md
@@ -1,0 +1,135 @@
+# Gateway Probe (plugin)
+
+Observe existing OpenClaw gateway activity and normalize it into a compact event
+stream for audit and operational visibility.
+
+This plugin is intentionally small and conservative:
+
+- disabled by default
+- observe-only: it never blocks or rewrites tool or model behavior
+- avoids high-frequency streaming or delta-style event output
+- no network egress unless you explicitly enable Kafka output
+- no new inbound listener or external control-plane dependency
+
+## Enable
+
+Bundled plugins are disabled by default. Enable this one:
+
+```bash
+openclaw plugins enable gateway-probe
+```
+
+Restart the Gateway after enabling.
+
+## Event Volume Policy
+
+`gateway-probe` keeps event volume intentionally low:
+
+- no chat-delta or token-delta events
+- tool events are emitted only after a tool call finishes
+- model events are emitted only on terminal model output / usage
+- diagnostics keep only low-frequency terminal or abnormal events
+
+This keeps one conversation turn from exploding into many streaming events.
+
+## What it captures
+
+`gateway-probe` listens to existing plugin hooks, diagnostics, and structured app
+logs, then emits normalized events such as:
+
+- session start and stop
+- completed tool calls
+- terminal model usage events
+- low-frequency abnormal diagnostics such as `webhook.error`, `session.stuck`, and `tool.loop`
+- selected gateway error and security log events already present in app logs
+
+For the event names and source mapping, see `extensions/gateway-probe/EVENT_CATALOG.md`.
+
+## Supported Event Types
+
+Current event types emitted by this plugin:
+
+- `audit.session.started`
+- `audit.session.ended`
+- `audit.gateway.started`
+- `audit.gateway.stopped`
+- `audit.tool.call.finished`
+- `audit.model.response.usage`
+- `realtime.trace.action_span`
+- `realtime.message.processed`
+- `realtime.webhook.error`
+- `realtime.session.stuck`
+- `realtime.tool.loop`
+- `ops.subsystem.error`
+- `security.ws.unauthorized`
+- `security.http.tool_invoke.failed`
+- `security.http.malformed_or_reset`
+- `security.device.role_escalation`
+
+## Configuration
+
+Configure under `plugins.entries.gateway-probe.config`.
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "gateway-probe": {
+        "enabled": true,
+        "config": {
+          "probe": {
+            "probeId": "",
+            "name": "gateway-prod-01",
+          },
+          "labels": {
+            "env": "prod",
+          },
+          "kafka": {
+            "enabled": true,
+            "brokers": ["kafka-1:9092", "kafka-2:9092"],
+            "topic": "openclaw.gateway.probe.events",
+            "clientId": "openclaw-gateway-probe",
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- `probe.probeId` defaults to a persisted local UUID under the state dir.
+- `labels.hostname` is added automatically.
+- Kafka publishing is disabled by default; enable it only after brokers and topic are ready.
+
+## Environment overrides
+
+```bash
+export OPENCLAW_PROBE_ID=""
+export OPENCLAW_PROBE_NAME="gateway-prod-01"
+export OPENCLAW_PROBE_LABELS='{"env":"prod"}'
+
+export OPENCLAW_PROBE_KAFKA_ENABLED="true"
+export OPENCLAW_PROBE_KAFKA_BROKERS="kafka-1:9092,kafka-2:9092"
+export OPENCLAW_PROBE_KAFKA_TOPIC="openclaw.gateway.probe.events"
+export OPENCLAW_PROBE_KAFKA_CLIENT_ID="openclaw-gateway-probe"
+```
+
+## Verification
+
+1. Enable the plugin and restart the gateway.
+2. Confirm startup logs include `gateway-probe: started`.
+3. Trigger one simple run and one tool call.
+4. Confirm you do not see streaming token or delta-style events.
+5. If Kafka is enabled, confirm a small number of terminal events land in your configured topic.
+
+## Scope Boundary
+
+`gateway-probe` does not:
+
+- expose an OTLP or HTTP ingest endpoint
+- emit chat-delta or token-delta events
+- perform high-risk or policy-style tool detection
+- block or redact tool results
+- require the separate `platform/` stack

--- a/extensions/gateway-probe/index.ts
+++ b/extensions/gateway-probe/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Gateway Probe plugin entry point.
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { createGatewayProbeService } from "./src/service.js";
+
+const plugin = {
+  id: "gateway-probe",
+  name: "Gateway Probe",
+  description: "Observe-only gateway telemetry collector with optional Kafka output",
+
+  register(api: OpenClawPluginApi) {
+    api.registerService(createGatewayProbeService(api));
+  },
+};
+
+export default plugin;

--- a/extensions/gateway-probe/openclaw.plugin.json
+++ b/extensions/gateway-probe/openclaw.plugin.json
@@ -1,0 +1,67 @@
+{
+  "id": "gateway-probe",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "probe": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "probeId": {
+            "type": "string",
+            "description": "Unique probe identifier (persistent local UUID if empty)"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for this gateway node"
+          }
+        }
+      },
+      "labels": {
+        "type": "object",
+        "description": "Extra labels attached to every emitted event",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "kafka": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Enable Kafka publishing; disabled by default"
+          },
+          "brokers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Kafka broker addresses, for example [\"127.0.0.1:9092\"]"
+          },
+          "topic": {
+            "type": "string",
+            "description": "Kafka topic for probe events"
+          },
+          "clientId": {
+            "type": "string",
+            "description": "Kafka client id"
+          },
+          "flushIntervalMs": {
+            "type": "number",
+            "description": "Batch flush interval in milliseconds"
+          },
+          "batchMaxSize": {
+            "type": "number",
+            "description": "Maximum events per Kafka send request"
+          },
+          "maxQueueSize": {
+            "type": "number",
+            "description": "In-memory queue cap before dropping oldest events"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/gateway-probe/package.json
+++ b/extensions/gateway-probe/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/gateway-probe",
+  "version": "2026.3.2",
+  "description": "Optional observe-only gateway telemetry probe plugin",
+  "type": "module",
+  "dependencies": {
+    "kafkajs": "^2.2.4"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/gateway-probe/src/config.test.ts
+++ b/extensions/gateway-probe/src/config.test.ts
@@ -1,0 +1,184 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveConfig } from "./config.js";
+
+function createTmpStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "gateway-probe-config-"));
+}
+
+describe("resolveConfig", () => {
+  it("returns safe defaults when called with no arguments", () => {
+    const cfg = resolveConfig(undefined, { stateDir: createTmpStateDir() });
+
+    expect(cfg.probe.probeId).toBeTruthy();
+    expect(cfg.probe.name).toMatch(/^probe-/);
+    expect(cfg.kafka.enabled).toBe(false);
+    expect(cfg.kafka.brokers).toEqual(["127.0.0.1:9092"]);
+    expect(cfg.kafka.topic).toBe("openclaw.gateway.probe.events");
+    expect(cfg.kafka.clientId).toBe("openclaw-gateway-probe");
+    expect(cfg.kafka.flushIntervalMs).toBe(1000);
+    expect(cfg.kafka.batchMaxSize).toBe(100);
+    expect(cfg.kafka.maxQueueSize).toBe(5000);
+    expect(cfg.labels).toHaveProperty("agent.type", "openclaw");
+    expect(cfg.labels).toHaveProperty("hostname");
+    expect(cfg.labels).not.toHaveProperty("host.ip");
+    expect(cfg.labels).not.toHaveProperty("host.ips");
+  });
+
+  it("keeps persisted probe id stable for the same state dir", () => {
+    const stateDir = createTmpStateDir();
+
+    const first = resolveConfig(undefined, { stateDir }).probe.probeId;
+    const second = resolveConfig(undefined, { stateDir }).probe.probeId;
+
+    expect(first).toBeTruthy();
+    expect(second).toBe(first);
+  });
+
+  it("merges user-provided probe config", () => {
+    const cfg = resolveConfig(
+      {
+        probe: {
+          probeId: "my-probe-1",
+          name: "prod-probe",
+        },
+      },
+      { stateDir: createTmpStateDir() },
+    );
+
+    expect(cfg.probe.probeId).toBe("my-probe-1");
+    expect(cfg.probe.name).toBe("prod-probe");
+  });
+
+  it("merges user-provided kafka config", () => {
+    const cfg = resolveConfig(
+      {
+        kafka: {
+          enabled: true,
+          brokers: ["kafka-a:9092", "kafka-b:9092"],
+          topic: "probe.events",
+          clientId: "probe-client",
+          flushIntervalMs: 2500,
+          batchMaxSize: 200,
+          maxQueueSize: 10000,
+        },
+      },
+      { stateDir: createTmpStateDir() },
+    );
+
+    expect(cfg.kafka.enabled).toBe(true);
+    expect(cfg.kafka.brokers).toEqual(["kafka-a:9092", "kafka-b:9092"]);
+    expect(cfg.kafka.topic).toBe("probe.events");
+    expect(cfg.kafka.clientId).toBe("probe-client");
+    expect(cfg.kafka.flushIntervalMs).toBe(2500);
+    expect(cfg.kafka.batchMaxSize).toBe(200);
+    expect(cfg.kafka.maxQueueSize).toBe(10000);
+  });
+
+  it("enforces minimum kafka limits", () => {
+    const cfg = resolveConfig(
+      {
+        kafka: {
+          flushIntervalMs: 1,
+          batchMaxSize: 0,
+          maxQueueSize: 1,
+        },
+      },
+      { stateDir: createTmpStateDir() },
+    );
+
+    expect(cfg.kafka.flushIntervalMs).toBe(200);
+    expect(cfg.kafka.batchMaxSize).toBe(1);
+    expect(cfg.kafka.maxQueueSize).toBe(100);
+  });
+
+  it("merges labels with conservative auto-detected defaults", () => {
+    const cfg = resolveConfig(
+      {
+        labels: { env: "production", team: "platform" },
+      },
+      { stateDir: createTmpStateDir() },
+    );
+
+    expect(cfg.labels).toHaveProperty("agent.type", "openclaw");
+    expect(cfg.labels).toHaveProperty("hostname");
+    expect(cfg.labels).toHaveProperty("env", "production");
+    expect(cfg.labels).toHaveProperty("team", "platform");
+  });
+
+  it("user labels override auto-detected defaults", () => {
+    const cfg = resolveConfig(
+      {
+        labels: { hostname: "custom-host" },
+      },
+      { stateDir: createTmpStateDir() },
+    );
+
+    expect(cfg.labels.hostname).toBe("custom-host");
+  });
+
+  it("accepts environment overrides", () => {
+    const cfg = resolveConfig(undefined, {
+      stateDir: createTmpStateDir(),
+      env: {
+        OPENCLAW_PROBE_NAME: "gateway-prod-01",
+        OPENCLAW_PROBE_LABELS: JSON.stringify({ env: "prod" }),
+        OPENCLAW_PROBE_KAFKA_ENABLED: "true",
+        OPENCLAW_PROBE_KAFKA_BROKERS: "kafka-a:9092, kafka-b:9092",
+        OPENCLAW_PROBE_KAFKA_TOPIC: "probe.prod",
+        OPENCLAW_PROBE_KAFKA_CLIENT_ID: "gateway-probe-prod",
+      },
+    });
+
+    expect(cfg.probe.name).toBe("gateway-prod-01");
+    expect(cfg.labels.env).toBe("prod");
+    expect(cfg.kafka.enabled).toBe(true);
+    expect(cfg.kafka.brokers).toEqual(["kafka-a:9092", "kafka-b:9092"]);
+    expect(cfg.kafka.topic).toBe("probe.prod");
+    expect(cfg.kafka.clientId).toBe("gateway-probe-prod");
+  });
+
+  it("lets environment overrides win over file config", () => {
+    const cfg = resolveConfig(
+      {
+        probe: {
+          probeId: "file-probe",
+          name: "file-name",
+        },
+        labels: {
+          env: "staging",
+          hostname: "file-host",
+        },
+        kafka: {
+          enabled: false,
+          brokers: ["file-kafka:9092"],
+          topic: "file.topic",
+          clientId: "file-client",
+        },
+      },
+      {
+        stateDir: createTmpStateDir(),
+        env: {
+          OPENCLAW_PROBE_ID: "env-probe",
+          OPENCLAW_PROBE_NAME: "env-name",
+          OPENCLAW_PROBE_LABELS: JSON.stringify({ env: "prod", hostname: "env-host" }),
+          OPENCLAW_PROBE_KAFKA_ENABLED: "true",
+          OPENCLAW_PROBE_KAFKA_BROKERS: "env-kafka-a:9092, env-kafka-b:9092",
+          OPENCLAW_PROBE_KAFKA_TOPIC: "env.topic",
+          OPENCLAW_PROBE_KAFKA_CLIENT_ID: "env-client",
+        },
+      },
+    );
+
+    expect(cfg.probe.probeId).toBe("env-probe");
+    expect(cfg.probe.name).toBe("env-name");
+    expect(cfg.labels.env).toBe("prod");
+    expect(cfg.labels.hostname).toBe("env-host");
+    expect(cfg.kafka.enabled).toBe(true);
+    expect(cfg.kafka.brokers).toEqual(["env-kafka-a:9092", "env-kafka-b:9092"]);
+    expect(cfg.kafka.topic).toBe("env.topic");
+    expect(cfg.kafka.clientId).toBe("env-client");
+  });
+});

--- a/extensions/gateway-probe/src/config.ts
+++ b/extensions/gateway-probe/src/config.ts
@@ -1,0 +1,181 @@
+/**
+ * Configuration resolution: merge user-provided plugin config with defaults.
+ */
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import { hostname } from "node:os";
+import path from "node:path";
+import type { GatewayProbeConfig, ResolvedProbeConfig } from "./types.js";
+
+const DEFAULTS = {
+  probe: {
+    probeId: "",
+    name: "",
+  },
+  kafka: {
+    enabled: false,
+    brokers: ["127.0.0.1:9092"],
+    topic: "openclaw.gateway.probe.events",
+    clientId: "openclaw-gateway-probe",
+    flushIntervalMs: 1000,
+    batchMaxSize: 100,
+    maxQueueSize: 5000,
+  },
+} as const;
+
+const PROBE_ID_FILE_RELATIVE = path.join("extensions", "gateway-probe", "probe-id.json");
+
+type ResolveConfigOptions = {
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+};
+
+type StoredProbeId = {
+  version: 1;
+  probeId: string;
+  createdAtMs: number;
+};
+
+function toTrimmedStringArray(values?: string[]): string[] {
+  return (values ?? []).map((value) => value.trim()).filter((value) => value.length > 0);
+}
+
+function parseEnvLabels(raw: string | undefined): Record<string, string> {
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).filter(
+        ([, value]) => typeof value === "string",
+      ),
+    ) as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+function parseEnvBrokers(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function parseEnvBoolean(raw: string | undefined): boolean | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+function resolveProbeIdPath(stateDir?: string): string | null {
+  const base = stateDir?.trim();
+  if (!base) {
+    return null;
+  }
+  return path.join(base, PROBE_ID_FILE_RELATIVE);
+}
+
+function loadOrCreatePersistedProbeId(stateDir?: string): string {
+  const filePath = resolveProbeIdPath(stateDir);
+  if (!filePath) {
+    return randomUUID();
+  }
+
+  try {
+    if (fs.existsSync(filePath)) {
+      const raw = fs.readFileSync(filePath, "utf8");
+      const parsed = JSON.parse(raw) as StoredProbeId;
+      if (parsed?.version === 1 && typeof parsed.probeId === "string" && parsed.probeId.trim()) {
+        return parsed.probeId;
+      }
+    }
+  } catch {
+    // Ignore read/parse failures and regenerate.
+  }
+
+  const probeId = randomUUID();
+
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    const stored: StoredProbeId = {
+      version: 1,
+      probeId,
+      createdAtMs: Date.now(),
+    };
+    fs.writeFileSync(filePath, `${JSON.stringify(stored, null, 2)}\n`, { mode: 0o600 });
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // Best effort persistence; keep the generated id for the current process.
+  }
+
+  return probeId;
+}
+
+export function resolveConfig(
+  raw?: Record<string, unknown>,
+  options?: ResolveConfigOptions,
+): ResolvedProbeConfig {
+  const cfg = (raw ?? {}) as GatewayProbeConfig;
+  const env = options?.env ?? process.env;
+
+  const envProbeId = env.OPENCLAW_PROBE_ID?.trim();
+  const envProbeName = env.OPENCLAW_PROBE_NAME?.trim();
+  const envLabels = parseEnvLabels(env.OPENCLAW_PROBE_LABELS);
+  const envKafkaEnabled = parseEnvBoolean(env.OPENCLAW_PROBE_KAFKA_ENABLED);
+  const envKafkaBrokers = parseEnvBrokers(env.OPENCLAW_PROBE_KAFKA_BROKERS);
+  const envKafkaTopic = env.OPENCLAW_PROBE_KAFKA_TOPIC?.trim();
+  const envKafkaClientId = env.OPENCLAW_PROBE_KAFKA_CLIENT_ID?.trim();
+
+  const probeId =
+    envProbeId ||
+    cfg.probe?.probeId?.trim() ||
+    loadOrCreatePersistedProbeId(options?.stateDir);
+  const name = envProbeName || cfg.probe?.name?.trim() || `probe-${hostname()}`;
+
+  const labels: Record<string, string> = {
+    "agent.type": "openclaw",
+    hostname: hostname(),
+    ...(cfg.labels ?? {}),
+    ...envLabels,
+  };
+
+  const cfgKafkaBrokers = toTrimmedStringArray(cfg.kafka?.brokers);
+  const kafkaBrokers = (envKafkaBrokers.length > 0 ? envKafkaBrokers : undefined) ??
+    (cfgKafkaBrokers.length > 0 ? cfgKafkaBrokers : undefined) ?? [...DEFAULTS.kafka.brokers];
+
+  return {
+    probe: {
+      probeId,
+      name,
+    },
+    labels,
+    kafka: {
+      enabled: envKafkaEnabled ?? cfg.kafka?.enabled ?? DEFAULTS.kafka.enabled,
+      brokers: kafkaBrokers,
+      topic: envKafkaTopic || cfg.kafka?.topic?.trim() || DEFAULTS.kafka.topic,
+      clientId: envKafkaClientId || cfg.kafka?.clientId?.trim() || DEFAULTS.kafka.clientId,
+      flushIntervalMs: Math.max(200, cfg.kafka?.flushIntervalMs ?? DEFAULTS.kafka.flushIntervalMs),
+      batchMaxSize: Math.max(1, cfg.kafka?.batchMaxSize ?? DEFAULTS.kafka.batchMaxSize),
+      maxQueueSize: Math.max(100, cfg.kafka?.maxQueueSize ?? DEFAULTS.kafka.maxQueueSize),
+    },
+  };
+}

--- a/extensions/gateway-probe/src/event-docs.test.ts
+++ b/extensions/gateway-probe/src/event-docs.test.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { PROBE_EVENT_TYPES } from "./types.js";
+
+const DOC_FILES = [
+  path.resolve(import.meta.dirname, "..", "README.md"),
+  path.resolve(import.meta.dirname, "..", "EVENT_CATALOG.md"),
+];
+
+describe("gateway-probe docs", () => {
+  it("documents every supported event type", () => {
+    const expected = Object.values(PROBE_EVENT_TYPES) as string[];
+    const expectedSet = new Set(expected);
+
+    for (const docFile of DOC_FILES) {
+      const content = fs.readFileSync(docFile, "utf8");
+      const documented = Array.from(
+        new Set(
+          Array.from(content.matchAll(/`([a-z0-9_.]+)`/g))
+            .map((match) => match[1])
+            .filter(
+              (value): value is string => typeof value === "string" && expectedSet.has(value),
+            ),
+        ),
+      ).sort();
+
+      expect(documented, path.basename(docFile)).toEqual([...expected].sort());
+    }
+  });
+});

--- a/extensions/gateway-probe/src/hooks/hook-registry.ts
+++ b/extensions/gateway-probe/src/hooks/hook-registry.ts
@@ -1,0 +1,15 @@
+/**
+ * Central hook registration for the observe-only probe plugin.
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { TelemetryCollector } from "../telemetry/collector.js";
+import { registerModelHooks } from "./model-hooks.js";
+import { registerSessionHooks } from "./session-hooks.js";
+import { registerToolHooks } from "./tool-hooks.js";
+
+export function registerAllHooks(api: OpenClawPluginApi, collector: TelemetryCollector): void {
+  registerSessionHooks(api, collector);
+  registerToolHooks(api, collector);
+  registerModelHooks(api, collector);
+}

--- a/extensions/gateway-probe/src/hooks/model-hooks.test.ts
+++ b/extensions/gateway-probe/src/hooks/model-hooks.test.ts
@@ -1,0 +1,86 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { TelemetryCollector } from "../telemetry/collector.js";
+import { registerModelHooks } from "./model-hooks.js";
+
+type GenericHookHandler = (event: unknown, ctx: unknown) => unknown;
+
+type HookRegistration = {
+  handler: GenericHookHandler;
+  opts?: { priority?: number };
+};
+
+function createMockCollector(): TelemetryCollector {
+  return {
+    recordSessionStart: vi.fn(),
+    recordSessionEnd: vi.fn(),
+    recordGatewayStart: vi.fn(),
+    recordGatewayStop: vi.fn(),
+    recordToolCallFinished: vi.fn(),
+    recordModelResponseUsage: vi.fn(),
+    recordMappedEvent: vi.fn(),
+  };
+}
+
+function createMockApiHarness() {
+  const handlers = new Map<string, HookRegistration[]>();
+
+  const api = {
+    on: vi.fn((hookName: string, handler: GenericHookHandler, opts?: { priority?: number }) => {
+      const list = handlers.get(hookName) ?? [];
+      list.push({ handler, opts });
+      handlers.set(hookName, list);
+    }),
+  } as unknown as OpenClawPluginApi;
+
+  function getHandler(hookName: string): HookRegistration {
+    const list = handlers.get(hookName) ?? [];
+    const first = list[0];
+    expect(first).toBeDefined();
+    return first as HookRegistration;
+  }
+
+  return { api, getHandler };
+}
+
+describe("registerModelHooks", () => {
+  it("registers only llm_output for terminal model usage", () => {
+    const harness = createMockApiHarness();
+    const collector = createMockCollector();
+
+    registerModelHooks(harness.api, collector);
+
+    expect(harness.api.on).toHaveBeenCalledTimes(1);
+    expect(harness.api.on).toHaveBeenCalledWith("llm_output", expect.any(Function));
+  });
+
+  it("records llm_output as model response usage", () => {
+    const harness = createMockApiHarness();
+    const collector = createMockCollector();
+
+    registerModelHooks(harness.api, collector);
+
+    const llmOutput = harness.getHandler("llm_output");
+    llmOutput.handler(
+      {
+        runId: "run-2",
+        provider: "openai",
+        model: "gpt-4.1",
+        sessionId: "s2",
+        usage: { input: 100, output: 50, cacheRead: 10, cacheWrite: 5, total: 165 },
+      },
+      {
+        agentId: "a2",
+      },
+    );
+
+    expect(collector.recordModelResponseUsage).toHaveBeenCalledWith({
+      runId: "run-2",
+      provider: "openai",
+      model: "gpt-4.1",
+      agentId: "a2",
+      sessionId: "s2",
+      usage: { input: 100, output: 50, cacheRead: 10, cacheWrite: 5, total: 165 },
+    });
+  });
+});

--- a/extensions/gateway-probe/src/hooks/model-hooks.ts
+++ b/extensions/gateway-probe/src/hooks/model-hooks.ts
@@ -1,0 +1,15 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { TelemetryCollector } from "../telemetry/collector.js";
+
+export function registerModelHooks(api: OpenClawPluginApi, collector: TelemetryCollector): void {
+  api.on("llm_output", (event, ctx) => {
+    collector.recordModelResponseUsage({
+      runId: event.runId,
+      provider: event.provider,
+      model: event.model,
+      agentId: ctx.agentId,
+      sessionId: event.sessionId,
+      usage: event.usage,
+    });
+  });
+}

--- a/extensions/gateway-probe/src/hooks/session-hooks.test.ts
+++ b/extensions/gateway-probe/src/hooks/session-hooks.test.ts
@@ -1,0 +1,72 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { TelemetryCollector } from "../telemetry/collector.js";
+import { registerSessionHooks } from "./session-hooks.js";
+
+type GenericHookHandler = (event: unknown, ctx: unknown) => unknown;
+
+type HookRegistration = {
+  handler: GenericHookHandler;
+  opts?: { priority?: number };
+};
+
+function createMockCollector(): TelemetryCollector {
+  return {
+    recordSessionStart: vi.fn(),
+    recordSessionEnd: vi.fn(),
+    recordGatewayStart: vi.fn(),
+    recordGatewayStop: vi.fn(),
+    recordToolCallFinished: vi.fn(),
+    recordModelResponseUsage: vi.fn(),
+    recordMappedEvent: vi.fn(),
+  };
+}
+
+function createMockApiHarness() {
+  const handlers = new Map<string, HookRegistration[]>();
+
+  const api = {
+    on: vi.fn((hookName: string, handler: GenericHookHandler, opts?: { priority?: number }) => {
+      const list = handlers.get(hookName) ?? [];
+      list.push({ handler, opts });
+      handlers.set(hookName, list);
+    }),
+  } as unknown as OpenClawPluginApi;
+
+  function getHandler(hookName: string): HookRegistration {
+    const list = handlers.get(hookName) ?? [];
+    const first = list[0];
+    expect(first).toBeDefined();
+    return first as HookRegistration;
+  }
+
+  return { api, getHandler };
+}
+
+describe("registerSessionHooks", () => {
+  it("records session_start with the stable session key", () => {
+    const harness = createMockApiHarness();
+    const collector = createMockCollector();
+
+    registerSessionHooks(harness.api, collector);
+
+    const sessionStart = harness.getHandler("session_start");
+    sessionStart.handler(
+      {
+        sessionId: "s1",
+        sessionKey: "sk1",
+        resumedFrom: "s0",
+      },
+      {
+        agentId: "a1",
+      },
+    );
+
+    expect(collector.recordSessionStart).toHaveBeenCalledWith({
+      sessionId: "s1",
+      sessionKey: "sk1",
+      resumedFrom: "s0",
+      agentId: "a1",
+    });
+  });
+});

--- a/extensions/gateway-probe/src/hooks/session-hooks.ts
+++ b/extensions/gateway-probe/src/hooks/session-hooks.ts
@@ -1,0 +1,34 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { TelemetryCollector } from "../telemetry/collector.js";
+
+export function registerSessionHooks(api: OpenClawPluginApi, collector: TelemetryCollector): void {
+  api.on("session_start", (event, ctx) => {
+    collector.recordSessionStart({
+      sessionId: event.sessionId,
+      resumedFrom: event.resumedFrom,
+      agentId: ctx.agentId,
+      sessionKey: event.sessionKey,
+    });
+  });
+
+  api.on("session_end", (event, ctx) => {
+    collector.recordSessionEnd({
+      sessionId: event.sessionId,
+      agentId: ctx.agentId,
+      durationMs: event.durationMs,
+      messageCount: event.messageCount,
+    });
+  });
+
+  api.on("gateway_start", (event) => {
+    collector.recordGatewayStart({
+      port: event.port,
+    });
+  });
+
+  api.on("gateway_stop", (event) => {
+    collector.recordGatewayStop({
+      reason: event.reason,
+    });
+  });
+}

--- a/extensions/gateway-probe/src/hooks/tool-hooks.test.ts
+++ b/extensions/gateway-probe/src/hooks/tool-hooks.test.ts
@@ -1,0 +1,84 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { TelemetryCollector } from "../telemetry/collector.js";
+import { registerToolHooks } from "./tool-hooks.js";
+
+type GenericHookHandler = (event: unknown, ctx: unknown) => unknown;
+
+type HookRegistration = {
+  handler: GenericHookHandler;
+  opts?: { priority?: number };
+};
+
+function createMockCollector(): TelemetryCollector {
+  return {
+    recordSessionStart: vi.fn(),
+    recordSessionEnd: vi.fn(),
+    recordGatewayStart: vi.fn(),
+    recordGatewayStop: vi.fn(),
+    recordToolCallFinished: vi.fn(),
+    recordModelResponseUsage: vi.fn(),
+    recordMappedEvent: vi.fn(),
+  };
+}
+
+function createMockApiHarness() {
+  const handlers = new Map<string, HookRegistration[]>();
+
+  const api = {
+    on: vi.fn((hookName: string, handler: GenericHookHandler, opts?: { priority?: number }) => {
+      const list = handlers.get(hookName) ?? [];
+      list.push({ handler, opts });
+      handlers.set(hookName, list);
+    }),
+  } as unknown as OpenClawPluginApi;
+
+  function getHandler(hookName: string): HookRegistration {
+    const list = handlers.get(hookName) ?? [];
+    const first = list[0];
+    expect(first).toBeDefined();
+    return first as HookRegistration;
+  }
+
+  return { api, getHandler };
+}
+
+describe("registerToolHooks", () => {
+  it("registers only after_tool_call", () => {
+    const harness = createMockApiHarness();
+    const collector = createMockCollector();
+
+    registerToolHooks(harness.api, collector);
+
+    expect(harness.api.on).toHaveBeenCalledTimes(1);
+    expect(harness.api.on).toHaveBeenCalledWith("after_tool_call", expect.any(Function));
+  });
+
+  it("records finished tool calls", () => {
+    const harness = createMockApiHarness();
+    const collector = createMockCollector();
+
+    registerToolHooks(harness.api, collector);
+
+    const after = harness.getHandler("after_tool_call");
+    after.handler(
+      {
+        toolName: "read",
+        durationMs: 25,
+        error: "file not found",
+      },
+      {
+        agentId: "a2",
+        sessionKey: "sk2",
+      },
+    );
+
+    expect(collector.recordToolCallFinished).toHaveBeenCalledWith({
+      toolName: "read",
+      durationMs: 25,
+      error: "file not found",
+      agentId: "a2",
+      sessionKey: "sk2",
+    });
+  });
+});

--- a/extensions/gateway-probe/src/hooks/tool-hooks.ts
+++ b/extensions/gateway-probe/src/hooks/tool-hooks.ts
@@ -1,0 +1,14 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { TelemetryCollector } from "../telemetry/collector.js";
+
+export function registerToolHooks(api: OpenClawPluginApi, collector: TelemetryCollector): void {
+  api.on("after_tool_call", (event, ctx) => {
+    collector.recordToolCallFinished({
+      toolName: event.toolName,
+      durationMs: event.durationMs,
+      error: event.error,
+      agentId: ctx.agentId,
+      sessionKey: ctx.sessionKey,
+    });
+  });
+}

--- a/extensions/gateway-probe/src/kafka/writer.test.ts
+++ b/extensions/gateway-probe/src/kafka/writer.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProbeEvent, ResolvedProbeConfig } from "../types.js";
+
+const sendMock = vi.fn();
+const connectMock = vi.fn(async () => {});
+const disconnectMock = vi.fn(async () => {});
+
+vi.mock("kafkajs", () => ({
+  Kafka: vi.fn().mockImplementation(function KafkaMock() {
+    return {
+      producer: () => ({
+        connect: connectMock,
+        disconnect: disconnectMock,
+        send: sendMock,
+      }),
+    };
+  }),
+  logLevel: {
+    NOTHING: 0,
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeConfig(): ResolvedProbeConfig {
+  return {
+    probe: {
+      probeId: "probe-1",
+      name: "probe-main",
+    },
+    labels: {
+      env: "test",
+    },
+    kafka: {
+      enabled: true,
+      brokers: ["127.0.0.1:9092"],
+      topic: "probe.events",
+      clientId: "gateway-probe-test",
+      flushIntervalMs: 60_000,
+      batchMaxSize: 1,
+      maxQueueSize: 100,
+    },
+  };
+}
+
+function makeEvent(id: string): ProbeEvent {
+  return {
+    schemaVersion: "1.0",
+    pluginVersion: "2026.3.2",
+    eventId: id,
+    probeId: "probe-1",
+    probeName: "probe-main",
+    labels: {},
+    eventType: "audit.session.started",
+    occurredAt: new Date("2026-03-17T00:00:00.000Z").toISOString(),
+    source: "session_hook",
+    severity: "info",
+    sessionId: id,
+    sessionKey: `session-${id}`,
+    payload: {},
+  };
+}
+
+describe("startKafkaWriter", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("drains the remaining queue on shutdown after an in-flight flush completes", async () => {
+    const { startKafkaWriter } = await import("./writer.js");
+    const firstSend = deferred<void>();
+
+    sendMock.mockImplementationOnce(() => firstSend.promise);
+    sendMock.mockResolvedValueOnce(undefined);
+
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const writer = await startKafkaWriter(makeConfig(), logger);
+    writer.enqueue(makeEvent("event-1"));
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledTimes(1);
+    });
+
+    writer.enqueue(makeEvent("event-2"));
+
+    const stopPromise = writer.stop();
+    firstSend.resolve();
+    await stopPromise;
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("unsent events during shutdown"),
+    );
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/gateway-probe/src/kafka/writer.ts
+++ b/extensions/gateway-probe/src/kafka/writer.ts
@@ -1,0 +1,150 @@
+import { Kafka, logLevel, type Producer } from "kafkajs";
+import type { ProbeEvent, ResolvedProbeConfig } from "../types.js";
+
+interface Logger {
+  info(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+}
+
+export interface KafkaWriterHandle {
+  enqueue(event: ProbeEvent): void;
+  stop(): Promise<void>;
+}
+
+export async function startKafkaWriter(
+  config: ResolvedProbeConfig,
+  logger: Logger,
+): Promise<KafkaWriterHandle> {
+  const kafka = new Kafka({
+    clientId: config.kafka.clientId,
+    brokers: config.kafka.brokers,
+    logLevel: logLevel.NOTHING,
+  });
+
+  const producer = kafka.producer({ allowAutoTopicCreation: false });
+  await producer.connect();
+
+  logger.info(
+    `gateway-probe: kafka producer connected (brokers=${config.kafka.brokers.join(",")}, topic=${config.kafka.topic})`,
+  );
+
+  const state = {
+    queue: [] as ProbeEvent[],
+    dropped: 0,
+    flushing: false,
+    stopped: false,
+  };
+
+  let flushPromise: Promise<void> | null = null;
+
+  async function flushBatch(p: Producer): Promise<boolean> {
+    if (state.flushing || state.queue.length === 0) {
+      return true;
+    }
+
+    state.flushing = true;
+
+    const batch = state.queue.splice(0, config.kafka.batchMaxSize);
+
+    try {
+      await p.send({
+        topic: config.kafka.topic,
+        messages: batch.map((event) => ({
+          key: event.sessionId ?? event.sessionKey ?? event.probeId,
+          value: JSON.stringify(event),
+        })),
+      });
+      return true;
+    } catch (err) {
+      // Requeue on send failure; oldest entries are dropped if queue is already at cap.
+      state.queue.unshift(...batch);
+      if (state.queue.length > config.kafka.maxQueueSize) {
+        const overflow = state.queue.length - config.kafka.maxQueueSize;
+        state.queue.splice(0, overflow);
+        state.dropped += overflow;
+        logger.warn(
+          `gateway-probe: dropped ${overflow} queued events after send failure (queue cap=${config.kafka.maxQueueSize})`,
+        );
+      }
+
+      logger.error(
+        `gateway-probe: kafka send failed (${err instanceof Error ? err.message : String(err)})`,
+      );
+      return false;
+    } finally {
+      state.flushing = false;
+    }
+  }
+
+  async function flushLoop(forceAll: boolean): Promise<void> {
+    if (flushPromise) {
+      await flushPromise;
+      if (!forceAll) {
+        return;
+      }
+    }
+
+    flushPromise = (async () => {
+      do {
+        const sent = await flushBatch(producer);
+        if (forceAll && !sent) {
+          break;
+        }
+      } while (forceAll && state.queue.length > 0);
+    })();
+
+    try {
+      await flushPromise;
+    } finally {
+      flushPromise = null;
+    }
+  }
+
+  const timer = setInterval(() => {
+    if (state.stopped) {
+      return;
+    }
+    void flushLoop(false);
+  }, config.kafka.flushIntervalMs);
+  timer.unref?.();
+
+  return {
+    enqueue(event: ProbeEvent) {
+      if (state.stopped) {
+        return;
+      }
+
+      if (state.queue.length >= config.kafka.maxQueueSize) {
+        state.queue.shift();
+        state.dropped += 1;
+        if (state.dropped === 1 || state.dropped % 100 === 0) {
+          logger.warn(
+            `gateway-probe: dropped ${state.dropped} total events because queue is full (maxQueueSize=${config.kafka.maxQueueSize})`,
+          );
+        }
+      }
+
+      state.queue.push(event);
+      if (state.queue.length >= config.kafka.batchMaxSize) {
+        void flushLoop(false);
+      }
+    },
+
+    async stop() {
+      state.stopped = true;
+      clearInterval(timer);
+
+      await flushLoop(true);
+      if (state.queue.length > 0) {
+        logger.warn(`gateway-probe: dropping ${state.queue.length} unsent events during shutdown`);
+        state.queue.length = 0;
+      }
+      await producer.disconnect().catch((err: unknown) => {
+        logger.error(
+          `gateway-probe: kafka disconnect failed (${err instanceof Error ? err.message : String(err)})`,
+        );
+      });
+    },
+  };
+}

--- a/extensions/gateway-probe/src/service.ts
+++ b/extensions/gateway-probe/src/service.ts
@@ -1,0 +1,111 @@
+/**
+ * Probe service lifecycle.
+ *
+ * The plugin observes existing OpenClaw hooks, diagnostics, and app logs,
+ * normalizes them into a stable event envelope, and optionally forwards them to
+ * Kafka. It never blocks or mutates runtime behavior.
+ */
+
+import {
+  onDiagnosticEvent,
+  registerLogTransport,
+  type DiagnosticEventPayload,
+  type OpenClawPluginApi,
+  type OpenClawPluginService,
+} from "openclaw/plugin-sdk";
+import { resolveConfig } from "./config.js";
+import { registerAllHooks } from "./hooks/hook-registry.js";
+import { startKafkaWriter, type KafkaWriterHandle } from "./kafka/writer.js";
+import { createTelemetryCollector } from "./telemetry/collector.js";
+import { mapDiagnosticEvent } from "./telemetry/diagnostic-mapper.js";
+import { mapAppLogRecord } from "./telemetry/log-mapper.js";
+
+const PLUGIN_VERSION = "2026.3.2";
+
+export function createGatewayProbeService(api: OpenClawPluginApi): OpenClawPluginService {
+  let writer: KafkaWriterHandle | null = null;
+  let unsubscribeDiagnostics: (() => void) | null = null;
+  let unsubscribeLogs: (() => void) | null = null;
+
+  return {
+    id: "gateway-probe",
+
+    async start() {
+      const stateDir = api.runtime.state.resolveStateDir(process.env);
+      const config = resolveConfig(api.pluginConfig, {
+        env: process.env,
+        stateDir,
+      });
+
+      if (config.kafka.enabled) {
+        try {
+          writer = await startKafkaWriter(config, {
+            info: (msg) => api.logger.info(msg),
+            warn: (msg) => api.logger.warn(msg),
+            error: (msg) => api.logger.error(msg),
+          });
+        } catch (err) {
+          api.logger.error(
+            `gateway-probe: failed to start kafka writer: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      } else {
+        api.logger.info(
+          "gateway-probe: kafka publishing disabled; running in observe-only local mode",
+        );
+      }
+
+      const collector = createTelemetryCollector({
+        pluginVersion: PLUGIN_VERSION,
+        probeId: config.probe.probeId,
+        probeName: config.probe.name,
+        labels: config.labels,
+        emit: (event) => writer?.enqueue(event),
+      });
+
+      registerAllHooks(api, collector);
+
+      unsubscribeDiagnostics = onDiagnosticEvent((evt: DiagnosticEventPayload) => {
+        try {
+          for (const event of mapDiagnosticEvent(evt)) {
+            collector.recordMappedEvent(event);
+          }
+        } catch (err) {
+          api.logger.error(
+            `gateway-probe: diagnostic mapper error: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      });
+
+      unsubscribeLogs = registerLogTransport((logObj) => {
+        try {
+          for (const event of mapAppLogRecord(logObj as Record<string, unknown>)) {
+            collector.recordMappedEvent(event);
+          }
+        } catch (err) {
+          api.logger.error(
+            `gateway-probe: app-log mapper error: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      });
+
+      api.logger.info(
+        `gateway-probe: started (probe=${config.probe.probeId}, name=${config.probe.name}, ` +
+          `kafkaEnabled=${config.kafka.enabled}, labels=${JSON.stringify(config.labels)})`,
+      );
+    },
+
+    async stop() {
+      unsubscribeDiagnostics?.();
+      unsubscribeDiagnostics = null;
+
+      unsubscribeLogs?.();
+      unsubscribeLogs = null;
+
+      if (writer) {
+        await writer.stop();
+        writer = null;
+      }
+    },
+  } satisfies OpenClawPluginService;
+}

--- a/extensions/gateway-probe/src/telemetry/collector.test.ts
+++ b/extensions/gateway-probe/src/telemetry/collector.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { PROBE_EVENT_TYPES, type ProbeEvent } from "../types.js";
+import { createTelemetryCollector } from "./collector.js";
+
+function createCollectorHarness() {
+  const emitted: ProbeEvent[] = [];
+
+  const collector = createTelemetryCollector({
+    pluginVersion: "2026.3.2",
+    probeId: "probe-1",
+    probeName: "probe-main",
+    labels: { env: "test" },
+    emit(event) {
+      emitted.push(event);
+    },
+  });
+
+  return { collector, emitted };
+}
+
+describe("TelemetryCollector", () => {
+  it("emits audit.session.started with a normalized envelope", () => {
+    const { collector, emitted } = createCollectorHarness();
+
+    collector.recordSessionStart({
+      sessionId: "s1",
+      agentId: "a1",
+      sessionKey: "sk1",
+      resumedFrom: "s0",
+    });
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      schemaVersion: "1.0",
+      pluginVersion: "2026.3.2",
+      probeId: "probe-1",
+      probeName: "probe-main",
+      labels: { env: "test" },
+      eventType: PROBE_EVENT_TYPES.AUDIT_SESSION_STARTED,
+      source: "session_hook",
+      severity: "info",
+      sessionId: "s1",
+      sessionKey: "sk1",
+      agentId: "a1",
+      payload: {
+        resumedFrom: "s0",
+      },
+    });
+    expect(emitted[0].eventId).toBeTruthy();
+    expect(new Date(emitted[0].occurredAt).toString()).not.toBe("Invalid Date");
+  });
+
+  it("emits warn severity for failed tool calls", () => {
+    const { collector, emitted } = createCollectorHarness();
+
+    collector.recordToolCallFinished({
+      toolName: "exec",
+      durationMs: 42,
+      error: "permission denied",
+      sessionKey: "sk1",
+      agentId: "a1",
+    });
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.AUDIT_TOOL_CALL_FINISHED,
+      severity: "warn",
+      payload: {
+        toolName: "exec",
+        durationMs: 42,
+        error: "permission denied",
+      },
+    });
+  });
+
+  it("emits only terminal model-response events", () => {
+    const { collector, emitted } = createCollectorHarness();
+
+    collector.recordModelResponseUsage({
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-4.1",
+      sessionId: "s1",
+    });
+
+    expect(emitted).toHaveLength(2);
+    expect(emitted[0]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.AUDIT_MODEL_RESPONSE_USAGE,
+      traceId: "run-1",
+      payload: {
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-4.1",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+    });
+
+    expect(emitted[1]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.REALTIME_TRACE_ACTION_SPAN,
+      traceId: "run-1",
+      spanId: "run-1:model.response",
+      payload: {
+        stage: "model.response",
+        status: "completed",
+      },
+    });
+  });
+
+  it("normalizes mapped events and converts numeric timestamps to ISO", () => {
+    const { collector, emitted } = createCollectorHarness();
+
+    collector.recordMappedEvent({
+      eventType: "custom.event",
+      source: "diagnostic",
+      severity: "warn",
+      occurredAt: 1_700_000_000_000,
+      payload: {
+        key: "value",
+      },
+    });
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      eventType: "custom.event",
+      source: "diagnostic",
+      severity: "warn",
+      payload: { key: "value" },
+    });
+    expect(emitted[0].occurredAt).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+});

--- a/extensions/gateway-probe/src/telemetry/collector.ts
+++ b/extensions/gateway-probe/src/telemetry/collector.ts
@@ -1,0 +1,251 @@
+/**
+ * Telemetry collector facade consumed by hook handlers and mappers.
+ *
+ * It normalizes all probe events into a single envelope and emits them through
+ * the provided sink callback.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  PROBE_EVENT_TYPES,
+  type ProbeEvent,
+  type ProbeEventSeverity,
+  type ProbeEventSource,
+} from "../types.js";
+import { redactSensitiveText } from "./redact.js";
+
+interface CollectorContext {
+  pluginVersion: string;
+  probeId: string;
+  probeName: string;
+  labels: Record<string, string>;
+  emit(event: ProbeEvent): void;
+}
+
+type UsageMetrics = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  total?: number;
+};
+
+export interface ProbeMappedEventInput {
+  eventType: string;
+  source: ProbeEventSource;
+  severity?: ProbeEventSeverity;
+  occurredAt?: string | number | Date;
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  traceId?: string;
+  spanId?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface TelemetryCollector {
+  recordSessionStart(attrs: {
+    sessionId: string;
+    agentId?: string;
+    sessionKey?: string;
+    resumedFrom?: string;
+  }): void;
+  recordSessionEnd(attrs: {
+    sessionId: string;
+    agentId?: string;
+    durationMs?: number;
+    messageCount: number;
+  }): void;
+  recordGatewayStart(attrs: { port?: number }): void;
+  recordGatewayStop(attrs: { reason?: string }): void;
+  recordToolCallFinished(attrs: {
+    toolName: string;
+    durationMs?: number;
+    error?: string;
+    agentId?: string;
+    sessionKey?: string;
+  }): void;
+  recordModelResponseUsage(attrs: {
+    runId: string;
+    provider: string;
+    model: string;
+    usage?: UsageMetrics;
+    agentId?: string;
+    sessionId?: string;
+  }): void;
+  recordMappedEvent(input: ProbeMappedEventInput): void;
+}
+
+function sanitizePayloadValue(value: unknown, depth = 0): unknown {
+  if (value == null) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return redactSensitiveText(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (depth >= 5) {
+    return "[truncated]";
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, 50).map((item) => sanitizePayloadValue(item, depth + 1));
+  }
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value).slice(0, 80)) {
+      out[key] = sanitizePayloadValue(nested, depth + 1);
+    }
+    return out;
+  }
+  return String(value);
+}
+
+function normalizeOccurredAt(input: ProbeMappedEventInput["occurredAt"]): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (typeof input === "number") {
+    return new Date(input).toISOString();
+  }
+  if (input instanceof Date) {
+    return input.toISOString();
+  }
+  return new Date().toISOString();
+}
+
+export function createTelemetryCollector(context: CollectorContext): TelemetryCollector {
+  const emitProbeEvent = (input: ProbeMappedEventInput): void => {
+    const payload = (sanitizePayloadValue(input.payload ?? {}, 0) as Record<string, unknown>) ?? {};
+    context.emit({
+      schemaVersion: "1.0",
+      pluginVersion: context.pluginVersion,
+      eventId: randomUUID(),
+      probeId: context.probeId,
+      probeName: context.probeName,
+      labels: context.labels,
+      eventType: input.eventType,
+      occurredAt: normalizeOccurredAt(input.occurredAt),
+      source: input.source,
+      severity: input.severity ?? "info",
+      ...(input.agentId ? { agentId: input.agentId } : {}),
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+      ...(input.sessionKey ? { sessionKey: input.sessionKey } : {}),
+      ...(input.traceId ? { traceId: input.traceId } : {}),
+      ...(input.spanId ? { spanId: input.spanId } : {}),
+      payload,
+    });
+  };
+
+  return {
+    recordSessionStart({ sessionId, agentId, sessionKey, resumedFrom }) {
+      emitProbeEvent({
+        eventType: PROBE_EVENT_TYPES.AUDIT_SESSION_STARTED,
+        source: "session_hook",
+        agentId,
+        sessionId,
+        sessionKey,
+        payload: { resumedFrom: resumedFrom ?? null },
+      });
+    },
+
+    recordSessionEnd({ sessionId, agentId, durationMs, messageCount }) {
+      emitProbeEvent({
+        eventType: PROBE_EVENT_TYPES.AUDIT_SESSION_ENDED,
+        source: "session_hook",
+        agentId,
+        sessionId,
+        payload: {
+          durationMs: durationMs ?? null,
+          messageCount,
+        },
+      });
+    },
+
+    recordGatewayStart({ port }) {
+      emitProbeEvent({
+        eventType: PROBE_EVENT_TYPES.AUDIT_GATEWAY_STARTED,
+        source: "session_hook",
+        payload: { port: port ?? null },
+      });
+    },
+
+    recordGatewayStop({ reason }) {
+      emitProbeEvent({
+        eventType: PROBE_EVENT_TYPES.AUDIT_GATEWAY_STOPPED,
+        source: "session_hook",
+        payload: { reason: reason ?? null },
+      });
+    },
+
+    recordToolCallFinished({ toolName, durationMs, error, agentId, sessionKey }) {
+      emitProbeEvent({
+        eventType: PROBE_EVENT_TYPES.AUDIT_TOOL_CALL_FINISHED,
+        source: "session_hook",
+        severity: error ? "warn" : "info",
+        agentId,
+        sessionKey,
+        payload: {
+          toolName,
+          durationMs: durationMs ?? null,
+          error: error ? redactSensitiveText(error) : null,
+        },
+      });
+    },
+
+    recordModelResponseUsage({ runId, provider, model, usage, agentId, sessionId }) {
+      const input = usage?.input ?? 0;
+      const output = usage?.output ?? 0;
+      const cacheRead = usage?.cacheRead ?? 0;
+      const cacheWrite = usage?.cacheWrite ?? 0;
+      const total = usage?.total ?? input + output + cacheRead + cacheWrite;
+
+      emitProbeEvent({
+        eventType: PROBE_EVENT_TYPES.AUDIT_MODEL_RESPONSE_USAGE,
+        source: "session_hook",
+        agentId,
+        sessionId,
+        traceId: runId,
+        payload: {
+          runId,
+          provider,
+          model,
+          usage: {
+            input,
+            output,
+            cacheRead,
+            cacheWrite,
+            total,
+          },
+        },
+      });
+
+      emitProbeEvent({
+        eventType: PROBE_EVENT_TYPES.REALTIME_TRACE_ACTION_SPAN,
+        source: "session_hook",
+        agentId,
+        sessionId,
+        traceId: runId,
+        spanId: `${runId}:model.response`,
+        payload: {
+          stage: "model.response",
+          provider,
+          model,
+          status: "completed",
+          usage: {
+            input,
+            output,
+            cacheRead,
+            cacheWrite,
+            total,
+          },
+        },
+      });
+    },
+
+    recordMappedEvent(input) {
+      emitProbeEvent(input);
+    },
+  };
+}

--- a/extensions/gateway-probe/src/telemetry/diagnostic-mapper.test.ts
+++ b/extensions/gateway-probe/src/telemetry/diagnostic-mapper.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { PROBE_EVENT_TYPES } from "../types.js";
+import { mapDiagnosticEvent } from "./diagnostic-mapper.js";
+
+describe("mapDiagnosticEvent", () => {
+  it("ignores high-frequency non-terminal diagnostics", () => {
+    expect(
+      mapDiagnosticEvent({
+        type: "model.usage",
+        ts: 1_700_000_000_000,
+        seq: 1,
+        sessionId: "s1",
+        sessionKey: "sk1",
+        provider: "openai",
+        model: "gpt-4.1",
+        usage: { input: 10, output: 5, total: 15 },
+        costUsd: 0.002,
+        durationMs: 120,
+      }),
+    ).toEqual([]);
+
+    expect(
+      mapDiagnosticEvent({
+        type: "message.queued",
+        ts: 1_700_000_000_100,
+        seq: 2,
+        sessionId: "s2",
+        sessionKey: "sk2",
+        source: "telegram",
+      }),
+    ).toEqual([]);
+  });
+
+  it("maps message.processed into a single terminal event", () => {
+    const events = mapDiagnosticEvent({
+      type: "message.processed",
+      ts: 1_700_000_000_200,
+      seq: 3,
+      sessionId: "s3",
+      sessionKey: "sk3",
+      channel: "telegram",
+      messageId: "m1",
+      chatId: "c1",
+      durationMs: 320,
+      outcome: "completed",
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.REALTIME_MESSAGE_PROCESSED,
+      severity: "info",
+      sessionId: "s3",
+      payload: {
+        channel: "telegram",
+        messageId: "m1",
+        durationMs: 320,
+        outcome: "completed",
+      },
+    });
+  });
+
+  it("maps session.stuck severity to critical when age exceeds threshold", () => {
+    const events = mapDiagnosticEvent({
+      type: "session.stuck",
+      ts: 1_700_000_000_300,
+      seq: 4,
+      sessionId: "s4",
+      sessionKey: "sk4",
+      state: "processing",
+      ageMs: 11 * 60 * 1000,
+      queueDepth: 9,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.REALTIME_SESSION_STUCK,
+      severity: "critical",
+      sessionId: "s4",
+      payload: {
+        ageMs: 11 * 60 * 1000,
+        queueDepth: 9,
+      },
+    });
+  });
+
+  it("maps webhook.error and tool.loop as low-frequency abnormal events", () => {
+    const webhookEvents = mapDiagnosticEvent({
+      type: "webhook.error",
+      ts: 1_700_000_000_400,
+      seq: 5,
+      channel: "telegram",
+      chatId: "c1",
+      updateType: "message",
+      error: "timeout",
+    });
+    expect(webhookEvents).toHaveLength(1);
+    expect(webhookEvents[0]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.REALTIME_WEBHOOK_ERROR,
+      severity: "error",
+    });
+
+    const loopEvents = mapDiagnosticEvent({
+      type: "tool.loop",
+      ts: 1_700_000_000_500,
+      seq: 6,
+      sessionId: "s6",
+      sessionKey: "sk6",
+      toolName: "read",
+      level: "warning",
+      action: "warn",
+      detector: "generic_repeat",
+      count: 4,
+      message: "repeated tool loop",
+    });
+    expect(loopEvents).toHaveLength(1);
+    expect(loopEvents[0]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.REALTIME_TOOL_LOOP,
+      severity: "warn",
+    });
+  });
+});

--- a/extensions/gateway-probe/src/telemetry/diagnostic-mapper.ts
+++ b/extensions/gateway-probe/src/telemetry/diagnostic-mapper.ts
@@ -1,0 +1,111 @@
+import type { DiagnosticEventPayload } from "openclaw/plugin-sdk";
+import { PROBE_EVENT_TYPES, type ProbeEventSeverity } from "../types.js";
+import type { ProbeMappedEventInput } from "./collector.js";
+
+function traceIdForEvent(evt: DiagnosticEventPayload): string | undefined {
+  if ("runId" in evt && typeof evt.runId === "string") {
+    return evt.runId;
+  }
+  if ("sessionId" in evt && typeof evt.sessionId === "string") {
+    return evt.sessionId;
+  }
+  if ("sessionKey" in evt && typeof evt.sessionKey === "string") {
+    return evt.sessionKey;
+  }
+  return undefined;
+}
+
+export function mapDiagnosticEvent(evt: DiagnosticEventPayload): ProbeMappedEventInput[] {
+  const occurredAt = evt.ts;
+
+  switch (evt.type) {
+    case "webhook.error":
+      return [
+        {
+          eventType: PROBE_EVENT_TYPES.REALTIME_WEBHOOK_ERROR,
+          source: "diagnostic",
+          severity: "error",
+          occurredAt,
+          payload: {
+            seq: evt.seq,
+            channel: evt.channel,
+            updateType: evt.updateType ?? null,
+            chatId: evt.chatId ?? null,
+            error: evt.error,
+          },
+        },
+      ];
+
+    case "message.processed": {
+      const severity: ProbeEventSeverity = evt.outcome === "error" ? "error" : "info";
+      return [
+        {
+          eventType: PROBE_EVENT_TYPES.REALTIME_MESSAGE_PROCESSED,
+          source: "diagnostic",
+          severity,
+          occurredAt,
+          sessionId: evt.sessionId,
+          sessionKey: evt.sessionKey,
+          traceId: traceIdForEvent(evt),
+          payload: {
+            seq: evt.seq,
+            channel: evt.channel,
+            messageId: evt.messageId ?? null,
+            chatId: evt.chatId ?? null,
+            durationMs: evt.durationMs ?? null,
+            outcome: evt.outcome,
+            reason: evt.reason ?? null,
+            error: evt.error ?? null,
+          },
+        },
+      ];
+    }
+
+    case "session.stuck": {
+      const severity: ProbeEventSeverity = evt.ageMs >= 10 * 60 * 1000 ? "critical" : "warn";
+      return [
+        {
+          eventType: PROBE_EVENT_TYPES.REALTIME_SESSION_STUCK,
+          source: "diagnostic",
+          severity,
+          occurredAt,
+          sessionId: evt.sessionId,
+          sessionKey: evt.sessionKey,
+          traceId: traceIdForEvent(evt),
+          payload: {
+            seq: evt.seq,
+            state: evt.state,
+            ageMs: evt.ageMs,
+            queueDepth: evt.queueDepth ?? null,
+          },
+        },
+      ];
+    }
+
+    case "tool.loop":
+      return [
+        {
+          eventType: PROBE_EVENT_TYPES.REALTIME_TOOL_LOOP,
+          source: "diagnostic",
+          severity: evt.level === "critical" ? "critical" : "warn",
+          occurredAt,
+          sessionId: evt.sessionId,
+          sessionKey: evt.sessionKey,
+          traceId: traceIdForEvent(evt),
+          payload: {
+            seq: evt.seq,
+            toolName: evt.toolName,
+            level: evt.level,
+            action: evt.action,
+            detector: evt.detector,
+            count: evt.count,
+            message: evt.message,
+            pairedToolName: evt.pairedToolName ?? null,
+          },
+        },
+      ];
+
+    default:
+      return [];
+  }
+}

--- a/extensions/gateway-probe/src/telemetry/log-mapper.test.ts
+++ b/extensions/gateway-probe/src/telemetry/log-mapper.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { PROBE_EVENT_TYPES } from "../types.js";
+import { mapAppLogRecord } from "./log-mapper.js";
+
+function makeLogRecord(input: {
+  level: "INFO" | "WARN" | "ERROR" | "FATAL";
+  message: string;
+  name?: string;
+  parents?: string[];
+  bindingsJson?: string;
+}) {
+  return {
+    _meta: {
+      logLevelName: input.level,
+      date: new Date("2026-03-03T00:00:00.000Z"),
+      name: input.name,
+      parentNames: input.parents,
+    },
+    ...(input.bindingsJson ? { 0: input.bindingsJson, 1: input.message } : { 0: input.message }),
+  };
+}
+
+describe("mapAppLogRecord", () => {
+  it("maps FATAL with bind/config/listen keywords to ops.subsystem.error", () => {
+    const events = mapAppLogRecord(
+      makeLogRecord({
+        level: "FATAL",
+        message: "gateway listen bind failed on 0.0.0.0:18789",
+        name: "gateway",
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.OPS_SUBSYSTEM_ERROR,
+      source: "app_log",
+      severity: "critical",
+      payload: {
+        level: "FATAL",
+        subsystem: "gateway",
+        hasCoreKeyword: true,
+      },
+    });
+  });
+
+  it("maps websocket unauthorized rejection logs", () => {
+    const events = mapAppLogRecord(
+      makeLogRecord({
+        level: "WARN",
+        message: "unauthorized conn=ws-1 remote=1.2.3.4 client=web reason=token_mismatch",
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.SECURITY_WS_UNAUTHORIZED,
+      severity: "warn",
+      payload: {
+        connId: "ws-1",
+        remoteIp: "1.2.3.4",
+        client: "web",
+        reason: "token_mismatch",
+      },
+    });
+  });
+
+  it("maps tools-invoke permission denial to HTTP tool failure", () => {
+    const events = mapAppLogRecord(
+      makeLogRecord({
+        level: "ERROR",
+        message:
+          "tools-invoke: tool execution failed EACCES: permission denied, open '/etc/shadow'",
+        bindingsJson: '{"subsystem":"tools-invoke"}',
+      }),
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.SECURITY_HTTP_TOOL_INVOKE_FAILED,
+      severity: "error",
+      payload: {
+        subsystem: "tools-invoke",
+        permissionDenied: true,
+      },
+    });
+  });
+
+  it("maps malformed/reset network errors", () => {
+    const events = mapAppLogRecord(
+      makeLogRecord({
+        level: "INFO",
+        message: "gateway request parse failed: Invalid JSON",
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.SECURITY_HTTP_MALFORMED_OR_RESET,
+      severity: "info",
+      payload: {
+        reason: "invalid_json",
+      },
+    });
+  });
+
+  it("does not map normal info-level connection closed logs", () => {
+    const events = mapAppLogRecord(
+      makeLogRecord({
+        level: "INFO",
+        message: "websocket connection closed cleanly",
+      }),
+    );
+
+    expect(events).toEqual([]);
+  });
+
+  it("maps device role escalation and flags owner promotion as critical", () => {
+    const events = mapAppLogRecord(
+      makeLogRecord({
+        level: "INFO",
+        message:
+          "security audit: device access upgrade requested reason=pair_upgrade device=dev-1 roleFrom=none roleTo=owner scopesFrom=read scopesTo=all ip=8.8.8.8 auth=token client=web",
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: PROBE_EVENT_TYPES.SECURITY_DEVICE_ROLE_ESCALATION,
+      severity: "critical",
+      payload: {
+        deviceId: "dev-1",
+        roleFrom: "none",
+        roleTo: "owner",
+        remoteIp: "8.8.8.8",
+      },
+    });
+  });
+});

--- a/extensions/gateway-probe/src/telemetry/log-mapper.ts
+++ b/extensions/gateway-probe/src/telemetry/log-mapper.ts
@@ -1,0 +1,216 @@
+import { PROBE_EVENT_TYPES, type ProbeEventSeverity } from "../types.js";
+import type { ProbeMappedEventInput } from "./collector.js";
+import { redactSensitiveText } from "./redact.js";
+
+type LogMeta = {
+  logLevelName?: string;
+  date?: Date;
+  name?: string;
+  parentNames?: string[];
+};
+
+type ParsedLogRecord = {
+  message: string;
+  level: string;
+  occurredAt: number;
+  loggerName?: string;
+  loggerParents?: string[];
+  bindings?: Record<string, unknown>;
+};
+
+function toProbeSeverity(level: string): ProbeEventSeverity {
+  if (level === "FATAL") {
+    return "critical";
+  }
+  if (level === "ERROR") {
+    return "error";
+  }
+  if (level === "WARN") {
+    return "warn";
+  }
+  return "info";
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseLogRecord(logObj: Record<string, unknown>): ParsedLogRecord {
+  const meta = (logObj._meta as LogMeta | undefined) ?? {};
+  const numericArgs = Object.entries(logObj)
+    .filter(([key]) => /^\d+$/.test(key))
+    .toSorted((a, b) => Number(a[0]) - Number(b[0]))
+    .map(([, value]) => value);
+
+  let bindings: Record<string, unknown> | undefined;
+  if (typeof numericArgs[0] === "string" && numericArgs[0].trim().startsWith("{")) {
+    try {
+      const parsed = JSON.parse(numericArgs[0]);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        bindings = parsed as Record<string, unknown>;
+        numericArgs.shift();
+      }
+    } catch {
+      // ignore malformed bindings
+    }
+  }
+
+  let message = "";
+  if (numericArgs.length > 0 && typeof numericArgs[numericArgs.length - 1] === "string") {
+    message = String(numericArgs.pop());
+  } else if (numericArgs.length === 1) {
+    message = safeStringify(numericArgs[0]);
+  } else if (numericArgs.length > 1) {
+    message = safeStringify(numericArgs);
+  }
+
+  return {
+    message: message || "log",
+    level: (meta.logLevelName ?? "INFO").toUpperCase(),
+    occurredAt: meta.date instanceof Date ? meta.date.getTime() : Date.now(),
+    loggerName: meta.name,
+    loggerParents: meta.parentNames,
+    bindings,
+  };
+}
+
+function parseMessagePairs(message: string): Record<string, string> {
+  const map: Record<string, string> = {};
+  const regex = /([a-zA-Z][a-zA-Z0-9]*)=([^\s]+)/g;
+  for (const match of message.matchAll(regex)) {
+    const key = match[1];
+    const value = match[2];
+    if (key && value) {
+      map[key] = value;
+    }
+  }
+  return map;
+}
+
+function getSubsystem(parsed: ParsedLogRecord): string | undefined {
+  const subsystem = parsed.bindings?.subsystem;
+  if (typeof subsystem === "string" && subsystem.trim().length > 0) {
+    return subsystem;
+  }
+  if (parsed.loggerParents && parsed.loggerParents.length > 0) {
+    return parsed.loggerParents.join(".");
+  }
+  return parsed.loggerName;
+}
+
+export function mapAppLogRecord(logObj: Record<string, unknown>): ProbeMappedEventInput[] {
+  const parsed = parseLogRecord(logObj);
+  const lowered = parsed.message.toLowerCase();
+  const severity = toProbeSeverity(parsed.level);
+  const events: ProbeMappedEventInput[] = [];
+  const isErrorLevel =
+    parsed.level === "WARN" || parsed.level === "ERROR" || parsed.level === "FATAL";
+
+  if (parsed.level === "ERROR" || parsed.level === "FATAL") {
+    const hasCoreKeyword = /\b(bind|config|listen)\b/i.test(parsed.message);
+    events.push({
+      eventType: PROBE_EVENT_TYPES.OPS_SUBSYSTEM_ERROR,
+      source: "app_log",
+      severity,
+      occurredAt: parsed.occurredAt,
+      payload: {
+        level: parsed.level,
+        subsystem: getSubsystem(parsed) ?? null,
+        message: redactSensitiveText(parsed.message),
+        hasCoreKeyword,
+      },
+    });
+  }
+
+  if (lowered.includes("unauthorized conn=") && lowered.includes("reason=")) {
+    const kv = parseMessagePairs(parsed.message);
+    events.push({
+      eventType: PROBE_EVENT_TYPES.SECURITY_WS_UNAUTHORIZED,
+      source: "app_log",
+      severity: "warn",
+      occurredAt: parsed.occurredAt,
+      payload: {
+        connId: kv.conn ?? null,
+        remoteIp: kv.remote ?? null,
+        client: kv.client ?? null,
+        reason: kv.reason ?? null,
+        message: redactSensitiveText(parsed.message),
+      },
+    });
+  }
+
+  if (
+    lowered.includes("tools-invoke: tool execution failed") ||
+    (lowered.includes("tools-invoke") &&
+      (lowered.includes("eacces") || lowered.includes("permission denied")))
+  ) {
+    events.push({
+      eventType: PROBE_EVENT_TYPES.SECURITY_HTTP_TOOL_INVOKE_FAILED,
+      source: "app_log",
+      severity: "error",
+      occurredAt: parsed.occurredAt,
+      payload: {
+        subsystem: getSubsystem(parsed) ?? null,
+        permissionDenied: lowered.includes("eacces") || lowered.includes("permission denied"),
+        message: redactSensitiveText(parsed.message),
+      },
+    });
+  }
+
+  const malformedReason = lowered.includes("invalid json")
+    ? "invalid_json"
+    : lowered.includes("connection reset by peer")
+      ? "connection_reset"
+      : lowered.includes("request body timeout")
+        ? "request_body_timeout"
+        : isErrorLevel &&
+            (lowered.includes("connection closed unexpectedly") ||
+              ((lowered.includes("request") || lowered.includes("body")) &&
+                lowered.includes("connection closed")))
+          ? "connection_closed"
+          : null;
+
+  if (malformedReason) {
+    events.push({
+      eventType: PROBE_EVENT_TYPES.SECURITY_HTTP_MALFORMED_OR_RESET,
+      source: "app_log",
+      severity: malformedReason === "connection_reset" ? "warn" : "info",
+      occurredAt: parsed.occurredAt,
+      payload: {
+        reason: malformedReason,
+        message: redactSensitiveText(parsed.message),
+      },
+    });
+  }
+
+  if (
+    lowered.includes("security audit: device access upgrade requested") &&
+    lowered.includes("roleto=")
+  ) {
+    const kv = parseMessagePairs(parsed.message);
+    const roleTo = kv.roleTo ?? null;
+    events.push({
+      eventType: PROBE_EVENT_TYPES.SECURITY_DEVICE_ROLE_ESCALATION,
+      source: "app_log",
+      severity: roleTo === "owner" ? "critical" : "warn",
+      occurredAt: parsed.occurredAt,
+      payload: {
+        reason: kv.reason ?? null,
+        deviceId: kv.device ?? null,
+        roleFrom: kv.roleFrom ?? null,
+        roleTo,
+        scopesFrom: kv.scopesFrom ?? null,
+        scopesTo: kv.scopesTo ?? null,
+        remoteIp: kv.ip ?? null,
+        authMethod: kv.auth ?? null,
+        client: kv.client ?? null,
+      },
+    });
+  }
+
+  return events;
+}

--- a/extensions/gateway-probe/src/telemetry/redact.ts
+++ b/extensions/gateway-probe/src/telemetry/redact.ts
@@ -1,0 +1,16 @@
+const KEY_VALUE_PATTERNS: RegExp[] = [
+  /\b(authorization|token|access[_-]?token|refresh[_-]?token|api[_-]?key|password|secret|cookie)=([^\s,;]+)/gi,
+  /\b(authorization|token|access[_-]?token|refresh[_-]?token|api[_-]?key|password|secret|cookie):\s*([^\s,;]+)/gi,
+];
+
+const BEARER_PATTERN = /\b(Bearer)\s+([A-Za-z0-9._~+/=-]+)/gi;
+
+export function redactSensitiveText(text: string): string {
+  let redacted = text;
+
+  for (const pattern of KEY_VALUE_PATTERNS) {
+    redacted = redacted.replace(pattern, (_match, key: string) => `${key}=[redacted]`);
+  }
+
+  return redacted.replace(BEARER_PATTERN, "$1 [redacted]");
+}

--- a/extensions/gateway-probe/src/types.ts
+++ b/extensions/gateway-probe/src/types.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared types for the gateway-probe plugin.
+ *
+ * Scope: observe existing gateway/runtime events, normalize them, and optionally
+ * forward them to Kafka. The plugin never blocks or mutates core behavior.
+ */
+
+export interface GatewayProbeConfig {
+  probe?: {
+    /** Unique probe identifier (persistent local UUID if empty). */
+    probeId?: string;
+    /** Human-readable name for this gateway node. */
+    name?: string;
+  };
+  /** Extra labels attached to every emitted event. */
+  labels?: Record<string, string>;
+  kafka?: {
+    /** Enable Kafka publishing. Disabled by default for a zero-egress baseline. */
+    enabled?: boolean;
+    /** Kafka brokers (for example ["127.0.0.1:9092"]). */
+    brokers?: string[];
+    /** Destination topic for probe events. */
+    topic?: string;
+    /** Kafka client id. */
+    clientId?: string;
+    /** Batch flush interval in milliseconds. */
+    flushIntervalMs?: number;
+    /** Maximum events sent in one Kafka request. */
+    batchMaxSize?: number;
+    /** In-memory queue cap before dropping oldest events. */
+    maxQueueSize?: number;
+  };
+}
+
+export const PROBE_EVENT_TYPES = {
+  AUDIT_SESSION_STARTED: "audit.session.started",
+  AUDIT_SESSION_ENDED: "audit.session.ended",
+  AUDIT_GATEWAY_STARTED: "audit.gateway.started",
+  AUDIT_GATEWAY_STOPPED: "audit.gateway.stopped",
+  AUDIT_TOOL_CALL_FINISHED: "audit.tool.call.finished",
+  AUDIT_MODEL_RESPONSE_USAGE: "audit.model.response.usage",
+  OPS_SUBSYSTEM_ERROR: "ops.subsystem.error",
+  SECURITY_WS_UNAUTHORIZED: "security.ws.unauthorized",
+  SECURITY_HTTP_TOOL_INVOKE_FAILED: "security.http.tool_invoke.failed",
+  SECURITY_HTTP_MALFORMED_OR_RESET: "security.http.malformed_or_reset",
+  SECURITY_DEVICE_ROLE_ESCALATION: "security.device.role_escalation",
+  REALTIME_WEBHOOK_ERROR: "realtime.webhook.error",
+  REALTIME_MESSAGE_PROCESSED: "realtime.message.processed",
+  REALTIME_SESSION_STUCK: "realtime.session.stuck",
+  REALTIME_TOOL_LOOP: "realtime.tool.loop",
+  REALTIME_TRACE_ACTION_SPAN: "realtime.trace.action_span",
+} as const;
+
+export type ProbeEventType = (typeof PROBE_EVENT_TYPES)[keyof typeof PROBE_EVENT_TYPES];
+
+export type ProbeEventSource = "session_hook" | "diagnostic" | "app_log";
+
+export type ProbeEventSeverity = "info" | "warn" | "error" | "critical";
+
+export interface ProbeEvent {
+  schemaVersion: "1.0";
+  pluginVersion: string;
+  eventId: string;
+  probeId: string;
+  probeName: string;
+  labels: Record<string, string>;
+  eventType: ProbeEventType | string;
+  occurredAt: string;
+  source: ProbeEventSource;
+  severity: ProbeEventSeverity;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  traceId?: string;
+  spanId?: string;
+  payload: Record<string, unknown>;
+}
+
+export interface ResolvedProbeConfig {
+  probe: {
+    probeId: string;
+    name: string;
+  };
+  labels: Record<string, string>;
+  kafka: {
+    enabled: boolean;
+    brokers: string[];
+    topic: string;
+    clientId: string;
+    flushIntervalMs: number;
+    batchMaxSize: number;
+    maxQueueSize: number;
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,6 +359,12 @@ importers:
 
   extensions/firecrawl: {}
 
+  extensions/gateway-probe:
+    dependencies:
+      kafkajs:
+        specifier: ^2.2.4
+        version: 2.2.4
+
   extensions/github-copilot: {}
 
   extensions/google: {}
@@ -5046,6 +5052,10 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  kafkajs@2.2.4:
+    resolution: {integrity: sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==}
+    engines: {node: '>=14.0.0'}
 
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
@@ -12338,6 +12348,8 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  kafkajs@2.2.4: {}
 
   keyv@5.6.0:
     dependencies:


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw already exposes useful internal hooks, diagnostics, and structured logs, but there is no small, reviewable way to turn those existing signals into a compact event stream that helps operators understand what happened during a gateway session.
- Why it matters: Session review, incident triage, and behavior debugging currently require stitching together scattered hook payloads and logs. A normalized low-volume event stream makes those workflows much easier without changing core runtime behavior.
- What changed: This PR adds a new bundled extension, `gateway-probe`, that listens to existing plugin hooks, diagnostic events, and selected structured app logs, then emits a compact normalized event envelope. It is disabled by default and only sends events to Kafka when Kafka is explicitly enabled.
- What changed: The implementation is intentionally extension-local, documents every emitted event type, and adds focused tests for config resolution, hook wiring, event mapping, and doc/catalog drift.
- What did NOT change (scope boundary): This PR does not add an inbound HTTP or OTLP endpoint, does not change tool/model execution behavior, does not add policy enforcement or blocking, does not emit token/chat delta streams, and does not depend on the separate `platform/` stack.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

- Adds a new bundled plugin: `gateway-probe`
- The plugin is disabled by default
- When enabled, it emits a compact normalized event stream from existing session/tool/model hooks, selected diagnostics, and selected structured app logs
- Event output is intentionally low-volume: no token deltas, no chat deltas, no per-step streaming flood
- Optional Kafka publishing is available only when explicitly enabled in plugin config
- Adds English documentation for the plugin and full event catalog

## Security Impact (required)

- New permissions/capabilities? Yes
- Secrets/tokens handling changed? Yes
- New/changed network calls? Yes
- Command/tool execution surface changed? No
- Data access scope changed? Yes
- If any `Yes`, explain risk + mitigation:
  - This plugin can observe existing runtime hook payloads, diagnostic events, and selected app log records when enabled, and it can optionally publish normalized events to Kafka.
  - Mitigations:
    - disabled by default
    - observe-only; it does not block, rewrite, or steer tool/model execution
    - no new inbound listener or external control-plane dependency
    - string payloads are redacted before emission
    - event volume is intentionally constrained to terminal or abnormal events only
    - Kafka egress is opt-in and isolated behind explicit plugin config

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm, Vitest
- Model/provider: N/A for focused tests
- Integration/channel (if any): N/A for focused tests
- Relevant config (redacted):
  - `plugins.entries.gateway-probe.enabled=true`
  - `plugins.entries.gateway-probe.config.kafka.enabled=false` for default local mode
  - optional Kafka config only when explicitly testing egress

### Steps

1. Enable `gateway-probe`
2. Start the gateway and trigger a simple session plus one completed tool call and one model response
3. Review emitted probe events or run the focused plugin tests

### Expected

- A small, reviewable set of normalized events is emitted
- Session lifecycle events are present
- Tool activity emits only a terminal `audit.tool.call.finished` event
- Model activity emits only terminal usage output plus a terminal action span companion event
- Low-frequency abnormal diagnostics and selected structured log events are mapped into stable event names
- No chat delta/token delta event flood appears
- No core runtime behavior changes

### Actual

- The plugin emits the documented compact event set only
- Focused tests pass on both the local repo state and a fresh integration on top of the latest `UgOrange/openclaw` `main`
- No probe-specific type errors were introduced during fork-baseline validation
- The only remaining full-repo `pnpm tsgo` failures on the fork baseline are unrelated pre-existing `extensions/tlon` dependency issues

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation run:

```bash
pnpm vitest run \
  extensions/gateway-probe/src/config.test.ts \
  extensions/gateway-probe/src/event-docs.test.ts \
  extensions/gateway-probe/src/telemetry/collector.test.ts \
  extensions/gateway-probe/src/telemetry/diagnostic-mapper.test.ts \
  extensions/gateway-probe/src/telemetry/log-mapper.test.ts \
  extensions/gateway-probe/src/hooks/model-hooks.test.ts \
  extensions/gateway-probe/src/hooks/tool-hooks.test.ts
```

Result:

- `7` test files passed
- `26` tests passed

Fork-baseline validation:

- Based on `UgOrange/openclaw` `main` at `6a8f5bc12f72399264c03444b07949e5d5c140e9`
- Focused `gateway-probe` tests passed there as well

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - The plugin stays disabled unless explicitly enabled
  - The supported event set is documented and checked by test
  - Hook registration is limited to low-volume terminal events (`session_*`, `gateway_*`, `after_tool_call`, `llm_output`)
  - Diagnostic mapping keeps only abnormal or terminal events
  - Structured log mapping stays focused on selected gateway/runtime events
  - The extension remains usable on top of the latest fork baseline
- Edge cases checked:
  - No delta/token streaming events
  - No inbound listener added
  - Kafka remains optional and off by default
  - Payload string redaction is applied before emission
  - Probe docs fail test if the documented event list drifts from implementation
- What you did **not** verify:
  - Full cross-channel manual testing

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes
- Migration needed? No
- If yes, exact upgrade steps:
  - None required for existing users
  - To use this feature, explicitly enable `gateway-probe` and optionally configure Kafka output

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Disable the plugin: `openclaw plugins disable gateway-probe`
  - Or set `plugins.entries.gateway-probe.enabled=false`
  - Or revert this PR commit
- Files/config to restore:
  - Remove or disable `plugins.entries.gateway-probe` config
  - Remove any optional `OPENCLAW_PROBE_*` environment overrides
- Known bad symptoms reviewers should watch for:
  - Unexpected Kafka connection warnings if Kafka is enabled but not configured correctly
  - More event volume than expected if future hook/log mappings are expanded without care
  - Any sign that the plugin changes runtime behavior rather than only emitting events

## Risks and Mitigations

- Risk: Reviewers may worry this expands scope beyond a small extension
  - Mitigation: The implementation is extension-local, disabled by default, and does not add an inbound endpoint, control plane, or runtime enforcement path

- Risk: Event volume could become noisy
  - Mitigation: This PR intentionally emits only terminal or abnormal events and excludes token/chat delta streams

- Risk: Sensitive text could leak into exported events
  - Mitigation: String payload fields are redacted before emission, nested payloads are truncated, and Kafka egress is opt-in only

- Risk: Future core changes could break the extension if it depends on too much internal behavior
  - Mitigation: The plugin uses a small plugin-sdk-facing surface and keeps non-essential logic local to the extension

- Risk: Kafka misconfiguration could create operational noise
  - Mitigation: Kafka is disabled by default, failures are logged, and the plugin does not block gateway startup or execution