### PR TITLE
fix: add placeholder transcript for silent voice notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Docs: https://docs.openclaw.ai
   keeping those envelopes out of ACP transcripts.
 - TTS/status: show configured TTS model, voice, and sanitized custom endpoint in `/status`, preserve OpenAI-compatible TTS instructions on custom endpoints, and retry empty Microsoft/Edge TTS output once. Addresses #46602, #47232, and #43936. Thanks @leekuangtao, @Huntterxx, and @rex993.
 - Agents/Gateway: steer agent-driven config edits and restarts through the owner-only `gateway` tool, document `config.schema.lookup` as the field-doc source, and warn against using `gateway stop && gateway start` as a restart substitute on macOS. Fixes #71929. Thanks @ygc3817922006-sketch.
+- Media understanding/audio: inject a deterministic transcript placeholder for too-small voice notes so agents do not hallucinate transcription or provider failures. Fixes #48944. Thanks @eulicesl.
 - Providers/vLLM: send Nemotron 3 chat-template kwargs when thinking is off
   and honor configured `params.chat_template_kwargs` for OpenAI-compatible
   completions, so vLLM/Nemotron replies stay visible instead of becoming

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -130,7 +130,7 @@ Recommended defaults:
 Rules:
 
 - If media exceeds `maxBytes`, that model is skipped and the **next model is tried**.
-- Audio files smaller than **1024 bytes** are treated as empty/corrupt and skipped before provider/CLI transcription.
+- Audio files smaller than **1024 bytes** are treated as empty/corrupt and skipped before provider/CLI transcription; inbound reply context receives a deterministic placeholder transcript so the agent knows the note was too small.
 - If the model returns more than `maxChars`, output is trimmed.
 - `prompt` defaults to simple “Describe the {media}.” plus the `maxChars` guidance (image/video only).
 - If the active primary image model already supports vision natively, OpenClaw

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -459,8 +459,7 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Audio]\nTranscript:\nwhatsapp transcript");
   });
 
