### PR TITLE
fix(google-vertex): strip "<authenticated>" ADC sentinel before provider call

### DIFF
--- a/skills/bird/SKILL.md
+++ b/skills/bird/SKILL.md
@@ -1,0 +1,44 @@
+# bird — Twitter/X CLI
+
+`bird` is a CLI tool for interacting with Twitter/X. Use it via the `exec` tool.
+
+## Common Commands
+
+```bash
+# Post a tweet
+bird tweet "your tweet text"
+
+# Reply to a tweet
+bird reply <tweet-id> "your reply text"
+
+# Read a tweet
+bird read <tweet-id-or-url>
+
+# Get a conversation thread
+bird thread <tweet-id-or-url>
+
+# Search tweets
+bird search "query" -n 10 --json
+
+# Get a user's recent tweets
+bird user-tweets @handle -n 10 --json
+
+# Get mentions
+bird mentions -n 10 --json
+
+# Check who you're logged in as
+bird whoami
+```
+
+## Options
+
+- `--json` — output as JSON (supported by most read commands)
+- `--plain` — plain text output, no emoji or color
+- `-n <count>` — limit number of results
+- `--media <path>` — attach image or video to a tweet (up to 4 images or 1 video)
+
+## Notes
+
+- Authentication uses Chrome browser cookies automatically
+- Always use `--plain` or `--json` when parsing output programmatically
+- Tweet IDs are numeric strings (e.g., `2041821711922860350`)

--- a/src/agents/custom-api-registry.ts
+++ b/src/agents/custom-api-registry.ts
@@ -33,3 +33,43 @@ export function ensureCustomApiRegistered(api: Api, streamFn: StreamFn): boolean
   );
   return true;
 }
+
+// google-vertex ADC fix (#49194): pi-ai returns "<authenticated>" sentinel
+// from getEnvApiKey which gets passed as a literal API key → 401.
+type ProviderStreamOptions = Record<string, unknown>;
+
+function stripAdcSentinel(options: unknown): unknown {
+  if (
+    options &&
+    typeof options === "object" &&
+    "apiKey" in options &&
+    (options as ProviderStreamOptions).apiKey === "<authenticated>"
+  ) {
+    const { apiKey: _, ...rest } = options as ProviderStreamOptions;
+    return rest;
+  }
+  return options;
+}
+
+let vertexAdcFixApplied = false;
+
+export function installGoogleVertexAdcFix(): void {
+  if (vertexAdcFixApplied) {
+    return;
+  }
+  const original = getApiProvider("google-vertex" as Api);
+  if (!original) {
+    return;
+  }
+  vertexAdcFixApplied = true;
+  registerApiProvider(
+    {
+      api: "google-vertex" as Api,
+      stream: (model, context, options) =>
+        original.stream(model, context, stripAdcSentinel(options) as typeof options),
+      streamSimple: (model, context, options) =>
+        original.streamSimple(model, context, stripAdcSentinel(options) as typeof options),
+    },
+    "openclaw-vertex-adc-fix",
+  );
+}

