### PR TITLE
fix(browser): add missing Linux Chromium fallback paths to findChro...

### DIFF
--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -571,6 +571,7 @@ export function findGoogleChromeExecutableLinux(): BrowserExecutable | null {
     "/usr/bin/google-chrome-stable",
     "/usr/bin/google-chrome-beta",
     "/usr/bin/google-chrome-unstable",
+    "/opt/google/chrome/chrome",
     "/snap/bin/google-chrome",
   ]);
 }

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -547,14 +547,18 @@ export function findChromeExecutableLinux(): BrowserExecutable | null {
     { kind: "chrome", path: "/usr/bin/google-chrome" },
     { kind: "chrome", path: "/usr/bin/google-chrome-stable" },
     { kind: "chrome", path: "/usr/bin/chrome" },
+    { kind: "chrome", path: "/opt/google/chrome/chrome" },
     { kind: "brave", path: "/usr/bin/brave-browser" },
     { kind: "brave", path: "/usr/bin/brave-browser-stable" },
     { kind: "brave", path: "/usr/bin/brave" },
     { kind: "brave", path: "/snap/bin/brave" },
+    { kind: "brave", path: "/opt/brave.com/brave/brave-browser" },
     { kind: "edge", path: "/usr/bin/microsoft-edge" },
     { kind: "edge", path: "/usr/bin/microsoft-edge-stable" },
     { kind: "chromium", path: "/usr/bin/chromium" },
     { kind: "chromium", path: "/usr/bin/chromium-browser" },
+    { kind: "chromium", path: "/usr/lib/chromium/chromium" },
+    { kind: "chromium", path: "/usr/lib/chromium-browser/chromium-browser" },
     { kind: "chromium", path: "/snap/bin/chromium" },
   ];
 

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -10,6 +10,7 @@ import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import {
   decorateOpenClawProfile,
   ensureProfileCleanExit,
+  findChromeExecutableLinux,
   findChromeExecutableMac,
   findChromeExecutableWindows,
   getChromeWebSocketUrl,
@@ -265,6 +266,48 @@ describe("browser chrome helpers", () => {
   it("returns null when no Chrome candidate exists on Windows", () => {
     const exists = vi.spyOn(fs, "existsSync").mockReturnValue(false);
     expect(findChromeExecutableWindows()).toBeNull();
+    exists.mockRestore();
+  });
+
+  it("finds Chromium at /usr/lib/chromium/chromium on Linux", () => {
+    const target = "/usr/lib/chromium/chromium";
+    const exists = mockExistsSync((p) => p === target);
+    const exe = findChromeExecutableLinux();
+    expect(exe?.kind).toBe("chromium");
+    expect(exe?.path).toBe(target);
+    exists.mockRestore();
+  });
+
+  it("finds Chromium at /usr/lib/chromium-browser/chromium-browser on Linux", () => {
+    const target = "/usr/lib/chromium-browser/chromium-browser";
+    const exists = mockExistsSync((p) => p === target);
+    const exe = findChromeExecutableLinux();
+    expect(exe?.kind).toBe("chromium");
+    expect(exe?.path).toBe(target);
+    exists.mockRestore();
+  });
+
+  it("finds Chrome at /opt/google/chrome/chrome on Linux", () => {
+    const target = "/opt/google/chrome/chrome";
+    const exists = mockExistsSync((p) => p === target);
+    const exe = findChromeExecutableLinux();
+    expect(exe?.kind).toBe("chrome");
+    expect(exe?.path).toBe(target);
+    exists.mockRestore();
+  });
+
+  it("finds Brave at /opt/brave.com/brave/brave-browser on Linux", () => {
+    const target = "/opt/brave.com/brave/brave-browser";
+    const exists = mockExistsSync((p) => p === target);
+    const exe = findChromeExecutableLinux();
+    expect(exe?.kind).toBe("brave");
+    expect(exe?.path).toBe(target);
+    exists.mockRestore();
+  });
+
+  it("returns null when no Chrome candidate exists on Linux", () => {
+    const exists = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    expect(findChromeExecutableLinux()).toBeNull();
     exists.mockRestore();
   });
 

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -305,7 +305,8 @@ export async function launchOpenClawChrome(
   const exe = resolveBrowserExecutable(resolved);
   if (!exe) {
     throw new Error(
-      "No supported browser found (Chrome/Brave/Edge/Chromium on macOS, Linux, or Windows).",
+      "No supported browser found (Chrome/Brave/Edge/Chromium on macOS, Linux, or Windows)." +
+        " Set browser.executablePath in ~/.openclaw/openclaw.json to the path of a Chromium-based browser.",
     );
   }
 

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -306,7 +306,7 @@ export async function launchOpenClawChrome(
   if (!exe) {
     throw new Error(
       "No supported browser found (Chrome/Brave/Edge/Chromium on macOS, Linux, or Windows)." +
-        " Set `browser.executablePath` in your OpenClaw config to the path of a Chromium-based browser.",
+        ` Set \`browser.executablePath\` in ${CONFIG_DIR}/openclaw.json to the path of a Chromium-based browser.`,
     );
   }
 

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -306,7 +306,7 @@ export async function launchOpenClawChrome(
   if (!exe) {
     throw new Error(
       "No supported browser found (Chrome/Brave/Edge/Chromium on macOS, Linux, or Windows)." +
-        " Set browser.executablePath in ~/.openclaw/openclaw.json to the path of a Chromium-based browser.",
+        " Set `browser.executablePath` in your OpenClaw config to the path of a Chromium-based browser.",
     );
   }
 


### PR DESCRIPTION
Linux browser detection misses common Chromium install paths (e.g. /usr/lib/chromium/chromium) and the error message doesn't guide users to set browser.executablePath in config as a workaround

Closes #19185

Changes:
- Add additional Linux fallback paths to findChromeExecutableLinux() in src/browser/chrome.executables.ts: /usr/lib/chromium/chromium, /usr/lib/chromium-browser/chromium-browser, /opt/google/chrome/chrome, /opt/brave.com/brave/brave-browser
- Update the error message in src/browser/chrome.ts launchOpenClawChrome() to suggest setting browser.executablePath in ~/.openclaw/openclaw.json when no browser is auto-detected
- Add test coverage for the new fallback paths in existing browser detection tests

Testing:
- pnpm build && pnpm check && pnpm test
- Run existing browser detection tests (pnpm test -- src/browser/chrome.test.ts src/browser/chrome.default-browser.test.ts) and verify the new paths are checked; verify error message includes config hint

---
AI-assisted (Claude + Codex committee consensus, fully tested).

---

### AI-Assisted PR Checklist
- [x] Marked as AI-assisted
- [x] Testing degree: fully tested (pnpm build + check + test gates passed)
- [x] Code reviewed by LLM committee (Claude Opus + Codex dual-model review with consensus gate — equivalent to codex review)
- [x] I understand what the code does
- [x] Bot review conversations addressed and resolved