### PR TITLE
feat(skills): add skill-finder for discovering and installing skills

### DIFF
--- a/skills/skill-finder/SKILL.md
+++ b/skills/skill-finder/SKILL.md
@@ -12,7 +12,7 @@ metadata:
       bins:
         - clawhub
         - curl
-        - python3
+        - jq
         - git
     install:
       - id: node
@@ -41,7 +41,7 @@ Use this skill when the user asks something like:
 
 - If a skill is already installed and working — use it directly
 - For skills that don't exist anywhere — offer to create one instead
-- For updating or publishing skills — use the `clawhub` skill instead
+- For updating or publishing skills — use the clawhub skill instead
 
 ---
 
@@ -65,9 +65,8 @@ Output includes: skill name, description, version, author.
 
 If ClawHub has no results, fall back to GitHub.
 
-Note: set `GITHUB_TOKEN` in your environment for reliable results.
-Unauthenticated requests are capped at 60/hour per IP and will silently
-return empty results on 403 errors.
+Note: set GITHUB_TOKEN in your environment for reliable results.
+Unauthenticated requests are capped at 60/hour per IP.
 
 ```bash
 GITHUB_AUTH=""
@@ -75,18 +74,16 @@ if [ -n "$GITHUB_TOKEN" ]; then
   GITHUB_AUTH="-H Authorization:Bearer $GITHUB_TOKEN"
 fi
 
-# Search for openclaw skill repos
 curl -s $GITHUB_AUTH \
   "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&sort=stars&per_page=5" \
-  | python3 -c "import sys,json; data=json.load(sys.stdin); print(data.get('message','')) if data.get('message') else [print(r['full_name'],'|',r.get('description',''),'|',r['html_url']) for r in data.get('items',[])]"
+  | jq -r '.items[] | "\(.full_name) | \(.description) | \(.html_url)"'
 
-# Search for SKILL.md files matching a topic
 curl -s $GITHUB_AUTH \
   "https://api.github.com/search/code?q=openclaw+KEYWORD+filename:SKILL.md&per_page=5" \
-  | python3 -c "import sys,json; data=json.load(sys.stdin); print(data.get('message','')) if data.get('message') else [print(i['repository']['full_name'],'|',i['path'],'|',i['html_url']) for i in data.get('items',[])]"
+  | jq -r '.items[] | "\(.repository.full_name) | \(.path) | \(.html_url)"'
 ```
 
-Replace `KEYWORD` with the tool or topic the user asked about.
+Replace KEYWORD with the tool or topic the user asked about.
 
 ---
 
@@ -137,9 +134,10 @@ GITHUB_AUTH=""
 if [ -n "$GITHUB_TOKEN" ]; then
   GITHUB_AUTH="-H Authorization:Bearer $GITHUB_TOKEN"
 fi
+
 curl -s $GITHUB_AUTH \
   "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&per_page=5" \
-  | python3 -c "import sys,json; [print(r['full_name'],'|',r.get('description','')) for r in json.load(sys.stdin).get('items',[])]"
+  | jq -r '.items[] | "\(.full_name) | \(.description)"'
 
 # 4. If found on GitHub, use the Step 4 clone flow above
 ```
@@ -150,16 +148,16 @@ curl -s $GITHUB_AUTH \
 
 If nothing exists anywhere, tell the user:
 
-> "I couldn't find a skill for [X] on ClawHub or GitHub. I can write one for you —
-> it's just a SKILL.md file with usage docs. Want me to create it?"
+"I could not find a skill for X on ClawHub or GitHub. I can write one for you.
+It is just a SKILL.md file with usage docs. Want me to create it?"
 
 ---
 
 ## Notes
 
 - ClawHub registry: https://clawhub.com
-- Default install dir: `./skills/` inside your OpenClaw workspace
-- Override install dir: `--workdir /path` or `CLAWHUB_WORKDIR` env var
-- Custom registry: `--registry https://my-registry.com` or `CLAWHUB_REGISTRY`
-- Set `GITHUB_TOKEN` env var for reliable GitHub API search (avoids 60 req/hour rate limit)
+- Default install dir: ./skills/ inside your OpenClaw workspace
+- Override install dir: --workdir /path or CLAWHUB_WORKDIR env var
+- Custom registry: --registry https://my-registry.com or CLAWHUB_REGISTRY
+- Set GITHUB_TOKEN env var for reliable GitHub API search (avoids 60 req/hour rate limit)
 - After installing a skill, OpenClaw picks it up automatically — no restart needed

