### PR TITLE
fix(message): treat zero poll duration as unset to prevent send misclassification

### DIFF
--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -23,14 +23,20 @@ describe("poll params", () => {
     },
   );
 
-  it("treats finite numeric poll params as poll creation intent", () => {
-    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(true);
+  it("treats positive finite numeric poll params as poll creation intent", () => {
     expect(hasPollCreationParams({ pollDurationSeconds: 60 })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "60" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "1e3" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationHours: Number.NaN })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: Infinity })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: "60abc" })).toBe(false);
+  });
+
+  it("does not treat zero duration as poll creation intent (#48730)", () => {
+    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationSeconds: 0 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: "0" })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationSeconds: "0" })).toBe(false);
   });
 
   it("treats string-encoded boolean poll params as poll creation intent when true", () => {

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -54,12 +54,13 @@ export function hasPollCreationParams(params: Record<string, unknown>): boolean 
       }
     }
     if (def.kind === "number") {
-      if (typeof value === "number" && Number.isFinite(value)) {
+      if (typeof value === "number" && Number.isFinite(value) && value !== 0) {
         return true;
       }
       if (typeof value === "string") {
         const trimmed = value.trim();
-        if (trimmed.length > 0 && Number.isFinite(Number(trimmed))) {
+        const num = Number(trimmed);
+        if (trimmed.length > 0 && Number.isFinite(num) && num !== 0) {
           return true;
         }
       }


### PR DESCRIPTION
## Summary

`hasPollCreationParams()` treated `pollDurationHours: 0` as valid poll creation intent. Since the tool schema defaults this field to `0`, every `message send` action to Feishu was misclassified as a poll and rejected with:

> Poll fields require action "poll"; use action "poll" instead of "send".

## Root Cause

In `poll-params.ts`, the `kind === "number"` branch returned `true` for any finite number — including `0`. When the message tool schema provides `pollDurationHours` with a default value of `0`, this zero bleeds into every send call and triggers the poll guard in `message-action-runner.ts`.

## Fix

Exclude zero (both numeric `0` and string `"0"`) from the finite-number check so that only explicitly positive durations signal poll creation intent. This aligns with how booleans are handled — only `true` triggers, not `false`.

## Changes

- `src/poll-params.ts`: Add `&& value !== 0` / `&& num !== 0` guards to the number kind check
- `src/poll-params.test.ts`: Update existing test expectation (`pollDurationHours: 0` → `false`), add dedicated test case for zero values (numeric and string)

## Testing

```
npx vitest run src/poll-params.test.ts
# 10 tests passed
```

Fixes #48730