### PR TITLE
whatsapp: stop gating explicit outbound targets on allowFrom

### DIFF
--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -179,6 +179,14 @@ describe("resolveWhatsAppOutboundTarget", () => {
   });
 
   describe("explicit/custom modes", () => {
+    it("allows explicit targets even when not present in allowList", () => {
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce(SECONDARY_TARGET)
+        .mockReturnValueOnce(PRIMARY_TARGET);
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+      expectAllowedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "explicit" });
+    });
+
     it("allows message in null mode when allowList is not set", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET);
       expectAllowedForTarget({ allowFrom: undefined, mode: null });

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -31,9 +31,8 @@ export function resolveWhatsAppOutboundTarget(params: {
     if (isWhatsAppGroupJid(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
-    // Enforce allowFrom for all direct-message send modes (including explicit).
-    // Group destinations are handled by group policy and are allowed above.
-    if (hasWildcard || allowList.length === 0) {
+    // Explicit outbound targets are user-chosen destinations, not allowlist-derived routing.
+    if (params.mode === "explicit" || hasWildcard || allowList.length === 0) {
       return { ok: true, to: normalizedTo };
     }
     if (allowList.includes(normalizedTo)) {


### PR DESCRIPTION
## Concise Summary

Allow explicit outbound WhatsApp targets to bypass `allowFrom` gating while keeping implicit routing on the existing allowlist-backed path.

## Problem

Explicit outbound sends to valid E.164 targets were being rejected if the target was not also present in `allowFrom`, even though `allowFrom` is intended to control implicit routing and inbound authorization.

## Fix

- Accept valid normalized direct targets immediately when `mode === "explicit"`.
- Preserve existing gating for implicit and heartbeat-style routing.
- Add regression coverage proving explicit valid E.164 targets outside `allowFrom` succeed while implicit targets still fail.

## Tests

- `corepack pnpm exec vitest run src/whatsapp/resolve-outbound-target.test.ts`
- Result:
  - `Test Files 1 passed (1)`
  - `Tests 22 passed (22)`

## Risks / Limitations

- Low risk. This narrows allowlist enforcement to the modes that already represent implicit/allowlist-backed routing.
