### PR TITLE
fix(feishu): pass mediaLocalRoots to sendMediaFeishu in reply dispatcher

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -3,6 +3,7 @@ import {
   resolveConfiguredBindingRoute,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
+import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import { deriveLastRoutePolicy } from "openclaw/plugin-sdk/routing";
 import { resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/routing";
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
@@ -995,6 +996,7 @@ export async function handleFeishuMessage(params: {
         if (agentId === activeAgentId) {
           // Active agent: real Feishu dispatcher (responds on Feishu)
           const identity = resolveAgentOutboundIdentity(cfg, agentId);
+          const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, agentId);
           const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
             cfg,
             agentId,
@@ -1008,6 +1010,7 @@ export async function handleFeishuMessage(params: {
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
             identity,
+            mediaLocalRoots,
             messageCreateTimeMs,
           });
 
@@ -1096,6 +1099,7 @@ export async function handleFeishuMessage(params: {
       );
 
       const identity = resolveAgentOutboundIdentity(cfg, route.agentId);
+      const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
       const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
         cfg,
         agentId: route.agentId,
@@ -1109,6 +1113,7 @@ export async function handleFeishuMessage(params: {
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
         identity,
+        mediaLocalRoots,
         messageCreateTimeMs,
       });
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -87,6 +87,10 @@ export type CreateFeishuReplyDispatcherParams = {
   mentionTargets?: MentionTarget[];
   accountId?: string;
   identity?: OutboundIdentity;
+  /** Allowed local-filesystem roots for media path reads (post CVE-2026-26321).
+   *  Without this, sendMediaFeishu cannot read local image paths and falls back
+   *  to sending the raw path as plain text. */
+  mediaLocalRoots?: readonly string[];
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
@@ -106,6 +110,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     mentionTargets,
     accountId,
     identity,
+    mediaLocalRoots,
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
   const threadReplyMode = threadReply === true;
@@ -343,6 +348,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           replyToMessageId: sendReplyToMessageId,
           replyInThread: effectiveReplyInThread,
           accountId,
+          mediaLocalRoots,
         });
       },
     });


### PR DESCRIPTION
## Problem

After the security hardening for CVE-2026-26321, `assertLocalMediaAllowed` requires `mediaLocalRoots` to be passed in order to read local image file paths.

`outbound.ts` correctly passes this parameter to `sendMediaFeishu`, but `reply-dispatcher.ts` does not. This causes `sendMediaFeishu` to fail the security check silently and fall back to sending the raw file path as plain text — instead of uploading the image to Feishu.

**User-facing impact**: When an agent replies with a local image path (e.g. via the `message` tool with a `path` parameter), the user receives a text string like `/path/to/image.png` instead of the actual image.

## Fix

- Add `mediaLocalRoots?: readonly string[]` to `CreateFeishuReplyDispatcherParams`
- Destructure it alongside other params
- Thread it through to both `sendMediaFeishu` call sites (line ~410 and ~455)

## Testing

Tested locally by having an agent send a local image via the reply path. Before the fix: user receives the file path as text. After the fix: image is uploaded via `im.image.create` and sent as `msg_type: "image"` correctly.

## Related

- CVE-2026-26321 security hardening
- `outbound.ts` already passes `mediaLocalRoots` correctly (this PR aligns `reply-dispatcher.ts` with that pattern)
