### PR TITLE
browser: add /status endpoint for browser server

### DIFF
--- a/src/browser/routes/basic.ts
+++ b/src/browser/routes/basic.ts
@@ -59,6 +59,32 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
     }
   });
 
+  // Gateway status (lightweight, profile-aware)
+  app.get("/status", async (req, res) => {
+    let current;
+    try {
+      current = ctx.state();
+    } catch {
+      return jsonError(res, 503, "browser server not started");
+    }
+
+    const profileCtx = getProfileContext(req, ctx);
+    if ("error" in profileCtx) {
+      return jsonError(res, profileCtx.status, profileCtx.error);
+    }
+
+    const profileState = current.profiles.get(profileCtx.profile.name);
+
+    res.json({
+      running: !!profileState?.running,
+      pid: profileState?.running?.pid ?? null,
+      profile: profileCtx.profile.name,
+      headless: current.resolved.headless,
+      enabled: current.resolved.enabled,
+      timestamp: Date.now(),
+    });
+  });
+
   // Get status (profile-aware)
   app.get("/", async (req, res) => {
     let current: ReturnType<typeof ctx.state>;


### PR DESCRIPTION
## Summary

- Problem: The browser control server had no lightweight /status endpoint to report runtime state.

- Why it matters: Developers and automation cannot easily check if the browser service is running or which profile is active.

- What changed: Added a GET /status route in src/browser/routes/basic.ts that returns basic browser runtime state.

- What did NOT change (scope boundary): No authentication behavior, gateway logic, browser launch logic, or profile management behavior changed.
- 
## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48220 
- Related #48224, #48096, #47888

## User-visible / Behavior Changes

Adds a new browser server endpoint:

GET /status

Returns JSON describing browser runtime state.

No existing endpoints or behavior changed.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

OS: Linux (Ubuntu)
Runtime/container: Node 22
Model/provider: Ollama (qwen2.5:1.5b)
Integration/channel: None
Relevant config (redacted): standard local ~/.openclaw/openclaw.json

### Steps

1. Start gateway locally
2. Call browser control endpoint
3. Inspect response

### Expected

- JSON response describing browser runtime status

### Actual

```
 {
  "running": false,
  "pid": null,
  "profile": "openclaw",
  "headless": false,
  "enabled": true,
  "timestamp": 1773678236497
}
```

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Example response:
curl http://127.0.0.1:18791/status
{"running":false,"pid":null,"profile":"openclaw","headless":false,"enabled":true,"timestamp":1773678236497}

## Human Verification (required)

What you personally verified (not just CI), and how:

-Verified scenarios:

Gateway running, Browser server reachable, /status endpoint returns valid JSON

- Edge cases checked:

Browser not running, Browser server reachable but no active process

What I did not verify:

Multi-profile environments, chrome-mcp driver path

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:

Revert the commit introducing the /status route.

Files/config to restore:

src/browser/routes/basic.ts

Known bad symptoms reviewers should watch for:

Browser server route conflict

Unexpected route override
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

Risk: Route path collision with another /status handler
Mitigation: Verified route only exists in browser server scope and does not override gateway routes.
