### PR TITLE
 fix: accept `target` as an alias for `message send --to`

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -399,7 +399,9 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   } = ctx;
   throwIfAborted(abortSignal);
   const action: ChannelMessageActionName = "send";
-  const to = readStringParam(params, "to", { required: true });
+  const to =
+    readStringParam(params, "to") ??
+    readStringParam(params, "target", { required: true });
   // Support media, path, and filePath parameters for attachments
   const mediaHint =
     readStringParam(params, "media", { trim: false }) ??


### PR DESCRIPTION
 ## Summary

  `handleSendAction()` currently requires `params.to`, but there are code paths
  and user flows that populate `target` instead.

  That causes direct outbound sends to fail before channel plugins are even
  reached, with an error like:

  `ToolInputError: to required`

  This patch changes the generic send handler to accept:

  - `to`, if present
  - otherwise `target`

  ## Minimal Change

  ```ts
  const to =
    readStringParam(params, "to") ??
    readStringParam(params, "target", { required: true });

  ## Why this belongs in core

  The failure happens in OpenClaw core's generic message send handler, not in
  the QQ plugin itself.

  A plugin-side compatibility patch is still useful, but it cannot fix the
  ToolInputError: to required failure when core rejects the request before the
  plugin is called.

  ## Verification

  Local runtime verification after applying the equivalent core patch:

  - direct QQ send with openclaw message send --target ... succeeded
  - returned a real messageId
  - no further ToolInputError: to required
  - scheduled cron delivery to QQ also succeeded with deliveryStatus: delivered

  ## Runtime Evidence

  - direct send verification date: 2026-03-17
  - cron verification job id:
    126d09fd-2f07-494f-b2c1-a676d0ecab26
  - cron run record:
    /root/openclaw-docker/data/openclaw/cron/runs/126d09fd-2f07-494f-b2c1-a676d0ecab26.jsonl

  ## Notes

  I did not include a test in this patch material because I prepared it from the
  upstream source file plus a locally verified runtime fix, not from a full local
  checkout of the OpenClaw repository. The change is intentionally minimal and
  isolated to the generic send handler.
