### PR TITLE
fix stale Control UI context warning math

### DIFF
--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -389,6 +389,7 @@ export type GatewaySessionRow = {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  totalTokensFresh?: boolean;
   model?: string;
   modelProvider?: string;
   contextTokens?: number;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -249,6 +249,64 @@ function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewPr
 }
 
 describe("chat view", () => {
+  it("does not show the context warning from accumulated input tokens when current context is below threshold", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          sessions: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: 128_000 },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                inputTokens: 128_000,
+                totalTokens: 64_000,
+                contextTokens: 128_000,
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).not.toContain("context used");
+  });
+
+  it("hides the context warning when the cached total token snapshot is stale", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          sessions: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: 128_000 },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                totalTokens: 120_000,
+                totalTokensFresh: false,
+                contextTokens: 128_000,
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).not.toContain("context used");
+  });
+
   it("uses the assistant avatar URL for the welcome state when the identity avatar is only initials", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -255,7 +255,7 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  const used = session?.inputTokens ?? 0;
+  const used = session?.totalTokensFresh === false ? 0 : (session?.totalTokens ?? 0);
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
AI-assisted: Codex

Fixes #49076.

## Summary
This change stops the Control UI from showing misleading `100% context used` warnings when the session row only has accumulated input token counts rather than a fresh current-context snapshot.

## Root Cause
The chat view used `inputTokens / contextTokens` for the warning banner. `inputTokens` is accumulated across calls and tool loops, so it can reach the context limit even when the current live context is much smaller.

## Fix
The warning now keys off `totalTokens`, which the gateway already persists as the current context-sized token total, and it suppresses the warning entirely when that cached total is marked stale. The UI tests now cover both the accumulated-input false positive and the stale-snapshot case.

## Validation
- `pnpm exec vitest run "ui/src/ui/views/chat.test.ts"`
