### PR TITLE
Refresh persisted skills snapshots when agent skill filters change

### DIFF
--- a/src/auto-reply/reply/session-updates.skill-filter.test.ts
+++ b/src/auto-reply/reply/session-updates.skill-filter.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+
+vi.mock("../../agents/skills.js", () => ({
+  buildWorkspaceSkillSnapshot: vi.fn(),
+}));
+
+vi.mock("../../agents/skills/refresh.js", () => ({
+  ensureSkillsWatcher: vi.fn(),
+  getSkillsSnapshotVersion: vi.fn(() => 0),
+}));
+
+vi.mock("../../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: vi.fn(() => undefined),
+}));
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    updateSessionStore: vi.fn(),
+  };
+});
+
+import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
+import { getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
+import { ensureSkillSnapshot } from "./session-updates.js";
+
+describe("ensureSkillSnapshot skill filter refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.OPENCLAW_TEST_FAST;
+    vi.mocked(getSkillsSnapshotVersion).mockReturnValue(0);
+  });
+
+  it("refreshes a stale cached snapshot when the effective skillFilter changes to empty", async () => {
+    const refreshedSnapshot = {
+      prompt: "",
+      skills: [],
+      skillFilter: [],
+      version: 0,
+    };
+    vi.mocked(buildWorkspaceSkillSnapshot).mockReturnValue(refreshedSnapshot);
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      skillsSnapshot: {
+        prompt: "<available_skills><skill>weather</skill></available_skills>",
+        skills: [{ name: "weather" }],
+        version: 0,
+      },
+    };
+    const sessionStore = { "agent:main:main": { ...sessionEntry } };
+
+    const result = await ensureSkillSnapshot({
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:main",
+      isFirstTurnInSession: false,
+      workspaceDir: "/tmp/workspace",
+      cfg: {},
+      skillFilter: [],
+    });
+
+    expect(buildWorkspaceSkillSnapshot).toHaveBeenCalledOnce();
+    expect(vi.mocked(buildWorkspaceSkillSnapshot).mock.calls[0]?.[1]).toMatchObject({
+      skillFilter: [],
+    });
+    expect(result.skillsSnapshot).toEqual(refreshedSnapshot);
+    expect(sessionStore["agent:main:main"]?.skillsSnapshot).toEqual(refreshedSnapshot);
+  });
+
+  it("reuses the cached snapshot when the normalized filter is unchanged", async () => {
+    const cachedSnapshot = {
+      prompt: "<available_skills><skill>weather</skill></available_skills>",
+      skills: [{ name: "weather" }],
+      skillFilter: ["meme-factory", "weather"],
+      version: 0,
+    };
+
+    const result = await ensureSkillSnapshot({
+      sessionEntry: {
+        sessionId: "session-2",
+        updatedAt: 1,
+        skillsSnapshot: cachedSnapshot,
+      },
+      sessionStore: {
+        "agent:main:main": {
+          sessionId: "session-2",
+          updatedAt: 1,
+          skillsSnapshot: cachedSnapshot,
+        },
+      },
+      sessionKey: "agent:main:main",
+      isFirstTurnInSession: false,
+      workspaceDir: "/tmp/workspace",
+      cfg: {},
+      skillFilter: [" weather ", "meme-factory", "weather"],
+    });
+
+    expect(buildWorkspaceSkillSnapshot).not.toHaveBeenCalled();
+    expect(result.skillsSnapshot).toEqual(cachedSnapshot);
+  });
+
+  it("does not rebuild the snapshot twice on first turn when a filtered session starts empty", async () => {
+    const refreshedSnapshot = {
+      prompt: "<available_skills><skill>weather</skill></available_skills>",
+      skills: [{ name: "weather" }],
+      skillFilter: ["weather"],
+      version: 0,
+    };
+    vi.mocked(buildWorkspaceSkillSnapshot).mockReturnValue(refreshedSnapshot);
+
+    const sessionStore: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "session-3",
+        updatedAt: 1,
+      },
+    };
+
+    const result = await ensureSkillSnapshot({
+      sessionEntry: sessionStore["agent:main:main"],
+      sessionStore,
+      sessionKey: "agent:main:main",
+      isFirstTurnInSession: true,
+      workspaceDir: "/tmp/workspace",
+      cfg: {},
+      skillFilter: ["weather"],
+    });
+
+    expect(buildWorkspaceSkillSnapshot).toHaveBeenCalledOnce();
+    expect(result.skillsSnapshot).toEqual(refreshedSnapshot);
+    expect(sessionStore["agent:main:main"]?.skillsSnapshot).toEqual(refreshedSnapshot);
+  });
+});

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { resolveUserTimezone } from "../../agents/date-time.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
+import { matchesSkillFilter } from "../../agents/skills/filter.js";
 import { ensureSkillsWatcher, getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
@@ -178,11 +179,14 @@ export async function ensureSkillSnapshot(params: {
 
   let nextEntry = sessionEntry;
   let systemSent = sessionEntry?.systemSent ?? false;
+  let rebuiltSnapshotThisTurn = false;
   const remoteEligibility = getRemoteSkillEligibility();
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   ensureSkillsWatcher({ workspaceDir, config: cfg });
+  const existingSnapshot = nextEntry?.skillsSnapshot;
   const shouldRefreshSnapshot =
-    snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion;
+    (snapshotVersion > 0 && (existingSnapshot?.version ?? 0) < snapshotVersion) ||
+    !matchesSkillFilter(existingSnapshot?.skillFilter, skillFilter);
 
   if (isFirstTurnInSession && sessionStore && sessionKey) {
     const current = nextEntry ??
@@ -190,15 +194,13 @@ export async function ensureSkillSnapshot(params: {
         sessionId: sessionId ?? crypto.randomUUID(),
         updatedAt: Date.now(),
       };
-    const skillSnapshot =
-      isFirstTurnInSession || !current.skillsSnapshot || shouldRefreshSnapshot
-        ? buildWorkspaceSkillSnapshot(workspaceDir, {
-            config: cfg,
-            skillFilter,
-            eligibility: { remote: remoteEligibility },
-            snapshotVersion,
-          })
-        : current.skillsSnapshot;
+    const skillSnapshot = buildWorkspaceSkillSnapshot(workspaceDir, {
+      config: cfg,
+      skillFilter,
+      eligibility: { remote: remoteEligibility },
+      snapshotVersion,
+    });
+    rebuiltSnapshotThisTurn = true;
     nextEntry = {
       ...current,
       sessionId: sessionId ?? current.sessionId ?? crypto.randomUUID(),
@@ -210,7 +212,9 @@ export async function ensureSkillSnapshot(params: {
     systemSent = true;
   }
 
-  const skillsSnapshot = shouldRefreshSnapshot
+  const shouldRefreshAfterFirstTurn = !rebuiltSnapshotThisTurn && shouldRefreshSnapshot;
+
+  const skillsSnapshot = shouldRefreshAfterFirstTurn
     ? buildWorkspaceSkillSnapshot(workspaceDir, {
         config: cfg,
         skillFilter,
@@ -231,7 +235,7 @@ export async function ensureSkillSnapshot(params: {
     sessionStore &&
     sessionKey &&
     !isFirstTurnInSession &&
-    (!nextEntry?.skillsSnapshot || shouldRefreshSnapshot)
+    (!nextEntry?.skillsSnapshot || shouldRefreshAfterFirstTurn)
   ) {
     const current = nextEntry ?? {
       sessionId: sessionId ?? crypto.randomUUID(),

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -8,6 +8,8 @@ import { FailoverError } from "../agents/failover-error.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import * as modelSelectionModule from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
+import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import * as commandSecretGatewayModule from "../cli/command-secret-gateway.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as configModule from "../config/config.js";
@@ -803,6 +805,105 @@ describe("agentCommand", () => {
     } finally {
       vi.mocked(modelSelectionModule.isCliProvider).mockImplementation(() => false);
     }
+  });
+
+  it("refreshes cached skills snapshots when the agent-level skills filter changes without a version bump", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const sessionKey = "agent:ops:main";
+      writeSessionStoreSeed(store, {
+        [sessionKey]: {
+          sessionId: "session-ops",
+          updatedAt: Date.now(),
+          skillsSnapshot: {
+            prompt: "<available_skills><skill>meme-factory</skill></available_skills>",
+            skills: [{ name: "meme-factory" }],
+            version: 0,
+          },
+        },
+      });
+
+      configSpy.mockReturnValue({
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-5" },
+            models: { "anthropic/claude-opus-4-5": {} },
+            workspace: path.join(home, "openclaw"),
+          },
+          list: [{ id: "ops", default: true, skills: ["weather"] }],
+        },
+        session: { store, mainKey: "main" },
+      } as unknown as OpenClawConfig);
+
+      vi.mocked(getSkillsSnapshotVersion).mockReturnValueOnce(0);
+      vi.mocked(buildWorkspaceSkillSnapshot).mockReturnValueOnce({
+        prompt: "<available_skills><skill>weather</skill></available_skills>",
+        skills: [{ name: "weather" }],
+        skillFilter: ["weather"],
+        version: 0,
+      } as never);
+
+      await agentCommand({ message: "hi", sessionKey }, runtime);
+
+      expect(buildWorkspaceSkillSnapshot).toHaveBeenCalledOnce();
+      expect(vi.mocked(buildWorkspaceSkillSnapshot).mock.calls[0]?.[1]).toMatchObject({
+        skillFilter: ["weather"],
+        snapshotVersion: 0,
+      });
+
+      const saved = readSessionStore<{
+        skillsSnapshot?: { skillFilter?: string[]; skills?: Array<{ name: string }> };
+      }>(store);
+      expect(saved[sessionKey]?.skillsSnapshot?.skillFilter).toEqual(["weather"]);
+      expect(saved[sessionKey]?.skillsSnapshot?.skills).toEqual([{ name: "weather" }]);
+    });
+  });
+
+  it("reuses cached skills snapshots when version is missing and the normalized filter is unchanged", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const sessionKey = "agent:ops:main";
+      const cachedSnapshot = {
+        prompt: "<available_skills><skill>weather</skill></available_skills>",
+        skills: [{ name: "weather" }],
+        skillFilter: ["weather"],
+      };
+      writeSessionStoreSeed(store, {
+        [sessionKey]: {
+          sessionId: "session-ops",
+          updatedAt: Date.now(),
+          skillsSnapshot: cachedSnapshot,
+        },
+      });
+
+      configSpy.mockReturnValue({
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-5" },
+            models: { "anthropic/claude-opus-4-5": {} },
+            workspace: path.join(home, "openclaw"),
+          },
+          list: [{ id: "ops", default: true, skills: [" weather "] }],
+        },
+        session: { store, mainKey: "main" },
+      } as unknown as OpenClawConfig);
+
+      vi.mocked(getSkillsSnapshotVersion).mockReturnValueOnce(0);
+
+      await agentCommand({ message: "hi", sessionKey }, runtime);
+
+      expect(buildWorkspaceSkillSnapshot).not.toHaveBeenCalled();
+
+      const saved = readSessionStore<{
+        skillsSnapshot?: {
+          prompt?: string;
+          skillFilter?: string[];
+          skills?: Array<{ name: string }>;
+          version?: number;
+        };
+      }>(store);
+      expect(saved[sessionKey]?.skillsSnapshot).toEqual(cachedSnapshot);
+    });
   });
 
   it("rejects unknown agent overrides", async () => {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -39,6 +39,7 @@ import {
 import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
+import { matchesSkillFilter } from "../agents/skills/filter.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import { normalizeSpawnedRunMetadata } from "../agents/spawned-context.js";
 import { resolveAgentTimeoutMs } from "../agents/timeout.js";
@@ -873,9 +874,15 @@ async function agentCommandInternal(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
+    const existingSkillsSnapshot = sessionEntry?.skillsSnapshot;
+    const needsSkillsSnapshot =
+      isNewSession ||
+      !existingSkillsSnapshot ||
+      (skillsSnapshotVersion > 0 &&
+        (existingSkillsSnapshot.version ?? 0) < skillsSnapshotVersion) ||
+      !matchesSkillFilter(existingSkillsSnapshot.skillFilter, skillFilter);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {
           config: cfg,


### PR DESCRIPTION
## Summary

Refresh cached  entries in persisted-session paths when the effective agent-level  changes.

This brings the persisted-session behavior in line with the existing cron path, which already invalidates cached snapshots when  changes.

## Problem

OpenClaw already:
- stores  in 
- normalizes and compares skill filters
- refreshes cron/isolated-agent snapshots when the filter changes

However, two persisted-session paths could still reuse an older cached  even after the agent’s configured skills filter changed:

- 
- 

That meant cases like this could stay stale across existing sessions:



or switching from an unrestricted session to a smaller allowlist.

## Root Cause

The persisted-session refresh checks only considered:
- missing snapshot
- new session
- snapshot version changes

They did not invalidate cached snapshots when the current effective  no longer matched the cached snapshot’s stored .

The cron path already had the correct behavior via .

## Change

This patch adds the same -change invalidation to the persisted-session paths:

- 
- 

A cached snapshot is now refreshed when:
- the snapshot version changes, or
- the current effective  no longer matches the cached snapshot’s 

## Tests

Added/updated coverage for the stale persisted-session case:

- new 
- updated 
- verified existing parity/reference coverage still passes:
  - 

## Verification

Ran the minimal relevant test set:

 ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE  No package found in this workspace
 ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE  No package found in this workspace
 ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE  No package found in this workspace

Also validated  on the earlier clean branch before the upstream base introduced an unrelated  check failure.

Closes #47019