### PR TITLE
fix(channels): bypass debounce for bare abort triggers

### DIFF
--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -5,12 +5,14 @@ import {
 } from "./inbound-debounce-policy.js";
 
 describe("shouldDebounceTextInbound", () => {
-  it("rejects blank text, media, and control commands", () => {
+  it("rejects blank text, media, slash commands, and bare abort triggers", () => {
     const cfg = {} as Parameters<typeof shouldDebounceTextInbound>[0]["cfg"];
 
     expect(shouldDebounceTextInbound({ text: "   ", cfg })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "hello", cfg, hasMedia: true })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "/status", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "stop", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "wait", cfg })).toBe(false);
   });
 
   it("accepts normal text when debounce is allowed", () => {

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -1,4 +1,4 @@
-import { hasControlCommand } from "../auto-reply/command-detection.js";
+import { isControlCommandMessage } from "../auto-reply/command-detection.js";
 import type { CommandNormalizeOptions } from "../auto-reply/commands-registry.js";
 import {
   createInboundDebouncer,
@@ -24,7 +24,7 @@ export function shouldDebounceTextInbound(params: {
   if (!text) {
     return false;
   }
-  return !hasControlCommand(text, params.cfg, params.commandOptions);
+  return !isControlCommandMessage(text, params.cfg, params.commandOptions);
 }
 
 export function createChannelInboundDebouncer<T>(


### PR DESCRIPTION
## Summary

- Problem: `src/channels/inbound-debounce-policy.ts` only bypassed debouncing for slash commands because it used `hasControlCommand()`.
- Why it matters: bare abort phrases like `stop` and `wait` could sit in the inbound debounce window instead of flushing immediately.
- What changed: switched the debounce gate to `isControlCommandMessage()` so bare abort triggers follow the same fast path as `/stop`, and added regression coverage for bare abort phrases.
- What did NOT change (scope boundary): debounce timing and normal non-control message behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48684
- Related #46445

## User-visible / Behavior Changes

Bare abort messages handled by channel inbound debouncers now bypass the debounce gate the same way `/stop` already did.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.1
- Runtime/container: local Node checkout
- Model/provider: N/A
- Integration/channel (if any): shared inbound debounce path for debounced channels
- Relevant config (redacted): inbound debounce enabled

### Steps

1. Send a bare abort phrase such as `stop` or `wait` through a channel that uses `createChannelInboundDebouncer`.
2. Let `shouldDebounceTextInbound()` decide whether to hold or flush the message.
3. Observe whether the abort phrase bypasses the debounce gate like `/stop` does.

### Expected

- Bare abort phrases bypass debouncing immediately.

### Actual

- Before this change, `shouldDebounceTextInbound()` called `hasControlCommand()`, so bare abort phrases were treated like normal text and debounced.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression coverage for bare `stop` and `wait` in `src/channels/inbound-debounce-policy.test.ts`.
  - Confirmed the new regression fails on `HEAD^` (`stop` still debounced there) and passes on this branch.
  - Confirmed slash commands and normal text behavior still match existing expectations.
- Edge cases checked:
  - blank text
  - media messages
  - slash control commands
  - bare abort triggers
- What you did **not** verify:
  - end-to-end channel delivery on Slack/Discord/Telegram/Signal

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `src/channels/inbound-debounce-policy.ts`
- Known bad symptoms reviewers should watch for: unexpected debounce bypass for non-control text

## Risks and Mitigations

- Risk: `isControlCommandMessage()` is slightly broader than `hasControlCommand()`.
  - Mitigation: regression coverage now includes both slash commands and bare abort phrases, while normal text still stays debounced.

AI-assisted: yes.

## Verification Commands Run

- `npm exec --yes pnpm@10.23.0 -- vitest run src/channels/inbound-debounce-policy.test.ts`
- `npm exec --yes pnpm@10.23.0 -- exec oxfmt --check src/channels/inbound-debounce-policy.ts src/channels/inbound-debounce-policy.test.ts`
- `npm exec --yes pnpm@10.23.0 -- exec oxlint src/channels/inbound-debounce-policy.ts src/channels/inbound-debounce-policy.test.ts`
- `/Users/jamesavery/.openclaw/openclaw-pr-check.sh`

Repo-wide `build` and `check` completed successfully. Repo-wide `test` hit unrelated current-baseline failures outside this change in `src/plugin-sdk/channel-import-guardrails.test.ts` and `src/memory/embeddings-gemini.test.ts` while running on top of current `upstream/main`.
