### PR TITLE
BlueBubbles: prefer iMessage over SMS when both DM threads exist

### DIFF
--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -321,6 +321,43 @@ describe("send", () => {
       expect(result).toBe("SMS;-;+15551234567");
     });
 
+    it("respects explicit imessage: target preference when both chats exist", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  guid: "SMS;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+                {
+                  guid: "iMessage;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "imessage",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      expect(result).toBe("iMessage;-;+15551234567");
+    });
+
     it("returns null when chat not found", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -247,6 +247,80 @@ describe("send", () => {
       expect(result).toBeNull();
     });
 
+    it("prefers iMessage chat over SMS when both exist for same handle", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  guid: "SMS;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+                {
+                  guid: "iMessage;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "auto",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      expect(result).toBe("iMessage;-;+15551234567");
+    });
+
+    it("respects explicit sms: target preference when both chats exist", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  guid: "iMessage;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+                {
+                  guid: "SMS;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "sms",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      expect(result).toBe("SMS;-;+15551234567");
+    });
+
     it("returns null when chat not found", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -159,6 +159,17 @@ function extractChatIdentifierFromChatGuid(chatGuid: string): string | null {
   return identifier ? identifier : null;
 }
 
+function extractServiceFromChatGuid(chatGuid: string): "imessage" | "sms" | "other" {
+  const service = chatGuid.split(";")[0]?.trim().toLowerCase();
+  if (service === "imessage") {
+    return "imessage";
+  }
+  if (service === "sms") {
+    return "sms";
+  }
+  return "other";
+}
+
 function extractParticipantAddresses(chat: BlueBubblesChatRecord): string[] {
   const raw =
     (Array.isArray(chat.participants) ? chat.participants : null) ??
@@ -238,7 +249,14 @@ export async function resolveChatGuidForTarget(params: {
     params.target.kind === "chat_identifier" ? params.target.chatIdentifier : null;
 
   const limit = 500;
-  let participantMatch: string | null = null;
+  const preferredService = params.target.kind === "handle" ? params.target.service : "auto";
+  let imessageDirectMatch: string | null = null;
+  let smsDirectMatch: string | null = null;
+  let otherDirectMatch: string | null = null;
+  let imessageParticipantMatch: string | null = null;
+  let smsParticipantMatch: string | null = null;
+  let otherParticipantMatch: string | null = null;
+
   for (let offset = 0; offset < 5000; offset += limit) {
     const chats = await queryChats({
       baseUrl: params.baseUrl,
@@ -287,11 +305,24 @@ export async function resolveChatGuidForTarget(params: {
       }
       if (normalizedHandle) {
         const guid = extractChatGuid(chat);
+        const service = guid ? extractServiceFromChatGuid(guid) : "other";
         const directHandle = guid ? extractHandleFromChatGuid(guid) : null;
-        if (directHandle && directHandle === normalizedHandle) {
-          return guid;
+        if (directHandle && directHandle === normalizedHandle && guid) {
+          if (service === "imessage") {
+            imessageDirectMatch ??= guid;
+            if (preferredService === "imessage") {
+              return guid;
+            }
+          } else if (service === "sms") {
+            smsDirectMatch ??= guid;
+            if (preferredService === "sms") {
+              return guid;
+            }
+          } else {
+            otherDirectMatch ??= guid;
+          }
         }
-        if (!participantMatch && guid) {
+        if (guid) {
           // Only consider DM chats (`;-;` separator) as participant matches.
           // Group chats (`;+;` separator) should never match when searching by handle/phone.
           // This prevents routing "send to +1234567890" to a group chat that contains that number.
@@ -301,14 +332,56 @@ export async function resolveChatGuidForTarget(params: {
               normalizeBlueBubblesHandle(entry),
             );
             if (participants.includes(normalizedHandle)) {
-              participantMatch = guid;
+              if (service === "imessage") {
+                imessageParticipantMatch ??= guid;
+                if (preferredService === "imessage") {
+                  return guid;
+                }
+              } else if (service === "sms") {
+                smsParticipantMatch ??= guid;
+                if (preferredService === "sms") {
+                  return guid;
+                }
+              } else {
+                otherParticipantMatch ??= guid;
+              }
             }
           }
         }
       }
     }
   }
-  return participantMatch;
+
+  if (preferredService === "imessage") {
+    return (
+      imessageDirectMatch ??
+      imessageParticipantMatch ??
+      otherDirectMatch ??
+      otherParticipantMatch ??
+      smsDirectMatch ??
+      smsParticipantMatch
+    );
+  }
+  if (preferredService === "sms") {
+    return (
+      smsDirectMatch ??
+      smsParticipantMatch ??
+      otherDirectMatch ??
+      otherParticipantMatch ??
+      imessageDirectMatch ??
+      imessageParticipantMatch
+    );
+  }
+
+  // Default behavior for "auto": prefer iMessage over SMS when both exist.
+  return (
+    imessageDirectMatch ??
+    imessageParticipantMatch ??
+    otherDirectMatch ??
+    otherParticipantMatch ??
+    smsDirectMatch ??
+    smsParticipantMatch
+  );
 }
 
 /**

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -334,14 +334,8 @@ export async function resolveChatGuidForTarget(params: {
             if (participants.includes(normalizedHandle)) {
               if (service === "imessage") {
                 imessageParticipantMatch ??= guid;
-                if (preferredService === "imessage") {
-                  return guid;
-                }
               } else if (service === "sms") {
                 smsParticipantMatch ??= guid;
-                if (preferredService === "sms") {
-                  return guid;
-                }
               } else {
                 otherParticipantMatch ??= guid;
               }


### PR DESCRIPTION
## Summary
Fix BlueBubbles handle target resolution so dual-thread contacts prefer iMessage over SMS by default.

## Problem
When both DM chats exist for the same handle:
- iMessage;-;+1555...
- SMS;-;+1555...

resolution could pick SMS first, causing green-bubble routing even for imessage:/auto workflows.

## Changes
- In extensions/bluebubbles/src/send.ts:
  - Track candidate matches by service (iMessage, SMS, other) for both direct-handle and participant-based DM matches.
  - Respect explicit preference first:
    - imessage: -> prefer iMessage matches
    - sms: -> prefer SMS matches
  - For auto, prefer iMessage over SMS.
- In extensions/bluebubbles/src/send.test.ts:
  - Add regression test for dual-thread handle preferring iMessage in auto mode.
  - Add test ensuring explicit sms: preference is still honored.

## Notes
- Repro and examples are sanitized (no real handles).
- Local targeted test execution was blocked in this environment due missing pnpm/node_modules bootstrap; tests added for CI coverage.

Closes #48669