-  it("skips URL-only audio when remote file is too small", async () => {
-    // Override the default mock to return a tiny buffer (below MIN_AUDIO_FILE_BYTES)
+  it("injects a placeholder transcript when URL-only audio is too small", async () => {
     mockedFetchRemoteMedia.mockResolvedValueOnce({
       buffer: Buffer.alloc(100),
       contentType: "audio/ogg",
@@ -499,7 +498,21 @@ describe("applyMediaUnderstanding", () => {
     });
 
     expect(transcribeAudio).not.toHaveBeenCalled();
-    expect(result.appliedAudio).toBe(false);
+    expect(result.appliedAudio).toBe(true);
+    expect(result.outputs).toEqual([
+      expect.objectContaining({
+        kind: "audio.transcription",
+        text: "[Voice note was empty or contained only silence — no speech detected]",
+        provider: "openclaw",
+        model: "synthetic-empty-audio",
+      }),
+    ]);
+    expect(ctx.Transcript).toBe(
+      "[Voice note was empty or contained only silence — no speech detected]",
+    );
+    expect(ctx.Body).toBe(
+      "[Audio]\nTranscript:\n[Voice note was empty or contained only silence — no speech detected]",
+    );
   });
 
   it("skips audio transcription when attachment exceeds maxBytes", async () => {

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -502,16 +502,16 @@ describe("applyMediaUnderstanding", () => {
     expect(result.outputs).toEqual([
       expect.objectContaining({
         kind: "audio.transcription",
-        text: "[Voice note was empty or contained only silence — no speech detected]",
+        text: "[Voice note could not be transcribed because the audio attachment was too small]",
         provider: "openclaw",
         model: "synthetic-empty-audio",
       }),
     ]);
     expect(ctx.Transcript).toBe(
-      "[Voice note was empty or contained only silence — no speech detected]",
+      "[Voice note could not be transcribed because the audio attachment was too small]",
     );
     expect(ctx.Body).toBe(
-      "[Audio]\nTranscript:\n[Voice note was empty or contained only silence — no speech detected]",
+      "[Audio]\nTranscript:\n[Voice note could not be transcribed because the audio attachment was too small]",
     );
   });
 
@@ -547,16 +547,16 @@ describe("applyMediaUnderstanding", () => {
     expect(result.outputs).toEqual([
       expect.objectContaining({
         kind: "audio.transcription",
-        text: "[Voice note was empty or contained only silence — no speech detected]",
+        text: "[Voice note could not be transcribed because the audio attachment was too small]",
         provider: "openclaw",
         model: "synthetic-empty-audio",
       }),
     ]);
     expect(ctx.Transcript).toBe(
-      "[Voice note was empty or contained only silence — no speech detected]",
+      "[Voice note could not be transcribed because the audio attachment was too small]",
     );
     expect(ctx.Body).toBe(
-      "[Audio]\nTranscript:\n[Voice note was empty or contained only silence — no speech detected]",
+      "[Audio]\nTranscript:\n[Voice note could not be transcribed because the audio attachment was too small]",
     );
   });
 

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -515,6 +515,51 @@ describe("applyMediaUnderstanding", () => {
     );
   });
 
+  it("injects a placeholder transcript when local-path audio is too small", async () => {
+    const ctx = await createAudioCtx({
+      fileName: "tiny.ogg",
+      mediaType: "audio/ogg",
+      content: Buffer.alloc(100),
+    });
+    const transcribeAudio = vi.fn(async () => ({ text: "should-not-run" }));
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          audio: {
+            enabled: true,
+            maxBytes: 1024 * 1024,
+            models: [{ provider: "groq" }],
+          },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg,
+      providers: {
+        groq: { id: "groq", transcribeAudio },
+      },
+    });
+
+    expect(transcribeAudio).not.toHaveBeenCalled();
+    expect(result.appliedAudio).toBe(true);
+    expect(result.outputs).toEqual([
+      expect.objectContaining({
+        kind: "audio.transcription",
+        text: "[Voice note was empty or contained only silence — no speech detected]",
+        provider: "openclaw",
+        model: "synthetic-empty-audio",
+      }),
+    ]);
+    expect(ctx.Transcript).toBe(
+      "[Voice note was empty or contained only silence — no speech detected]",
+    );
+    expect(ctx.Body).toBe(
+      "[Audio]\nTranscript:\n[Voice note was empty or contained only silence — no speech detected]",
+    );
+  });
+
   it("skips audio transcription when attachment exceeds maxBytes", async () => {
     const ctx = await createAudioCtx({
       fileName: "large.wav",

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1027,6 +1027,56 @@ describe("applyMediaUnderstanding", () => {
     );
   });
 
+  it("adds placeholder for tooSmall audio while preserving real transcript for valid audio", async () => {
+    const dir = await createTempMediaDir();
+    const validAudio = createSafeAudioFixtureBuffer(2048);
+    const tinyAudio = Buffer.alloc(100);
+    const validPath = path.join(dir, "valid.ogg");
+    const tinyPath = path.join(dir, "tiny.ogg");
+    await fs.writeFile(validPath, validAudio);
+    await fs.writeFile(tinyPath, tinyAudio);
+
+    const ctx: MsgContext = {
+      Body: "<media:audio>",
+      MediaPaths: [validPath, tinyPath],
+      MediaTypes: ["audio/ogg", "audio/ogg"],
+    };
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          audio: {
+            enabled: true,
+            attachments: { mode: "all", maxAttachments: 2 },
+            models: [{ provider: "groq" }],
+          },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg,
+      providers: {
+        groq: {
+          id: "groq",
+          transcribeAudio: async (req) => ({ text: `transcribed ${req.fileName ?? "unknown"}` }),
+        },
+      },
+    });
+
+    expect(result.appliedAudio).toBe(true);
+    expect(ctx.Transcript).toContain("transcribed valid.ogg");
+    expect(ctx.Transcript).toContain(
+      "[Voice note could not be transcribed because the audio attachment was too small]",
+    );
+    expect(ctx.Body).toContain("[Audio 1/2]");
+    expect(ctx.Body).toContain("transcribed valid.ogg");
+    expect(ctx.Body).toContain("[Audio 2/2]");
+    expect(ctx.Body).toContain(
+      "[Voice note could not be transcribed because the audio attachment was too small]",
+    );
+  });
+
   it("orders mixed media outputs as image, audio, video", async () => {
     const dir = await createTempMediaDir();
     const imagePath = path.join(dir, "photo.jpg");

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1136,6 +1136,68 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.BodyForCommands).toBe("audio ok");
   });
 
+  it("orders synthetic too-small audio output between image and video", async () => {
+    const dir = await createTempMediaDir();
+    const imagePath = path.join(dir, "photo.jpg");
+    const audioPath = path.join(dir, "silent.ogg");
+    const videoPath = path.join(dir, "clip.mp4");
+    await fs.writeFile(imagePath, "image-bytes");
+    await fs.writeFile(audioPath, Buffer.alloc(100));
+    await fs.writeFile(videoPath, "video-bytes");
+
+    const ctx: MsgContext = {
+      Body: "<media:mixed>",
+      MediaPaths: [imagePath, audioPath, videoPath],
+      MediaTypes: ["image/jpeg", "audio/ogg", "video/mp4"],
+    };
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          image: { enabled: true, models: [{ provider: "openai", model: "gpt-5.4" }] },
+          audio: { enabled: true, models: [{ provider: "groq" }] },
+          video: { enabled: true, models: [{ provider: "google", model: "gemini-3" }] },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg,
+      agentDir: dir,
+      providers: {
+        openai: {
+          id: "openai",
+          describeImage: async () => ({ text: "image ok" }),
+        },
+        groq: {
+          id: "groq",
+          transcribeAudio: async () => ({ text: "audio should not run" }),
+        },
+        google: {
+          id: "google",
+          describeVideo: async () => ({ text: "video ok" }),
+        },
+      },
+    });
+
+    const placeholder =
+      "[Voice note could not be transcribed because the audio attachment was too small]";
+
+    expect(result.appliedImage).toBe(true);
+    expect(result.appliedAudio).toBe(true);
+    expect(result.appliedVideo).toBe(true);
+    expect(ctx.Body).toBe(
+      [
+        "[Image]\nDescription:\nimage ok",
+        `[Audio]\nTranscript:\n${placeholder}`,
+        "[Video]\nDescription:\nvideo ok",
+      ].join("\n\n"),
+    );
+    expect(ctx.Transcript).toBe(placeholder);
+    expect(ctx.CommandBody).toBe(placeholder);
+    expect(ctx.BodyForCommands).toBe(placeholder);
+  });
+
   it("treats text-like attachments as CSV (comma wins over tabs)", async () => {
     const csvText = '"a","b"\t"c"\n"1","2"\t"3"';
     const csvPath = await createTempMediaFile({

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -48,6 +48,8 @@ export type ApplyMediaUnderstandingResult = {
 };
 
 const CAPABILITY_ORDER: MediaUnderstandingCapability[] = ["image", "audio", "video"];
+const EMPTY_VOICE_NOTE_PLACEHOLDER =
+  "[Voice note was empty or contained only silence — no speech detected]";
 const EXTRA_TEXT_MIMES = [
   "application/xml",
   "text/xml",
@@ -306,6 +308,32 @@ function resolveTextMimeFromName(name?: string): string | undefined {
   return TEXT_EXT_MIME.get(ext);
 }
 
+function buildSyntheticSkippedAudioOutputs(
+  decisions: MediaUnderstandingDecision[],
+): MediaUnderstandingOutput[] {
+  const audioDecision = decisions.find((decision) => decision.capability === "audio");
+  if (!audioDecision) {
+    return [];
+  }
+  return audioDecision.attachments.flatMap((attachment) => {
+    const reason = attachment.attempts
+      .map((attempt) => attempt.reason?.trim())
+      .find((value): value is string => Boolean(value));
+    if (!reason?.startsWith("tooSmall")) {
+      return [];
+    }
+    return [
+      {
+        kind: "audio.transcription" as const,
+        attachmentIndex: attachment.attachmentIndex,
+        text: EMPTY_VOICE_NOTE_PLACEHOLDER,
+        provider: "openclaw",
+        model: "synthetic-empty-audio",
+      },
+    ];
+  });
+}
+
 function isBinaryMediaMime(mime?: string): boolean {
   if (!mime) {
     return false;
@@ -525,6 +553,10 @@ export async function applyMediaUnderstanding(params: {
         outputs.push(output);
       }
       decisions.push(entry.decision);
+    }
+
+    if (!outputs.some((output) => output.kind === "audio.transcription")) {
+      outputs.push(...buildSyntheticSkippedAudioOutputs(decisions));
     }
 
     if (decisions.length > 0) {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -334,6 +334,19 @@ function buildSyntheticSkippedAudioOutputs(
   });
 }
 
+function mergeAudioOutputsPreservingAttachmentOrder(params: {
+  outputs: MediaUnderstandingOutput[];
+  syntheticOutputs: MediaUnderstandingOutput[];
+}): MediaUnderstandingOutput[] {
+  const { outputs, syntheticOutputs } = params;
+  if (syntheticOutputs.length === 0) {
+    return outputs;
+  }
+  return [...outputs, ...syntheticOutputs].sort(
+    (left, right) => left.attachmentIndex - right.attachmentIndex,
+  );
+}
+
 function isBinaryMediaMime(mime?: string): boolean {
   if (!mime) {
     return false;
@@ -563,8 +576,32 @@ export async function applyMediaUnderstanding(params: {
     const syntheticSkippedAudioOutputs = buildSyntheticSkippedAudioOutputs(decisions).filter(
       (output) => !audioOutputAttachmentIndexes.has(output.attachmentIndex),
     );
-    outputs.push(...syntheticSkippedAudioOutputs);
-    outputs.sort((left, right) => left.attachmentIndex - right.attachmentIndex);
+
+    // Merge synthetic placeholders into the audio outputs only — sorted by
+    // attachmentIndex within the audio slice — then splice them back into
+    // their original position in the outputs array. This preserves:
+    //  1. Cross-capability ordering (image → audio → video from CAPABILITY_ORDER)
+    //  2. Per-capability `attachments.prefer` ordering for non-audio outputs
+    //  3. Correct attachment-index ordering for audio (real + synthetic mixed)
+    if (syntheticSkippedAudioOutputs.length > 0) {
+      const firstAudioIdx = outputs.findIndex((o) => o.kind === "audio.transcription");
+      if (firstAudioIdx >= 0) {
+        // Split: keep non-audio in place, replace audio slice with merged+sorted version
+        const before = outputs.slice(0, firstAudioIdx);
+        const existingAudio = outputs.filter((o) => o.kind === "audio.transcription");
+        const afterLastAudio = outputs.slice(
+          outputs.reduce((last, o, i) => (o.kind === "audio.transcription" ? i : last), firstAudioIdx) + 1,
+        );
+        const mergedAudio = [...existingAudio, ...syntheticSkippedAudioOutputs].sort(
+          (a, b) => a.attachmentIndex - b.attachmentIndex,
+        );
+        outputs.length = 0;
+        outputs.push(...before, ...mergedAudio, ...afterLastAudio);
+      } else {
+        // No real audio outputs — append synthetic at end
+        outputs.push(...syntheticSkippedAudioOutputs);
+      }
+    }
 
     if (decisions.length > 0) {
       ctx.MediaUnderstandingDecisions = [...(ctx.MediaUnderstandingDecisions ?? []), ...decisions];
@@ -599,9 +636,19 @@ export async function applyMediaUnderstanding(params: {
       }
       ctx.MediaUnderstanding = [...(ctx.MediaUnderstanding ?? []), ...outputs];
     }
+    // Only skip file extraction for attachments that have a real (non-synthetic)
+    // audio transcription. Synthetic placeholders should not prevent file extraction
+    // for tiny audio-MIME files that could be recovered as text via forcedTextMime.
+    const syntheticAudioIndexes = new Set(
+      syntheticSkippedAudioOutputs.map((o) => o.attachmentIndex),
+    );
     const audioAttachmentIndexes = new Set(
       outputs
-        .filter((output) => output.kind === "audio.transcription")
+        .filter(
+          (output) =>
+            output.kind === "audio.transcription" &&
+            !syntheticAudioIndexes.has(output.attachmentIndex),
+        )
         .map((output) => output.attachmentIndex),
     );
     const fileBlocks = await extractFileBlocks({

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -316,10 +316,10 @@ function buildSyntheticSkippedAudioOutputs(
     return [];
   }
   return audioDecision.attachments.flatMap((attachment) => {
-    const reason = attachment.attempts
-      .map((attempt) => attempt.reason?.trim())
-      .find((value): value is string => Boolean(value));
-    if (!reason?.startsWith("tooSmall")) {
+    const hasTooSmallAttempt = attachment.attempts.some((attempt) =>
+      attempt.reason?.trim().startsWith("tooSmall"),
+    );
+    if (!hasTooSmallAttempt) {
       return [];
     }
     return [
@@ -555,9 +555,15 @@ export async function applyMediaUnderstanding(params: {
       decisions.push(entry.decision);
     }
 
-    if (!outputs.some((output) => output.kind === "audio.transcription")) {
-      outputs.push(...buildSyntheticSkippedAudioOutputs(decisions));
-    }
+    const audioOutputAttachmentIndexes = new Set(
+      outputs
+        .filter((output) => output.kind === "audio.transcription")
+        .map((output) => output.attachmentIndex),
+    );
+    const syntheticSkippedAudioOutputs = buildSyntheticSkippedAudioOutputs(decisions).filter(
+      (output) => !audioOutputAttachmentIndexes.has(output.attachmentIndex),
+    );
+    outputs.push(...syntheticSkippedAudioOutputs);
 
     if (decisions.length > 0) {
       ctx.MediaUnderstandingDecisions = [...(ctx.MediaUnderstandingDecisions ?? []), ...decisions];

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -334,19 +334,6 @@ function buildSyntheticSkippedAudioOutputs(
   });
 }
 
-function mergeAudioOutputsPreservingAttachmentOrder(params: {
-  outputs: MediaUnderstandingOutput[];
-  syntheticOutputs: MediaUnderstandingOutput[];
-}): MediaUnderstandingOutput[] {
-  const { outputs, syntheticOutputs } = params;
-  if (syntheticOutputs.length === 0) {
-    return outputs;
-  }
-  return [...outputs, ...syntheticOutputs].sort(
-    (left, right) => left.attachmentIndex - right.attachmentIndex,
-  );
-}
-
 function isBinaryMediaMime(mime?: string): boolean {
   if (!mime) {
     return false;
@@ -590,9 +577,12 @@ export async function applyMediaUnderstanding(params: {
         const before = outputs.slice(0, firstAudioIdx);
         const existingAudio = outputs.filter((o) => o.kind === "audio.transcription");
         const afterLastAudio = outputs.slice(
-          outputs.reduce((last, o, i) => (o.kind === "audio.transcription" ? i : last), firstAudioIdx) + 1,
+          outputs.reduce(
+            (last, o, i) => (o.kind === "audio.transcription" ? i : last),
+            firstAudioIdx,
+          ) + 1,
         );
-        const mergedAudio = [...existingAudio, ...syntheticSkippedAudioOutputs].sort(
+        const mergedAudio = [...existingAudio, ...syntheticSkippedAudioOutputs].toSorted(
           (a, b) => a.attachmentIndex - b.attachmentIndex,
         );
         outputs.length = 0;

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -564,6 +564,7 @@ export async function applyMediaUnderstanding(params: {
       (output) => !audioOutputAttachmentIndexes.has(output.attachmentIndex),
     );
     outputs.push(...syntheticSkippedAudioOutputs);
+    outputs.sort((left, right) => left.attachmentIndex - right.attachmentIndex);
 
     if (decisions.length > 0) {
       ctx.MediaUnderstandingDecisions = [...(ctx.MediaUnderstandingDecisions ?? []), ...decisions];

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -564,32 +564,41 @@ export async function applyMediaUnderstanding(params: {
       (output) => !audioOutputAttachmentIndexes.has(output.attachmentIndex),
     );
 
-    // Merge synthetic placeholders into the audio outputs only — sorted by
-    // attachmentIndex within the audio slice — then splice them back into
-    // their original position in the outputs array. This preserves:
-    //  1. Cross-capability ordering (image → audio → video from CAPABILITY_ORDER)
-    //  2. Per-capability `attachments.prefer` ordering for non-audio outputs
-    //  3. Correct attachment-index ordering for audio (real + synthetic mixed)
+    // Merge synthetic placeholders into the audio slice while preserving the
+    // selected audio attachment order from `runCapability()` / `attachments.prefer`.
+    // When audio produced no real outputs, insert the synthetic slice at the
+    // audio capability slot (before video) instead of appending at the end.
     if (syntheticSkippedAudioOutputs.length > 0) {
+      const audioDecision = decisions.find((decision) => decision.capability === "audio");
+      const audioAttachmentOrder = audioDecision?.attachments.map((attachment) => attachment.attachmentIndex) ?? [];
+      const audioOutputsByAttachmentIndex = new Map<number, MediaUnderstandingOutput>();
+      for (const output of outputs) {
+        if (output.kind === "audio.transcription") {
+          audioOutputsByAttachmentIndex.set(output.attachmentIndex, output);
+        }
+      }
+      for (const output of syntheticSkippedAudioOutputs) {
+        audioOutputsByAttachmentIndex.set(output.attachmentIndex, output);
+      }
+      const mergedAudio = audioAttachmentOrder
+        .map((attachmentIndex) => audioOutputsByAttachmentIndex.get(attachmentIndex))
+        .filter((output): output is MediaUnderstandingOutput => Boolean(output));
+
       const firstAudioIdx = outputs.findIndex((o) => o.kind === "audio.transcription");
       if (firstAudioIdx >= 0) {
-        // Split: keep non-audio in place, replace audio slice with merged+sorted version
         const before = outputs.slice(0, firstAudioIdx);
-        const existingAudio = outputs.filter((o) => o.kind === "audio.transcription");
         const afterLastAudio = outputs.slice(
           outputs.reduce(
             (last, o, i) => (o.kind === "audio.transcription" ? i : last),
             firstAudioIdx,
           ) + 1,
         );
-        const mergedAudio = [...existingAudio, ...syntheticSkippedAudioOutputs].toSorted(
-          (a, b) => a.attachmentIndex - b.attachmentIndex,
-        );
         outputs.length = 0;
         outputs.push(...before, ...mergedAudio, ...afterLastAudio);
       } else {
-        // No real audio outputs — append synthetic at end
-        outputs.push(...syntheticSkippedAudioOutputs);
+        const firstVideoIdx = outputs.findIndex((o) => o.kind === "video.description");
+        const audioInsertIdx = firstVideoIdx >= 0 ? firstVideoIdx : outputs.length;
+        outputs.splice(audioInsertIdx, 0, ...mergedAudio);
       }
     }
 

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -570,7 +570,8 @@ export async function applyMediaUnderstanding(params: {
     // audio capability slot (before video) instead of appending at the end.
     if (syntheticSkippedAudioOutputs.length > 0) {
       const audioDecision = decisions.find((decision) => decision.capability === "audio");
-      const audioAttachmentOrder = audioDecision?.attachments.map((attachment) => attachment.attachmentIndex) ?? [];
+      const audioAttachmentOrder =
+        audioDecision?.attachments.map((attachment) => attachment.attachmentIndex) ?? [];
       const audioOutputsByAttachmentIndex = new Map<number, MediaUnderstandingOutput>();
       for (const output of outputs) {
         if (output.kind === "audio.transcription") {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -49,7 +49,7 @@ export type ApplyMediaUnderstandingResult = {
 
 const CAPABILITY_ORDER: MediaUnderstandingCapability[] = ["image", "audio", "video"];
 const EMPTY_VOICE_NOTE_PLACEHOLDER =
-  "[Voice note was empty or contained only silence — no speech detected]";
+  "[Voice note could not be transcribed because the audio attachment was too small]";
 const EXTRA_TEXT_MIMES = [
   "application/xml",
   "text/xml",

--- a/src/media-understanding/format.test.ts
+++ b/src/media-understanding/format.test.ts
@@ -88,4 +88,29 @@ describe("formatMediaUnderstandingBody", () => {
     });
     expect(body).toBe("[Image]\nDescription:\na cat");
   });
+
+  it("labels audio transcripts by their attachment order", () => {
+    const body = formatMediaUnderstandingBody({
+      outputs: [
+        {
+          kind: "audio.transcription",
+          attachmentIndex: 0,
+          text: "first clip was silent",
+          provider: "openclaw",
+        },
+        {
+          kind: "audio.transcription",
+          attachmentIndex: 1,
+          text: "second clip has speech",
+          provider: "groq",
+        },
+      ],
+    });
+    expect(body).toBe(
+      [
+        "[Audio 1/2]\nTranscript:\nfirst clip was silent",
+        "[Audio 2/2]\nTranscript:\nsecond clip has speech",
+      ].join("\n\n"),
+    );
+  });
 });

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -69,11 +69,18 @@ function stripInlineLeakedInternalContext(value: string): string {
 
 function sanitizeTaskStatusValue(value: unknown, errorContext: boolean): unknown {
   if (typeof value === "string") {
-    const sanitized = sanitizeUserFacingText(stripInlineLeakedInternalContext(value), {
+    const withoutInlineInternalContext = stripInlineLeakedInternalContext(value);
+    const sanitized = sanitizeUserFacingText(withoutInlineInternalContext, {
       errorContext,
     })
       .replace(/\s+/g, " ")
       .trim();
+    if (!sanitized && withoutInlineInternalContext !== value) {
+      const visiblePrefix = withoutInlineInternalContext.replace(/\s+/g, " ").trim();
+      if (visiblePrefix) {
+        return visiblePrefix;
+      }
+    }
     return sanitized || undefined;
   }
   if (Array.isArray(value)) {

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -69,18 +69,11 @@ function stripInlineLeakedInternalContext(value: string): string {
 
 function sanitizeTaskStatusValue(value: unknown, errorContext: boolean): unknown {
   if (typeof value === "string") {
-    const withoutInlineInternalContext = stripInlineLeakedInternalContext(value);
-    const sanitized = sanitizeUserFacingText(withoutInlineInternalContext, {
+    const sanitized = sanitizeUserFacingText(stripInlineLeakedInternalContext(value), {
       errorContext,
     })
       .replace(/\s+/g, " ")
       .trim();
-    if (!sanitized && withoutInlineInternalContext !== value) {
-      const visiblePrefix = withoutInlineInternalContext.replace(/\s+/g, " ").trim();
-      if (visiblePrefix) {
-        return visiblePrefix;
-      }
-    }
     return sanitized || undefined;
   }
   if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary

- Problem: tiny or silent voice notes skipped as `tooSmall` left no transcript signal in downstream context.
- Why it matters: the agent could respond as if context were missing or ambiguous instead of correctly stating that the voice note was empty/silent.
- What changed: when audio is skipped with the `tooSmall` reason, `applyMediaUnderstanding()` now emits a synthetic placeholder transcription and preserves the existing formatting/body flow.
- What did NOT change (scope boundary): no provider call behavior changed for normal-sized audio, and no speech model/network behavior was expanded.
- AI-assisted: yes (AI-assisted implementation, contributor-reviewed).
- Testing level: targeted local validation; full `pnpm test` was not fully green on upstream main in that environment.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48944
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the `tooSmall` skip path intentionally bypassed provider transcription but did not emit any synthetic transcript/body signal, leaving downstream context unaware that the attachment was intentionally skipped because it was empty/silent.
- Missing detection / guardrail: tests covered skip behavior but did not fully lock in downstream transcript/body behavior for the tiny-audio path.
- Prior context (`git blame`, prior PR, issue, or refactor if known): reported in #48944.
- Why this regressed now: the optimization to skip tiny audio avoided wasted provider calls, but the user-facing/context-facing fallback message was never added.
- If unknown, what was ruled out: the issue was not a provider transcription quality problem; it occurred before provider transcription was ever attempted.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/media-understanding/apply.test.ts`
  - `src/media-understanding/format.test.ts`
  - `src/media-understanding/runner.skip-tiny-audio.test.ts`
- Scenario the test should lock in: a tiny/silent audio attachment skipped as `tooSmall` should still yield deterministic transcript/body context explaining silence/emptiness.
- Why this is the smallest reliable guardrail: the bug is in the local media-understanding fallback path, so unit tests can cover it directly without a live transcription provider.
- Existing test that already covers this (if any): skip-tiny-audio coverage existed, but it was not sufficient to assert the final transcript/body behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Silent or empty voice notes now produce a placeholder transcript instead of a confusing blank context gap.
- Downstream responses can accurately say the note was empty/silent.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: local macOS dev environment
- Runtime/container: repo-local Node/pnpm test environment
- Model/provider: N/A (skip path does not call provider)
- Integration/channel (if any): media-understanding pipeline
- Relevant config (redacted): default local test env

### Steps

1. Feed a tiny or silent voice note that falls below `MIN_AUDIO_FILE_BYTES`.
2. Let media-understanding process the attachment.
3. Inspect the resulting transcript/body context.

### Expected

- The attachment is still skipped for provider transcription.
- A deterministic placeholder transcript is emitted explaining that the note was empty/silent.

### Actual

- Matched expected in targeted tests after this patch.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Targeted validation run:
  - `pnpm build` ✅
  - `pnpm check` ✅
  - `src/media-understanding/runner.skip-tiny-audio.test.ts` ✅
  - `src/media-understanding/apply.test.ts` ✅
  - `src/media-understanding/format.test.ts` ✅

## Human Verification (required)

- Verified scenarios:
  - placeholder transcript emitted for `tooSmall` path
  - formatting/body flow still works with synthetic transcript output
  - URL-only tiny-audio path gets deterministic context
- Edge cases checked:
  - normal-sized audio behavior left alone
  - skip path stays provider-free
- What you did **not** verify:
  - `codex review --base origin/main` in that environment (CLI unavailable there)
  - a fully green `pnpm test` run in that prior environment because unrelated upstream failures reproduced independently on clean main

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A



## Risks and Mitigations

- Risk: synthetic placeholder text could surface in the wrong audio path.
  - Mitigation: the fallback is explicitly limited to the `tooSmall` skip reason and covered by targeted tests.

