### PR TITLE
fix(docker): add plugins/runtime as tsdown entry for Docker channel startup

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -126,6 +126,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "channels/plugins/actions/discord": "src/channels/plugins/actions/discord.ts",
     "channels/plugins/actions/signal": "src/channels/plugins/actions/signal.ts",
     "channels/plugins/actions/telegram": "src/channels/plugins/actions/telegram.ts",
+    "plugins/runtime/index": "src/plugins/runtime/index.ts",
     "telegram/audit": "extensions/telegram/src/audit.ts",
     "telegram/token": "extensions/telegram/src/token.ts",
     "line/accounts": "src/line/accounts.ts",


### PR DESCRIPTION
## Summary

Fixes #48422

In Docker builds (v2026.3.14), Discord and WhatsApp channels fail to start with:

```
channel startup failed: Error: Unable to resolve plugin runtime module
```

`resolvePluginRuntimeModulePath()` in `src/plugins/loader.ts` looks for `dist/plugins/runtime/index.js` in production/Docker builds, but this file was never generated because `plugins/runtime` was not listed as a tsdown build entry.

## Fix

Add `"plugins/runtime/index": "src/plugins/runtime/index.ts"` to `buildCoreDistEntries()` in `tsdown.config.ts` so tsdown produces `dist/plugins/runtime/index.js` during the build -- exactly what the runtime resolver expects.

## Test plan

- [ ] `pnpm build` succeeds and `dist/plugins/runtime/index.js` is generated
- [ ] Docker build produces a working image where Discord/WhatsApp channels start without the "Unable to resolve plugin runtime module" error