### PR TITLE
Fix Discord post-reset startup queue race

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -217,6 +217,171 @@ describe("runReplyAgent onAgentRunStart", () => {
   });
 });
 
+describe("runReplyAgent queued post-rotation startup messages", () => {
+  it("wraps queued owner steer text when a Discord thread reset startup window is active", async () => {
+    const { queueEmbeddedPiMessage } = await import("../../agents/pi-embedded.js");
+    const queueEmbeddedPiMessageMock = vi.mocked(queueEmbeddedPiMessage);
+    queueEmbeddedPiMessageMock.mockReturnValueOnce(true);
+
+    const typing = createMockTypingController();
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun: {
+        prompt: "please continue",
+        summaryLine: "please continue",
+        enqueuedAt: Date.now(),
+        run: {
+          sessionId: "session",
+          sessionKey: "main",
+          messageProvider: "discord",
+          senderIsOwner: true,
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/tmp",
+          config: {},
+          skillsSnapshot: {},
+          provider: "anthropic",
+          model: "claude",
+          thinkLevel: "low",
+          verboseLevel: "off",
+          elevatedLevel: "off",
+          bashElevated: {
+            enabled: false,
+            allowed: false,
+            defaultLevel: "off",
+          },
+          timeoutMs: 1_000,
+          blockReplyBreak: "message_end",
+        },
+      } as unknown as FollowupRun,
+      queueKey: "main",
+      resolvedQueue: { mode: "interrupt" } as QueueSettings,
+      shouldSteer: true,
+      shouldFollowup: false,
+      isActive: true,
+      isStreaming: true,
+      typing,
+      sessionCtx: {
+        Provider: "discord",
+        OriginatingTo: "channel:thread-1",
+        AccountId: "primary",
+        MessageSid: "msg",
+        MessageThreadId: "thread-1",
+      } as unknown as TemplateContext,
+      sessionEntry: {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        postRotationStartupUntilMs: Date.now() + 30_000,
+      },
+      defaultModel: "anthropic/claude",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toBeUndefined();
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith(
+      "session",
+      expect.stringContaining("If any Session Startup preload reads were interrupted or skipped"),
+    );
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith(
+      "session",
+      expect.stringContaining("Owner message:\n\nplease continue"),
+    );
+  });
+
+  it("clears the post-rotation startup window after a run completes", async () => {
+    const storePath = path.join(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-startup-window-")),
+      "sessions.json",
+    );
+    const sessionKey = "main";
+    await saveSessionStore(storePath, {
+      [sessionKey]: {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        postRotationStartupUntilMs: Date.now() + 30_000,
+      },
+    });
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun: {
+        prompt: "hello",
+        summaryLine: "hello",
+        enqueuedAt: Date.now(),
+        run: {
+          sessionId: "session",
+          sessionKey,
+          messageProvider: "discord",
+          senderIsOwner: true,
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/tmp",
+          config: {},
+          skillsSnapshot: {},
+          provider: "anthropic",
+          model: "claude",
+          thinkLevel: "low",
+          verboseLevel: "off",
+          elevatedLevel: "off",
+          bashElevated: {
+            enabled: false,
+            allowed: false,
+            defaultLevel: "off",
+          },
+          timeoutMs: 1_000,
+          blockReplyBreak: "message_end",
+        },
+      } as unknown as FollowupRun,
+      queueKey: sessionKey,
+      resolvedQueue: { mode: "interrupt" } as QueueSettings,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing: createMockTypingController(),
+      sessionCtx: {
+        Provider: "discord",
+        OriginatingTo: "channel:thread-1",
+        AccountId: "primary",
+        MessageSid: "msg",
+        MessageThreadId: "thread-1",
+      } as unknown as TemplateContext,
+      sessionEntry: {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        postRotationStartupUntilMs: Date.now() + 30_000,
+      },
+      sessionStore: {
+        [sessionKey]: {
+          sessionId: "session",
+          updatedAt: Date.now(),
+          postRotationStartupUntilMs: Date.now() + 30_000,
+        },
+      },
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toMatchObject({ text: "ok" });
+    const stored = loadSessionStore(storePath, { skipCache: true });
+    expect(stored[sessionKey]?.postRotationStartupUntilMs).toBeUndefined();
+  });
+});
+
 describe("runReplyAgent authProfileId fallback scoping", () => {
   it("drops authProfileId when provider changes during fallback", async () => {
     runWithModelFallbackMock.mockImplementationOnce(

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -60,6 +60,63 @@ import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 
+function shouldApplyPostRotationStartupSteer(params: {
+  sessionEntry?: SessionEntry;
+  followupRun: FollowupRun;
+  sessionCtx: TemplateContext;
+  now?: number;
+}): boolean {
+  const now = params.now ?? Date.now();
+  return Boolean(
+    params.followupRun.run.senderIsOwner &&
+    params.sessionCtx.Provider === "discord" &&
+    typeof params.sessionCtx.MessageThreadId !== "undefined" &&
+    typeof params.sessionEntry?.postRotationStartupUntilMs === "number" &&
+    params.sessionEntry.postRotationStartupUntilMs > now,
+  );
+}
+
+function buildPostRotationStartupSteerPrompt(text: string): string {
+  const trimmed = text.trim();
+  const ownerMessage = trimmed.length > 0 ? trimmed : text;
+  return [
+    "System: This is the first owner message after /new or /reset in a Discord thread-bound session.",
+    "It arrived while Session Startup preload reads were still running.",
+    "Treat it as implicit-mention-equivalent for this turn. Prioritize the owner message now.",
+    "If any Session Startup preload reads were interrupted or skipped because this message was queued, continue and finish them before you end the turn.",
+    "Do not re-greet or explain the startup mechanics unless the owner asks.",
+    "Owner message:",
+    ownerMessage,
+  ].join("\n\n");
+}
+
+async function clearPostRotationStartupWindow(params: {
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey?: string;
+  storePath?: string;
+}): Promise<void> {
+  const { sessionEntry, sessionStore, sessionKey, storePath } = params;
+  if (!sessionKey || !sessionEntry?.postRotationStartupUntilMs) {
+    return;
+  }
+  sessionEntry.postRotationStartupUntilMs = undefined;
+  if (sessionStore) {
+    sessionStore[sessionKey] = {
+      ...sessionStore[sessionKey],
+      ...sessionEntry,
+      postRotationStartupUntilMs: undefined,
+    };
+  }
+  if (storePath) {
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey,
+      update: async () => ({ postRotationStartupUntilMs: undefined }),
+    });
+  }
+}
+
 export async function runReplyAgent(params: {
   commandBody: string;
   followupRun: FollowupRun;
@@ -195,7 +252,14 @@ export async function runReplyAgent(params: {
   };
 
   if (shouldSteer && isStreaming) {
-    const steered = queueEmbeddedPiMessage(followupRun.run.sessionId, followupRun.prompt);
+    const steerPrompt = shouldApplyPostRotationStartupSteer({
+      sessionEntry: activeSessionEntry,
+      followupRun,
+      sessionCtx,
+    })
+      ? buildPostRotationStartupSteerPrompt(followupRun.prompt)
+      : followupRun.prompt;
+    const steered = queueEmbeddedPiMessage(followupRun.run.sessionId, steerPrompt);
     if (steered && !shouldFollowup) {
       await touchActiveSessionEntry();
       typing.cleanup();
@@ -222,6 +286,7 @@ export async function runReplyAgent(params: {
     return undefined;
   }
 
+  let startedRun = false;
   await typingSignals.signalRunStart();
 
   activeSessionEntry = await runMemoryFlushIfNeeded({
@@ -282,6 +347,7 @@ export async function runReplyAgent(params: {
       model: undefined,
       contextTokens: undefined,
       systemPromptReport: undefined,
+      postRotationStartupUntilMs: undefined,
       fallbackNoticeSelectedModel: undefined,
       fallbackNoticeActiveModel: undefined,
       fallbackNoticeReason: undefined,
@@ -344,6 +410,7 @@ export async function runReplyAgent(params: {
     });
   try {
     const runStartedAt = Date.now();
+    startedRun = true;
     const runOutcome = await runAgentTurnWithFallback({
       commandBody,
       followupRun,
@@ -712,6 +779,14 @@ export async function runReplyAgent(params: {
     finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     throw error;
   } finally {
+    if (startedRun) {
+      await clearPostRotationStartupWindow({
+        sessionEntry: activeSessionEntry,
+        sessionStore: activeSessionStore,
+        sessionKey,
+        storePath,
+      });
+    }
     blockReplyPipeline?.stop();
     typing.markRunComplete();
     // Safety net: the dispatcher's onIdle callback normally fires

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -433,6 +433,29 @@ describe("initSessionState RawBody", () => {
     expect(resetResult.bodyStripped).toBe("");
   });
 
+  it("marks explicit thread resets with a short post-rotation startup window", async () => {
+    vi.setSystemTime(new Date("2026-03-17T09:25:31Z"));
+    const root = await makeCaseDir("openclaw-thread-reset-startup-window-");
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        SessionKey: "agent:main:discord:channel:c1:thread:123",
+        ThreadLabel: "Discord thread #ops",
+        MessageThreadId: "123",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionEntry.postRotationStartupUntilMs).toBe(Date.now() + 30_000);
+  });
+
   it("preserves argument casing while still matching reset triggers case-insensitively", async () => {
     const root = await makeCaseDir("openclaw-rawbody-reset-case-");
     const storePath = path.join(root, "sessions.json");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -51,6 +51,7 @@ import { forkSessionFromParent, resolveParentForkMaxTokens } from "./session-for
 import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./session-hooks.js";
 
 const log = createSubsystemLogger("session-init");
+const POST_ROTATION_STARTUP_WINDOW_MS = 30_000;
 
 export type SessionInitResult = {
   sessionCtx: TemplateContext;
@@ -406,12 +407,20 @@ export async function initSessionState(params: {
   const lastTo = deliveryFields.lastTo ?? lastToRaw;
   const lastAccountId = deliveryFields.lastAccountId ?? lastAccountIdRaw;
   const lastThreadId = deliveryFields.lastThreadId ?? lastThreadIdRaw;
+  const postRotationStartupUntilMs =
+    resetTriggered && isThread
+      ? now + POST_ROTATION_STARTUP_WINDOW_MS
+      : typeof baseEntry?.postRotationStartupUntilMs === "number" &&
+          baseEntry.postRotationStartupUntilMs > now
+        ? baseEntry.postRotationStartupUntilMs
+        : undefined;
   sessionEntry = {
     ...baseEntry,
     sessionId,
     updatedAt: Date.now(),
     systemSent,
     abortedLastRun,
+    postRotationStartupUntilMs,
     // Persist previously stored thinking/verbose levels when present.
     thinkingLevel: persistedThinking ?? baseEntry?.thinkingLevel,
     verboseLevel: persistedVerbose ?? baseEntry?.verboseLevel,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -91,6 +91,12 @@ export type SessionEntry = {
   systemSent?: boolean;
   abortedLastRun?: boolean;
   /**
+   * Grace window for the first owner message after an explicit /new or /reset in a thread-bound
+   * session. While active, queued owner messages can carry startup-recovery instructions so
+   * interrupted Session Startup preload reads are completed before the turn ends.
+   */
+  postRotationStartupUntilMs?: number;
+  /**
    * Session-level stop cutoff captured when /stop is received.
    * Messages at/before this boundary are skipped to avoid replaying
    * queued pre-stop backlog.


### PR DESCRIPTION
$## Summary\n- add a one-shot post-reset startup window for explicit thread /new and /reset flows\n- prioritize the first queued owner message without leaving Session Startup half-skipped\n- instruct the resumed turn to finish interrupted startup preload reads before ending\n- clear the startup window once the run completes\n- add focused regression coverage for the Discord thread queued-message race\n\n## Root cause\nAfter an explicit thread reset, the fresh session had no durable marker that startup was still pending. If the first owner message arrived while startup preload reads were still running, the live run was steered to that queued message, the startup reads were skipped, and nothing told the resumed turn to finish startup cleanly before ending. That created temporary thread/session ordering drift and visible desync.\n\n## Validation\n- corepack pnpm install --frozen-lockfile\n- corepack pnpm vitest run src/auto-reply/reply/session.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts\n- 81/81 tests passed\n\n## Scope note\nThis is a narrow session-layer guard for the observed Discord thread first-owner-message race after /new or /reset. It does not attempt a deeper interruption-model refactor.