### PR TITLE
fix(model): keep @version suffixes in custom model ids

### DIFF
--- a/src/agents/model-ref-profile.test.ts
+++ b/src/agents/model-ref-profile.test.ts
@@ -47,6 +47,12 @@ describe("splitTrailingAuthProfile", () => {
     });
   });
 
+  it("keeps model ids with pure numeric @version suffixes", () => {
+    expect(splitTrailingAuthProfile("custom-litellm/vertex-ai_claude-haiku-4-5@20251001")).toEqual({
+      model: "custom-litellm/vertex-ai_claude-haiku-4-5@20251001",
+    });
+  });
+
   it("uses first @ after last slash for email-based auth profiles", () => {
     expect(splitTrailingAuthProfile("flash@google-gemini-cli:test@gmail.com")).toEqual({
       model: "flash",

--- a/src/agents/model-ref-profile.ts
+++ b/src/agents/model-ref-profile.ts
@@ -19,5 +19,11 @@ export function splitTrailingAuthProfile(raw: string): {
     return { model: trimmed };
   }
 
+  // Preserve provider model ids that use a pure numeric @version suffix
+  // (for example LiteLLM / Vertex AI style model refs like @20251001).
+  if (/^\d{8}$/.test(profile)) {
+    return { model: trimmed };
+  }
+
   return { model, profile };
 }


### PR DESCRIPTION
## Summary

Keep custom model IDs intact when they use a pure numeric `@version` suffix (for example `@20251001`) so OpenClaw does not misinterpret the suffix as an auth-profile override.

## Change Type

- Bug fix

## Scope

- Model reference parsing for `/model` and related model-selection paths
- Regression coverage for versioned custom provider model IDs

## User-visible / Behavior Changes

- Versioned custom model IDs like `custom-litellm/vertex-ai_claude-haiku-4-5@20251001` now stay intact instead of being truncated before provider dispatch.
- Existing auth-profile overrides like `@work` and email-based profile refs still parse as before.

## Test plan

- `pnpm exec vitest run src/agents/model-ref-profile.test.ts`

Closes #48854
