### PR TITLE
fix(whatsapp): fall back when inbound from is missing

### DIFF
--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts
@@ -125,6 +125,41 @@ describe("web auto-reply last-route", () => {
     await store.cleanup();
   });
 
+  it("falls back to conversationId when a direct message is missing from", async () => {
+    const now = Date.now();
+    const mainSessionKey = "agent:main:main";
+    const store = await makeSessionStore({
+      [mainSessionKey]: { sessionId: "sid", updatedAt: now - 1 },
+    });
+
+    const { handler, backgroundTasks } = createLastRouteHarness(store.storePath);
+
+    await expect(
+      handler({
+        id: "m-missing-from",
+        from: undefined,
+        conversationId: "+1000",
+        to: "+2000",
+        body: "hello",
+        timestamp: now,
+        chatType: "direct",
+        chatId: "direct:+1000",
+        accountId: "default",
+        sendComposing: vi.fn().mockResolvedValue(undefined),
+        reply: vi.fn().mockResolvedValue(undefined),
+        sendMedia: vi.fn().mockResolvedValue(undefined),
+      } as never),
+    ).resolves.toBeUndefined();
+
+    await awaitBackgroundTasks(backgroundTasks);
+
+    const stored = await readStoredRoutes(store.storePath);
+    expect(stored[mainSessionKey]?.lastChannel).toBe("whatsapp");
+    expect(stored[mainSessionKey]?.lastTo).toBe("+1000");
+
+    await store.cleanup();
+  });
+
   it("updates last-route for group chats with account id", async () => {
     const now = Date.now();
     const groupSessionKey = "agent:main:whatsapp:group:123@g.us";

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -12,7 +12,7 @@ import type { EchoTracker } from "./echo.js";
 import type { GroupHistoryEntry } from "./group-gating.js";
 import { applyGroupGating } from "./group-gating.js";
 import { updateLastRouteInBackground } from "./last-route.js";
-import { resolvePeerId } from "./peer.js";
+import { resolveConversationId, resolvePeerId } from "./peer.js";
 import { processMessage } from "./process-message.js";
 
 export function createWebOnMessageHandler(params: {
@@ -61,7 +61,7 @@ export function createWebOnMessageHandler(params: {
     });
 
   return async (msg: WebInboundMsg) => {
-    const conversationId = msg.conversationId ?? msg.from;
+    const conversationId = resolveConversationId(msg);
     const peerId = resolvePeerId(msg);
     // Fresh config for bindings lookup; other routing inputs are payload-derived.
     const route = resolveAgentRoute({
@@ -97,7 +97,7 @@ export function createWebOnMessageHandler(params: {
 
     if (msg.chatType === "group") {
       const metaCtx = {
-        From: msg.from,
+        From: conversationId,
         To: msg.to,
         SessionKey: route.sessionKey,
         AccountId: route.accountId,

--- a/extensions/whatsapp/src/auto-reply/monitor/peer.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/peer.ts
@@ -1,15 +1,41 @@
 import { jidToE164, normalizeE164 } from "openclaw/plugin-sdk/text-runtime";
 import type { WebInboundMsg } from "../types.js";
 
-export function resolvePeerId(msg: WebInboundMsg) {
-  if (msg.chatType === "group") {
-    return msg.conversationId ?? msg.from;
+function firstNonEmpty(...values: Array<string | undefined>): string | null {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
   }
+  return null;
+}
+
+export function resolveConversationId(
+  msg: Pick<WebInboundMsg, "conversationId" | "from" | "chatId">,
+): string {
+  return firstNonEmpty(msg.conversationId, msg.from, msg.chatId) ?? "unknown";
+}
+
+export function resolveDirectPeerId(
+  msg: Pick<WebInboundMsg, "senderE164" | "conversationId" | "from" | "chatId">,
+): string | null {
   if (msg.senderE164) {
     return normalizeE164(msg.senderE164) ?? msg.senderE164;
   }
-  if (msg.from.includes("@")) {
-    return jidToE164(msg.from) ?? msg.from;
+  const candidate = firstNonEmpty(msg.from, msg.conversationId, msg.chatId);
+  if (!candidate) {
+    return null;
   }
-  return normalizeE164(msg.from) ?? msg.from;
+  if (candidate.includes("@")) {
+    return jidToE164(candidate) ?? candidate;
+  }
+  return normalizeE164(candidate) ?? candidate;
+}
+
+export function resolvePeerId(msg: WebInboundMsg) {
+  if (msg.chatType === "group") {
+    return resolveConversationId(msg);
+  }
+  return resolveDirectPeerId(msg) ?? resolveConversationId(msg);
 }

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -220,11 +220,13 @@ export async function processMessage(params: {
   });
 
   const correlationId = params.msg.id ?? newConnectionId();
+  const directPeerId = params.msg.chatType === "group" ? null : resolveDirectPeerId(params.msg);
+  const directFrom = directPeerId ?? conversationId;
   params.replyLogger.info(
     {
       connectionId: params.connectionId,
       correlationId,
-      from: params.msg.chatType === "group" ? conversationId : params.msg.from,
+      from: params.msg.chatType === "group" ? conversationId : directFrom,
       to: params.msg.to,
       body: elide(combinedBody, 240),
       mediaType: params.msg.mediaType ?? null,
@@ -233,8 +235,6 @@ export async function processMessage(params: {
     "inbound web message",
   );
 
-  const directPeerId = params.msg.chatType === "group" ? null : resolveDirectPeerId(params.msg);
-  const directFrom = directPeerId ?? conversationId;
   const fromDisplay = params.msg.chatType === "group" ? conversationId : directFrom;
   const kindLabel = params.msg.mediaType ? `, ${params.msg.mediaType}` : "";
   whatsappInboundLog.info(

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -40,6 +40,7 @@ import { maybeSendAckReaction } from "./ack-reaction.js";
 import { formatGroupMembers } from "./group-members.js";
 import { trackBackgroundTask, updateLastRouteInBackground } from "./last-route.js";
 import { buildInboundLine } from "./message-line.js";
+import { resolveConversationId, resolveDirectPeerId } from "./peer.js";
 
 export type GroupHistoryEntry = {
   sender: string;
@@ -151,7 +152,7 @@ export async function processMessage(params: {
   groupHistory?: GroupHistoryEntry[];
   suppressGroupHistoryClear?: boolean;
 }) {
-  const conversationId = params.msg.conversationId ?? params.msg.from;
+  const conversationId = resolveConversationId(params.msg);
   const { storePath, envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
     cfg: params.cfg,
     agentId: params.route.agentId,
@@ -232,7 +233,9 @@ export async function processMessage(params: {
     "inbound web message",
   );
 
-  const fromDisplay = params.msg.chatType === "group" ? conversationId : params.msg.from;
+  const directPeerId = params.msg.chatType === "group" ? null : resolveDirectPeerId(params.msg);
+  const directFrom = directPeerId ?? conversationId;
+  const fromDisplay = params.msg.chatType === "group" ? conversationId : directFrom;
   const kindLabel = params.msg.mediaType ? `, ${params.msg.mediaType}` : "";
   whatsappInboundLog.info(
     `Inbound message ${fromDisplay} -> ${params.msg.to} (${params.msg.chatType}${kindLabel}, ${combinedBody.length} chars)`,
@@ -241,19 +244,7 @@ export async function processMessage(params: {
     whatsappInboundLog.debug(`Inbound body: ${elide(combinedBody, 400)}`);
   }
 
-  const dmRouteTarget =
-    params.msg.chatType !== "group"
-      ? (() => {
-          if (params.msg.senderE164) {
-            return normalizeE164(params.msg.senderE164);
-          }
-          // In direct chats, `msg.from` is already the canonical conversation id.
-          if (params.msg.from.includes("@")) {
-            return jidToE164(params.msg.from);
-          }
-          return normalizeE164(params.msg.from);
-        })()
-      : undefined;
+  const dmRouteTarget = directPeerId ?? undefined;
 
   const textLimit = params.maxMediaTextChunkLimit ?? resolveTextChunkLimit(params.cfg, "whatsapp");
   const chunkMode = resolveChunkMode(params.cfg, "whatsapp", params.route.accountId);
@@ -275,10 +266,11 @@ export async function processMessage(params: {
     channel: "whatsapp",
     accountId: params.route.accountId,
   });
+  const normalizedDirectPeerId = directPeerId ? normalizeE164(directPeerId) : null;
   const isSelfChat =
     params.msg.chatType !== "group" &&
     Boolean(params.msg.selfE164) &&
-    normalizeE164(params.msg.from) === normalizeE164(params.msg.selfE164 ?? "");
+    normalizedDirectPeerId === normalizeE164(params.msg.selfE164 ?? "");
   const responsePrefix =
     prefixOptions.responsePrefix ??
     (configuredResponsePrefix === undefined && isSelfChat
@@ -302,7 +294,7 @@ export async function processMessage(params: {
     InboundHistory: inboundHistory,
     RawBody: params.msg.body,
     CommandBody: params.msg.body,
-    From: params.msg.from,
+    From: directFrom,
     To: params.msg.to,
     SessionKey: params.route.sessionKey,
     AccountId: params.route.accountId,
@@ -314,7 +306,7 @@ export async function processMessage(params: {
     MediaUrl: params.msg.mediaUrl,
     MediaType: params.msg.mediaType,
     ChatType: params.msg.chatType,
-    ConversationLabel: params.msg.chatType === "group" ? conversationId : params.msg.from,
+    ConversationLabel: conversationId,
     GroupSubject: params.msg.groupSubject,
     GroupMembers: formatGroupMembers({
       participants: params.msg.groupParticipants,
@@ -330,7 +322,7 @@ export async function processMessage(params: {
     Provider: "whatsapp",
     Surface: "whatsapp",
     OriginatingChannel: "whatsapp",
-    OriginatingTo: params.msg.from,
+    OriginatingTo: conversationId,
   });
 
   // Only update main session's lastRoute when DM actually IS the main session.


### PR DESCRIPTION
## Summary

Fix the WhatsApp web auto-reply path when inbound direct messages arrive without a `from` field.

- make peer resolution fall back through `conversationId` and `chatId`
- use the same safe fallback when building direct-message route targets and inbound context
- add a handler-level regression test that exercises the real web auto-reply message path with a malformed direct inbound event

Closes #49094.

## Testing

Passed:
- `npm exec --yes pnpm@10.23.0 -- vitest run extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts`
- `npm exec --yes pnpm@10.23.0 -- exec oxfmt --check extensions/whatsapp/src/auto-reply/monitor/peer.ts extensions/whatsapp/src/auto-reply/monitor/on-message.ts extensions/whatsapp/src/auto-reply/monitor/process-message.ts extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts`
- `npm exec --yes pnpm@10.23.0 -- exec oxlint extensions/whatsapp/src/auto-reply/monitor/peer.ts extensions/whatsapp/src/auto-reply/monitor/on-message.ts extensions/whatsapp/src/auto-reply/monitor/process-message.ts extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts`
- `npm exec --yes pnpm@10.23.0 -- build`

Attempted but not green:
- `npm exec --yes pnpm@10.23.0 -- check`
  - currently stops on an untouched repo baseline formatting failure in `docs/tools/plugin.md`
- `npm exec --yes pnpm@10.23.0 -- test:extension whatsapp`
  - currently surfaces additional failures in the broader WhatsApp suite outside the touched files, so I am not claiming this as green for the PR

## AI Use

This pull request was prepared with AI assistance.
