### PR TITLE
feat(thinking): allow custom model compat to opt into xhigh

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -132,8 +132,13 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
           `Invalid thinking level "${thinkingRaw}". Use one of: ${INVALID_THINKING_LEVELS_HINT}.`,
         );
       }
-      if (thinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
-        throw new Error(`Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`);
+      if (
+        thinkLevel === "xhigh" &&
+        !supportsXHighThinking(provider, model, { config: api.config })
+      ) {
+        throw new Error(
+          `Thinking level "xhigh" is only supported for ${formatXHighModelHint({ config: api.config })}.`,
+        );
       }
 
       const timeoutMs =

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -125,7 +125,10 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   const stream = ndJsonStream(input, output);
 
   new AgentSideConnection((conn: AgentSideConnection) => {
-    agent = new AcpGatewayAgent(conn, gateway, opts);
+    agent = new AcpGatewayAgent(conn, gateway, {
+      ...opts,
+      cfg,
+    });
     agent.start();
     return agent;
   }, stream);

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 import { describe, expect, it, vi } from "vitest";
 import { listThinkingLevels } from "../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../config/types.js";
 import type { GatewayClient } from "../gateway/client.js";
 import type { EventFrame } from "../gateway/protocol/index.js";
 import { createInMemorySessionStore } from "./session.js";
@@ -238,6 +239,77 @@ describe("acp session UX bridge behavior", () => {
         }),
       ]),
     );
+
+    sessionStore.clearAllSessionsForTest();
+  });
+
+  it("keeps ACP thought-level modes config-aware for custom xhigh models", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          robot: {
+            baseUrl: "https://example.test/v1",
+            models: [
+              {
+                id: "gpt-5.4",
+                name: "robot/gpt-5.4",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128000,
+                maxTokens: 8192,
+                compat: { supportsXHighThinking: true },
+              },
+            ],
+          },
+        },
+      },
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "robot-session",
+              kind: "direct",
+              updatedAt: 1_710_000_000_000,
+              thinkingLevel: "high",
+              modelProvider: "robot",
+              model: "gpt-5.4",
+              totalTokens: 0,
+              totalTokensFresh: true,
+              contextTokens: 0,
+            },
+          ],
+        };
+      }
+      if (method === "sessions.get") {
+        return { messages: [] };
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+      cfg,
+      sessionStore,
+    });
+
+    const result = await agent.loadSession(createLoadSessionRequest("robot-session"));
+
+    expect(result.modes?.availableModes.map((mode) => mode.id)).toContain("xhigh");
+    expect(
+      result.configOptions?.find((option) => option.id === "thought_level")?.options.map(
+        (option) => option.value,
+      ),
+    ).toContain("xhigh");
 
     sessionStore.clearAllSessionsForTest();
   });

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -15,9 +15,7 @@ import { createInMemorySessionStore } from "./session.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
 