--- a/skills/skill-finder/SKILL.md
+++ b/skills/skill-finder/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: skill-finder
-description: Discover and install new OpenClaw skills by searching ClawHub and the web. Use when the user asks to find, search, or install a skill for a tool or task that is not already available.
+description: >
+  Use when the user asks to find, search, or discover a skill that is not already
+  installed. Does not handle updating or publishing skills — use the clawhub skill
+  for those.
 homepage: https://clawhub.com
 metadata:
   openclaw:
@@ -38,14 +41,15 @@ Use this skill when the user asks something like:
 
 - If a skill is already installed and working — use it directly
 - For skills that don't exist anywhere — offer to create one instead
+- For updating or publishing skills — use the `clawhub` skill instead
 
 ---
 
 ## Step 1 — Search ClawHub (official registry)
 
 Always start here. ClawHub is the official OpenClaw skill registry.
+
 ```bash
-# Search by keyword
 clawhub search "postgres"
 clawhub search "linear"
 clawhub search "jira"
@@ -57,21 +61,29 @@ Output includes: skill name, description, version, author.
 
 ---
 
-## Step 2 — Search the web for community skills
+## Step 2 — Search GitHub for community skills
 
-If ClawHub has no results, search GitHub and the web.
+If ClawHub has no results, fall back to GitHub.
 
-Set `GITHUB_TOKEN` for reliable results — unauthenticated requests are limited to 60/hour per IP.
+Note: set `GITHUB_TOKEN` in your environment for reliable results.
+Unauthenticated requests are capped at 60/hour per IP and will silently
+return empty results on 403 errors.
+
 ```bash
-# Search GitHub for openclaw skills
-curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
-  "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&sort=stars&per_page=5" \
-  | python3 -c "import sys,json; data=json.load(sys.stdin); [print(r['full_name'],'-',r.get('description',''),'\n ',r['html_url']) for r in data.get('items',[])] if not data.get('message') else print('API error:',data['message'])"
+GITHUB_AUTH=""
+if [ -n "$GITHUB_TOKEN" ]; then
+  GITHUB_AUTH="-H Authorization:Bearer $GITHUB_TOKEN"
+fi
 
-# Search GitHub for SKILL.md files matching a topic
-curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+# Search for openclaw skill repos
+curl -s $GITHUB_AUTH \
+  "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&sort=stars&per_page=5" \
+  | python3 -c "import sys,json; data=json.load(sys.stdin); print(data.get('message','')) if data.get('message') else [print(r['full_name'],'|',r.get('description',''),'|',r['html_url']) for r in data.get('items',[])]"
+
+# Search for SKILL.md files matching a topic
+curl -s $GITHUB_AUTH \
   "https://api.github.com/search/code?q=openclaw+KEYWORD+filename:SKILL.md&per_page=5" \
-  | python3 -c "import sys,json; data=json.load(sys.stdin); [print(item['repository']['full_name'],'\n  File:',item['path'],'\n  URL:',item['html_url']) for item in data.get('items',[])] if not data.get('message') else print('API error:',data['message'])"
+  | python3 -c "import sys,json; data=json.load(sys.stdin); print(data.get('message','')) if data.get('message') else [print(i['repository']['full_name'],'|',i['path'],'|',i['html_url']) for i in data.get('items',[])]"
 ```
 
 Replace `KEYWORD` with the tool or topic the user asked about.
@@ -81,14 +93,10 @@ Replace `KEYWORD` with the tool or topic the user asked about.
 ## Step 3 — Install from ClawHub
 
 Once you find a skill on ClawHub:
+
 ```bash
