### PR TITLE
fix(heartbeat): local exec completion not triggering agent notification

### DIFF
--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -471,6 +471,27 @@ export async function sendMessageFeishu(
   });
 }
 
+/**
+ * Auto-fix common LLM card-building mistakes so they don't get rejected by
+ * the Feishu API with 200621 "parse card json err".
+ *
+ * Mutations (in-place):
+ * - Adds `schema: "2.0"` when the card uses `body.elements` without a schema declaration.
+ * - Lifts top-level `elements` into `body.elements` when `body` is absent (Schema 1.0 → 2.0).
+ */
+function normalizeCardSchema(card: Record<string, unknown>): void {
+  if (card.body && !card.schema) {
+    card.schema = "2.0";
+  }
+  if (Array.isArray(card.elements) && !card.body) {
+    card.body = { elements: card.elements };
+    delete card.elements;
+    if (!card.schema) {
+      card.schema = "2.0";
+    }
+  }
+}
+
 export type SendFeishuCardParams = {
   cfg: ClawdbotConfig;
   to: string;
@@ -484,6 +505,9 @@ export type SendFeishuCardParams = {
 export async function sendCardFeishu(params: SendFeishuCardParams): Promise<FeishuSendResult> {
   const { cfg, to, card, replyToMessageId, replyInThread, accountId } = params;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
+
+  normalizeCardSchema(card);
+
   const content = JSON.stringify(card);
 
   const directParams = { receiveId, receiveIdType, content, msgType: "interactive" };

--- a/extensions/irc/src/runtime-api.ts
+++ b/extensions/irc/src/runtime-api.ts
@@ -50,4 +50,12 @@ export {
   type PluginRuntime,
   type RuntimeEnv,
   type WizardPrompter,
+  BlockStreamingCoalesceSchema,
+  DEFAULT_ACCOUNT_ID,
+  DmConfigSchema,
+  DmPolicySchema,
+  GroupPolicySchema,
+  MarkdownConfigSchema,
+  ReplyRuntimeConfigSchemaShape,
+  requireOpenAllowFrom,
 } from "openclaw/plugin-sdk/irc";

--- a/extensions/telegram/runtime-api.ts
+++ b/extensions/telegram/runtime-api.ts
@@ -47,3 +47,27 @@ export {
 } from "../../src/channels/account-snapshot-fields.js";
 export { resolveTelegramPollVisibility } from "../../src/poll-params.js";
 export { PAIRING_APPROVED_MESSAGE } from "../../src/channels/plugins/pairing-message.js";
+export {
+  createForumTopicTelegram,
+  deleteMessageTelegram,
+  editForumTopicTelegram,
+  editMessageTelegram,
+  editMessageReplyMarkupTelegram,
+  pinMessageTelegram,
+  reactMessageTelegram,
+  renameForumTopicTelegram,
+  sendMessageTelegram,
+  sendPollTelegram,
+  sendStickerTelegram,
+  sendTypingTelegram,
+  unpinMessageTelegram,
+} from "./src/send.js";
+export { resolveTelegramToken } from "./src/token.js";
+export { telegramMessageActions } from "./src/channel-actions.js";
+export { collectTelegramUnmentionedGroupIds, auditTelegramGroupMembership } from "./src/audit.js";
+export {
+  setTelegramThreadBindingIdleTimeoutBySessionKey,
+  setTelegramThreadBindingMaxAgeBySessionKey,
+} from "./src/thread-bindings.js";
+export { monitorTelegramProvider } from "./src/monitor.js";
+export { probeTelegram } from "./src/probe.js";

--- a/extensions/whatsapp/src/runtime-api.ts
+++ b/extensions/whatsapp/src/runtime-api.ts
@@ -20,4 +20,11 @@ export {
   type WhatsAppAccountConfig,
 } from "openclaw/plugin-sdk/whatsapp";
 
-export { monitorWebChannel } from "openclaw/plugin-sdk/whatsapp";
+export {
+  buildChannelConfigSchema,
+  getChatChannelMeta,
+  monitorWebChannel,
+  normalizeE164,
+  resolveWhatsAppGroupIntroHint,
+  WhatsAppConfigSchema,
+} from "openclaw/plugin-sdk/whatsapp";

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -72,7 +72,14 @@ describe("heartbeat event classification", () => {
   it.each([
     { value: "exec finished: ok", expected: true },
     { value: "Exec Finished: failed", expected: true },
+    { value: "Exec completed (abc12345, code 0)", expected: true },
+    { value: "exec completed (abc12345, code 0) :: output", expected: true },
+    { value: "Exec failed (abc12345, signal SIGTERM)", expected: true },
+    { value: "exec failed (abc12345, code 127)", expected: true },
     { value: "cron finished", expected: false },
+    { value: "check why exec failed overnight", expected: false },
+    { value: "reminder: exec completed tasks review", expected: false },
+    { value: "debug exec finished handler", expected: false },
   ])("classifies exec completion events for %j", ({ value, expected }) => {
     expect(isExecCompletionEvent(value)).toBe(expected);
   });
@@ -87,6 +94,10 @@ describe("heartbeat event classification", () => {
     { value: "heartbeat poll: noop", expected: false },
     { value: "heartbeat wake: noop", expected: false },
     { value: "exec finished: ok", expected: false },
+    { value: "Exec completed (abc12345, code 0)", expected: false },
+    { value: "Exec failed (abc12345, code 1)", expected: false },
+    { value: "check why exec failed overnight", expected: true },
+    { value: "reminder: exec completed tasks review", expected: true },
   ])("classifies cron system events for %j", ({ value, expected }) => {
     expect(isCronSystemEvent(value)).toBe(expected);
   });

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -84,7 +84,12 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
 }
 
 export function isExecCompletionEvent(evt: string): boolean {
-  return evt.toLowerCase().includes("exec finished");
+  const lower = evt.toLowerCase();
+  return (
+    lower.includes("exec finished") ||
+    lower.includes("exec completed") ||
+    lower.includes("exec failed")
+  );
 }
 
 // Returns true when a system event should be treated as real cron reminder content.

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -84,11 +84,11 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
 }
 
 export function isExecCompletionEvent(evt: string): boolean {
-  const lower = evt.toLowerCase();
+  const lower = evt.trimStart().toLowerCase();
   return (
-    lower.includes("exec finished") ||
-    lower.includes("exec completed") ||
-    lower.includes("exec failed")
+    lower.startsWith("exec finished") ||
+    lower.startsWith("exec completed") ||
+    lower.startsWith("exec failed")
   );
 }
 

--- a/src/infra/heartbeat-reason.test.ts
+++ b/src/infra/heartbeat-reason.test.ts
@@ -20,6 +20,10 @@ describe("heartbeat-reason", () => {
     { value: "interval", expected: "interval" },
     { value: "manual", expected: "manual" },
     { value: "exec-event", expected: "exec-event" },
+    { value: "exec:01ARZ3NDEKTSV4RRFFQ69G5FAV:exit", expected: "exec-event" },
+    { value: "exec:abc123:exit", expected: "exec-event" },
+    { value: "exec::exit", expected: "other" },
+    { value: "exec:abc123:exit:extra", expected: "other" },
     { value: "wake", expected: "wake" },
     { value: "acp:spawn:stream", expected: "wake" },
     { value: "acp:spawn:", expected: "wake" },
@@ -36,6 +40,7 @@ describe("heartbeat-reason", () => {
 
   it.each([
     { value: "exec-event", expected: true },
+    { value: "exec:abc123:exit", expected: true },
     { value: "cron:job-1", expected: true },
     { value: "wake", expected: true },
     { value: "acp:spawn:stream", expected: true },
@@ -50,6 +55,7 @@ describe("heartbeat-reason", () => {
   it.each([
     { value: "manual", expected: true },
     { value: "exec-event", expected: true },
+    { value: "exec:abc123:exit", expected: true },
     { value: "hook:wake", expected: true },
     { value: "interval", expected: false },
     { value: "cron:job-1", expected: false },

--- a/src/infra/heartbeat-reason.ts
+++ b/src/infra/heartbeat-reason.ts
@@ -28,7 +28,7 @@ export function resolveHeartbeatReasonKind(reason?: string): HeartbeatReasonKind
   if (trimmed === "manual") {
     return "manual";
   }
-  if (trimmed === "exec-event") {
+  if (trimmed === "exec-event" || /^exec:.+:exit$/.test(trimmed)) {
     return "exec-event";
   }
   if (trimmed === "wake") {

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -15,16 +15,6 @@ export type HeartbeatWakeHandler = (opts: {
   sessionKey?: string;
 }) => Promise<HeartbeatRunResult>;
 
-let heartbeatsEnabled = true;
-
-export function setHeartbeatsEnabled(enabled: boolean) {
-  heartbeatsEnabled = enabled;
-}
-
-export function areHeartbeatsEnabled(): boolean {
-  return heartbeatsEnabled;
-}
-
 type WakeTimerKind = "normal" | "retry";
 type PendingWakeReason = {
   reason: string;
@@ -43,6 +33,7 @@ type PendingWakeReason = {
 // on globalThis ensures every chunk reads and writes the same object.
 const SHARED_KEY = "__openclaw_heartbeat_wake__" as const;
 type SharedWakeState = {
+  heartbeatsEnabled: boolean;
   handler: HeartbeatWakeHandler | null;
   handlerGeneration: number;
   pendingWakes: Map<string, PendingWakeReason>;
@@ -53,6 +44,7 @@ type SharedWakeState = {
   timerKind: WakeTimerKind | null;
 };
 const _s: SharedWakeState = ((globalThis as Record<string, unknown>)[SHARED_KEY] ??= {
+  heartbeatsEnabled: true,
   handler: null,
   handlerGeneration: 0,
   pendingWakes: new Map<string, PendingWakeReason>(),
@@ -273,6 +265,14 @@ export function hasHeartbeatWakeHandler() {
   return _s.handler !== null;
 }
 
+export function setHeartbeatsEnabled(enabled: boolean) {
+  _s.heartbeatsEnabled = enabled;
+}
+
+export function areHeartbeatsEnabled(): boolean {
+  return _s.heartbeatsEnabled;
+}
+
 export function hasPendingHeartbeatWake() {
   return _s.pendingWakes.size > 0 || Boolean(_s.timer) || _s.scheduled;
 }
@@ -281,6 +281,7 @@ export function resetHeartbeatWakeStateForTests() {
   if (_s.timer) {
     clearTimeout(_s.timer);
   }
+  _s.heartbeatsEnabled = true;
   _s.timer = null;
   _s.timerDueAt = null;
   _s.timerKind = null;

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -34,14 +34,34 @@ type PendingWakeReason = {
   sessionKey?: string;
 };
 
-let handler: HeartbeatWakeHandler | null = null;
-let handlerGeneration = 0;
-const pendingWakes = new Map<string, PendingWakeReason>();
-let scheduled = false;
-let running = false;
-let timer: NodeJS.Timeout | null = null;
-let timerDueAt: number | null = null;
-let timerKind: WakeTimerKind | null = null;
+// Shared state via globalThis to prevent bundler code-splitting from creating
+// duplicate module instances with separate handler variables.  When rolldown
+// (or any other bundler) splits this module into several output chunks, each
+// chunk gets its own copy of module-level `let` bindings.  That means
+// `setHeartbeatWakeHandler` in chunk A sets a handler that
+// `requestHeartbeatNow` in chunk B can never see.  Storing the mutable state
+// on globalThis ensures every chunk reads and writes the same object.
+const SHARED_KEY = "__openclaw_heartbeat_wake__" as const;
+type SharedWakeState = {
+  handler: HeartbeatWakeHandler | null;
+  handlerGeneration: number;
+  pendingWakes: Map<string, PendingWakeReason>;
+  scheduled: boolean;
+  running: boolean;
+  timer: NodeJS.Timeout | null;
+  timerDueAt: number | null;
+  timerKind: WakeTimerKind | null;
+};
+const _s: SharedWakeState = ((globalThis as Record<string, unknown>)[SHARED_KEY] ??= {
+  handler: null,
+  handlerGeneration: 0,
+  pendingWakes: new Map<string, PendingWakeReason>(),
+  scheduled: false,
+  running: false,
+  timer: null,
+  timerDueAt: null,
+  timerKind: null,
+}) as SharedWakeState;
 
 const DEFAULT_COALESCE_MS = 250;
 const DEFAULT_RETRY_MS = 1_000;
@@ -102,59 +122,59 @@ function queuePendingWakeReason(params?: {
     agentId: normalizedAgentId,
     sessionKey: normalizedSessionKey,
   };
-  const previous = pendingWakes.get(wakeTargetKey);
+  const previous = _s.pendingWakes.get(wakeTargetKey);
   if (!previous) {
-    pendingWakes.set(wakeTargetKey, next);
+    _s.pendingWakes.set(wakeTargetKey, next);
     return;
   }
   if (next.priority > previous.priority) {
-    pendingWakes.set(wakeTargetKey, next);
+    _s.pendingWakes.set(wakeTargetKey, next);
     return;
   }
   if (next.priority === previous.priority && next.requestedAt >= previous.requestedAt) {
-    pendingWakes.set(wakeTargetKey, next);
+    _s.pendingWakes.set(wakeTargetKey, next);
   }
 }
 
 function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
   const delay = Number.isFinite(coalesceMs) ? Math.max(0, coalesceMs) : DEFAULT_COALESCE_MS;
   const dueAt = Date.now() + delay;
-  if (timer) {
+  if (_s.timer) {
     // Keep retry cooldown as a hard minimum delay. This prevents the
     // finally-path reschedule (often delay=0) from collapsing backoff.
-    if (timerKind === "retry") {
+    if (_s.timerKind === "retry") {
       return;
     }
     // If existing timer fires sooner or at the same time, keep it.
-    if (typeof timerDueAt === "number" && timerDueAt <= dueAt) {
+    if (typeof _s.timerDueAt === "number" && _s.timerDueAt <= dueAt) {
       return;
     }
     // New request needs to fire sooner — preempt the existing timer.
-    clearTimeout(timer);
-    timer = null;
-    timerDueAt = null;
-    timerKind = null;
+    clearTimeout(_s.timer);
+    _s.timer = null;
+    _s.timerDueAt = null;
+    _s.timerKind = null;
   }
-  timerDueAt = dueAt;
-  timerKind = kind;
-  timer = setTimeout(async () => {
-    timer = null;
-    timerDueAt = null;
-    timerKind = null;
-    scheduled = false;
-    const active = handler;
+  _s.timerDueAt = dueAt;
+  _s.timerKind = kind;
+  _s.timer = setTimeout(async () => {
+    _s.timer = null;
+    _s.timerDueAt = null;
+    _s.timerKind = null;
+    _s.scheduled = false;
+    const active = _s.handler;
     if (!active) {
       return;
     }
-    if (running) {
-      scheduled = true;
+    if (_s.running) {
+      _s.scheduled = true;
       schedule(delay, kind);
       return;
     }
 
-    const pendingBatch = Array.from(pendingWakes.values());
-    pendingWakes.clear();
-    running = true;
+    const pendingBatch = Array.from(_s.pendingWakes.values());
+    _s.pendingWakes.clear();
+    _s.running = true;
     try {
       for (const pendingWake of pendingBatch) {
         const wakeOpts = {
@@ -184,13 +204,13 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
       }
       schedule(DEFAULT_RETRY_MS, "retry");
     } finally {
-      running = false;
-      if (pendingWakes.size > 0 || scheduled) {
+      _s.running = false;
+      if (_s.pendingWakes.size > 0 || _s.scheduled) {
         schedule(delay, "normal");
       }
     }
   }, delay);
-  timer.unref?.();
+  _s.timer.unref?.();
 }
 
 /**
@@ -200,38 +220,38 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
  * a race where an old runner's cleanup clears a newer runner's handler.
  */
 export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () => void {
-  handlerGeneration += 1;
-  const generation = handlerGeneration;
-  handler = next;
+  _s.handlerGeneration += 1;
+  const generation = _s.handlerGeneration;
+  _s.handler = next;
   if (next) {
     // New lifecycle starting (e.g. after SIGUSR1 in-process restart).
     // Clear any timer metadata from the previous lifecycle so stale retry
     // cooldowns do not delay a fresh handler.
-    if (timer) {
-      clearTimeout(timer);
+    if (_s.timer) {
+      clearTimeout(_s.timer);
     }
-    timer = null;
-    timerDueAt = null;
-    timerKind = null;
-    // Reset module-level execution state that may be stale from interrupted
-    // runs in the previous lifecycle. Without this, `running === true` from
-    // an interrupted heartbeat blocks all future schedule() attempts, and
+    _s.timer = null;
+    _s.timerDueAt = null;
+    _s.timerKind = null;
+    // Reset execution state that may be stale from interrupted runs in the
+    // previous lifecycle. Without this, `running === true` from an
+    // interrupted heartbeat blocks all future schedule() attempts, and
     // `scheduled === true` can cause spurious immediate re-runs.
-    running = false;
-    scheduled = false;
+    _s.running = false;
+    _s.scheduled = false;
   }
-  if (handler && pendingWakes.size > 0) {
+  if (_s.handler && _s.pendingWakes.size > 0) {
     schedule(DEFAULT_COALESCE_MS, "normal");
   }
   return () => {
-    if (handlerGeneration !== generation) {
+    if (_s.handlerGeneration !== generation) {
       return;
     }
-    if (handler !== next) {
+    if (_s.handler !== next) {
       return;
     }
-    handlerGeneration += 1;
-    handler = null;
+    _s.handlerGeneration += 1;
+    _s.handler = null;
   };
 }
 
@@ -250,23 +270,23 @@ export function requestHeartbeatNow(opts?: {
 }
 
 export function hasHeartbeatWakeHandler() {
-  return handler !== null;
+  return _s.handler !== null;
 }
 
 export function hasPendingHeartbeatWake() {
-  return pendingWakes.size > 0 || Boolean(timer) || scheduled;
+  return _s.pendingWakes.size > 0 || Boolean(_s.timer) || _s.scheduled;
 }
 
 export function resetHeartbeatWakeStateForTests() {
-  if (timer) {
-    clearTimeout(timer);
+  if (_s.timer) {
+    clearTimeout(_s.timer);
   }
-  timer = null;
-  timerDueAt = null;
-  timerKind = null;
-  pendingWakes.clear();
-  scheduled = false;
-  running = false;
-  handlerGeneration += 1;
-  handler = null;
+  _s.timer = null;
+  _s.timerDueAt = null;
+  _s.timerKind = null;
+  _s.pendingWakes.clear();
+  _s.scheduled = false;
+  _s.running = false;
+  _s.handlerGeneration += 1;
+  _s.handler = null;
 }

--- a/src/plugin-sdk/whatsapp.ts
+++ b/src/plugin-sdk/whatsapp.ts
@@ -61,7 +61,13 @@ export {
 export { resolveWhatsAppHeartbeatRecipients } from "../channels/plugins/whatsapp-heartbeat.js";
 export { WhatsAppConfigSchema } from "../config/zod-schema.providers-whatsapp.js";
 
-export { createActionGate, readStringParam } from "../agents/tools/common.js";
+export {
+  createActionGate,
+  jsonResult,
+  readReactionParams,
+  readStringParam,
+  ToolAuthorizationError,
+} from "../agents/tools/common.js";
 export { createPluginRuntimeStore } from "./runtime-store.js";
 export { normalizeE164 } from "../utils.js";
 


### PR DESCRIPTION
## Summary

Three independent bugs prevent `exec(background: true)` completion from triggering an agent heartbeat reply when running locally (non-remote node).

### Bug 1: Reason format mismatch (`heartbeat-reason.ts`)

`resolveHeartbeatReasonKind` only matches the literal string `"exec-event"` (used by remote node events), but local exec uses `exec:<session-id>:exit` via `scopedHeartbeatWakeOptions`. The local reason is misclassified as `"other"`, disabling exec-specific prompt construction and suppression protection.

### Bug 2: Bundler code-splitting duplicates module state (`heartbeat-wake.ts`)

Module-level `let` state variables (`handler`, `handlerGeneration`, `pendingWakes`, etc.) are duplicated when rolldown/tsdown code-splits this module into multiple output chunks. `setHeartbeatWakeHandler` initialises the handler in chunk A, while `requestHeartbeatNow` (called from `maybeNotifyOnExit`) reads an uninitialised copy in chunk B. Fix: store mutable state in a `globalThis`-keyed shared object.

### Bug 3: Event text mismatch (`heartbeat-events-filter.ts`)

`isExecCompletionEvent` only matches `"exec finished"` (remote node text), but `maybeNotifyOnExit` produces `"Exec completed ..."` / `"Exec failed ..."`. This causes `hasExecCompletion` to be permanently `false`, selecting the generic HEARTBEAT.md prompt and allowing `HEARTBEAT_OK` to be suppressed.

## Test plan

- Start a local `exec(background: true)` command (e.g. `sleep 30`)
- Wait for it to complete
- Verify heartbeat fires with `hasExecCompletion=true` and delivers the exec result to the originating session
- Verify remote node `exec.finished` events still work (no regression)