### PR TITLE
fix(plugins): stage bundled skills inside runtime root

### DIFF
--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -23,6 +23,7 @@ function shouldWrapRuntimeJsFile(sourcePath) {
 function shouldCopyRuntimeFile(sourcePath) {
   const relativePath = sourcePath.replace(/\\/g, "/");
   return (
+    relativePath.includes("/skills/") ||
     relativePath.endsWith("/package.json") ||
     relativePath.endsWith("/openclaw.plugin.json") ||
     relativePath.endsWith("/.codex-plugin/plugin.json") ||

--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -24,6 +24,7 @@ function shouldCopyRuntimeFile(sourcePath) {
   const relativePath = sourcePath.replace(/\\/g, "/");
   return (
     relativePath.includes("/skills/") ||
+    relativePath.includes("/bundled-skills/") ||
     relativePath.endsWith("/package.json") ||
     relativePath.endsWith("/openclaw.plugin.json") ||
     relativePath.endsWith("/.codex-plugin/plugin.json") ||

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -233,6 +233,34 @@ describe("stageBundledPluginRuntime", () => {
     expect(fs.readFileSync(runtimeAssetPath, "utf8")).toBe("ok\n");
   });
 
+  it("copies plugin skills into the runtime overlay so they stay within the runtime root", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-skills-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "acpx");
+    const distSkillDir = path.join(distPluginDir, "skills", "acp-router");
+    fs.mkdirSync(distSkillDir, { recursive: true });
+    fs.writeFileSync(path.join(distSkillDir, "SKILL.md"), "# ACP Router\n", "utf8");
+    fs.writeFileSync(path.join(distSkillDir, "guide.txt"), "ok\n", "utf8");
+
+    stageBundledPluginRuntime({ repoRoot });
+
+    const runtimeSkillDir = path.join(
+      repoRoot,
+      "dist-runtime",
+      "extensions",
+      "acpx",
+      "skills",
+      "acp-router",
+    );
+    const runtimeSkillPath = path.join(runtimeSkillDir, "SKILL.md");
+    const runtimeGuidePath = path.join(runtimeSkillDir, "guide.txt");
+
+    expect(fs.lstatSync(runtimeSkillPath).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(runtimeSkillPath, "utf8")).toBe("# ACP Router\n");
+    expect(fs.realpathSync(runtimeSkillPath)).toBe(runtimeSkillPath);
+    expect(fs.lstatSync(runtimeGuidePath).isSymbolicLink()).toBe(false);
+    expect(fs.realpathSync(runtimeGuidePath)).toBe(runtimeGuidePath);
+  });
+
   it("preserves package metadata needed for bundled plugin discovery from dist-runtime", () => {
     const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-discovery-");
     const distPluginDir = path.join(repoRoot, "dist", "extensions", "demo");

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -253,12 +253,51 @@ describe("stageBundledPluginRuntime", () => {
     );
     const runtimeSkillPath = path.join(runtimeSkillDir, "SKILL.md");
     const runtimeGuidePath = path.join(runtimeSkillDir, "guide.txt");
+    const realRuntimeSkillDir = fs.realpathSync(runtimeSkillDir);
 
     expect(fs.lstatSync(runtimeSkillPath).isSymbolicLink()).toBe(false);
     expect(fs.readFileSync(runtimeSkillPath, "utf8")).toBe("# ACP Router\n");
-    expect(fs.realpathSync(runtimeSkillPath)).toBe(runtimeSkillPath);
+    expect(fs.realpathSync(runtimeSkillPath)).toBe(path.join(realRuntimeSkillDir, "SKILL.md"));
     expect(fs.lstatSync(runtimeGuidePath).isSymbolicLink()).toBe(false);
-    expect(fs.realpathSync(runtimeGuidePath)).toBe(runtimeGuidePath);
+    expect(fs.realpathSync(runtimeGuidePath)).toBe(path.join(realRuntimeSkillDir, "guide.txt"));
+  });
+
+  it("copies bundled dependency-backed skills into the runtime overlay", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-generated-skills-");
+    const bundledSkillDir = path.join(
+      repoRoot,
+      "dist",
+      "extensions",
+      "tlon",
+      "bundled-skills",
+      "@tloncorp",
+      "tlon-skill",
+    );
+    fs.mkdirSync(path.join(bundledSkillDir, "references"), { recursive: true });
+    fs.writeFileSync(path.join(bundledSkillDir, "SKILL.md"), "# Tlon\n", "utf8");
+    fs.writeFileSync(path.join(bundledSkillDir, "references", "hooks.md"), "ok\n", "utf8");
+
+    stageBundledPluginRuntime({ repoRoot });
+
+    const runtimeSkillDir = path.join(
+      repoRoot,
+      "dist-runtime",
+      "extensions",
+      "tlon",
+      "bundled-skills",
+      "@tloncorp",
+      "tlon-skill",
+    );
+    const runtimeSkillPath = path.join(runtimeSkillDir, "SKILL.md");
+    const runtimeReferencePath = path.join(runtimeSkillDir, "references", "hooks.md");
+    const realRuntimeSkillDir = fs.realpathSync(runtimeSkillDir);
+
+    expect(fs.lstatSync(runtimeSkillPath).isSymbolicLink()).toBe(false);
+    expect(fs.realpathSync(runtimeSkillPath)).toBe(path.join(realRuntimeSkillDir, "SKILL.md"));
+    expect(fs.lstatSync(runtimeReferencePath).isSymbolicLink()).toBe(false);
+    expect(fs.realpathSync(runtimeReferencePath)).toBe(
+      path.join(realRuntimeSkillDir, "references", "hooks.md"),
+    );
   });
 
   it("preserves package metadata needed for bundled plugin discovery from dist-runtime", () => {


### PR DESCRIPTION
## Summary

- Problem: bundled extension `skills/` files get symlinked from `dist-runtime` back into `dist`, which makes skill discovery treat them as outside the configured runtime root.
- Why it matters: built-in extensions can spam `Skipping skill path that resolves outside its configured root.` warnings even though the bundled skills are part of the shipped runtime.
- What changed: copy `skills/` trees into `dist-runtime` alongside existing copied plugin metadata files, and add regression coverage for the runtime-root case.
- What did NOT change (scope boundary): this does not relax root validation or change workspace-skill loading behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43745
- Related #49134

## User-visible / Behavior Changes

Built-in extension skills staged under `dist-runtime` no longer warn as “outside its configured root” during skill discovery.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22 source checkout
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): none

### Steps

1. Build bundled extensions so they are staged into `dist-runtime`.
2. Inspect a bundled extension skill path under `dist-runtime/extensions/*/skills/*`.
3. Run skill discovery or doctor.

### Expected

- Bundled extension skills resolve inside the runtime root and do not trigger root-validation warnings.

### Actual

- Before this change, bundled extension skills were symlinked back into `dist`, so discovery could warn that they resolved outside the configured root.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: copied a bundled plugin `skills/` tree into `dist-runtime` with the updated staging script and confirmed both `SKILL.md` and companion files resolved inside the runtime root; ran `CI=1 pnpm exec vitest run src/plugins/stage-bundled-plugin-runtime.test.ts src/config/sessions/artifacts.test.ts src/config/sessions/store.pruning.integration.test.ts` on the maintained source tree and confirmed the plugin test file passed.
- Edge cases checked: companion non-JS files inside `skills/` are copied instead of symlinked.
- What you did **not** verify: a packaged npm/global install end-to-end.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit; bundled runtime staging falls back to the previous symlink behavior.
- Files/config to restore: `scripts/stage-bundled-plugin-runtime.mjs`
- Known bad symptoms reviewers should watch for: bundled extension skill warnings reappearing, or unexpected runtime-root validation failures for built-in skills.

## Risks and Mitigations

- Risk: copying `skills/` trees changes how bundled extension assets are materialized in `dist-runtime`.
  - Mitigation: the change is limited to `skills/` paths, preserves existing symlink behavior for other assets, and adds targeted regression coverage.
