### PR TITLE
feat: add logging.dir config for custom log directory

### DIFF
--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -20,7 +20,8 @@ OpenClaw has two log “surfaces”:
 - Default rolling log file is under `/tmp/openclaw/` (one file per day): `openclaw-YYYY-MM-DD.log`
   - Date uses the gateway host's local timezone.
 - The log file path and level can be configured via `~/.openclaw/openclaw.json`:
-  - `logging.file`
+  - `logging.dir` — custom directory, keeps daily rolling filenames (`openclaw-YYYY-MM-DD.log`)
+  - `logging.file` — full path override (disables rolling); takes priority over `logging.dir`
   - `logging.level`
 
 The file format is one JSON object per line.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -25,7 +25,19 @@ By default, the Gateway writes a rolling log file under:
 
 The date uses the gateway host's local timezone.
 
-You can override this in `~/.openclaw/openclaw.json`:
+You can customize the log directory while keeping daily rolling filenames:
+
+```json
+{
+  "logging": {
+    "dir": "/var/log/openclaw"
+  }
+}
+```
+
+This writes to `/var/log/openclaw/openclaw-YYYY-MM-DD.log`.
+
+To override the full path (disabling rolling filenames), use `file` instead:
 
 ```json
 {
@@ -34,6 +46,8 @@ You can override this in `~/.openclaw/openclaw.json`:
   }
 }
 ```
+
+Priority: `logging.file` > `logging.dir` > default (`/tmp/openclaw`).
 
 ## How to read logs
 
