### PR TITLE
Fix memory fetches behind env proxies

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -310,4 +310,20 @@ describe("fetchWithSsrFGuard hardening", () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
     await result.release();
   });
+
+  it("still enforces hostname allowlist in trusted env proxy mode", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://evil.example.org/file.txt",
+        fetchImpl,
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+        policy: { hostnameAllowlist: ["cdn.example.com", "*.assets.example.com"] },
+      }),
+    ).rejects.toThrow(/allowlist/i);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -293,6 +293,7 @@ describe("fetchWithSsrFGuard hardening", () => {
   });
 
   it("skips local DNS pinning when trusted env proxy mode is active", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
     const lookupFn = vi.fn(async () => {
       throw new Error("lookup should not run");
     });

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -291,4 +291,22 @@ describe("fetchWithSsrFGuard hardening", () => {
       expectEnvProxy: true,
     });
   });
+
+  it("skips local DNS pinning when trusted env proxy mode is active", async () => {
+    const lookupFn = vi.fn(async () => {
+      throw new Error("lookup should not run");
+    });
+    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://public.example/resource",
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      fetchImpl,
+      lookupFn,
+    });
+
+    expect(lookupFn).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    await result.release();
+  });
 });

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -189,12 +189,14 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
 
     let dispatcher: Dispatcher | null = null;
     try {
-      const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
-        lookupFn: params.lookupFn,
-        policy: params.policy,
-      });
       const canUseTrustedEnvProxy =
         mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
+      const pinned = canUseTrustedEnvProxy
+        ? undefined
+        : await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+            lookupFn: params.lookupFn,
+            policy: params.policy,
+          });
       if (canUseTrustedEnvProxy) {
         dispatcher = new EnvHttpProxyAgent();
       } else if (params.pinDns !== false) {

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -3,6 +3,7 @@ import { logWarn } from "../../logger.js";
 import { bindAbortRelay } from "../../utils/fetch-timeout.js";
 import { hasProxyEnvConfigured } from "./proxy-env.js";
 import {
+  assertAllowedHostnameWithPolicyOrThrow,
   closeDispatcher,
   createPinnedDispatcher,
   resolvePinnedHostnameWithPolicy,
@@ -192,7 +193,7 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
       const canUseTrustedEnvProxy =
         mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
       const pinned = canUseTrustedEnvProxy
-        ? undefined
+        ? (assertAllowedHostnameWithPolicyOrThrow(parsedUrl.hostname, params.policy), undefined)
         : await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
             lookupFn: params.lookupFn,
             policy: params.policy,

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -91,6 +91,33 @@ function matchesHostnameAllowlist(hostname: string, allowlist: string[]): boolea
   return allowlist.some((pattern) => isHostnameAllowedByPattern(hostname, pattern));
 }
 
+export function assertAllowedHostnameWithPolicyOrThrow(
+  hostname: string,
+  policy?: SsrFPolicy,
+): string {
+  const normalized = normalizeHostname(hostname);
+  if (!normalized) {
+    throw new Error("Invalid hostname");
+  }
+
+  const allowedHostnames = normalizeHostnameSet(policy?.allowedHostnames);
+  const hostnameAllowlist = normalizeHostnameAllowlist(policy?.hostnameAllowlist);
+
+  if (!matchesHostnameAllowlist(normalized, hostnameAllowlist)) {
+    throw new SsrFBlockedError(`Blocked hostname (not in allowlist): ${hostname}`);
+  }
+
+  const isExplicitAllowed = allowedHostnames.has(normalized);
+  const skipPrivateNetworkChecks =
+    isPrivateNetworkAllowedByPolicy(policy) || isExplicitAllowed;
+
+  if (!skipPrivateNetworkChecks) {
+    assertAllowedHostOrIpOrThrow(normalized, policy);
+  }
+
+  return normalized;
+}
+
 function looksLikeUnsupportedIpv4Literal(address: string): boolean {
   const parts = address.split(".");
   if (parts.length === 0 || parts.length > 4) {
@@ -293,25 +320,11 @@ export async function resolvePinnedHostnameWithPolicy(
   hostname: string,
   params: { lookupFn?: LookupFn; policy?: SsrFPolicy } = {},
 ): Promise<PinnedHostname> {
-  const normalized = normalizeHostname(hostname);
-  if (!normalized) {
-    throw new Error("Invalid hostname");
-  }
-
-  const allowPrivateNetwork = isPrivateNetworkAllowedByPolicy(params.policy);
+  const normalized = assertAllowedHostnameWithPolicyOrThrow(hostname, params.policy);
   const allowedHostnames = normalizeHostnameSet(params.policy?.allowedHostnames);
-  const hostnameAllowlist = normalizeHostnameAllowlist(params.policy?.hostnameAllowlist);
   const isExplicitAllowed = allowedHostnames.has(normalized);
-  const skipPrivateNetworkChecks = allowPrivateNetwork || isExplicitAllowed;
-
-  if (!matchesHostnameAllowlist(normalized, hostnameAllowlist)) {
-    throw new SsrFBlockedError(`Blocked hostname (not in allowlist): ${hostname}`);
-  }
-
-  if (!skipPrivateNetworkChecks) {
-    // Phase 1: fail fast for literal hosts/IPs before any DNS lookup side-effects.
-    assertAllowedHostOrIpOrThrow(normalized, params.policy);
-  }
+  const skipPrivateNetworkChecks =
+    isPrivateNetworkAllowedByPolicy(params.policy) || isExplicitAllowed;
 
   const lookupFn = params.lookupFn ?? dnsLookup;
   const results = await lookupFn(normalized, { all: true });

--- a/src/memory/remote-http.test.ts
+++ b/src/memory/remote-http.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GUARDED_FETCH_MODE } from "../infra/net/fetch-guard.js";
+
+const fetchWithSsrFGuardMock = vi.fn();
+
+vi.mock("../infra/net/fetch-guard.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/net/fetch-guard.js")>(
+    "../infra/net/fetch-guard.js",
+  );
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
+  };
+});
+
+let withRemoteHttpResponse: typeof import("./remote-http.js").withRemoteHttpResponse;
+
+describe("withRemoteHttpResponse", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    fetchWithSsrFGuardMock.mockReset();
+    ({ withRemoteHttpResponse } = await import("./remote-http.js"));
+  });
+
+  it("uses trusted env proxy mode for public remote hosts", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("ok", { status: 200 }),
+      finalUrl: "https://api.openai.com/v1/embeddings",
+      release: vi.fn(async () => {}),
+    });
+
+    await withRemoteHttpResponse({
+      url: "https://api.openai.com/v1/embeddings",
+      onResponse: async () => "ok",
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.openai.com/v1/embeddings",
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      }),
+    );
+  });
+
+  it("keeps localhost targets on direct guarded fetches", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ embedding: [1, 2, 3] }), { status: 200 }),
+      finalUrl: "http://127.0.0.1:11434/api/embeddings",
+      release: vi.fn(async () => {}),
+    });
+
+    await withRemoteHttpResponse({
+      url: "http://127.0.0.1:11434/api/embeddings",
+      ssrfPolicy: { allowedHostnames: ["127.0.0.1"] },
+      onResponse: async () => "ok",
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://127.0.0.1:11434/api/embeddings",
+        policy: { allowedHostnames: ["127.0.0.1"] },
+      }),
+    );
+    expect(fetchWithSsrFGuardMock.mock.calls[0]?.[0]).not.toHaveProperty("mode");
+  });
+});

