### PR TITLE
fix(feishu): improve streaming card update performance

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -209,7 +209,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         await streamingStartPromise;
       }
       if (streaming?.isActive()) {
-        await streaming.update(combined);
+        // Fire-and-forget: don't block the queue waiting for the HTTP round-trip.
+        void streaming.update(combined);
       }
     });
   };

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -167,8 +167,8 @@ export class FeishuStreamingSession {
   private log?: (msg: string) => void;
   private lastUpdateTime = 0;
   private pendingText: string | null = null;
-  private flushTimer: ReturnType<typeof setTimeout> | null = null;
-  private updateThrottleMs = 100; // Throttle updates to max 10/sec
+  private pendingTimer: ReturnType<typeof setTimeout> | null = null;
+  private updateThrottleMs = 50; // Throttle updates to max 20/sec (match CardKit print_frequency_ms)
 
   constructor(client: Client, creds: Credentials, log?: (msg: string) => void) {
     this.client = client;
@@ -202,7 +202,7 @@ export class FeishuStreamingSession {
       config: {
         streaming_mode: true,
         summary: { content: "[Generating...]" },
-        streaming_config: { print_frequency_ms: { default: 50 }, print_step: { default: 1 } },
+        streaming_config: { print_frequency_ms: { default: 50 }, print_step: { default: 3 } },
       },
       body: { elements },
     };
@@ -325,36 +325,50 @@ export class FeishuStreamingSession {
     if (!this.state || this.closed) {
       return;
     }
-    const mergedInput = mergeStreamingText(this.pendingText ?? this.state.currentText, text);
-    if (!mergedInput || mergedInput === this.state.currentText) {
+    // Treat incoming text as a full snapshot — the reply dispatcher already
+    // builds the complete combined text via buildCombinedStreamText().
+    if (!text || text === this.state.currentText) {
       return;
     }
 
-    // Throttle: skip if updated recently, but remember pending text
+    // Throttle: skip if updated recently, but remember pending text and
+    // schedule a flush so throttled content is never silently dropped.
     const now = Date.now();
     if (now - this.lastUpdateTime < this.updateThrottleMs) {
-      this.pendingText = mergedInput;
+      this.pendingText = text;
+      if (!this.pendingTimer) {
+        this.pendingTimer = setTimeout(() => {
+          this.pendingTimer = null;
+          if (this.pendingText && this.state && !this.closed) {
+            void this.flushUpdate(this.pendingText);
+          }
+        }, this.updateThrottleMs);
+      }
       return;
     }
+    void this.flushUpdate(text);
+  }
+
+  private async flushUpdate(text: string): Promise<void> {
     this.pendingText = null;
-    this.lastUpdateTime = now;
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
+    this.lastUpdateTime = Date.now();
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+      this.pendingTimer = null;
     }
 
     this.queue = this.queue.then(async () => {
       if (!this.state || this.closed) {
         return;
       }
-      const mergedText = mergeStreamingText(this.state.currentText, mergedInput);
-      if (!mergedText || mergedText === this.state.currentText) {
+      if (!text || text === this.state.currentText) {
         return;
       }
-      this.state.currentText = mergedText;
-      await this.updateCardContent(mergedText, (e) => this.log?.(`Update failed: ${String(e)}`));
+      // Direct replace — incoming text is already a complete snapshot.
+      this.state.currentText = text;
+      await this.updateCardContent(text, (e) => this.log?.(`Update failed: ${String(e)}`));
     });
-    await this.queue;
+    // Fire-and-forget: don't block the caller waiting for the HTTP round-trip.
   }
 
   private async updateNoteContent(note: string): Promise<void> {
@@ -391,9 +405,9 @@ export class FeishuStreamingSession {
       return;
     }
     this.closed = true;
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+      this.pendingTimer = null;
     }
     await this.queue;
 


### PR DESCRIPTION
## Summary

- Remove double serial `await` in streaming card update path — `update()` no longer blocks on HTTP round-trip, and `flushStreamingCardUpdate` in reply-dispatcher uses fire-and-forget (`void` instead of `await`)
- Add `pendingTimer` so throttled text is never silently dropped — previously `pendingText` was stored but had no re-send mechanism
- Replace `mergeStreamingText` calls in `streaming-card.ts` with direct snapshot assignment — the reply dispatcher already sends complete combined text via `buildCombinedStreamText()`, so re-merging caused tool status lines to accumulate
- Reduce `updateThrottleMs` from 100 ms → 50 ms (matching CardKit `print_frequency_ms` advisory)
- Increase `print_step` from 1 → 3 for smoother visual rendering (~60 chars/sec)

## Why

The Feishu streaming card path had three bottlenecks causing visible stutter:

1. `update()` awaited the HTTP queue (~100-200 ms per PUT), so back-to-back partial-reply callbacks stacked up
2. Throttled content was silently lost if no follow-up `update()` arrived
3. Redundant `mergeStreamingText` in the card layer concatenated old+new content instead of replacing, causing tool status lines like `🔧 Using: read...🔧 Using: exec...` to accumulate

## Test plan

- [ ] Send a message requiring multiple tool calls in Feishu — verify streaming text appears smoothly without stutter
- [ ] Verify tool status lines (if using the tool-status PR) replace each other instead of accumulating
- [ ] Verify throttled partial text is not lost (send a long response and check final card content matches)
- [ ] Run `pnpm test -- extensions/feishu/src/streaming-card.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)