### PR TITLE
fix: remove cron from coding tool profile

### DIFF
--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -198,7 +198,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "cron",
     description: "Schedule tasks",
     sectionId: "automation",
-    profiles: ["coding"],
+    profiles: [],
     includeInOpenClawGroup: true,
   },
   {


### PR DESCRIPTION
## Summary

Fixes #49098 — the `cron` tool was included in the `coding` profile but docs define `coding` as `group:fs`, `group:runtime`, `group:sessions`, `group:memory`, `image`. The `cron` tool belongs to `group:automation`, not `coding`.

## Problem

On 2026.3.13, users with `tools.profile: "coding"` see this warning:

```
[tools] tools.profile (coding) allowlist contains unknown entries (cron).
These entries are shipped core tools but unavailable in the current runtime/provider/model/config.
```

## Fix

Remove `"coding"` from the `cron` tool entry's `profiles` array in `tool-catalog.ts`, aligning the code with the documented profile definitions.