### PR TITLE
docker: fix self-build breakage after extension migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@
 # Two runtime variants:
 #   Default (bookworm):      docker build .
 #   Slim (bookworm-slim):    docker build --build-arg OPENCLAW_VARIANT=slim .
-ARG OPENCLAW_EXTENSIONS=""
+# Default: build all bundled extensions. Pass a space-separated list to
+# build only a subset (e.g. "whatsapp device-pair").
+ARG OPENCLAW_EXTENSIONS="__all__"
 ARG OPENCLAW_VARIANT=default
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR=extensions
 ARG OPENCLAW_DOCKER_APT_UPGRADE=1
@@ -30,14 +32,26 @@ FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS ext-deps
 ARG OPENCLAW_EXTENSIONS
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR
 COPY ${OPENCLAW_BUNDLED_PLUGIN_DIR} /tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}
-# Copy package.json for opted-in extensions so pnpm resolves their deps.
+# Copy package.json for extensions so pnpm resolves their deps.
+# When OPENCLAW_EXTENSIONS is empty or "__all__", include every extension
+# that has a package.json. Otherwise, only include the listed names.
 RUN mkdir -p /out && \
-    for ext in $OPENCLAW_EXTENSIONS; do \
-      if [ -f "/tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}/$ext/package.json" ]; then \
-        mkdir -p "/out/$ext" && \
-        cp "/tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}/$ext/package.json" "/out/$ext/package.json"; \
-      fi; \
-    done
+    if [ -z "$OPENCLAW_EXTENSIONS" ] || [ "$OPENCLAW_EXTENSIONS" = "__all__" ]; then \
+      for dir in /tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}/*/; do \
+        ext="$(basename "$dir")" && \
+        if [ -f "/tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}/$ext/package.json" ]; then \
+          mkdir -p "/out/$ext" && \
+          cp "/tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}/$ext/package.json" "/out/$ext/package.json"; \
+        fi; \
+      done; \
+    else \
+      for ext in $OPENCLAW_EXTENSIONS; do \
+        if [ -f "/tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}/$ext/package.json" ]; then \
+          mkdir -p "/out/$ext" && \
+          cp "/tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}/$ext/package.json" "/out/$ext/package.json"; \
+        fi; \
+      done; \
+    fi
 
 # ── Stage 2: Build ──────────────────────────────────────────────
 FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS build
@@ -103,6 +117,9 @@ RUN pnpm ui:build
 FROM build AS runtime-assets
 RUN CI=true pnpm prune --prod && \
     find dist -type f \( -name '*.d.ts' -o -name '*.d.mts' -o -name '*.d.cts' -o -name '*.map' \) -delete
+# Restore self-referencing package link removed by pnpm prune --prod.
+# Required for openclaw/plugin-sdk/* subpath imports at runtime.
+RUN ln -s /app /app/node_modules/openclaw
 
 # ── Runtime base images ─────────────────────────────────────────
 FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS base-default


### PR DESCRIPTION
# docker: fix self-build breakage after extension migration

## Summary

Fix two Docker self-build issues that prevent the gateway from starting
after the channel-to-extension migration (`16505718e8`, `439c21e078`).
These affect anyone building from the stock `Dockerfile` on current `main`
and will affect the next tagged release (v2026.3.14+).

The official GHCR image for v2026.3.13 is **not** affected because channels
had not yet been moved to `extensions/` at that point.

## Problem

After the channel migration to `extensions/`, bundled extensions now contain
hundreds of relative `../../../src/` imports that the tsdown bundler resolves
at build time. Two issues in the Docker build pipeline prevent this from
working for self-builders:

1. **`OPENCLAW_EXTENSIONS` defaults to empty** — the ext-deps stage produces
   zero `package.json` files, so extension npm deps are never installed.
   tsdown silently produces zero extension output. The gateway falls back to
   Jiti transpilation, which fails because `/app/src/` is excluded from the
   runtime image.

2. **`pnpm prune --prod` removes the self-referencing `node_modules/openclaw`
   symlink** — plugins import from `openclaw/plugin-sdk/*` which requires
   this link to resolve in the pruned runtime image.

## Changes (Dockerfile only)

### 1) Default `OPENCLAW_EXTENSIONS` to all bundled extensions

```diff
-ARG OPENCLAW_EXTENSIONS=""
+# Default: build all bundled extensions. Pass a space-separated list to
+# build only a subset (e.g. "whatsapp device-pair").
+ARG OPENCLAW_EXTENSIONS="__all__"
```

Update the ext-deps RUN block so that when `OPENCLAW_EXTENSIONS` is empty
**or** `"__all__"`, package manifests are copied for every bundled extension.
Otherwise, preserve the existing explicit subset behavior.

The empty-string check is critical: `docker-setup.sh` always passes
`--build-arg "OPENCLAW_EXTENSIONS=${OPENCLAW_EXTENSIONS}"`. When the host
env var is unset, this sends an empty string — overriding the Dockerfile
ARG default. Treating empty as "all" ensures both `docker build .` and
`docker-setup.sh` produce working builds.

### 2) Restore self-referencing package link after prune

```diff
+# Restore self-referencing package link removed by pnpm prune --prod.
+# Required for openclaw/plugin-sdk/* subpath imports at runtime.
+RUN ln -s /app /app/node_modules/openclaw
```

Added in the `runtime-assets` stage after `pnpm prune --prod`.

## Root cause commits

| Commit | Description | Impact |
|--------|-------------|--------|
| `16505718e8` | Move WhatsApp to `extensions/` (#45725) | First channel extension with `../../../src/` imports |
| `439c21e078` | Remove channel shim dirs (#45967) | Completes migration; all channels now in `extensions/` |
| `57f19f0d5c` | Add `OPENCLAW_EXTENSIONS` build arg (#32223) | Introduced empty default that silently breaks extension compilation |
| `b46ac250d1` | WhatsApp: use scoped plugin SDK imports | Made `node_modules/openclaw` symlink essential |
| `e9cf3506fd` | Telegram: use scoped plugin SDK imports | Same — all channels now need the self-referencing link |

## Verification

```bash
# Build with default (all extensions)
docker build -t openclaw:local -f Dockerfile .

# Verify extensions compiled
docker run --rm openclaw:local sh -c \
  'ls /app/dist/extensions/ | wc -l && echo "extensions built"'

# Verify self-ref link
docker run --rm openclaw:local ls -la /app/node_modules/openclaw

# Verify runtime module (fixed independently on main)
docker run --rm openclaw:local ls /app/dist/plugins/runtime/index.js

# Verify gateway starts
docker run --rm openclaw:local timeout 15 node openclaw.mjs gateway \
  --allow-unconfigured 2>&1 | grep -E "listening|error" | head -5
```

## Backward compatibility

- **Empty `OPENCLAW_EXTENSIONS`** (including the implicit empty string from
  `docker-setup.sh` when the env var is unset) now builds all extensions
  instead of building none. This is the key behavior change — it turns a
  broken default into a working one.
- **`OPENCLAW_EXTENSIONS="__all__"`** is accepted as an explicit alias for
  the same behavior.
- **`OPENCLAW_EXTENSIONS="whatsapp telegram"`** (etc.) continues to work
  as before — only the listed extensions have their npm deps installed
  at build time. tsdown still compiles all extensions found via
  `openclaw.plugin.json`; extensions whose third-party deps are missing
  emit unresolved-import warnings but produce working output for any
  imports resolved from the root package deps.
- No changes to runtime behavior, plugin loading, or config format.
- No platform-specific changes (Dockerfile runs in Linux container).
- The symlink `ln -s` is POSIX standard, compatible with all Docker base images.

## Testing

- [x] `docker build` with no `--build-arg` produces working image with all extensions
- [x] Gateway starts and loads channels without errors
- [x] WhatsApp channel connects and receives messages
- [ ] `docker build --build-arg OPENCLAW_EXTENSIONS="whatsapp device-pair"` builds with subset deps
- [ ] `docker-setup.sh` with unset `OPENCLAW_EXTENSIONS` env var builds all extensions
- [ ] `pnpm exec vitest run --config vitest.gateway.config.ts` passes

## Related

- Issue: #48552
- Duplicate (Bug 3, now fixed on main): #48422
- Similar pattern: #18846, #32662, #37915