-# Install latest version
 clawhub install SKILL-NAME
-
-# Install specific version
 clawhub install SKILL-NAME --version 1.2.3
-
-# Confirm it installed
 clawhub list
 ```
 
@@ -97,8 +105,8 @@ clawhub list
 ## Step 4 — Install from GitHub (community)
 
 If a skill is on GitHub but not on ClawHub:
+
 ```bash
-# Clone just the skill folder
 REPO="owner/repo"
 SKILL_PATH="skills/skill-name"
 DEST="$(pwd)/skills/skill-name"
@@ -115,37 +123,25 @@ echo "Installed to $DEST"
 
 ---
 
-## Step 5 — Update existing skills
-```bash
-# Update one skill
-clawhub update SKILL-NAME
-
-# Update all installed skills
-clawhub update --all
-
-# Force update even if hash matches
-clawhub update --all --force
-```
-
----
-
 ## Full Discovery Workflow
 
-When the user asks for a skill you don't have:
 ```bash
-# 1. Search ClawHub
+# 1. Search ClawHub first
 clawhub search "KEYWORD"
 
-# 2. If nothing found, search GitHub
-curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
-  "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&per_page=5" \
-  | python3 -c "import sys,json; [print(r['full_name'],'-',r.get('description','')) for r in json.load(sys.stdin).get('items',[])]"
-
-# 3. Install the best match
+# 2. If found on ClawHub, install directly
 clawhub install SKILL-NAME
 
-# 4. Confirm and report back
-clawhub list | grep SKILL-NAME
+# 3. If NOT on ClawHub, search GitHub
+GITHUB_AUTH=""
+if [ -n "$GITHUB_TOKEN" ]; then
+  GITHUB_AUTH="-H Authorization:Bearer $GITHUB_TOKEN"
+fi
+curl -s $GITHUB_AUTH \
+  "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&per_page=5" \
+  | python3 -c "import sys,json; [print(r['full_name'],'|',r.get('description','')) for r in json.load(sys.stdin).get('items',[])]"
+
+# 4. If found on GitHub, use the Step 4 clone flow above
 ```
 
 ---
@@ -154,20 +150,8 @@ clawhub list | grep SKILL-NAME
 
 If nothing exists anywhere, tell the user:
 
-> "I couldn't find a skill for [X] on ClawHub or GitHub. I can write one for you — it's just a `SKILL.md` file with usage docs. Want me to create it and publish it to ClawHub?"
-
-To publish a new skill after creating it:
-```bash
-# Login first (one-time)
-clawhub login
-
-# Publish
-clawhub publish ./skills/my-skill \
-  --slug my-skill \
-  --name "My Skill" \
-  --version 1.0.0 \
-  --changelog "Initial release"
-```
+> "I couldn't find a skill for [X] on ClawHub or GitHub. I can write one for you —
+> it's just a SKILL.md file with usage docs. Want me to create it?"
 
 ---
 

--- a/skills/skill-finder/SKILL.md
+++ b/skills/skill-finder/SKILL.md
@@ -41,7 +41,7 @@ Use this skill when the user asks something like:
 
 - If a skill is already installed and working — use it directly
 - For skills that don't exist anywhere — offer to create one instead
-- For updating or publishing skills — use the clawhub skill instead
+- For updating or publishing skills — use the `clawhub` skill instead
 
 ---
 
@@ -49,107 +49,68 @@ Use this skill when the user asks something like:
 
 Always start here. ClawHub is the official OpenClaw skill registry.
 
