### PR TITLE
Auto-retry on message ordering conflict instead of asking user to retry

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -140,6 +140,7 @@ export async function runAgentTurnWithFallback(params: {
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
   let didResetAfterCompactionFailure = false;
   let didRetryTransientHttpError = false;
+  let didRetryAfterRoleOrderingConflict = false;
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
@@ -515,11 +516,15 @@ export async function runAgentTurnWithFallback(params: {
       }
       if (embeddedError?.kind === "role_ordering") {
         const didReset = await params.resetSessionAfterRoleOrderingConflict(embeddedError.message);
+        if (didReset && !didRetryAfterRoleOrderingConflict) {
+          didRetryAfterRoleOrderingConflict = true;
+          continue;
+        }
         if (didReset) {
           return {
             kind: "final",
             payload: {
-              text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
+              text: "⚠️ Message ordering conflict persists after reset. Use /new to start a fresh session.",
             },
           };
         }
@@ -550,11 +555,15 @@ export async function runAgentTurnWithFallback(params: {
       }
       if (isRoleOrderingError) {
         const didReset = await params.resetSessionAfterRoleOrderingConflict(message);
+        if (didReset && !didRetryAfterRoleOrderingConflict) {
+          didRetryAfterRoleOrderingConflict = true;
+          continue;
+        }
         if (didReset) {
           return {
             kind: "final",
             payload: {
-              text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
+              text: "⚠️ Message ordering conflict persists after reset. Use /new to start a fresh session.",
             },
           };
         }

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1376,7 +1376,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(payload.text).toContain("/new");
   });
 
-  it("resets the session after role ordering payloads", async () => {
+  it("auto-retries after role ordering payload and returns success response", async () => {
     await withTempStateDir(async (stateDir) => {
       const sessionId = "session";
       const storePath = path.join(stateDir, "sessions", "sessions.json");
@@ -1389,6 +1389,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
       await fs.writeFile(transcriptPath, "ok", "utf-8");
 
+      // First call: role ordering error
       state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
         payloads: [{ text: "Message ordering conflict - please try again.", isError: true }],
         meta: {
@@ -1399,6 +1400,11 @@ describe("runReplyAgent typing (heartbeat)", () => {
           },
         },
       }));
+      // Second call (auto-retry after reset): success
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
+        payloads: [{ text: "Hello!" }],
+        meta: { durationMs: 1 },
+      }));
 
       const { run } = createMinimalRun({
         sessionEntry,
@@ -1408,19 +1414,62 @@ describe("runReplyAgent typing (heartbeat)", () => {
       });
       const res = await run();
 
-      const payload = Array.isArray(res) ? res[0] : res;
-      expect(payload).toMatchObject({
-        text: expect.stringContaining("Message ordering conflict"),
-      });
-      if (!payload) {
-        throw new Error("expected payload");
-      }
-      expect(payload.text?.toLowerCase()).toContain("reset");
+      // Both calls should have been made (error + auto-retry)
+      expect(state.runEmbeddedPiAgentMock).toHaveBeenCalledTimes(2);
+
+      // Session should have been reset before the retry
       expect(sessionStore.main.sessionId).not.toBe(sessionId);
       await expect(fs.access(transcriptPath)).rejects.toBeDefined();
 
       const persisted = JSON.parse(await fs.readFile(storePath, "utf-8"));
       expect(persisted.main.sessionId).toBe(sessionStore.main.sessionId);
+
+      // Final response should be the success reply, not an error
+      const payload = Array.isArray(res) ? res[0] : res;
+      expect(payload).toMatchObject({ text: "Hello!" });
+    });
+  });
+
+  it("returns error message when role ordering conflict persists after auto-retry", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const transcriptPath = sessions.resolveSessionTranscriptPath(sessionId);
+      const sessionEntry = { sessionId, updatedAt: Date.now(), sessionFile: transcriptPath };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "ok", "utf-8");
+
+      const roleOrderingError = {
+        payloads: [{ text: "Message ordering conflict - please try again.", isError: true }],
+        meta: {
+          durationMs: 1,
+          error: {
+            kind: "role_ordering",
+            message: 'messages: roles must alternate between "user" and "assistant"',
+          },
+        },
+      };
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => roleOrderingError);
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => roleOrderingError);
+
+      const { run } = createMinimalRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      const res = await run();
+
+      expect(state.runEmbeddedPiAgentMock).toHaveBeenCalledTimes(2);
+
+      const payload = Array.isArray(res) ? res[0] : res;
+      expect(payload).toMatchObject({
+        text: expect.stringContaining("Message ordering conflict persists"),
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Detect role ordering errors (consecutive user/assistant turns) and automatically reset the session + retry the turn, rather than surfacing a "please try again" message.
- A one-shot guard (`didRetryAfterRoleOrderingConflict`) prevents infinite loops: if the conflict persists after the auto-retry, return an error suggesting `/new`.
- Handles both paths: embedded runner returning `error.kind === "role_ordering"` and thrown exceptions matching the pattern.

## Test plan

- [ ] `auto-retries after role ordering payload and returns success response` — verifies mock called twice, session reset, final response is success
- [ ] `returns error message when role ordering conflict persists after auto-retry` — verifies error message on second consecutive failure
- [ ] `returns friendly message for role ordering errors thrown as exceptions` (no session) — behavior unchanged when no session store available

Fixes #998