### PR TITLE
fix: pass sessionKey to buildEmbeddedExtensionFactories

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -761,6 +761,7 @@ export async function compactEmbeddedPiSessionDirect(
       // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.
       const extensionFactories = buildEmbeddedExtensionFactories({
+        sessionKey: params.sessionKey,
         cfg: params.config,
         sessionManager,
         provider,

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -67,6 +67,7 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: Model<Api> | undefined;
+  sessionKey?: string;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1801,6 +1801,7 @@ export async function runEmbeddedAttempt(
       // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.
       const extensionFactories = buildEmbeddedExtensionFactories({
+        sessionKey: params.sessionKey,
         cfg: params.config,
         sessionManager,
         provider: params.provider,


### PR DESCRIPTION
## Problem

`buildEmbeddedExtensionFactories` in `extensions.ts` does not receive `sessionKey`, even though both call sites (`compact.ts` and `attempt.ts`) have it available via `params.sessionKey`.

This makes it impossible for Pi extensions registered through the factory (e.g. custom compaction handlers) to identify which session they are operating on. Extensions that need session-scoped state must fall back to hard-coded defaults or skip session-dependent logic entirely.

## Fix

Adds an optional `sessionKey` parameter to the `buildEmbeddedExtensionFactories` function signature and threads it through from both call sites.

## Changes

- `extensions.ts`: add `sessionKey?: string` to the params type
- `compact.ts`: pass `sessionKey: params.sessionKey` at the call site
- `attempt.ts`: pass `sessionKey: params.sessionKey` at the call site

3 lines added, 0 removed. No behavioral change to existing code — `sessionKey` is optional and unused by built-in extensions.

Relates to #27836