### PR TITLE
fix(repair): strip tool_use blocks from error/aborted messages instead of skipping

### DIFF
--- a/PR_FIX_TASK.md
+++ b/PR_FIX_TASK.md
@@ -1,0 +1,71 @@
+# Task: Fix PR #48888 and rebase onto main
+
+## Context
+
+This is PR https://github.com/openclaw/openclaw/pull/48888
+Branch: fix/repair-tool-use-error-aborted
+Target: main
+
+The PR fixes `repairToolUseResultPairing()` to strip orphaned tool_use blocks from
+error/aborted assistant messages instead of passing them through unchanged.
+The core idea is correct. There are 4 bugs to fix, plus a rebase conflict to resolve.
+
+## Files to modify
+
+- `src/agents/session-transcript-repair.ts`
+- `src/agents/session-transcript-repair.test.ts`
+
+## The 4 bugs (from Greptile review)
+
+### Bug 1: Type-incorrect `added` push
+
+In session-transcript-repair.ts, find where strings like `"stripped-error-<id>"`
+are pushed into the `added` array. The `added` array is typed as
+`Array<Extract<AgentMessage, { role: "toolResult" }>>`.
+Fix: just set `changed = true` instead of pushing to `added`.
+
+### Bug 2: `result.changed` doesn't exist on return type
+
+In session-transcript-repair.test.ts, find `expect(result.changed).toBe(true)`.
+`ToolUseRepairReport` has no `changed` field — only `messages`, `added`,
+`droppedDuplicateCount`, `droppedOrphanCount`, and `moved`.
+Fix: replace `expect(result.changed).toBe(true)` with
+`expect(result.moved).toBeTruthy()` or check that `result.messages` changed.
+Actually the best fix: add `changed: boolean` to `ToolUseRepairReport` and return it.
+
+### Bug 3: `functionCall` blocks not stripped
+
+In session-transcript-repair.ts, find the filter that strips tool blocks.
+It likely says `b.type !== "toolCall" && b.type !== "toolUse"`.
+Fix: also add `&& b.type !== "functionCall"` to the filter.
+
+### Bug 4: Existing test broken by new `added` push
+
+In session-transcript-repair.test.ts, find a test that expects
+`result.added.toHaveLength(0)` after an aborted message.
+Fix: update the assertion after fixing Bug 1 (since we won't push to `added` anymore,
+the original assertion of toHaveLength(0) may still be correct — verify).
+
+## Rebase approach
+
+The current branch (fix/repair-tool-use-error-aborted) has a conflict when
+cherry-picking onto main. The conflict is in session-transcript-repair.ts around
+line 496 — the PR removes the old `stopReason === "error" || stopReason === "aborted"`
+skip block, but main has updated that same area.
+
+Steps:
+
+1. First understand both the PR diff and the current main version of the file
+2. Apply the PR's logic (strip tool_use from error/aborted messages) on top of main
+3. Fix the 4 bugs above
+4. Run: pnpm install && pnpm check && pnpm test -- --testPathPattern session-transcript-repair
+5. If tests pass, commit with message: "fix(repair): strip tool_use blocks from error/aborted messages (fixes #48354)"
+
+## Important
+
+- Work on branch fix-48888-v2 (already created, currently pointing to main HEAD)
+- Do NOT push — just get to a clean commit with passing tests
+- Report which bugs you fixed and test results
+
+When completely finished, run:
+openclaw system event --text "PR #48888 fix complete: ready to review and push" --mode now

--- a/package.json
+++ b/package.json
@@ -1197,6 +1197,7 @@
     "node-edge-tts": "^1.2.10",
     "osc-progress": "^0.3.0",
     "pdfjs-dist": "^5.6.205",
+    "picomatch": "^4.0.4",
     "playwright-core": "1.58.2",
     "qrcode-terminal": "^0.12.0",
     "sharp": "^0.34.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       pdfjs-dist:
         specifier: ^5.6.205
         version: 5.6.205