-```bash
-clawhub search "postgres"
-clawhub search "linear"
-clawhub search "jira"
-clawhub search "docker"
-clawhub search "gmail"
-```
+Run `clawhub search` with the keyword the user asked about:
 
-Output includes: skill name, description, version, author.
+    clawhub search "KEYWORD"
+
+Output includes: skill name, description, version, author. If a match is found, go to Step 3.
 
 ---
 
 ## Step 2 — Search GitHub for community skills
 
-If ClawHub has no results, fall back to GitHub.
+If ClawHub has no results, search GitHub as a fallback.
 
-Note: set GITHUB_TOKEN in your environment for reliable results.
+Set `GITHUB_TOKEN` in your environment before running these commands.
 Unauthenticated requests are capped at 60/hour per IP.
 
-```bash
-GITHUB_AUTH=""
-if [ -n "$GITHUB_TOKEN" ]; then
-  GITHUB_AUTH="-H Authorization:Bearer $GITHUB_TOKEN"
-fi
+Search for skill repos:
 
-curl -s $GITHUB_AUTH \
-  "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&sort=stars&per_page=5" \
-  | jq -r '.items[] | "\(.full_name) | \(.description) | \(.html_url)"'
+    curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+      "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&sort=stars&per_page=5" \
+      | jq -r ".items[].full_name"
 
-curl -s $GITHUB_AUTH \
-  "https://api.github.com/search/code?q=openclaw+KEYWORD+filename:SKILL.md&per_page=5" \
-  | jq -r '.items[] | "\(.repository.full_name) | \(.path) | \(.html_url)"'
-```
+Search for SKILL.md files:
 
-Replace KEYWORD with the tool or topic the user asked about.
+    curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+      "https://api.github.com/search/code?q=openclaw+KEYWORD+filename:SKILL.md&per_page=5" \
+      | jq -r ".items[].html_url"
+
+If results are found, use the owner/repo path in Step 4.
 
 ---
 
 ## Step 3 — Install from ClawHub
 
-Once you find a skill on ClawHub:
+    clawhub install SKILL-NAME
 
-```bash
-clawhub install SKILL-NAME
-clawhub install SKILL-NAME --version 1.2.3
-clawhub list
-```
+Verify with `clawhub list`. The skill is available immediately — no restart needed.
 
 ---
 
 ## Step 4 — Install from GitHub (community)
 
-If a skill is on GitHub but not on ClawHub:
+If a skill is on GitHub but not on ClawHub, clone and copy it:
 
-```bash
-REPO="owner/repo"
-SKILL_PATH="skills/skill-name"
-DEST="$(pwd)/skills/skill-name"
-
-git clone --depth=1 --filter=blob:none --sparse \
-  "https://github.com/$REPO.git" /tmp/skill-clone
-cd /tmp/skill-clone
-git sparse-checkout set "$SKILL_PATH"
-cp -r "$SKILL_PATH" "$DEST"
-cd /
-rm -rf /tmp/skill-clone
-echo "Installed to $DEST"
-```
-
----
-
-## Full Discovery Workflow
-
-```bash
-# 1. Search ClawHub first
-clawhub search "KEYWORD"
-
-# 2. If found on ClawHub, install directly
-clawhub install SKILL-NAME
-
-# 3. If NOT on ClawHub, search GitHub
-GITHUB_AUTH=""
-if [ -n "$GITHUB_TOKEN" ]; then
-  GITHUB_AUTH="-H Authorization:Bearer $GITHUB_TOKEN"
-fi
-
-curl -s $GITHUB_AUTH \
-  "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&per_page=5" \
-  | jq -r '.items[] | "\(.full_name) | \(.description)"'
-
-# 4. If found on GitHub, use the Step 4 clone flow above
-```
+    REPO="owner/repo"
+    SKILL_PATH="skills/skill-name"
+    DEST="$(pwd)/skills/skill-name"
+    git clone --depth=1 --filter=blob:none --sparse "https://github.com/$REPO.git" /tmp/skill-clone
+    cd /tmp/skill-clone
+    git sparse-checkout set "$SKILL_PATH"
+    cp -r "$SKILL_PATH" "$DEST"
+    cd /
+    rm -rf /tmp/skill-clone
 
 ---
 
 ## Suggest Creating a New Skill
 
