### PR TITLE
fix: suppress false-positive duplicate plugin warning for npm installs

### DIFF
--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -361,7 +361,40 @@ export function loadPluginManifestRegistry(params: {
         }
         const existingReal = safeRealpathSync(existing.candidate.rootDir, realpathCache);
         const candidateReal = safeRealpathSync(candidate.rootDir, realpathCache);
-        return Boolean(existingReal && candidateReal && existingReal === candidateReal);
+        if (Boolean(existingReal && candidateReal && existingReal === candidateReal)) {
+          return true;
+        }
+        // Suppress false-positive duplicate warnings when an npm-installed plugin
+        // produces both a config-origin entry (auto-generated from plugins.installs
+        // into plugins.entries on each startup) and a global-origin candidate
+        // discovered from the extensions directory. On Windows the two path
+        // representations can differ after realpath resolution even though they
+        // refer to the same installation, so check the install record explicitly.
+        const installRecord = config.plugins?.installs?.[manifest.id];
+        if (installRecord) {
+          const isConfigGlobalPair =
+            (existing.candidate.origin === "config" && candidate.origin === "global") ||
+            (existing.candidate.origin === "global" && candidate.origin === "config");
+          if (isConfigGlobalPair) {
+            const globalCandidate =
+              existing.candidate.origin === "global" ? existing.candidate : candidate;
+            const trackedPaths = [installRecord.installPath, installRecord.sourcePath]
+              .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+              .map((entry) => resolveUserPath(entry, env));
+            // No tracked paths → the install record covers this plugin ID without path
+            // pinning; any global candidate for this ID is linked to the install.
+            if (trackedPaths.length === 0) {
+              return true;
+            }
+            const globalSource = resolveUserPath(globalCandidate.source, env);
+            const globalRoot =
+              safeRealpathSync(globalCandidate.rootDir, realpathCache) ?? globalCandidate.rootDir;
+            return trackedPaths.some(
+              (p) => globalSource === p || isPathInside(p, globalSource) || isPathInside(p, globalRoot),
+            );
+          }
+        }
+        return false;
       })();
       if (samePlugin) {
         // Prefer higher-precedence origins even if candidates are passed in


### PR DESCRIPTION
When a plugin is installed via npm (plugins.installs), the gateway auto-generates a plugins.entries entry on each startup. Discovery then produces two candidates for the same plugin ID:
  - config-origin: from the auto-generated plugins.entries entry
  - global-origin: from the npm install path discovered in extensions dir

The existing samePlugin check only compares physical rootDir paths via safeRealpathSync. On Windows, the tilde-expanded config entry path and the fully-resolved npm install path can differ after realpath resolution even though they refer to the same installation, causing a false-positive 'duplicate plugin id detected' warning on every startup.

Fix: extend the samePlugin check to also recognise config/global candidate pairs that are both linked to the same plugins.installs record for this plugin ID. When such a pair is found, suppress the duplicate warning and let the existing precedence ranking (config > global install) determine which candidate wins — no behaviour change, just silence the spurious warning.

Fixes #48605

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