+      picomatch:
+        specifier: ^4.0.4
+        version: 4.0.4
       playwright-core:
         specifier: 1.58.2
         version: 1.58.2

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -144,10 +144,11 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
-  it("skips tool call extraction for assistant messages with stopReason 'error'", () => {
-    // When an assistant message has stopReason: "error", its tool_use blocks may be
-    // incomplete/malformed. We should NOT create synthetic tool_results for them,
-    // as this causes API 400 errors: "unexpected tool_use_id found in tool_result blocks"
+  it("strips tool_use blocks from assistant messages with stopReason 'error'", () => {
+    // When an assistant message has stopReason: "error", its tool_use blocks are
+    // orphaned (no tool_result will ever come). Instead of passing them through
+    // (which causes permanent session corruption — see #48354), strip the tool
+    // call blocks entirely. Do NOT create synthetic tool_results either (#4597).
     const input = castAgentMessages([
       {
         role: "assistant",
@@ -159,17 +160,19 @@ describe("sanitizeToolUseResultPairing", () => {
 
     const result = repairToolUseResultPairing(input);
 
-    // Should NOT add synthetic tool results for errored messages
+    // Should strip the tool call block, not create synthetic results
     expect(result.added).toHaveLength(0);
-    // The assistant message should be passed through unchanged
     expect(result.messages[0]?.role).toBe("assistant");
+    const assistantContent = (result.messages[0] as { content: { type: string }[] }).content;
+    expect(assistantContent.every((b: { type: string }) => b.type !== "toolCall")).toBe(true);
     expect(result.messages[1]?.role).toBe("user");
     expect(result.messages).toHaveLength(2);
+    expect(result.changed).toBe(true);
   });
 
-  it("skips tool call extraction for assistant messages with stopReason 'aborted'", () => {
-    // When a request is aborted mid-stream, the assistant message may have incomplete
-    // tool_use blocks (with partialJson). We should NOT create synthetic tool_results.
+  it("strips tool_use blocks from assistant messages with stopReason 'aborted'", () => {
+    // When a request is aborted mid-stream, strip orphaned tool_use blocks
+    // to prevent permanent session corruption from dangling tool calls.
     const input = castAgentMessages([
       {
         role: "assistant",
@@ -181,12 +184,38 @@ describe("sanitizeToolUseResultPairing", () => {
 
     const result = repairToolUseResultPairing(input);
 
-    // Should NOT add synthetic tool results for aborted messages
+    // Tool call blocks should be stripped
     expect(result.added).toHaveLength(0);
-    // Messages should be passed through without synthetic insertions
     expect(result.messages).toHaveLength(2);
     expect(result.messages[0]?.role).toBe("assistant");
+    const assistantContent = (result.messages[0] as { content: { type: string }[] }).content;
+    expect(assistantContent.every((b: { type: string }) => b.type !== "toolCall")).toBe(true);
     expect(result.messages[1]?.role).toBe("user");
+    expect(result.changed).toBe(true);
+  });
+
+  it("preserves text content alongside stripped tool_use in error messages", () => {
+    // If the errored assistant message has both text and tool_use blocks,
+    // only strip the tool calls and keep the text.
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me try running that..." },
+          { type: "toolCall", id: "call_err2", name: "exec", arguments: {} },
+        ],
+        stopReason: "error",
+      },
+      { role: "user", content: "what happened?" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    const assistantContent = (result.messages[0] as { content: { type: string; text?: string }[] })
+      .content;
+    expect(assistantContent).toHaveLength(1);
+    expect(assistantContent[0]?.type).toBe("text");
+    expect(assistantContent[0]?.text).toBe("Let me try running that...");
   });
 
   it("still repairs tool results for normal assistant messages with stopReason 'toolUse'", () => {
@@ -207,9 +236,9 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(result.added[0]?.toolCallId).toBe("call_normal");
   });
 
-  it("retains matching tool results that follow an aborted assistant message", () => {
-    // Aborted assistant turns do not synthesize missing tool results, but real
-    // matching results in the same span remain part of the repaired transcript.
+  it("strips tool_use and drops matching tool results for aborted assistant messages", () => {
+    // With tool_use blocks stripped from aborted messages, any trailing tool results
+    // for those calls become orphans and are dropped.
     const input = castAgentMessages([
       {
         role: "assistant",
@@ -228,40 +257,11 @@ describe("sanitizeToolUseResultPairing", () => {
 
     const result = repairToolUseResultPairing(input);
 
-    expect(result.droppedOrphanCount).toBe(0);
-    expect(result.messages).toHaveLength(3);
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("toolResult");
-    expect(result.messages[2]?.role).toBe("user");
-    expect(result.added).toHaveLength(0);
-  });
-
-  it("drops matching tool results for aborted assistant messages when requested", () => {
-    const input = castAgentMessages([
-      {
-        role: "assistant",
-        content: [{ type: "toolCall", id: "call_aborted", name: "exec", arguments: {} }],
-        stopReason: "aborted",
-      },
-      {
-        role: "toolResult",
-        toolCallId: "call_aborted",
-        toolName: "exec",
-        content: [{ type: "text", text: "partial result" }],
-        isError: false,
-      },
-      { role: "user", content: "retrying" },
-    ]);
-
-    const result = repairToolUseResultPairing(input, {
-      erroredAssistantResultPolicy: "drop",
-    });
-
-    expect(result.droppedOrphanCount).toBe(0);
     expect(result.messages).toHaveLength(2);
     expect(result.messages[0]?.role).toBe("assistant");
     expect(result.messages[1]?.role).toBe("user");
     expect(result.added).toHaveLength(0);
+    expect(result.changed).toBe(true);
   });
 });
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -346,15 +346,12 @@ export type ToolUseRepairReport = {
   droppedDuplicateCount: number;
   droppedOrphanCount: number;
   moved: boolean;
+  changed: boolean;
 };
-
-function shouldDropErroredAssistantResults(options?: ToolUseResultPairingOptions): boolean {
-  return options?.erroredAssistantResultPolicy === "drop";
-}
 
 export function repairToolUseResultPairing(
   messages: AgentMessage[],
-  options?: ToolUseResultPairingOptions,
+  _options?: ToolUseResultPairingOptions,
 ): ToolUseRepairReport {
   // Anthropic (and Cloud Code Assist) reject transcripts where assistant tool calls are not
   // immediately followed by matching tool results. Session files can end up with results
@@ -463,22 +460,30 @@ export function repairToolUseResultPairing(
       }
     }
 
-    // Aborted/errored assistant turns should never synthesize missing tool results, but
-    // the replay sanitizer can still legitimately retain real tool results for surviving
-    // tool calls in the same turn after malformed siblings are dropped.
+    // Aborted/errored assistant turns: strip orphaned tool_use/toolCall/functionCall
+    // blocks from the assistant message instead of passing them through unchanged.
+    // Previously we skipped synthesis to avoid creating synthetic tool_results for
+    // incomplete tool calls (#4597), but preserving orphaned blocks causes permanent
+    // session corruption — Anthropic rejects every subsequent request with
+    // "tool_use ids were found without tool_result blocks" (#48354).
     const stopReason = (assistant as { stopReason?: string }).stopReason;
     if (stopReason === "error" || stopReason === "aborted") {
-      out.push(msg);
-      if (!shouldDropErroredAssistantResults(options)) {
-        for (const toolCall of toolCalls) {
-          const result = spanResultsById.get(toolCall.id);
-          if (!result) {
-            continue;
-          }
-          pushToolResult(result);
-        }
-      } else if (spanResultsById.size > 0) {
+      const content = Array.isArray(assistant.content) ? assistant.content : [];
+      const stripped = content.filter(
+        (b: { type?: string }) =>
+          b && b.type !== "toolCall" && b.type !== "toolUse" && b.type !== "functionCall",
+      );
+      if (stripped.length < content.length) {
         changed = true;
+        out.push({
+          ...assistant,
+          content:
+            stripped.length > 0
+              ? stripped
+              : [{ type: "text" as const, text: "[tool calls from errored turn stripped]" }],
+        } as typeof assistant);
+      } else {
+        out.push(msg);
       }
       for (const rem of remainder) {
         out.push(rem);
@@ -526,5 +531,6 @@ export function repairToolUseResultPairing(
     droppedDuplicateCount,
     droppedOrphanCount,
     moved: changedOrMoved,
+    changed: changedOrMoved,
   };
 }

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -349,9 +349,16 @@ export type ToolUseRepairReport = {
   changed: boolean;
 };
 
+function shouldPreserveErroredAssistantResults(options?: ToolUseResultPairingOptions): boolean {
+  return (
+    options?.erroredAssistantResultPolicy !== undefined &&
+    options.erroredAssistantResultPolicy !== "drop"
+  );
+}
+
 export function repairToolUseResultPairing(
   messages: AgentMessage[],
-  _options?: ToolUseResultPairingOptions,
+  options?: ToolUseResultPairingOptions,
 ): ToolUseRepairReport {
   // Anthropic (and Cloud Code Assist) reject transcripts where assistant tool calls are not
   // immediately followed by matching tool results. Session files can end up with results
@@ -402,6 +409,93 @@ export function repairToolUseResultPairing(
     }
 
     const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+
+    // Check for error/aborted stop reason early, before extractToolCallsFromAssistant,
+    // because that function skips blocks without a non-empty id. For error/aborted
+    // messages we need to strip ALL tool-like blocks regardless of id presence.
+    const stopReason = (assistant as { stopReason?: string }).stopReason;
+    if (stopReason === "error" || stopReason === "aborted") {
+      // If the caller explicitly set erroredAssistantResultPolicy to "preserve",
+      // fall back to the old behavior: push the message through unchanged and
+      // optionally retain matching tool results for surviving tool calls.
+      if (shouldPreserveErroredAssistantResults(options)) {
+        const toolCalls = extractToolCallsFromAssistant(assistant);
+        out.push(msg);
+        if (toolCalls.length > 0) {
+          const toolCallIds = new Set(toolCalls.map((t) => t.id));
+          const toolCallNamesById = new Map(toolCalls.map((t) => [t.id, t.name] as const));
+          let j = i + 1;
+          for (; j < messages.length; j += 1) {
+            const next = messages[j];
+            if (!next || typeof next !== "object") {
+              continue;
+            }
+            const nextRole = (next as { role?: unknown }).role;
+            if (nextRole === "assistant") {
+              break;
+            }
+            if (nextRole === "toolResult") {
+              const toolResult = next as Extract<AgentMessage, { role: "toolResult" }>;
+              const id = extractToolResultId(toolResult);
+              if (id && toolCallIds.has(id)) {
+                const normalizedToolResult = normalizeToolResultName(
+                  toolResult,
+                  toolCallNamesById.get(id),
+                );
+                pushToolResult(normalizedToolResult);
+              }
+            }
+          }
+          i = j - 1;
+        }
+        continue;
+      }
+
+      // Default behavior: strip orphaned tool_use/toolCall/functionCall blocks from
+      // the assistant message instead of passing them through unchanged.
+      // Previously we skipped synthesis to avoid creating synthetic tool_results for
+      // incomplete tool calls (#4597), but preserving orphaned blocks causes permanent
+      // session corruption — Anthropic rejects every subsequent request with
+      // "tool_use ids were found without tool_result blocks" (#48354).
+      const content = Array.isArray(assistant.content) ? assistant.content : [];
+      const stripped = content.filter(
+        (b: { type?: string }) =>
+          b && b.type !== "toolCall" && b.type !== "toolUse" && b.type !== "functionCall",
+      );
+      if (stripped.length < content.length) {
+        changed = true;
+        out.push({
+          ...assistant,
+          content:
+            stripped.length > 0
+              ? stripped
+              : [{ type: "text" as const, text: "[tool calls from errored turn stripped]" }],
+        } as typeof assistant);
+      } else {
+        out.push(msg);
+      }
+      // Skip past any trailing messages up to the next assistant turn
+      let j = i + 1;
+      for (; j < messages.length; j += 1) {
+        const next = messages[j];
+        if (!next || typeof next !== "object") {
+          out.push(next);
+          continue;
+        }
+        const nextRole = (next as { role?: unknown }).role;
+        if (nextRole === "assistant") {
+          break;
+        }
+        if (nextRole !== "toolResult") {
+          out.push(next);
+        } else {
+          // Drop orphaned tool results for the stripped tool calls
+          changed = true;
+        }
+      }
+      i = j - 1;
+      continue;
+    }
 
     const toolCalls = extractToolCallsFromAssistant(assistant);
     if (toolCalls.length === 0) {
@@ -458,38 +552,6 @@ export function repairToolUseResultPairing(
         droppedOrphanCount += 1;
         changed = true;
       }
-    }
-
-    // Aborted/errored assistant turns: strip orphaned tool_use/toolCall/functionCall
-    // blocks from the assistant message instead of passing them through unchanged.
-    // Previously we skipped synthesis to avoid creating synthetic tool_results for
-    // incomplete tool calls (#4597), but preserving orphaned blocks causes permanent
-    // session corruption — Anthropic rejects every subsequent request with
-    // "tool_use ids were found without tool_result blocks" (#48354).
-    const stopReason = (assistant as { stopReason?: string }).stopReason;
-    if (stopReason === "error" || stopReason === "aborted") {
-      const content = Array.isArray(assistant.content) ? assistant.content : [];
-      const stripped = content.filter(
-        (b: { type?: string }) =>
-          b && b.type !== "toolCall" && b.type !== "toolUse" && b.type !== "functionCall",
-      );
-      if (stripped.length < content.length) {
-        changed = true;
-        out.push({
-          ...assistant,
-          content:
-            stripped.length > 0
-              ? stripped
-              : [{ type: "text" as const, text: "[tool calls from errored turn stripped]" }],
-        } as typeof assistant);
-      } else {
-        out.push(msg);
-      }
-      for (const rem of remainder) {
-        out.push(rem);
-      }
-      i = j - 1;
-      continue;
     }
 
     out.push(msg);


### PR DESCRIPTION
## fix: strip tool_use blocks from error/aborted assistant messages in repairToolUseResultPairing

### Problem

`repairToolUseResultPairing()` currently skips assistant messages with `stopReason === "error" || "aborted"`:

```typescript
if (stopReason === "error" || stopReason === "aborted") {
    out.push(msg);
    continue;
}
```

These are exactly the messages most likely to contain orphaned `tool_use` blocks — the tool call started but the result was never generated due to the error/abort. By skipping them entirely, the function preserves the orphaned blocks, which then cause Anthropic API rejections on every subsequent request.

### Fix

Instead of skipping error/aborted messages, extract any `tool_use`/`toolCall` blocks from them. If found, strip the tool call blocks and preserve any remaining text content. If the message becomes empty after stripping, insert a placeholder `[tool calls from errored turn stripped]`.

### Testing

Verified locally against sessions with known orphaned tool_use blocks from:
- Opus timeouts mid-tool-call
- Process crashes during tool execution  
- API overload causing incomplete responses

After applying this fix + #46866 (type mismatch fix), previously corrupted sessions recover automatically on next interaction instead of entering infinite retry loops.

### Related Issues

- #48354 — Session corruption from orphaned tool_use blocks (root cause analysis)
- #46866 — `stripDanglingAnthropicToolUses` type mismatch fix (prerequisite)
- #45393 — End-of-conversation orphan fix
- #33621 — Original dangling tool_use after compaction report
