### PR TITLE
fix(model-ref): preserve version suffixes in model IDs

### DIFF
--- a/src/agents/model-ref-profile.test.ts
+++ b/src/agents/model-ref-profile.test.ts
@@ -54,9 +54,47 @@ describe("splitTrailingAuthProfile", () => {
     });
   });
 
-  it("keeps @YYYYMMDD version suffixes in model ids", () => {
-    expect(splitTrailingAuthProfile("custom/vertex-ai_claude-haiku-4-5@20251001")).toEqual({
-      model: "custom/vertex-ai_claude-haiku-4-5@20251001",
+  it("preserves numeric version suffixes (date format)", () => {
+    expect(splitTrailingAuthProfile("vertex-ai_claude-haiku-4-5@20251001")).toEqual({
+      model: "vertex-ai_claude-haiku-4-5@20251001",
+    });
+  });
+
+  it("preserves numeric version suffixes in custom provider models", () => {
+    expect(splitTrailingAuthProfile("custom-litellm/vertex-ai_claude-haiku-4-5@20251001")).toEqual({
+      model: "custom-litellm/vertex-ai_claude-haiku-4-5@20251001",
+    });
+  });
+
+  it("preserves semver-like version suffixes", () => {
+    expect(splitTrailingAuthProfile("provider/model@v1.2.3")).toEqual({
+      model: "provider/model@v1.2.3",
+    });
+  });
+
+  it("preserves numeric build number suffixes", () => {
+    expect(splitTrailingAuthProfile("provider/model@1234")).toEqual({
+      model: "provider/model@1234",
+    });
+  });
+
+  it("preserves semver with prerelease", () => {
+    expect(splitTrailingAuthProfile("provider/model@1.0.0-beta.1")).toEqual({
+      model: "provider/model@1.0.0-beta.1",
+    });
+  });
+
+  it("still splits non-version profile suffixes", () => {
+    expect(splitTrailingAuthProfile("provider/model@work")).toEqual({
+      model: "provider/model",
+      profile: "work",
+    });
+  });
+
+  it("still splits namespaced profile suffixes", () => {
+    expect(splitTrailingAuthProfile("provider/model@cf:default")).toEqual({
+      model: "provider/model",
+      profile: "cf:default",
     });
   });
 

--- a/src/agents/model-ref-profile.test.ts
+++ b/src/agents/model-ref-profile.test.ts
@@ -60,6 +60,12 @@ describe("splitTrailingAuthProfile", () => {
     });
   });
 
+  it("preserves claude model version suffix (e.g. @20250219)", () => {
+    expect(splitTrailingAuthProfile("claude-3-7-sonnet@20250219")).toEqual({
+      model: "claude-3-7-sonnet@20250219",
+    });
+  });
+
   it("preserves numeric version suffixes in custom provider models", () => {
     expect(splitTrailingAuthProfile("custom-litellm/vertex-ai_claude-haiku-4-5@20251001")).toEqual({
       model: "custom-litellm/vertex-ai_claude-haiku-4-5@20251001",

--- a/src/agents/model-ref-profile.ts
+++ b/src/agents/model-ref-profile.ts
@@ -1,3 +1,20 @@
+/**
+ * Check if a suffix looks like a version string rather than an auth profile.
+ * Version suffixes are typically numeric dates (20251001) or semver-like (v1.2.3).
+ * Auth profiles are alphanumeric names like "work", "default", or "cf:default".
+ */
+function looksLikeVersionSuffix(suffix: string): boolean {
+  // Pure numeric (e.g., "20251001" for dates, "1234" for build numbers)
+  if (/^\d+$/.test(suffix)) {
+    return true;
+  }
+  // Semver-like patterns: v1, v1.2, v1.2.3, 1.2.3
+  if (/^v?\d+(\.\d+)*(-[\w.]+)?(\+[\w.]+)?$/.test(suffix)) {
+    return true;
+  }
+  return false;
+}
+
 export function splitTrailingAuthProfile(raw: string): {
   model: string;
   profile?: string;
@@ -25,6 +42,11 @@ export function splitTrailingAuthProfile(raw: string): {
   const model = trimmed.slice(0, profileDelimiter).trim();
   const profile = trimmed.slice(profileDelimiter + 1).trim();
   if (!model || !profile) {
+    return { model: trimmed };
+  }
+
+  // Don't split if the suffix looks like a version rather than an auth profile
+  if (looksLikeVersionSuffix(profile)) {
     return { model: trimmed };
   }
 

--- a/src/agents/model-ref-profile.ts
+++ b/src/agents/model-ref-profile.ts
@@ -2,17 +2,14 @@
  * Check if a suffix looks like a version string rather than an auth profile.
  * Version suffixes are typically numeric dates (20251001) or semver-like (v1.2.3).
  * Auth profiles are alphanumeric names like "work", "default", or "cf:default".
+ *
+ * Note: A purely numeric auth profile (e.g., @1234) would be mistakenly treated as
+ * a version, but this is an unlikely edge case in practice.
  */
 function looksLikeVersionSuffix(suffix: string): boolean {
-  // Pure numeric (e.g., "20251001" for dates, "1234" for build numbers)
-  if (/^\d+$/.test(suffix)) {
-    return true;
-  }
-  // Semver-like patterns: v1, v1.2, v1.2.3, 1.2.3
-  if (/^v?\d+(\.\d+)*(-[\w.]+)?(\+[\w.]+)?$/.test(suffix)) {
-    return true;
-  }
-  return false;
+  // Semver-like patterns: v1, v1.2, v1.2.3, 1.2.3, or pure numeric (e.g., "20251001" for dates)
+  // Pure numeric strings match this pattern via the single \d+ group with optional parts absent.
+  return /^v?\d+(\.\d+)*(-[\w.]+)?(\+[\w.]+)?$/.test(suffix);
 }
 
 export function splitTrailingAuthProfile(raw: string): {


### PR DESCRIPTION
Reopening #48861 after reducing PR queue to comply with 10 PR limit.

---

**Original description:**
Fixes an issue where version suffixes like `-20250219` in model IDs (e.g., `claude-3-7-sonnet-20250219`) were being truncated during model reference resolution.

The fix preserves the full model ID when it contains version suffixes that should not be stripped.