### PR TITLE
feat(discord): expand allowed directories for file uploads

### DIFF
--- a/extensions/whatsapp/src/media.test.ts
+++ b/extensions/whatsapp/src/media.test.ts
@@ -474,16 +474,21 @@ describe("local media root guard", () => {
     );
   });
 
-  it("rejects default OpenClaw state per-agent workspace-* roots without explicit local roots", async () => {
+  it("allows default OpenClaw state per-agent workspace-* roots (glob pattern support)", async () => {
     const stateDir = resolveStateDir();
     const readFile = vi.fn(async () => Buffer.from("generated-media"));
 
+    // Should now allow workspace-* directories via the workspace-* glob pattern
     await expect(
       loadWebMedia(path.join(stateDir, "workspace-clawdy", "tmp", "render.bin"), {
         maxBytes: 1024 * 1024,
         readFile,
       }),
-    ).rejects.toMatchObject({ code: "path-not-allowed" });
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: undefined,
+      }),
+    );
   });
 
   it("allows per-agent workspace-* paths with explicit local roots", async () => {

--- a/extensions/whatsapp/src/media.ts
+++ b/extensions/whatsapp/src/media.ts
@@ -94,27 +94,27 @@ async function assertLocalMediaAllowed(
     resolved = path.resolve(mediaPath);
   }
 
-  // Hardening: the default allowlist includes the OpenClaw temp dir, and tests/CI may
-  // override the state dir into tmp. Avoid accidentally allowing per-agent
-  // `workspace-*` state roots via the temp-root prefix match; require explicit
-  // localRoots for those.
-  if (localRoots === undefined) {
-    const workspaceRoot = roots.find((root) => path.basename(root) === "workspace");
-    if (workspaceRoot) {
-      const stateDir = path.dirname(workspaceRoot);
-      const rel = path.relative(stateDir, resolved);
-      if (rel && !rel.startsWith("..") && !path.isAbsolute(rel)) {
-        const firstSegment = rel.split(path.sep)[0] ?? "";
-        if (firstSegment.startsWith("workspace-")) {
-          throw new LocalMediaAccessError(
-            "path-not-allowed",
-            `Local media path is not under an allowed directory: ${mediaPath}`,
-          );
-        }
-      }
-    }
-  }
+  // NOTE: Previously blocked workspace-* directories to prevent temp-root prefix matches.
+  // Now allows all workspace subdirectories since they are legitimate user workspaces.
+  // Users can further restrict via explicit localRoots if needed.
   for (const root of roots) {
+    // Handle glob patterns like "workspace-*"
+    if (root.includes("*")) {
+      const rootDir = path.dirname(root);
+      const pattern = path.basename(root);
+      // Convert simple glob pattern to regex
+      const regexPattern = "^" + pattern.replace(/\*/g, ".*") + "$";
+      const regex = new RegExp(regexPattern);
+      const pathRelativeToStateDir = path.relative(rootDir, resolved);
+      const firstSegment = pathRelativeToStateDir.split(path.sep)[0] ?? "";
+
+      if (regex.test(firstSegment)) {
+        return; // Matches the pattern, allow it
+      }
+      continue; // Try next root
+    }
+
+    // Standard exact path matching
     let resolvedRoot: string;
     try {
       resolvedRoot = await fs.realpath(root);
@@ -131,9 +131,10 @@ async function assertLocalMediaAllowed(
       return;
     }
   }
+  const allowedDirsList = roots.map((r) => `  - ${r}`).join("\n");
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Local media path is not under an allowed directory: ${mediaPath}`,
+    `Local media path is not under an allowed directory: ${mediaPath}\n\nAllowed directories:\n${allowedDirsList}\n\nYou can:\n  - Move your file to one of the allowed directories above\n  - Configure custom allowed directories via localRoots parameter\n  - Set localRoots: "any" to disable checks (not recommended for security)`,
   );
 }
 

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -17,6 +17,10 @@ function resolveCachedPreferredTmpDir(): string {
   return cachedPreferredTmpDir;
 }
 
+/**
+ * Build list of allowed local media root directories.
+ * Uses a glob-like pattern to allow all workspace-* subdirectories.
+ */
 function buildMediaLocalRoots(
   stateDir: string,
   options: BuildMediaLocalRootsOptions = {},
@@ -28,6 +32,7 @@ function buildMediaLocalRoots(
     path.join(resolvedStateDir, "media"),
     path.join(resolvedStateDir, "agents"),
     path.join(resolvedStateDir, "workspace"),
+    path.join(resolvedStateDir, "workspace-*"), // Allow all workspace-* directories
     path.join(resolvedStateDir, "sandboxes"),
   ];
 }


### PR DESCRIPTION
## Problem

OpenClaw's Discord message tool has a whitelist restriction that only allows sending files from the `workspace-ceo` directory. This prevents users from sending files from other workspace directories like `workspace-cow`, `workspace-growth`, etc., resulting in the error:

``
Local media path is not under an allowed directory
``

## Solution

This PR expands the allowed directory whitelist to support all workspace directories:

### Changes Made

1. **Removed workspace-* blocking** (`extensions/whatsapp/src/media.ts`)
   - Previously, a hardening check explicitly blocked all `workspace-*` directories
   - This check has been removed to allow legitimate workspace directories

2. **Added glob pattern support** (`extensions/whatsapp/src/media.ts`)
   - Media path validation now supports glob patterns like `workspace-*`
   - Allows matching multiple directories with a single pattern

3. **Updated default allowed roots** (`src/media/local-roots.ts`)
   - Added `workspace-*` pattern to the default media local roots
   - All workspace subdirectories are now accessible by default

4. **Improved error messages** (`extensions/whatsapp/src/media.ts`)
   - Error messages now show which directories ARE allowed
   - Include helpful tips for users to fix the issue

5. **Updated tests** (`extensions/whatsapp/src/media.test.ts`)
   - Test now verifies that `workspace-*` directories are allowed
   - Reflects the new behavior

### Benefits

- Users can now send files from any workspace directory (workspace-ceo, workspace-cow, workspace-growth, etc.)
- More flexible for multi-workspace OpenClaw setups
- Better error messages help users understand and fix permission issues
- Glob pattern support makes it easy to allow groups of directories

### Backward Compatibility

This is a **breaking change** for setups that relied on the implicit blocking of `workspace-*` directories. Users who want stricter restrictions can:
- Pass explicit `localRoots` parameter to specify exact allowed directories
- Use custom configuration to override defaults

## Testing

- Modified test to verify `workspace-*` directories are now allowed
- Tested that error messages show helpful information
- Verified glob pattern matching logic works correctly

## Example Usage

Before this change:
``bash
# This would fail with "not under an allowed directory"
message send discord:general --media /Users/hekmon/.openclaw/workspace-cow/output/image.png
``

After this change:
``bash
# Now works automatically
message send discord:general --media /Users/hekmon/.openclaw/workspace-cow/output/image.png
``

## Related

This affects all channels that use the shared media loader (Discord, WhatsApp, etc.), not just Discord.