### PR TITLE
Skills: refresh stale session snapshots after restart

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -92,6 +92,7 @@ import { prepareSessionManagerForRun } from "./pi-embedded-runner/session-manage
 import { runEmbeddedPiAgent } from "./pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "./skills.js";
 import { getSkillsSnapshotVersion } from "./skills/refresh.js";
+import { resolveSessionSkillsSnapshot } from "./skills/session-snapshot.js";
 import { normalizeSpawnedRunMetadata } from "./spawned-context.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 import { ensureAgentWorkspace } from "./workspace.js";
@@ -905,19 +906,23 @@ async function agentCommandInternal(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
-    const skillsSnapshot = needsSkillsSnapshot
-      ? buildWorkspaceSkillSnapshot(workspaceDir, {
-          config: cfg,
-          eligibility: { remote: getRemoteSkillEligibility() },
-          snapshotVersion: skillsSnapshotVersion,
-          skillFilter,
-        })
-      : sessionEntry?.skillsSnapshot;
+    const { skillsSnapshot, shouldPersist: shouldPersistSkillsSnapshot } =
+      resolveSessionSkillsSnapshot({
+        currentSnapshot: sessionEntry?.skillsSnapshot,
+        isNewSession,
+        snapshotVersion: skillsSnapshotVersion,
+        buildSnapshot: () =>
+          buildWorkspaceSkillSnapshot(workspaceDir, {
+            config: cfg,
+            eligibility: { remote: getRemoteSkillEligibility() },
+            snapshotVersion: skillsSnapshotVersion,
+            skillFilter,
+          }),
+      });
 
-    if (skillsSnapshot && sessionStore && sessionKey && needsSkillsSnapshot) {
+    if (skillsSnapshot && sessionStore && sessionKey && shouldPersistSkillsSnapshot) {
       const current = sessionEntry ?? {
         sessionId,
         updatedAt: Date.now(),

--- a/src/agents/skills/session-snapshot.test.ts
+++ b/src/agents/skills/session-snapshot.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveSessionSkillsSnapshot } from "./session-snapshot.js";
+
+describe("resolveSessionSkillsSnapshot", () => {
+  it("refreshes when the observed snapshot version increases", () => {
+    const buildSnapshot = vi.fn(() => ({
+      prompt: "new skills",
+      skills: [{ name: "new-skill" }],
+      version: 12,
+    }));
+
+    const result = resolveSessionSkillsSnapshot({
+      currentSnapshot: {
+        prompt: "old skills",
+        skills: [{ name: "old-skill" }],
+        version: 4,
+      },
+      isNewSession: false,
+      snapshotVersion: 12,
+      buildSnapshot,
+    });
+
+    expect(buildSnapshot).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      skillsSnapshot: {
+        prompt: "new skills",
+        skills: [{ name: "new-skill" }],
+        version: 12,
+      },
+      shouldPersist: true,
+    });
+  });
+
+  it("refreshes stale snapshots on cold start when content changed but version stayed at zero", () => {
+    const buildSnapshot = vi.fn(() => ({
+      prompt: "new skills",
+      skills: [{ name: "new-skill" }],
+      version: 0,
+    }));
+
+    const result = resolveSessionSkillsSnapshot({
+      currentSnapshot: {
+        prompt: "old skills",
+        skills: [{ name: "old-skill" }],
+        version: 0,
+      },
+      isNewSession: false,
+      snapshotVersion: 0,
+      buildSnapshot,
+    });
+
+    expect(buildSnapshot).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      skillsSnapshot: {
+        prompt: "new skills",
+        skills: [{ name: "new-skill" }],
+        version: 0,
+      },
+      shouldPersist: true,
+    });
+  });
+
+  it("keeps existing snapshots on cold start when the rebuilt content matches", () => {
+    const currentSnapshot = {
+      prompt: "same skills",
+      skills: [{ name: "same-skill" }],
+      version: 7,
+    };
+    const buildSnapshot = vi.fn(() => ({
+      prompt: "same skills",
+      skills: [{ name: "same-skill" }],
+      version: 0,
+    }));
+
+    const result = resolveSessionSkillsSnapshot({
+      currentSnapshot,
+      isNewSession: false,
+      snapshotVersion: 0,
+      buildSnapshot,
+    });
+
+    expect(buildSnapshot).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      skillsSnapshot: currentSnapshot,
+      shouldPersist: false,
+    });
+  });
+});

