### PR TITLE
fix(agent): suppress silent gateway wait summaries

### DIFF
--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -107,6 +107,21 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("suppresses silent gateway summaries when no payloads are returned", async () => {
+    await withTempStore(async () => {
+      vi.mocked(callGateway).mockResolvedValue({
+        runId: "idem-1",
+        status: "ok",
+        summary: " ANNOUNCE_SKIP ",
+        result: { payloads: [], meta: { stub: true } },
+      });
+
+      await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(runtime.log).not.toHaveBeenCalled();
+    });
+  });
+
   it("falls back to embedded agent when gateway fails", async () => {
     await withTempStore(async () => {
       vi.mocked(callGateway).mockRejectedValue(new Error("gateway not connected"));

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -14,6 +14,8 @@ import {
 import { agentCommand } from "./agent.js";
 import { resolveSessionKeyForRequest } from "./agent/session.js";
 
+const SILENT_AGENT_SUMMARIES = new Set(["NO_REPLY", "ANNOUNCE_SKIP"]);
+
 type AgentGatewayResult = {
   payloads?: Array<{
     text?: string;
@@ -31,6 +33,11 @@ type GatewayAgentResponse = {
 };
 
 const NO_GATEWAY_TIMEOUT_MS = 2_147_000_000;
+
+function isSilentAgentSummary(text: string | undefined): boolean {
+  const normalized = text?.trim();
+  return normalized ? SILENT_AGENT_SUMMARIES.has(normalized) : false;
+}
 
 export type AgentCliOpts = {
   message: string;
@@ -163,7 +170,10 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   const payloads = result?.payloads ?? [];
 
   if (payloads.length === 0) {
-    runtime.log(response?.summary ? String(response.summary) : "No reply from agent.");
+    const summary = response?.summary ? String(response.summary) : undefined;
+    if (!isSilentAgentSummary(summary)) {
+      runtime.log(summary ?? "No reply from agent.");
+    }
     return response;
   }
 


### PR DESCRIPTION
Summary
- suppress `No reply from agent.` logging when gateway runs end with silent orchestration summaries such as `NO_REPLY` or `ANNOUNCE_SKIP`
- keep the existing fallback log for genuinely empty gateway responses
- add a regression test covering whitespace-padded `ANNOUNCE_SKIP` summaries with no payloads

Change Type
- bug fix

Scope
- CLI gateway agent response logging (`src/commands/agent-via-gateway.ts`)

User-visible / Behavior Changes
- `openclaw agent` no longer logs a misleading `No reply from agent.` line when the gateway already marked the run as intentionally silent via `NO_REPLY` / `ANNOUNCE_SKIP`

Test plan
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run --config vitest.unit.config.ts src/commands/agent-via-gateway.test.ts src/commands/agent.delivery.test.ts`

Closes #49047
