### PR TITLE
fix: avoid exiting interactive PowerShell in install script

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -297,6 +297,15 @@ function Add-ToPath {
     }
 }
 
+$script:InstallExitCode = 0
+
+function Fail-Install {
+    param([int]$Code = 1)
+
+    $script:InstallExitCode = $Code
+    return $false
+}
+
 # Main
 function Main {
     Write-Banner
@@ -307,16 +316,16 @@ function Main {
     if (!(Ensure-ExecutionPolicy)) {
         Write-Host ""
         Write-Host "Installation cannot continue due to execution policy restrictions" -Level error
-        exit 1
+        return (Fail-Install)
     }
     
     if (!(Ensure-Node)) {
-        exit 1
+        return (Fail-Install)
     }
     
     if ($InstallMethod -eq "git") {
         if (!(Ensure-Git)) {
-            exit 1
+            return (Fail-Install)
         }
         
         if ($DryRun) {
@@ -334,7 +343,7 @@ function Main {
             Write-Host "[DRY RUN] Would install OpenClaw via npm ($((Resolve-PackageInstallSpec -Target $Tag)))" -Level info
         } else {
             if (!(Install-OpenClawNpm -Target $Tag)) {
-                exit 1
+                return (Fail-Install)
             }
         }
     }
@@ -354,6 +363,14 @@ function Main {
     
     Write-Host ""
     Write-Host "🦞 OpenClaw installed successfully!" -Level success
+    return $true
 }
 
-Main
+$installSucceeded = Main
+
+# Preserve non-zero exit codes for direct script execution, but avoid terminating
+# an existing interactive PowerShell session when the installer is run via iex
+# or a downloaded scriptblock.
+if (-not $installSucceeded -and $PSCommandPath) {
+    exit $script:InstallExitCode
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -306,6 +306,24 @@ function Fail-Install {
     return $false
 }
 
+function Complete-Install {
+    param([bool]$Succeeded)
+
+    if ($Succeeded) {
+        return
+    }
+
+    # `exit` kills the current PowerShell host when the installer is invoked via
+    # `iex`/scriptblock. Keep that behavior only for direct script execution and
+    # use a terminating error otherwise so callers still observe a non-zero
+    # failure without losing their interactive session.
+    if ($PSCommandPath) {
+        exit $script:InstallExitCode
+    }
+
+    throw "OpenClaw installation failed with exit code $($script:InstallExitCode)."
+}
+
 # Main
 function Main {
     Write-Banner
@@ -368,9 +386,4 @@ function Main {
 
 $installSucceeded = Main
 
-# Preserve non-zero exit codes for direct script execution, but avoid terminating
-# an existing interactive PowerShell session when the installer is run via iex
-# or a downloaded scriptblock.
-if (-not $installSucceeded -and $PSCommandPath) {
-    exit $script:InstallExitCode
-}
+Complete-Install -Succeeded:$installSucceeded

--- a/test/scripts/install.ps1.test.ts
+++ b/test/scripts/install.ps1.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function extractFunctionBody(source: string, name: string): string {
+  const signature = `function ${name} {`;
+  const start = source.indexOf(signature);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  let depth = 0;
+  let bodyStart = -1;
+  for (let i = start; i < source.length; i += 1) {
+    const char = source[i];
+    if (char === "{") {
+      depth += 1;
+      if (bodyStart === -1) {
+        bodyStart = i + 1;
+      }
+      continue;
+    }
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0 && bodyStart !== -1) {
+        return source.slice(bodyStart, i);
+      }
+    }
+  }
+
+  throw new Error(`Could not extract body for ${name}`);
+}
+
+describe("scripts/install.ps1 failure handling", () => {
+  const scriptPath = path.resolve(import.meta.dirname, "../../scripts/install.ps1");
+  const source = fs.readFileSync(scriptPath, "utf8");
+
+  it("does not exit directly from inside Main", () => {
+    const mainBody = extractFunctionBody(source, "Main");
+    expect(mainBody).not.toMatch(/\bexit\b/i);
+  });
+
+  it("only exits at the top level when invoked as a script file", () => {
+    expect(source).toMatch(
+      /if \(-not \$installSucceeded -and \$PSCommandPath\) \{\s+exit \$script:InstallExitCode\s+\}/m,
+    );
+  });
+});

--- a/test/scripts/install.ps1.test.ts
+++ b/test/scripts/install.ps1.test.ts
@@ -2,31 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
-function extractFunctionBody(source: string, name: string): string {
-  const signature = `function ${name} {`;
-  const start = source.indexOf(signature);
-  expect(start).toBeGreaterThanOrEqual(0);
-
-  let depth = 0;
-  let bodyStart = -1;
-  for (let i = start; i < source.length; i += 1) {
-    const char = source[i];
-    if (char === "{") {
-      depth += 1;
-      if (bodyStart === -1) {
-        bodyStart = i + 1;
-      }
-      continue;
-    }
-    if (char === "}") {
-      depth -= 1;
-      if (depth === 0 && bodyStart !== -1) {
-        return source.slice(bodyStart, i);
-      }
-    }
-  }
-
-  throw new Error(`Could not extract body for ${name}`);
+function extractMainBody(source: string): string {
+  const match = source.match(/^function Main \{\r?\n([\s\S]*?)^}\r?\n\r?\n\$installSucceeded = Main/m);
+  expect(match?.[1]).toBeDefined();
+  return match![1];
 }
 
 describe("scripts/install.ps1 failure handling", () => {
@@ -34,13 +13,22 @@ describe("scripts/install.ps1 failure handling", () => {
   const source = fs.readFileSync(scriptPath, "utf8");
 
   it("does not exit directly from inside Main", () => {
-    const mainBody = extractFunctionBody(source, "Main");
+    const mainBody = extractMainBody(source);
     expect(mainBody).not.toMatch(/\bexit\b/i);
   });
 
   it("only exits at the top level when invoked as a script file", () => {
     expect(source).toMatch(
-      /if \(-not \$installSucceeded -and \$PSCommandPath\) \{\s+exit \$script:InstallExitCode\s+\}/m,
+      /if \(\$PSCommandPath\) \{\s+exit \$script:InstallExitCode\s+\}/m,
+    );
+  });
+
+  it("throws for scriptblock installs so failures still surface without exiting the host", () => {
+    expect(source).toMatch(
+      /Complete-Install -Succeeded:\$installSucceeded/,
+    );
+    expect(source).toMatch(
+      /throw "OpenClaw installation failed with exit code \$\(\$script:InstallExitCode\)\."/m,
     );
   });
 });


### PR DESCRIPTION
## Summary

- Problem: `scripts/install.ps1` called `exit 1` inside `Main`, which can terminate an interactive PowerShell session when the installer is run via `iex` or a downloaded scriptblock.
- Why it matters: a failed install should return control to the user's shell instead of killing the whole session.
- What changed: failure paths now record an exit code and return from `Main`; top-level non-zero exit is preserved only for direct script-file execution.
- What did NOT change (scope boundary): no CLI flags, config schema, or public API changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41797
- Related #

## User-visible / Behavior Changes

Failed Windows installs no longer terminate the user's interactive PowerShell session when the installer is run via `iex` or a downloaded scriptblock. Direct script-file execution still returns a non-zero exit code on failure.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (authoring/tests), bug affects Windows PowerShell behavior
- Runtime/container: Node.js / pnpm
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1. Run the Windows installer via `iex` / downloaded scriptblock.
2. Trigger a failure path inside `Main` (for example missing install prerequisites or npm install failure).
3. Observe shell behavior.

### Expected

- Installer reports the failure and returns control to the current PowerShell session.
- Direct script-file execution still exits non-zero.

### Actual

- Before this change, failure paths inside `Main` could terminate the current interactive PowerShell session.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: added regression coverage to ensure `Main` does not call `exit` directly and that top-level exit remains guarded by direct script execution.
- Edge cases checked: failure in execution policy check, Node/Git prerequisite checks, and npm install path all return through the new failure path.
- What you did **not** verify: manual execution on a real Windows PowerShell host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `scripts/install.ps1`
- Known bad symptoms reviewers should watch for: installer failures no longer returning a non-zero exit code for direct script-file execution

## Risks and Mitigations

- Risk: changing failure control flow could accidentally suppress the expected non-zero exit behavior for direct script execution.
  - Mitigation: regression test asserts the top-level guarded `exit` path remains in place.

AI-assisted: yes  
Tested: `corepack pnpm vitest --run test/scripts/install.ps1.test.ts test/scripts/ui.test.ts`

