### PR TITLE
Telegram: avoid aborting sends on polling restart

### DIFF
--- a/extensions/telegram/src/bot.fetch-abort.test.ts
+++ b/extensions/telegram/src/bot.fetch-abort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { botCtorSpy } from "./bot.create-telegram-bot.test-harness.js";
+import { botCtorSpy, useSpy } from "./bot.create-telegram-bot.test-harness.js";
 import { createTelegramBot } from "./bot.js";
 import { getTelegramNetworkErrorOrigin } from "./network-errors.js";
 
@@ -18,24 +18,68 @@ function createWrappedTelegramClientFetch(proxyFetch: typeof fetch) {
 }
 
 describe("createTelegramBot fetch abort", () => {
-  it("aborts wrapped client fetch when fetchAbortSignal aborts", async () => {
-    const fetchSpy = vi.fn(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
+  it("aborts getUpdates when fetchAbortSignal aborts", async () => {
+    createWrappedTelegramClientFetch(vi.fn() as unknown as typeof fetch);
+    const shutdown = new AbortController();
+    useSpy.mockClear();
+    createTelegramBot({
+      token: "tok",
+      fetchAbortSignal: shutdown.signal,
+      proxyFetch: vi.fn() as unknown as typeof fetch,
+    });
+    const pollingAbortMiddleware = useSpy.mock.calls.at(-1)?.[0] as
+      | ((
+          prev: (method: string, payload: unknown, signal?: AbortSignal) => Promise<AbortSignal>,
+          method: string,
+          payload: unknown,
+          signal?: AbortSignal,
+        ) => Promise<AbortSignal>)
+      | undefined;
+    expect(typeof pollingAbortMiddleware).toBe("function");
+
+    const observedSignalPromise = pollingAbortMiddleware!(
+      (_method, _payload, signal) =>
         new Promise<AbortSignal>((resolve) => {
-          const signal = init?.signal as AbortSignal;
-          signal.addEventListener("abort", () => resolve(signal), { once: true });
+          signal?.addEventListener("abort", () => resolve(signal), { once: true });
         }),
-    );
-    const { clientFetch, shutdown } = createWrappedTelegramClientFetch(
-      fetchSpy as unknown as typeof fetch,
+      "getUpdates",
+      {},
     );
 
-    const observedSignalPromise = clientFetch("https://example.test");
     shutdown.abort(new Error("shutdown"));
-    const observedSignal = (await observedSignalPromise) as AbortSignal;
-
-    expect(observedSignal).toBeInstanceOf(AbortSignal);
+    const observedSignal = await observedSignalPromise;
     expect(observedSignal.aborted).toBe(true);
+  });
+
+  it("does not abort non-polling requests when fetchAbortSignal aborts", async () => {
+    const shutdown = new AbortController();
+    useSpy.mockClear();
+    createTelegramBot({
+      token: "tok",
+      fetchAbortSignal: shutdown.signal,
+      proxyFetch: vi.fn() as unknown as typeof fetch,
+    });
+    const pollingAbortMiddleware = useSpy.mock.calls.at(-1)?.[0] as
+      | ((
+          prev: (method: string, payload: unknown, signal?: AbortSignal) => Promise<AbortSignal>,
+          method: string,
+          payload: unknown,
+          signal?: AbortSignal,
+        ) => Promise<AbortSignal>)
+      | undefined;
+    expect(typeof pollingAbortMiddleware).toBe("function");
+
+    const originalSignal = new AbortController().signal;
+    const observedSignal = await pollingAbortMiddleware!(
+      async (_method, _payload, signal) => signal ?? originalSignal,
+      "sendMessage",
+      {},
+      originalSignal,
+    );
+    shutdown.abort(new Error("shutdown"));
+
+    expect(observedSignal).toBe(originalSignal);
+    expect(observedSignal.aborted).toBe(false);
   });
 
   it("tags wrapped Telegram fetch failures with the Bot API method", async () => {

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -74,8 +74,6 @@ export { getTelegramSequentialKey };
 
 type TelegramFetchInput = Parameters<NonNullable<ApiClientOptions["fetch"]>>[0];
 type TelegramFetchInit = Parameters<NonNullable<ApiClientOptions["fetch"]>>[1];
-type GlobalFetchInput = Parameters<typeof globalThis.fetch>[0];
-type GlobalFetchInit = Parameters<typeof globalThis.fetch>[1];
 
 function readRequestUrl(input: TelegramFetchInput): string | null {
   if (typeof input === "string") {
@@ -103,6 +101,45 @@ function extractTelegramApiMethod(input: TelegramFetchInput): string | null {
   } catch {
     return null;
   }
+}
+
+function createPollingAbortMiddleware(shutdownSignal: AbortSignal) {
+  return <T>(
+    prev: (method: string, payload: unknown, signal?: AbortSignal) => Promise<T>,
+    method: string,
+    payload: unknown,
+    signal?: AbortSignal,
+  ) => {
+    if (method !== "getUpdates") {
+      return prev(method, payload, signal);
+    }
+
+    const controller = new AbortController();
+    const abortWith = (source: AbortSignal) => controller.abort(source.reason);
+    const onShutdown = () => abortWith(shutdownSignal);
+    let onRequestAbort: (() => void) | undefined;
+
+    if (shutdownSignal.aborted) {
+      abortWith(shutdownSignal);
+    } else {
+      shutdownSignal.addEventListener("abort", onShutdown, { once: true });
+    }
+    if (signal) {
+      if (signal.aborted) {
+        abortWith(signal);
+      } else {
+        onRequestAbort = () => abortWith(signal);
+        signal.addEventListener("abort", onRequestAbort, { once: true });
+      }
+    }
+
+    return prev(method, payload, controller.signal).finally(() => {
+      shutdownSignal.removeEventListener("abort", onShutdown);
+      if (signal && onRequestAbort) {
+        signal.removeEventListener("abort", onRequestAbort);
+      }
+    });
+  };
 }
 
 export function createTelegramBot(opts: TelegramBotOptions) {
@@ -145,50 +182,10 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     ApiClientOptions["fetch"]
   >;
 
-  // When a shutdown abort signal is provided, wrap fetch so every Telegram API request
-  // (especially long-polling getUpdates) aborts immediately on shutdown. Without this,
-  // the in-flight getUpdates hangs for up to 30s, and a new gateway instance starting
-  // its own poll triggers a 409 Conflict from Telegram.
+  // Keep Telegram transport tagging/proxy handling at the fetch layer. Polling abort is
+  // injected later via API middleware for getUpdates only so in-flight sendMessage and
+  // sendChatAction calls are not canceled when polling restarts after a stall.
   let finalFetch = shouldProvideFetch ? fetchForClient : undefined;
-  if (opts.fetchAbortSignal) {
-    const baseFetch =
-      finalFetch ?? (globalThis.fetch as unknown as NonNullable<ApiClientOptions["fetch"]>);
-    const shutdownSignal = opts.fetchAbortSignal;
-    // Cast baseFetch to global fetch to avoid node-fetch ↔ global-fetch type divergence;
-    // they are runtime-compatible (the codebase already casts at every fetch boundary).
-    const callFetch = baseFetch as unknown as typeof globalThis.fetch;
-    // Use manual event forwarding instead of AbortSignal.any() to avoid the cross-realm
-    // AbortSignal issue in Node.js (grammY's signal may come from a different module context,
-    // causing "signals[0] must be an instance of AbortSignal" errors).
-    finalFetch = ((input: TelegramFetchInput, init?: TelegramFetchInit) => {
-      const controller = new AbortController();
-      const abortWith = (signal: AbortSignal) => controller.abort(signal.reason);
-      const onShutdown = () => abortWith(shutdownSignal);
-      let onRequestAbort: (() => void) | undefined;
-      if (shutdownSignal.aborted) {
-        abortWith(shutdownSignal);
-      } else {
-        shutdownSignal.addEventListener("abort", onShutdown, { once: true });
-      }
-      if (init?.signal) {
-        if (init.signal.aborted) {
-          abortWith(init.signal as unknown as AbortSignal);
-        } else {
-          onRequestAbort = () => abortWith(init.signal as AbortSignal);
-          init.signal.addEventListener("abort", onRequestAbort);
-        }
-      }
-      return callFetch(input as GlobalFetchInput, {
-        ...(init as GlobalFetchInit),
-        signal: controller.signal,
-      }).finally(() => {
-        shutdownSignal.removeEventListener("abort", onShutdown);
-        if (init?.signal && onRequestAbort) {
-          init.signal.removeEventListener("abort", onRequestAbort);
-        }
-      });
-    }) as unknown as NonNullable<ApiClientOptions["fetch"]>;
-  }
   if (finalFetch) {
     const baseFetch = finalFetch;
     finalFetch = ((input: TelegramFetchInput, init?: TelegramFetchInit) => {
@@ -221,6 +218,13 @@ export function createTelegramBot(opts: TelegramBotOptions) {
 
   const bot = new Bot(opts.token, client ? { client } : undefined);
   bot.api.config.use(apiThrottler());
+  if (opts.fetchAbortSignal) {
+    bot.api.config.use(
+      createPollingAbortMiddleware(opts.fetchAbortSignal) as Parameters<
+        typeof bot.api.config.use
+      >[0],
+    );
+  }
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {
     runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));


### PR DESCRIPTION
## Summary
When Telegram polling stalls, OpenClaw restarts the polling session by aborting the shared Telegram fetch abort signal. That currently aborts in-flight `sendMessage` / `sendChatAction` requests too, which turns a polling recovery into visible reply failures.

This change scopes the shutdown abort behavior to `getUpdates` only, so polling restarts no longer cancel unrelated outbound Telegram API sends.

## What changed
- moved shutdown abort handling from the shared Telegram fetch wrapper to a `bot.api.config.use(...)` middleware that only applies to `getUpdates`
- kept existing polling restart behavior for long-poll requests
- added regression tests to verify:
  - `getUpdates` is still aborted on shutdown/restart
  - non-polling requests such as `sendMessage` are not aborted by the polling restart path

## Why
In local reproduction, polling stalls were causing log patterns like:

```text
Polling stall detected ... forcing restart.
telegram sendChatAction failed ... <- AbortError
telegram sendMessage failed ... <- AbortError
```

The stall itself is one bug; aborting unrelated sends during recovery is a separate, fixable regression that makes the user-facing impact much worse.

## Validation
- `pnpm test -- extensions/telegram/src/bot.fetch-abort.test.ts extensions/telegram/src/monitor.test.ts`

## Related
- Follow-up startup long-poll stall issue: #48536
