### PR TITLE
Plugin SDK: expose session binding adapter registration

### DIFF
--- a/src/plugin-sdk/index.test.ts
+++ b/src/plugin-sdk/index.test.ts
@@ -96,6 +96,8 @@ describe("plugin-sdk exports", () => {
       "resolveChannelEntryMatchWithFallback",
       "normalizeChannelSlug",
       "buildChannelKeyCandidates",
+      "registerSessionBindingAdapter",
+      "unregisterSessionBindingAdapter",
     ];
 
     for (const key of requiredFunctions) {

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -127,12 +127,18 @@ export type {
   UsageWindow,
 } from "../infra/provider-usage.types.js";
 export type {
+  BindingTargetKind,
   ConversationRef,
+  SessionBindingAdapter,
   SessionBindingBindInput,
   SessionBindingCapabilities,
   SessionBindingRecord,
   SessionBindingService,
   SessionBindingUnbindInput,
+} from "../infra/outbound/session-binding-service.js";
+export {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
 } from "../infra/outbound/session-binding-service.js";
 export type {
   GatewayRequestHandler,


### PR DESCRIPTION
## Summary

- Problem: third-party plugins that need to register session-binding adapters cannot access `registerSessionBindingAdapter` / `unregisterSessionBindingAdapter` through the public `openclaw/plugin-sdk` surface.
- Why it matters: channel plugins implementing session binding must import these functions to wire up their adapters at activation time.
- What changed: re-exported `registerSessionBindingAdapter`, `unregisterSessionBindingAdapter` and the related types (`BindingTargetKind`, `SessionBindingAdapter`) from `openclaw/plugin-sdk`; updated the plugin-sdk export snapshot test.
- What did NOT change (scope boundary): no runtime behavior change; the underlying `SessionBindingService` and adapter registry are untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None. This is a plugin SDK surface addition only; no user-facing behavior changes.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout, pnpm

### Steps

1. `import { registerSessionBindingAdapter } from "openclaw/plugin-sdk"` in a plugin.
2. Verify the import resolves and the function is callable.

### Expected

- The two functions and types are available from the plugin-sdk public surface.

### Actual

- Matches expected after this change.

## Evidence

- [x] Failing test/log before + passing after (plugin-sdk export snapshot test)

## Human Verification (required)

- Verified scenarios: plugin-sdk export snapshot test passes with the new entries; `pnpm build` and `pnpm check` clean.
- Edge cases checked: confirmed the module-local adapter registry is shared at runtime via jiti alias + Node require cache (no cross-chunk duplication).
- What you did **not** verify: live end-to-end session binding through a third-party plugin.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR; no runtime behavior depends on it.
- Files/config to restore: none.
- Known bad symptoms reviewers should watch for: none expected.

## Risks and Mitigations

None.