### PR TITLE
fix(tools): remove cron from coding profile to match docs

### DIFF
--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -198,7 +198,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "cron",
     description: "Schedule tasks",
     sectionId: "automation",
-    profiles: ["coding"],
+    profiles: [],
     includeInOpenClawGroup: true,
   },
   {

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -56,7 +56,7 @@ describe("tool-policy", () => {
   it("resolves known profiles and ignores unknown ones", () => {
     const coding = resolveToolProfilePolicy("coding");
     expect(coding?.allow).toContain("read");
-    expect(coding?.allow).toContain("cron");
+    expect(coding?.allow).not.toContain("cron");
     expect(coding?.allow).not.toContain("gateway");
     expect(resolveToolProfilePolicy("nope")).toBeUndefined();
   });

--- a/src/gateway/tools-invoke-http.cron-regression.test.ts
+++ b/src/gateway/tools-invoke-http.cron-regression.test.ts
@@ -125,7 +125,7 @@ describe("tools invoke HTTP denylist", () => {
     expect(cronRes.status).toBe(200);
   });
 
-  it("keeps cron available under coding profile without exposing gateway", async () => {
+  it("keeps cron available via gateway.tools.allow without exposing gateway", async () => {
     cfg = {
       tools: {
         profile: "coding",


### PR DESCRIPTION
## Summary

- Remove `cron` from the `coding` tool profile's allowlist to match documented behavior
- Docs define `coding` as: `group:fs`, `group:runtime`, `group:sessions`, `group:memory`, `image` — no `cron`
- `cron` belongs to `group:automation` alongside `gateway` (which already had `profiles: []`)
- This eliminates the runtime warning: `tools.profile (coding) allowlist contains unknown entries (cron)`

## Changes

- `src/agents/tool-catalog.ts`: Change `cron` tool's `profiles` from `["coding"]` to `[]`
- `src/agents/tool-policy.test.ts`: Update assertion to expect `cron` NOT in `coding` profile
- `src/gateway/tools-invoke-http.cron-regression.test.ts`: Update test description (behavior unchanged — `gateway.tools.allow` still controls access)

## Test plan

- [x] `tool-policy.test.ts` — 21/21 pass
- [x] `tools-invoke-http.cron-regression.test.ts` — 3/3 pass
- [x] Users who need `cron` can still enable it via `gateway.tools.allow: ["cron"]` or `tools.profile: "full"`

Fixes #49098