### PR TITLE
fix: suppress heartbeat re-entry from exec-event wakes + add interval floor

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { startHeartbeatRunner } from "./heartbeat-runner.js";
+import { MIN_HEARTBEAT_INTERVAL_MS, resolveHeartbeatIntervalMs } from "./heartbeat-summary.js";
 import { requestHeartbeatNow, resetHeartbeatWakeStateForTests } from "./heartbeat-wake.js";
 
 describe("startHeartbeatRunner", () => {
@@ -255,6 +256,24 @@ describe("startHeartbeatRunner", () => {
     });
 
     runner.stop();
+  });
+
+  it("clamps heartbeat interval to the minimum floor (#48723)", () => {
+    // A user who sets every: "1s" should not get sub-minute heartbeats.
+    const cfg = {
+      agents: { defaults: { heartbeat: { every: "1s" } } },
+    } as OpenClawConfig;
+    const ms = resolveHeartbeatIntervalMs(cfg);
+    expect(ms).toBe(MIN_HEARTBEAT_INTERVAL_MS);
+    expect(ms).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it("does not clamp intervals already above the floor", () => {
+    const cfg = {
+      agents: { defaults: { heartbeat: { every: "5m" } } },
+    } as OpenClawConfig;
+    const ms = resolveHeartbeatIntervalMs(cfg);
+    expect(ms).toBe(5 * 60_000);
   });
 
   it("does not fan out to unrelated agents for session-scoped exec wakes", async () => {

--- a/src/infra/heartbeat-summary.ts
+++ b/src/infra/heartbeat-summary.ts
@@ -23,6 +23,13 @@ export type HeartbeatSummary = {
 
 const DEFAULT_HEARTBEAT_TARGET = "none";
 
+/**
+ * Minimum heartbeat interval (60 s). Prevents misconfiguration from causing
+ * runaway token burn — a user who sets `every: "1s"` would otherwise trigger
+ * continuous LLM calls that exhaust their API balance in minutes. (#48723)
+ */
+export const MIN_HEARTBEAT_INTERVAL_MS = 60_000;
+
 function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
   const list = cfg.agents?.list ?? [];
   return list.some((entry) => Boolean(entry?.heartbeat));
@@ -66,7 +73,7 @@ export function resolveHeartbeatIntervalMs(
   if (ms <= 0) {
     return null;
   }
-  return ms;
+  return Math.max(ms, MIN_HEARTBEAT_INTERVAL_MS);
 }
 
 export function resolveHeartbeatSummaryForAgent(

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -283,6 +283,70 @@ describe("heartbeat-wake", () => {
     });
   });
 
+  it("suppresses exec-event wakes while a heartbeat run is in progress (#48723)", async () => {
+    vi.useFakeTimers();
+
+    // Simulate a long-running heartbeat: handler takes 500ms to resolve.
+    // During that time, an exec-event wake arrives (from the heartbeat's own
+    // tool call completing). It should be silently dropped.
+    let resolveRun: () => void;
+    const runPromise = new Promise<void>((r) => {
+      resolveRun = r;
+    });
+    const handler = vi
+      .fn()
+      .mockReturnValue(runPromise.then(() => ({ status: "ran" as const, durationMs: 500 })));
+    setHeartbeatWakeHandler(handler);
+
+    // Trigger initial heartbeat
+    requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // While the heartbeat is running, an exec-event fires (tool completion).
+    // This should be suppressed — no pending wake should be queued.
+    requestHeartbeatNow({ reason: "exec-event", coalesceMs: 0 });
+
+    // Finish the heartbeat run
+    resolveRun!();
+    await vi.advanceTimersByTimeAsync(1);
+
+    // Give plenty of time for any queued wake to fire
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // Only the original heartbeat should have run — no re-entry
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("still allows non-exec wakes while heartbeat is running", async () => {
+    vi.useFakeTimers();
+
+    let resolveRun: () => void;
+    const runPromise = new Promise<void>((r) => {
+      resolveRun = r;
+    });
+    const handler = vi
+      .fn()
+      .mockReturnValueOnce(runPromise.then(() => ({ status: "ran" as const, durationMs: 500 })))
+      .mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // A cron wake during the heartbeat run should NOT be suppressed
+    requestHeartbeatNow({ reason: "cron:job-1", coalesceMs: 0 });
+
+    resolveRun!();
+    await vi.advanceTimersByTimeAsync(1);
+
+    // The cron wake should have been queued and fired after the run finished
+    await vi.advanceTimersByTimeAsync(500);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1]?.[0]).toEqual({ reason: "cron:job-1" });
+  });
+
   it("executes distinct targeted wakes queued in the same coalescing window", async () => {
     vi.useFakeTimers();
     const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -241,6 +241,16 @@ export function requestHeartbeatNow(opts?: {
   agentId?: string;
   sessionKey?: string;
 }) {
+  // When a heartbeat run is in progress, its own tool calls (exec, read, etc.)
+  // fire exec-event wakes on completion. Allowing these through creates a
+  // re-entry loop: heartbeat → tool call → exec-event wake → heartbeat → …
+  // The loop burns tokens at ~30 s intervals until the API balance is exhausted.
+  // Since no user commands run while heartbeat holds the main lane, any
+  // exec-event during `running` is guaranteed to originate from the heartbeat
+  // itself and can be safely suppressed. (#48723)
+  if (running && opts?.reason === "exec-event") {
+    return;
+  }
   queuePendingWakeReason({
     reason: opts?.reason,
     agentId: opts?.agentId,


### PR DESCRIPTION
## Problem

Ran into this while debugging a runaway session — heartbeat was firing every ~30s non-stop and burned through ¥323 in about 75 minutes (roughly 60× normal rate). The OpenRouter logs showed a clean repeating pattern: heartbeat run → bash tool call → exec-event wake → heartbeat run → …

Root cause: `requestHeartbeatNow()` in `heartbeat-wake.ts` doesn't distinguish between exec-event wakes from *user* tool calls and exec-event wakes from the *heartbeat's own* tool calls. When the heartbeat handler runs a bash/read/write tool, the tool completion fires `requestHeartbeatNow({ reason: "exec-event" })` (see `bash-tools.exec-runtime.ts:224,286`). Since the heartbeat holds the main lane, this queues a new wake that fires immediately after the current run finishes — creating an infinite loop.

## Fix

Two complementary guards, both intentionally minimal:

### 1. Re-entry suppression (`heartbeat-wake.ts`)

```typescript
if (running && opts?.reason === "exec-event") {
  return;
}
```

While a heartbeat run is in progress, no user commands can execute (heartbeat holds the main lane), so any `exec-event` during `running === true` is guaranteed to originate from the heartbeat itself. Safe to drop.

Non-exec wakes (cron, interval, manual) are still allowed through — they queue normally and fire after the current run completes.

### 2. Minimum interval floor (`heartbeat-summary.ts`)

```typescript
export const MIN_HEARTBEAT_INTERVAL_MS = 60_000;
// ...
return Math.max(ms, MIN_HEARTBEAT_INTERVAL_MS);
```

Clamps any configured heartbeat interval to ≥ 60s. A user who accidentally sets `every: "1s"` would otherwise get continuous LLM calls. This is a safety net, not the primary fix.

## Tests

4 regression tests added:

- `suppresses exec-event wakes while a heartbeat run is in progress` — simulates a long-running heartbeat, fires an exec-event mid-run, verifies no re-entry
- `still allows non-exec wakes while heartbeat is running` — verifies cron wakes are not suppressed (important: we only block exec-events, not everything)
- `clamps heartbeat interval to the minimum floor` — `every: "1s"` → 60000ms
- `does not clamp intervals already above the floor` — `every: "5m"` → 300000ms

## Changed files

| File | Change |
|------|--------|
| `src/infra/heartbeat-wake.ts` | Re-entry guard in `requestHeartbeatNow()` |
| `src/infra/heartbeat-summary.ts` | `MIN_HEARTBEAT_INTERVAL_MS` constant + clamp in `resolveHeartbeatIntervalMs()` |
| `src/infra/heartbeat-wake.test.ts` | 2 regression tests |
| `src/infra/heartbeat-runner.scheduler.test.ts` | 2 interval floor tests |

Closes #48723