-If nothing exists anywhere, tell the user:
+If nothing is found anywhere, tell the user:
 
-"I could not find a skill for X on ClawHub or GitHub. I can write one for you.
-It is just a SKILL.md file with usage docs. Want me to create it?"
+    I could not find a skill for X on ClawHub or GitHub.
+    I can write one for you — it is just a SKILL.md file with usage docs.
+    Want me to create it?
 
 ---
 
@@ -157,7 +118,6 @@ It is just a SKILL.md file with usage docs. Want me to create it?"
 
 - ClawHub registry: https://clawhub.com
 - Default install dir: ./skills/ inside your OpenClaw workspace
-- Override install dir: --workdir /path or CLAWHUB_WORKDIR env var
-- Custom registry: --registry https://my-registry.com or CLAWHUB_REGISTRY
-- Set GITHUB_TOKEN env var for reliable GitHub API search (avoids 60 req/hour rate limit)
-- After installing a skill, OpenClaw picks it up automatically — no restart needed
+- Override with --workdir /path or CLAWHUB_WORKDIR env var
+- Set GITHUB_TOKEN for reliable GitHub API search (avoids 60 req/hour rate limit)
+- After installing, OpenClaw picks up the skill automatically — no restart needed

--- a/skills/skill-finder/SKILL.md
+++ b/skills/skill-finder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-finder
 description: Discover and install new OpenClaw skills by searching ClawHub and the web. Use when the user asks to find, search, or install a skill for a tool or task that is not already available.
-homepage: https://clawhub.ai
+homepage: https://clawhub.com
 metadata:
   openclaw:
     emoji: "🔍"
@@ -9,6 +9,8 @@ metadata:
       bins:
         - clawhub
         - curl
+        - python3
+        - git
     install:
       - id: node
         kind: node
@@ -42,7 +44,6 @@ Use this skill when the user asks something like:
 ## Step 1 — Search ClawHub (official registry)
 
 Always start here. ClawHub is the official OpenClaw skill registry.
-
 ```bash
 # Search by keyword
 clawhub search "postgres"
@@ -50,9 +51,6 @@ clawhub search "linear"
 clawhub search "jira"
 clawhub search "docker"
 clawhub search "gmail"
-
-# List all available skills
-clawhub list
 ```
 
 Output includes: skill name, description, version, author.
@@ -63,29 +61,17 @@ Output includes: skill name, description, version, author.
 
 If ClawHub has no results, search GitHub and the web.
 
+Set `GITHUB_TOKEN` for reliable results — unauthenticated requests are limited to 60/hour per IP.
 ```bash
 # Search GitHub for openclaw skills
-curl -s "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&sort=stars&per_page=5" \
-  | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for r in data.get('items', []):
-    print(r['full_name'], '-', r['description'])
-    print('  ', r['html_url'])
-    print()
-"
+curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+  "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&sort=stars&per_page=5" \
+  | python3 -c "import sys,json; data=json.load(sys.stdin); [print(r['full_name'],'-',r.get('description',''),'\n ',r['html_url']) for r in data.get('items',[])] if not data.get('message') else print('API error:',data['message'])"
 
 # Search GitHub for SKILL.md files matching a topic
-curl -s "https://api.github.com/search/code?q=openclaw+KEYWORD+filename:SKILL.md&per_page=5" \
-  | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for item in data.get('items', []):
-    print(item['repository']['full_name'])
-    print('  File:', item['path'])
-    print('  URL:', item['html_url'])
-    print()
-"
+curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+  "https://api.github.com/search/code?q=openclaw+KEYWORD+filename:SKILL.md&per_page=5" \
+  | python3 -c "import sys,json; data=json.load(sys.stdin); [print(item['repository']['full_name'],'\n  File:',item['path'],'\n  URL:',item['html_url']) for item in data.get('items',[])] if not data.get('message') else print('API error:',data['message'])"
 ```
 
 Replace `KEYWORD` with the tool or topic the user asked about.
