### PR TITLE
fix(telegram): recover from HTML parse errors during streaming preview

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -687,3 +687,263 @@ describe("draft stream initial message debounce", () => {
     });
   });
 });
+
+describe("HTML parse error fallback", () => {
+  afterEach(() => {
+    __testing.resetTelegramDraftStreamForTests();
+  });
+
+  const htmlRenderer = (text: string) => ({ text: `<i>${text}</i>`, parseMode: "HTML" as const });
+
+  function createRenderedStream(
+    api: ReturnType<typeof createMockDraftApi>,
+    overrides: Omit<Partial<TelegramDraftStreamParams>, "api" | "chatId"> = {},
+  ) {
+    return createDraftStream(api, { renderText: htmlRenderer, ...overrides });
+  }
+
+  it("retries editMessageText as plain text when HTML parse error occurs", async () => {
+    const api = createMockDraftApi();
+    api.editMessageText
+      .mockRejectedValueOnce(
+        new Error("400: Bad Request: can't parse entities: unexpected end tag"),
+      )
+      .mockResolvedValueOnce(true);
+    const warn = vi.fn();
+    const stream = createRenderedStream(api, { warn });
+
+    stream.update("hello");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<i>hello</i>", { parse_mode: "HTML" });
+
+    stream.update("hello again");
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledTimes(2);
+    expect(api.editMessageText).toHaveBeenNthCalledWith(1, 123, 17, "<i>hello again</i>", {
+      parse_mode: "HTML",
+    });
+    expect(api.editMessageText).toHaveBeenNthCalledWith(2, 123, 17, "hello again");
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream preview edit: HTML parse error, retrying as plain text",
+    );
+  });
+
+  it("propagates to outer handler when edit plain text retry also fails", async () => {
+    const api = createMockDraftApi();
+    api.editMessageText
+      .mockRejectedValueOnce(
+        new Error("400: Bad Request: can't parse entities: unexpected end tag"),
+      )
+      .mockRejectedValueOnce(new Error("500: Internal Server Error"));
+    const warn = vi.fn();
+    const stream = createRenderedStream(api, { warn });
+
+    stream.update("hello");
+    await stream.flush();
+
+    stream.update("hello again");
+    await stream.flush();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("telegram stream preview failed: 500: Internal Server Error"),
+    );
+
+    // Stream is stopped — further updates are no-ops
+    stream.update("third");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries first sendMessage as plain text when HTML parse error occurs", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockRejectedValueOnce(
+        new Error("400: Bad Request: can't parse entities: unexpected end tag"),
+      )
+      .mockResolvedValueOnce({ message_id: 17 });
+    const warn = vi.fn();
+    const stream = createRenderedStream(api, { warn });
+
+    stream.update("hello");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "<i>hello</i>", { parse_mode: "HTML" });
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "hello", undefined);
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream preview send: HTML parse error, retrying as plain text",
+    );
+
+    // Stream continues with captured message id
+    stream.update("hello again");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "hello again");
+  });
+
+  it("retries sendMessageDraft as plain text when HTML parse error occurs", async () => {
+    const api = createMockDraftApi();
+    api.sendMessageDraft
+      .mockRejectedValueOnce(
+        new Error("400: Bad Request: can't parse entities: unexpected end tag"),
+      )
+      .mockResolvedValueOnce(true);
+    const warn = vi.fn();
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "draft",
+      renderText: htmlRenderer,
+      warn,
+    });
+
+    stream.update("hello");
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenCalledTimes(2);
+    expect(api.sendMessageDraft).toHaveBeenNthCalledWith(
+      1,
+      123,
+      expect.any(Number),
+      "<i>hello</i>",
+      { message_thread_id: 42, parse_mode: "HTML" },
+    );
+    expect(api.sendMessageDraft).toHaveBeenNthCalledWith(2, 123, expect.any(Number), "hello", {
+      message_thread_id: 42,
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream draft preview: HTML parse error, retrying as plain text",
+    );
+  });
+
+  it("treats MESSAGE_NOT_MODIFIED on edit as success and continues streaming", async () => {
+    const api = createMockDraftApi();
+    api.editMessageText
+      .mockRejectedValueOnce(new Error("400: Bad Request: message is not modified"))
+      .mockResolvedValue(true);
+    const stream = createDraftStream(api);
+
+    stream.update("hello");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+
+    stream.update("hello2");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenCalledTimes(1);
+
+    // Stream continues working after MESSAGE_NOT_MODIFIED
+    stream.update("hello3");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenCalledTimes(2);
+  });
+
+  it("disables parse_mode for remaining updates in the same generation after a parse error", async () => {
+    const api = createMockDraftApi();
+    api.editMessageText
+      .mockRejectedValueOnce(
+        new Error("400: Bad Request: can't parse entities: unexpected end tag"),
+      )
+      .mockResolvedValue(true);
+    const warn = vi.fn();
+    const stream = createRenderedStream(api, { warn });
+
+    stream.update("hello");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<i>hello</i>", { parse_mode: "HTML" });
+
+    // Edit triggers parse error → plain text retry
+    stream.update("hello again");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenNthCalledWith(2, 123, 17, "hello again");
+
+    // Subsequent update uses plain text directly (no parse_mode)
+    stream.update("third update");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenCalledTimes(3);
+    expect(api.editMessageText.mock.calls[2]).toEqual([123, 17, "third update"]);
+  });
+
+  it("re-enables HTML parse mode after forceNewMessage resets the generation", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockResolvedValueOnce({ message_id: 17 })
+      .mockResolvedValueOnce({ message_id: 42 });
+    api.editMessageText
+      .mockRejectedValueOnce(
+        new Error("400: Bad Request: can't parse entities: unexpected end tag"),
+      )
+      .mockResolvedValue(true);
+    const warn = vi.fn();
+    const stream = createRenderedStream(api, { warn });
+
+    stream.update("hello");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<i>hello</i>", { parse_mode: "HTML" });
+
+    // Edit triggers parse error → disables parse mode for gen 0
+    stream.update("hello again");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenNthCalledWith(2, 123, 17, "hello again");
+
+    // Force new message → new generation, parse mode re-enabled
+    stream.forceNewMessage();
+    stream.update("new message");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "<i>new message</i>", {
+      parse_mode: "HTML",
+    });
+  });
+
+  it("does not stop stream when HTML parse error reaches outer handler", async () => {
+    const api = createMockDraftApi();
+    api.editMessageText
+      .mockRejectedValueOnce(
+        new Error("400: Bad Request: can't parse entities: unexpected end tag"),
+      )
+      .mockRejectedValueOnce(
+        new Error("400: Bad Request: can't parse entities: unexpected end tag"),
+      )
+      .mockResolvedValue(true);
+    const warn = vi.fn();
+    const stream = createRenderedStream(api, { warn });
+
+    stream.update("hello");
+    await stream.flush();
+
+    // Both HTML edit and plain text retry fail with parse errors
+    stream.update("hello again");
+    await stream.flush();
+
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream preview: HTML parse error escaped to outer handler (degrading to plain text)",
+    );
+
+    // Stream still works (not stopped)
+    stream.update("third update");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenCalledTimes(3);
+    expect(api.editMessageText.mock.calls[2]).toEqual([123, 17, "third update"]);
+  });
+
+  it("stops stream on non-parse errors in outer handler", async () => {
+    const api = createMockDraftApi();
+    api.editMessageText.mockRejectedValueOnce(new Error("429: Too Many Requests"));
+    const warn = vi.fn();
+    const stream = createRenderedStream(api, { warn });
+
+    stream.update("hello");
+    await stream.flush();
+
+    stream.update("hello again");
+    await stream.flush();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("telegram stream preview failed: 429: Too Many Requests"),
+    );
+
+    // Stream is stopped — further updates are no-ops
+    stream.update("third");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -282,12 +282,21 @@ export function createTelegramDraftStream(params: {
         // HTML rejected on first send — retry as plain text.
         parseModeDisabledForGeneration = sendGeneration;
         params.warn?.("telegram stream preview send: HTML parse error, retrying as plain text");
-        ({ sent } = await sendRenderedMessageWithThreadFallback({
-          renderedText: plainText,
-          renderedParseMode: undefined,
-          fallbackWarnMessage:
-            "telegram stream preview send (plain) failed with message_thread_id, retrying without thread",
-        }));
+        try {
+          ({ sent } = await sendRenderedMessageWithThreadFallback({
+            renderedText: plainText,
+            renderedParseMode: undefined,
+            fallbackWarnMessage:
+              "telegram stream preview send (plain) failed with message_thread_id, retrying without thread",
+          }));
+        } catch (plainErr) {
+          // Plain text retry also failed — reset messageSendAttempted when the
+          // error guarantees the message was never delivered.
+          if (isSafeToRetrySendError(plainErr) || isTelegramClientRejection(plainErr)) {
+            messageSendAttempted = false;
+          }
+          throw plainErr;
+        }
       } else {
         // Pre-connect failures (DNS, refused) and explicit Telegram rejections (4xx)
         // guarantee the message was never delivered — clear the flag so

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -375,12 +375,17 @@ export function createTelegramDraftStream(params: {
     if (!renderedText) {
       return false;
     }
-    if (renderedText.length > maxChars) {
-      // Telegram text messages/edits cap at 4096 chars.
+    // Telegram text messages/edits cap at 4096 chars.
+    // Use the effective payload length: when HTML parse mode is disabled for
+    // this generation, the actual payload is the shorter plain text, not the
+    // expanded HTML renderedText.
+    const effectiveLength =
+      parseModeDisabledForGeneration === generation ? trimmed.length : renderedText.length;
+    if (effectiveLength > maxChars) {
       // Stop streaming once we exceed the cap to avoid repeated API failures.
       streamState.stopped = true;
       params.warn?.(
-        `telegram stream preview stopped (text length ${renderedText.length} > ${maxChars})`,
+        `telegram stream preview stopped (text length ${effectiveLength} > ${maxChars})`,
       );
       return false;
     }
@@ -430,7 +435,7 @@ export function createTelegramDraftStream(params: {
           plainText: trimmed,
         });
       }
-      if (sent) {
+      if (sent && sendGeneration === generation) {
         previewRevision += 1;
         lastDeliveredText = trimmed;
         // Reflect the actual text and parse mode that was delivered. When the

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -269,6 +269,8 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     messageSendAttempted = true;
+    let actualSentText = effectiveText;
+    let actualSentParseMode = effectiveParseMode;
     let sent: Awaited<ReturnType<typeof sendRenderedMessageWithThreadFallback>>["sent"];
     try {
       ({ sent } = await sendRenderedMessageWithThreadFallback({
@@ -281,6 +283,8 @@ export function createTelegramDraftStream(params: {
       if (effectiveParseMode && isTelegramHtmlParseError(err)) {
         // HTML rejected on first send — retry as plain text.
         parseModeDisabledForGeneration = sendGeneration;
+        actualSentText = plainText;
+        actualSentParseMode = undefined;
         params.warn?.("telegram stream preview send: HTML parse error, retrying as plain text");
         try {
           ({ sent } = await sendRenderedMessageWithThreadFallback({
@@ -317,8 +321,8 @@ export function createTelegramDraftStream(params: {
     if (sendGeneration !== generation) {
       params.onSupersededPreview?.({
         messageId: normalizedMessageId,
-        textSnapshot: renderedText,
-        parseMode: renderedParseMode,
+        textSnapshot: actualSentText,
+        parseMode: actualSentParseMode,
       });
       return true;
     }

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -437,7 +437,7 @@ export function createTelegramDraftStream(params: {
       // update will arrive with more text that may produce valid HTML, and
       // the transport functions already disable parse_mode for this generation.
       if (isTelegramHtmlParseError(err)) {
-        parseModeDisabledForGeneration = generation;
+        parseModeDisabledForGeneration = sendGeneration;
         params.warn?.(
           `telegram stream preview: HTML parse error escaped to outer handler (degrading to plain text)`,
         );

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -240,16 +240,18 @@ export function createTelegramDraftStream(params: {
     // Resolve effective parse mode: disabled for this generation after a prior parse error.
     const effectiveParseMode =
       parseModeDisabledForGeneration === sendGeneration ? undefined : renderedParseMode;
-    const effectiveText = effectiveParseMode ? renderedText : plainText;
+    const effectiveText =
+      parseModeDisabledForGeneration === sendGeneration ? plainText : renderedText;
 
-    if (typeof streamMessageId === "number") {
+    const editTargetId = streamMessageId;
+    if (typeof editTargetId === "number") {
       try {
         if (effectiveParseMode) {
-          await params.api.editMessageText(chatId, streamMessageId, effectiveText, {
+          await params.api.editMessageText(chatId, editTargetId, effectiveText, {
             parse_mode: effectiveParseMode,
           });
         } else {
-          await params.api.editMessageText(chatId, streamMessageId, effectiveText);
+          await params.api.editMessageText(chatId, editTargetId, effectiveText);
         }
       } catch (err) {
         if (isMessageNotModifiedError(err)) {
@@ -259,9 +261,11 @@ export function createTelegramDraftStream(params: {
         if (effectiveParseMode && isTelegramHtmlParseError(err)) {
           // HTML rejected by Telegram — retry as plain text and disable
           // parse_mode for the rest of this generation.
-          parseModeDisabledForGeneration = sendGeneration;
+          if (sendGeneration === generation) {
+            parseModeDisabledForGeneration = sendGeneration;
+          }
           params.warn?.("telegram stream preview edit: HTML parse error, retrying as plain text");
-          await params.api.editMessageText(chatId, streamMessageId, plainText);
+          await params.api.editMessageText(chatId, editTargetId, plainText);
           return true;
         }
         throw err;
@@ -282,7 +286,9 @@ export function createTelegramDraftStream(params: {
     } catch (err) {
       if (effectiveParseMode && isTelegramHtmlParseError(err)) {
         // HTML rejected on first send — retry as plain text.
-        parseModeDisabledForGeneration = sendGeneration;
+        if (sendGeneration === generation) {
+          parseModeDisabledForGeneration = sendGeneration;
+        }
         actualSentText = plainText;
         actualSentParseMode = undefined;
         params.warn?.("telegram stream preview send: HTML parse error, retrying as plain text");
@@ -337,7 +343,8 @@ export function createTelegramDraftStream(params: {
   }: PreviewSendParams): Promise<boolean> => {
     const effectiveParseMode =
       parseModeDisabledForGeneration === sendGeneration ? undefined : renderedParseMode;
-    const effectiveText = effectiveParseMode ? renderedText : plainText;
+    const effectiveText =
+      parseModeDisabledForGeneration === sendGeneration ? plainText : renderedText;
     const draftId = streamDraftId ?? allocateTelegramDraftId();
     streamDraftId = draftId;
     const buildDraftParams = (parseMode: "HTML" | undefined) => {
@@ -354,7 +361,9 @@ export function createTelegramDraftStream(params: {
       await resolvedDraftApi!(chatId, draftId, effectiveText, buildDraftParams(effectiveParseMode));
     } catch (err) {
       if (effectiveParseMode && isTelegramHtmlParseError(err)) {
-        parseModeDisabledForGeneration = sendGeneration;
+        if (sendGeneration === generation) {
+          parseModeDisabledForGeneration = sendGeneration;
+        }
         params.warn?.("telegram stream draft preview: HTML parse error, retrying as plain text");
         await resolvedDraftApi!(chatId, draftId, plainText, buildDraftParams(undefined));
       } else {
@@ -455,7 +464,9 @@ export function createTelegramDraftStream(params: {
       // update will arrive with more text that may produce valid HTML, and
       // the transport functions already disable parse_mode for this generation.
       if (isTelegramHtmlParseError(err)) {
-        parseModeDisabledForGeneration = sendGeneration;
+        if (sendGeneration === generation) {
+          parseModeDisabledForGeneration = sendGeneration;
+        }
         params.warn?.(
           `telegram stream preview: HTML parse error escaped to outer handler (degrading to plain text)`,
         );

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -5,6 +5,18 @@ import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helper
 import { isSafeToRetrySendError, isTelegramClientRejection } from "./network-errors.js";
 import { normalizeTelegramReplyToMessageId } from "./outbound-params.js";
 
+const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
+const MESSAGE_NOT_MODIFIED_RE =
+  /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
+
+function isTelegramHtmlParseError(err: unknown): boolean {
+  return PARSE_ERR_RE.test(formatErrorMessage(err));
+}
+
+function isMessageNotModifiedError(err: unknown): boolean {
+  return MESSAGE_NOT_MODIFIED_RE.test(formatErrorMessage(err));
+}
+
 const TELEGRAM_STREAM_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 1000;
 const TELEGRAM_DRAFT_ID_MAX = 2_147_483_647;
@@ -176,10 +188,14 @@ export function createTelegramDraftStream(params: {
   let lastSentParseMode: "HTML" | undefined;
   let previewRevision = 0;
   let generation = 0;
+  /** Generation for which HTML parse_mode has been disabled due to parse errors. */
+  let parseModeDisabledForGeneration: number | undefined;
   type PreviewSendParams = {
     renderedText: string;
     renderedParseMode: "HTML" | undefined;
     sendGeneration: number;
+    /** Original unrendered text for plain-text fallback on HTML parse errors. */
+    plainText: string;
   };
   const sendRenderedMessageWithThreadFallback = async (sendArgs: {
     renderedText: string;
@@ -219,14 +235,36 @@ export function createTelegramDraftStream(params: {
     renderedText,
     renderedParseMode,
     sendGeneration,
+    plainText,
   }: PreviewSendParams): Promise<boolean> => {
+    // Resolve effective parse mode: disabled for this generation after a prior parse error.
+    const effectiveParseMode =
+      parseModeDisabledForGeneration === sendGeneration ? undefined : renderedParseMode;
+    const effectiveText = effectiveParseMode ? renderedText : plainText;
+
     if (typeof streamMessageId === "number") {
-      if (renderedParseMode) {
-        await params.api.editMessageText(chatId, streamMessageId, renderedText, {
-          parse_mode: renderedParseMode,
-        });
-      } else {
-        await params.api.editMessageText(chatId, streamMessageId, renderedText);
+      try {
+        if (effectiveParseMode) {
+          await params.api.editMessageText(chatId, streamMessageId, effectiveText, {
+            parse_mode: effectiveParseMode,
+          });
+        } else {
+          await params.api.editMessageText(chatId, streamMessageId, effectiveText);
+        }
+      } catch (err) {
+        if (isMessageNotModifiedError(err)) {
+          // Harmless noop — content identical to current message.
+          return true;
+        }
+        if (effectiveParseMode && isTelegramHtmlParseError(err)) {
+          // HTML rejected by Telegram — retry as plain text and disable
+          // parse_mode for the rest of this generation.
+          parseModeDisabledForGeneration = sendGeneration;
+          params.warn?.("telegram stream preview edit: HTML parse error, retrying as plain text");
+          await params.api.editMessageText(chatId, streamMessageId, plainText);
+          return true;
+        }
+        throw err;
       }
       return true;
     }
@@ -234,19 +272,31 @@ export function createTelegramDraftStream(params: {
     let sent: Awaited<ReturnType<typeof sendRenderedMessageWithThreadFallback>>["sent"];
     try {
       ({ sent } = await sendRenderedMessageWithThreadFallback({
-        renderedText,
-        renderedParseMode,
+        renderedText: effectiveText,
+        renderedParseMode: effectiveParseMode,
         fallbackWarnMessage:
           "telegram stream preview send failed with message_thread_id, retrying without thread",
       }));
     } catch (err) {
-      // Pre-connect failures (DNS, refused) and explicit Telegram rejections (4xx)
-      // guarantee the message was never delivered — clear the flag so
-      // sendMayHaveLanded() doesn't suppress fallback.
-      if (isSafeToRetrySendError(err) || isTelegramClientRejection(err)) {
-        messageSendAttempted = false;
+      if (effectiveParseMode && isTelegramHtmlParseError(err)) {
+        // HTML rejected on first send — retry as plain text.
+        parseModeDisabledForGeneration = sendGeneration;
+        params.warn?.("telegram stream preview send: HTML parse error, retrying as plain text");
+        ({ sent } = await sendRenderedMessageWithThreadFallback({
+          renderedText: plainText,
+          renderedParseMode: undefined,
+          fallbackWarnMessage:
+            "telegram stream preview send (plain) failed with message_thread_id, retrying without thread",
+        }));
+      } else {
+        // Pre-connect failures (DNS, refused) and explicit Telegram rejections (4xx)
+        // guarantee the message was never delivered — clear the flag so
+        // sendMayHaveLanded() doesn't suppress fallback.
+        if (isSafeToRetrySendError(err) || isTelegramClientRejection(err)) {
+          messageSendAttempted = false;
+        }
+        throw err;
       }
-      throw err;
     }
     const sentMessageId = sent?.message_id;
     if (typeof sentMessageId !== "number" || !Number.isFinite(sentMessageId)) {
@@ -269,21 +319,35 @@ export function createTelegramDraftStream(params: {
   const sendDraftTransportPreview = async ({
     renderedText,
     renderedParseMode,
+    sendGeneration,
+    plainText,
   }: PreviewSendParams): Promise<boolean> => {
+    const effectiveParseMode =
+      parseModeDisabledForGeneration === sendGeneration ? undefined : renderedParseMode;
+    const effectiveText = effectiveParseMode ? renderedText : plainText;
     const draftId = streamDraftId ?? allocateTelegramDraftId();
     streamDraftId = draftId;
-    const draftParams = {
-      ...(threadParams?.message_thread_id != null
-        ? { message_thread_id: threadParams.message_thread_id }
-        : {}),
-      ...(renderedParseMode ? { parse_mode: renderedParseMode } : {}),
+    const buildDraftParams = (parseMode: "HTML" | undefined) => {
+      const p: { message_thread_id?: number; parse_mode?: "HTML" } = {};
+      if (threadParams?.message_thread_id != null) {
+        p.message_thread_id = threadParams.message_thread_id;
+      }
+      if (parseMode) {
+        p.parse_mode = parseMode;
+      }
+      return Object.keys(p).length > 0 ? p : undefined;
     };
-    await resolvedDraftApi!(
-      chatId,
-      draftId,
-      renderedText,
-      Object.keys(draftParams).length > 0 ? draftParams : undefined,
-    );
+    try {
+      await resolvedDraftApi!(chatId, draftId, effectiveText, buildDraftParams(effectiveParseMode));
+    } catch (err) {
+      if (effectiveParseMode && isTelegramHtmlParseError(err)) {
+        parseModeDisabledForGeneration = sendGeneration;
+        params.warn?.("telegram stream draft preview: HTML parse error, retrying as plain text");
+        await resolvedDraftApi!(chatId, draftId, plainText, buildDraftParams(undefined));
+      } else {
+        throw err;
+      }
+    }
     return true;
   };
 
@@ -323,8 +387,6 @@ export function createTelegramDraftStream(params: {
       }
     }
 
-    lastSentText = renderedText;
-    lastSentParseMode = renderedParseMode;
     try {
       let sent = false;
       if (previewTransport === "draft") {
@@ -333,6 +395,7 @@ export function createTelegramDraftStream(params: {
             renderedText,
             renderedParseMode,
             sendGeneration,
+            plainText: trimmed,
           });
         } catch (err) {
           if (!shouldFallbackFromDraftTransport(err)) {
@@ -347,6 +410,7 @@ export function createTelegramDraftStream(params: {
             renderedText,
             renderedParseMode,
             sendGeneration,
+            plainText: trimmed,
           });
         }
       } else {
@@ -354,20 +418,36 @@ export function createTelegramDraftStream(params: {
           renderedText,
           renderedParseMode,
           sendGeneration,
+          plainText: trimmed,
         });
       }
       if (sent) {
         previewRevision += 1;
         lastDeliveredText = trimmed;
+        // Reflect the actual text and parse mode that was delivered. When the
+        // transport fell back to plain text, these may differ from the original
+        // renderedText/renderedParseMode.
+        lastSentText = parseModeDisabledForGeneration === sendGeneration ? trimmed : renderedText;
+        lastSentParseMode =
+          parseModeDisabledForGeneration === sendGeneration ? undefined : renderedParseMode;
       }
       return sent;
     } catch (err) {
+      // HTML parse errors should not permanently kill the stream — the next
+      // update will arrive with more text that may produce valid HTML, and
+      // the transport functions already disable parse_mode for this generation.
+      if (isTelegramHtmlParseError(err)) {
+        parseModeDisabledForGeneration = generation;
+        params.warn?.(
+          `telegram stream preview: HTML parse error escaped to outer handler (degrading to plain text)`,
+        );
+        return false;
+      }
       streamState.stopped = true;
       params.warn?.(`telegram stream preview failed: ${formatErrorMessage(err)}`);
       return false;
     }
   };
-
   const { loop, update, stop, clear } = createFinalizableDraftLifecycle({
     throttleMs,
     state: streamState,
@@ -416,13 +496,21 @@ export function createTelegramDraftStream(params: {
     if (previewTransport === "message" && typeof streamMessageId === "number") {
       return streamMessageId;
     }
-    // For draft transport, use the rendered snapshot first so parse_mode stays
-    // aligned with the text being materialized.
-    const renderedText = lastSentText || lastDeliveredText;
+    // For draft transport, prefer the unrendered text when HTML parse mode has
+    // been disabled for the current generation — avoids re-sending the same
+    // malformed HTML that caused the parse error during streaming.
+    const htmlDisabled = parseModeDisabledForGeneration === generation;
+    const renderedText = htmlDisabled
+      ? lastDeliveredText || lastSentText
+      : lastSentText || lastDeliveredText;
     if (!renderedText) {
       return undefined;
     }
-    const renderedParseMode = lastSentText ? lastSentParseMode : undefined;
+    const renderedParseMode = htmlDisabled
+      ? undefined
+      : lastSentText
+        ? lastSentParseMode
+        : undefined;
     try {
       const { sent, usedThreadParams } = await sendRenderedMessageWithThreadFallback({
         renderedText,


### PR DESCRIPTION
## Summary

During Telegram streaming (`streaming: "partial"`), `editMessageText` with `parse_mode: "HTML"` can fail when partial markdown (e.g., unclosed `**bold`) produces malformed HTML. Previously, **any** preview error permanently stopped the stream (`streamState.stopped = true`), leaving users with truncated messages while the full response was visible in the web UI.

This PR adds HTML parse error fallback to the streaming preview pipeline in `draft-stream.ts`, aligning it with the existing fallback behavior in `send.ts` and `bot/delivery.send.ts`.

Related: #47772 (same pipeline — may partially overlap with the Telegram delivery issues reported there)

## Changes

### Core fix: HTML parse error → plain text fallback

- **`sendMessageTransportPreview`**: When `editMessageText` or first `sendMessage` with `parse_mode: "HTML"` fails with a parse error, retry immediately as plain text (no `parse_mode`).
- **`sendDraftTransportPreview`**: Same fallback for the draft transport path (`sendMessageDraft`).
- **Outer `sendOrEditStreamMessage` catch**: HTML parse errors no longer set `streamState.stopped = true`. The stream continues; only truly fatal errors (network, missing message) stop it.

### Per-generation circuit breaker

- New `parseModeDisabledForGeneration` flag: once HTML parse fails for a generation, all subsequent updates in the same generation use plain text — prevents repeated failures.
- Resets automatically on `forceNewMessage()` (generation increment) without explicit cleanup.

### Additional fixes found during review

- **`MESSAGE_NOT_MODIFIED` handling**: Treated as successful noop on edit (consistent with `lane-delivery-text-deliverer.ts`), instead of killing the stream.
- **`materialize()` respects disabled parse mode**: When HTML is disabled for the current generation, materialize uses `lastDeliveredText` (plain text) instead of re-sending the malformed HTML.
- **`lastSentText`/`lastSentParseMode` state accuracy**: Updated after successful delivery (not before `try` block) to reflect the actual text/mode sent, preventing dedup collisions on retry.
- **`messageSendAttempted` reset on fallback retry failure**: When plain-text fallback retry fails with a pre-connect or 4xx error, correctly resets `messageSendAttempted = false` so `sendMayHaveLanded()` doesn't suppress final delivery.
- **Type safety in `buildDraftParams`**: Replaced `Record<string, unknown>` + cast with proper typed object.

## Testing

- 9 new test cases added covering all fallback paths:
  - Edit parse error → plain text retry
  - Edit parse error → plain text retry also fails (propagates)
  - First send parse error → plain text retry
  - Draft transport parse error → plain text retry
  - `MESSAGE_NOT_MODIFIED` on edit → success
  - Parse mode disabled persists per generation
  - `forceNewMessage()` resets parse mode
  - Outer catch handles escaped parse error (stream continues)
  - Non-parse error still stops stream
- All 40 tests pass (31 existing + 9 new)
- Full Telegram extension test suite: 795 tests pass, 0 regressions

## Root Cause Analysis

The streaming preview pipeline (`draft-stream.ts`) was the **only** Telegram message delivery path without HTML parse error fallback:

| Path | HTML fallback | Before this PR |
|------|:---:|:---:|
| `send.ts` (`editMessageTelegram`) | ✅ `withTelegramHtmlParseFallback` | — |
| `bot/delivery.send.ts` (`sendTelegramText`) | ✅ `PARSE_ERR_RE` + plain retry | — |
| `lane-delivery-text-deliverer.ts` (final delivery) | ✅ `isTelegramClientRejection` → fallback | — |
| `draft-stream.ts` (streaming preview) | ❌ → `streamState.stopped = true` | **Now ✅** |