### PR TITLE
UI: render markdown in cron job prompts and run summaries

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1708,12 +1708,6 @@
   max-width: 100%;
 }
 
-.cron-run-entry__summary table {
-  display: table;
-  width: 100%;
-  max-width: 100%;
-}
-
 .cron-job-detail-value pre {
   width: 100%;
   max-width: 100%;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1067,21 +1067,130 @@
   accent-color: var(--accent);
 }
 
-.cron-run-entry {
-  align-items: start;
+.list-item.cron-run-entry {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.cron-run-entry__header {
+  display: flex;
+  flex-direction: column;
+  align-items: baseline;
+  gap: 8px;
+  padding: 12px;
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--secondary);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  border-bottom: 1px solid var(--border);
+}
+
+@media (min-width: 1101px) {
+  .cron-run-entry__header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(200px, 260px);
+    gap: 16px;
+    align-items: start;
+  }
+}
+
+:root[data-theme="light"] .cron-run-entry__header {
+  background: var(--bg-muted);
 }
 
 .cron-run-entry__meta {
   text-align: right;
-  min-width: 220px;
+  min-width: 0;
 }
 
-.cron-run-entry__summary {
-  white-space: pre-wrap;
+.cron-run-entry__body {
+  padding: 12px;
   line-height: 1.45;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.cron-run-entry__body table,
+.cron-job-detail-value table {
+  display: table;
+  width: 100%;
+  max-width: 100%;
+  table-layout: auto;
+}
+
+.cron-run-entry__body pre,
+.cron-run-entry__body blockquote,
+.cron-job-detail-value pre,
+.cron-job-detail-value blockquote {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.cron-run-entry__body pre,
+.cron-run-entry__body blockquote,
+.cron-run-entry__body table {
+  margin-bottom: 0.75em;
+}
+
+.cron-run-entry__body p + p,
+.cron-run-entry__body p + pre,
+.cron-run-entry__body p + blockquote,
+.cron-run-entry__body p + table,
+.cron-run-entry__body pre + p,
+.cron-run-entry__body blockquote + p,
+.cron-run-entry__body table + p {
+  margin-top: 0.75em;
+}
+
+.cron-run-entry__body > :last-child {
+  margin-bottom: 0;
 }
 
 @media (max-width: 1100px) {
+  .cron-job.list-item {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    overflow: hidden;
+    max-width: 100%;
+  }
+
+  .cron-job .cron-job-header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+    width: 100%;
+  }
+
+  .cron-job .list-meta {
+    min-width: 0;
+  }
+
+  .cron-job .cron-job-header .cron-job-state {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 16px;
+  }
+
+  .cron-job .cron-job-detail {
+    padding: 8px 10px 10px;
+    width: 100%;
+    box-sizing: border-box;
+    overflow-x: hidden;
+  }
+
+  .cron-job .cron-job-footer {
+    padding: 8px 10px 10px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
   .cron-summary-strip {
     flex-direction: column;
   }
@@ -1144,6 +1253,85 @@
   .cron-run-entry__meta {
     min-width: 0;
     text-align: left;
+  }
+
+  .list-item.cron-run-entry {
+    padding: 0;
+  }
+
+  .cron-run-entry__header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px;
+  }
+
+  .cron-run-entry__body {
+    padding: 10px;
+  }
+
+  .cron-run-entry__body table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .cron-run-entry__body pre {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+@media (max-width: 600px) {
+  .cron-job .cron-job-header {
+    padding: 10px;
+    gap: 6px;
+  }
+
+  .cron-job .cron-job-header .cron-job-state {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 12px;
+  }
+
+  .cron-job .cron-job-detail {
+    padding: 10px;
+  }
+
+  .cron-job .cron-job-detail-value {
+    font-size: 13px;
+    overflow-x: auto;
+  }
+
+  .cron-job .cron-job-detail-value table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .cron-job .cron-job-detail-value pre {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .cron-job .cron-job-footer {
+    padding: 8px 10px 10px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    flex-wrap: nowrap;
+    gap: 8px;
+  }
+
+  .cron-job .cron-job-footer .chip-row {
+    flex-wrap: nowrap;
+    flex-shrink: 0;
+  }
+
+  .cron-job .cron-job-footer .cron-job-actions {
+    flex-wrap: nowrap;
+    flex-shrink: 0;
+    gap: 6px;
   }
 }
 
@@ -1310,6 +1498,10 @@
   font: inherit;
 }
 
+:root[data-theme="light"] .cron-job .cron-job-header {
+  background: var(--bg-muted);
+}
+
 /* ===========================================
    Lists
    =========================================== */
@@ -1411,13 +1603,56 @@
 .cron-job {
   grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);
   grid-template-areas:
-    "main meta"
+    "header header"
+    "payload payload"
     "footer footer";
-  row-gap: 10px;
+  row-gap: 0;
+  padding: 0;
+}
+
+.cron-job .cron-job-header {
+  grid-area: header;
+  display: flex;
+  flex-direction: column;
+  align-items: baseline;
+  gap: 8px;
+  padding: 12px;
+  background: var(--secondary);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  border-bottom: 1px solid var(--border);
+}
+
+@media (min-width: 1101px) {
+  .cron-job .cron-job-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);
+    gap: 16px;
+    align-items: start;
+  }
+}
+
+.cron-job .cron-job-detail {
+  grid-area: payload;
+  padding: 8px 12px 12px;
+}
+
+.cron-job .cron-job-detail-label {
+  padding: 4px 8px;
+  background: var(--secondary);
+  border-radius: var(--radius-sm);
+  display: inline-block;
+  margin-bottom: 4px;
+}
+
+.cron-job .cron-job-footer {
+  padding: 4px 12px 12px;
+  border-top: none;
 }
 
 .cron-job .list-main {
-  grid-area: main;
+  display: grid;
+  gap: 4px;
+  min-width: 0;
 }
 
 .cron-job .list-meta {
@@ -1442,8 +1677,15 @@
 
 .cron-job-detail {
   display: grid;
-  gap: 3px;
+  gap: 8px;
   margin-top: 2px;
+  overflow: hidden;
+}
+
+.cron-job-detail-section {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
 }
 
 .cron-job-detail-label {
@@ -1457,6 +1699,51 @@
 .cron-job-detail-value {
   font-size: 13px;
   line-height: 1.35;
+  min-width: 0;
+}
+
+.cron-job-detail-value table {
+  display: table;
+  width: 100%;
+  max-width: 100%;
+}
+
+.cron-run-entry__summary table {
+  display: table;
+  width: 100%;
+  max-width: 100%;
+}
+
+.cron-job-detail-value pre {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.cron-job-detail-value blockquote {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.cron-job-detail-value p + p,
+.cron-job-detail-value p + pre,
+.cron-job-detail-value p + blockquote,
+.cron-job-detail-value p + table,
+.cron-job-detail-value pre + p,
+.cron-job-detail-value blockquote + p,
+.cron-job-detail-value table + p {
+  margin-top: 0.75em;
+}
+
+.cron-job-detail-value pre,
+.cron-job-detail-value blockquote,
+.cron-job-detail-value table {
+  margin-bottom: 0.75em;
+}
+
+.cron-job-detail-value > :last-child {
+  margin-bottom: 0;
 }
 
 .cron-job-state {
@@ -3773,4 +4060,49 @@
     grid-template-columns: 1fr;
     gap: 4px;
   }
+}
+
+/* Cron markdown overrides — must come after .chat-text rules to win cascade */
+.cron-run-entry__body.chat-text table,
+.cron-job-detail-value.chat-text table {
+  display: table;
+  width: 100%;
+}
+
+.cron-run-entry__body.chat-text pre,
+.cron-run-entry__body.chat-text blockquote,
+.cron-job-detail-value.chat-text pre,
+.cron-job-detail-value.chat-text blockquote {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.cron-run-entry__body.chat-text pre + p,
+.cron-run-entry__body.chat-text blockquote + p,
+.cron-run-entry__body.chat-text table + p,
+.cron-run-entry__body.chat-text p + pre,
+.cron-run-entry__body.chat-text p + blockquote,
+.cron-run-entry__body.chat-text p + table,
+.cron-job-detail-value.chat-text pre + p,
+.cron-job-detail-value.chat-text blockquote + p,
+.cron-job-detail-value.chat-text table + p,
+.cron-job-detail-value.chat-text p + pre,
+.cron-job-detail-value.chat-text p + blockquote,
+.cron-job-detail-value.chat-text p + table {
+  margin-top: 0.75em;
+}
+
+.cron-run-entry__body.chat-text pre,
+.cron-run-entry__body.chat-text blockquote,
+.cron-run-entry__body.chat-text table,
+.cron-job-detail-value.chat-text pre,
+.cron-job-detail-value.chat-text blockquote,
+.cron-job-detail-value.chat-text table {
+  margin-bottom: 0.75em;
+}
+
+.cron-run-entry__body.chat-text > :last-child,
+.cron-job-detail-value.chat-text > :last-child {
+  margin-bottom: 0;
 }

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../../i18n/index.ts";
 import type {
   CronFieldErrors,
@@ -8,6 +9,7 @@ import type {
   CronJobsScheduleKindFilter,
 } from "../controllers/cron.ts";
 import { formatRelativeTimestamp, formatMs } from "../format.ts";
+import { toSanitizedMarkdownHtml } from "../markdown.ts";
 import { pathForTab } from "../navigation.ts";
 import { formatCronSchedule, formatNextRun } from "../presenter.ts";
 import type { ChannelUiMetaEntry, CronJob, CronRunLogEntry, CronStatus } from "../types.ts";
@@ -1498,15 +1500,17 @@ function renderJob(job: CronJob, props: CronProps) {
   };
   return html`
     <div class=${itemClass} @click=${() => props.onLoadRuns(job.id)}>
-      <div class="list-main">
-        <div class="list-title">${job.name}</div>
-        <div class="list-sub">${formatCronSchedule(job)}</div>
-        ${renderJobPayload(job)}
-        ${job.agentId ? html`<div class="muted cron-job-agent">${t("cron.jobDetail.agent")}: ${job.agentId}</div>` : nothing}
+      <div class="cron-job-header">
+        <div class="list-main">
+          <div class="list-title">${job.name}</div>
+          <div class="list-sub">${formatCronSchedule(job)}</div>
+          ${job.agentId ? html`<div class="muted cron-job-agent">${t("cron.jobDetail.agent")}: ${job.agentId}</div>` : nothing}
+        </div>
+        <div class="list-meta">
+          ${renderJobState(job)}
+        </div>
       </div>
-      <div class="list-meta">
-        ${renderJobState(job)}
-      </div>
+      ${renderJobPayload(job)}
       <div class="cron-job-footer">
         <div class="chip-row cron-job-chips">
           <span class=${`chip ${job.enabled ? "chip-ok" : "chip-danger"}`}>
@@ -1612,17 +1616,19 @@ function renderJobPayload(job: CronJob) {
 
   return html`
     <div class="cron-job-detail">
-      <span class="cron-job-detail-label">${t("cron.jobDetail.prompt")}</span>
-      <span class="muted cron-job-detail-value">${job.payload.message}</span>
+      <div class="cron-job-detail-section">
+        <span class="cron-job-detail-label">${t("cron.jobDetail.prompt")}</span>
+        <div class="muted cron-job-detail-value chat-text">${unsafeHTML(toSanitizedMarkdownHtml(job.payload.message))}</div>
+      </div>
+      ${
+        delivery
+          ? html`<div class="cron-job-detail-section">
+              <span class="cron-job-detail-label">${t("cron.jobDetail.delivery")}</span>
+              <span class="muted cron-job-detail-value">${delivery.mode}${deliveryTarget}</span>
+            </div>`
+          : nothing
+      }
     </div>
-    ${
-      delivery
-        ? html`<div class="cron-job-detail">
-            <span class="cron-job-detail-label">${t("cron.jobDetail.delivery")}</span>
-            <span class="muted cron-job-detail-value">${delivery.mode}${deliveryTarget}</span>
-          </div>`
-        : nothing
-    }
   `;
 }
 
@@ -1725,36 +1731,38 @@ function renderRun(entry: CronRunLogEntry, basePath: string) {
         : null;
   return html`
     <div class="list-item cron-run-entry">
-      <div class="list-main cron-run-entry__main">
-        <div class="list-title cron-run-entry__title">
-          ${entry.jobName ?? entry.jobId}
-          <span class="muted"> · ${status}</span>
+      <div class="cron-run-entry__header">
+        <div class="list-main cron-run-entry__main">
+          <div class="list-title cron-run-entry__title">
+            ${entry.jobName ?? entry.jobId}
+            <span class="muted"> · ${status}</span>
+          </div>
+          <div class="chip-row" style="margin-top: 4px;">
+            <span class="chip">${delivery}</span>
+            ${entry.model ? html`<span class="chip">${entry.model}</span>` : nothing}
+            ${entry.provider ? html`<span class="chip">${entry.provider}</span>` : nothing}
+            ${usageSummary ? html`<span class="chip">${usageSummary}</span>` : nothing}
+          </div>
         </div>
-        <div class="list-sub cron-run-entry__summary">${entry.summary ?? entry.error ?? t("cron.runEntry.noSummary")}</div>
-        <div class="chip-row" style="margin-top: 6px;">
-          <span class="chip">${delivery}</span>
-          ${entry.model ? html`<span class="chip">${entry.model}</span>` : nothing}
-          ${entry.provider ? html`<span class="chip">${entry.provider}</span>` : nothing}
-          ${usageSummary ? html`<span class="chip">${usageSummary}</span>` : nothing}
+        <div class="list-meta cron-run-entry__meta">
+          <div>${formatMs(entry.ts)}</div>
+          ${typeof entry.runAtMs === "number" ? html`<div class="muted">${t("cron.runEntry.runAt")} ${formatMs(entry.runAtMs)}</div>` : nothing}
+          <div class="muted">${entry.durationMs ?? 0}ms</div>
+          ${
+            typeof entry.nextRunAtMs === "number"
+              ? html`<div class="muted">${formatRunNextLabel(entry.nextRunAtMs)}</div>`
+              : nothing
+          }
+          ${
+            chatUrl
+              ? html`<div><a class="session-link" href=${chatUrl}>${t("cron.runEntry.openRunChat")}</a></div>`
+              : nothing
+          }
+          ${entry.error ? html`<div class="muted">${entry.error}</div>` : nothing}
+          ${entry.deliveryError ? html`<div class="muted">${entry.deliveryError}</div>` : nothing}
         </div>
       </div>
-      <div class="list-meta cron-run-entry__meta">
-        <div>${formatMs(entry.ts)}</div>
-        ${typeof entry.runAtMs === "number" ? html`<div class="muted">${t("cron.runEntry.runAt")} ${formatMs(entry.runAtMs)}</div>` : nothing}
-        <div class="muted">${entry.durationMs ?? 0}ms</div>
-        ${
-          typeof entry.nextRunAtMs === "number"
-            ? html`<div class="muted">${formatRunNextLabel(entry.nextRunAtMs)}</div>`
-            : nothing
-        }
-        ${
-          chatUrl
-            ? html`<div><a class="session-link" href=${chatUrl}>${t("cron.runEntry.openRunChat")}</a></div>`
-            : nothing
-        }
-        ${entry.error ? html`<div class="muted">${entry.error}</div>` : nothing}
-        ${entry.deliveryError ? html`<div class="muted">${entry.deliveryError}</div>` : nothing}
-      </div>
+      <div class="cron-run-entry__body chat-text">${unsafeHTML(toSanitizedMarkdownHtml(entry.summary ?? entry.error ?? t("cron.runEntry.noSummary")))}</div>
     </div>
   `;
 }

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -1618,7 +1618,7 @@ function renderJobPayload(job: CronJob) {
     <div class="cron-job-detail">
       <div class="cron-job-detail-section">
         <span class="cron-job-detail-label">${t("cron.jobDetail.prompt")}</span>
-        <div class="muted cron-job-detail-value chat-text">${unsafeHTML(toSanitizedMarkdownHtml(job.payload.message))}</div>
+        <div class="muted cron-job-detail-value chat-text" @click=${stopPropagationForInteractive}>${unsafeHTML(toSanitizedMarkdownHtml(job.payload.message))}</div>
       </div>
       ${
         delivery
@@ -1630,6 +1630,13 @@ function renderJobPayload(job: CronJob) {
       }
     </div>
   `;
+}
+
+function stopPropagationForInteractive(event: MouseEvent) {
+  const target = event.target as HTMLElement | null;
+  if (target?.closest("a,button,input,textarea,select,summary,[role='button'],[role='link']")) {
+    event.stopPropagation();
+  }
 }
 
 function formatStateRelative(ms?: number) {
@@ -1729,6 +1736,8 @@ function renderRun(entry: CronRunLogEntry, basePath: string) {
       : usage && typeof usage.input_tokens === "number" && typeof usage.output_tokens === "number"
         ? `${usage.input_tokens} in / ${usage.output_tokens} out`
         : null;
+  const bodySource = entry.summary ?? entry.error ?? t("cron.runEntry.noSummary");
+  const showErrorInMeta = !!entry.error && entry.summary != null;
   return html`
     <div class="list-item cron-run-entry">
       <div class="cron-run-entry__header">
@@ -1758,11 +1767,11 @@ function renderRun(entry: CronRunLogEntry, basePath: string) {
               ? html`<div><a class="session-link" href=${chatUrl}>${t("cron.runEntry.openRunChat")}</a></div>`
               : nothing
           }
-          ${entry.error ? html`<div class="muted">${entry.error}</div>` : nothing}
+          ${showErrorInMeta ? html`<div class="muted">${entry.error}</div>` : nothing}
           ${entry.deliveryError ? html`<div class="muted">${entry.deliveryError}</div>` : nothing}
         </div>
       </div>
-      <div class="cron-run-entry__body chat-text">${unsafeHTML(toSanitizedMarkdownHtml(entry.summary ?? entry.error ?? t("cron.runEntry.noSummary")))}</div>
+      <div class="cron-run-entry__body chat-text">${unsafeHTML(toSanitizedMarkdownHtml(bodySource))}</div>
     </div>
   `;
 }


### PR DESCRIPTION
The /cron dashboard page now renders markdown content using the existing marked + dompurify pipeline. Job prompts and run summaries display formatted headings, tables, code blocks, blockquotes, lists, and links instead of raw markdown text.

Restructures the job card and run entry layouts to separate the header (title, status, meta) from the markdown body, giving block-level content full card width. Adds responsive styles for tablet and mobile breakpoints.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Cron job prompts and run summaries render as raw markdown text in the /cron dashboard,
  making formatted content (tables, code blocks, lists, headings) unreadable.
- Why it matters: Users author markdown prompts for cron jobs and receive markdown summaries from
  agent runs — these should render the same way chat messages do.
- What changed: Job prompts and run summaries now pass through toSanitizedMarkdownHtml() +
  unsafeHTML() (the same pipeline used by the chat view). Job cards and run entries are restructured
  into header/body/footer sections so markdown block elements get full card width. Responsive styles
  added for tablet and mobile.
- What did NOT change (scope boundary): No changes to the markdown parser, sanitizer, or allowed
  tags/attributes. No changes to cron business logic, API, or data model. Chat view rendering is
  untouched.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

 - Cron job prompt text in the Jobs list now renders as formatted markdown (headings, tables, code
  blocks, lists, links, images, blockquotes, horizontal rules).
  - Cron run summaries in Run History now render as formatted markdown.
  - Job cards have a visually distinct header section (darker background, border) separating
  title/status from the prompt body.
  - Run history entries have the same header/body split.
  - On tablet/mobile, card layouts stack vertically; tables and action buttons are horizontally
  scrollable.

## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No
  - All markdown passes through the existing toSanitizedMarkdownHtml() which uses marked (GFM, with
  raw HTML escaped) + DOMPurify with a strict allowlist of tags and attributes. No new tags or
  attributes were added.

## Repro + Verification

### Environment

  - OS: macOS (Darwin 25.3.0)
  - Runtime/container: Node 25.1.0, pnpm
  - Model/provider: N/A (UI-only change)
  - Integration/channel: N/A
  - Relevant config: Default gateway config

### Steps

  1. Start gateway
  2. Add a cron job with markdown in the message
  3. Open dashboard, navigate to Cron tab
  4. View the job card prompt and any run history summaries

### Expected

  - Markdown renders as formatted HTML (headings, tables with borders, styled code blocks,
  blockquotes, lists)
  - Full-width block elements within the card body
  - Responsive layout on mobile (stacked header, scrollable tables/buttons)

### Actual

- Renders plain markdown text

## Evidence

<img width="1920" height="877" alt="Screenshot 2026-03-16 at 21 47 03" src="https://github.com/user-attachments/assets/a9357112-9c95-4927-9205-ff0bec4526d6" />
<img width="1914" height="877" alt="Screenshot 2026-03-16 at 21 47 21" src="https://github.com/user-attachments/assets/d81cae14-a92e-4cd2-a4c2-6be6a851daf0" />


## Human Verification (required)

What you personally verified (not just CI), and how:

  - Verified scenarios: Desktop rendering of job prompt with full markdown (headings, tables, code
  blocks, blockquotes, lists, links, images, HR). Run history summary with same. Mobile/tablet
  responsive layouts at multiple viewport widths.
  - Edge cases checked: Jobs with systemEvent payload (plain text, no markdown applied). Delivery
  section rendering alongside prompt. Empty/missing summaries in run entries.
  - What you did not verify: Light theme rendering. RTL text direction. Extremely long markdown
  content or pathological markdown patterns (covered by existing toSanitizedMarkdownHtml safeguards).
  Pre-existing test failures (2 sort-order tests fail on main).

## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: Revert commit; the two files (ui/src/ui/views/cron.ts,
  ui/src/styles/components.css) are self-contained.
  - Files/config to restore: ui/src/ui/views/cron.ts, ui/src/styles/components.css
  - Known bad symptoms reviewers should watch for: Markdown rendering as escaped HTML or raw text in
  cron cards. Layout overflow on mobile. Job cards or run entries with broken grid/flex alignment.

## Risks and Mitigations

  - Risk: CSS specificity conflicts with future changes to .chat-text or .list-item base styles.
  - Mitigation: Overrides use compound selectors (.cron-run-entry__body.chat-text table) and are
  placed at the end of components.css with a comment explaining cascade ordering. Mobile-first flex
  layout with min-width: 1101px media query for desktop grid avoids cascade order issues with
  responsive rules.
