### PR TITLE
fix: allow /tmp paths in sandboxed image tool

### DIFF
--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -161,6 +161,61 @@ describe("image tool implicit imageModel config", () => {
     );
   });
 
+  it("allows /tmp paths in sandboxed mode", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-sandbox-"));
+    const agentDir = path.join(stateDir, "agent");
+    const sandboxRoot = path.join(stateDir, "sandbox");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(sandboxRoot, { recursive: true });
+
+    // Create a temp file outside the sandbox
+    const tmpFile = path.join(os.tmpdir(), `openclaw-image-tmp-${Date.now()}.png`);
+    const pngB64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    await fs.writeFile(tmpFile, Buffer.from(pngB64, "base64"));
+
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(),
+      json: async () => ({
+        content: "a red square",
+        base_resp: { status_code: 0, status_msg: "" },
+      }),
+    });
+    // @ts-expect-error partial global
+    global.fetch = fetch;
+    vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "minimax/MiniMax-M2.1" },
+          imageModel: { primary: "minimax/MiniMax-VL-01" },
+        },
+      },
+    };
+    const tool = createImageTool({ config: cfg, agentDir, sandboxRoot });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("expected image tool");
+    }
+
+    // /tmp paths should be allowed even in sandboxed mode
+    const res = await tool.execute("t1", {
+      prompt: "Describe the image.",
+      image: tmpFile,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const text = res.content?.find((b) => b.type === "text")?.text ?? "";
+    expect(text).toBe("a red square");
+
+    // Cleanup
+    await fs.unlink(tmpFile).catch(() => {});
+  });
+
   it("rewrites inbound absolute paths into sandbox media/inbound", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-sandbox-"));
     const agentDir = path.join(stateDir, "agent");

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 import { type Api, type Context, complete, type Model } from "@mariozechner/pi-ai";
@@ -180,12 +181,32 @@ function buildImageContext(prompt: string, base64: string, mimeType: string): Co
   };
 }
 
+function isInAllowedMediaRoot(filePath: string): boolean {
+  const resolved = path.resolve(filePath);
+  const tmpDir = os.tmpdir();
+  // Allow paths in system temp directories (/tmp, /var/tmp, etc.)
+  if (resolved.startsWith(tmpDir + path.sep) || resolved === tmpDir) {
+    return true;
+  }
+  // Also allow /tmp explicitly (on some systems os.tmpdir() may differ)
+  if (resolved.startsWith("/tmp/") || resolved === "/tmp") {
+    return true;
+  }
+  return false;
+}
+
 async function resolveSandboxedImagePath(params: {
   sandboxRoot: string;
   imagePath: string;
 }): Promise<{ resolved: string; rewrittenFrom?: string }> {
   const normalize = (p: string) => (p.startsWith("file://") ? p.slice("file://".length) : p);
   const filePath = normalize(params.imagePath);
+
+  // Allow paths in system temp directories (e.g., /tmp) without sandbox restrictions
+  if (isInAllowedMediaRoot(filePath)) {
+    return { resolved: path.resolve(filePath) };
+  }
+
   try {
     const out = await assertSandboxPath({
       filePath,


### PR DESCRIPTION
Ticket: ab344731-071b-4072-9bc8-c388628c29fd

The image tool was rejecting paths in /tmp despite /tmp being an allowed media root. This fix allows paths in system temp directories to be used directly without sandbox restrictions.

Changes:
- Added \+isInAllowedMediaRoot() helper to check if path is in temp dirs
- Modified resolveSandboxedImagePath() to allow temp paths without sandbox validation
- Added test case to verify /tmp paths work in sandboxed mode