### PR TITLE
[AI-assisted] Telegram: clear status reactions after terminal states

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import type { Bot } from "grammy";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { STATE_DIR } from "../../../src/config/paths.js";
 import {
   createSequencedTestDraftStream,
@@ -58,6 +58,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
     resolveStorePath.mockClear();
     resolveStorePath.mockReturnValue("/tmp/sessions.json");
     loadSessionStore.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   const createDraftStream = (messageId?: number) => createTestDraftStream({ messageId });
@@ -2241,6 +2245,94 @@ describe("dispatchTelegramMessage draft streaming", () => {
       ),
     );
     expect(finalTextSentViaDeliverReplies).toBe(true);
+  });
+
+  it("clears status reaction after the done hold window", async () => {
+    vi.useFakeTimers();
+
+    const reactionApi = vi.fn(async () => {});
+    const statusReactionController = {
+      setThinking: vi.fn(async () => {}),
+      setCompacting: vi.fn(async () => {}),
+      setTool: vi.fn(async () => {}),
+      setDone: vi.fn(async () => {}),
+      setError: vi.fn(async () => {}),
+      setQueued: vi.fn(async () => {}),
+      cancelPending: vi.fn(() => {}),
+      clear: vi.fn(async () => {}),
+      restoreInitial: vi.fn(async () => {}),
+    };
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({ queuedFinal: true });
+
+    await dispatchWithContext({
+      context: createContext({
+        reactionApi: reactionApi as never,
+        statusReactionController: statusReactionController as never,
+      }),
+      streamMode: "off",
+      cfg: {
+        messages: {
+          statusReactions: {
+            timing: {
+              doneHoldMs: 25,
+            },
+          },
+        },
+      },
+    });
+
+    await vi.runAllTicks();
+    expect(statusReactionController.setDone).toHaveBeenCalledTimes(1);
+    expect(reactionApi).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(reactionApi).toHaveBeenCalledWith(123, 456, []);
+  });
+
+  it("clears status reaction after the error hold window", async () => {
+    vi.useFakeTimers();
+
+    const reactionApi = vi.fn(async () => {});
+    const statusReactionController = {
+      setThinking: vi.fn(async () => {}),
+      setCompacting: vi.fn(async () => {}),
+      setTool: vi.fn(async () => {}),
+      setDone: vi.fn(async () => {}),
+      setError: vi.fn(async () => {}),
+      setQueued: vi.fn(async () => {}),
+      cancelPending: vi.fn(() => {}),
+      clear: vi.fn(async () => {}),
+      restoreInitial: vi.fn(async () => {}),
+    };
+    dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(new Error("boom"));
+    deliverReplies.mockResolvedValue({ delivered: false });
+
+    await dispatchWithContext({
+      context: createContext({
+        reactionApi: reactionApi as never,
+        statusReactionController: statusReactionController as never,
+      }),
+      streamMode: "off",
+      cfg: {
+        messages: {
+          statusReactions: {
+            timing: {
+              errorHoldMs: 30,
+            },
+          },
+        },
+      },
+    });
+
+    await vi.runAllTicks();
+    expect(statusReactionController.setError).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.setDone).not.toHaveBeenCalled();
+    expect(reactionApi).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(30);
+
+    expect(reactionApi).toHaveBeenCalledWith(123, 456, []);
   });
 
   it("shows compacting reaction during auto-compaction and resumes thinking", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -13,6 +13,7 @@ import type { ReplyPayload } from "../../../src/auto-reply/types.js";
 import { removeAckReactionAfterReply } from "../../../src/channels/ack-reactions.js";
 import { logAckFailure, logTypingFailure } from "../../../src/channels/logging.js";
 import { createReplyPrefixOptions } from "../../../src/channels/reply-prefix.js";
+import { DEFAULT_TIMING } from "../../../src/channels/status-reactions.js";
 import { createTypingCallbacks } from "../../../src/channels/typing.js";
 import { resolveMarkdownTableMode } from "../../../src/config/markdown-tables.js";
 import {
@@ -136,6 +137,30 @@ function resolveTelegramReasoningLevel(params: {
     // Fall through to default.
   }
   return "off";
+}
+
+function finalizeTelegramStatusReaction(params: {
+  controller: NonNullable<TelegramMessageContext["statusReactionController"]>;
+  reactionApi: NonNullable<TelegramMessageContext["reactionApi"]>;
+  chatId: number;
+  messageId: number;
+  state: "done" | "error";
+  holdMs: number;
+}): void {
+  const { controller, reactionApi, chatId, messageId, state, holdMs } = params;
+  const setTerminal =
+    state === "done" ? controller.setDone.bind(controller) : controller.setError.bind(controller);
+
+  void (async () => {
+    await setTerminal();
+    if (holdMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, holdMs));
+    }
+    await reactionApi(chatId, messageId, []);
+  })().catch((err) => {
+    const phase = state === "done" ? "finalize" : "error finalize";
+    logVerbose(`telegram: status reaction ${phase} failed: ${String(err)}`);
+  });
 }
 
 export const dispatchTelegramMessage = async ({
@@ -824,11 +849,28 @@ export const dispatchTelegramMessage = async ({
   }
 
   const hasFinalResponse = queuedFinal || sentFallback;
+  const statusReactionTiming = cfg.messages?.statusReactions?.timing;
 
-  if (statusReactionController && !hasFinalResponse) {
-    void statusReactionController.setError().catch((err) => {
-      logVerbose(`telegram: status reaction error finalize failed: ${String(err)}`);
-    });
+  if (statusReactionController && reactionApi && typeof msg.message_id === "number") {
+    if (!hasFinalResponse) {
+      finalizeTelegramStatusReaction({
+        controller: statusReactionController,
+        reactionApi,
+        chatId,
+        messageId: msg.message_id,
+        state: "error",
+        holdMs: statusReactionTiming?.errorHoldMs ?? DEFAULT_TIMING.errorHoldMs,
+      });
+    } else {
+      finalizeTelegramStatusReaction({
+        controller: statusReactionController,
+        reactionApi,
+        chatId,
+        messageId: msg.message_id,
+        state: "done",
+        holdMs: statusReactionTiming?.doneHoldMs ?? DEFAULT_TIMING.doneHoldMs,
+      });
+    }
   }
 
   if (!hasFinalResponse) {
@@ -836,11 +878,7 @@ export const dispatchTelegramMessage = async ({
     return;
   }
 
-  if (statusReactionController) {
-    void statusReactionController.setDone().catch((err) => {
-      logVerbose(`telegram: status reaction finalize failed: ${String(err)}`);
-    });
-  } else {
+  if (!statusReactionController) {
     removeAckReactionAfterReply({
       removeAfterReply: removeAckAfterReply,
       ackReactionPromise,


### PR DESCRIPTION
## Summary

This PR finishes the Telegram status-reaction lifecycle by clearing the reaction after the terminal state hold window expires.

Telegram already sets `queued`, `thinking`, `tool`, `done`, and `error` reactions, but the current dispatch path stops at `setDone()` / `setError()`. That leaves the final reaction stuck on the source message instead of cleaning it up after the configured hold period.

## What changed

### `extensions/telegram/src/bot-message-dispatch.ts`
- Added Telegram-specific terminal reaction finalization helper.
- After `done` / `error`, wait for the configured hold window:
  - `messages.statusReactions.timing.doneHoldMs`
  - `messages.statusReactions.timing.errorHoldMs`
- Clear the Telegram message reaction via `setMessageReaction(..., [])` once the hold window expires.
- Keep the existing ack-reaction cleanup path unchanged when status reactions are disabled.

### `extensions/telegram/src/bot-message-dispatch.test.ts`
- Added coverage for:
  - `done -> clear` after hold window
  - `error -> clear` after hold window
- Added timer cleanup between tests.

## Why

Without this, Telegram status reactions show progress, but the terminal reaction lingers after the bot has already replied.

This makes Telegram behavior match the intended lifecycle more closely:
- show progress while work is happening
- briefly show terminal state
- remove reaction after completion

## Testing

Ran targeted tests:

```bash
pnpm vitest run extensions/telegram/src/bot-message-dispatch.test.ts
```

Result:
- `1 passed`
- `72 passed`

## AI Assistance Disclosure

- AI-assisted: yes
- Degree of testing: lightly tested (targeted unit tests + local runtime validation)
- I reviewed and understood the changed code before submission.
