### PR TITLE
fix: add nostr-tools to root dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -612,6 +612,7 @@
     "long": "^5.3.2",
     "markdown-it": "^14.1.1",
     "node-edge-tts": "^1.2.10",
+    "nostr-tools": "^2.23.3",
     "opusscript": "^0.1.1",
     "osc-progress": "^0.3.0",
     "pdfjs-dist": "^5.5.207",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       node-llama-cpp:
         specifier: 3.16.2
         version: 3.16.2(typescript@5.9.3)
+      nostr-tools:
+        specifier: ^2.23.3
+        version: 2.23.3(typescript@5.9.3)
       opusscript:
         specifier: ^0.1.1
         version: 0.1.1
@@ -342,6 +345,8 @@ importers:
 
   extensions/discord: {}
 
+  extensions/elevenlabs: {}
+
   extensions/feishu:
     dependencies:
       '@larksuiteoapi/node-sdk':
@@ -450,6 +455,8 @@ importers:
       openai:
         specifier: ^6.29.0
         version: 6.29.0(ws@8.19.0)(zod@4.3.6)
+
+  extensions/microsoft: {}
 
   extensions/minimax: {}
 


### PR DESCRIPTION
This PR adds `nostr-tools` to the root `package.json` to ensure it is installed in Docker containers and available for the bundled application, resolving the `ERR_MODULE_NOT_FOUND` error reported in #48797.