### PR TITLE
fix(gateway): resolve {} empty auth trap causing scope rejection in loopback probes

### DIFF
--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -71,6 +71,16 @@ describe("probeGateway", () => {
     expect(gatewayClientState.options?.deviceIdentity).toBeUndefined();
   });
 
+  it("keeps device identity enabled for authenticated loopback probes with empty auth object", async () => {
+    await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: {},
+      timeoutMs: 1_000,
+    });
+
+    expect(gatewayClientState.options?.deviceIdentity).toBeUndefined();
+  });
+
   it("keeps device identity disabled for unauthenticated loopback probes", async () => {
     await probeGateway({
       url: "ws://127.0.0.1:18789",

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -47,7 +47,7 @@ export async function probeGateway(opts: {
       const hostname = new URL(opts.url).hostname;
       // Local authenticated probes should stay device-bound so read/detail RPCs
       // are not scope-limited by the shared-auth scope stripping hardening.
-      return isLoopbackHost(hostname) && !(opts.auth?.token || opts.auth?.password);
+      return isLoopbackHost(hostname) && opts.auth === undefined // Preserves device identity for empty but present auth objects (e.g. {});
     } catch {
       return false;
     }

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -47,7 +47,7 @@ export async function probeGateway(opts: {
       const hostname = new URL(opts.url).hostname;
       // Local authenticated probes should stay device-bound so read/detail RPCs
       // are not scope-limited by the shared-auth scope stripping hardening.
-      return isLoopbackHost(hostname) && opts.auth === undefined // Preserves device identity for empty but present auth objects (e.g. {});
+      return isLoopbackHost(hostname) && opts.auth === undefined; // Preserves device identity for empty but present auth objects (e.g. {})
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Running `openclaw status` locally against a running gateway with authentication enabled fails with `unreachable (missing scope: operator.read)`.
- Root Cause (The `{}` trap): In `status.scan.shared.ts`, when local auth credentials are not explicitly provided via flags, the resolution logic returns an empty object (`auth: {}`). The original logic `!(opts.auth?.token || opts.auth?.password)` evaluated to `true` when given `{}`, incorrectly stripping the device identity and triggering scope rejection.
- What changed: This is **NOT** a De Morgan's Law refactor. This fix changes the condition to check strictly for `opts.auth === undefined` (a literal anonymous probe) to accurately distinguish an empty auth object from a lack of auth.
- Why it matters: Authenticated loopback probes now correctly retain device identity, allowing users to read gateway health. Legacy anonymous pings still have their identity stripped, maintaining security.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

Closes #46014
Closes #45835
Closes #48538
Closes #46000
Closes #46358
Closes #47113
Closes #48007
Closes #48444
Closes #46897
Closes #47307
Closes #46117
Closes #46568
Closes #45908
Closes #48113
Closes #46422
Closes #47640
Closes #47987
Closes #46689
Closes #46583
Closes #47650
Closes #46716
Closes #48167
Closes #46100
Closes #46650
Closes #45945
Closes #46821
Closes #48002
Closes #17745

## User-visible / Behavior Changes

- Local authenticated gateway probes now correctly retain device identity on loopback, allowing `openclaw status` to display diagnostic details instead of scope errors.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: n/a

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22
- Relevant config (redacted): loopback gateway + token auth

### Steps

1. Run `openclaw status` locally on a machine with a paired device.
2. Observe `missing scope: operator.read` before fix.
3. Run with patch and observe success.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Local `openclaw status` returns full JSON details when authenticated via token on loopback.
- Edge cases checked: Anonymous loopback pings (no auth provided) still have their identity stripped as per legacy safety hardening.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## AI Assistance Transparency

- [x] AI-assisted PR
- Testing degree: Targeted manual verification + existing test suite
- I confirm I understand the changes.