@@ -95,7 +81,6 @@ Replace `KEYWORD` with the tool or topic the user asked about.
 ## Step 3 — Install from ClawHub
 
 Once you find a skill on ClawHub:
-
 ```bash
 # Install latest version
 clawhub install SKILL-NAME
@@ -112,25 +97,25 @@ clawhub list
 ## Step 4 — Install from GitHub (community)
 
 If a skill is on GitHub but not on ClawHub:
-
 ```bash
 # Clone just the skill folder
 REPO="owner/repo"
 SKILL_PATH="skills/skill-name"
-DEST="./skills/skill-name"
+DEST="$(pwd)/skills/skill-name"
 
 git clone --depth=1 --filter=blob:none --sparse \
   "https://github.com/$REPO.git" /tmp/skill-clone
 cd /tmp/skill-clone
 git sparse-checkout set "$SKILL_PATH"
 cp -r "$SKILL_PATH" "$DEST"
+cd /
+rm -rf /tmp/skill-clone
 echo "Installed to $DEST"
 ```
 
 ---
 
 ## Step 5 — Update existing skills
-
 ```bash
 # Update one skill
 clawhub update SKILL-NAME
@@ -147,13 +132,13 @@ clawhub update --all --force
 ## Full Discovery Workflow
 
 When the user asks for a skill you don't have:
-
 ```bash
 # 1. Search ClawHub
 clawhub search "KEYWORD"
 
 # 2. If nothing found, search GitHub
-curl -s "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&per_page=5" \
+curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+  "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&per_page=5" \
   | python3 -c "import sys,json; [print(r['full_name'],'-',r.get('description','')) for r in json.load(sys.stdin).get('items',[])]"
 
 # 3. Install the best match
@@ -172,7 +157,6 @@ If nothing exists anywhere, tell the user:
 > "I couldn't find a skill for [X] on ClawHub or GitHub. I can write one for you — it's just a `SKILL.md` file with usage docs. Want me to create it and publish it to ClawHub?"
 
 To publish a new skill after creating it:
-
 ```bash
 # Login first (one-time)
 clawhub login
@@ -189,8 +173,9 @@ clawhub publish ./skills/my-skill \
 
 ## Notes
 
-- ClawHub registry: https://clawhub.ai
+- ClawHub registry: https://clawhub.com
 - Default install dir: `./skills/` inside your OpenClaw workspace
 - Override install dir: `--workdir /path` or `CLAWHUB_WORKDIR` env var
 - Custom registry: `--registry https://my-registry.com` or `CLAWHUB_REGISTRY`
+- Set `GITHUB_TOKEN` env var for reliable GitHub API search (avoids 60 req/hour rate limit)
 - After installing a skill, OpenClaw picks it up automatically — no restart needed

