### PR TITLE
fix poll send false-positive when duration sentinel is zero

### DIFF
--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -163,6 +163,17 @@ describe("runMessageAction context isolation", () => {
       },
       toolContext: { currentChannelId: "C12345678" },
     },
+    {
+      name: "allows send when poll duration sentinel is zero",
+      cfg: slackConfig,
+      actionParams: {
+        channel: "slack",
+        target: "#C12345678",
+        message: "hi",
+        pollDurationHours: 0,
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    },
   ])("$name", async ({ cfg, actionParams, toolContext }) => {
     const result = await runDrySend({
       cfg,

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -23,8 +23,10 @@ describe("poll params", () => {
     },
   );
 
-  it("treats finite numeric poll params as poll creation intent", () => {
-    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(true);
+  it("only treats positive finite numeric poll params as poll creation intent", () => {
+    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: "0" })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: -1 })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: 60 })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "60" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "1e3" })).toBe(true);

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -21,6 +21,10 @@ export type PollCreationParamName = keyof typeof POLL_CREATION_PARAM_DEFS;
 
 export const POLL_CREATION_PARAM_NAMES = Object.keys(POLL_CREATION_PARAM_DEFS);
 
+function isPositiveFinitePollNumber(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
 function readPollParamRaw(params: Record<string, unknown>, key: string): unknown {
   return readSnakeCaseParamRaw(params, key);
 }
@@ -54,12 +58,12 @@ export function hasPollCreationParams(params: Record<string, unknown>): boolean 
       }
     }
     if (def.kind === "number") {
-      if (typeof value === "number" && Number.isFinite(value)) {
+      if (typeof value === "number" && isPositiveFinitePollNumber(value)) {
         return true;
       }
       if (typeof value === "string") {
         const trimmed = value.trim();
-        if (trimmed.length > 0 && Number.isFinite(Number(trimmed))) {
+        if (trimmed.length > 0 && isPositiveFinitePollNumber(Number(trimmed))) {
           return true;
         }
       }


### PR DESCRIPTION
AI-assisted: Codex

Fixes #48928.

## Summary
This change prevents `message(action=send)` calls from being misclassified as poll creation requests when poll duration fields are present only as zero-value sentinels.

## Root Cause
`hasPollCreationParams` treated any finite numeric poll field as poll intent, including `0` and stringified `"0"`. That caused `send` actions carrying zero-valued placeholders to trip the `Poll fields require action "poll"` guard even though no poll was being created.

## Fix
The numeric poll-intent check now only treats positive finite values as poll creation parameters. The regression coverage also verifies that `send` remains allowed when `pollDurationHours=0` is present, while valid positive poll durations still behave as poll creation intent.

## Validation
- `pnpm exec vitest run "src/poll-params.test.ts" "src/infra/outbound/message-action-runner.context.test.ts" "src/infra/outbound/message-action-runner.poll.test.ts"`
