### PR TITLE
fix(ui): show provider name for qualified model ids

### DIFF
--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -43,6 +43,12 @@ describe("chat-model-ref helpers", () => {
     expect(formatChatModelDisplay("alias-only")).toBe("alias-only");
   });
 
+  it("formats provider-qualified model ids using the first path segment as provider", () => {
+    expect(formatChatModelDisplay("openrouter/google/gemini-2.5-flash")).toBe(
+      "google/gemini-2.5-flash · openrouter",
+    );
+  });
+
   it("resolves server session data to qualified option values", () => {
     expect(resolveServerChatModelValue("gpt-5-mini", "openai")).toBe("openai/gpt-5-mini");
     expect(resolveServerChatModelValue("alias-only", null)).toBe("alias-only");

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -77,11 +77,11 @@ export function formatChatModelDisplay(value: string): string {
   if (!trimmed) {
     return "";
   }
-  const separator = trimmed.indexOf("/");
-  if (separator <= 0) {
+  const parts = trimmed.split("/").filter(Boolean);
+  if (parts.length < 2) {
     return trimmed;
   }
-  return `${trimmed.slice(separator + 1)} · ${trimmed.slice(0, separator)}`;
+  return `${parts.slice(1).join("/")} · ${parts[0]}`;
 }
 
 export function buildChatModelOption(entry: ModelCatalogEntry): { value: string; label: string } {


### PR DESCRIPTION
## Summary
- fix web UI model display formatting for provider-qualified model ids
- keep the first path segment as the provider label for ids like `openrouter/google/gemini-2.5-flash`
- add a regression test covering multi-segment qualified ids

## Problem
The web UI formatted model labels by splitting on the first slash and assuming everything after it was the model id. For provider-qualified ids like `openrouter/google/gemini-2.5-flash`, that caused the UI to collapse the provider distinction and mislabel the active provider in the header/status display.

Fixes #48443.

## Testing
- `npm --prefix ui test -- chat-model-ref.test.ts`