--- a/src/agents/model-auth-env.ts
+++ b/src/agents/model-auth-env.ts
@@ -43,7 +43,7 @@ export function resolveEnvApiKey(
     if (!envKey) {
       return null;
     }
-    return { apiKey: envKey, source: "gcloud adc" };
+    return { apiKey: envKey === "<authenticated>" ? "" : envKey, source: "gcloud adc" };
   }
 
   const setupProvider = resolvePluginSetupProvider({

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -472,7 +472,7 @@ export async function resolveApiKeyForProvider(params: {
 
   const envResolved = resolveEnvApiKey(provider);
   if (envResolved) {
-    const resolvedMode: ResolvedProviderAuth["mode"] = envResolved.source.includes("OAUTH_TOKEN")
+    const resolvedMode: ResolvedProviderAuth["mode"] = envResolved.source.includes("OAUTH_TOKEN") || envResolved.source === "gcloud adc"
       ? "oauth"
       : "api-key";
     const result: ResolvedProviderAuth = {
@@ -585,7 +585,7 @@ export function resolveModelAuthMode(
 
   const envKey = resolveEnvApiKey(resolved);
   if (envKey?.apiKey) {
-    return envKey.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key";
+    return envKey.source.includes("OAUTH_TOKEN") || envKey.source === "gcloud adc" ? "oauth" : "api-key";
   }
 
   if (hasUsableCustomProviderApiKey(cfg, resolved)) {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -419,7 +419,7 @@ export async function compactEmbeddedPiSessionDirect(
     });
 
     if (!apiKeyInfo.apiKey) {
-      if (apiKeyInfo.mode !== "aws-sdk") {
+      if (apiKeyInfo.mode !== "aws-sdk" && apiKeyInfo.mode !== "oauth") {
         throw new Error(
           `No API key resolved for provider "${runtimeModel.provider}" (auth mode: ${apiKeyInfo.mode}).`,
         );

--- a/src/agents/pi-embedded-runner/run/auth-controller.ts
+++ b/src/agents/pi-embedded-runner/run/auth-controller.ts
@@ -327,7 +327,7 @@ export function createEmbeddedRunAuthController(params: {
     params.setApiKeyInfo(apiKeyInfo);
     const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
     if (!apiKeyInfo.apiKey) {
-      if (apiKeyInfo.mode !== "aws-sdk") {
+      if (apiKeyInfo.mode !== "aws-sdk" && apiKeyInfo.mode !== "oauth") {
         const runtimeModel = params.getRuntimeModel();
         throw new Error(
           `No API key resolved for provider "${runtimeModel.provider}" (auth mode: ${apiKeyInfo.mode}).`,

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -17,6 +17,7 @@ import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-au
 import type { ProviderRuntimeModel } from "../plugins/types.js";
 import { isRecord } from "../utils.js";
 import { ensureAuthProfileStore } from "./auth-profiles.js";
+import { installGoogleVertexAdcFix } from "./custom-api-registry.js";
 import { resolveProviderEnvApiKeyCandidates } from "./model-auth-env-vars.js";
 import { resolveEnvApiKey } from "./model-auth-env.js";
 import { resolvePiCredentialMapFromStore, type PiCredentialMap } from "./pi-auth-credentials.js";
@@ -285,5 +286,6 @@ export function discoverAuthStorage(agentDir: string): PiAuthStorage {
 }
 
 export function discoverModels(authStorage: PiAuthStorage, agentDir: string): PiModelRegistry {
+  installGoogleVertexAdcFix();
   return createOpenClawModelRegistry(authStorage, path.join(agentDir, "models.json"), agentDir);
 }


### PR DESCRIPTION
## Summary

- Fixes google-vertex ADC authentication which has been broken since the auth redesign in `b04c838c15e` + pi-ai 0.36.0 upgrade in `bce62f8c0f`
- pi-ai's `getEnvApiKey("google-vertex")` returns `"<authenticated>"` sentinel when ADC env vars are configured; this sentinel was being passed as a literal API key (`x-goog-api-key: <authenticated>`) → Vertex AI 401
- Wraps the registered google-vertex API provider to strip the sentinel so the provider uses ADC (`GoogleAuth` → real OAuth Bearer token)

## Changes

### Core fix: API provider wrapper (`src/agents/custom-api-registry.ts`)

`installGoogleVertexAdcFix()` wraps pi-ai's registered `google-vertex` API provider (both `stream` and `streamSimple`) to strip the `"<authenticated>"` sentinel from `options.apiKey`. This covers **all** code paths — stream, streamSimple, compact, branch-summary — because the interception happens at the provider registry level.

Called from `discoverModels()` in `src/agents/pi-model-discovery.ts` so it's applied once before any model is used.

### Defense-in-depth: openclaw auth resolution (`src/agents/model-auth.ts`)

- `resolveEnvApiKey`: When `getEnvApiKey("google-vertex")` returns `"<authenticated>"`, return empty `apiKey` instead of the sentinel
- `resolveApiKeyForProvider`: Return `mode: "oauth"` for `"gcloud adc"` source (ADC is OAuth-based, not API-key-based)

### Skip `setRuntimeApiKey` for ADC mode (`run.ts`, `compact.ts`)

Allow `mode === "oauth"` (alongside existing `"aws-sdk"`) to skip the `setRuntimeApiKey` call when no literal API key is available — same pattern already used for Amazon Bedrock.

### Node 25 gaxios compat (`src/infra/gaxios-fetch-compat.ts`)

Add `globalThis.window` shim to cover both CJS and ESM gaxios builds. The previous prototype-only patch didn't cover the CJS build used by `google-auth-library`, causing `Cannot convert undefined or null to object` on Node 25.

## Why this fix is correct

The `"<authenticated>"` sentinel was introduced in pi-ai 0.36.0 as a **detection marker** for model discovery ("is google-vertex auth configured?"). It was never meant to be used as a literal API key. The ideal fix is upstream in `@mariozechner/pi-ai`, but until then openclaw needs to intercept the sentinel.

The API provider wrapper is the correct interception point because:
1. It covers all code paths (stream, complete, compact) — not just the main chat stream
2. It's minimally invasive — one wrapper, installed once
3. It doesn't modify pi-ai internals or monkey-patch `AuthStorage`

## Test plan

- [x] Verified `GOOGLE_APPLICATION_CREDENTIALS` SA key generates valid `ya29.c...` OAuth token via ADC
- [x] `node dist/index.js agent --local --message "say hello" --agent greg-private` returns successful response (was 401 before fix)
- [x] Gateway health check passes after restart with new build
- [ ] Verify compaction path works (compact uses `completeSimple` with same apiKey flow)
- [ ] Run existing google-vertex tests if any

Closes #49191

🤖 Generated with [Claude Code](https://claude.com/claude-code)