### PR TITLE
Gateway/Agent: suppress false no-reply logs for silent completions

### DIFF
--- a/src/agents/command/delivery.silent-completion.test.ts
+++ b/src/agents/command/delivery.silent-completion.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../../runtime.js";
+import { deliverAgentCommandResult } from "./delivery.js";
+
+describe("deliverAgentCommandResult silent completion", () => {
+  it("keeps silent completions out of local logs when no payload is produced", async () => {
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+    } as unknown as RuntimeEnv;
+
+    await deliverAgentCommandResult({
+      cfg: {} as never,
+      deps: {} as never,
+      runtime,
+      opts: {
+        message: "hello",
+        deliver: false,
+      } as never,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: {
+        payloads: [],
+        meta: {
+          durationMs: 1,
+          silentCompletion: true,
+        },
+      } as never,
+      payloads: [],
+    });
+
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -62,6 +62,15 @@ function logNestedOutput(
   }
 }
 
+function isSilentCompletionMeta(meta: unknown): boolean {
+  return Boolean(
+    meta &&
+    typeof meta === "object" &&
+    "silentCompletion" in meta &&
+    (meta as { silentCompletion?: unknown }).silentCompletion === true,
+  );
+}
+
 export async function deliverAgentCommandResult(params: {
   cfg: OpenClawConfig;
   deps: CliDeps;
@@ -191,7 +200,9 @@ export async function deliverAgentCommandResult(params: {
   }
 
   if (!payloads || payloads.length === 0) {
-    runtime.log("No reply from agent.");
+    if (!isSilentCompletionMeta(result.meta)) {
+      runtime.log("No reply from agent.");
+    }
     return { payloads: [], meta: result.meta };
   }
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -71,7 +71,7 @@ import { resolveModelAsync } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
 import { createFailoverDecisionLogger } from "./run/failover-observation.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
-import { buildEmbeddedRunPayloads } from "./run/payloads.js";
+import { buildEmbeddedRunPayloads, hasEmbeddedSilentCompletion } from "./run/payloads.js";
 import {
   truncateOversizedToolResultsInSession,
   sessionLikelyHasOversizedToolResults,
@@ -1612,6 +1612,12 @@ export async function runEmbeddedPiAgent(
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
             didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
           });
+          const silentCompletion =
+            payloads.length === 0 &&
+            hasEmbeddedSilentCompletion({
+              assistantTexts: attempt.assistantTexts,
+              lastAssistant: attempt.lastAssistant,
+            });
 
           // Timeout aborts can leave the run without any assistant payloads.
           // Emit an explicit timeout error instead of silently completing, so
@@ -1663,6 +1669,7 @@ export async function runEmbeddedPiAgent(
               durationMs: Date.now() - started,
               agentMeta,
               aborted,
+              silentCompletion: silentCompletion || undefined,
               systemPromptReport: attempt.systemPromptReport,
               // Handle client tool calls (OpenResponses hosted tools)
               // Propagate the LLM stop reason so callers (lifecycle events,

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { hasEmbeddedSilentCompletion } from "./payloads.js";
 import { buildPayloads, expectSingleToolErrorPayload } from "./payloads.test-helpers.js";
 
 describe("buildEmbeddedRunPayloads tool-error warnings", () => {
@@ -89,5 +90,23 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
       assistantTexts: ["Approval is needed. Please run /approve abc allow-once"],
       didSendDeterministicApprovalPrompt: true,
     });
+  });
+
+  it("marks exact NO_REPLY turns as silent completion candidates", () => {
+    expect(
+      hasEmbeddedSilentCompletion({
+        assistantTexts: ["  NO_REPLY  "],
+        lastAssistant: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not mark substantive replies as silent completion candidates", () => {
+    expect(
+      hasEmbeddedSilentCompletion({
+        assistantTexts: ["NO_REPLY -- explanation"],
+        lastAssistant: undefined,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -345,3 +345,15 @@ export function buildEmbeddedRunPayloads(params: {
       return true;
     });
 }
+
+export function hasEmbeddedSilentCompletion(params: {
+  assistantTexts: string[];
+  lastAssistant: AssistantMessage | undefined;
+}): boolean {
+  const visibleTexts = params.assistantTexts.length
+    ? params.assistantTexts
+    : params.lastAssistant
+      ? [extractAssistantText(params.lastAssistant)]
+      : [];
+  return visibleTexts.some((text) => isSilentReplyText(text, SILENT_REPLY_TOKEN));
+}

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -34,6 +34,7 @@ export type EmbeddedPiRunMeta = {
   durationMs: number;
   agentMeta?: EmbeddedPiAgentMeta;
   aborted?: boolean;
+  silentCompletion?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
   error?: {
     kind:

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -138,4 +138,25 @@ describe("agentCliCommand", () => {
       expect(runtime.log).toHaveBeenCalledWith("local");
     });
   });
+
+  it("keeps silent gateway completions out of CLI logs when no payload is returned", async () => {
+    await withTempStore(async () => {
+      vi.mocked(callGateway).mockResolvedValue({
+        runId: "idem-1",
+        status: "ok",
+        summary: "completed",
+        result: {
+          payloads: [],
+          meta: {
+            silentCompletion: true,
+          },
+        },
+      });
+
+      await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(runtime.log).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -84,6 +84,15 @@ function formatPayloadForLog(payload: {
   return lines.join("\n").trimEnd();
 }
 
+function isSilentCompletionMeta(meta: unknown): boolean {
+  return Boolean(
+    meta &&
+    typeof meta === "object" &&
+    "silentCompletion" in meta &&
+    (meta as { silentCompletion?: unknown }).silentCompletion === true,
+  );
+}
+
 export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: RuntimeEnv) {
   const body = (opts.message ?? "").trim();
   if (!body) {
@@ -163,7 +172,9 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   const payloads = result?.payloads ?? [];
 
   if (payloads.length === 0) {
-    runtime.log(response?.summary ? String(response.summary) : "No reply from agent.");
+    if (!isSilentCompletionMeta(result?.meta)) {
+      runtime.log(response?.summary ? String(response.summary) : "No reply from agent.");
+    }
     return response;
   }
 


### PR DESCRIPTION
## Summary
- preserve an explicit silent-completion marker for embedded agent runs that end with exact `NO_REPLY`
- suppress misleading `No reply from agent.` logging in local delivery and gateway CLI paths when the run completed silently by design
- cover the silent completion marker and both logging surfaces with focused regression tests

Closes #49047

## Test Plan
- pnpm exec vitest run "src/agents/command/delivery.silent-completion.test.ts" "src/commands/agent-via-gateway.test.ts" "src/agents/pi-embedded-runner/run/payloads.test.ts"
- pnpm exec vitest run "src/commands/agent.acp.test.ts" "src/agents/pi-embedded-runner/run/payloads.errors.test.ts"
- `src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts` currently requires provider auth in this environment and was not used as pass/fail evidence
