### PR TITLE
Fix/dist-runtime skill copy instead of symlink

### DIFF
--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -3,9 +3,48 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { removePathIfExists } from "./runtime-postbuild-shared.mjs";
 
-const CODEX_BUNDLE_MANIFEST = ".codex-plugin/plugin.json";
-const CLAUDE_BUNDLE_MANIFEST = ".claude-plugin/plugin.json";
-const CURSOR_BUNDLE_MANIFEST = ".cursor-plugin/plugin.json";
+const RUNTIME_COPY_MANIFESTS = [
+  {
+    manifestRelativePath: "openclaw.plugin.json",
+    resolvePaths(manifest) {
+      return normalizePathList(manifest.skills);
+    },
+  },
+  {
+    manifestRelativePath: ".codex-plugin/plugin.json",
+    resolvePaths(manifest, sourceDir) {
+      const declaredSkills = normalizePathList(manifest.skills);
+      return declaredSkills.length > 0
+        ? declaredSkills
+        : defaultExistingPaths(sourceDir, ["skills"]);
+    },
+  },
+  {
+    manifestRelativePath: ".claude-plugin/plugin.json",
+    resolvePaths(manifest, sourceDir) {
+      return mergePathLists(
+        normalizePathList(manifest.skills),
+        normalizePathList(manifest.commands),
+        defaultExistingPaths(sourceDir, ["skills", "commands"]),
+      );
+    },
+  },
+  {
+    manifestRelativePath: ".cursor-plugin/plugin.json",
+    resolvePaths(manifest, sourceDir) {
+      return mergePathLists(
+        defaultExistingPaths(sourceDir, ["skills", ".cursor/commands"]),
+        normalizePathList(manifest.skills),
+        normalizePathList(manifest.commands),
+      );
+    },
+  },
+];
+
+const RUNTIME_METADATA_COPY_PATHS = [
+  "package.json",
+  ...RUNTIME_COPY_MANIFESTS.map((entry) => entry.manifestRelativePath),
+];
 
 function symlinkType() {
   return process.platform === "win32" ? "junction" : "dir";
@@ -91,41 +130,12 @@ function resolveDeclaredRuntimeCopyPaths(sourceDir) {
     }
   };
 
