### PR TITLE
fix(feishu): hide meaningless 'main' card header in streaming and static cards

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -47,8 +47,11 @@ function resolveCardHeader(
   agentId: string,
   identity: OutboundIdentity | undefined,
 ): CardHeaderConfig {
-  const name = identity?.name?.trim() || agentId;
+  // Fall back to agentId, but suppress the generic "main" default since it
+  // provides no useful information to the end user.
+  const name = identity?.name?.trim() || (agentId === "main" ? "" : agentId);
   const emoji = identity?.emoji?.trim();
+  if (!name && !emoji) return { title: "", template: identity?.theme ?? "blue" };
   return {
     title: emoji ? `${emoji} ${name}` : name,
     template: identity?.theme ?? "blue",
@@ -265,7 +268,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           replyToMessageId,
           replyInThread: effectiveReplyInThread,
           rootId,
-          header: cardHeader,
+          header: cardHeader.title ? cardHeader : undefined,
           note: cardNote,
         });
       } catch (error) {
@@ -427,7 +430,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 replyInThread: effectiveReplyInThread,
                 mentions: first ? mentionTargets : undefined,
                 accountId,
-                header: cardHeader,
+                header: cardHeader.title ? cardHeader : undefined,
                 note: cardNote,
               });
               first = false;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -53,7 +53,7 @@ function resolveCardHeader(
   const emoji = identity?.emoji?.trim();
   if (!name && !emoji) return { title: "", template: identity?.theme ?? "blue" };
   return {
-    title: emoji ? `${emoji} ${name}` : name,
+    title: (emoji ? `${emoji} ${name}` : name).trim(),
     template: identity?.theme ?? "blue",
   };
 }


### PR DESCRIPTION
## Summary

- Suppress the `"main"` fallback in `resolveCardHeader` when `agentId === "main"` and no identity name/emoji is configured
- Skip the card header entirely when both name and emoji are empty
- Applies to both streaming cards and static card replies

## Why

When no agent identity is configured (the common default setup), the card header displays the raw `agentId` value `"main"`, which is confusing and provides no useful information to end users.

## Test plan

- [ ] Default agent (no identity configured) — verify streaming and static cards have no header
- [ ] Agent with custom identity name — verify header shows the configured name
- [ ] Agent with custom emoji — verify header shows the emoji
- [ ] Subagent with non-"main" agentId — verify header shows the agentId as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)