### PR TITLE
fix(media): harden MIME type sanitization

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -29,6 +29,7 @@ const runExecMock = vi.hoisted(() => vi.fn());
 
 let applyMediaUnderstanding: typeof import("./apply.js").applyMediaUnderstanding;
 let clearMediaUnderstandingBinaryCacheForTests: typeof import("./runner.js").clearMediaUnderstandingBinaryCacheForTests;
+let sanitizeMimeType: typeof import("./apply.js").sanitizeMimeType;
 const mockedResolveApiKey = resolveApiKeyForProviderMock;
 const mockedFetchRemoteMedia = fetchRemoteMediaMock;
 const mockedRunExec = runExecMock;
@@ -283,6 +284,7 @@ describe("applyMediaUnderstanding", () => {
     const baseDir = resolvePreferredOpenClawTmpDir();
     await fs.mkdir(baseDir, { recursive: true });
     suiteTempMediaRootDir = await fs.mkdtemp(path.join(baseDir, TEMP_MEDIA_PREFIX));
+    ({ applyMediaUnderstanding, sanitizeMimeType } = await import("./apply.js"));
   });
 
   beforeEach(() => {
@@ -311,6 +313,14 @@ describe("applyMediaUnderstanding", () => {
     suiteTempMediaRootDir = "";
     sharedTempMediaCacheDir = "";
     tempMediaFileCache.clear();
+  });
+
+  it("accepts case-insensitive MIME types with parameters", () => {
+    expect(sanitizeMimeType(" Text/Plain; Charset=UTF-8 ")).toBe("text/plain");
+  });
+
+  it("rejects trailing MIME junk outside parameters", () => {
+    expect(sanitizeMimeType("text/plain<script")).toBeUndefined();
   });
 
   it("sets Transcript and replaces Body when audio transcription succeeds", async () => {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -69,25 +69,6 @@ const TEXT_EXT_MIME = new Map<string, string>([
   [".xml", "application/xml"],
 ]);
 
-const XML_ESCAPE_MAP: Record<string, string> = {
-  "<": "&lt;",
-  ">": "&gt;",
-  "&": "&amp;",
-  '"': "&quot;",
-  "'": "&apos;",
-};
-
-/**
- * Escapes special XML characters in attribute values to prevent injection.
- */
-function xmlEscapeAttr(value: string): string {
-  return value.replace(/[<>&"']/g, (char) => XML_ESCAPE_MAP[char] ?? char);
-}
-
-function escapeFileBlockContent(value: string): string {
-  return value.replace(/<\s*\/\s*file\s*>/gi, "&lt;/file&gt;").replace(/<\s*file\b/gi, "&lt;file");
-}
-
 export function sanitizeMimeType(value?: string): string | undefined {
   if (!value) {
     return undefined;

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -69,16 +69,35 @@ const TEXT_EXT_MIME = new Map<string, string>([
   [".xml", "application/xml"],
 ]);
 
-function sanitizeMimeType(value?: string): string | undefined {
+const XML_ESCAPE_MAP: Record<string, string> = {
+  "<": "&lt;",
+  ">": "&gt;",
+  "&": "&amp;",
+  '"': "&quot;",
+  "'": "&apos;",
+};
+
+/**
+ * Escapes special XML characters in attribute values to prevent injection.
+ */
+function xmlEscapeAttr(value: string): string {
+  return value.replace(/[<>&"']/g, (char) => XML_ESCAPE_MAP[char] ?? char);
+}
+
+function escapeFileBlockContent(value: string): string {
+  return value.replace(/<\s*\/\s*file\s*>/gi, "&lt;/file&gt;").replace(/<\s*file\b/gi, "&lt;file");
+}
+
+export function sanitizeMimeType(value?: string): string | undefined {
   if (!value) {
     return undefined;
   }
-  const trimmed = value.trim().toLowerCase();
+  const trimmed = value.trim();
   if (!trimmed) {
     return undefined;
   }
-  const match = trimmed.match(/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)/);
-  return match?.[1];
+  const match = trimmed.match(/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)(?:\s*;.*)?$/i);
+  return match?.[1]?.toLowerCase();
 }
 
 function resolveFileLimits(cfg: OpenClawConfig) {


### PR DESCRIPTION
## Summary
- anchor MIME type sanitization so trailing junk is rejected instead of silently truncated
- keep MIME parsing case-insensitive and continue normalizing accepted types to lowercase
- add regression coverage for parameterized and malformed MIME inputs

## Testing
- git diff --check
- pnpm exec vitest run src/media-understanding/apply.test.ts

Fixes #9795