### PR TITLE
fix(hooks): suppress system event injection when deliver is false

### DIFF
--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -519,6 +519,99 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("suppresses system event when mapping sets deliver: false", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      mappings: [
+        {
+          match: { path: "silent" },
+          action: "agent",
+          name: "SilentTriage",
+          messageTemplate: "Triage: {{payload.subject}}",
+          deliver: false,
+        },
+      ],
+    };
+    await withGatewayServer(async ({ port }) => {
+      cronIsolatedRun.mockClear();
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "ok",
+        summary: "labeled inbox",
+      });
+
+      const res = await postHook(port, "/hooks/silent", { subject: "Hello" });
+      expect(res.status).toBe(200);
+
+      // Give the async dispatch time to complete.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // No system event should be injected — deliver: false means fully silent.
+      expect(peekSystemEvents(resolveMainKey()).length).toBe(0);
+
+      // Verify the isolated run was still invoked.
+      expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      const call = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
+        job?: { payload?: { deliver?: boolean } };
+      };
+      expect(call?.job?.payload?.deliver).toBe(false);
+    });
+  });
+
+  test("still surfaces errors to main session even when deliver: false", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      mappings: [
+        {
+          match: { path: "silent-err" },
+          action: "agent",
+          name: "SilentBroken",
+          messageTemplate: "Triage: {{payload.subject}}",
+          deliver: false,
+        },
+      ],
+    };
+    await withGatewayServer(async ({ port }) => {
+      cronIsolatedRun.mockClear();
+      cronIsolatedRun.mockRejectedValueOnce(new Error("model quota exceeded"));
+
+      const res = await postHook(port, "/hooks/silent-err", { subject: "Boom" });
+      expect(res.status).toBe(200);
+
+      // Error should still be surfaced to main session despite deliver: false.
+      const events = await waitForSystemEvent();
+      expect(events.some((e) => e.includes("SilentBroken") && e.includes("error"))).toBe(true);
+      expect(events.some((e) => e.includes("model quota exceeded"))).toBe(true);
+      drainSystemEvents(resolveMainKey());
+    });
+  });
+
+  test("direct /hooks/agent with deliver: false suppresses system event", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    await withGatewayServer(async ({ port }) => {
+      cronIsolatedRun.mockClear();
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "ok",
+        summary: "silently done",
+      });
+
+      const res = await postHook(port, "/hooks/agent", {
+        message: "Label this email",
+        name: "GmailTriage",
+        deliver: false,
+      });
+      expect(res.status).toBe(200);
+
+      // Give the async dispatch time to complete.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // No system event — deliver: false.
+      expect(peekSystemEvents(resolveMainKey()).length).toBe(0);
+      expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+    });
+  });
+
   test("rejects non-POST hook requests without consuming auth failure budget", async () => {
     testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
     await withGatewayServer(async ({ port }) => {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -103,6 +103,8 @@ export function createGatewayHooksRequestHandler(params: {
         }
       } catch (err) {
         logHooks.warn(`hook agent failed: ${String(err)}`);
+        // Errors are always surfaced to the main session regardless of the
+        // `deliver` flag — silent failures are harder to debug than noisy ones.
         enqueueSystemEvent(`Hook ${value.name} (error): ${String(err)}`, {
           sessionKey: mainSessionKey,
         });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -89,7 +89,11 @@ export function createGatewayHooksRequestHandler(params: {
         const summary = result.summary?.trim() || result.error?.trim() || result.status;
         const prefix =
           result.status === "ok" ? `Hook ${value.name}` : `Hook ${value.name} (${result.status})`;
-        if (!result.delivered) {
+        // When deliver is explicitly false the caller opted out of all
+        // delivery *and* main-session notification.  Only inject a system
+        // event when delivery was requested but did not succeed (e.g. the
+        // target channel could not be resolved).
+        if (!result.delivered && value.deliver !== false) {
           enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
             sessionKey: mainSessionKey,
           });


### PR DESCRIPTION
## Summary / What changed

Builds on the fix from #36332 by @cioclawcode, rebased onto current main with test coverage added.

### Fix (commits 1-2 by @cioclawcode)
- `src/gateway/server/hooks.ts`: Guard `enqueueSystemEvent` with `value.deliver !== false` so hooks with `deliver: false` complete silently — no delivery, no system event injected into the main session.
- Error path intentionally still surfaces to main session (silent failures are harder to debug than noisy ones). This asymmetry is documented with an inline comment.

### Tests (commit 3)
Addresses the [Greptile 3/5 review](https://github.com/openclaw/openclaw/pull/36332#issuecomment-2705741329) on the original PR:
- **`suppresses system event when mapping sets deliver: false`** — verifies no system event is enqueued when a mapping completes successfully with `deliver: false`
- **`still surfaces errors to main session even when deliver: false`** — confirms the intentional error-path asymmetry is working as designed
- **`direct /hooks/agent with deliver: false suppresses system event`** — covers the `/hooks/agent` direct endpoint path (not just mappings)

## Why
When `deliver: false` is set on a hook mapping (e.g. for silent email triage), the hook run summary was still injected as a system event into the main session, which then got announced to the last active channel (Telegram, Discord, etc.). This made `deliver: false` ineffective for truly silent background automations.

## Issue
Fixes #36325
Supersedes #36332

Co-authored-by: @cioclawcode (original fix + docs commits preserved with authorship)