### PR TITLE
fix(cli): accept local policy closes during gateway restart health checks

### DIFF
--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -219,6 +219,20 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.healthy).toBe(true);
   });
 
+  it.each([
+    "connect failed",
+    "device required",
+    "pairing required",
+    "",
+  ])("treats policy-close %j as healthy gateway reachability", async (reason) => {
+    const snapshot = await inspectAmbiguousOwnershipWithProbe({
+      ok: false,
+      close: { code: 1008, reason },
+    });
+
+    expect(snapshot.healthy).toBe(true);
+  });
+
   it("treats busy ports with unavailable listener details as healthy when runtime is running", async () => {
     const service = {
       readRuntime: vi.fn(async () => ({ status: "running", pid: 8000 })),

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -51,11 +51,15 @@ function looksLikeAuthClose(code: number | undefined, reason: string | undefined
   }
   const normalized = (reason ?? "").toLowerCase();
   return (
+    !normalized ||
+    normalized.includes("connect failed") ||
     normalized.includes("auth") ||
     normalized.includes("token") ||
     normalized.includes("password") ||
     normalized.includes("scope") ||
-    normalized.includes("role")
+    normalized.includes("role") ||
+    normalized.includes("device") ||
+    normalized.includes("pair")
   );
 }
 


### PR DESCRIPTION
## Summary

Treat local WebSocket policy closes as healthy-enough during gateway restart reachability checks so Windows Scheduled Task restarts do not falsely time out when the gateway is already alive but rejects unauthenticated probe connections.

## Change Type

- Bug fix

## Scope

- CLI gateway restart health checks
- Targeted test coverage for policy-close restart probing

## User-visible / Behavior Changes

- `openclaw gateway restart` no longer waits out the full timeout when a restarted local gateway is already listening but closes the loopback probe with `1008` reasons like `connect failed`, `device required`, or `pairing required`.
- Existing auth/token/scope policy-close handling remains intact.

## Test plan

- `pnpm exec vitest run src/cli/daemon-cli/restart-health.test.ts src/daemon/schtasks.test.ts`

Closes #48771