### PR TITLE
fix: normalize FormData body in proxy fetch for undici compatibility

### DIFF
--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -13,41 +13,54 @@ const ORIGINAL_PROXY_ENV = Object.fromEntries(
   PROXY_ENV_KEYS.map((key) => [key, process.env[key]]),
 ) as Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>;
 
-const { ProxyAgent, EnvHttpProxyAgent, undiciFetch, proxyAgentSpy, envAgentSpy, getLastAgent } =
-  vi.hoisted(() => {
-    const undiciFetch = vi.fn();
-    const proxyAgentSpy = vi.fn();
-    const envAgentSpy = vi.fn();
-    class ProxyAgent {
-      static lastCreated: ProxyAgent | undefined;
-      proxyUrl: string;
-      constructor(proxyUrl: string) {
-        this.proxyUrl = proxyUrl;
-        ProxyAgent.lastCreated = this;
-        proxyAgentSpy(proxyUrl);
-      }
-    }
-    class EnvHttpProxyAgent {
-      static lastCreated: EnvHttpProxyAgent | undefined;
-      constructor() {
-        EnvHttpProxyAgent.lastCreated = this;
-        envAgentSpy();
-      }
-    }
+const {
+  ProxyAgent,
+  EnvHttpProxyAgent,
+  RealUndiciFormData,
+  undiciFetch,
+  proxyAgentSpy,
+  envAgentSpy,
+  getLastAgent,
+} = vi.hoisted(() => {
+  // Pull the real FormData from undici so normalizeInitForUndici can compare
+  // class identity between globalThis.FormData and undici's FormData.
+  const { FormData: RealUndiciFormData } = require("undici") as typeof import("undici");
 
-    return {
-      ProxyAgent,
-      EnvHttpProxyAgent,
-      undiciFetch,
-      proxyAgentSpy,
-      envAgentSpy,
-      getLastAgent: () => ProxyAgent.lastCreated,
-    };
-  });
+  const undiciFetch = vi.fn();
+  const proxyAgentSpy = vi.fn();
+  const envAgentSpy = vi.fn();
+  class ProxyAgent {
+    static lastCreated: ProxyAgent | undefined;
+    proxyUrl: string;
+    constructor(proxyUrl: string) {
+      this.proxyUrl = proxyUrl;
+      ProxyAgent.lastCreated = this;
+      proxyAgentSpy(proxyUrl);
+    }
+  }
+  class EnvHttpProxyAgent {
+    static lastCreated: EnvHttpProxyAgent | undefined;
+    constructor() {
+      EnvHttpProxyAgent.lastCreated = this;
+      envAgentSpy();
+    }
+  }
+
+  return {
+    ProxyAgent,
+    EnvHttpProxyAgent,
+    RealUndiciFormData,
+    undiciFetch,
+    proxyAgentSpy,
+    envAgentSpy,
+    getLastAgent: () => ProxyAgent.lastCreated,
+  };
+});
 
 vi.mock("undici", () => ({
   ProxyAgent,
   EnvHttpProxyAgent,
+  FormData: RealUndiciFormData,
   fetch: undiciFetch,
 }));
 
@@ -192,6 +205,29 @@ describe("resolveProxyFetchFromEnv", () => {
     expect(envAgentSpy).toHaveBeenCalled();
   });
 
