### PR TITLE
fix(agents): recognize snake_case tool call types in session history repair (#48915)

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -8,7 +8,14 @@ import {
 } from "./session-transcript-repair.js";
 import { castAgentMessage, castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
 
-const TOOL_CALL_BLOCK_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+const TOOL_CALL_BLOCK_TYPES = new Set([
+  "toolCall",
+  "toolUse",
+  "functionCall",
+  "tool_call",
+  "tool_use",
+  "function_call",
+]);
 
 function getAssistantToolCallBlocks(messages: AgentMessage[]) {
   const assistant = messages[0] as Extract<AgentMessage, { role: "assistant" }> | undefined;
@@ -271,6 +278,20 @@ describe("sanitizeToolCallInputs", () => {
       { role: "user", content: "hello" },
     ]);
 
+    const out = sanitizeToolCallInputs(input);
+    expect(out.map((m) => m.role)).toEqual(["user"]);
+  });
+
+  it("repairs snake_case tool_use blocks missing input (#48915)", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_1", name: "read" }],
+      },
+      { role: "user", content: "hello" },
+    ]);
+
+    // tool_use block without input should be dropped, just like camelCase variants
     const out = sanitizeToolCallInputs(input);
     expect(out.map((m) => m.role)).toEqual(["user"]);
   });

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -19,7 +19,13 @@ function isRawToolCallBlock(block: unknown): block is RawToolCallBlock {
   const type = (block as { type?: unknown }).type;
   return (
     typeof type === "string" &&
-    (type === "toolCall" || type === "toolUse" || type === "functionCall")
+    (type === "toolCall" ||
+      type === "toolUse" ||
+      type === "functionCall" ||
+      // Anthropic and some providers emit snake_case type variants.
+      type === "tool_call" ||
+      type === "tool_use" ||
+      type === "function_call")
   );
 }
 


### PR DESCRIPTION
## Summary

`isRawToolCallBlock` only matched camelCase block types (`toolCall`, `toolUse`, `functionCall`), missing the snake_case variants (`tool_call`, `tool_use`, `function_call`) emitted by Anthropic and some other providers. This caused `repairToolCallInputs` to skip over broken `tool_use` blocks that were missing their `input` field, leading to persistent "corrupted session" errors that even `/new` could not resolve.

## Root Cause

When a streamed tool call is interrupted mid-stream (e.g. timeout, abort), a `tool_use` block without an `input` field gets persisted in the session transcript. On the next message, the history repair pass calls `isRawToolCallBlock` to detect these blocks — but because it only checks camelCase types, the snake_case `tool_use` block is invisible to the repair logic. Anthropic's API then rejects the request with `messages.N.content.N.tool_use.input: field required`.

## Changes

- `src/agents/session-transcript-repair.ts`: Add `tool_call`, `tool_use`, `function_call` to the type check in `isRawToolCallBlock`
- `src/agents/session-transcript-repair.test.ts`: Add regression test for snake_case `tool_use` block without input; update `TOOL_CALL_BLOCK_TYPES` test helper

## Test

All 24 tests pass (23 existing + 1 new regression test):
```
✓ src/agents/session-transcript-repair.test.ts (24 tests) 9ms
```

Closes #48915