### PR TITLE
fix: break circular reexport cycles between plugin-sdk and line/nostr extensions

### DIFF
--- a/extensions/line/src/setup-core.ts
+++ b/extensions/line/src/setup-core.ts
@@ -1,11 +1,6 @@
 import type { ChannelSetupAdapter, OpenClawConfig } from "openclaw/plugin-sdk/setup";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/setup";
-import {
-  listLineAccountIds,
-  normalizeAccountId,
-  resolveLineAccount,
-  type LineConfig,
-} from "../api.js";
+import { normalizeAccountId, resolveLineAccount, type LineConfig } from "../api.js";
 
 const channel = "line" as const;
 
@@ -157,5 +152,3 @@ export const lineSetupAdapter: ChannelSetupAdapter = {
     });
   },
 };
-
-export { listLineAccountIds };

--- a/extensions/line/src/setup-surface.ts
+++ b/extensions/line/src/setup-surface.ts
@@ -7,13 +7,8 @@ import {
   type ChannelSetupDmPolicy,
   type ChannelSetupWizard,
 } from "openclaw/plugin-sdk/setup";
-import { resolveLineAccount } from "../api.js";
-import {
-  isLineConfigured,
-  listLineAccountIds,
-  parseLineAllowFromId,
-  patchLineAccountConfig,
-} from "./setup-core.js";
+import { listLineAccountIds, resolveLineAccount } from "../api.js";
+import { isLineConfigured, parseLineAllowFromId, patchLineAccountConfig } from "./setup-core.js";
 
 const channel = "line" as const;
 

--- a/src/plugin-sdk/line.ts
+++ b/src/plugin-sdk/line.ts
@@ -32,8 +32,8 @@ export {
   resolveDefaultLineAccountId,
   resolveLineAccount,
 } from "../line/accounts.js";
-export { lineSetupAdapter } from "../../extensions/line/api.js";
-export { lineSetupWizard } from "../../extensions/line/api.js";
+export { lineSetupAdapter } from "../../extensions/line/src/setup-core.js";
+export { lineSetupWizard } from "../../extensions/line/src/setup-surface.js";
 export { LineConfigSchema } from "../line/config-schema.js";
 export type { LineChannelData, LineConfig, ResolvedLineAccount } from "../line/types.js";
 export {

--- a/src/plugin-sdk/nostr.ts
+++ b/src/plugin-sdk/nostr.ts
@@ -19,4 +19,4 @@ export {
 } from "./status-helpers.js";
 export { createFixedWindowRateLimiter } from "./webhook-memory-guards.js";
 export { mapAllowFromEntries } from "./channel-config-helpers.js";
-export { nostrSetupAdapter, nostrSetupWizard } from "../../extensions/nostr/api.js";
+export { nostrSetupAdapter, nostrSetupWizard } from "../../extensions/nostr/src/setup-surface.js";


### PR DESCRIPTION
## Summary

- Import `lineSetupAdapter` and `lineSetupWizard` from their source files (`setup-core.ts`, `setup-surface.ts`) instead of the barrel `extensions/line/api.ts`, breaking the `export *` ↔ re-export cycle
- Import `nostrSetupAdapter` and `nostrSetupWizard` from `extensions/nostr/src/setup-surface.ts` instead of `extensions/nostr/api.ts`
- Remove the redundant `listLineAccountIds` re-export from `extensions/line/src/setup-core.ts` (it's already exported via `src/line/accounts.ts` → `src/plugin-sdk/line.ts`) and move its import in `setup-surface.ts` to `../api.js`

Fixes 10 `CIRCULAR_REEXPORT` build warnings from rolldown/tsdown.

## Test plan

- [x] `pnpm build` passes with 0 `CIRCULAR_REEXPORT` errors
- [x] `pnpm test -- src/plugin-sdk/subpaths.test.ts` — all 32 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)