-type SelectSessionConfigOption = SessionConfigOption & {
-  options: Array<{ value: string }>;
-};
+type SelectSessionConfigOption = SessionConfigOption & { options: Array<{ value: string }> };
 
 function createNewSessionRequest(cwd = "/tmp"): NewSessionRequest {
   return {
@@ -46,12 +44,6 @@ function createPromptRequest(
     prompt: [{ type: "text", text }],
     _meta: meta,
   } as unknown as PromptRequest;
-}
-
-function isSelectConfigOption(
-  option: SessionConfigOption,
-): option is SelectSessionConfigOption {
-  return "options" in option && Array.isArray(option.options);
 }
 
 function createSetSessionModeRequest(sessionId: string, modeId: string): SetSessionModeRequest {
@@ -316,7 +308,7 @@ describe("acp session UX bridge behavior", () => {
     const result = await agent.loadSession(createLoadSessionRequest("robot-session"));
     const thoughtLevelOption = result.configOptions?.find(
       (option): option is SelectSessionConfigOption =>
-        option.id === "thought_level" && isSelectConfigOption(option),
+        option.id === "thought_level" && "options" in option,
     );
 
     expect(result.modes?.availableModes.map((mode) => mode.id)).toContain("xhigh");

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -2,6 +2,7 @@ import type {
   LoadSessionRequest,
   NewSessionRequest,
   PromptRequest,
+  SessionConfigOption,
   SetSessionConfigOptionRequest,
   SetSessionModeRequest,
 } from "@agentclientprotocol/sdk";
@@ -13,6 +14,10 @@ import type { EventFrame } from "../gateway/protocol/index.js";
 import { createInMemorySessionStore } from "./session.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+type SelectSessionConfigOption = SessionConfigOption & {
+  options: Array<{ value: string }>;
+};
 
 function createNewSessionRequest(cwd = "/tmp"): NewSessionRequest {
   return {
@@ -41,6 +46,12 @@ function createPromptRequest(
     prompt: [{ type: "text", text }],
     _meta: meta,
   } as unknown as PromptRequest;
+}
+
+function isSelectConfigOption(
+  option: SessionConfigOption,
+): option is SelectSessionConfigOption {
+  return "options" in option && Array.isArray(option.options);
 }
 
 function createSetSessionModeRequest(sessionId: string, modeId: string): SetSessionModeRequest {
@@ -304,7 +315,8 @@ describe("acp session UX bridge behavior", () => {
 
     const result = await agent.loadSession(createLoadSessionRequest("robot-session"));
     const thoughtLevelOption = result.configOptions?.find(
-      (option) => option.id === "thought_level" && "options" in option,
+      (option): option is SelectSessionConfigOption =>
+        option.id === "thought_level" && isSelectConfigOption(option),
     );
 
     expect(result.modes?.availableModes.map((mode) => mode.id)).toContain("xhigh");

--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -303,13 +303,12 @@ describe("acp session UX bridge behavior", () => {
     });
 
     const result = await agent.loadSession(createLoadSessionRequest("robot-session"));
+    const thoughtLevelOption = result.configOptions?.find(
+      (option) => option.id === "thought_level" && "options" in option,
+    );
 
     expect(result.modes?.availableModes.map((mode) => mode.id)).toContain("xhigh");
-    expect(
-      result.configOptions?.find((option) => option.id === "thought_level")?.options.map(
-        (option) => option.value,
-      ),
-    ).toContain("xhigh");
+    expect(thoughtLevelOption?.options.map((option) => option.value)).toContain("xhigh");
 
     sessionStore.clearAllSessionsForTest();
   });

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -28,6 +28,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 import { listThinkingLevels } from "../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../config/types.js";
 import type { GatewayClient } from "../gateway/client.js";
 import type { EventFrame } from "../gateway/protocol/index.js";
 import type { GatewaySessionRow, SessionsListResult } from "../gateway/session-utils.js";
@@ -79,6 +80,7 @@ type PendingToolCall = {
 };
 
 type AcpGatewayAgentOptions = AcpServerOptions & {
+  cfg?: Pick<OpenClawConfig, "models"> | null;
   sessionStore?: AcpSessionStore;
 };
 
@@ -179,6 +181,7 @@ function buildSelectConfigOption(params: {
 }
 
 function buildSessionPresentation(params: {
+  cfg?: Pick<OpenClawConfig, "models"> | null;
   row?: GatewaySessionPresentationRow;
   overrides?: Partial<GatewaySessionPresentationRow>;
 }): SessionPresentation {
@@ -186,7 +189,10 @@ function buildSessionPresentation(params: {
     ...params.row,
     ...params.overrides,
   };
-  const availableLevelIds: string[] = [...listThinkingLevels(row.modelProvider, row.model)];
+  const thinkingSupportSource = params.cfg ? { config: params.cfg } : undefined;
+  const availableLevelIds: string[] = [
+    ...listThinkingLevels(row.modelProvider, row.model, thinkingSupportSource),
+  ];
   const currentModeId = row.thinkingLevel?.trim() || "adaptive";
   if (!availableLevelIds.includes(currentModeId)) {
     availableLevelIds.push(currentModeId);
@@ -907,14 +913,14 @@ export class AcpGatewayAgent implements Agent {
     try {
       const row = await this.getGatewaySessionRow(sessionKey);
       return {
-        ...buildSessionPresentation({ row, overrides }),
+        ...buildSessionPresentation({ cfg: this.opts.cfg, row, overrides }),
         metadata: buildSessionMetadata({ row, sessionKey }),
         usage: buildSessionUsageSnapshot(row),
       };
     } catch (err) {
       this.log(`session presentation fallback for ${sessionKey}: ${String(err)}`);
       return {
-        ...buildSessionPresentation({ overrides }),
+        ...buildSessionPresentation({ cfg: this.opts.cfg, overrides }),
         metadata: buildSessionMetadata({ sessionKey }),
       };
     }

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -598,7 +598,12 @@ async function prepareAgentCommandExecution(
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const thinkingLevelsHint = formatThinkingLevels(configuredModel.provider, configuredModel.model);
+  const thinkingLevelsHint = formatThinkingLevels(
+    configuredModel.provider,
+    configuredModel.model,
+    ", ",
+    { config: cfg },
+  );
 
   const thinkOverride = normalizeThinkLevel(opts.thinking);
   const thinkOnce = normalizeThinkLevel(opts.thinkingOnce);
@@ -1101,10 +1106,15 @@ async function agentCommandInternal(
         catalog: catalogForThinking,
       });
     }
-    if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
+    if (
+      resolvedThinkLevel === "xhigh" &&
+      !supportsXHighThinking(provider, model, { config: cfg })
+    ) {
       const explicitThink = Boolean(thinkOnce || thinkOverride);
       if (explicitThink) {
-        throw new Error(`Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`);
+        throw new Error(
+          `Thinking level "xhigh" is only supported for ${formatXHighModelHint({ config: cfg })}.`,
+        );
       }
       resolvedThinkLevel = "high";
       if (sessionEntry && sessionStore && sessionKey && sessionEntry.thinkingLevel === "xhigh") {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -454,7 +454,7 @@ export async function spawnSubagentDirect(
     const normalized = normalizeThinkLevel(thinkingCandidateRaw);
     if (!normalized) {
       const { provider, model } = splitModelRef(resolvedModel);
-      const hint = formatThinkingLevels(provider, model);
+      const hint = formatThinkingLevels(provider, model, ", ", { config: cfg });
       return {
         status: "error",
         error: `Invalid thinking level "${thinkingCandidateRaw}". Use one of: ${hint}.`,

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -634,7 +634,8 @@ function buildChatCommands(): ChatCommandDefinition[] {
           name: "level",
           description: "off, minimal, low, medium, high, xhigh",
           type: "string",
-          choices: ({ provider, model }) => listThinkingLevels(provider, model),
+          choices: ({ cfg, provider, model }) =>
+            listThinkingLevels(provider, model, cfg ? { config: cfg } : undefined),
         },
       ],
       argsMenu: "auto",

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
@@ -417,6 +418,47 @@ describe("commands registry args", () => {
     expect(seenChoice?.argName).toBe("level");
     expect(seenChoice?.provider).toBeTruthy();
     expect(seenChoice?.model).toBeTruthy();
+  });
+
+  it("keeps think arg choices config-aware for custom xhigh models", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          robot: {
+            baseUrl: "https://example.test/v1",
+            models: [
+              {
+                id: "gpt-5.4",
+                name: "robot/gpt-5.4",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128000,
+                maxTokens: 8192,
+                compat: { supportsXHighThinking: true },
+              },
+            ],
+          },
+        },
+      },
+    };
+    const command = listChatCommands().find((entry) => entry.key === "think");
+    const arg = command?.args?.find((entry) => entry.name === "level");
+    expect(command).toBeTruthy();
+    expect(arg).toBeTruthy();
+    if (!command || !arg) {
+      throw new Error("think level arg is missing from the command registry");
+    }
+
+    const choices = resolveCommandArgChoices({
+      command,
+      arg,
+      cfg,
+      provider: "robot",
+      model: "gpt-5.4",
+    });
+
+    expect(choices.map((choice) => choice.value)).toContain("xhigh");
   });
 
   it("does not show menus when args were provided as raw text only", () => {

--- a/src/auto-reply/reply.directive.directive-behavior.applies-inline-reasoning-mixed-messages-acks-immediately.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.applies-inline-reasoning-mixed-messages-acks-immediately.test.ts
@@ -249,6 +249,61 @@ describe("directive behavior", () => {
       expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
     });
   });
+
+  it("allows custom provider config to opt into xhigh", async () => {
+    await withTempHome(async (home) => {
+      const cfg = makeWhatsAppDirectiveConfig(
+        home,
+        {
+          model: "robot/gpt-5.4",
+          thinkingDefault: "high",
+        },
+        {
+          models: {
+            providers: {
+              robot: {
+                baseUrl: "https://example.test/v1",
+                api: "openai-responses",
+                models: [
+                  {
+                    id: "gpt-5.4",
+                    name: "gpt-5.4 (robot)",
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 128000,
+                    maxTokens: 8192,
+                    compat: { supportsXHighThinking: true },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      );
+
+      const statusRes = await getReplyFromConfig(
+        { Body: "/think", From: "+1222", To: "+1222", CommandAuthorized: true },
+        {},
+        cfg,
+      );
+      expect(replyText(statusRes)).toContain(
+        "Options: off, minimal, low, medium, high, xhigh, adaptive.",
+      );
+
+      const setRes = await getReplyFromConfig(
+        {
+          Body: "/thinking xhigh",
+          From: "+1004",
+          To: "+2000",
+          CommandAuthorized: true,
+        },
+        {},
+        cfg,
+      );
+      expect(replyTexts(setRes)).toContain("Thinking level set to xhigh.");
+    });
+  });
   it("keeps reserved command aliases from matching after trimming", async () => {
     await withTempHome(async (home) => {
       const res = await getReplyFromConfig(

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -150,12 +150,12 @@ export async function handleDirectiveOnly(
       return {
         text: withOptions(
           `Current thinking level: ${level}.`,
-          formatThinkingLevels(resolvedProvider, resolvedModel),
+          formatThinkingLevels(resolvedProvider, resolvedModel, ", ", { config: params.cfg }),
         ),
       };
     }
     return {
-      text: `Unrecognized thinking level "${directives.rawThinkLevel}". Valid levels: ${formatThinkingLevels(resolvedProvider, resolvedModel)}.`,
+      text: `Unrecognized thinking level "${directives.rawThinkLevel}". Valid levels: ${formatThinkingLevels(resolvedProvider, resolvedModel, ", ", { config: params.cfg })}.`,
     };
   }
   if (directives.hasVerboseDirective && !directives.verboseLevel) {
@@ -283,10 +283,10 @@ export async function handleDirectiveOnly(
   if (
     directives.hasThinkDirective &&
     directives.thinkLevel === "xhigh" &&
-    !supportsXHighThinking(resolvedProvider, resolvedModel)
+    !supportsXHighThinking(resolvedProvider, resolvedModel, { config: params.cfg })
   ) {
     return {
-      text: `Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`,
+      text: `Thinking level "xhigh" is only supported for ${formatXHighModelHint({ config: params.cfg })}.`,
     };
   }
 
@@ -296,7 +296,7 @@ export async function handleDirectiveOnly(
   const shouldDowngradeXHigh =
     !directives.hasThinkDirective &&
     nextThinkLevel === "xhigh" &&
-    !supportsXHighThinking(resolvedProvider, resolvedModel);
+    !supportsXHighThinking(resolvedProvider, resolvedModel, { config: params.cfg });
 
   const prevElevatedLevel =
     currentElevatedLevel ??

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -339,7 +339,10 @@ export async function runPreparedReply(
   if (!resolvedThinkLevel && prefixedBodyBase) {
     const parts = prefixedBodyBase.split(/\s+/);
     const maybeLevel = normalizeThinkLevel(parts[0]);
-    if (maybeLevel && (maybeLevel !== "xhigh" || supportsXHighThinking(provider, model))) {
+    if (
+      maybeLevel &&
+      (maybeLevel !== "xhigh" || supportsXHighThinking(provider, model, { config: cfg }))
+    ) {
       resolvedThinkLevel = maybeLevel;
       prefixedBodyBase = parts.slice(1).join(" ").trim();
     }
@@ -390,12 +393,12 @@ export async function runPreparedReply(
   if (!resolvedThinkLevel) {
     resolvedThinkLevel = await modelState.resolveDefaultThinkingLevel();
   }
-  if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
+  if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model, { config: cfg })) {
     const explicitThink = directives.hasThinkDirective && directives.thinkLevel !== undefined;
     if (explicitThink) {
       typing.cleanup();
       return {
-        text: `Thinking level "xhigh" is only supported for ${formatXHighModelHint()}. Use /think high or switch to one of those models.`,
+        text: `Thinking level "xhigh" is only supported for ${formatXHighModelHint({ config: cfg })}. Use /think high or switch to one of those models.`,
       };
     }
     resolvedThinkLevel = "high";

--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -1,3 +1,5 @@
+import type { ModelCompatConfig } from "../config/types.models.js";
+
 export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
 export type VerboseLevel = "off" | "on" | "full";
 export type NoticeLevel = "off" | "on" | "full";
@@ -9,6 +11,7 @@ export type ThinkingCatalogEntry = {
   provider: string;
   id: string;
   reasoning?: boolean;
+  compat?: Pick<ModelCompatConfig, "supportsXHighThinking">;
 };
 
 const BASE_THINKING_LEVELS: ThinkLevel[] = ["off", "minimal", "low", "medium", "high", "adaptive"];

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -168,6 +168,7 @@ describe("listThinkingLevels", () => {
     expect(supportsXHighThinking("zai", "gpt-5.4", source)).toBe(false);
     expect(listThinkingLevels("zai", "gpt-5.4", source)).not.toContain("xhigh");
     expect(listThinkingLevelLabels("zai", "gpt-5.4", source)).toEqual(["off", "on"]);
+    expect(formatXHighModelHint(source)).toBe(formatXHighModelHint());
   });
 
   it("always includes adaptive", () => {

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -12,12 +12,45 @@ vi.mock("../plugins/provider-runtime.js", () => ({
   resolveProviderXHighThinking: providerRuntimeMocks.resolveProviderXHighThinking,
 }));
 import {
+  formatXHighModelHint,
   listThinkingLevelLabels,
   listThinkingLevels,
   normalizeReasoningLevel,
   normalizeThinkLevel,
   resolveThinkingDefaultForModel,
+  supportsXHighThinking,
+  type ThinkingSupportSource,
 } from "./thinking.js";
+
+function createThinkingSupportSource(
+  provider: string,
+  supportsXHighThinking: boolean,
+): ThinkingSupportSource {
+  return {
+    config: {
+      models: {
+        providers: {
+          [provider]: {
+            baseUrl:
+              provider === "openai" ? "https://api.openai.com/v1" : "https://example.test/v1",
+            models: [
+              {
+                id: "gpt-5.4",
+                name: `${provider}/gpt-5.4`,
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128000,
+                maxTokens: 8192,
+                compat: { supportsXHighThinking },
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+}
 
 beforeEach(() => {
   providerRuntimeMocks.resolveProviderBinaryThinking.mockReset();
@@ -95,6 +128,37 @@ describe("listThinkingLevels", () => {
 
   it("excludes xhigh for non-codex models", () => {
     expect(listThinkingLevels(undefined, "gpt-4.1-mini")).not.toContain("xhigh");
+  });
+
+  it("allows config-defined custom models to opt in to xhigh", () => {
+    const source = createThinkingSupportSource("robot", true);
+
+    expect(supportsXHighThinking("robot", "gpt-5.4", source)).toBe(true);
+    expect(listThinkingLevels("robot", "gpt-5.4", source)).toContain("xhigh");
+    expect(formatXHighModelHint(source)).toContain("robot/gpt-5.4");
+  });
+
+  it("allows config to explicitly disable xhigh for an otherwise supported ref", () => {
+    const source = createThinkingSupportSource("openai", false);
+
+    expect(supportsXHighThinking("openai", "gpt-5.4", source)).toBe(false);
+    expect(listThinkingLevels("openai", "gpt-5.4", source)).not.toContain("xhigh");
+  });
+
+  it("keeps catalog overrides aligned with xhigh hint generation", () => {
+    const source: ThinkingSupportSource = {
+      ...createThinkingSupportSource("openai", true),
+      catalog: [
+        {
+          provider: "openai",
+          id: "gpt-5.4",
+          compat: { supportsXHighThinking: false },
+        },
+      ],
+    };
+
+    expect(supportsXHighThinking("openai", "gpt-5.4", source)).toBe(false);
+    expect(formatXHighModelHint(source)).not.toContain("openai/gpt-5.4");
   });
 
   it("always includes adaptive", () => {

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -135,7 +135,8 @@ describe("listThinkingLevels", () => {
 
     expect(supportsXHighThinking("robot", "gpt-5.4", source)).toBe(true);
     expect(listThinkingLevels("robot", "gpt-5.4", source)).toContain("xhigh");
-    expect(formatXHighModelHint(source)).toContain("robot/gpt-5.4");
+    expect(formatXHighModelHint(source)).toContain("config-defined models: robot/gpt-5.4");
+    expect(formatXHighModelHint(source)).not.toContain("including");
   });
 
   it("allows config to explicitly disable xhigh for an otherwise supported ref", () => {
@@ -159,6 +160,14 @@ describe("listThinkingLevels", () => {
 
     expect(supportsXHighThinking("openai", "gpt-5.4", source)).toBe(false);
     expect(formatXHighModelHint(source)).not.toContain("openai/gpt-5.4");
+  });
+
+  it("does not allow explicit xhigh overrides for binary thinking providers", () => {
+    const source = createThinkingSupportSource("zai", true);
+
+    expect(supportsXHighThinking("zai", "gpt-5.4", source)).toBe(false);
+    expect(listThinkingLevels("zai", "gpt-5.4", source)).not.toContain("xhigh");
+    expect(listThinkingLevelLabels("zai", "gpt-5.4", source)).toEqual(["off", "on"]);
   });
 
   it("always includes adaptive", () => {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -1,5 +1,7 @@
+import type { OpenClawConfig } from "../config/types.js";
 import {
   formatThinkingLevels as formatThinkingLevelsFallback,
+  formatXHighModelHint as formatXHighModelHintFallback,
   isBinaryThinkingProvider as isBinaryThinkingProviderFallback,
   listThinkingLevelLabels as listThinkingLevelLabelsFallback,
   listThinkingLevels as listThinkingLevelsFallback,
@@ -9,7 +11,6 @@ import {
 } from "./thinking.shared.js";
 import type { ThinkLevel, ThinkingCatalogEntry } from "./thinking.shared.js";
 export {
-  formatXHighModelHint,
   normalizeElevatedLevel,
   normalizeFastMode,
   normalizeNoticeLevel,
@@ -36,6 +37,152 @@ import {
   resolveProviderXHighThinking,
 } from "../plugins/provider-runtime.js";
 
+export type ThinkingSupportSource = {
+  config?: Pick<OpenClawConfig, "models"> | null;
+  catalog?: ThinkingCatalogEntry[] | null;
+};
+
+function normalizeModelId(model?: string | null): string {
+  return model?.trim().toLowerCase() ?? "";
+}
+
+function normalizeModelRef(provider?: string | null, model?: string | null): string {
+  const providerKey = normalizeProviderId(provider);
+  const modelKey = normalizeModelId(model);
+  return providerKey && modelKey ? `${providerKey}/${modelKey}` : "";
+}
+
+function resolveCatalogXHighOverride(
+  provider?: string | null,
+  model?: string | null,
+  source?: ThinkingSupportSource,
+): boolean | undefined {
+  const ref = normalizeModelRef(provider, model);
+  if (!ref) {
+    return undefined;
+  }
+  const entry = source?.catalog?.find(
+    (candidate) => normalizeModelRef(candidate.provider, candidate.id) === ref,
+  );
+  return typeof entry?.compat?.supportsXHighThinking === "boolean"
+    ? entry.compat.supportsXHighThinking
+    : undefined;
+}
+
+function resolveConfigXHighOverride(
+  provider?: string | null,
+  model?: string | null,
+  source?: ThinkingSupportSource,
+): boolean | undefined {
+  const providerKey = normalizeProviderId(provider);
+  const modelKey = normalizeModelId(model);
+  if (!providerKey || !modelKey) {
+    return undefined;
+  }
+
+  const providers = source?.config?.models?.providers;
+  if (!providers || typeof providers !== "object") {
+    return undefined;
+  }
+
+  for (const [configuredProviderId, configuredProvider] of Object.entries(providers)) {
+    if (normalizeProviderId(configuredProviderId) !== providerKey) {
+      continue;
+    }
+    if (!configuredProvider || typeof configuredProvider !== "object") {
+      continue;
+    }
+    const configuredModels = (configuredProvider as { models?: unknown }).models;
+    if (!Array.isArray(configuredModels)) {
+      continue;
+    }
+    for (const configuredModel of configuredModels) {
+      if (!configuredModel || typeof configuredModel !== "object") {
+        continue;
+      }
+      const configuredModelId = (configuredModel as { id?: unknown }).id;
+      if (
+        typeof configuredModelId !== "string" ||
+        normalizeModelId(configuredModelId) !== modelKey
+      ) {
+        continue;
+      }
+      const compat = (configuredModel as { compat?: { supportsXHighThinking?: unknown } }).compat;
+      if (typeof compat?.supportsXHighThinking === "boolean") {
+        return compat.supportsXHighThinking;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function resolveExplicitXHighOverride(
+  provider?: string | null,
+  model?: string | null,
+  source?: ThinkingSupportSource,
+): boolean | undefined {
+  return (
+    resolveCatalogXHighOverride(provider, model, source) ??
+    resolveConfigXHighOverride(provider, model, source)
+  );
+}
+
+function collectExplicitXHighRefs(
+  source?: ThinkingSupportSource,
+): Array<{ ref: string; supported: boolean }> {
+  const out = new Map<string, { ref: string; supported: boolean }>();
+
+  const add = (provider?: string | null, model?: string | null, supported?: unknown) => {
+    if (typeof supported !== "boolean") {
+      return;
+    }
+    const ref = normalizeModelRef(provider, model);
+    if (!ref) {
+      return;
+    }
+    out.set(ref, { ref, supported });
+  };
+
+  const providers = source?.config?.models?.providers;
+  if (providers && typeof providers === "object") {
+    for (const [providerId, providerConfig] of Object.entries(providers)) {
+      const configuredModels =
+        providerConfig && typeof providerConfig === "object"
+          ? (providerConfig as { models?: unknown }).models
+          : undefined;
+      if (!Array.isArray(configuredModels)) {
+        continue;
+      }
+      for (const configuredModel of configuredModels) {
+        if (!configuredModel || typeof configuredModel !== "object") {
+          continue;
+        }
+        const modelId = (configuredModel as { id?: unknown }).id;
+        const compat = (configuredModel as { compat?: { supportsXHighThinking?: unknown } }).compat;
+        add(
+          providerId,
+          typeof modelId === "string" ? modelId : undefined,
+          compat?.supportsXHighThinking,
+        );
+      }
+    }
+  }
+
+  // Match resolveExplicitXHighOverride(): catalog entries override config for the same ref.
+  for (const entry of source?.catalog ?? []) {
+    add(entry.provider, entry.id, entry.compat?.supportsXHighThinking);
+  }
+
+  return [...out.values()];
+}
+
+function listSupportedXHighModelRefs(source?: ThinkingSupportSource): string[] {
+  return collectExplicitXHighRefs(source)
+    .filter((entry) => entry.supported)
+    .map((entry) => entry.ref);
+}
+
 export function isBinaryThinkingProvider(provider?: string | null, model?: string | null): boolean {
   if (isBinaryThinkingProviderFallback(provider)) {
     return true;
@@ -58,8 +205,17 @@ export function isBinaryThinkingProvider(provider?: string | null, model?: strin
   return isBinaryThinkingProviderFallback(provider);
 }
 
-export function supportsXHighThinking(provider?: string | null, model?: string | null): boolean {
-  const modelKey = model?.trim().toLowerCase();
+export function supportsXHighThinking(
+  provider?: string | null,
+  model?: string | null,
+  source?: ThinkingSupportSource,
+): boolean {
+  const explicitOverride = resolveExplicitXHighOverride(provider, model, source);
+  if (typeof explicitOverride === "boolean") {
+    return explicitOverride;
+  }
+
+  const modelKey = normalizeModelId(model);
   if (!modelKey) {
     return false;
   }
@@ -82,29 +238,48 @@ export function supportsXHighThinking(provider?: string | null, model?: string |
   return false;
 }
 
-export function listThinkingLevels(provider?: string | null, model?: string | null): ThinkLevel[] {
+export function listThinkingLevels(
+  provider?: string | null,
+  model?: string | null,
+  source?: ThinkingSupportSource,
+): ThinkLevel[] {
   const levels = listThinkingLevelsFallback(provider, model);
-  if (supportsXHighThinking(provider, model)) {
+  if (supportsXHighThinking(provider, model, source)) {
     levels.splice(levels.length - 1, 0, "xhigh");
   }
   return levels;
 }
 
-export function listThinkingLevelLabels(provider?: string | null, model?: string | null): string[] {
+export function listThinkingLevelLabels(
+  provider?: string | null,
+  model?: string | null,
+  source?: ThinkingSupportSource,
+): string[] {
   if (isBinaryThinkingProvider(provider, model)) {
     return ["off", "on"];
   }
-  return listThinkingLevelLabelsFallback(provider, model);
+  return supportsXHighThinking(provider, model, source)
+    ? listThinkingLevels(provider, model, source)
+    : listThinkingLevelLabelsFallback(provider, model);
 }
 
 export function formatThinkingLevels(
   provider?: string | null,
   model?: string | null,
   separator = ", ",
+  source?: ThinkingSupportSource,
 ): string {
-  return supportsXHighThinking(provider, model)
-    ? listThinkingLevelLabels(provider, model).join(separator)
+  return supportsXHighThinking(provider, model, source)
+    ? listThinkingLevelLabels(provider, model, source).join(separator)
     : formatThinkingLevelsFallback(provider, model, separator);
+}
+
+export function formatXHighModelHint(source?: ThinkingSupportSource): string {
+  const explicitRefs = listSupportedXHighModelRefs(source);
+  if (explicitRefs.length === 0) {
+    return formatXHighModelHintFallback();
+  }
+  return `${formatXHighModelHintFallback()} (including ${explicitRefs.join(", ")})`;
 }
 
 export function resolveThinkingDefaultForModel(params: {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -130,8 +130,11 @@ function resolveExplicitXHighOverride(
 
 function collectExplicitXHighRefs(
   source?: ThinkingSupportSource,
-): Array<{ ref: string; supported: boolean }> {
-  const out = new Map<string, { ref: string; supported: boolean }>();
+): Array<{ provider?: string | null; model?: string | null; ref: string; supported: boolean }> {
+  const out = new Map<
+    string,
+    { provider?: string | null; model?: string | null; ref: string; supported: boolean }
+  >();
 
   const add = (provider?: string | null, model?: string | null, supported?: unknown) => {
     if (typeof supported !== "boolean") {
@@ -141,7 +144,7 @@ function collectExplicitXHighRefs(
     if (!ref) {
       return;
     }
-    out.set(ref, { ref, supported });
+    out.set(ref, { provider, model, ref, supported });
   };
 
   const providers = source?.config?.models?.providers;
@@ -179,7 +182,7 @@ function collectExplicitXHighRefs(
 
 function listSupportedXHighModelRefs(source?: ThinkingSupportSource): string[] {
   return collectExplicitXHighRefs(source)
-    .filter((entry) => entry.supported)
+    .filter((entry) => entry.supported && !isBinaryThinkingProvider(entry.provider, entry.model))
     .map((entry) => entry.ref);
 }
 

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -210,6 +210,10 @@ export function supportsXHighThinking(
   model?: string | null,
   source?: ThinkingSupportSource,
 ): boolean {
+  if (isBinaryThinkingProvider(provider, model)) {
+    return false;
+  }
+
   const explicitOverride = resolveExplicitXHighOverride(provider, model, source);
   if (typeof explicitOverride === "boolean") {
     return explicitOverride;
@@ -279,7 +283,7 @@ export function formatXHighModelHint(source?: ThinkingSupportSource): string {
   if (explicitRefs.length === 0) {
     return formatXHighModelHintFallback();
   }
-  return `${formatXHighModelHintFallback()} (including ${explicitRefs.join(", ")})`;
+  return `${formatXHighModelHintFallback()} or config-defined models: ${explicitRefs.join(", ")}`;
 }
 
 export function resolveThinkingDefaultForModel(params: {

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -37,6 +37,7 @@ export type ModelCompatConfig = SupportedOpenAICompatFields & {
   toolSchemaProfile?: "xai";
   nativeWebSearchTool?: boolean;
   toolCallArgumentsEncoding?: "html-entities";
+  supportsXHighThinking?: boolean;
   requiresMistralToolIds?: boolean;
   requiresOpenAiAnthropicToolPayload?: boolean;
 };

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -189,6 +189,7 @@ export const ModelCompatSchema = z
     supportsUsageInStreaming: z.boolean().optional(),
     supportsTools: z.boolean().optional(),
     supportsStrictMode: z.boolean().optional(),
+    supportsXHighThinking: z.boolean().optional(),
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -445,7 +445,10 @@ export async function runCronIsolatedAgentTurn(params: {
       catalog: await loadCatalog(),
     });
   }
-  if (thinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
+  if (
+    thinkLevel === "xhigh" &&
+    !supportsXHighThinking(provider, model, { config: cfgWithAgentDefaults })
+  ) {
     logWarn(
       `[cron:${params.job.id}] Thinking level "xhigh" is not supported for ${provider}/${model}; downgrading to "high".`,
     );

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -246,7 +246,7 @@ export async function applySessionsPatchToStore(params: {
         const hintProvider = existing?.providerOverride?.trim() || resolvedDefault.provider;
         const hintModel = existing?.modelOverride?.trim() || resolvedDefault.model;
         return invalid(
-          `invalid thinkingLevel (use ${formatThinkingLevels(hintProvider, hintModel, "|")})`,
+          `invalid thinkingLevel (use ${formatThinkingLevels(hintProvider, hintModel, "|", { config: cfg })})`,
         );
       }
       next.thinkingLevel = normalized;
@@ -423,9 +423,11 @@ export async function applySessionsPatchToStore(params: {
   if (next.thinkingLevel === "xhigh") {
     const effectiveProvider = next.providerOverride ?? resolvedDefault.provider;
     const effectiveModel = next.modelOverride ?? resolvedDefault.model;
-    if (!supportsXHighThinking(effectiveProvider, effectiveModel)) {
+    if (!supportsXHighThinking(effectiveProvider, effectiveModel, { config: cfg })) {
       if ("thinkingLevel" in patch) {
-        return invalid(`thinkingLevel "xhigh" is only supported for ${formatXHighModelHint()}`);
+        return invalid(
+          `thinkingLevel "xhigh" is only supported for ${formatXHighModelHint({ config: cfg })}`,
+        );
       }
       next.thinkingLevel = "high";
     }

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -51,7 +51,12 @@ export function parseCommand(input: string): ParsedCommand {
 }
 
 export function getSlashCommands(options: SlashCommandOptions = {}): SlashCommand[] {
-  const thinkLevels = listThinkingLevelLabels(options.provider, options.model);
+  const thinkingSupportSource = options.cfg ? { config: options.cfg } : undefined;
+  const thinkLevels = listThinkingLevelLabels(
+    options.provider,
+    options.model,
+    thinkingSupportSource,
+  );
   const verboseCompletions = createLevelCompletion(VERBOSE_LEVELS);
   const fastCompletions = createLevelCompletion(FAST_LEVELS);
   const reasoningCompletions = createLevelCompletion(REASONING_LEVELS);
@@ -139,7 +144,13 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
 }
 
 export function helpText(options: SlashCommandOptions = {}): string {
-  const thinkLevels = formatThinkingLevels(options.provider, options.model, "|");
+  const thinkingSupportSource = options.cfg ? { config: options.cfg } : undefined;
+  const thinkLevels = formatThinkingLevels(
+    options.provider,
+    options.model,
+    "|",
+    thinkingSupportSource,
+  );
   return [
     "Slash commands:",
     "/help",

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
 import { createCommandHandlers } from "./tui-command-handlers.js";
 
 type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
@@ -11,8 +12,10 @@ function createHarness(params?: {
   setSession?: SetSessionMock;
   loadHistory?: LoadHistoryMock;
   setActivityStatus?: SetActivityStatusMock;
+  config?: OpenClawConfig;
   isConnected?: boolean;
   activeChatRunId?: string | null;
+  sessionInfo?: Record<string, unknown>;
 }) {
   const sendChat = params?.sendChat ?? vi.fn().mockResolvedValue({ runId: "r1" });
   const resetSession = params?.resetSession ?? vi.fn().mockResolvedValue({ ok: true });
@@ -29,7 +32,7 @@ function createHarness(params?: {
     currentSessionKey: "agent:main:main",
     activeChatRunId: params?.activeChatRunId ?? null,
     isConnected: params?.isConnected ?? true,
-    sessionInfo: {},
+    sessionInfo: params?.sessionInfo ?? {},
   };
 
   const { handleCommand } = createCommandHandlers({
@@ -37,6 +40,7 @@ function createHarness(params?: {
     chatLog: { addUser, addSystem } as never,
     tui: { requestRender } as never,
     opts: {},
+    config: params?.config,
     state: state as never,
     deliverDefault: false,
     openOverlay: vi.fn(),
@@ -201,5 +205,49 @@ describe("tui command handlers", () => {
     expect(addUser).not.toHaveBeenCalled();
     expect(addSystem).toHaveBeenCalledWith("not connected to gateway — message not sent");
     expect(setActivityStatus).toHaveBeenLastCalledWith("disconnected");
+  });
+
+  it("uses config-aware xhigh hints for help and think usage", async () => {
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          robot: {
+            baseUrl: "https://example.test/v1",
+            models: [
+              {
+                id: "gpt-5.4",
+                name: "robot/gpt-5.4",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128000,
+                maxTokens: 8192,
+                compat: { supportsXHighThinking: true },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const { handleCommand, addSystem } = createHarness({
+      config,
+      sessionInfo: {
+        modelProvider: "robot",
+        model: "gpt-5.4",
+      },
+    });
+
+    await handleCommand("/help");
+    await handleCommand("/think");
+
+    expect(addSystem).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/think <off|minimal|low|medium|high|xhigh|adaptive>"),
+    );
+    expect(addSystem).toHaveBeenNthCalledWith(
+      2,
+      "usage: /think <off|minimal|low|medium|high|xhigh|adaptive>",
+    );
   });
 });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -5,6 +5,7 @@ import {
   normalizeUsageDisplay,
   resolveResponseUsageMode,
 } from "../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../config/types.js";
 import type { SessionsPatchResult } from "../gateway/protocol/index.js";
 import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -30,6 +31,7 @@ type CommandHandlerContext = {
   chatLog: ChatLog;
   tui: TUI;
   opts: TuiOptions;
+  config?: OpenClawConfig;
   state: TuiStateAccess;
   deliverDefault: boolean;
   openOverlay: (component: Component) => void;
@@ -59,6 +61,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     chatLog,
     tui,
     opts,
+    config,
     state,
     deliverDefault,
     openOverlay,
@@ -250,6 +253,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "help":
         chatLog.addSystem(
           helpText({
+            cfg: config,
             provider: state.sessionInfo.modelProvider,
             model: state.sessionInfo.model,
           }),
@@ -320,6 +324,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             state.sessionInfo.modelProvider,
             state.sessionInfo.model,
             "|",
+            config ? { config } : undefined,
           );
           chatLog.addSystem(`usage: /think <${levels}>`);
           break;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -870,6 +870,7 @@ export async function runTui(opts: TuiOptions) {
       chatLog,
       tui,
       opts,
+      config,
       state,
       deliverDefault,
       openOverlay,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: custom `models.providers.*.models[*]` definitions could not opt into `xhigh`; validation and help paths only trusted built-in/provider-advertised support and rejected or downgraded those refs.
- Why it matters: OpenAI-compatible custom endpoints that genuinely support stronger reasoning were forced down to `high` and surfaced misleading guidance.
- What changed: added `compat.supportsXHighThinking`, taught thinking helpers to honor config/catalog overrides in a browser-safe way, and threaded config-aware hints/validation through reply, gateway, agent, cron, TUI, and `llm-task` entry points with regression coverage.
- What did NOT change (scope boundary): no CI/format rescue commits from the superseded branch, no provider-runtime allowlist changes, and no local project execution in this environment.

AI-assisted: Yes (`Codex`)
Testing: Untested locally; statically reviewed only (project execution was intentionally not run in this environment)
Prompts/session logs: available in the Codex session history

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #45112

## User-visible / Behavior Changes

- Custom model definitions can now opt into `xhigh` by setting `models.providers.*.models[*].compat.supportsXHighThinking: true`.
- Config can explicitly disable `xhigh` for an otherwise provider-advertised model with `compat.supportsXHighThinking: false`.
- `/think` help, validation errors, gateway session patches, agent CLI validation, cron fallback, and `llm-task` errors now reflect config-aware `xhigh` support.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: not run locally
- Model/provider: static review only
- Integration/channel (if any): reply pipeline, gateway session patch, TUI, agent CLI, cron isolated agent, `llm-task`
- Relevant config (redacted): `models.providers.robot.models[0].compat.supportsXHighThinking = true`

### Steps

1. Add a custom model definition with `compat.supportsXHighThinking: true`.
2. Hit any `xhigh` validation/help path such as `/think`, gateway session patching, agent CLI validation, or `llm-task`.
3. Flip the same flag to `false` on a provider-advertised `xhigh` model and repeat the same paths.

### Expected

- `xhigh` is surfaced and accepted for explicit custom opt-ins.
- Explicit `false` suppresses `xhigh` and updates the hint/error text consistently.

### Actual

- Not executed locally; verified statically that schema, thinking resolution, downgrade checks, and user-facing hints now read the same config-aware support source.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Static inspection snippets:

```text
$ git diff --check --cached
(no output)

$ git diff --cached --stat
17 files changed, 418 insertions(+), 31 deletions(-)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: traced `compat.supportsXHighThinking` from config/schema into `supportsXHighThinking()`, then through reply handling, session patch validation, agent CLI checks, cron downgrade logic, TUI help/completions, and `llm-task` validation.
- Edge cases checked: catalog overrides take precedence over config for the same ref, explicit `false` suppresses built-in/provider-advertised `xhigh`, and the thinking helper stays browser-safe by consuming injected config instead of runtime config lookup.
- What you did **not** verify: no local code execution, tests, builds, CI reruns, or `codex review --base origin/main` in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `Yes` (new optional `compat.supportsXHighThinking`)
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove `compat.supportsXHighThinking` from the affected model config or revert this commit.
- Files/config to restore: `models.providers.*.models[*].compat`, `src/auto-reply/thinking.ts`, and the caller validations listed in this PR.
- Known bad symptoms reviewers should watch for: `xhigh` appears for a model that should stay at `high`, or a config-opted model still gets downgraded/rejected.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: a misconfigured custom model can advertise `xhigh` even if the backend does not actually support it.
- Mitigation: opt-in remains explicit per model, explicit `false` still disables `xhigh`, and all validation/help paths now consistently read the same override source.
- Risk: browser-facing code could accidentally depend on runtime config access while reading custom overrides.
- Mitigation: the thinking helper only consumes injected config snapshots via `ThinkingSupportSource` and does not call runtime config loaders.
