### PR TITLE
fix: check "toolCall" instead of "toolUse" in stripDanglingAnthropicToolUses (closes #41571)

### DIFF
--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -497,6 +497,54 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     expect(secondPass).toEqual(firstPass);
   });
 
+  it("should strip dangling toolCall blocks (pi-agent-core format)", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "tool-1", name: "test", input: {} },
+          { type: "text", text: "I'll check that" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([{ type: "text", text: "I'll check that" }]);
+  });
+
+  it("should preserve toolCall blocks with matching tool_result", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "tool-1", name: "test", input: {} },
+          { type: "text", text: "Here's result" },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "Result" }] },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([
+      { type: "toolCall", id: "tool-1", name: "test", input: {} },
+      { type: "text", text: "Here's result" },
+    ]);
+  });
+
   it("does not crash when assistant content is non-array", () => {
     const msgs = [
       { role: "user", content: [{ type: "text", text: "Use tool" }] },

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 type AnthropicContentBlock = {
-  type: "text" | "toolUse" | "toolResult";
+  type: "text" | "toolCall" | "toolResult";
   text?: string;
   id?: string;
   name?: string;
@@ -65,7 +65,7 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       if (!block) {
         return false;
       }
-      if (block.type !== "toolUse") {
+      if (block.type !== "toolCall") {
         return true;
       }
       // Keep tool_use if its id is in the valid set

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 type AnthropicContentBlock = {
-  type: "text" | "toolCall" | "toolResult";
+  type: "text" | "toolCall" | "toolUse" | "toolResult";
   text?: string;
   id?: string;
   name?: string;
@@ -9,7 +9,7 @@ type AnthropicContentBlock = {
 };
 
 /**
- * Strips dangling tool_use blocks from assistant messages when the immediately
+ * Strips dangling toolCall/toolUse blocks from assistant messages when the immediately
  * following user message does not contain a matching tool_result block.
  * This fixes the "tool_use ids found without tool_result blocks" error from Anthropic.
  */
@@ -59,16 +59,16 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       }
     }
 
-    // Filter out tool_use blocks that don't have matching tool_result
+    // Filter out tool call blocks that don't have matching tool_result
     const originalContent = Array.isArray(assistantMsg.content) ? assistantMsg.content : [];
     const filteredContent = originalContent.filter((block) => {
       if (!block) {
         return false;
       }
-      if (block.type !== "toolCall") {
+      if (block.type !== "toolCall" && block.type !== "toolUse") {
         return true;
       }
-      // Keep tool_use if its id is in the valid set
+      // Keep tool call block if its id is in the valid set
       return validToolUseIds.has(block.id || "");
     });
 


### PR DESCRIPTION
## Summary

- Problem: `stripDanglingAnthropicToolUses` checks `block.type !== "toolUse"` but pi-agent-core stores tool calls as `type: "toolCall"`. Since `"toolCall" !== "toolUse"` is always true, the filter keeps all blocks, making the function a no-op.
- Why it matters: Dangling tool call blocks are never removed after context truncation, causing `"tool_use ids found without tool_result blocks"` errors from the Anthropic API. This breaks long-running sessions that hit context limits.
- What changed: Updated the type check in `stripDanglingAnthropicToolUses` from `"toolUse"` to `"toolCall"` in `src/agents/pi-embedded-helpers/turns.ts`. Also corrected the local `AnthropicContentBlock` type union and updated test fixtures to use `"toolCall"`.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #41571

## User-visible / Behavior Changes

Long-running sessions that hit context truncation will now correctly strip dangling tool call blocks, preventing Anthropic API rejection errors.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No