### PR TITLE
fix(infra): lazy-evaluate fs.constants in tmp-openclaw-dir to fix browser bundle (#48062)

### DIFF
--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -3,7 +3,13 @@ import os from "node:os";
 import path from "node:path";
 
 export const POSIX_OPENCLAW_TMP_DIR = "/tmp/openclaw";
-const TMP_DIR_ACCESS_MODE = fs.constants.W_OK | fs.constants.X_OK;
+
+// Lazily resolve access-mode flags so the module can be imported in browser
+// bundles where `node:fs` is externalized to `undefined`.  Accessing
+// `fs.constants` at module scope crashes the Vite-bundled Control UI.
+function getTmpDirAccessMode(): number {
+  return fs.constants.W_OK | fs.constants.X_OK;
+}
 
 type ResolvePreferredOpenClawTmpDirOptions = {
   accessSync?: (path: string, mode?: number) => void;
@@ -86,7 +92,7 @@ export function resolvePreferredOpenClawTmpDir(
       if (!isTrustedTmpDir(candidate)) {
         return "invalid";
       }
-      accessSync(candidatePath, TMP_DIR_ACCESS_MODE);
+      accessSync(candidatePath, getTmpDirAccessMode());
       return "available";
     } catch (err) {
       if (isNodeErrorWithCode(err, "ENOENT")) {
@@ -152,7 +158,7 @@ export function resolvePreferredOpenClawTmpDir(
   }
 
   try {
-    accessSync("/tmp", TMP_DIR_ACCESS_MODE);
+    accessSync("/tmp", getTmpDirAccessMode());
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_OPENCLAW_TMP_DIR, { recursive: true, mode: 0o700 });
     chmodSync(POSIX_OPENCLAW_TMP_DIR, 0o700);


### PR DESCRIPTION
## Summary
- Fix Control UI blank screen caused by `fs.constants.W_OK` evaluated at module scope
- When `src/infra/tmp-openclaw-dir.ts` is bundled into the browser via Vite, `node:fs` is externalized to `undefined`, causing `Cannot read properties of undefined (reading 'W_OK')` at import time
- Move `fs.constants.W_OK | fs.constants.X_OK` into a lazy getter function so the module can be safely imported in browser contexts without crashing

## Changes
- `src/infra/tmp-openclaw-dir.ts`: Replace module-scope `TMP_DIR_ACCESS_MODE` constant with `getTmpDirAccessMode()` lazy getter

## Test
- All 16 existing tests in `tmp-openclaw-dir.test.ts` pass

Closes #48062