-  const pluginManifest = readJsonFileIfExists(path.join(sourceDir, "openclaw.plugin.json"));
-  if (pluginManifest && typeof pluginManifest === "object") {
-    addPaths(normalizePathList(pluginManifest.skills));
-  }
-
-  const codexManifest = readJsonFileIfExists(path.join(sourceDir, CODEX_BUNDLE_MANIFEST));
-  if (codexManifest && typeof codexManifest === "object") {
-    addPaths(
-      mergePathLists(
-        normalizePathList(codexManifest.skills),
-        defaultExistingPaths(sourceDir, ["skills"]),
-      ),
-    );
-  }
-
-  const claudeManifest = readJsonFileIfExists(path.join(sourceDir, CLAUDE_BUNDLE_MANIFEST));
-  if (claudeManifest && typeof claudeManifest === "object") {
-    addPaths(
-      mergePathLists(
-        normalizePathList(claudeManifest.skills),
-        normalizePathList(claudeManifest.commands),
-        defaultExistingPaths(sourceDir, ["skills", "commands"]),
-      ),
-    );
-  }
-
-  const cursorManifest = readJsonFileIfExists(path.join(sourceDir, CURSOR_BUNDLE_MANIFEST));
-  if (cursorManifest && typeof cursorManifest === "object") {
-    addPaths(
-      mergePathLists(
-        defaultExistingPaths(sourceDir, ["skills", ".cursor/commands"]),
-        normalizePathList(cursorManifest.skills),
-        normalizePathList(cursorManifest.commands),
-      ),
-    );
+  for (const entry of RUNTIME_COPY_MANIFESTS) {
+    const manifest = readJsonFileIfExists(path.join(sourceDir, entry.manifestRelativePath));
+    if (!manifest || typeof manifest !== "object") {
+      continue;
+    }
+    addPaths(entry.resolvePaths(manifest, sourceDir));
   }
 
   return new Set(resolved);
@@ -148,14 +158,14 @@ function shouldWrapRuntimeJsFile(sourcePath) {
   return path.extname(sourcePath) === ".js";
 }
 
+function hasRuntimeMetadataCopySuffix(sourcePath, relativePath) {
+  const normalizedSourcePath = sourcePath.replace(/\\/g, "/");
+  return normalizedSourcePath === relativePath || normalizedSourcePath.endsWith(`/${relativePath}`);
+}
+
 function shouldCopyRuntimeFile(sourcePath) {
-  const relativePath = sourcePath.replace(/\\/g, "/");
-  return (
-    relativePath.endsWith("/package.json") ||
-    relativePath.endsWith("/openclaw.plugin.json") ||
-    relativePath.endsWith("/.codex-plugin/plugin.json") ||
-    relativePath.endsWith("/.claude-plugin/plugin.json") ||
-    relativePath.endsWith("/.cursor-plugin/plugin.json")
+  return RUNTIME_METADATA_COPY_PATHS.some((relativePath) =>
+    hasRuntimeMetadataCopySuffix(sourcePath, relativePath),
   );
 }
 

--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -120,7 +120,12 @@ function readJsonFileIfExists(filePath) {
   if (!fs.existsSync(filePath)) {
     return undefined;
   }
-  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const raw = fs.readFileSync(filePath, "utf8");
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`Failed to parse manifest JSON at ${filePath}`);
+  }
 }
 
 function defaultExistingPaths(sourceDir, paths) {

--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -91,17 +91,29 @@ function mergePathLists(...groups) {
   return merged;
 }
 
-function ensurePathInsideRoot(rootDir, rawPath) {
-  const resolved = path.resolve(rootDir, rawPath);
-  const relative = path.relative(rootDir, resolved);
-  if (
+function isPathInside(rootDir, candidatePath) {
+  const relative = path.relative(rootDir, candidatePath);
+  return (
     relative === "" ||
     relative === "." ||
     (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
-  ) {
+  );
+}
+
+function ensurePathInsideRoot(rootDir, rawPath) {
+  const resolved = path.resolve(rootDir, rawPath);
+  if (isPathInside(rootDir, resolved)) {
     return resolved;
   }
   throw new Error(`path escapes plugin root: ${rawPath}`);
+}
+
+function ensureRealPathInsideRoot(rootRealDir, candidatePath, rawPath = candidatePath) {
+  const resolvedRealPath = fs.realpathSync(candidatePath);
+  if (isPathInside(rootRealDir, resolvedRealPath)) {
+    return resolvedRealPath;
+  }
+  throw new Error(`path escapes plugin root via symlink: ${rawPath}`);
 }
 
 function readJsonFileIfExists(filePath) {
@@ -115,7 +127,7 @@ function defaultExistingPaths(sourceDir, paths) {
   return paths.filter((relativePath) => fs.existsSync(path.join(sourceDir, relativePath)));
 }
 
-function resolveDeclaredRuntimeCopyPaths(sourceDir) {
+function resolveDeclaredRuntimeCopyPaths(sourceDir, sourceRealDir) {
   const resolved = [];
   const addPaths = (rawPaths) => {
     for (const rawPath of rawPaths) {
@@ -123,6 +135,7 @@ function resolveDeclaredRuntimeCopyPaths(sourceDir) {
       if (!fs.existsSync(sourcePath)) {
         continue;
       }
+      ensureRealPathInsideRoot(sourceRealDir, sourcePath, rawPath);
       const relativePath = normalizeManifestPath(path.relative(sourceDir, sourcePath));
       if (relativePath) {
         resolved.push(relativePath);
@@ -184,11 +197,17 @@ function writeRuntimeModuleWrapper(sourcePath, targetPath) {
   );
 }
 
-function copyRuntimeOverlayPath(sourcePath, targetPath) {
+function copyRuntimeOverlayPath(sourcePath, targetPath, options) {
   fs.cpSync(sourcePath, targetPath, {
     dereference: true,
     force: true,
     recursive: true,
+    filter(candidatePath) {
+      const displayPath =
+        normalizeManifestPath(path.relative(options.pluginRootDir, candidatePath)) || candidatePath;
+      ensureRealPathInsideRoot(options.pluginRootRealDir, candidatePath, displayPath);
+      return true;
+    },
   });
 }
 
@@ -207,7 +226,7 @@ function stagePluginRuntimeOverlay(sourceDir, targetDir, options) {
     // Skill trees must stay physically inside dist-runtime so the realpath
     // containment checks still accept bundled plugin skills from the runtime root.
     if (shouldCopyDeclaredRuntimePath(relativePath, options.copiedPaths)) {
-      copyRuntimeOverlayPath(sourcePath, targetPath);
+      copyRuntimeOverlayPath(sourcePath, targetPath, options);
       continue;
     }
 
@@ -269,13 +288,15 @@ export function stageBundledPluginRuntime(params = {}) {
       continue;
     }
     const distPluginDir = path.join(distExtensionsRoot, dirent.name);
+    const distPluginRealDir = fs.realpathSync(distPluginDir);
     const runtimePluginDir = path.join(runtimeExtensionsRoot, dirent.name);
     const sourcePluginNodeModulesDir = path.join(sourceExtensionsRoot, dirent.name, "node_modules");
-    const copiedPaths = resolveDeclaredRuntimeCopyPaths(distPluginDir);
+    const copiedPaths = resolveDeclaredRuntimeCopyPaths(distPluginDir, distPluginRealDir);
 
     stagePluginRuntimeOverlay(distPluginDir, runtimePluginDir, {
       copiedPaths,
       pluginRootDir: distPluginDir,
+      pluginRootRealDir: distPluginRealDir,
     });
     linkPluginNodeModules({
       runtimePluginDir,

--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -3,6 +3,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { removePathIfExists } from "./runtime-postbuild-shared.mjs";
 
+const CODEX_BUNDLE_MANIFEST = ".codex-plugin/plugin.json";
+const CLAUDE_BUNDLE_MANIFEST = ".claude-plugin/plugin.json";
+const CURSOR_BUNDLE_MANIFEST = ".cursor-plugin/plugin.json";
+
 function symlinkType() {
   return process.platform === "win32" ? "junction" : "dir";
 }
@@ -14,6 +18,130 @@ function relativeSymlinkTarget(sourcePath, targetPath) {
 
 function symlinkPath(sourcePath, targetPath, type) {
   fs.symlinkSync(relativeSymlinkTarget(sourcePath, targetPath), targetPath, type);
+}
+
+function normalizeManifestPath(rawPath) {
+  return rawPath.replaceAll("\\", "/").replace(/^\.\//u, "").replace(/\/+$/u, "");
+}
+
+function normalizePathList(value) {
+  if (typeof value === "string") {
+    const normalized = normalizeManifestPath(value.trim());
+    return normalized ? [normalized] : [];
+  }
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => (typeof entry === "string" ? normalizeManifestPath(entry.trim()) : ""))
+    .filter(Boolean);
+}
+
+function mergePathLists(...groups) {
+  const merged = [];
+  const seen = new Set();
+  for (const group of groups) {
+    for (const entry of group) {
+      if (seen.has(entry)) {
+        continue;
+      }
+      seen.add(entry);
+      merged.push(entry);
+    }
+  }
+  return merged;
+}
+
+function ensurePathInsideRoot(rootDir, rawPath) {
+  const resolved = path.resolve(rootDir, rawPath);
+  const relative = path.relative(rootDir, resolved);
+  if (
+    relative === "" ||
+    relative === "." ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
+  ) {
+    return resolved;
+  }
+  throw new Error(`path escapes plugin root: ${rawPath}`);
+}
+
+function readJsonFileIfExists(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return undefined;
+  }
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function defaultExistingPaths(sourceDir, paths) {
+  return paths.filter((relativePath) => fs.existsSync(path.join(sourceDir, relativePath)));
+}
+
+function resolveDeclaredRuntimeCopyPaths(sourceDir) {
+  const resolved = [];
+  const addPaths = (rawPaths) => {
+    for (const rawPath of rawPaths) {
+      const sourcePath = ensurePathInsideRoot(sourceDir, rawPath);
+      if (!fs.existsSync(sourcePath)) {
+        continue;
+      }
+      const relativePath = normalizeManifestPath(path.relative(sourceDir, sourcePath));
+      if (relativePath) {
+        resolved.push(relativePath);
+      }
+    }
+  };
+
+  const pluginManifest = readJsonFileIfExists(path.join(sourceDir, "openclaw.plugin.json"));
+  if (pluginManifest && typeof pluginManifest === "object") {
+    addPaths(normalizePathList(pluginManifest.skills));
+  }
+
+  const codexManifest = readJsonFileIfExists(path.join(sourceDir, CODEX_BUNDLE_MANIFEST));
+  if (codexManifest && typeof codexManifest === "object") {
+    addPaths(
+      mergePathLists(
+        normalizePathList(codexManifest.skills),
+        defaultExistingPaths(sourceDir, ["skills"]),
+      ),
+    );
+  }
+
+  const claudeManifest = readJsonFileIfExists(path.join(sourceDir, CLAUDE_BUNDLE_MANIFEST));
+  if (claudeManifest && typeof claudeManifest === "object") {
+    addPaths(
+      mergePathLists(
+        normalizePathList(claudeManifest.skills),
+        normalizePathList(claudeManifest.commands),
+        defaultExistingPaths(sourceDir, ["skills", "commands"]),
+      ),
+    );
+  }
+
+  const cursorManifest = readJsonFileIfExists(path.join(sourceDir, CURSOR_BUNDLE_MANIFEST));
+  if (cursorManifest && typeof cursorManifest === "object") {
+    addPaths(
+      mergePathLists(
+        defaultExistingPaths(sourceDir, ["skills", ".cursor/commands"]),
+        normalizePathList(cursorManifest.skills),
+        normalizePathList(cursorManifest.commands),
+      ),
+    );
+  }
+
+  return new Set(resolved);
+}
+
+function shouldCopyDeclaredRuntimePath(relativePath, copiedPaths) {
+  const normalizedPath = normalizeManifestPath(relativePath);
+  if (!normalizedPath) {
+    return false;
+  }
+  for (const copiedPath of copiedPaths) {
+    if (normalizedPath === copiedPath || normalizedPath.startsWith(`${copiedPath}/`)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function shouldWrapRuntimeJsFile(sourcePath) {
@@ -46,7 +174,15 @@ function writeRuntimeModuleWrapper(sourcePath, targetPath) {
   );
 }
 
-function stagePluginRuntimeOverlay(sourceDir, targetDir) {
+function copyRuntimeOverlayPath(sourcePath, targetPath) {
+  fs.cpSync(sourcePath, targetPath, {
+    dereference: true,
+    force: true,
+    recursive: true,
+  });
+}
+
+function stagePluginRuntimeOverlay(sourceDir, targetDir, options) {
   fs.mkdirSync(targetDir, { recursive: true });
 
   for (const dirent of fs.readdirSync(sourceDir, { withFileTypes: true })) {
@@ -56,9 +192,17 @@ function stagePluginRuntimeOverlay(sourceDir, targetDir) {
 
     const sourcePath = path.join(sourceDir, dirent.name);
     const targetPath = path.join(targetDir, dirent.name);
+    const relativePath = path.relative(options.pluginRootDir, sourcePath);
+
+    // Skill trees must stay physically inside dist-runtime so the realpath
+    // containment checks still accept bundled plugin skills from the runtime root.
+    if (shouldCopyDeclaredRuntimePath(relativePath, options.copiedPaths)) {
+      copyRuntimeOverlayPath(sourcePath, targetPath);
+      continue;
+    }
 
     if (dirent.isDirectory()) {
-      stagePluginRuntimeOverlay(sourcePath, targetPath);
+      stagePluginRuntimeOverlay(sourcePath, targetPath, options);
       continue;
     }
 
@@ -117,8 +261,12 @@ export function stageBundledPluginRuntime(params = {}) {
     const distPluginDir = path.join(distExtensionsRoot, dirent.name);
     const runtimePluginDir = path.join(runtimeExtensionsRoot, dirent.name);
     const sourcePluginNodeModulesDir = path.join(sourceExtensionsRoot, dirent.name, "node_modules");
+    const copiedPaths = resolveDeclaredRuntimeCopyPaths(distPluginDir);
 
-    stagePluginRuntimeOverlay(distPluginDir, runtimePluginDir);
+    stagePluginRuntimeOverlay(distPluginDir, runtimePluginDir, {
+      copiedPaths,
+      pluginRootDir: distPluginDir,
+    });
     linkPluginNodeModules({
       runtimePluginDir,
       sourcePluginNodeModulesDir,

--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -19,6 +19,9 @@ const RUNTIME_COPY_MANIFESTS = [
         : defaultExistingPaths(sourceDir, ["skills"]);
     },
   },
+  // Claude and Cursor bundle manifests treat declared skill/command roots as additive
+  // in OpenClaw bundle loading. Keep runtime copies aligned so default roots still
+  // stay inside dist-runtime and pass later realpath containment checks.
   {
     manifestRelativePath: ".claude-plugin/plugin.json",
     resolvePaths(manifest, sourceDir) {
@@ -123,8 +126,8 @@ function readJsonFileIfExists(filePath) {
   const raw = fs.readFileSync(filePath, "utf8");
   try {
     return JSON.parse(raw);
-  } catch {
-    throw new Error(`Failed to parse manifest JSON at ${filePath}`);
+  } catch (error) {
+    throw new Error(`Failed to parse manifest JSON at ${filePath}`, { cause: error });
   }
 }
 

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -10,6 +10,7 @@ import { discoverOpenClawPlugins } from "./discovery.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 
 const tempDirs: string[] = [];
+const DIR_SYMLINK_TYPE = process.platform === "win32" ? "junction" : "dir";
 
 function makeRepoRoot(prefix: string): string {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -314,6 +315,90 @@ describe("stageBundledPluginRuntime", () => {
     expect(fs.realpathSync(runtimeDefaultSkillPath)).toBe(
       path.join(distPluginDir, "skills", "default-skill", "SKILL.md"),
     );
+  });
+
+  it("rejects manifest-declared skill roots that escape the plugin tree via symlink", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-escape-root-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "codex-demo");
+    const escapedSkillsDir = path.join(repoRoot, "external-skills");
+    fs.mkdirSync(path.join(distPluginDir, ".codex-plugin"), { recursive: true });
+    writeJson(path.join(distPluginDir, "package.json"), {
+      name: "@openclaw/codex-demo",
+    });
+    writeJson(path.join(distPluginDir, ".codex-plugin", "plugin.json"), {
+      name: "Codex Demo",
+      skills: ["bundle-skills"],
+    });
+    writeSkill(
+      path.join(escapedSkillsDir, "secret-skill", "SKILL.md"),
+      "secret-skill",
+      "Escaped content",
+    );
+    fs.symlinkSync(escapedSkillsDir, path.join(distPluginDir, "bundle-skills"), DIR_SYMLINK_TYPE);
+
+    expect(() => stageBundledPluginRuntime({ repoRoot })).toThrow(
+      "path escapes plugin root via symlink: bundle-skills",
+    );
+    expect(
+      fs.existsSync(
+        path.join(
+          repoRoot,
+          "dist-runtime",
+          "extensions",
+          "codex-demo",
+          "bundle-skills",
+          "secret-skill",
+          "SKILL.md",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects nested symlink escapes under copied runtime skill trees", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-escape-nested-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "codex-demo");
+    const escapedSkillsDir = path.join(repoRoot, "external-skills");
+    fs.mkdirSync(path.join(distPluginDir, ".codex-plugin"), { recursive: true });
+    writeJson(path.join(distPluginDir, "package.json"), {
+      name: "@openclaw/codex-demo",
+    });
+    writeJson(path.join(distPluginDir, ".codex-plugin", "plugin.json"), {
+      name: "Codex Demo",
+      skills: ["bundle-skills"],
+    });
+    writeSkill(
+      path.join(distPluginDir, "bundle-skills", "safe-skill", "SKILL.md"),
+      "safe-skill",
+      "Safe content",
+    );
+    writeSkill(
+      path.join(escapedSkillsDir, "secret-skill", "SKILL.md"),
+      "secret-skill",
+      "Escaped content",
+    );
+    fs.symlinkSync(
+      escapedSkillsDir,
+      path.join(distPluginDir, "bundle-skills", "escaped"),
+      DIR_SYMLINK_TYPE,
+    );
+
+    expect(() => stageBundledPluginRuntime({ repoRoot })).toThrow(
+      "path escapes plugin root via symlink: bundle-skills/escaped",
+    );
+    expect(
+      fs.existsSync(
+        path.join(
+          repoRoot,
+          "dist-runtime",
+          "extensions",
+          "codex-demo",
+          "bundle-skills",
+          "escaped",
+          "secret-skill",
+          "SKILL.md",
+        ),
+      ),
+    ).toBe(false);
   });
 
   it("preserves package metadata needed for bundled plugin discovery from dist-runtime", () => {

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -32,15 +32,6 @@ function writeSkill(filePath: string, name: string, description: string): void {
   );
 }
 
-function writeMarkdownSkill(filePath: string, name: string, description: string): void {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(
-    filePath,
-    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
-    "utf8",
-  );
-}
-
 function expectRuntimeFileCopied(filePath: string): void {
   expect(fs.lstatSync(filePath).isSymbolicLink()).toBe(false);
   expect(fs.realpathSync(filePath)).toBe(filePath);
@@ -392,7 +383,7 @@ describe("stageBundledPluginRuntime", () => {
       "default-skill",
       "Default Claude skill",
     );
-    writeMarkdownSkill(
+    writeSkill(
       path.join(distPluginDir, "commands", "default-review.md"),
       "default-review",
       "Default Claude command skill",
@@ -402,7 +393,7 @@ describe("stageBundledPluginRuntime", () => {
       "custom-skill",
       "Declared Claude skill",
     );
-    writeMarkdownSkill(
+    writeSkill(
       path.join(distPluginDir, "extra-commands", "custom-review.md"),
       "custom-review",
       "Declared Claude command skill",
@@ -453,7 +444,7 @@ describe("stageBundledPluginRuntime", () => {
       "default-skill",
       "Default Cursor skill",
     );
-    writeMarkdownSkill(
+    writeSkill(
       path.join(distPluginDir, ".cursor", "commands", "default-review.md"),
       "default-review",
       "Default Cursor command skill",
@@ -463,7 +454,7 @@ describe("stageBundledPluginRuntime", () => {
       "custom-skill",
       "Declared Cursor skill",
     );
-    writeMarkdownSkill(
+    writeSkill(
       path.join(distPluginDir, "extra-commands", "custom-review.md"),
       "custom-review",
       "Declared Cursor command skill",
@@ -678,26 +669,11 @@ describe("stageBundledPluginRuntime", () => {
 
     stageBundledPluginRuntime({ repoRoot });
 
-    const snapshot = withEnv(
-      {
-        HOME: workspaceDir,
-        OPENCLAW_BUNDLED_PLUGINS_DIR: runtimeExtensionsDir,
-        OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
-        OPENCLAW_DISABLE_PLUGIN_MANIFEST_CACHE: "1",
-      },
-      () =>
-        buildWorkspaceSkillSnapshot(workspaceDir, {
-          bundledSkillsDir: path.join(workspaceDir, ".bundled"),
-          config: {
-            plugins: {
-              entries: {
-                acpx: { enabled: true },
-              },
-            },
-          },
-          managedSkillsDir: path.join(workspaceDir, ".managed"),
-        }),
-    );
+    const snapshot = buildBundledRuntimeSkillSnapshot({
+      workspaceDir,
+      runtimeExtensionsDir,
+      enabledPluginId: "acpx",
+    });
 
     expect(snapshot.skills.map((skill) => skill.name)).toContain("acp-router");
     expect(snapshot.prompt).toContain("acp-router");

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { stageBundledPluginRuntime } from "../../scripts/stage-bundled-plugin-runtime.mjs";
+import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
+import { withEnv } from "../test-utils/env.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 
@@ -13,6 +15,20 @@ function makeRepoRoot(prefix: string): string {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   tempDirs.push(repoRoot);
   return repoRoot;
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeSkill(filePath: string, name: string, description: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
+    "utf8",
+  );
 }
 
 afterEach(() => {
@@ -184,20 +200,24 @@ describe("stageBundledPluginRuntime", () => {
     ).resolves.toEqual({ text: "paired:now" });
   });
 
-  it("copies package metadata files but symlinks other non-js plugin artifacts into the runtime overlay", () => {
+  it("copies manifest-declared skill assets into dist-runtime while symlinking unrelated artifacts", () => {
     const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-assets-");
     const distPluginDir = path.join(repoRoot, "dist", "extensions", "diffs");
     fs.mkdirSync(path.join(distPluginDir, "assets"), { recursive: true });
-    fs.writeFileSync(
-      path.join(distPluginDir, "package.json"),
-      JSON.stringify(
-        { name: "@openclaw/diffs", openclaw: { extensions: ["./index.js"] } },
-        null,
-        2,
-      ),
-      "utf8",
+    writeJson(path.join(distPluginDir, "package.json"), {
+      name: "@openclaw/diffs",
+      openclaw: { extensions: ["./index.js"] },
+    });
+    writeJson(path.join(distPluginDir, "openclaw.plugin.json"), {
+      id: "diffs",
+      configSchema: { type: "object" },
+      skills: ["./skills"],
+    });
+    writeSkill(
+      path.join(distPluginDir, "skills", "acp-router", "SKILL.md"),
+      "acp-router",
+      "Routes ACP requests",
     );
-    fs.writeFileSync(path.join(distPluginDir, "openclaw.plugin.json"), "{}\n", "utf8");
     fs.writeFileSync(path.join(distPluginDir, "assets", "info.txt"), "ok\n", "utf8");
 
     stageBundledPluginRuntime({ repoRoot });
@@ -224,11 +244,23 @@ describe("stageBundledPluginRuntime", () => {
       "assets",
       "info.txt",
     );
+    const runtimeSkillPath = path.join(
+      repoRoot,
+      "dist-runtime",
+      "extensions",
+      "diffs",
+      "skills",
+      "acp-router",
+      "SKILL.md",
+    );
 
     expect(fs.lstatSync(runtimePackagePath).isSymbolicLink()).toBe(false);
     expect(fs.readFileSync(runtimePackagePath, "utf8")).toContain('"extensions": [');
     expect(fs.lstatSync(runtimeManifestPath).isSymbolicLink()).toBe(false);
-    expect(fs.readFileSync(runtimeManifestPath, "utf8")).toBe("{}\n");
+    expect(fs.readFileSync(runtimeManifestPath, "utf8")).toContain('"skills": [');
+    expect(fs.lstatSync(runtimeSkillPath).isSymbolicLink()).toBe(false);
+    expect(fs.realpathSync(runtimeSkillPath)).toBe(runtimeSkillPath);
+    expect(fs.readFileSync(runtimeSkillPath, "utf8")).toContain("acp-router");
     expect(fs.lstatSync(runtimeAssetPath).isSymbolicLink()).toBe(true);
     expect(fs.readFileSync(runtimeAssetPath, "utf8")).toBe("ok\n");
   });
@@ -306,6 +338,55 @@ describe("stageBundledPluginRuntime", () => {
     expect(manifestRegistry.plugins[0]?.startupDeferConfiguredChannelFullLoadUntilAfterListen).toBe(
       true,
     );
+  });
+
+  it("keeps acpx-style skills loadable from the dist-runtime bundled plugin root", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-skills-");
+    const workspaceDir = makeRepoRoot("openclaw-stage-bundled-runtime-workspace-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "acpx");
+    const runtimeExtensionsDir = path.join(repoRoot, "dist-runtime", "extensions");
+    fs.mkdirSync(distPluginDir, { recursive: true });
+    writeJson(path.join(distPluginDir, "package.json"), {
+      name: "@openclaw/acpx",
+      openclaw: { extensions: ["./index.js"] },
+    });
+    writeJson(path.join(distPluginDir, "openclaw.plugin.json"), {
+      id: "acpx",
+      configSchema: { type: "object" },
+      skills: ["./skills"],
+    });
+    fs.writeFileSync(path.join(distPluginDir, "index.js"), "export default {};\n", "utf8");
+    writeSkill(
+      path.join(distPluginDir, "skills", "acp-router", "SKILL.md"),
+      "acp-router",
+      "Routes ACP requests",
+    );
+
+    stageBundledPluginRuntime({ repoRoot });
+
+    const snapshot = withEnv(
+      {
+        HOME: workspaceDir,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: runtimeExtensionsDir,
+        OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
+        OPENCLAW_DISABLE_PLUGIN_MANIFEST_CACHE: "1",
+      },
+      () =>
+        buildWorkspaceSkillSnapshot(workspaceDir, {
+          bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+          config: {
+            plugins: {
+              entries: {
+                acpx: { enabled: true },
+              },
+            },
+          },
+          managedSkillsDir: path.join(workspaceDir, ".managed"),
+        }),
+    );
+
+    expect(snapshot.skills.map((skill) => skill.name)).toContain("acp-router");
+    expect(snapshot.prompt).toContain("acp-router");
   });
 
   it("removes stale runtime plugin directories that are no longer in dist", () => {

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -32,6 +32,47 @@ function writeSkill(filePath: string, name: string, description: string): void {
   );
 }
 
+function writeMarkdownSkill(filePath: string, name: string, description: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
+    "utf8",
+  );
+}
+
+function expectRuntimeFileCopied(filePath: string): void {
+  expect(fs.lstatSync(filePath).isSymbolicLink()).toBe(false);
+  expect(fs.realpathSync(filePath)).toBe(filePath);
+}
+
+function buildBundledRuntimeSkillSnapshot(params: {
+  workspaceDir: string;
+  runtimeExtensionsDir: string;
+  enabledPluginId: string;
+}) {
+  return withEnv(
+    {
+      HOME: params.workspaceDir,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: params.runtimeExtensionsDir,
+      OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
+      OPENCLAW_DISABLE_PLUGIN_MANIFEST_CACHE: "1",
+    },
+    () =>
+      buildWorkspaceSkillSnapshot(params.workspaceDir, {
+        bundledSkillsDir: path.join(params.workspaceDir, ".bundled"),
+        config: {
+          plugins: {
+            entries: {
+              [params.enabledPluginId]: { enabled: true },
+            },
+          },
+        },
+        managedSkillsDir: path.join(params.workspaceDir, ".managed"),
+      }),
+  );
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0, tempDirs.length)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -314,6 +355,143 @@ describe("stageBundledPluginRuntime", () => {
     expect(fs.lstatSync(runtimeDefaultSkillPath).isSymbolicLink()).toBe(true);
     expect(fs.realpathSync(runtimeDefaultSkillPath)).toBe(
       path.join(distPluginDir, "skills", "default-skill", "SKILL.md"),
+    );
+  });
+
+  it("surfaces malformed runtime manifest JSON with the manifest path", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-bad-manifest-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "codex-demo");
+    const manifestPath = path.join(distPluginDir, ".codex-plugin", "plugin.json");
+    fs.mkdirSync(path.join(distPluginDir, ".codex-plugin"), { recursive: true });
+    writeJson(path.join(distPluginDir, "package.json"), {
+      name: "@openclaw/codex-demo",
+    });
+    fs.writeFileSync(manifestPath, "{\n", "utf8");
+
+    expect(() => stageBundledPluginRuntime({ repoRoot })).toThrow(
+      `Failed to parse manifest JSON at ${manifestPath}`,
+    );
+  });
+
+  it("keeps Claude runtime skill copies additive when custom roots are declared", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-claude-");
+    const workspaceDir = makeRepoRoot("openclaw-stage-bundled-runtime-claude-workspace-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "claude-demo");
+    const runtimeExtensionsDir = path.join(repoRoot, "dist-runtime", "extensions");
+    fs.mkdirSync(path.join(distPluginDir, ".claude-plugin"), { recursive: true });
+    writeJson(path.join(distPluginDir, "package.json"), {
+      name: "@openclaw/claude-demo",
+    });
+    writeJson(path.join(distPluginDir, ".claude-plugin", "plugin.json"), {
+      name: "Claude Demo",
+      skills: ["team-skills"],
+      commands: "extra-commands",
+    });
+    writeSkill(
+      path.join(distPluginDir, "skills", "default-skill", "SKILL.md"),
+      "default-skill",
+      "Default Claude skill",
+    );
+    writeMarkdownSkill(
+      path.join(distPluginDir, "commands", "default-review.md"),
+      "default-review",
+      "Default Claude command skill",
+    );
+    writeSkill(
+      path.join(distPluginDir, "team-skills", "custom-skill", "SKILL.md"),
+      "custom-skill",
+      "Declared Claude skill",
+    );
+    writeMarkdownSkill(
+      path.join(distPluginDir, "extra-commands", "custom-review.md"),
+      "custom-review",
+      "Declared Claude command skill",
+    );
+
+    stageBundledPluginRuntime({ repoRoot });
+
+    expectRuntimeFileCopied(
+      path.join(runtimeExtensionsDir, "claude-demo", "skills", "default-skill", "SKILL.md"),
+    );
+    expectRuntimeFileCopied(
+      path.join(runtimeExtensionsDir, "claude-demo", "commands", "default-review.md"),
+    );
+    expectRuntimeFileCopied(
+      path.join(runtimeExtensionsDir, "claude-demo", "team-skills", "custom-skill", "SKILL.md"),
+    );
+    expectRuntimeFileCopied(
+      path.join(runtimeExtensionsDir, "claude-demo", "extra-commands", "custom-review.md"),
+    );
+
+    const snapshot = buildBundledRuntimeSkillSnapshot({
+      workspaceDir,
+      runtimeExtensionsDir,
+      enabledPluginId: "claude-demo",
+    });
+
+    expect(snapshot.skills.map((skill) => skill.name)).toEqual(
+      expect.arrayContaining(["custom-skill", "default-skill"]),
+    );
+  });
+
+  it("keeps Cursor runtime skill copies additive when custom roots are declared", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-cursor-");
+    const workspaceDir = makeRepoRoot("openclaw-stage-bundled-runtime-cursor-workspace-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "cursor-demo");
+    const runtimeExtensionsDir = path.join(repoRoot, "dist-runtime", "extensions");
+    fs.mkdirSync(path.join(distPluginDir, ".cursor-plugin"), { recursive: true });
+    writeJson(path.join(distPluginDir, "package.json"), {
+      name: "@openclaw/cursor-demo",
+    });
+    writeJson(path.join(distPluginDir, ".cursor-plugin", "plugin.json"), {
+      name: "Cursor Demo",
+      skills: ["team-skills"],
+      commands: "extra-commands",
+    });
+    writeSkill(
+      path.join(distPluginDir, "skills", "default-skill", "SKILL.md"),
+      "default-skill",
+      "Default Cursor skill",
+    );
+    writeMarkdownSkill(
+      path.join(distPluginDir, ".cursor", "commands", "default-review.md"),
+      "default-review",
+      "Default Cursor command skill",
+    );
+    writeSkill(
+      path.join(distPluginDir, "team-skills", "custom-skill", "SKILL.md"),
+      "custom-skill",
+      "Declared Cursor skill",
+    );
+    writeMarkdownSkill(
+      path.join(distPluginDir, "extra-commands", "custom-review.md"),
+      "custom-review",
+      "Declared Cursor command skill",
+    );
+
+    stageBundledPluginRuntime({ repoRoot });
+
+    expectRuntimeFileCopied(
+      path.join(runtimeExtensionsDir, "cursor-demo", "skills", "default-skill", "SKILL.md"),
+    );
+    expectRuntimeFileCopied(
+      path.join(runtimeExtensionsDir, "cursor-demo", ".cursor", "commands", "default-review.md"),
+    );
+    expectRuntimeFileCopied(
+      path.join(runtimeExtensionsDir, "cursor-demo", "team-skills", "custom-skill", "SKILL.md"),
+    );
+    expectRuntimeFileCopied(
+      path.join(runtimeExtensionsDir, "cursor-demo", "extra-commands", "custom-review.md"),
+    );
+
+    const snapshot = buildBundledRuntimeSkillSnapshot({
+      workspaceDir,
+      runtimeExtensionsDir,
+      enabledPluginId: "cursor-demo",
+    });
+
+    expect(snapshot.skills.map((skill) => skill.name)).toEqual(
+      expect.arrayContaining(["custom-skill", "default-skill"]),
     );
   });
 

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -265,6 +265,57 @@ describe("stageBundledPluginRuntime", () => {
     expect(fs.readFileSync(runtimeAssetPath, "utf8")).toBe("ok\n");
   });
 
+  it("keeps Codex runtime skill copies aligned with the declared skill roots", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-codex-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "codex-demo");
+    fs.mkdirSync(path.join(distPluginDir, ".codex-plugin"), { recursive: true });
+    writeJson(path.join(distPluginDir, "package.json"), {
+      name: "@openclaw/codex-demo",
+    });
+    writeJson(path.join(distPluginDir, ".codex-plugin", "plugin.json"), {
+      name: "Codex Demo",
+      skills: ["bundle-skills"],
+    });
+    writeSkill(
+      path.join(distPluginDir, "bundle-skills", "custom-skill", "SKILL.md"),
+      "custom-skill",
+      "Custom declared skill",
+    );
+    writeSkill(
+      path.join(distPluginDir, "skills", "default-skill", "SKILL.md"),
+      "default-skill",
+      "Default fallback skill",
+    );
+
+    stageBundledPluginRuntime({ repoRoot });
+
+    const runtimeDeclaredSkillPath = path.join(
+      repoRoot,
+      "dist-runtime",
+      "extensions",
+      "codex-demo",
+      "bundle-skills",
+      "custom-skill",
+      "SKILL.md",
+    );
+    const runtimeDefaultSkillPath = path.join(
+      repoRoot,
+      "dist-runtime",
+      "extensions",
+      "codex-demo",
+      "skills",
+      "default-skill",
+      "SKILL.md",
+    );
+
+    expect(fs.lstatSync(runtimeDeclaredSkillPath).isSymbolicLink()).toBe(false);
+    expect(fs.realpathSync(runtimeDeclaredSkillPath)).toBe(runtimeDeclaredSkillPath);
+    expect(fs.lstatSync(runtimeDefaultSkillPath).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(runtimeDefaultSkillPath)).toBe(
+      path.join(distPluginDir, "skills", "default-skill", "SKILL.md"),
+    );
+  });
+
   it("preserves package metadata needed for bundled plugin discovery from dist-runtime", () => {
     const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-discovery-");
     const distPluginDir = path.join(repoRoot, "dist", "extensions", "demo");


### PR DESCRIPTION
## Summary

- Problem: `dist-runtime` staged bundled plugin skill trees as symlinks back into `dist/...`, so the skill loader's realpath containment check saw those bundled skills as escaping the configured runtime root and skipped them.
- Why it matters: bundled extension skills such as `acpx/skills/acp-router` could disappear from the runtime overlay even though the containment guard was working as intended.
- What changed: the runtime overlay still keeps manifest-declared bundled skill trees physically copied inside `dist-runtime`, but the manifest handling is now descriptor-driven and the Codex path resolution matches the canonical bundle semantics instead of additively copying the default `skills/` tree when a manifest declares a different root.
- What did NOT change (scope boundary): this does not relax the skill-loader containment check, trust manifestless bundle layouts, or change unrelated symlink behavior outside the declared runtime skill trees.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #43745
- Related #41651
- Related #44522
- Related #47601
- Related #48595

## User-visible / Behavior Changes

- Bundled extension skills declared by plugin manifests stay loadable from `dist-runtime` instead of being skipped as escaped paths.
- Runtime staging now mirrors the current host bundle-manifest semantics for each supported bundle format:
- Codex: declared skill roots when present, otherwise conventional defaults
- Claude / Cursor: declared roots remain additive with conventional defaults, matching current `src/plugins/bundle-manifest.ts` behavior
- Unrelated runtime-overlay artifacts keep the prior symlink/wrapper behavior.


## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

Notes:
- This remains a packaging/runtime-overlay fix, not a skill-loader security weakening.
- The realpath containment check stays in place.
- Manifest-declared paths still go through plugin-root containment checks before being copied.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: `dist/` + `dist-runtime` bundled plugin overlay
- Model/provider: N/A
- Integration/channel (if any): :
- Relevant config (redacted): 

### Steps

1. Build/stage bundled plugins so the runtime overlay exposes bundled skill trees under `dist-runtime/extensions/<plugin>`.
2. Run the targeted runtime-staging test suite.
3. Let the skill loader resolve those paths with `realpath` against the configured bundled root under `dist-runtime`.

### Expected

- Manifest-declared bundled skills remain physically inside `dist-runtime` and pass the existing containment check.
- The runtime copy set stays limited to the declared skill roots for each supported manifest format.

### Actual

- Before the patch, those skill paths were symlinked back into `dist/...`, so the loader resolved them outside the configured `dist-runtime` root and skipped them.
- Before this review refinement, Codex bundles with an explicit custom skill root would also copy the default `skills/` tree additively inside `dist-runtime`, which was broader than the canonical bundle semantics.
- After the final patch, declared bundled skill trees stay copied inside `dist-runtime`, and the Codex copy behavior stays bound to the declared roots.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [X] Screenshot/recording
- [ ] Perf numbers (if relevant)

` 
18:24:51 warn skills {"subsystem":"skills"} {"source":"openclaw-extra","rootDir":"/root/openclaw/dist-runtime/extensions/acpx/skills","path":"/root/openclaw/dist-runtime/extensions/acpx/skills/acp-router/SKILL.md","realPath":"/root/openclaw/dist/extensions/acpx/skills/acp-router/SKILL.md"} Skipping skill path that resolves outside its configured root.`
<img width="881" height="333" alt="image" src="https://github.com/user-attachments/assets/8d65a3f2-3104-4531-bbe1-091b2d4778da" />
After skill loaded succefully
<img width="837" height="312" alt="image" src="https://github.com/user-attachments/assets/b7880b02-670c-4793-bd82-9e1d2f5cfa3d" />


Evidence summary:
- Targeted regression suite: `pnpm test -- src/plugins/stage-bundled-plugin-runtime.test.ts`
- Result on the final review branch: `9/9` tests passed
- Coverage verifies all of:
  - native manifest-declared skill assets are copied into `dist-runtime` while unrelated artifacts stay symlinked
  - acpx-style bundled skills remain loadable from the `dist-runtime` bundled plugin root
  - Codex bundles only copy the declared skill root, not an extra default `skills/` tree when a custom root is declared

## Human Verification (required)

What was verified for this draft:

- Verified scenarios:
  - reviewed the runtime-packaging diff on `fix/acpx-runtime-skill-copy`
  - confirmed the final implementation keeps the fix at the packaging layer and preserves the containment guard
  - targeted test `src/plugins/stage-bundled-plugin-runtime.test.ts` passed (`9/9`)
- Edge cases checked:
  - unrelated overlay artifacts stayed on the existing symlink/wrapper path
  - Codex bundles with an explicit custom skill root no longer copy the fallback `skills/` tree additively
  - manifest-declared paths are still rejected if they escape the plugin root
- What you did **not** verify:
  - full repo test suite
  - live packaged build/manual runtime smoke outside the targeted test coverage
  - every bundle format end-to-end via discovery + execution

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the merge commit.
- Files/config to restore: `scripts/stage-bundled-plugin-runtime.mjs`, `src/plugins/stage-bundled-plugin-runtime.test.ts`
- Known bad symptoms reviewers should watch for: bundled extension skills disappearing again from `dist-runtime`, escaped-root warnings returning for bundled plugin skills that should live under the runtime root, or Codex bundles copying undeclared default skill trees into the runtime overlay.

## Risks and Mitigations

- Risk: copying more than the intended plugin paths into `dist-runtime` could widen the runtime overlay and reintroduce layout problems.
  - Mitigation: the copy set is still limited to declared skill roots, and the Codex case now matches the canonical declared-path semantics instead of copying an additive default.
- Risk: manifest parsing could accidentally accept paths outside the plugin root.
  - Mitigation: the staging script still normalizes declared paths and rejects escaped paths before copying.
- Risk: over-generalizing the staging script could make it trust layouts that the runtime loader does not actually recognize.
  - Mitigation: the final change stops at supported manifest files only; it does not add manifestless heuristics.

## Scope / Non-goals

- This PR fixes runtime-overlay packaging so `dist-runtime` stays consistent with the existing bundle-manifest loader.
- This PR does **not** redefine cross-format bundle semantics.
- If OpenClaw later wants all bundle formats to use declared-or-defaults semantics, that should be handled as a separate behavioral change in `src/plugins/bundle-manifest.ts`.

## AI-Assisted Disclosure

- [X] AI-assisted: Yes
- [X] Tools used: Codex/OpenClaw-assisted implementation and iteration
- [X] Testing level: manually validated + targeted automated tests
- [X] Author verification: final code paths, config behavior, and runtime checks were reviewed.