+  it("converts globalThis.FormData body to undici FormData", async () => {
+    undiciFetch.mockResolvedValue({ ok: true });
+
+    const fetchFn = resolveProxyFetchFromEnv({
+      HTTP_PROXY: "",
+      HTTPS_PROXY: "http://proxy.test:8080",
+    });
+    expect(fetchFn).toBeDefined();
+
+    const form = new globalThis.FormData();
+    form.append("file", new Blob([new Uint8Array(8)], { type: "audio/wav" }), "test.wav");
+    form.append("model", "test-model");
+
+    await fetchFn!("https://api.example.com/v1/audio/transcriptions", {
+      method: "POST",
+      body: form,
+    });
+
+    const passedInit = undiciFetch.mock.calls[0]?.[1];
+    expect(passedInit.body).toBeInstanceOf(RealUndiciFormData);
+    expect(passedInit.body.get("model")).toBe("test-model");
+  });
+
   it("returns undefined when EnvHttpProxyAgent constructor throws", () => {
     envAgentSpy.mockImplementationOnce(() => {
       throw new Error("Invalid URL");
@@ -204,5 +240,62 @@ describe("resolveProxyFetchFromEnv", () => {
       HTTPS_PROXY: "not-a-valid-url",
     });
     expect(fetchFn).toBeUndefined();
+  });
+});
+
+describe("FormData normalization", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("converts globalThis.FormData to undici FormData for makeProxyFetch", async () => {
+    undiciFetch.mockResolvedValue({ ok: true });
+
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+    const form = new globalThis.FormData();
+    form.append("model", "whisper-1");
+    form.append("file", new Blob([new Uint8Array(4)], { type: "audio/ogg" }), "voice.ogg");
+
+    await proxyFetch("https://api.example.com/v1/audio/transcriptions", {
+      method: "POST",
+      body: form,
+    });
+
+    const passedInit = undiciFetch.mock.calls[0]?.[1];
+    // The body must be an undici FormData, not globalThis.FormData.
+    expect(passedInit.body).toBeInstanceOf(RealUndiciFormData);
+    expect(passedInit.body.get("model")).toBe("whisper-1");
+    const file = passedInit.body.get("file") as Blob;
+    expect(file).toBeInstanceOf(Blob);
+  });
+
+  it("passes non-FormData bodies through unchanged", async () => {
+    undiciFetch.mockResolvedValue({ ok: true });
+
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+    const jsonBody = JSON.stringify({ hello: "world" });
+
+    await proxyFetch("https://api.example.com/test", {
+      method: "POST",
+      body: jsonBody,
+    });
+
+    const passedInit = undiciFetch.mock.calls[0]?.[1];
+    expect(passedInit.body).toBe(jsonBody);
+  });
+
+  it("preserves undici FormData without re-conversion", async () => {
+    undiciFetch.mockResolvedValue({ ok: true });
+
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+    const form = new RealUndiciFormData();
+    form.append("key", "value");
+
+    await proxyFetch("https://api.example.com/test", {
+      method: "POST",
+      body: form as unknown as BodyInit,
+    });
+
+    const passedInit = undiciFetch.mock.calls[0]?.[1];
+    // Should be the exact same instance — no conversion needed.
+    expect(passedInit.body).toBe(form);
   });
 });

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -1,6 +1,51 @@
-import { EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
+import {
+  EnvHttpProxyAgent,
+  FormData as UndiciFormData,
+  ProxyAgent,
+  fetch as undiciFetch,
+} from "undici";
 import { logWarn } from "../../logger.js";
 import { hasEnvHttpProxyConfigured } from "./proxy-env.js";
+
+/**
+ * When the caller constructs a `FormData` via `globalThis.FormData` but the
+ * request is dispatched through `undici.fetch`, undici won't recognize it
+ * (different class in Node 22+) and will serialize the body as the string
+ * `"[object FormData]"` instead of proper `multipart/form-data`.
+ *
+ * This helper converts a global `FormData` body into undici's `FormData` so
+ * the proxy-fetch wrappers remain drop-in compatible with `globalThis.fetch`.
+ */
+function normalizeInitForUndici(init: RequestInit | undefined): RequestInit | undefined {
+  if (!init?.body) {
+    return init;
+  }
+  // In Node 22+ globalThis.FormData and undici's FormData can be different
+  // classes. undici.fetch only recognizes its own FormData for multipart
+  // serialization — a globalThis.FormData body is stringified as
+  // "[object FormData]". Convert when the classes diverge.
+  const GlobalFormData = globalThis.FormData as unknown;
+  if (
+    GlobalFormData !== UndiciFormData &&
+    typeof GlobalFormData === "function" &&
+    init.body instanceof (GlobalFormData as { new (): unknown }) &&
+    !(init.body instanceof UndiciFormData)
+  ) {
+    const src = init.body as { entries(): IterableIterator<[string, unknown]> };
+    const dst = new UndiciFormData();
+    for (const [key, value] of src.entries()) {
+      if (typeof value === "string") {
+        dst.append(key, value);
+      } else {
+        // Preserve filename for File/Blob entries.
+        const blobValue = value as Blob & { name?: string };
+        dst.append(key, blobValue, blobValue.name || undefined);
+      }
+    }
+    return { ...init, body: dst as unknown as BodyInit };
+  }
+  return init;
+}
 
 export const PROXY_FETCH_PROXY_URL = Symbol.for("openclaw.proxyFetch.proxyUrl");
 type ProxyFetchWithMetadata = typeof fetch & {
@@ -23,7 +68,7 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
   const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
     undiciFetch(input as string | URL, {
-      ...(init as Record<string, unknown>),
+      ...(normalizeInitForUndici(init) as Record<string, unknown>),
       dispatcher: resolveAgent(),
     }) as unknown as Promise<Response>) as ProxyFetchWithMetadata;
   Object.defineProperty(proxyFetch, PROXY_FETCH_PROXY_URL, {
@@ -61,7 +106,7 @@ export function resolveProxyFetchFromEnv(
     const agent = new EnvHttpProxyAgent();
     return ((input: RequestInfo | URL, init?: RequestInit) =>
       undiciFetch(input as string | URL, {
-        ...(init as Record<string, unknown>),
+        ...(normalizeInitForUndici(init) as Record<string, unknown>),
         dispatcher: agent,
       }) as unknown as Promise<Response>) as typeof fetch;
   } catch (err) {


### PR DESCRIPTION
## Summary

- **Problem:** When `HTTPS_PROXY` is set, `resolveProxyFetchFromEnv()` and `makeProxyFetch()` wrap `undici.fetch` as a drop-in for `globalThis.fetch`. But in Node 22+, `globalThis.FormData` and `undici.FormData` are different classes — undici doesn't recognize the global one and serializes it as `"[object FormData]"` instead of `multipart/form-data`.
- **Why it matters:** Audio transcription and batch file uploads silently fail for all users behind an HTTP proxy. Voice messages are never transcribed.
- **What changed:** Added `normalizeInitForUndici()` in `proxy-fetch.ts` that converts `globalThis.FormData` to undici's `FormData` before dispatch. Applied to both `makeProxyFetch()` and `resolveProxyFetchFromEnv()`.
- **Scope boundary:** No changes to callers (`audio.ts`, `batch-upload.ts`) — they correctly use `new FormData()`. The proxy wrapper was the broken contract.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue

Closes #48554

## User-visible / Behavior Changes

Audio transcription via Telegram/Discord voice messages now works correctly when `HTTPS_PROXY` or `HTTP_PROXY` is set.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same requests, just properly formatted
- Command/tool execution surface changed? No
- Data access scope changed? No

## Reproduction + Verification

### Environment
- OS: Ubuntu 24.04 (Docker)
- Runtime: Node.js 24.14.0, undici 7.24.1
- Integration: Telegram voice messages
- Config: `HTTPS_PROXY` set, `tools.media.audio` configured with OpenAI-compatible provider (Speaches/local Whisper)

### Steps
1. Set `HTTPS_PROXY` in OpenClaw container
2. Configure `tools.media.audio` with a local Whisper endpoint
3. Send a Telegram voice message

### Expected
Audio transcribed, agent responds to transcript

### Actual (before fix)
Request body is literal string `[object FormData]`, Content-Type is `text/plain;charset=UTF-8`. Transcription fails with HTTP 422 (missing file and model fields).

## Evidence

- [x] 4 new unit tests (FormData conversion for both wrappers, non-FormData passthrough, no double-conversion)
- [x] End-to-end verified: Telegram voice → Speaches transcription working after fix
- [x] `pnpm check` passes (build + format + lint + full test suite)

## Human Verification

- [x] Reproduced bug inside OpenClaw container with debug HTTP server capturing raw request
- [x] Confirmed `globalThis.FormData !== require("undici").FormData` in Node 24
- [x] Verified fix resolves the issue end-to-end via Telegram voice messages
- [x] Verified non-FormData bodies pass through unchanged
- [x] Verified undici FormData instances are not re-converted

## AI Assistance

- [x] AI-assisted (Claude Code)
- [x] Fully tested
- [x] I understand what the code does

## Compatibility / Migration

- Backward compatible: Yes
- Config/env changes required: No
- Migration needed: No

## Failure Recovery

- Revert this commit
- No config changes needed

## Risks and Mitigations

- **Risk:** FormData entry iteration might miss edge cases (e.g., multiple values for same key)
  - **Mitigation:** `FormData.entries()` returns all entries including duplicates; `append()` preserves them
- **Risk:** `globalThis.FormData` might not exist in some environments
  - **Mitigation:** Guard checks `typeof GlobalFormData === "function"` before `instanceof`