### PR TITLE
feat(memory-lancedb): Add Gemini embedding model support

### DIFF
--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 export type MemoryConfig = {
   embedding: {
-    provider: "openai";
+    provider: "openai" | "google";
     model: string;
     apiKey: string;
     baseUrl?: string;
@@ -53,6 +53,10 @@ const DEFAULT_DB_PATH = resolveDefaultDbPath();
 const EMBEDDING_DIMENSIONS: Record<string, number> = {
   "text-embedding-3-small": 1536,
   "text-embedding-3-large": 3072,
+  "text-embedding-004": 768,
+  "models/text-embedding-004": 768,
+  "gemini-embedding-001": 768,
+  "models/gemini-embedding-001": 768,
 };
 
 function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], label: string) {
@@ -105,9 +109,15 @@ export const memoryConfigSchema = {
     if (!embedding || typeof embedding.apiKey !== "string") {
       throw new Error("embedding.apiKey is required");
     }
-    assertAllowedKeys(embedding, ["apiKey", "model", "baseUrl", "dimensions"], "embedding config");
+    assertAllowedKeys(embedding, ["apiKey", "model", "baseUrl", "dimensions", "provider"], "embedding config");
 
     const model = resolveEmbeddingModel(embedding);
+    
+    // Auto-detect Google provider if model is a known Google model and provider isn't explicitly set
+    let provider = typeof embedding.provider === "string" ? embedding.provider : "openai";
+    if (model.includes("text-embedding-004") || model.includes("gemini-embedding-001") || model.startsWith("models/")) {
+      provider = "google";
+    }
 
     const captureMaxChars =
       typeof cfg.captureMaxChars === "number" ? Math.floor(cfg.captureMaxChars) : undefined;
@@ -120,7 +130,7 @@ export const memoryConfigSchema = {
 
     return {
       embedding: {
-        provider: "openai",
+        provider: provider as "openai" | "google",
         model,
         apiKey: resolveEnvVars(embedding.apiKey),
         baseUrl:
@@ -135,10 +145,10 @@ export const memoryConfigSchema = {
   },
   uiHints: {
     "embedding.apiKey": {
-      label: "OpenAI API Key",
+      label: "API Key",
       sensitive: true,
       placeholder: "sk-proj-...",
-      help: "API key for OpenAI embeddings (or use ${OPENAI_API_KEY})",
+      help: "API key for OpenAI or Gemini embeddings (or use ${OPENAI_API_KEY} / ${GOOGLE_API_KEY})",
     },
     "embedding.baseUrl": {
       label: "Base URL",
@@ -155,7 +165,13 @@ export const memoryConfigSchema = {
     "embedding.model": {
       label: "Embedding Model",
       placeholder: DEFAULT_MODEL,
-      help: "OpenAI embedding model to use",
+      help: "OpenAI or Google embedding model to use",
+    },
+    "embedding.provider": {
+      label: "Provider",
+      placeholder: "openai",
+      help: "API Provider (openai or google). Auto-detected for known models.",
+      advanced: true,
     },
     dbPath: {
       label: "Database Path",

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -114,9 +114,13 @@ export const memoryConfigSchema = {
     const model = resolveEmbeddingModel(embedding);
     
     // Auto-detect Google provider if model is a known Google model and provider isn't explicitly set
-    let provider = typeof embedding.provider === "string" ? embedding.provider : "openai";
-    if (model.includes("text-embedding-004") || model.includes("gemini-embedding-001") || model.startsWith("models/")) {
-      provider = "google";
+    let provider = typeof embedding.provider === "string" ? embedding.provider : undefined;
+    if (!provider) {
+      if (model.includes("text-embedding-004") || model.includes("gemini-embedding-001") || model.startsWith("models/")) {
+        provider = "google";
+      } else {
+        provider = "openai";
+      }
     }
 
     const captureMaxChars =

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -157,32 +157,137 @@ class MemoryDB {
 }
 
 // ============================================================================
-// OpenAI Embeddings
 // ============================================================================
 
-class Embeddings {
+// Embeddings Providers
+
+// ============================================================================
+
+
+
+interface IEmbeddings {
+
+  embed(text: string): Promise<number[]>;
+
+}
+
+
+
+class OpenAIEmbeddings implements IEmbeddings {
+
   private client: OpenAI;
 
+
+
   constructor(
+
     apiKey: string,
+
     private model: string,
+
     baseUrl?: string,
+
     private dimensions?: number,
+
   ) {
+
     this.client = new OpenAI({ apiKey, baseURL: baseUrl });
+
   }
 
+
+
   async embed(text: string): Promise<number[]> {
+
     const params: { model: string; input: string; dimensions?: number } = {
+
       model: this.model,
+
       input: text,
+
     };
+
     if (this.dimensions) {
+
       params.dimensions = this.dimensions;
+
     }
+
     const response = await this.client.embeddings.create(params);
+
     return response.data[0].embedding;
+
   }
+
+}
+
+
+
+class GoogleEmbeddings implements IEmbeddings {
+
+  private apiKey: string;
+
+  private model: string;
+
+
+
+  constructor(apiKey: string, model: string) {
+
+    this.apiKey = apiKey;
+
+    this.model = model.startsWith("models/") ? model : `models/${model}`;
+
+  }
+
+
+
+  async embed(text: string): Promise<number[]> {
+
+    const url = `https://generativelanguage.googleapis.com/v1beta/${this.model}:embedContent?key=${this.apiKey}`;
+
+    const response = await fetch(url, {
+
+      method: "POST",
+
+      headers: { "Content-Type": "application/json" },
+
+      body: JSON.stringify({
+
+        model: this.model,
+
+        content: { parts: [{ text }] },
+
+      }),
+
+    });
+
+
+
+    if (!response.ok) {
+
+      const errorText = await response.text();
+
+      throw new Error(`Google Embeddings API error: ${response.status} ${response.statusText} - ${errorText}`);
+
+    }
+
+
+
+    const data = await (response.json() as Promise<any>);
+
+    if (!data.embedding || !data.embedding.values) {
+
+      throw new Error(`Google Embeddings API returned invalid response format: ${JSON.stringify(data)}`);
+
+    }
+
+
+
+    return data.embedding.values;
+
+  }
+
+}
 }
 
 // ============================================================================
@@ -303,7 +408,7 @@ const memoryPlugin = {
 
     const vectorDim = dimensions ?? vectorDimsForModel(model);
     const db = new MemoryDB(resolvedDbPath, vectorDim);
-    const embeddings = new Embeddings(apiKey, model, baseUrl, dimensions);
+    const embeddings: IEmbeddings = cfg.embedding.provider === "google" ? new GoogleEmbeddings(apiKey, model) : new OpenAIEmbeddings(apiKey, model, baseUrl, dimensions);
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -243,13 +243,13 @@ class GoogleEmbeddings implements IEmbeddings {
 
   async embed(text: string): Promise<number[]> {
 
-    const url = `https://generativelanguage.googleapis.com/v1beta/${this.model}:embedContent?key=${this.apiKey}`;
+    const url = `https://generativelanguage.googleapis.com/v1beta/${this.model}:embedContent`;
 
     const response = await fetch(url, {
 
       method: "POST",
 
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "x-goog-api-key": this.apiKey },
 
       body: JSON.stringify({
 
@@ -287,7 +287,6 @@ class GoogleEmbeddings implements IEmbeddings {
 
   }
 
-}
 }
 
 // ============================================================================


### PR DESCRIPTION
This PR adds native support for Google Gemini embeddings (e.g. `gemini-embedding-001`, `text-embedding-004`) to the `memory-lancedb` plugin alongside the existing OpenAI embeddings.

### Changes:
- Updated `config.ts` to auto-detect `provider: "google"` for known Gemini models and added their vector dimensions (`768`).
- Refactored `Embeddings` into an `IEmbeddings` interface with `OpenAIEmbeddings` and `GoogleEmbeddings` implementations.
- Modified the plugin registration to initialize the correct embedding provider based on the config.

### Motivation
This allows users to use Google Gemini for long-term memory embeddings, saving on OpenAI quota/costs.