### PR TITLE
fix: race condition in WebSocket handshake on Windows + Node.js v24

### DIFF
--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -183,7 +183,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         return;
       }
       closed = true;
-      clearTimeout(handshakeTimer);
+      if (handshakeTimer) clearTimeout(handshakeTimer);
       if (client) {
         clients.delete(client);
       }

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -265,16 +265,11 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     });
 
     const handshakeTimeoutMs = getHandshakeTimeoutMs();
-    const handshakeTimer = setTimeout(() => {
-      if (!client) {
-        handshakeState = "failed";
-        setCloseCause("handshake-timeout", {
-          handshakeMs: Date.now() - openedAt,
-        });
-        logWsControl.warn(`handshake timeout conn=${connId} remote=${remoteAddr ?? "?"}`);
-        close();
-      }
-    }, handshakeTimeoutMs);
+    // FIX: Attach message handler BEFORE starting the handshake timer.
+    // On Windows + Node.js v24, the timer callback can fire before the
+    // WebSocket "message" event is processed in the event loop, causing
+    // legitimate connect requests to be rejected with a handshake timeout.
+    let handshakeTimer: ReturnType<typeof setTimeout> | undefined;
 
     attachGatewayWsMessageHandler({
       socket,
@@ -298,7 +293,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       send,
       close,
       isClosed: () => closed,
-      clearHandshakeTimer: () => clearTimeout(handshakeTimer),
+      clearHandshakeTimer: () => {
+        if (handshakeTimer) clearTimeout(handshakeTimer);
+      },
       getClient: () => client,
       setClient: (next) => {
         client = next;
@@ -314,5 +311,16 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       logHealth,
       logWsControl,
     });
+
+    handshakeTimer = setTimeout(() => {
+      if (!client) {
+        handshakeState = "failed";
+        setCloseCause("handshake-timeout", {
+          handshakeMs: Date.now() - openedAt,
+        });
+        logWsControl.warn(`handshake timeout conn=${connId} remote=${remoteAddr ?? "?"}`);
+        close();
+      }
+    }, handshakeTimeoutMs);
   });
 }


### PR DESCRIPTION
On Windows with Node.js v24, the handshake timeout timer can fire before the WebSocket 'message' event is processed by the event loop. This causes legitimate connect requests to be rejected with a handshake timeout error.

The fix moves the setTimeout call to AFTER attachGatewayWsMessageHandler, ensuring the message handler is ready before the timer starts counting.

Symptom: 'openclaw browser' CLI commands fail with 'gateway closed (1000)' on Windows, while raw WebSocket connections work fine.

Root cause: Timer callback has higher priority than message event processing in Node.js v24's Windows event loop implementation.

Summary

On Windows + Node.js v24, openclaw browser CLI commands fail with "gateway closed (1000)" due to a race condition
The handshake timeout timer starts before the WebSocket message handler is attached, so the timer fires before the connect request is processed
Moving setTimeout after attachGatewayWsMessageHandler ensures the message handler is ready before the timer begins
Why it matters:
All openclaw browser CLI commands are broken on Windows + Node.js v24 without this fix.

What changed:
Reordered timer and message handler attachment in src/gateway/server/ws-connection.ts

What did NOT change:
No changes to auth, protocol, timeouts duration, or any other gateway behavior.

Change Type: ✅ Bug fix

Scope: ✅ Gateway / orchestration

Security Impact:

New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No
Data access scope changed? No
Repro + Verification

Environment:

OS: Windows 11 (Build 26200)
Runtime: Node.js v24.14.0
OpenClaw: 2026.3.13
Steps:

Run openclaw browser status on Windows + Node.js v24
Expected: Returns browser status

Actual (before fix): gateway connect failed: Error: gateway closed (1000)

Actual (after fix): Returns browser status successfully

Human Verification:

Verified openclaw browser status works after fix on Windows 11 + Node.js v24
Verified with openclaw browser start and openclaw browser tabs as well
Did not verify on Linux/macOS (no access), but the fix is platform-agnostic and should not affect other platforms
Compatibility / Migration:

Backward compatible? Yes
Config/env changes? No
Migration needed? No

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
