### PR TITLE
feat(feishu): add tool/compaction status to streaming cards and prevent duplicate final cards

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -182,6 +182,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamText = "";
   let lastPartial = "";
   let reasoningText = "";
+  let statusLine = "";
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
@@ -200,6 +201,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (thinking) parts.push(formatReasoningPrefix(thinking));
     if (thinking && answer) parts.push("\n\n---\n\n");
     if (answer) parts.push(answer);
+    if (statusLine && !answer) parts.push(thinking ? `\n\n${statusLine}` : statusLine);
+    else if (statusLine) parts.push(`\n\n${statusLine}`);
     return parts.join("");
   };
 
@@ -282,6 +285,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
     await partialUpdateQueue;
     if (streaming?.isActive()) {
+      statusLine = "";
       let text = buildCombinedStreamText(reasoningText, streamText);
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
@@ -294,6 +298,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamText = "";
     lastPartial = "";
     reasoningText = "";
+    statusLine = "";
   };
 
   const sendChunkedTextReply = async (params: {
@@ -391,8 +396,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               queueStreamingUpdate(text, { mode: "delta" });
             }
             if (info?.kind === "final") {
-              streamText = mergeStreamingText(streamText, text);
-              await closeStreaming();
+              // Append final text but do NOT close yet — multiple finals in a
+              // single turn should merge into one card. onIdle closes the card.
+              queueStreamingUpdate(text, { mode: "snapshot" });
               deliveredFinalTexts.add(text);
             }
             // Send media even when streaming handled the text
@@ -496,6 +502,33 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
         : undefined,
       onReasoningEnd: streamingEnabled ? () => {} : undefined,
+      onToolStart: streamingEnabled
+        ? (payload: { name?: string; phase?: string }) => {
+            const label = payload.name ?? payload.phase ?? "tool";
+            statusLine = `🔧 *Using: ${label}...*`;
+            startStreaming();
+            flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+          }
+        : undefined,
+      onAssistantMessageStart: streamingEnabled
+        ? () => {
+            statusLine = "";
+            flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+          }
+        : undefined,
+      onCompactionStart: streamingEnabled
+        ? () => {
+            statusLine = "📦 *Compacting context...*";
+            startStreaming();
+            flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+          }
+        : undefined,
+      onCompactionEnd: streamingEnabled
+        ? () => {
+            statusLine = "";
+            flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+          }
+        : undefined,
     },
     markDispatchIdle,
   };


### PR DESCRIPTION
## Summary

- Wire `onToolStart`, `onAssistantMessageStart`, `onCompactionStart`, and `onCompactionEnd` callbacks into the Feishu streaming reply dispatcher
- When streaming is active, tool usage shows as `🔧 *Using: tool_name...*` and context compaction shows as `📦 *Compacting context...*` appended to the streaming card
- `onAssistantMessageStart` and `onCompactionEnd` clear the status line; the final closed card never includes transient status text
- Prevent duplicate streaming cards: `final` replies no longer immediately close the card — they append via `queueStreamingUpdate` in snapshot mode, and `onIdle` closes the card once when the turn completes

## Why

**Tool status:** Users had no visibility into what the agent was doing between responses. The Telegram channel already shows tool status via emoji reactions; this brings equivalent feedback to Feishu using inline card text, which is more natural for the card-based UI.

**Duplicate cards:** Turns with N tool calls produced N duplicate streaming cards because each `final` reply called `closeStreaming()` immediately. Now all finals merge into one card.

## Test plan

- [ ] Send a message that triggers tool calls — verify `🔧 *Using: tool_name...*` appears during execution
- [ ] Verify status line disappears from the final closed card
- [ ] Send a message with multiple tool calls — verify only one streaming card is produced (not N duplicates)
- [ ] Run `pnpm test -- extensions/feishu/src/reply-dispatcher.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)