### PR TITLE
fix(plugins): pin channel registry to prevent desync on runtime reload

### DIFF
--- a/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
+++ b/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
@@ -26,6 +26,7 @@ function makeBrowserState(): BrowserServerState {
       extraArgs: [],
       color: "#FF4500",
       headless: true,
+      gpuEnabled: false,
       noSandbox: false,
       attachOnly: false,
       ssrfPolicy: { allowPrivateNetwork: true },

--- a/src/browser/server-context.existing-session.test.ts
+++ b/src/browser/server-context.existing-session.test.ts
@@ -39,6 +39,7 @@ function makeState(): BrowserServerState {
       remoteCdpHandshakeTimeoutMs: 3000,
       color: "#FF4500",
       headless: false,
+      gpuEnabled: false,
       noSandbox: false,
       attachOnly: false,
       defaultProfile: "chrome-live",

--- a/src/browser/server-context.remote-tab-ops.harness.ts
+++ b/src/browser/server-context.remote-tab-ops.harness.ts
@@ -26,6 +26,7 @@ export function makeState(
       extraArgs: [],
       color: "#FF4500",
       headless: true,
+      gpuEnabled: false,
       noSandbox: false,
       attachOnly: false,
       ssrfPolicy: { allowPrivateNetwork: true },

--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -11,7 +11,11 @@ import type { TelegramProbe } from "../../../extensions/telegram/src/probe.js";
 import type { TelegramTokenResolution } from "../../../extensions/telegram/src/token.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { LineProbeResult } from "../../line/types.js";
-import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  pinActivePluginChannelRegistry,
+  releasePinnedPluginChannelRegistry,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
   createMSTeamsTestPluginBase,
@@ -69,6 +73,7 @@ describe("channel plugin registry", () => {
   });
 
   afterEach(() => {
+    releasePinnedPluginChannelRegistry();
     setActivePluginRegistry(emptyRegistry);
   });
 
@@ -104,6 +109,23 @@ describe("channel plugin registry", () => {
       },
     ] as typeof registry.channels;
     setActivePluginRegistry(registry, "registry-test");
+
+    expect(listChannelPlugins().map((plugin) => plugin.id)).toEqual(["telegram"]);
+  });
+
+  it("keeps channel plugin lookups on the pinned startup registry after later registry swaps", () => {
+    const startupRegistry = createTestRegistry([
+      {
+        pluginId: "telegram",
+        plugin: createPlugin("telegram"),
+        source: "test",
+      },
+    ]);
+    const laterRegistry = createTestRegistry([]);
+
+    setActivePluginRegistry(startupRegistry, "startup-registry");
+    pinActivePluginChannelRegistry(startupRegistry);
+    setActivePluginRegistry(laterRegistry, "later-registry");
 
     expect(listChannelPlugins().map((plugin) => plugin.id)).toEqual(["telegram"]);
   });
@@ -363,6 +385,7 @@ describe("channel plugin loader", () => {
   });
 
   afterEach(() => {
+    releasePinnedPluginChannelRegistry();
     setActivePluginRegistry(emptyRegistry);
   });
 

--- a/src/channels/plugins/registry.ts
+++ b/src/channels/plugins/registry.ts
@@ -1,6 +1,7 @@
+import type { PluginRegistry } from "../../plugins/registry.js";
 import {
   getActivePluginRegistryVersion,
-  requireActivePluginRegistry,
+  requireActivePluginChannelRegistry,
 } from "../../plugins/runtime.js";
 import { CHAT_CHANNEL_ORDER, type ChatChannelId, normalizeAnyChannelId } from "../registry.js";
 import type { ChannelId, ChannelPlugin } from "./types.js";
@@ -20,12 +21,14 @@ function dedupeChannels(channels: ChannelPlugin[]): ChannelPlugin[] {
 }
 
 type CachedChannelPlugins = {
+  registry: PluginRegistry | null;
   registryVersion: number;
   sorted: ChannelPlugin[];
   byId: Map<string, ChannelPlugin>;
 };
 
 const EMPTY_CHANNEL_PLUGIN_CACHE: CachedChannelPlugins = {
+  registry: null,
   registryVersion: -1,
   sorted: [],
   byId: new Map(),
@@ -34,10 +37,10 @@ const EMPTY_CHANNEL_PLUGIN_CACHE: CachedChannelPlugins = {
 let cachedChannelPlugins = EMPTY_CHANNEL_PLUGIN_CACHE;
 
 function resolveCachedChannelPlugins(): CachedChannelPlugins {
-  const registry = requireActivePluginRegistry();
+  const registry = requireActivePluginChannelRegistry();
   const registryVersion = getActivePluginRegistryVersion();
   const cached = cachedChannelPlugins;
-  if (cached.registryVersion === registryVersion) {
+  if (cached.registry === registry && cached.registryVersion === registryVersion) {
     return cached;
   }
 
@@ -57,6 +60,7 @@ function resolveCachedChannelPlugins(): CachedChannelPlugins {
   }
 
   const next: CachedChannelPlugins = {
+    registry,
     registryVersion,
     sorted,
     byId,

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -6,7 +6,9 @@ import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import {
+  pinActivePluginChannelRegistry,
   pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginChannelRegistry,
   releasePinnedPluginHttpRouteRegistry,
   resolveActivePluginHttpRouteRegistry,
 } from "../plugins/runtime.js";
@@ -97,6 +99,7 @@ export async function createGatewayRuntimeState(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   toolEventRecipients: ReturnType<typeof createToolEventRecipientRegistry>;
 }> {
+  pinActivePluginChannelRegistry(params.pluginRegistry);
   pinActivePluginHttpRouteRegistry(params.pluginRegistry);
   try {
     let canvasHost: CanvasHostHandler | null = null;
@@ -228,7 +231,10 @@ export async function createGatewayRuntimeState(params: {
 
     return {
       canvasHost,
-      releasePluginRouteRegistry: () => releasePinnedPluginHttpRouteRegistry(params.pluginRegistry),
+      releasePluginRouteRegistry: () => {
+        releasePinnedPluginChannelRegistry(params.pluginRegistry);
+        releasePinnedPluginHttpRouteRegistry(params.pluginRegistry);
+      },
       httpServer,
       httpServers,
       httpBindHosts,
@@ -247,6 +253,7 @@ export async function createGatewayRuntimeState(params: {
       toolEventRecipients,
     };
   } catch (err) {
+    releasePinnedPluginChannelRegistry(params.pluginRegistry);
     releasePinnedPluginHttpRouteRegistry(params.pluginRegistry);
     throw err;
   }

--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { createEmptyPluginRegistry } from "./registry.js";
 import {
+  getActivePluginChannelRegistry,
+  pinActivePluginChannelRegistry,
   pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginChannelRegistry,
   releasePinnedPluginHttpRouteRegistry,
   resolveActivePluginHttpRouteRegistry,
   setActivePluginRegistry,
@@ -9,6 +12,7 @@ import {
 
 describe("plugin runtime route registry", () => {
   afterEach(() => {
+    releasePinnedPluginChannelRegistry();
     releasePinnedPluginHttpRouteRegistry();
     setActivePluginRegistry(createEmptyPluginRegistry());
   });
@@ -66,5 +70,36 @@ describe("plugin runtime route registry", () => {
     pinActivePluginHttpRouteRegistry(startupRegistry);
 
     expect(resolveActivePluginHttpRouteRegistry(explicitRegistry)).toBe(startupRegistry);
+  });
+});
+
+describe("plugin runtime channel registry", () => {
+  afterEach(() => {
+    releasePinnedPluginChannelRegistry();
+    releasePinnedPluginHttpRouteRegistry();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("keeps the pinned channel registry when the active plugin registry changes", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const laterRegistry = createEmptyPluginRegistry();
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginChannelRegistry(startupRegistry);
+    setActivePluginRegistry(laterRegistry);
+
+    expect(getActivePluginChannelRegistry()).toBe(startupRegistry);
+  });
+
+  it("falls back to the active registry after releasing the pin", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    const laterRegistry = createEmptyPluginRegistry();
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginChannelRegistry(startupRegistry);
+    setActivePluginRegistry(laterRegistry);
+    releasePinnedPluginChannelRegistry(startupRegistry);
+
+    expect(getActivePluginChannelRegistry()).toBe(laterRegistry);
   });
 });

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -83,7 +83,9 @@ export function requireActivePluginChannelRegistry(): PluginRegistry {
     return existing;
   }
   const created = requireActivePluginRegistry();
-  state.channelRegistry = created;
+  if (!state.channelRegistryPinned) {
+    state.channelRegistry = created;
+  }
   return created;
 }
 
@@ -110,7 +112,9 @@ export function requireActivePluginHttpRouteRegistry(): PluginRegistry {
     return existing;
   }
   const created = requireActivePluginRegistry();
-  state.httpRouteRegistry = created;
+  if (!state.httpRouteRegistryPinned) {
+    state.httpRouteRegistry = created;
+  }
   return created;
 }
 

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -4,6 +4,8 @@ const REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
 
 type RegistryState = {
   registry: PluginRegistry | null;
+  channelRegistry: PluginRegistry | null;
+  channelRegistryPinned: boolean;
   httpRouteRegistry: PluginRegistry | null;
   httpRouteRegistryPinned: boolean;
   key: string | null;
@@ -17,6 +19,8 @@ const state: RegistryState = (() => {
   if (!globalState[REGISTRY_STATE]) {
     globalState[REGISTRY_STATE] = {
       registry: createEmptyPluginRegistry(),
+      channelRegistry: null,
+      channelRegistryPinned: false,
       httpRouteRegistry: null,
       httpRouteRegistryPinned: false,
       key: null,
@@ -28,6 +32,9 @@ const state: RegistryState = (() => {
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
   state.registry = registry;
+  if (!state.channelRegistryPinned) {
+    state.channelRegistry = registry;
+  }
   if (!state.httpRouteRegistryPinned) {
     state.httpRouteRegistry = registry;
   }
@@ -42,12 +49,42 @@ export function getActivePluginRegistry(): PluginRegistry | null {
 export function requireActivePluginRegistry(): PluginRegistry {
   if (!state.registry) {
     state.registry = createEmptyPluginRegistry();
+    if (!state.channelRegistryPinned) {
+      state.channelRegistry = state.registry;
+    }
     if (!state.httpRouteRegistryPinned) {
       state.httpRouteRegistry = state.registry;
     }
     state.version += 1;
   }
   return state.registry;
+}
+
+export function pinActivePluginChannelRegistry(registry: PluginRegistry) {
+  state.channelRegistry = registry;
+  state.channelRegistryPinned = true;
+}
+
+export function releasePinnedPluginChannelRegistry(registry?: PluginRegistry) {
+  if (registry && state.channelRegistry !== registry) {
+    return;
+  }
+  state.channelRegistryPinned = false;
+  state.channelRegistry = state.registry;
+}
+
+export function getActivePluginChannelRegistry(): PluginRegistry | null {
+  return state.channelRegistry ?? state.registry;
+}
+
+export function requireActivePluginChannelRegistry(): PluginRegistry {
+  const existing = getActivePluginChannelRegistry();
+  if (existing) {
+    return existing;
+  }
+  const created = requireActivePluginRegistry();
+  state.channelRegistry = created;
+  return created;
 }
 
 export function pinActivePluginHttpRouteRegistry(registry: PluginRegistry) {


### PR DESCRIPTION
## Summary

Mirrors the `httpRouteRegistry` pinning approach from #47902 to also protect channel plugin registrations from being lost when `loadOpenClawPlugins()` creates a new registry at runtime.

Without this, `getChannelPlugin()` reads from the freshly-created empty registry, causing the message tool to fail with `Unknown channel` errors for configured channels like Telegram.

Fixes #48790

## Changes

### `src/plugins/runtime.ts`
- Added `channelRegistry` and `channelRegistryPinned` to the global registry state
- Added `pinActivePluginChannelRegistry()` / `releasePinnedPluginChannelRegistry()` / `getActivePluginChannelRegistry()` / `requireActivePluginChannelRegistry()`
- `setActivePluginRegistry()` only updates `channelRegistry` when not pinned (matching httpRouteRegistry pattern)

### `src/channels/plugins/registry.ts`
- `resolveCachedChannelPlugins()` now reads from `requireActivePluginChannelRegistry()` instead of `requireActivePluginRegistry()`
- Cache invalidation hardened: checks both registry object identity AND version number to prevent stale lookups after pin release

### `src/gateway/server-runtime-state.ts`
- Pins channel registry alongside HTTP route registry at gateway startup
- Releases pin in both success and error cleanup paths

### Tests
- `src/plugins/runtime.test.ts` — pin survives registry swap; release falls back to active registry
- `src/channels/plugins/plugins-core.test.ts` — end-to-end regression test: `listChannelPlugins()` returns pinned Telegram plugin after empty registry swap

## Context

PR #47902 correctly identified and fixed this class of bug for `httpRoutes`. The same desynchronization affects `channels` but was not addressed. This PR completes the fix by applying the identical pattern to the channel registry.

The bug surfaces in multi-channel, multi-agent setups where runtime `loadOpenClawPlugins()` calls (from config lookups, schema validation, `maybeBootstrapChannelPlugin()`, provider resolution) create new registries that replace the active one, losing channel plugin registrations.

Co-authored-by: Claude <noreply@anthropic.com>