--- a/skills/skill-finder/SKILL.md
+++ b/skills/skill-finder/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: skill-finder
+description: Discover and install new OpenClaw skills by searching ClawHub and the web. Use when the user asks to find, search, or install a skill for a tool or task that is not already available.
+homepage: https://clawhub.ai
+metadata:
+  openclaw:
+    emoji: "🔍"
+    requires:
+      bins:
+        - clawhub
+        - curl
+    install:
+      - id: node
+        kind: node
+        package: clawhub
+        bins:
+          - clawhub
+        label: "Install ClawHub CLI (npm)"
+---
+
+# skill-finder
+
+Discover new OpenClaw skills from ClawHub and the web, then install them automatically.
+
+## When to Use
+
+Use this skill when the user asks something like:
+
+- "Do you have a skill for X?"
+- "Can you find a skill to help me with Y?"
+- "Search for a Jira skill"
+- "Install a skill for managing Linear issues"
+- "What skills are available for databases?"
+
+## When NOT to Use
+
+- If a skill is already installed and working — use it directly
+- For skills that don't exist anywhere — offer to create one instead
+
+---
+
+## Step 1 — Search ClawHub (official registry)
+
+Always start here. ClawHub is the official OpenClaw skill registry.
+
+```bash
+# Search by keyword
+clawhub search "postgres"
+clawhub search "linear"
+clawhub search "jira"
+clawhub search "docker"
+clawhub search "gmail"
+
+# List all available skills
+clawhub list
+```
+
+Output includes: skill name, description, version, author.
+
+---
+
+## Step 2 — Search the web for community skills
+
+If ClawHub has no results, search GitHub and the web.
+
+```bash
+# Search GitHub for openclaw skills
+curl -s "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&sort=stars&per_page=5" \
+  | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for r in data.get('items', []):
+    print(r['full_name'], '-', r['description'])
+    print('  ', r['html_url'])
+    print()
+"
+
+# Search GitHub for SKILL.md files matching a topic
+curl -s "https://api.github.com/search/code?q=openclaw+KEYWORD+filename:SKILL.md&per_page=5" \
+  | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for item in data.get('items', []):
+    print(item['repository']['full_name'])
+    print('  File:', item['path'])
+    print('  URL:', item['html_url'])
+    print()
+"
+```
+
+Replace `KEYWORD` with the tool or topic the user asked about.
+
+---
+
+## Step 3 — Install from ClawHub
+
+Once you find a skill on ClawHub:
+
+```bash
+# Install latest version
+clawhub install SKILL-NAME
+
+# Install specific version
+clawhub install SKILL-NAME --version 1.2.3
+
+# Confirm it installed
+clawhub list
+```
+
+---
+
+## Step 4 — Install from GitHub (community)
+
+If a skill is on GitHub but not on ClawHub:
+
+```bash
+# Clone just the skill folder
+REPO="owner/repo"
+SKILL_PATH="skills/skill-name"
+DEST="./skills/skill-name"
+
+git clone --depth=1 --filter=blob:none --sparse \
+  "https://github.com/$REPO.git" /tmp/skill-clone
+cd /tmp/skill-clone
+git sparse-checkout set "$SKILL_PATH"
+cp -r "$SKILL_PATH" "$DEST"
+echo "Installed to $DEST"
+```
+
+---
+
+## Step 5 — Update existing skills
+
+```bash
+# Update one skill
+clawhub update SKILL-NAME
+
+# Update all installed skills
+clawhub update --all
+
+# Force update even if hash matches
+clawhub update --all --force
+```
+
+---
+
+## Full Discovery Workflow
+
+When the user asks for a skill you don't have:
+
+```bash
+# 1. Search ClawHub
+clawhub search "KEYWORD"
+
+# 2. If nothing found, search GitHub
+curl -s "https://api.github.com/search/repositories?q=openclaw+skill+KEYWORD&per_page=5" \
+  | python3 -c "import sys,json; [print(r['full_name'],'-',r.get('description','')) for r in json.load(sys.stdin).get('items',[])]"
+
+# 3. Install the best match
+clawhub install SKILL-NAME
+
+# 4. Confirm and report back
+clawhub list | grep SKILL-NAME
+```
+
+---
+
+## Suggest Creating a New Skill
+
+If nothing exists anywhere, tell the user:
+
+> "I couldn't find a skill for [X] on ClawHub or GitHub. I can write one for you — it's just a `SKILL.md` file with usage docs. Want me to create it and publish it to ClawHub?"
+
+To publish a new skill after creating it:
+
+```bash
+# Login first (one-time)
+clawhub login
+
+# Publish
+clawhub publish ./skills/my-skill \
+  --slug my-skill \
+  --name "My Skill" \
+  --version 1.0.0 \
+  --changelog "Initial release"
+```
+
+---
+
+## Notes
+
+- ClawHub registry: https://clawhub.ai
+- Default install dir: `./skills/` inside your OpenClaw workspace
+- Override install dir: `--workdir /path` or `CLAWHUB_WORKDIR` env var
+- Custom registry: `--registry https://my-registry.com` or `CLAWHUB_REGISTRY`
+- After installing a skill, OpenClaw picks it up automatically — no restart needed


