### PR TITLE
fix(ui): bypass marked on escaped fence storms

### DIFF
--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -162,4 +162,32 @@ describe("toSanitizedMarkdownHtml", () => {
       warnSpy.mockRestore();
     }
   });
+
+  it("bypasses marked for repeated escaped code fences inside JSON-like dumps (#49021)", () => {
+    const input = [
+      "[",
+      "  {",
+      `    "content": "${Array.from(
+        { length: 10 },
+        (_, i) => `\\n\`\`\`shell\\ncmd${i}\\n\`\`\`\\nlabel${i}`,
+      ).join("")}"`,
+      "  }",
+      "]",
+    ].join("\n");
+    const parseSpy = vi.spyOn(marked, "parse").mockImplementation(() => {
+      throw new Error("marked.parse should not run for risky escaped-fence dumps");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const html = toSanitizedMarkdownHtml(input);
+      expect(parseSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(html).toContain('class="markdown-plain-text-fallback"');
+      expect(html).toContain("cmd0");
+      expect(html).toContain("label9");
+    } finally {
+      parseSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -60,6 +60,7 @@ const MARKDOWN_CHAR_LIMIT = 140_000;
 const MARKDOWN_PARSE_LIMIT = 40_000;
 const MARKDOWN_CACHE_LIMIT = 200;
 const MARKDOWN_CACHE_MAX_CHARS = 50_000;
+const ESCAPED_FENCE_STORM_THRESHOLD = 8;
 const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
 const markdownCache = new Map<string, string>();
 const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
@@ -127,6 +128,14 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
     // Large plain-text replies should stay readable without inheriting the
     // capped code-block chrome, while still preserving whitespace for logs
     // and other structured text that commonly trips the parse guard.
+    const html = renderEscapedPlainTextHtml(`${truncated.text}${suffix}`);
+    const sanitized = DOMPurify.sanitize(html, sanitizeOptions);
+    if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
+      setCachedMarkdown(input, sanitized);
+    }
+    return sanitized;
+  }
+  if (hasEscapedFenceStorm(truncated.text)) {
     const html = renderEscapedPlainTextHtml(`${truncated.text}${suffix}`);
     const sanitized = DOMPurify.sanitize(html, sanitizeOptions);
     if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
@@ -223,4 +232,17 @@ function escapeHtml(value: string): string {
 
 function renderEscapedPlainTextHtml(value: string): string {
   return `<div class="markdown-plain-text-fallback">${escapeHtml(value.replace(/\r\n?/g, "\n"))}</div>`;
+}
+
+function hasEscapedFenceStorm(value: string): boolean {
+  let count = 0;
+  let index = 0;
+  while ((index = value.indexOf("\\n```", index)) !== -1) {
+    count += 1;
+    if (count >= ESCAPED_FENCE_STORM_THRESHOLD) {
+      return true;
+    }
+    index += 5;
+  }
+  return false;
 }


### PR DESCRIPTION
Fixes #49021

## Summary
- bypass `marked.parse` for repeated escaped fenced-code dumps embedded in JSON-like text
- fall back to the existing plain-text markdown renderer for these high-risk inputs
- add a regression test that ensures the risky path never calls `marked.parse`
