### PR TITLE
fix: mirror bundled extension runtime deps

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -38,11 +38,6 @@
       "npmSpec": "@openclaw/googlechat",
       "localPath": "extensions/googlechat",
       "defaultChoice": "npm"
-    },
-    "releaseChecks": {
-      "rootDependencyMirrorAllowlist": [
-        "google-auth-library"
-      ]
     }
   }
 }

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -26,11 +26,6 @@
       "npmSpec": "@openclaw/nostr",
       "localPath": "extensions/nostr",
       "defaultChoice": "npm"
-    },
-    "releaseChecks": {
-      "rootDependencyMirrorAllowlist": [
-        "nostr-tools"
-      ]
     }
   }
 }

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -30,11 +30,6 @@
       "npmSpec": "@openclaw/zalouser",
       "localPath": "extensions/zalouser",
       "defaultChoice": "npm"
-    },
-    "releaseChecks": {
-      "rootDependencyMirrorAllowlist": [
-        "zca-js"
-      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -610,6 +610,7 @@
     "express": "^5.2.1",
     "file-type": "^21.3.2",
     "gaxios": "7.1.3",
+    "google-auth-library": "^10.6.1",
     "grammy": "^1.41.1",
     "hono": "4.12.7",
     "https-proxy-agent": "^8.0.0",
@@ -621,6 +622,7 @@
     "long": "^5.3.2",
     "markdown-it": "^14.1.1",
     "node-edge-tts": "^1.2.10",
+    "nostr-tools": "^2.23.3",
     "opusscript": "^0.1.1",
     "osc-progress": "^0.3.0",
     "pdfjs-dist": "^5.5.207",
@@ -633,6 +635,7 @@
     "undici": "^7.24.1",
     "ws": "^8.19.0",
     "yaml": "^2.8.2",
+    "zca-js": "2.1.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       gaxios:
         specifier: 7.1.3
         version: 7.1.3
+      google-auth-library:
+        specifier: ^10.6.1
+        version: 10.6.1
       grammy:
         specifier: ^1.41.1
         version: 1.41.1
@@ -164,6 +167,9 @@ importers:
       node-llama-cpp:
         specifier: 3.16.2
         version: 3.16.2(typescript@5.9.3)
+      nostr-tools:
+        specifier: ^2.23.3
+        version: 2.23.3(typescript@5.9.3)
       opusscript:
         specifier: ^0.1.1
         version: 0.1.1
@@ -200,6 +206,9 @@ importers:
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
+      zca-js:
+        specifier: 2.1.1
+        version: 2.1.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6

--- a/src/release-check.root-dependency-mirrors.test.ts
+++ b/src/release-check.root-dependency-mirrors.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+};
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readFileSync(new URL(relativePath, import.meta.url), "utf8")) as T;
+}
+
+describe("bundled extension root dependency mirrors", () => {
+  it("mirrors allowlisted bundled extension runtime deps into the root package", () => {
+    const rootPackage = readJson<PackageJson>("../package.json");
+    const rootDeps = {
+      ...rootPackage.dependencies,
+      ...rootPackage.optionalDependencies,
+    };
+
+    expect(rootDeps).toHaveProperty("google-auth-library");
+    expect(rootDeps).toHaveProperty("nostr-tools");
+    expect(rootDeps).toHaveProperty("zca-js");
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #49033.

Bundled channel extensions were importing runtime packages that were declared only inside their extension-local `package.json` files. In packaged installs that ship the extensions with the core runtime, those dependencies still need to exist in the root package dependency graph; otherwise `openclaw agent` can fail at startup with `ERR_MODULE_NOT_FOUND` when the bundled extension entrypoints are loaded.

This change:
- mirrors `google-auth-library`, `nostr-tools`, and `zca-js` into the root runtime dependencies
- removes the now-stale `rootDependencyMirrorAllowlist` exceptions from the bundled extension manifests
- adds a regression test that asserts the root package keeps these bundled runtime deps mirrored

## Testing
- `pnpm -C /root/pr/openclaw exec vitest run "src/release-check.root-dependency-mirrors.test.ts"`
- `cd /root/pr/openclaw && pnpm exec tsx -e 'import { readFileSync } from "node:fs"; import path from "node:path"; import { collectBundledExtensionRootDependencyGapErrors } from "./scripts/release-check.ts"; const readJson = (p) => JSON.parse(readFileSync(path.join(process.cwd(), p), "utf8")); const rootPackage = readJson("package.json"); const extensions = ["googlechat", "nostr", "zalouser"].map((id) => ({ id, packageJson: readJson(`extensions/${id}/package.json`) })); const errors = collectBundledExtensionRootDependencyGapErrors({ rootPackage, extensions }); if (errors.length) { console.error(errors.join("\n")); process.exit(1); } console.log("root dependency mirrors ok");'`

## Notes
- `pnpm exec tsx scripts/release-check.ts` was not used as a pass/fail gate here because the repo currently has no built `dist/` artifacts, and that script exits early on missing build output before reaching the dependency mirror checks.
