### PR TITLE
agents: repair empty Gemini tool names on every outbound request

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -79,7 +79,10 @@ import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 import { isXaiProvider } from "../../schema/clean-for-xai.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
-import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
+import {
+  sanitizeToolCallInputs,
+  sanitizeToolUseResultPairing,
+} from "../../session-transcript-repair.js";
 import {
   acquireSessionWriteLock,
   resolveSessionLockMaxHoldFromTimeout,
@@ -717,7 +720,11 @@ function trimWhitespaceFromToolCallNamesInMessage(
     if (!block || typeof block !== "object") {
       continue;
     }
-    const typedBlock = block as { type?: unknown; name?: unknown; id?: unknown };
+    const typedBlock = block as {
+      type?: unknown;
+      name?: unknown;
+      id?: unknown;
+    };
     if (!isToolCallBlockType(typedBlock.type)) {
       continue;
     }
@@ -1143,7 +1150,10 @@ function wrapStreamDecodeXaiToolCallArguments(
         async next() {
           const result = await iterator.next();
           if (!result.done && result.value && typeof result.value === "object") {
-            const event = result.value as { partial?: unknown; message?: unknown };
+            const event = result.value as {
+              partial?: unknown;
+              message?: unknown;
+            };
             decodeXaiToolCallArgumentsInMessage(event.partial);
             decodeXaiToolCallArgumentsInMessage(event.message);
           }
@@ -1315,7 +1325,10 @@ export function buildAfterTurnRuntimeContext(params: {
   };
 }
 
-function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
+function summarizeMessagePayload(msg: AgentMessage): {
+  textChars: number;
+  imageBlocks: number;
+} {
   const content = (msg as { content?: unknown }).content;
   if (typeof content === "string") {
     return { textChars: content.length, imageBlocks: 0 };
@@ -1440,7 +1453,10 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
-        warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+        warn: makeBootstrapWarn({
+          sessionLabel,
+          warn: (message) => log.warn(message),
+        }),
         contextMode: params.bootstrapContextMode,
         runKind: params.bootstrapContextRunKind,
       });
@@ -1566,7 +1582,10 @@ export async function runEmbeddedAttempt(
       tools: effectiveTools,
       clientTools,
     });
-    logToolSchemasForGoogle({ tools: effectiveTools, provider: params.provider });
+    logToolSchemasForGoogle({
+      tools: effectiveTools,
+      provider: params.provider,
+    });
 
     const machineName = await getMachineDisplayName();
     const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
@@ -1828,7 +1847,10 @@ export async function runEmbeddedAttempt(
       });
 
       // Add client tools (OpenResponses hosted tools) to customTools
-      let clientToolCallDetected: { name: string; params: Record<string, unknown> } | null = null;
+      let clientToolCallDetected: {
+        name: string;
+        params: Record<string, unknown>;
+      } | null = null;
       const clientToolLoopDetection = resolveToolLoopDetectionConfig({
         cfg: params.config,
         agentId: sessionAgentId,
@@ -2027,6 +2049,40 @@ export async function runEmbeddedAttempt(
         };
       }
 
+      // Gemini 3 (preview) can return functionCall blocks with empty name fields.
+      // sanitizeSessionHistory only runs at attempt start; tool call → result cycles
+      // within the agent loop bypass it. Re-run tool name repair on every outbound
+      // request so empty-name tool calls and their orphaned tool results are dropped
+      // before they reach the Gemini API and trigger a 400 INVALID_ARGUMENT error:
+      //   "GenerateContentRequest.contents[N].parts[0].function_response.name:
+      //    Name cannot be empty."
+      // See: https://github.com/openclaw/openclaw/issues/16263
+      if (transcriptPolicy.repairToolNamesOnEveryTurn) {
+        const inner = activeSession.agent.streamFn;
+        const repairAllowedToolNames = allowedToolNames;
+        activeSession.agent.streamFn = (model, context, options) => {
+          const ctx = context as unknown as { messages?: unknown };
+          const messages = ctx?.messages;
+          if (!Array.isArray(messages)) {
+            return inner(model, context, options);
+          }
+          // Drop tool calls with empty/invalid names from assistant messages, then
+          // drop any orphaned tool results whose call was removed above.
+          const repaired1 = sanitizeToolCallInputs(messages as AgentMessage[], {
+            allowedToolNames: repairAllowedToolNames,
+          });
+          const repaired2 = sanitizeToolUseResultPairing(repaired1);
+          if (repaired2 === messages) {
+            return inner(model, context, options);
+          }
+          const nextContext = {
+            ...(context as unknown as Record<string, unknown>),
+            messages: repaired2,
+          } as unknown;
+          return inner(model, nextContext as typeof context, options);
+        };
+      }
+
       if (
         params.model.api === "openai-responses" ||
         params.model.api === "openai-codex-responses"
@@ -2052,7 +2108,9 @@ export async function runEmbeddedAttempt(
 
       const innerStreamFn = activeSession.agent.streamFn;
       activeSession.agent.streamFn = (model, context, options) => {
-        const signal = runAbortController.signal as AbortSignal & { reason?: unknown };
+        const signal = runAbortController.signal as AbortSignal & {
+          reason?: unknown;
+        };
         if (yieldDetected && signal.aborted && signal.reason === "sessions_yield") {
           return createYieldAbortedResponse(model) as unknown as Awaited<
             ReturnType<typeof innerStreamFn>
@@ -2536,7 +2594,11 @@ export async function runEmbeddedAttempt(
           // Only pass images option if there are actually images to pass
           // This avoids potential issues with models that don't expect the images parameter
           if (imageResult.images.length > 0) {
-            await abortable(activeSession.prompt(effectivePrompt, { images: imageResult.images }));
+            await abortable(
+              activeSession.prompt(effectivePrompt, {
+                images: imageResult.images,
+              }),
+            );
           } else {
             await abortable(activeSession.prompt(effectivePrompt));
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2066,15 +2066,16 @@ export async function runEmbeddedAttempt(
           if (!Array.isArray(messages)) {
             return inner(model, context, options);
           }
-          // Drop tool calls with empty/invalid names from assistant messages, then
-          // drop any orphaned tool results whose call was removed above.
+          // Drop tool calls with empty/invalid names from assistant messages.
           const repaired1 = sanitizeToolCallInputs(messages as AgentMessage[], {
             allowedToolNames: repairAllowedToolNames,
           });
-          const repaired2 = sanitizeToolUseResultPairing(repaired1);
-          if (repaired2 === messages) {
+          // Fast path: nothing was dropped, no further work needed.
+          if (repaired1 === messages) {
             return inner(model, context, options);
           }
+          // Drop the now-orphaned tool results whose calls were removed above.
+          const repaired2 = sanitizeToolUseResultPairing(repaired1);
           const nextContext = {
             ...(context as unknown as Record<string, unknown>),
             messages: repaired2,

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -111,7 +111,10 @@ describe("sanitizeToolUseResultPairing", () => {
 
   it("drops duplicate tool results for the same id across the transcript", () => {
     const input = buildDuplicateToolResultInput({
-      middleMessage: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      middleMessage: {
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+      },
       secondText: "second (duplicate)",
     });
 
@@ -237,6 +240,39 @@ describe("sanitizeToolUseResultPairing", () => {
     // No synthetic results should be added
     expect(result.added).toHaveLength(0);
   });
+
+  it("drops empty-name tool calls and their paired tool results (Gemini #16263)", () => {
+    // Gemini 3 preview can return functionCall blocks with empty name fields.
+    // sanitizeToolCallInputs drops them from the assistant message; the subsequent
+    // sanitizeToolUseResultPairing then drops the now-orphaned tool result.
+    // This combination prevents "function_response.name: Name cannot be empty" 400s.
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "_1234567890_1", name: "", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "_1234567890_1",
+        toolName: "",
+        content: [{ type: "text", text: "result" }],
+        isError: false,
+      },
+      { role: "user", content: "next turn" },
+    ]);
+
+    // Step 1: sanitizeToolCallInputs drops the empty-name tool call.
+    // The assistant message has no remaining content blocks, so it is also dropped.
+    const afterInputRepair = sanitizeToolCallInputs(input);
+    expect(afterInputRepair.some((m) => m.role === "assistant")).toBe(false);
+
+    // Step 2: sanitizeToolUseResultPairing drops the now-orphaned tool result.
+    const result = repairToolUseResultPairing(afterInputRepair);
+    expect(result.droppedOrphanCount).toBe(1);
+    expect(result.messages.some((m) => m.role === "toolResult")).toBe(false);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
+  });
 });
 
 describe("sanitizeToolCallInputs", () => {
@@ -331,7 +367,12 @@ describe("sanitizeToolCallInputs", () => {
         role: "assistant",
         content: [
           { type: "text", text: "before" },
-          { type: "toolUse", id: "call_ok", name: "read", input: { path: "a" } },
+          {
+            type: "toolUse",
+            id: "call_ok",
+            name: "read",
+            input: { path: "a" },
+          },
           { type: "toolCall", id: "call_drop", name: "read" },
         ],
       },
@@ -354,7 +395,14 @@ describe("sanitizeToolCallInputs", () => {
     },
     {
       name: "trims trailing whitespace from tool names",
-      content: [{ type: "toolUse", id: "call_1", name: "exec ", input: { command: "ls" } }],
+      content: [
+        {
+          type: "toolUse",
+          id: "call_1",
+          name: "exec ",
+          input: { command: "ls" },
+        },
+      ],
       options: undefined,
       expectedNames: ["exec"],
     },
@@ -437,13 +485,20 @@ describe("sanitizeToolCallInputs", () => {
   });
   it("preserves other block properties when trimming tool names", () => {
     const toolCalls = sanitizeAssistantToolCalls([
-      { type: "toolCall", id: "call_1", name: " read ", arguments: { path: "/tmp/test" } },
+      {
+        type: "toolCall",
+        id: "call_1",
+        name: " read ",
+        arguments: { path: "/tmp/test" },
+      },
     ]);
 
     expect(toolCalls).toHaveLength(1);
     expect((toolCalls[0] as { name?: unknown }).name).toBe("read");
     expect((toolCalls[0] as { id?: unknown }).id).toBe("call_1");
-    expect((toolCalls[0] as { arguments?: unknown }).arguments).toEqual({ path: "/tmp/test" });
+    expect((toolCalls[0] as { arguments?: unknown }).arguments).toEqual({
+      path: "/tmp/test",
+    });
   });
 });
 
@@ -457,7 +512,11 @@ describe("stripToolResultDetails", () => {
         content: [{ type: "text", text: "ok" }],
         details: { internal: true },
       },
-      { role: "assistant", content: [{ type: "text", text: "keep me" }], details: { no: "touch" } },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "keep me" }],
+        details: { no: "touch" },
+      },
       { role: "user", content: "hello" },
     ]);
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -25,6 +25,29 @@ describe("resolveTranscriptPolicy", () => {
     });
   });
 
+  it("enables repairToolNamesOnEveryTurn for Google APIs", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "google",
+      modelId: "gemini-3-flash-preview",
+      modelApi: "google-generative-ai",
+    });
+    expect(policy.repairToolNamesOnEveryTurn).toBe(true);
+  });
+
+  it("disables repairToolNamesOnEveryTurn for non-Google providers", () => {
+    expect(
+      resolveTranscriptPolicy({
+        provider: "anthropic",
+        modelApi: "anthropic-messages",
+      }).repairToolNamesOnEveryTurn,
+    ).toBe(false);
+    expect(
+      resolveTranscriptPolicy({ provider: "openai", modelApi: "openai" })
+        .repairToolNamesOnEveryTurn,
+    ).toBe(false);
+    expect(resolveTranscriptPolicy({ provider: "mistral" }).repairToolNamesOnEveryTurn).toBe(false);
+  });
+
   it("enables sanitizeToolCallIds for Mistral provider", () => {
     const policy = resolveTranscriptPolicy({
       provider: "mistral",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -29,6 +29,11 @@ export type TranscriptPolicy = {
   validateGeminiTurns: boolean;
   validateAnthropicTurns: boolean;
   allowSyntheticToolResults: boolean;
+  // Re-run tool name repair on every outbound turn. Gemini 3 can return functionCall blocks
+  // with empty name fields (issue #16263); sanitizeSessionHistory only runs at attempt start,
+  // so new toolResult messages created mid-attempt bypass it. This flag enables a streamFn
+  // wrapper that drops empty-name tool calls + orphaned results before each API request.
+  repairToolNamesOnEveryTurn: boolean;
 };
 
 const OPENAI_MODEL_APIS = new Set([
@@ -86,7 +91,10 @@ export function resolveTranscriptPolicy(params: {
   // Anthropic Claude endpoints can reject replayed `thinking` blocks unless the
   // original signatures are preserved byte-for-byte. Drop them at send-time to
   // keep persisted sessions usable across follow-up turns.
-  const dropThinkingBlocks = shouldDropThinkingBlocksForModel({ provider, modelId });
+  const dropThinkingBlocks = shouldDropThinkingBlocksForModel({
+    provider,
+    modelId,
+  });
 
   const needsNonImageSanitize =
     isGoogle || isAnthropic || isMistral || shouldSanitizeGeminiThoughtSignaturesForProvider;
@@ -123,5 +131,6 @@ export function resolveTranscriptPolicy(params: {
     validateGeminiTurns: !isOpenAi && (isGoogle || isStrictOpenAiCompatible),
     validateAnthropicTurns: !isOpenAi && (isAnthropic || isStrictOpenAiCompatible),
     allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
+    repairToolNamesOnEveryTurn: isGoogle,
   };
 }


### PR DESCRIPTION
## Summary

- **Problem:** Gemini 3 (preview) can return `functionCall` blocks with empty `name` fields. When this happens, `pi-ai` stores `name: ""` in the assistant message and `pi-agent-core` creates a `toolResult` with `toolName: ""`. On the next turn, `google-shared.js` serializes this as `functionResponse.name: ""`. Gemini rejects the entire request with HTTP 400 INVALID_ARGUMENT:
  ```
  GenerateContentRequest.contents[N].parts[0].function_response.name: Name cannot be empty.
  ```
  In longer sessions, every subsequent turn in the same session fails — the empty-name entries accumulate in history and all get rejected together.
- **Why it matters:** Any user on a Gemini 3 model hitting a multi-tool session gets a hard 400 crash mid-conversation with no recovery path. Issue #16263.
- **Root cause:** `sanitizeSessionHistory` (which calls `sanitizeToolCallInputs` + `sanitizeToolUseResultPairing`) handles this case correctly, but it only runs **once at attempt start**. Tool call → result cycles within the agent loop build new messages and pass them directly to the provider, bypassing the repair.
- **What changed:** Added a `streamFn` wrapper (enabled via new `repairToolNamesOnEveryTurn` flag in `TranscriptPolicy`, set `true` for all Google model APIs) that re-runs `sanitizeToolCallInputs` + `sanitizeToolUseResultPairing` on every outbound request. Empty-name tool calls are dropped from the assistant message; the orphaned tool results are then dropped as well.
- **What did NOT change:** Non-Google providers are unaffected. No behavior change when all tool call names are valid. The fix is purely defensive.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution

## Linked Issue/PR

- Closes #16263
- Closes #47857
- Closes #46717
- Closes #43930
- Closes #41595

## User-visible / Behavior Changes

Google model sessions that previously crashed with "Name cannot be empty" 400 errors after the first tool call now recover gracefully — empty-name tool calls and their results are silently dropped, allowing the conversation to continue.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw gateway
- Model/provider: `google/gemini-3-flash-preview` via `google-generative-ai` API
- Integration/channel: Discord

### Steps

1. Configure OpenClaw with `google/gemini-3-flash-preview` as the primary model.
2. Send a message that causes the agent to use multiple tools (e.g., web search + a file read).
3. Observe subsequent turns in the same session.

### Expected

Conversation continues normally even after Gemini returns a function call with an empty name field.

### Actual (before fix)

```
LLM error: {
  "error": {
    "code": 400,
    "message": "* GenerateContentRequest.contents[2].parts[0].function_response.name: Name cannot be empty.
* GenerateContentRequest.contents[2].parts[1].function_response.name: Name cannot be empty.
* GenerateContentRequest.contents[4].parts[0].function_response.name: Name cannot be empty.
* GenerateContentRequest.contents[8].parts[0].function_response.name: Name cannot be empty.
...",
    "status": "INVALID_ARGUMENT"
  }
}
```

Every subsequent turn in the session accumulated more empty-name entries and continued to fail.

## Evidence

- [x] Failing test/log before + passing after

Regression test added: `"drops empty-name tool calls and their paired tool results (Gemini #16263)"` in `session-transcript-repair.test.ts`. Verifies the two-step repair pipeline correctly handles the empty-name scenario end-to-end.

Policy test added: `"enables repairToolNamesOnEveryTurn for Google APIs"` and `"disables repairToolNamesOnEveryTurn for non-Google providers"` in `transcript-policy.test.ts`.

Live verification: fix deployed on a local OpenClaw instance with `google/gemini-3-flash-preview`. Multi-turn tool use sessions that previously hard-crashed at turn 2+ now run to completion.

## Human Verification (required)

- Verified scenarios: multi-turn Gemini 3 Flash Preview session via Discord with tool use; confirmed 400 errors no longer occur
- Edge cases checked: Anthropic + OpenAI sessions unaffected (flag disabled for non-Google); empty-name tool calls correctly cleaned without dropping valid tool calls in the same message
- What I did not verify: Gemini 2.5 / Gemini 2.0 with the same edge case (they may not trigger empty-name function calls in practice)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `repairToolNamesOnEveryTurn: false` in `resolveTranscriptPolicy`
- Files/config to restore: `src/agents/transcript-policy.ts`
- Known bad symptoms: none expected; the wrapper is a no-op when all tool call names are valid

## Risks and Mitigations

- Risk: slight per-turn overhead from running `sanitizeToolCallInputs` + `sanitizeToolUseResultPairing` on every Google request
  - Mitigation: both functions return the input reference unchanged when no repair is needed (O(n) scan but no allocation), so the hot path is cheap

---

> 🤖 AI-assisted (Claude Sonnet 4.6 + human review). Fix was validated in live production before being cleaned up for upstream.