### PR TITLE
fix(embedded-run): prevent zombie state after compaction timeout

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -112,6 +112,7 @@ import { log } from "../logger.js";
 import { buildModelAliasLines } from "../model.js";
 import {
   clearActiveEmbeddedRun,
+  forceClearActiveEmbeddedRun,
   type EmbeddedPiQueueHandle,
   setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
@@ -2308,9 +2309,16 @@ export async function runEmbeddedAttempt(
               timedOutDuringCompaction = true;
             }
             abortRun(true);
+            // Safety net: force-clear the active run state after a brief grace
+            // period so the session returns to idle even if the normal cleanup
+            // path in the finally block never executes (zombie state).
+            // See: https://github.com/openclaw/openclaw/issues/48518
             if (!abortWarnTimer) {
               abortWarnTimer = setTimeout(() => {
                 if (!activeSession.isStreaming) {
+                  // Run already stopped — force-clear in case the finally
+                  // block hasn't (or won't) run due to a stuck await.
+                  forceClearActiveEmbeddedRun(params.sessionId, params.sessionKey);
                   return;
                 }
                 if (!isProbeSession) {
@@ -2318,6 +2326,9 @@ export async function runEmbeddedAttempt(
                     `embedded run abort still streaming: runId=${params.runId} sessionId=${params.sessionId}`,
                   );
                 }
+                // Force-clear regardless — after timeout + 10s grace, the run
+                // is definitively zombie.  The session must return to idle.
+                forceClearActiveEmbeddedRun(params.sessionId, params.sessionKey);
               }, 10_000);
             }
           },

--- a/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.test.ts
@@ -41,7 +41,7 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
     });
   });
 