--- a/src/agents/skills/session-snapshot.ts
+++ b/src/agents/skills/session-snapshot.ts
@@ -1,0 +1,59 @@
+import type { SkillSnapshot } from "./types.js";
+
+function normalizeSnapshot(snapshot: SkillSnapshot | undefined) {
+  if (!snapshot) {
+    return undefined;
+  }
+  return {
+    prompt: snapshot.prompt,
+    skills: snapshot.skills,
+    skillFilter: snapshot.skillFilter,
+  };
+}
+
+function areSkillSnapshotsEquivalent(
+  left: SkillSnapshot | undefined,
+  right: SkillSnapshot | undefined,
+): boolean {
+  return JSON.stringify(normalizeSnapshot(left)) === JSON.stringify(normalizeSnapshot(right));
+}
+
+export function resolveSessionSkillsSnapshot(params: {
+  currentSnapshot?: SkillSnapshot;
+  isNewSession: boolean;
+  snapshotVersion: number;
+  buildSnapshot: () => SkillSnapshot;
+}): {
+  skillsSnapshot?: SkillSnapshot;
+  shouldPersist: boolean;
+} {
+  if (params.isNewSession || !params.currentSnapshot) {
+    return {
+      skillsSnapshot: params.buildSnapshot(),
+      shouldPersist: true,
+    };
+  }
+
+  const currentVersion = params.currentSnapshot.version ?? 0;
+  if (currentVersion < params.snapshotVersion) {
+    return {
+      skillsSnapshot: params.buildSnapshot(),
+      shouldPersist: true,
+    };
+  }
+
+  if (params.snapshotVersion === 0) {
+    const rebuiltSnapshot = params.buildSnapshot();
+    if (!areSkillSnapshotsEquivalent(params.currentSnapshot, rebuiltSnapshot)) {
+      return {
+        skillsSnapshot: rebuiltSnapshot,
+        shouldPersist: true,
+      };
+    }
+  }
+
+  return {
+    skillsSnapshot: params.currentSnapshot,
+    shouldPersist: false,
+  };
+}

