### PR TITLE
Fix reply-tagged NO_REPLY suppression

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -11,6 +11,15 @@ describe("isSilentReplyText", () => {
     expect(isSilentReplyText("\nNO_REPLY\n")).toBe(true);
   });
 
+  it("returns true for reply-tagged silent token", () => {
+    expect(isSilentReplyText("[[reply_to_current]] NO_REPLY")).toBe(true);
+    expect(isSilentReplyText("[[ reply_to : 123 ]]\nNO_REPLY")).toBe(true);
+  });
+
+  it("returns false for reply-tagged substantive text containing token", () => {
+    expect(isSilentReplyText("[[reply_to_current]] NO_REPLY but here is more content")).toBe(false);
+  });
+
   it("returns false for undefined/empty", () => {
     expect(isSilentReplyText(undefined)).toBe(false);
     expect(isSilentReplyText("")).toBe(false);

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -1,4 +1,5 @@
 import { escapeRegExp } from "../utils.js";
+import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
@@ -37,7 +38,19 @@ export function isSilentReplyText(
   }
   // Match only the exact silent token with optional surrounding whitespace.
   // This prevents substantive replies ending with NO_REPLY from being suppressed (#19537).
-  return getSilentExactRegex(token).test(text);
+  if (getSilentExactRegex(token).test(text)) {
+    return true;
+  }
+  // Reply/audio directive tags may prefix otherwise-silent text, e.g.
+  // [[reply_to_current]] NO_REPLY. Strip directives before the exact-match check
+  // so silent turns stay silent on chat surfaces that use reply tags.
+  if (text.includes("[[")) {
+    const stripped = stripInlineDirectiveTagsForDisplay(text).text;
+    if (stripped && getSilentExactRegex(token).test(stripped)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary
- strip inline directive tags before checking for exact silent reply tokens
- keep mixed-content replies from being treated as silent
- add tests covering directive-tagged silent replies and non-silent mixed content

## Testing
- node node_modules/vitest/vitest.mjs run src/utils/directive-tags.test.ts
- node node_modules/vitest/vitest.mjs run src/auto-reply/tokens.test.ts