### PR TITLE
fix(channels): avoid built-in channel ID init cycles

### DIFF
--- a/src/auto-reply/reply/elevated-allowlist-matcher.ts
+++ b/src/auto-reply/reply/elevated-allowlist-matcher.ts
@@ -1,4 +1,4 @@
-import { CHAT_CHANNEL_ORDER } from "../../channels/registry.js";
+import { CHAT_CHANNEL_ORDER } from "../../channels/ids.js";
 import { normalizeAtHashSlug } from "../../shared/string-normalization.js";
 
 export type ExplicitElevatedAllowField = "id" | "from" | "e164" | "name" | "username" | "tag";

--- a/src/channels/plugins/registry.ts
+++ b/src/channels/plugins/registry.ts
@@ -2,7 +2,8 @@ import {
   getActivePluginRegistryVersion,
   requireActivePluginRegistry,
 } from "../../plugins/runtime.js";
-import { CHAT_CHANNEL_ORDER, type ChatChannelId, normalizeAnyChannelId } from "../registry.js";
+import { CHAT_CHANNEL_ORDER, type ChatChannelId } from "../ids.js";
+import { normalizeAnyChannelId } from "../registry.js";
 import type { ChannelId, ChannelPlugin } from "./types.js";
 
 function dedupeChannels(channels: ChannelPlugin[]): ChannelPlugin[] {

--- a/src/channels/plugins/setup-registry.ts
+++ b/src/channels/plugins/setup-registry.ts
@@ -2,7 +2,7 @@ import {
   getActivePluginRegistryVersion,
   requireActivePluginRegistry,
 } from "../../plugins/runtime.js";
-import { CHAT_CHANNEL_ORDER, type ChatChannelId } from "../registry.js";
+import { CHAT_CHANNEL_ORDER, type ChatChannelId } from "../ids.js";
 import { bundledChannelSetupPlugins } from "./bundled.js";
 import type { ChannelId, ChannelPlugin } from "./types.js";
 

--- a/src/cli/channel-options.ts
+++ b/src/cli/channel-options.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { CHAT_CHANNEL_ORDER } from "../channels/ids.js";
 import { listChannelPluginCatalogEntries } from "../channels/plugins/catalog.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
-import { CHAT_CHANNEL_ORDER } from "../channels/registry.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { ensurePluginRegistryLoaded } from "./plugin-registry.js";
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { CHANNEL_IDS } from "../channels/registry.js";
+import { CHANNEL_IDS } from "../channels/ids.js";
 import { VERSION } from "../version.js";
 import type { ConfigUiHint, ConfigUiHints } from "./schema.hints.js";
 import { applySensitiveHints, buildBaseHints, mapSensitivePaths } from "./schema.hints.js";

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/registry.js";
+import { CHANNEL_IDS } from "../channels/ids.js";
+import { normalizeChatChannelId } from "../channels/registry.js";
 import {
   normalizePluginsConfig,
   resolveEffectiveEnableState,


### PR DESCRIPTION
Summary
- import built-in channel ID constants from the leaf channels/ids module in config/CLI helpers and plugin sorting code
- keep runtime helpers like normalizeAnyChannelId on channels/registry while avoiding eager constant reads through that heavier module
- reduce the risk of bundled initialization order regressions that can surface as CHANNEL_IDS / CHAT_CHANNEL_ORDER not iterable during startup

Change Type
- bug fix

Scope
- channel ID imports for config validation, CLI channel option resolution, elevated allowlist matching, and channel plugin ordering

User-visible / Behavior Changes
- startup/build outputs no longer depend on channels/registry to initialize built-in channel ID arrays before config validation and plugin sorting read them
- fixes Windows startup regression where bundled builds could throw Cannot access 'CHANNEL_IDS' before initialization / CHAT_CHANNEL_ORDER is not iterable

Test plan
- node scripts/tsdown-build.mjs
- pnpm exec tsx -e "(async()=>{ const [{CHANNEL_IDS,CHAT_CHANNEL_ORDER}] = await Promise.all([import('./src/channels/registry.ts'), import('./src/config/validation.ts')]); console.log('CHANNEL_IDS', Array.isArray(CHANNEL_IDS), CHANNEL_IDS.length); console.log('CHAT_CHANNEL_ORDER', Array.isArray(CHAT_CHANNEL_ORDER), CHAT_CHANNEL_ORDER.length); })().catch(err=>{ console.error(err); process.exit(1); });"

Closes #48832