### PR TITLE
docs(plugins): add ClawPool community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,11 +45,6 @@ Use this format when adding entries:
 
 ## Listed plugins
 
-- **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
-  npm: `@icesword760/openclaw-wechat`
-  repo: `https://github.com/icesword0760/openclaw-wechat`
-  install: `openclaw plugins install @icesword760/openclaw-wechat`
-
 - **ClawPool** — ClawPool channel transport and onboarding plugin for OpenClaw, with a bundled skill for registration, login, API-agent bootstrap, and channel setup.
   npm: `@dhfpub/clawpool`
   repo: `https://github.com/askie/aibot/tree/main/openclaw_plugins/clawpool`
@@ -59,3 +54,8 @@ Use this format when adding entries:
   npm: `@dhfpub/clawpool-admin`
   repo: `https://github.com/askie/aibot/tree/main/openclaw_plugins/clawpool-admin`
   install: `openclaw plugins install @dhfpub/clawpool-admin`
+
+- **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
+  npm: `@icesword760/openclaw-wechat`
+  repo: `https://github.com/icesword0760/openclaw-wechat`
+  install: `openclaw plugins install @icesword760/openclaw-wechat`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,13 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **ClawPool** — ClawPool channel transport and onboarding plugin for OpenClaw, with a bundled skill for registration, login, API-agent bootstrap, and channel setup.
+  npm: `@dhfpub/clawpool`
+  repo: `https://github.com/askie/aibot/tree/main/openclaw_plugins/clawpool`
+  install: `openclaw plugins install @dhfpub/clawpool`
+
+- **ClawPool Admin** — Typed ClawPool group governance and API-agent admin tools for OpenClaw. Requires `@dhfpub/clawpool` and a configured `channels.clawpool` first.
+  npm: `@dhfpub/clawpool-admin`
+  repo: `https://github.com/askie/aibot/tree/main/openclaw_plugins/clawpool-admin`
+  install: `openclaw plugins install @dhfpub/clawpool-admin`


### PR DESCRIPTION
## Summary
- add `@dhfpub/clawpool` to the community plugins list
- add `@dhfpub/clawpool-admin` to the community plugins list

## Packages
- `@dhfpub/clawpool` `0.2.1`
- `@dhfpub/clawpool-admin` `0.1.2`

## Dependency notes
- `@dhfpub/clawpool` is the channel transport package and the package users install first
- `@dhfpub/clawpool` also bundles the onboarding skill for registration, login, API-agent bootstrap, and channel setup
- `@dhfpub/clawpool-admin` is intentionally separate and depends on an already configured `channels.clawpool`
- recommended order: install `@dhfpub/clawpool` -> configure `channels.clawpool` -> install `@dhfpub/clawpool-admin` if group/admin tools are needed
- for the admin tool path, OpenClaw also needs `tools.alsoAllow` to include `message`, `clawpool_group`, and `clawpool_agent_admin`, with `tools.sessions.visibility = agent`

## Verification
- `npm view @dhfpub/clawpool version dist-tags --registry=https://registry.npmjs.org`
- `npm view @dhfpub/clawpool-admin version dist-tags --registry=https://registry.npmjs.org`
- `openclaw plugins install @dhfpub/clawpool`
- `openclaw plugins install @dhfpub/clawpool-admin`

## Repos
- `https://github.com/askie/aibot/tree/main/openclaw_plugins/clawpool`
- `https://github.com/askie/aibot/tree/main/openclaw_plugins/clawpool-admin`

## Maintainer
- GitHub: `@askie`
- Issues: `https://github.com/askie/aibot/issues`