### PR TITLE
Infra: fix stale skills snapshot after gateway restart

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -71,3 +71,14 @@ describe("ensureSkillsWatcher", () => {
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/my-skill/SKILL.md"))).toBe(false);
   });
 });
+
+describe("getSkillsSnapshotVersion", () => {
+  it("initial globalVersion is > 0 so stale session snapshots are always detected", async () => {
+    // After a gateway restart the refresh guard checks `snapshotVersion > 0`.
+    // If globalVersion starts at 0 this is always false and stale snapshots
+    // from sessions.json are never rebuilt.
+    const mod = await import("./refresh.js");
+    const version = mod.getSkillsSnapshotVersion();
+    expect(version).toBeGreaterThan(0);
+  });
+});

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -24,7 +24,7 @@ const log = createSubsystemLogger("gateway/skills");
 const listeners = new Set<(event: SkillsChangeEvent) => void>();
 const workspaceVersions = new Map<string, number>();
 const watchers = new Map<string, SkillsWatchState>();
-let globalVersion = 0;
+let globalVersion = Date.now();
 
 export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.git([\\/]|$)/,


### PR DESCRIPTION
## Summary

- Problem: Skills installed while the gateway is stopped are invisible to agents after restart. Existing sessions keep their stale skills snapshot indefinitely.
- Why it matters: Users must manually delete session entries from `sessions.json` to pick up new skills — a confusing workaround that shouldn't be needed.
- What changed: `globalVersion` in `src/agents/skills/refresh.ts` initialized to `Date.now()` instead of `0`, plus a regression test.
- What did NOT change (scope boundary): No changes to session storage format, watcher logic, or version comparison semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: none found

## User-visible / Behavior Changes

After a gateway restart, agents in existing sessions now correctly see newly installed skills without requiring manual deletion of session entries from `sessions.json`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (reproducible on any platform)
- Runtime/container: Node 22+, dev source mode
- Model/provider: any
- Integration/channel: any

### Steps

1. Start gateway, send a message to an agent (creates session with `skillsSnapshot.version: 0`)
2. Stop gateway
3. Install a new skill (add `SKILL.md` to workspace skills dir)
4. Restart gateway
5. Send another message in the same session

### Expected

- Agent sees and can use the newly installed skill

### Actual

- Agent uses stale snapshot, new skill is invisible. The refresh guard `snapshotVersion > 0` evaluates to `false` because `globalVersion` starts at `0`.

## Evidence

- [x] Failing test/log before + passing after

The new regression test (`getSkillsSnapshotVersion > initial globalVersion is > 0`) fails with the old `let globalVersion = 0` and passes with `Date.now()`.

Root cause trace:
- `session-updates.ts:185`: `snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion`
- `getSkillsSnapshotVersion()` returns `globalVersion` (= `0` before fix)
- `0 > 0` → `false` → `shouldRefreshSnapshot = false` → stale snapshot reused

## Human Verification (required)

- Verified scenarios: Traced the full code path from `session-updates.ts:182-228` confirming that existing sessions (`isFirstTurnInSession = false`) rely entirely on `shouldRefreshSnapshot` to rebuild skill snapshots.
- Edge cases checked: `bumpVersion()` already produces `Date.now()`-scale numbers, so `Date.now()` initialization is consistent with the version space. `workspaceVersions` map entries default to `0` via `?? 0` but are always combined with `Math.max(globalVersion, local)`, so the fix covers workspace-scoped versions too.
- What I did **not** verify: Live end-to-end test with a running gateway (code analysis only).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single line back to `let globalVersion = 0`
- Files/config to restore: `src/agents/skills/refresh.ts`
- Known bad symptoms reviewers should watch for: Excessive skill snapshot rebuilds on every turn (unlikely — the version is persisted to the session, so after one rebuild the versions match again)

## Risks and Mitigations

- Risk: First agent turn after every gateway restart will always rebuild the skills snapshot (even if skills haven't changed).
  - Mitigation: This is a cold-path operation that's already expected on new sessions. The rebuild is lightweight (directory scan + prompt assembly). Subsequent turns in the same session skip it because the persisted version matches.