-  it("keeps waiting while compaction remains in flight", async () => {
+  it("keeps waiting while compaction remains in flight and resolves before cap", async () => {
     await withFakeTimers(async () => {
       const onTimeout = vi.fn();
       let compactionInFlight = true;
@@ -68,6 +68,31 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
 
       expect(result.timedOut).toBe(false);
       expectClearedTimeoutState(onTimeout, false);
+    });
+  });
+
+  it("caps in-flight extensions to prevent indefinite zombie state", async () => {
+    await withFakeTimers(async () => {
+      const onTimeout = vi.fn();
+      // Compaction reports in-flight forever (stuck signal)
+      const waitForCompactionRetry = vi.fn(async () => await new Promise<void>(() => {}));
+
+      const resultPromise = waitForCompactionRetryWithAggregateTimeout({
+        waitForCompactionRetry,
+        abortable: async (promise) => await promise,
+        aggregateTimeoutMs: 60_000,
+        onTimeout,
+        isCompactionStillInFlight: () => true, // always stuck
+      });
+
+      // MAX_COMPACTION_INFLIGHT_EXTENSIONS is 3, so after 4 timeout windows
+      // (initial + 3 extensions) the function should give up.
+      // 4 * 60_000 = 240_000ms
+      await vi.advanceTimersByTimeAsync(240_000);
+      const result = await resultPromise;
+
+      expect(result.timedOut).toBe(true);
+      expectClearedTimeoutState(onTimeout, true);
     });
   });
 

--- a/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
@@ -1,4 +1,17 @@
 /**
+ * Maximum number of times the timeout window can be extended while compaction
+ * reports itself as still in-flight.  Without a cap, a stuck
+ * `isCompactionStillInFlight` signal would extend the wait indefinitely,
+ * leaving the session in a zombie state.
+ *
+ * Each extension adds `aggregateTimeoutMs` to the total wait, so the absolute
+ * upper bound is `(MAX_EXTENSIONS + 1) * aggregateTimeoutMs`.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/48518
+ */
+const MAX_COMPACTION_INFLIGHT_EXTENSIONS = 3;
+
+/**
  * Wait for compaction retry completion with an aggregate timeout to avoid
  * holding a session lane indefinitely when retry resolution is lost.
  */
@@ -13,6 +26,7 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
   const timeoutMs = Number.isFinite(timeoutMsRaw) ? Math.max(1, Math.floor(timeoutMsRaw)) : 1;
 
   let timedOut = false;
+  let inflightExtensions = 0;
   const waitPromise = params.waitForCompactionRetry().then(() => "done" as const);
 
   while (true) {
@@ -31,9 +45,14 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
         break;
       }
 
-      // Keep extending the timeout window while compaction is actively running.
-      // We only trigger the fallback timeout once compaction appears idle.
-      if (params.isCompactionStillInFlight?.()) {
+      // Keep extending the timeout window while compaction is actively running,
+      // but only up to MAX_COMPACTION_INFLIGHT_EXTENSIONS times to prevent
+      // indefinite zombie state when isCompactionStillInFlight is stuck.
+      if (
+        params.isCompactionStillInFlight?.() &&
+        inflightExtensions < MAX_COMPACTION_INFLIGHT_EXTENSIONS
+      ) {
+        inflightExtensions++;
         continue;
       }
 

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -4,7 +4,9 @@ import {
   __testing,
   abortEmbeddedPiRun,
   clearActiveEmbeddedRun,
+  forceClearActiveEmbeddedRun,
   getActiveEmbeddedRunSnapshot,
+  isEmbeddedPiRunActive,
   setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
   waitForActiveEmbeddedRuns,
@@ -138,6 +140,70 @@ describe("pi-embedded runner run registry", () => {
       runsA.__testing.resetActiveEmbeddedRuns();
       runsB.__testing.resetActiveEmbeddedRuns();
     }
+  });
+
+  it("force-clears an active run regardless of handle identity", () => {
+    const handle = {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: vi.fn(),
+    };
+
+    setActiveEmbeddedRun("session-force", handle);
+    expect(isEmbeddedPiRunActive("session-force")).toBe(true);
+
+    // Force-clear does not require the original handle
+    forceClearActiveEmbeddedRun("session-force");
+    expect(isEmbeddedPiRunActive("session-force")).toBe(false);
+  });
+
+  it("force-clear on idle session is a no-op", () => {
+    // Should not throw or have side-effects when session is not active
+    expect(isEmbeddedPiRunActive("session-idle")).toBe(false);
+    forceClearActiveEmbeddedRun("session-idle");
+    expect(isEmbeddedPiRunActive("session-idle")).toBe(false);
+  });
+
+  it("clearActiveEmbeddedRun with old handle is a no-op after force-clear", () => {
+    const handle = {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: vi.fn(),
+    };
+
+    setActiveEmbeddedRun("session-double", handle);
+    expect(isEmbeddedPiRunActive("session-double")).toBe(true);
+
+    // Force-clear removes the run
+    forceClearActiveEmbeddedRun("session-double");
+    expect(isEmbeddedPiRunActive("session-double")).toBe(false);
+
+    // Subsequent clearActiveEmbeddedRun with the old handle should be a no-op
+    // (no error, no double-notify)
+    clearActiveEmbeddedRun("session-double", handle);
+    expect(isEmbeddedPiRunActive("session-double")).toBe(false);
+  });
+
+  it("force-clear also clears transcript snapshots", () => {
+    const handle = {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: vi.fn(),
+    };
+
+    setActiveEmbeddedRun("session-snap-force", handle);
+    updateActiveEmbeddedRunSnapshot("session-snap-force", {
+      transcriptLeafId: "assistant-1",
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 }],
+      inFlightPrompt: "keep going",
+    });
+    expect(getActiveEmbeddedRunSnapshot("session-snap-force")).toBeDefined();
+
+    forceClearActiveEmbeddedRun("session-snap-force");
+    expect(getActiveEmbeddedRunSnapshot("session-snap-force")).toBeUndefined();
   });
 
   it("tracks and clears per-session transcript snapshots for active runs", () => {

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -272,6 +272,31 @@ export function clearActiveEmbeddedRun(
   }
 }
 
+/**
+ * Force-clear the active run for a session regardless of handle identity.
+ *
+ * This is a safety net for timeout scenarios where the normal cleanup path
+ * (clearActiveEmbeddedRun with handle matching) may not execute because the
+ * run is stuck in a zombie state.  The timeout handler calls this to guarantee
+ * the session returns to idle so future runs are not blocked.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/48518
+ */
+export function forceClearActiveEmbeddedRun(sessionId: string, sessionKey?: string) {
+  if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
+    return;
+  }
+  ACTIVE_EMBEDDED_RUNS.delete(sessionId);
+  ACTIVE_EMBEDDED_RUN_SNAPSHOTS.delete(sessionId);
+  logSessionStateChange({ sessionId, sessionKey, state: "idle", reason: "force_cleared_timeout" });
+  if (!sessionId.startsWith("probe-")) {
+    diag.warn(
+      `run force-cleared after timeout: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`,
+    );
+  }
+  notifyEmbeddedRunEnded(sessionId);
+}
+
 export const __testing = {
   resetActiveEmbeddedRuns() {
     for (const waiters of EMBEDDED_RUN_WAITERS.values()) {


### PR DESCRIPTION
## Summary

Fixes #48518 — Embedded runs that trigger compaction mid-run get stuck in `active=true` zombie state until service restart.

## Root Cause

Two independent subsystems (embedded run tracker + compaction scheduler) each believe they own the session's active state. When compaction fires inside an embedded run, the compaction retry loop can hold the session indefinitely because:

1. `waitForCompactionRetryWithAggregateTimeout` extends the wait window every time `isCompactionStillInFlight()` returns true — with no upper bound
2. The run timeout fires `abortRun()` but the session stays `active=true` because the normal cleanup in the `finally` block may not execute (stuck on an unresolvable await)

## Changes

### 1. Cap compaction in-flight extensions (`compaction-retry-aggregate-timeout.ts`)

Added `MAX_COMPACTION_INFLIGHT_EXTENSIONS = 3` — the wait loop can only extend 3 times when compaction reports in-flight, giving an absolute upper bound of `4 * aggregateTimeoutMs` (240s at default 60s windows). Previously a stuck `isCompactionStillInFlight` signal would extend forever.

### 2. Add `forceClearActiveEmbeddedRun` (`runs.ts`)

New safety-net function that clears active run state regardless of handle identity. Logs at warn level with `force_cleared_timeout` reason for observability.

### 3. Force-clear on timeout + grace (`attempt.ts`)

The existing abort warn timer (10s after timeout) now calls `forceClearActiveEmbeddedRun` unconditionally. This guarantees the session returns to idle even if the `finally` block never reaches `clearActiveEmbeddedRun` due to a stuck await in the compaction retry path.

## Testing

- Updated existing tests for the capped extension behavior
- Added new test: `caps in-flight extensions to prevent indefinite zombie state` — verifies that a permanently-stuck `isCompactionStillInFlight` signal times out after 4 windows
- All 12 tests pass (`compaction-retry-aggregate-timeout.test.ts` + `runs.test.ts`)

## Related Issues

- #47888 (session state loss on crash)
- #48183 (overlapping state with no reconciliation)

Credit to @Ryce and @Hollychou924 for the root cause analysis and fix direction in #48518.