### PR TITLE
fix: suppress welcome state when context warning is active (#44869)

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -430,7 +430,7 @@ function resetSlashMenuState(): void {
 
 function updateSlashMenu(value: string, requestUpdate: () => void): void {
   // Arg mode: /command <partial-arg>
-  const argMatch = value.match(/^\/( \S+)\s(.*)$/);
+  const argMatch = value.match(/^\/(\S+)\s(.*)$/);
   if (argMatch) {
     const cmdName = argMatch[1].toLowerCase();
     const argFilter = argMatch[2].toLowerCase();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -430,7 +430,7 @@ function resetSlashMenuState(): void {
 
 function updateSlashMenu(value: string, requestUpdate: () => void): void {
   // Arg mode: /command <partial-arg>
-  const argMatch = value.match(/^\/(\S+)\s(.*)$/);
+  const argMatch = value.match(/^\/( \S+)\s(.*)$/);
   if (argMatch) {
     const cmdName = argMatch[1].toLowerCase();
     const argFilter = argMatch[2].toLowerCase();
@@ -850,7 +850,14 @@ export function renderChat(props: ChatProps) {
   };
 
   const chatItems = buildChatItems(props);
-  const isEmpty = chatItems.length === 0 && !props.loading;
+  // Don't show the welcome screen when a context warning is also active (#44869).
+  // High-context sessions have accumulated history (even if compacted), and the
+  // welcome state + context-notice badge together overflow the flex layout,
+  // pushing .agent-chat__input below the overflow:hidden boundary of .card.chat.
+  const contextUsed = activeSession?.inputTokens ?? 0;
+  const contextLimit = activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? 0;
+  const hasContextWarning = Boolean(contextUsed && contextLimit && contextUsed / contextLimit >= 0.85);
+  const isEmpty = chatItems.length === 0 && !props.loading && !hasContextWarning;
 
   const thread = html`
     <div


### PR DESCRIPTION
When context usage reaches 85%+ the context-notice badge renders as a flex sibling of .agent-chat__input inside .card.chat (overflow:hidden). At the same time, if chatMessages is temporarily empty (e.g. right after switching to a high-usage session), isEmpty=true causes renderWelcomeState to also render, which occupies a large flex-min-height inside the thread. Together the two elements push .agent-chat__input below the overflow boundary, making the input bar invisible.

The fix: treat a session with a context warning as non-empty so the welcome screen is never shown alongside the warning badge.  High-context sessions have accumulated history (even if compacted) so showing "Ready to chat" is both semantically wrong and layout-breaking.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