--- a/src/auto-reply/reply/session-updates.skills-snapshot.test.ts
+++ b/src/auto-reply/reply/session-updates.skills-snapshot.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../agents/skills/refresh.js", () => ({
+  ensureSkillsWatcher: vi.fn(),
+  getSkillsSnapshotVersion: vi.fn(),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  updateSessionStore: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: vi.fn(() => ({
+    platforms: [],
+    hasBin: () => false,
+    hasAnyBin: () => false,
+  })),
+}));
+
+import { getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
+import { ensureSkillSnapshot } from "./session-updates.js";
+
+describe("ensureSkillSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OPENCLAW_TEST_FAST = "0";
+  });
+
+  it("refreshes existing snapshots when cold-start versioning cannot detect new skills", async () => {
+    vi.mocked(getSkillsSnapshotVersion).mockReturnValue(0);
+
+    const sessionStore = {
+      "session-key": {
+        sessionId: "session-1",
+        updatedAt: 1,
+        skillsSnapshot: {
+          prompt: "old skills",
+          skills: [{ name: "old-skill" }],
+          version: 0,
+        },
+      },
+    };
+
+    const result = await ensureSkillSnapshot({
+      sessionEntry: sessionStore["session-key"],
+      sessionStore,
+      sessionKey: "session-key",
+      storePath: "/tmp/sessions.json",
+      sessionId: "session-1",
+      isFirstTurnInSession: false,
+      workspaceDir: "/tmp/workspace",
+      cfg: {} as never,
+    });
+
+    expect(result.skillsSnapshot?.prompt).not.toBe("old skills");
+    expect(result.skillsSnapshot?.skills).not.toEqual([{ name: "old-skill" }]);
+    expect(sessionStore["session-key"]?.skillsSnapshot).toEqual(result.skillsSnapshot);
+  });
+});

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { resolveUserTimezone } from "../../agents/date-time.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
 import { ensureSkillsWatcher, getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
+import { resolveSessionSkillsSnapshot } from "../../agents/skills/session-snapshot.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
 import { buildChannelSummary } from "../../infra/channel-summary.js";
@@ -181,8 +182,13 @@ export async function ensureSkillSnapshot(params: {
   const remoteEligibility = getRemoteSkillEligibility();
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   ensureSkillsWatcher({ workspaceDir, config: cfg });
-  const shouldRefreshSnapshot =
-    snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion;
+  const buildSkillsSnapshot = () =>
+    buildWorkspaceSkillSnapshot(workspaceDir, {
+      config: cfg,
+      skillFilter,
+      eligibility: { remote: remoteEligibility },
+      snapshotVersion,
+    });
 
   if (isFirstTurnInSession && sessionStore && sessionKey) {
     const current = nextEntry ??
@@ -190,15 +196,12 @@ export async function ensureSkillSnapshot(params: {
         sessionId: sessionId ?? crypto.randomUUID(),
         updatedAt: Date.now(),
       };
-    const skillSnapshot =
-      isFirstTurnInSession || !current.skillsSnapshot || shouldRefreshSnapshot
-        ? buildWorkspaceSkillSnapshot(workspaceDir, {
-            config: cfg,
-            skillFilter,
-            eligibility: { remote: remoteEligibility },
-            snapshotVersion,
-          })
-        : current.skillsSnapshot;
+    const { skillsSnapshot: skillSnapshot } = resolveSessionSkillsSnapshot({
+      currentSnapshot: current.skillsSnapshot,
+      isNewSession: true,
+      snapshotVersion,
+      buildSnapshot: buildSkillsSnapshot,
+    });
     nextEntry = {
       ...current,
       sessionId: sessionId ?? current.sessionId ?? crypto.randomUUID(),
@@ -210,28 +213,19 @@ export async function ensureSkillSnapshot(params: {
     systemSent = true;
   }
 
-  const skillsSnapshot = shouldRefreshSnapshot
-    ? buildWorkspaceSkillSnapshot(workspaceDir, {
-        config: cfg,
-        skillFilter,
-        eligibility: { remote: remoteEligibility },
-        snapshotVersion,
-      })
-    : (nextEntry?.skillsSnapshot ??
-      (isFirstTurnInSession
-        ? undefined
-        : buildWorkspaceSkillSnapshot(workspaceDir, {
-            config: cfg,
-            skillFilter,
-            eligibility: { remote: remoteEligibility },
-            snapshotVersion,
-          })));
+  const { skillsSnapshot, shouldPersist: shouldPersistSkillsSnapshot } =
+    resolveSessionSkillsSnapshot({
+      currentSnapshot: nextEntry?.skillsSnapshot,
+      isNewSession: isFirstTurnInSession,
+      snapshotVersion,
+      buildSnapshot: buildSkillsSnapshot,
+    });
   if (
     skillsSnapshot &&
     sessionStore &&
     sessionKey &&
     !isFirstTurnInSession &&
-    (!nextEntry?.skillsSnapshot || shouldRefreshSnapshot)
+    shouldPersistSkillsSnapshot
   ) {
     const current = nextEntry ?? {
       sessionId: sessionId ?? crypto.randomUUID(),


### PR DESCRIPTION
## Summary
- introduce a shared session-snapshot resolver that refreshes stored skill snapshots when watcher versions advance or a cold restart reveals different skill content
- use the shared resolver in both `agentCommand` and `ensureSkillSnapshot` so existing sessions can see newly installed skills after a gateway restart
- cover version-based refresh and cold-start content-diff refresh with focused regression tests

Closes #49059

## Test Plan
- pnpm exec vitest run "src/agents/skills/session-snapshot.test.ts" "src/auto-reply/reply/session-updates.skills-snapshot.test.ts"
