### PR TITLE
fix: auto-upgrade Node during update if new version requires it

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -644,15 +644,59 @@ async function ensureNodeSatisfiesUpdatedVersion(params: {
       return; // Can't check — skip gracefully
     }
 
-    // Import the freshly updated runtime guard
-    const guard = await import(guardPath);
-    const details = guard.detectRuntime?.();
-    if (!details || guard.runtimeSatisfies?.(details)) {
+    // Run the version check in a child process to bypass Node's module cache.
+    // The current process already loaded runtime-guard.js at startup, so
+    // `await import(guardPath)` would return the stale pre-update module.
+    const checkScript = [
+      `const g = require(${JSON.stringify(guardPath)});`,
+      `const d = g.detectRuntime?.();`,
+      `if (!d || g.runtimeSatisfies?.(d)) { process.exit(0); }`,
+      `process.stdout.write(JSON.stringify({ version: d.version }));`,
+      `process.exit(1);`,
+    ].join(" ");
+
+    const checkRes = await runCommandWithTimeout(
+      [process.execPath, "-e", checkScript],
+      { timeoutMs: 5_000 },
+    );
+
+    if (checkRes.code === 0) {
       return; // Current Node satisfies the new version — all good
     }
 
+    // Parse current version from child process output
+    let currentVersion = "unknown";
+    try {
+      const parsed = JSON.parse(checkRes.stdout.trim()) as { version?: string };
+      currentVersion = parsed.version ?? "unknown";
+    } catch {
+      // Fall through with "unknown"
+    }
+
+    // Detect platform
+    const os = await import("node:os");
+    const platform = os.platform();
+    const arch = os.arch();
+
+    // Windows: no POSIX toolchain — tell the user what to do instead of silently failing
+    if (platform === "win32") {
+      if (!params.jsonMode) {
+        defaultRuntime.log("");
+        defaultRuntime.log(
+          theme.warn(
+            `Node ${currentVersion} is too old for the updated OpenClaw.`,
+          ),
+        );
+        defaultRuntime.log(
+          theme.warn(
+            `Auto-upgrade is not supported on Windows. Please update Node manually: https://nodejs.org/en/download`,
+          ),
+        );
+      }
+      return;
+    }
+
     // Node is too old for the updated version — attempt auto-upgrade
-    const currentVersion = details.version ?? "unknown";
     if (!params.jsonMode) {
       defaultRuntime.log("");
       defaultRuntime.log(
@@ -661,11 +705,6 @@ async function ensureNodeSatisfiesUpdatedVersion(params: {
         ),
       );
     }
-
-    // Detect platform
-    const os = await import("node:os");
-    const platform = os.platform();
-    const arch = os.arch();
 
     const nodeArch = arch === "arm64" ? "arm64" : "x64";
     const nodePlatform = platform === "darwin" ? "darwin" : "linux";
@@ -685,16 +724,18 @@ async function ensureNodeSatisfiesUpdatedVersion(params: {
     const nodeDir = path.join(os.homedir(), ".local", "node");
     const dist = `node-${targetNodeVersion}-${nodePlatform}-${nodeArch}`;
     const url = `https://nodejs.org/dist/${targetNodeVersion}/${dist}.tar.xz`;
+    const tmpFile = "/tmp/node-upgrade.tar.xz";
 
     const upgradeRes = await runCommandWithTimeout(
       [
         "sh",
         "-c",
+        // trap ensures temp file is always cleaned up, even if tar/mkdir fails
+        `trap 'rm -f ${tmpFile}' EXIT; ` +
         [
           `mkdir -p "${nodeDir}"`,
-          `curl -fsSL "${url}" -o /tmp/node-upgrade.tar.xz`,
-          `tar -xJf /tmp/node-upgrade.tar.xz -C "${nodeDir}" --strip-components=1`,
-          `rm -f /tmp/node-upgrade.tar.xz`,
+          `curl -fsSL "${url}" -o ${tmpFile}`,
+          `tar -xJf ${tmpFile} -C "${nodeDir}" --strip-components=1`,
         ].join(" && "),
       ],
       { timeoutMs: 120_000 },

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -626,6 +626,110 @@ async function maybeRestartService(params: {
   }
 }
 
+/**
+ * After a core update, verify the running Node version still satisfies the
+ * updated runtime-guard requirements. If not, attempt an in-place Node upgrade
+ * so that plugin installs and subsequent CLI invocations don't crash with a
+ * cryptic "requires Node >=X.Y.Z" error.
+ */
+async function ensureNodeSatisfiesUpdatedVersion(params: {
+  root: string;
+  jsonMode: boolean;
+}): Promise<void> {
+  try {
+    // Re-read the updated runtime guard to see what Node version is now required.
+    // The updated code is already on disk at params.root after the core update.
+    const guardPath = path.join(params.root, "dist", "infra", "runtime-guard.js");
+    if (!(await pathExists(guardPath))) {
+      return; // Can't check — skip gracefully
+    }
+
+    // Import the freshly updated runtime guard
+    const guard = await import(guardPath);
+    const details = guard.detectRuntime?.();
+    if (!details || guard.runtimeSatisfies?.(details)) {
+      return; // Current Node satisfies the new version — all good
+    }
+
+    // Node is too old for the updated version — attempt auto-upgrade
+    const currentVersion = details.version ?? "unknown";
+    if (!params.jsonMode) {
+      defaultRuntime.log("");
+      defaultRuntime.log(
+        theme.warn(
+          `Node ${currentVersion} is too old for the updated OpenClaw. Attempting auto-upgrade...`,
+        ),
+      );
+    }
+
+    // Detect platform
+    const os = await import("node:os");
+    const platform = os.platform();
+    const arch = os.arch();
+
+    const nodeArch = arch === "arm64" ? "arm64" : "x64";
+    const nodePlatform = platform === "darwin" ? "darwin" : "linux";
+
+    // Resolve latest Node 22 LTS version
+    const latestRes = await runCommandWithTimeout(
+      [
+        "sh",
+        "-c",
+        `curl -fsSL 'https://nodejs.org/dist/index.json' 2>/dev/null | grep -o '"version":"v22\\.[^"]*"' | head -1 | sed 's/"version":"//;s/"//'`,
+      ],
+      { timeoutMs: 15_000 },
+    );
+    const targetNodeVersion = latestRes.stdout.trim() || "v22.16.0";
+
+    // Download and install Node
+    const nodeDir = path.join(os.homedir(), ".local", "node");
+    const dist = `node-${targetNodeVersion}-${nodePlatform}-${nodeArch}`;
+    const url = `https://nodejs.org/dist/${targetNodeVersion}/${dist}.tar.xz`;
+
+    const upgradeRes = await runCommandWithTimeout(
+      [
+        "sh",
+        "-c",
+        [
+          `mkdir -p "${nodeDir}"`,
+          `curl -fsSL "${url}" -o /tmp/node-upgrade.tar.xz`,
+          `tar -xJf /tmp/node-upgrade.tar.xz -C "${nodeDir}" --strip-components=1`,
+          `rm -f /tmp/node-upgrade.tar.xz`,
+        ].join(" && "),
+      ],
+      { timeoutMs: 120_000 },
+    );
+
+    if (upgradeRes.code === 0) {
+      if (!params.jsonMode) {
+        defaultRuntime.log(
+          theme.success(`Node upgraded to ${targetNodeVersion}. Continuing update...`),
+        );
+      }
+      // Update PATH for this process so subsequent steps (plugin install) use the new Node
+      const nodeBinDir = path.join(nodeDir, "bin");
+      process.env.PATH = `${nodeBinDir}:${process.env.PATH ?? ""}`;
+    } else {
+      if (!params.jsonMode) {
+        defaultRuntime.log(
+          theme.warn(
+            `Could not auto-upgrade Node. Please upgrade manually to ${targetNodeVersion}+:`,
+          ),
+        );
+        defaultRuntime.log(
+          theme.muted(`  curl -fsSL '${url}' | tar -xJf - -C ~/.local/node --strip-components=1`),
+        );
+        defaultRuntime.log(
+          theme.muted(`  export PATH="$HOME/.local/node/bin:$PATH"`),
+        );
+      }
+    }
+  } catch {
+    // Non-fatal — if we can't auto-upgrade, the user will get the runtime guard error
+    // on next invocation, which is no worse than the current behavior.
+  }
+}
+
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   suppressDeprecations();
 
@@ -888,6 +992,10 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     defaultRuntime.exit(0);
     return;
   }
+
+  // After core update, verify Node still satisfies the updated version's requirements.
+  // If not, auto-upgrade Node so plugin installs (and subsequent runs) don't fail.
+  await ensureNodeSatisfiesUpdatedVersion({ root, jsonMode: Boolean(opts.json) });
 
   await updatePluginsAfterCoreUpdate({
     root,


### PR DESCRIPTION
## Summary
- After `openclaw update` installs a new core version, the updated runtime-guard may require a newer Node than what's installed
- Previously this caused a cryptic `npm install failed: openclaw requires Node >=X.Y.Z` error during plugin install
- Now the update command re-checks the updated runtime-guard, and if Node is too old, auto-downloads the latest Node 22 LTS before continuing
- If auto-upgrade fails, prints a clear one-liner fix command instead of a wall of error text

## Test plan
- [ ] Run `openclaw update` on a machine with Node 22.14.0 — should auto-upgrade Node and continue
- [ ] Run `openclaw update` on a machine with Node 22.16.0+ — should skip the upgrade silently
- [ ] Run `openclaw update --json` — should handle JSON mode correctly (no TTY output)
- [ ] Verify plugin installs succeed after the auto-upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)