### PR TITLE
fix(tools): strip arg_value XML suffix from exec/read args

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -43,6 +43,7 @@ import {
   resolveWorkdir,
   truncateMiddle,
 } from "./bash-tools.shared.js";
+import { stripXmlArgValueSuffix } from "./pi-tools.params.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 
 export type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -225,6 +226,10 @@ export function createExecTool(
       if (!params.command) {
         throw new Error("Provide a command to start.");
       }
+
+      // Strip malformed XML closing-tag suffixes leaked by some providers (e.g. Qwen/DashScope).
+      // See https://github.com/openclaw/openclaw/issues/48780
+      params.command = stripXmlArgValueSuffix(params.command);
 
       const maxOutput = DEFAULT_MAX_OUTPUT;
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;

--- a/src/agents/pi-tools.params.test.ts
+++ b/src/agents/pi-tools.params.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolParams, stripXmlArgValueSuffix } from "./pi-tools.params.js";
+
+describe("stripXmlArgValueSuffix", () => {
+  it("strips </arg_value>> suffix", () => {
+    expect(stripXmlArgValueSuffix('echo "test</arg_value>>')).toBe('echo "test');
+  });
+
+  it("strips </arg_value> suffix (single >)", () => {
+    expect(stripXmlArgValueSuffix('echo "test</arg_value>')).toBe('echo "test');
+  });
+
+  it("strips </arg_value>>> suffix (triple >)", () => {
+    expect(stripXmlArgValueSuffix('echo "test</arg_value>>>')).toBe('echo "test');
+  });
+
+  it("leaves clean strings unchanged", () => {
+    expect(stripXmlArgValueSuffix('echo "hello world"')).toBe('echo "hello world"');
+  });
+
+  it("leaves empty string unchanged", () => {
+    expect(stripXmlArgValueSuffix("")).toBe("");
+  });
+
+  it("handles file paths with suffix", () => {
+    expect(stripXmlArgValueSuffix("/home/user/test.txt</arg_value>>")).toBe("/home/user/test.txt");
+  });
+});
+
+describe("normalizeToolParams strips XML arg_value suffixes", () => {
+  it("strips </arg_value>> from command param", () => {
+    const result = normalizeToolParams({ command: 'echo "test</arg_value>>' });
+    expect(result?.command).toBe('echo "test');
+  });
+
+  it("strips </arg_value>> from path param", () => {
+    const result = normalizeToolParams({ path: "/home/user/test.txt</arg_value>>" });
+    expect(result?.path).toBe("/home/user/test.txt");
+  });
+
+  it("strips </arg_value>> from file_path param (normalizes to path)", () => {
+    const result = normalizeToolParams({ file_path: "/home/user/test.txt</arg_value>>" });
+    expect(result?.path).toBe("/home/user/test.txt");
+  });
+
+  it("leaves clean params unchanged", () => {
+    const result = normalizeToolParams({ command: "ls -la", path: "/tmp" });
+    expect(result?.command).toBe("ls -la");
+    expect(result?.path).toBe("/tmp");
+  });
+
+  it("does not affect non-string values", () => {
+    const result = normalizeToolParams({ timeout: 5000, background: true });
+    expect(result?.timeout).toBe(5000);
+    expect(result?.background).toBe(true);
+  });
+});

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -82,6 +82,35 @@ function normalizeTextLikeParam(record: Record<string, unknown>, key: string) {
   }
 }
 
+/**
+ * Strip malformed XML closing-tag suffixes from tool call argument values.
+ *
+ * Some models (e.g. Qwen via DashScope) emit tool call arguments with
+ * trailing XML fragments like `</arg_value>>` or `</arg_value>` appended
+ * to string values. This corrupts exec commands and file paths on Windows
+ * (and elsewhere). Strip these artifacts so the actual argument value is
+ * preserved.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/48780
+ */
+const XML_ARG_VALUE_SUFFIX_RE = /<\/arg_value>>{0,2}$/;
+
+export function stripXmlArgValueSuffix(value: string): string {
+  if (!value || !value.includes("</arg_value>")) {
+    return value;
+  }
+  return value.replace(XML_ARG_VALUE_SUFFIX_RE, "");
+}
+
+function stripXmlArgValueSuffixFromRecord(record: Record<string, unknown>): void {
+  for (const key of Object.keys(record)) {
+    const value = record[key];
+    if (typeof value === "string" && value.includes("</arg_value>")) {
+      record[key] = stripXmlArgValueSuffix(value);
+    }
+  }
+}
+
 // Normalize tool parameters from Claude Code conventions to pi-coding-agent conventions.
 // Claude Code uses file_path/old_string/new_string while pi-coding-agent uses path/oldText/newText.
 // This prevents models trained on Claude Code from getting stuck in tool-call loops.
@@ -111,6 +140,9 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   normalizeTextLikeParam(normalized, "content");
   normalizeTextLikeParam(normalized, "oldText");
   normalizeTextLikeParam(normalized, "newText");
+  // Strip malformed XML closing-tag suffixes leaked by some providers (e.g. Qwen/DashScope).
+  // See https://github.com/openclaw/openclaw/issues/48780
+  stripXmlArgValueSuffixFromRecord(normalized);
   return normalized;
 }
 


### PR DESCRIPTION
## Summary

Fixes #48780

Some models (e.g. Qwen via DashScope) emit tool call arguments with trailing XML fragments like `</arg_value>>` appended to string values. This corrupts `exec()` commands (e.g. `echo "test"` becomes `echo "test</arg_value>>`) and `read()` file paths, blocking all file operations and command execution on affected platforms.

### Changes

- **`src/agents/pi-tools.params.ts`**: Add `stripXmlArgValueSuffix()` function and `stripXmlArgValueSuffixFromRecord()` helper that strips `</arg_value>` with optional trailing `>` characters from all string values in tool call argument records. Called from `normalizeToolParams()` which covers `read`, `write`, and `edit` tools.
- **`src/agents/bash-tools.exec.ts`**: Import and apply `stripXmlArgValueSuffix()` to the `command` parameter in the exec tool's execute handler, since exec does not go through `normalizeToolParams`.
- **`src/agents/pi-tools.params.test.ts`**: Add unit tests covering the suffix stripping for various patterns and integration with `normalizeToolParams`.

### Root cause

Models using XML-based internal tool calling formats (common with Qwen/DashScope) sometimes fail to properly separate the argument value from the XML closing tag, resulting in `</arg_value>>` being concatenated to the end of string argument values. This is a provider-side bug, but we can defensively strip these artifacts at the parameter normalization layer.

## Test plan

- [x] All 11 new unit tests pass
- [x] TypeScript type check passes
- [x] Existing lint/format checks pass