### PR TITLE
fix: prevent double provider prefix for already-qualified model IDs

### DIFF
--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -49,25 +49,28 @@ describe("chat-model-ref helpers", () => {
     expect(resolveServerChatModelValue("alias-only", null)).toBe("alias-only");
   });
 
-  describe("buildQualifiedChatModelValue — already-qualified IDs", () => {
-    it("does not double-prefix when model already contains a provider separator", () => {
-      // Scenario: session modelProvider is "openrouter" but stored model is
-      // already the fully-qualified "llamacpp/qwen3-14b.gguf".
-      expect(buildQualifiedChatModelValue("llamacpp/qwen3-14b.gguf", "openrouter")).toBe(
-        "llamacpp/qwen3-14b.gguf",
+  describe("buildQualifiedChatModelValue — double-prefix prevention", () => {
+    it("does not double-prefix when stored model already starts with the provider prefix", () => {
+      // Scenario: session stored model is already "openrouter/llamacpp/qwen3-14b.gguf";
+      // calling buildQualifiedChatModelValue with provider "openrouter" must not produce
+      // "openrouter/openrouter/llamacpp/qwen3-14b.gguf".
+      expect(
+        buildQualifiedChatModelValue("openrouter/llamacpp/qwen3-14b.gguf", "openrouter"),
+      ).toBe("openrouter/llamacpp/qwen3-14b.gguf");
+    });
+
+    it("does not double-prefix when stored ollama model already carries provider prefix", () => {
+      expect(buildQualifiedChatModelValue("openrouter/ollama/qwen3:14b", "openrouter")).toBe(
+        "openrouter/ollama/qwen3:14b",
       );
     });
 
-    it("does not double-prefix ollama models routed through openrouter", () => {
-      expect(buildQualifiedChatModelValue("ollama/qwen3:14b", "openrouter")).toBe(
-        "ollama/qwen3:14b",
-      );
-    });
-
-    it("does not double-prefix free models whose IDs already carry a vendor prefix", () => {
+    it("correctly qualifies a catalog entry whose id contains a vendor sub-prefix", () => {
+      // "nvidia/llama-3.1:free" is a catalog id under openrouter — it is NOT already
+      // qualified; the provider prefix must be prepended so the backend can route it.
       expect(
         buildQualifiedChatModelValue("nvidia/llama-3.1-nemotron-70b-instruct:free", "openrouter"),
-      ).toBe("nvidia/llama-3.1-nemotron-70b-instruct:free");
+      ).toBe("openrouter/nvidia/llama-3.1-nemotron-70b-instruct:free");
     });
 
     it("still qualifies a bare model ID with its provider", () => {
@@ -75,27 +78,36 @@ describe("chat-model-ref helpers", () => {
     });
   });
 
-  describe("buildChatModelOption — already-qualified catalog entries", () => {
-    it("uses the id as-is when it is already provider-qualified", () => {
+  describe("buildChatModelOption — catalog entries with slash-containing ids", () => {
+    it("qualifies catalog entry id with its provider even when id contains a slash", () => {
+      // The catalog stores id="llamacpp/qwen3-14b.gguf" with provider="openrouter".
+      // buildChatModelOption must produce "openrouter/llamacpp/qwen3-14b.gguf" so the
+      // backend can validate the model against the openrouter allowlist.
       const entry: ModelCatalogEntry = {
         id: "llamacpp/qwen3-14b.gguf",
         name: "Qwen3 14B",
         provider: "openrouter",
       };
       expect(buildChatModelOption(entry)).toEqual({
-        value: "llamacpp/qwen3-14b.gguf",
+        value: "openrouter/llamacpp/qwen3-14b.gguf",
         label: "llamacpp/qwen3-14b.gguf · openrouter",
       });
     });
   });
 
-  describe("resolveServerChatModelValue — already-qualified model from session row", () => {
-    it("does not prepend provider when stored model is already qualified", () => {
-      // After a user switches to "llamacpp/qwen3-14b.gguf" the gateway may
-      // store the full string as model while keeping modelProvider="openrouter".
+  describe("resolveServerChatModelValue — stored model from session row", () => {
+    it("prepends provider to a stored bare model id", () => {
+      // The gateway stores model="llamacpp/qwen3-14b.gguf" with modelProvider="openrouter".
+      // resolveServerChatModelValue must reconstruct the full qualified value.
       expect(resolveServerChatModelValue("llamacpp/qwen3-14b.gguf", "openrouter")).toBe(
-        "llamacpp/qwen3-14b.gguf",
+        "openrouter/llamacpp/qwen3-14b.gguf",
       );
+    });
+
+    it("does not double-prefix a stored model that is already fully qualified", () => {
+      expect(
+        resolveServerChatModelValue("openrouter/llamacpp/qwen3-14b.gguf", "openrouter"),
+      ).toBe("openrouter/llamacpp/qwen3-14b.gguf");
     });
   });
 });

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildChatModelOption,
+  buildQualifiedChatModelValue,
   createChatModelOverride,
   formatChatModelDisplay,
   normalizeChatModelOverrideValue,
@@ -46,5 +47,55 @@ describe("chat-model-ref helpers", () => {
   it("resolves server session data to qualified option values", () => {
     expect(resolveServerChatModelValue("gpt-5-mini", "openai")).toBe("openai/gpt-5-mini");
     expect(resolveServerChatModelValue("alias-only", null)).toBe("alias-only");
+  });
+
+  describe("buildQualifiedChatModelValue — already-qualified IDs", () => {
+    it("does not double-prefix when model already contains a provider separator", () => {
+      // Scenario: session modelProvider is "openrouter" but stored model is
+      // already the fully-qualified "llamacpp/qwen3-14b.gguf".
+      expect(buildQualifiedChatModelValue("llamacpp/qwen3-14b.gguf", "openrouter")).toBe(
+        "llamacpp/qwen3-14b.gguf",
+      );
+    });
+
+    it("does not double-prefix ollama models routed through openrouter", () => {
+      expect(buildQualifiedChatModelValue("ollama/qwen3:14b", "openrouter")).toBe(
+        "ollama/qwen3:14b",
+      );
+    });
+
+    it("does not double-prefix free models whose IDs already carry a vendor prefix", () => {
+      expect(
+        buildQualifiedChatModelValue("nvidia/llama-3.1-nemotron-70b-instruct:free", "openrouter"),
+      ).toBe("nvidia/llama-3.1-nemotron-70b-instruct:free");
+    });
+
+    it("still qualifies a bare model ID with its provider", () => {
+      expect(buildQualifiedChatModelValue("gpt-5-mini", "openai")).toBe("openai/gpt-5-mini");
+    });
+  });
+
+  describe("buildChatModelOption — already-qualified catalog entries", () => {
+    it("uses the id as-is when it is already provider-qualified", () => {
+      const entry: ModelCatalogEntry = {
+        id: "llamacpp/qwen3-14b.gguf",
+        name: "Qwen3 14B",
+        provider: "openrouter",
+      };
+      expect(buildChatModelOption(entry)).toEqual({
+        value: "llamacpp/qwen3-14b.gguf",
+        label: "llamacpp/qwen3-14b.gguf · openrouter",
+      });
+    });
+  });
+
+  describe("resolveServerChatModelValue — already-qualified model from session row", () => {
+    it("does not prepend provider when stored model is already qualified", () => {
+      // After a user switches to "llamacpp/qwen3-14b.gguf" the gateway may
+      // store the full string as model while keeping modelProvider="openrouter".
+      expect(resolveServerChatModelValue("llamacpp/qwen3-14b.gguf", "openrouter")).toBe(
+        "llamacpp/qwen3-14b.gguf",
+      );
+    });
   });
 });

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -11,16 +11,23 @@ export type ChatModelOverride =
     };
 
 export function buildQualifiedChatModelValue(model: string, provider?: string | null): string {
-  const trimmedModel = model.trim();
+  const trimmedModel = model?.trim() ?? "";
   if (!trimmedModel) {
     return "";
   }
-  // If the model ID is already provider-qualified (e.g. "llamacpp/qwen3-14b.gguf"),
-  // return it as-is to avoid double-prefixing (e.g. "openrouter/llamacpp/qwen3-14b.gguf").
-  if (trimmedModel.includes("/")) {
+  const trimmedProvider = provider?.trim();
+  // If the model is already prefixed with this exact provider, return as-is to avoid
+  // double-prefixing (e.g. stored value "openrouter/llamacpp/qwen3-14b.gguf" with
+  // provider "openrouter" must not become "openrouter/openrouter/llamacpp/qwen3-14b.gguf").
+  // NOTE: a slash-containing id that does NOT start with "{provider}/" is a catalog entry
+  // that still needs the provider prefix (e.g. "nvidia/llama-3.1:free" + "openrouter"
+  // → "openrouter/nvidia/llama-3.1:free").
+  if (
+    trimmedProvider &&
+    trimmedModel.toLowerCase().startsWith(`${trimmedProvider.toLowerCase()}/`)
+  ) {
     return trimmedModel;
   }
-  const trimmedProvider = provider?.trim();
   return trimmedProvider ? `${trimmedProvider}/${trimmedModel}` : trimmedModel;
 }
 

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -15,6 +15,11 @@ export function buildQualifiedChatModelValue(model: string, provider?: string | 
   if (!trimmedModel) {
     return "";
   }
+  // If the model ID is already provider-qualified (e.g. "llamacpp/qwen3-14b.gguf"),
+  // return it as-is to avoid double-prefixing (e.g. "openrouter/llamacpp/qwen3-14b.gguf").
+  if (trimmedModel.includes("/")) {
+    return trimmedModel;
+  }
   const trimmedProvider = provider?.trim();
   return trimmedProvider ? `${trimmedProvider}/${trimmedModel}` : trimmedModel;
 }


### PR DESCRIPTION
When a session's modelProvider is "openrouter" and the stored model is already a qualified ID like "llamacpp/qwen3-14b.gguf", the UI was constructing "openrouter/llamacpp/qwen3-14b.gguf" by calling buildQualifiedChatModelValue with both values.

The same issue affected catalog entries where the id already contains a provider separator (e.g. "nvidia/llama-3.1:free" with provider "openrouter"), producing "openrouter/nvidia/llama-3.1:free".

Fix: if the model string already contains "/" it is already qualified; return it as-is instead of prepending the provider again.

Fixes #48256

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