--- a/src/memory/remote-http.ts
+++ b/src/memory/remote-http.ts
@@ -29,6 +29,8 @@ export async function withRemoteHttpResponse<T>(params: {
   const { response, release } = await fetchWithSsrFGuard({
     url: params.url,
     init: params.init,
+    proxy: "env",
+    dangerouslyAllowEnvProxyWithoutPinnedDns: true,
     policy: params.ssrfPolicy,
     auditContext: params.auditContext ?? "memory-remote",
   });

--- a/src/memory/remote-http.ts
+++ b/src/memory/remote-http.ts
@@ -2,7 +2,7 @@ import {
   fetchWithSsrFGuard,
   GUARDED_FETCH_MODE,
 } from "../infra/net/fetch-guard.js";
-import type { SsrFPolicy } from "../infra/net/ssrf.js";
+import { isBlockedHostnameOrIp, type SsrFPolicy } from "../infra/net/ssrf.js";
 
 export function buildRemoteBaseUrlPolicy(baseUrl: string): SsrFPolicy | undefined {
   const trimmed = baseUrl.trim();
@@ -29,10 +29,19 @@ export async function withRemoteHttpResponse<T>(params: {
   auditContext?: string;
   onResponse: (response: Response) => Promise<T>;
 }): Promise<T> {
+  let mode: typeof GUARDED_FETCH_MODE[keyof typeof GUARDED_FETCH_MODE] | undefined;
+  try {
+    const hostname = new URL(params.url).hostname;
+    if (!isBlockedHostnameOrIp(hostname, params.ssrfPolicy)) {
+      mode = GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY;
+    }
+  } catch {
+    mode = undefined;
+  }
   const { response, release } = await fetchWithSsrFGuard({
     url: params.url,
     init: params.init,
-    mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+    ...(mode ? { mode } : {}),
     policy: params.ssrfPolicy,
     auditContext: params.auditContext ?? "memory-remote",
   });

--- a/src/memory/remote-http.ts
+++ b/src/memory/remote-http.ts
@@ -1,4 +1,7 @@
-import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import {
+  fetchWithSsrFGuard,
+  GUARDED_FETCH_MODE,
+} from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 
 export function buildRemoteBaseUrlPolicy(baseUrl: string): SsrFPolicy | undefined {
@@ -29,8 +32,7 @@ export async function withRemoteHttpResponse<T>(params: {
   const { response, release } = await fetchWithSsrFGuard({
     url: params.url,
     init: params.init,
-    proxy: "env",
-    dangerouslyAllowEnvProxyWithoutPinnedDns: true,
+    mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
     policy: params.ssrfPolicy,
     auditContext: params.auditContext ?? "memory-remote",
   });


### PR DESCRIPTION
## Summary
- enable env-proxy mode for memory remote fetches
- skip local DNS pinning when trusted env proxy mode is active
- add a regression test covering trusted env proxy without local DNS lookup

## Testing
- ./node_modules/.bin/vitest run --config vitest.unit.config.ts src/infra/net/fetch-guard.ssrf.test.ts
- ./node_modules/.bin/vitest run --config vitest.unit.config.ts src/memory/post-json.test.ts