### PR TITLE
fix(session): close tracked browser tabs on idle/daily session reset

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1559,6 +1559,111 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
   });
 });
 
+describe("initSessionState browser tab cleanup", () => {
+  let closeTabsSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const mod = await import("../../browser/session-tab-registry.js");
+    closeTabsSpy = vi.spyOn(mod, "closeTrackedBrowserTabsForSessions").mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    closeTabsSpy.mockRestore();
+  });
+
+  it("closes tracked browser tabs when idle session expires", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(2026, 0, 18, 5, 30, 0));
+      const storePath = await createStorePath("openclaw-tab-cleanup-idle-");
+      const sessionKey = "agent:main:whatsapp:dm:tab-idle";
+      const existingSessionId = "tab-idle-session-id";
+
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: new Date(2026, 0, 18, 4, 45, 0).getTime(),
+        },
+      });
+
+      const cfg = {
+        session: {
+          store: storePath,
+          reset: { mode: "daily", atHour: 4, idleMinutes: 30 },
+        },
+      } as OpenClawConfig;
+      const result = await initSessionState({
+        ctx: { Body: "hello", SessionKey: sessionKey },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(closeTabsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKeys: expect.arrayContaining([existingSessionId, sessionKey]),
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes tracked browser tabs on explicit /new reset", async () => {
+    const storePath = await createStorePath("openclaw-tab-cleanup-reset-");
+    const sessionKey = "agent:main:telegram:dm:tab-reset";
+    const existingSessionId = "tab-reset-session-id";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(closeTabsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKeys: expect.arrayContaining([existingSessionId, sessionKey]),
+      }),
+    );
+  });
+
+  it("does NOT close browser tabs for a fresh session (no previous entry)", async () => {
+    const storePath = await createStorePath("openclaw-tab-cleanup-fresh-");
+    const sessionKey = "agent:main:telegram:dm:tab-fresh";
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(closeTabsSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("drainFormattedSystemEvents", () => {
   it("adds a local timestamp to queued system events by default", async () => {
     vi.useFakeTimers();

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -7,6 +7,7 @@ import {
 } from "../../acp/conversation-id.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { clearBootstrapSnapshotOnSessionRollover } from "../../agents/bootstrap-cache.js";
+import { closeTrackedBrowserTabsForSessions } from "../../browser/session-tab-registry.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
@@ -551,6 +552,15 @@ export async function initSessionState(params: {
       agentId,
       reason: "reset",
     });
+
+    // Close browser tabs tracked against the previous session so they don't leak.
+    // The shared gateway reset path (session-reset-service.ts) handles tab cleanup
+    // for gateway API resets, but all other session rollovers (idle expiry, daily
+    // reset, chat /new and /reset) flow through initSessionState directly.
+    closeTrackedBrowserTabsForSessions({
+      sessionKeys: [previousSessionEntry.sessionId, sessionKey],
+      onWarn: (msg) => log.warn(msg),
+    }).catch((err) => log.warn(`browser tab cleanup failed: ${String(err)}`));
   }
 
   const sessionCtx: TemplateContext = {


### PR DESCRIPTION
## Summary

When sessions expire via idle timeout or daily reset boundary, `initSessionState` creates a new session ID and archives the old transcript but never closes browser tabs tracked against the old session. The shared gateway reset path (`session-reset-service.ts`) handles tab cleanup for gateway API resets, but all other session rollovers (idle expiry, daily reset, chat `/new` and `/reset`) flow through `initSessionState` directly — and were missing the cleanup call.

This adds a call to `closeTrackedBrowserTabsForSessions` after transcript archival in `initSessionState`, matching the existing pattern in the gateway reset path. The call is fire-and-forget with logging for observability.

### Changes
- `src/auto-reply/reply/session.ts` — import and call `closeTrackedBrowserTabsForSessions` when a previous session entry exists
- `src/auto-reply/reply/session.test.ts` — 3 regression tests: idle expiry cleanup, explicit `/new` cleanup, and no cleanup on fresh sessions

## Test plan

- [x] `pnpm build` — type-check passes
- [x] `pnpm check` — lint/format clean
- [x] `pnpm test -- src/auto-reply/reply/session.test.ts -t "browser tab cleanup"` — all 3 new tests pass
- [x] `pnpm test -- src/browser/session-tab-registry` — existing tests unaffected