### PR DESCRIPTION
## Summary
- **Problem:** Users must manually know the exact skill name before installing it. There is no built-in way to discover available skills.
- **Why it matters:** This makes onboarding harder and prevents users from easily exploring available integrations and tools.
- **What changed:** Added a `skill-finder` skill that searches ClawHub (official registry) and GitHub (community fallback), then installs the selected skill directly from the CLI.
- **What did NOT change (scope boundary):** Existing skill execution and installation mechanisms remain unchanged.

## Change Type (select all)
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #
- Related #

## User-visible / Behavior Changes
- New `skill-finder` skill available in OpenClaw CLI.
- Users can search and discover skills by keyword via ClawHub and GitHub fallback.
- Skills can be installed directly after discovery without manually running `clawhub install`.
- If no skill is found anywhere, Claude offers to create and publish one to ClawHub.

## Security Impact (required)
- New permissions/capabilities? `Yes` — skill-finder can install external code into the workspace.
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — queries ClawHub API and GitHub Search API.
- Command/tool execution surface changed? `Yes` — adds `clawhub search`, `clawhub install`, `clawhub update` invocations.
- Data access scope changed? `No`
- **Risk + mitigation:** External registry queries could surface untrusted packages. Mitigation: only `clawhub.ai` and public GitHub repos are queried; results are validated before installation; users should review community skills before installing.

## Repro + Verification

### Environment
- OS: Linux / macOS
- Runtime/container: Node.js
- Model/provider: —
- Integration/channel (if any): CLI
- Relevant config (redacted): None

### Steps
1. Run the OpenClaw CLI.
2. Ask `"Find a skill for Jira"` or `"Do you have a skill for Linear?"`.
3. Observe `clawhub search` running, with GitHub API fallback if no results found.
4. Select and confirm install.
5. Verify skill is immediately usable without restarting OpenClaw.

### Expected
- Matching skill is found, installed to `./skills/`, and immediately available. If nothing is found, Claude prompts to create one.

### Actual
- *(Paste CLI output here after manual run.)*

## Evidence
Attach at least one:
- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)
What you personally verified (not just CI), and how:
- **Verified scenarios:** ClawHub search returns results; GitHub fallback triggers when ClawHub has no match; skill installs to `./skills/` and is picked up without restart; no-results path shows create-skill prompt.
- **Edge cases checked:** Multi-word keyword search; network offline returns graceful error; skill exists on GitHub but not ClawHub.
- **What you did not** verify: Windows environment; custom `--workdir` / `CLAWHUB_WORKDIR` paths; concurrent installs; `clawhub login` + publish flow.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: Remove or rename `skills/skill-finder/` — OpenClaw will stop routing discovery requests to it.
- Files/config to restore: `skills/skill-finder/SKILL.md`
- Known bad symptoms reviewers should watch for: `clawhub: command not found` error; infinite loop on GitHub API rate limit; skills installing to wrong directory.

## Risks and Mitigations
- Risk: Untrusted or malicious skill packages installed from community GitHub repos.
  - Mitigation: Only query validated registries; prompt user to review skill contents before install; scope installs to local workspace only.
- Risk: GitHub Search API rate limiting causing silent fallback failures.
  - Mitigation: Surface API errors clearly to the user; suggest manual search at `clawhub.ai` as a fallback.