### PR TITLE
fix(plugins): resolve gateway auth against active http route registry

### DIFF
--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -461,4 +461,31 @@ describe("plugin HTTP route auth checks", () => {
     });
     expect(shouldEnforceGatewayAuthForPluginPath(registry, "/plugin/secure/report")).toBe(true);
   });
+
+  it("prefers the active route registry for auth checks when the explicit registry is stale", () => {
+    const startupRegistry = createTestRegistry();
+    const staleExplicitRegistry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/plugins/diffs", auth: "plugin" })],
+    });
+
+    setActivePluginRegistry(createTestRegistry());
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+
+    const unregister = registerPluginHttpRoute({
+      path: "/bluebubbles-webhook",
+      auth: "gateway",
+      handler: () => true,
+    });
+
+    try {
+      expect(
+        shouldEnforceGatewayAuthForPluginPath(staleExplicitRegistry, "/bluebubbles-webhook"),
+      ).toBe(true);
+      expect(shouldEnforceGatewayAuthForPluginPath(staleExplicitRegistry, "/plugins/diffs")).toBe(
+        false,
+      );
+    } finally {
+      unregister();
+    }
+  });
 });

--- a/src/gateway/server/plugins-http/route-auth.ts
+++ b/src/gateway/server/plugins-http/route-auth.ts
@@ -1,4 +1,5 @@
 import type { PluginRegistry } from "../../../plugins/registry.js";
+import { resolveActivePluginHttpRouteRegistry } from "../../../plugins/runtime.js";
 import {
   isProtectedPluginRoutePathFromContext,
   resolvePluginRoutePathContext,
@@ -26,5 +27,8 @@ export function shouldEnforceGatewayAuthForPluginPath(
   if (isProtectedPluginRoutePathFromContext(pathContext)) {
     return true;
   }
-  return matchedPluginRoutesRequireGatewayAuth(findMatchingPluginHttpRoutes(registry, pathContext));
+  const activeRegistry = resolveActivePluginHttpRouteRegistry(registry);
+  return matchedPluginRoutesRequireGatewayAuth(
+    findMatchingPluginHttpRoutes(activeRegistry, pathContext),
+  );
 }


### PR DESCRIPTION
## Summary
- resolve plugin webhook auth checks against the active HTTP route registry instead of a stale captured registry
- keep the provided registry as fallback when the active route registry has no routes yet
- add a regression test covering stale explicit registries after later plugin route registration

## Change Type
- bug fix
- test coverage

## Scope
- gateway plugin HTTP route auth enforcement
- no behavior changes outside plugin-owned HTTP route matching/auth

## User-visible / Behavior Changes
- plugin webhook routes registered after startup no longer fall through auth/path checks because of a stale registry capture
- gateway auth enforcement now follows the same active route registry resolution already used by request dispatch

## Test plan
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/server/plugins-http.test.ts -t "plugin HTTP route auth checks|prefers the pinned route registry over a stale explicit registry|handles routes registered into the pinned startup registry after the active registry changes"`
- Note: running the full `src/gateway/server/plugins-http.test.ts` file in this clean clone still hits an existing unrelated failure in `caps unauthenticated plugin routes to non-admin subagent scopes` (`Expected subagent runtime from loadGatewayPlugins`)

Closes #48734