@@ -104,6 +118,7 @@ All logging configuration lives under `logging` in `~/.openclaw/openclaw.json`.
 {
   "logging": {
     "level": "info",
+    "dir": "/tmp/openclaw",
     "file": "/tmp/openclaw/openclaw-YYYY-MM-DD.log",
     "consoleLevel": "info",
     "consoleStyle": "pretty",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -167,6 +167,8 @@ export type SessionMaintenanceConfig = {
 
 export type LoggingConfig = {
   level?: "silent" | "fatal" | "error" | "warn" | "info" | "debug" | "trace";
+  /** Custom log directory. Retains daily rolling filenames (openclaw-YYYY-MM-DD.log). Ignored when `file` is set. */
+  dir?: string;
   file?: string;
   /** Maximum size of a single log file in bytes before writes are suppressed. Default: 500 MB. */
   maxFileBytes?: number;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -304,6 +304,7 @@ export const OpenClawSchema = z
     logging: z
       .object({
         level: LoggingLevelSchema.optional(),
+        dir: z.string().optional(),
         file: z.string().optional(),
         maxFileBytes: z.number().int().positive().optional(),
         consoleLevel: LoggingLevelSchema.optional(),

--- a/src/logging/logger-settings.test.ts
+++ b/src/logging/logger-settings.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { fallbackRequireMock, readLoggingConfigMock } = vi.hoisted(() => ({
-  readLoggingConfigMock: vi.fn(() => undefined),
+  readLoggingConfigMock: vi.fn(
+    (): import("../config/types.base.js").LoggingConfig | undefined => undefined,
+  ),
   fallbackRequireMock: vi.fn(() => {
     throw new Error("config fallback should not be used in this test");
   }),
@@ -62,5 +64,26 @@ describe("getResolvedLoggerSettings", () => {
     process.env.OPENCLAW_TEST_FILE_LOG = "1";
     const settings = logging.getResolvedLoggerSettings();
     expect(settings.level).toBe("info");
+  });
+
+  it("uses logging.dir for rolling log path when set", () => {
+    process.env.OPENCLAW_TEST_FILE_LOG = "1";
+    logging.setLoggerOverride({ dir: "/custom/logs" });
+    const settings = logging.getResolvedLoggerSettings();
+    expect(settings.file).toMatch(/^\/custom\/logs\/openclaw-\d{4}-\d{2}-\d{2}\.log$/);
+  });
+
+  it("logging.file takes priority over logging.dir", () => {
+    process.env.OPENCLAW_TEST_FILE_LOG = "1";
+    logging.setLoggerOverride({ dir: "/custom/logs", file: "/exact/path.log" });
+    const settings = logging.getResolvedLoggerSettings();
+    expect(settings.file).toBe("/exact/path.log");
+  });
+
+  it("uses default dir when neither file nor dir is set", () => {
+    process.env.OPENCLAW_TEST_FILE_LOG = "1";
+    logging.setLoggerOverride({});
+    const settings = logging.getResolvedLoggerSettings();
+    expect(settings.file).toMatch(/^\/tmp\/openclaw\/openclaw-\d{4}-\d{2}-\d{2}\.log$/);
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -47,6 +47,8 @@ const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
 export type LoggerSettings = {
   level?: LogLevel;
+  /** Custom log directory. Retains daily rolling filenames. Ignored when `file` is set. */
+  dir?: string;
   file?: string;
   maxFileBytes?: number;
   consoleLevel?: LogLevel;

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -131,7 +131,7 @@ function resolveSettings(): ResolvedSettings {
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? defaultRollingPathForToday();
+  const file = cfg?.file ?? defaultRollingPathForToday(cfg?.dir);
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }
@@ -328,6 +328,7 @@ export function registerLogTransport(transport: LogTransport): () => void {
 
 export const __test__ = {
   shouldSkipLoadConfigFallback,
+  defaultRollingPathForToday,
 };
 
 function formatLocalDate(date: Date): string {
@@ -337,9 +338,9 @@ function formatLocalDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function defaultRollingPathForToday(): string {
+function defaultRollingPathForToday(dir?: string): string {
   const today = formatLocalDate(new Date());
-  return path.join(DEFAULT_LOG_DIR, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
+  return path.join(dir ?? DEFAULT_LOG_DIR, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
 }
 
 function isRollingPath(file: string): boolean {


### PR DESCRIPTION
Add `logging.dir` config option so users can customize the log directory while retaining daily rolling filenames (`openclaw-YYYY-MM-DD.log`).

## Summary

- **Problem:** Users who want a custom log directory must set `logging.file` to a full path, which loses the automatic daily rolling filename (`openclaw-YYYY-MM-DD.log`).
- **Why it matters:** Log rotation by date is a common operational requirement; forcing a fixed path breaks that.
- **What changed:** New `logging.dir` config key — sets the directory, keeps rolling filenames. Priority: `logging.file` > `logging.dir` > default (`/tmp/openclaw`).
- **What did NOT change (scope boundary):** `isRollingPath()`, `pruneOldRollingLogs()`, `buildLogger()` are untouched — they detect rolling filenames by pattern and auto-adapt.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None

## User-visible / Behavior Changes

- New config key `logging.dir` (string, optional) — sets the log directory while keeping `openclaw-YYYY-MM-DD.log` rolling filenames.
- Priority: `logging.file` > `logging.dir` > default `/tmp/openclaw`.
- No change to existing behavior when `logging.dir` is unset.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Set `"logging": { "dir": "/tmp/my-logs" }` in `~/.openclaw/openclaw.json`
2. Start the gateway
3. Check that logs are written to `/tmp/my-logs/openclaw-YYYY-MM-DD.log`

### Expected

- Logs appear in the custom directory with rolling filenames.

### Actual

- Confirmed via tests.

## Evidence

- [x] Failing test/log before + passing after
  - 3 new tests in `src/logging/logger-settings.test.ts`:
    - `logging.dir` produces correct rolling path
    - `logging.file` takes priority over `logging.dir`
    - Default `/tmp/openclaw` used when neither is set

## Human Verification (required)

- Verified scenarios: `pnpm tsgo` clean, `pnpm test -- src/logging` all pass, `pnpm check` clean
- Edge cases checked: `file` + `dir` both set (file wins), neither set (default), only `dir` set
- What I did **not** verify: manual gateway run with real config (test-covered only)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — new optional `logging.dir` key; no existing behavior changes
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Remove `logging.dir` from config to revert to default behavior.
- The change is additive; removing the key restores prior behavior exactly.

## Risks and Mitigations

None — additive config key with no impact on existing paths.