### PR TITLE
fix(tools): remove cron from coding profile

### DIFF
--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -198,7 +198,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "cron",
     description: "Schedule tasks",
     sectionId: "automation",
-    profiles: ["coding"],
+    profiles: [],
     includeInOpenClawGroup: true,
   },
   {

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -56,7 +56,7 @@ describe("tool-policy", () => {
   it("resolves known profiles and ignores unknown ones", () => {
     const coding = resolveToolProfilePolicy("coding");
     expect(coding?.allow).toContain("read");
-    expect(coding?.allow).toContain("cron");
+    expect(coding?.allow).not.toContain("cron");
     expect(coding?.allow).not.toContain("gateway");
     expect(resolveToolProfilePolicy("nope")).toBeUndefined();
   });

--- a/src/gateway/tools-invoke-http.cron-regression.test.ts
+++ b/src/gateway/tools-invoke-http.cron-regression.test.ts
@@ -125,10 +125,11 @@ describe("tools invoke HTTP denylist", () => {
     expect(cronRes.status).toBe(200);
   });
 
-  it("keeps cron available under coding profile without exposing gateway", async () => {
+  it("requires an explicit tool allow override to expose cron under coding profile", async () => {
     cfg = {
       tools: {
         profile: "coding",
+        allow: ["cron"],
       },
       gateway: {
         tools: {


### PR DESCRIPTION
Fixes #49098

## Summary
- stop including `cron` in the built-in `coding` tool profile so it matches the docs
- keep cron available only when it is explicitly allowed
- update regression coverage for profile resolution and HTTP tool invocation
