### PR TITLE
fix(ui): fall back to daily message counts in usage metrics

### DIFF
--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -91,6 +91,10 @@ const unitIsolatedFilesRaw = [
   "extensions/imessage/src/monitor.shutdown.unhandled-rejection.test.ts",
   // Mutates process.cwd() and mocks core module loaders; isolate from the shared fast lane.
   "src/infra/git-commit.test.ts",
+  // Loads bundled provider plugins via jiti; jiti's CJS transform is incompatible with
+  // vmForks (Cannot set property require of VM context which has only a getter). Run in
+  // process forks so vitest patches CJS require correctly and vi.mock works as expected.
+  "src/plugins/contracts/runtime.contract.test.ts",
 ];
 const unitIsolatedFiles = unitIsolatedFilesRaw.filter((file) => fs.existsSync(file));
 const unitSingletonIsolatedFilesRaw = [];

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -1,6 +1,17 @@
+import anthropicPlugin from "../../../extensions/anthropic/index.js";
+import githubCopilotPlugin from "../../../extensions/github-copilot/index.js";
+import googlePlugin from "../../../extensions/google/index.js";
+import minimaxPlugin from "../../../extensions/minimax/index.js";
+import mistralPlugin from "../../../extensions/mistral/index.js";
+import moonshotPlugin from "../../../extensions/moonshot/index.js";
+import openAIPlugin from "../../../extensions/openai/index.js";
+import qwenPortalAuthPlugin from "../../../extensions/qwen-portal-auth/index.js";
+import xaiPlugin from "../../../extensions/xai/index.js";
+import zaiPlugin from "../../../extensions/zai/index.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { withBundledPluginEnablementCompat } from "../bundled-compat.js";
 import { resolveBundledWebSearchPluginIds } from "../bundled-web-search.js";
+import { createCapturedPluginRegistration } from "../captured-registration.js";
 import { loadOpenClawPlugins } from "../loader.js";
 import { createPluginLoaderLogger } from "../logger.js";
 import { resolvePluginProviders } from "../providers.js";
@@ -11,6 +22,11 @@ import type {
   SpeechProviderPlugin,
   WebSearchProviderPlugin,
 } from "../types.js";
+
+type RegistrablePlugin = {
+  id: string;
+  register: (api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void;
+};
 
 type CapabilityContractEntry<T> = {
   pluginId: string;
@@ -65,25 +81,65 @@ export const providerContractRegistry: ProviderContractEntry[] = [];
 
 export let providerContractLoadError: Error | undefined;
 
+// Plugins with static imports that bypass jiti's CJS transform. jiti is
+// incompatible with vitest vmForks (Cannot set property require of VM context
+// which has only a getter) and can produce undefined exports for plugins whose
+// dependency chains re-import from the plugin SDK. Calling plugin.register()
+// directly here is safe in all vitest pool modes and avoids the jiti module
+// cache divergence that makes vi.mock() ineffective for jiti-loaded modules.
+const staticBundledProviderPlugins: RegistrablePlugin[] = [
+  anthropicPlugin,
+  githubCopilotPlugin,
+  googlePlugin,
+  minimaxPlugin,
+  mistralPlugin,
+  moonshotPlugin,
+  openAIPlugin,
+  qwenPortalAuthPlugin,
+  xaiPlugin,
+  zaiPlugin,
+];
+
+function captureRegistrations(plugin: RegistrablePlugin) {
+  const captured = createCapturedPluginRegistration();
+  plugin.register(captured.api);
+  return captured;
+}
+
+function buildStaticProviderEntries(): ProviderContractEntry[] {
+  return staticBundledProviderPlugins.flatMap((plugin) => {
+    const captured = captureRegistrations(plugin);
+    return captured.providers.map((provider) => ({ pluginId: plugin.id, provider }));
+  });
+}
+
 function loadBundledProviderRegistry(): ProviderContractEntry[] {
+  // Start with statically-imported providers (reliable in all vitest pool modes).
+  const staticEntries = buildStaticProviderEntries();
+  const staticPluginIdSet = new Set(staticBundledProviderPlugins.map((plugin) => plugin.id));
+
+  // Supplement with jiti-loaded providers for the remaining bundled plugins
+  // whose runtime contracts do not depend on vi.mock interception.
   try {
     providerContractLoadError = undefined;
-    return resolvePluginProviders({
+    const jitiEntries = resolvePluginProviders({
       bundledProviderAllowlistCompat: true,
       bundledProviderVitestCompat: true,
       cache: false,
       activate: false,
     })
-      .filter((provider): provider is ProviderPlugin & { pluginId: string } =>
-        Boolean(provider.pluginId),
+      .filter(
+        (provider): provider is ProviderPlugin & { pluginId: string } =>
+          Boolean(provider.pluginId) && !staticPluginIdSet.has(provider.pluginId as string),
       )
       .map((provider) => ({
         pluginId: provider.pluginId,
         provider,
       }));
+    return [...staticEntries, ...jitiEntries];
   } catch (error) {
     providerContractLoadError = error instanceof Error ? error : new Error(String(error));
-    return [];
+    return staticEntries;
   }
 }
 

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -1,20 +1,18 @@
 import anthropicPlugin from "../../../extensions/anthropic/index.js";
-import githubCopilotPlugin from "../../../extensions/github-copilot/index.js";
+import bravePlugin from "../../../extensions/brave/index.js";
+import elevenLabsPlugin from "../../../extensions/elevenlabs/index.js";
+import firecrawlPlugin from "../../../extensions/firecrawl/index.js";
 import googlePlugin from "../../../extensions/google/index.js";
+import microsoftPlugin from "../../../extensions/microsoft/index.js";
 import minimaxPlugin from "../../../extensions/minimax/index.js";
 import mistralPlugin from "../../../extensions/mistral/index.js";
 import moonshotPlugin from "../../../extensions/moonshot/index.js";
 import openAIPlugin from "../../../extensions/openai/index.js";
-import qwenPortalAuthPlugin from "../../../extensions/qwen-portal-auth/index.js";
+import perplexityPlugin from "../../../extensions/perplexity/index.js";
 import xaiPlugin from "../../../extensions/xai/index.js";
 import zaiPlugin from "../../../extensions/zai/index.js";
-import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { withBundledPluginEnablementCompat } from "../bundled-compat.js";
-import { resolveBundledWebSearchPluginIds } from "../bundled-web-search.js";
 import { createCapturedPluginRegistration } from "../captured-registration.js";
-import { loadOpenClawPlugins } from "../loader.js";
-import { createPluginLoaderLogger } from "../logger.js";
-import { resolvePluginProviders } from "../providers.js";
+import { loadPluginManifestRegistry } from "../manifest-registry.js";
 import type {
   ImageGenerationProviderPlugin,
   MediaUnderstandingProviderPlugin,
@@ -54,50 +52,38 @@ type PluginRegistrationContractEntry = {
   toolNames: string[];
 };
 
-const log = createSubsystemLogger("plugins");
+const bundledWebSearchPlugins: Array<RegistrablePlugin & { credentialValue: unknown }> = [
+  { ...bravePlugin, credentialValue: "BSA-test" },
+  { ...firecrawlPlugin, credentialValue: "fc-test" },
+  { ...googlePlugin, credentialValue: "AIza-test" },
+  { ...moonshotPlugin, credentialValue: "sk-test" },
+  { ...perplexityPlugin, credentialValue: "pplx-test" },
+  { ...xaiPlugin, credentialValue: "xai-test" },
+];
 
-const BUNDLED_WEB_SEARCH_CREDENTIAL_VALUES: Readonly<Record<string, unknown>> = {
-  brave: "BSA-test",
-  firecrawl: "fc-test",
-  google: "AIza-test",
-  moonshot: "sk-test",
-  perplexity: "pplx-test",
-  xai: "xai-test",
-};
+const bundledSpeechPlugins: RegistrablePlugin[] = [elevenLabsPlugin, microsoftPlugin, openAIPlugin];
 
-const BUNDLED_SPEECH_PLUGIN_IDS = ["elevenlabs", "microsoft", "openai"] as const;
-const BUNDLED_MEDIA_UNDERSTANDING_PLUGIN_IDS = [
-  "anthropic",
-  "google",
-  "minimax",
-  "mistral",
-  "moonshot",
-  "openai",
-  "zai",
-] as const;
-const BUNDLED_IMAGE_GENERATION_PLUGIN_IDS = ["google", "openai"] as const;
-
-export const providerContractRegistry: ProviderContractEntry[] = [];
-
-export let providerContractLoadError: Error | undefined;
-
-// Plugins with static imports that bypass jiti's CJS transform. jiti is
-// incompatible with vitest vmForks (Cannot set property require of VM context
-// which has only a getter) and can produce undefined exports for plugins whose
-// dependency chains re-import from the plugin SDK. Calling plugin.register()
-// directly here is safe in all vitest pool modes and avoids the jiti module
-// cache divergence that makes vi.mock() ineffective for jiti-loaded modules.
-const staticBundledProviderPlugins: RegistrablePlugin[] = [
+const bundledMediaUnderstandingPlugins: RegistrablePlugin[] = [
   anthropicPlugin,
-  githubCopilotPlugin,
   googlePlugin,
   minimaxPlugin,
   mistralPlugin,
   moonshotPlugin,
   openAIPlugin,
-  qwenPortalAuthPlugin,
-  xaiPlugin,
   zaiPlugin,
+];
+
+const bundledImageGenerationPlugins: RegistrablePlugin[] = [googlePlugin, openAIPlugin];
+
+const bundledPluginRegistrationList = [
+  ...new Map(
+    [
+      ...bundledSpeechPlugins,
+      ...bundledMediaUnderstandingPlugins,
+      ...bundledImageGenerationPlugins,
+      ...bundledWebSearchPlugins,
+    ].map((plugin) => [plugin.id, plugin]),
+  ).values(),
 ];
 
 function captureRegistrations(plugin: RegistrablePlugin) {
@@ -106,44 +92,156 @@ function captureRegistrations(plugin: RegistrablePlugin) {
   return captured;
 }
 
-function buildStaticProviderEntries(): ProviderContractEntry[] {
-  return staticBundledProviderPlugins.flatMap((plugin) => {
+function buildCapabilityContractRegistry<T>(params: {
+  plugins: RegistrablePlugin[];
+  select: (captured: ReturnType<typeof createCapturedPluginRegistration>) => T[];
+}): CapabilityContractEntry<T>[] {
+  return params.plugins.flatMap((plugin) => {
     const captured = captureRegistrations(plugin);
-    return captured.providers.map((provider) => ({ pluginId: plugin.id, provider }));
+    return params.select(captured).map((provider) => ({
+      pluginId: plugin.id,
+      provider,
+    }));
   });
 }
 
-function loadBundledProviderRegistry(): ProviderContractEntry[] {
-  // Start with statically-imported providers (reliable in all vitest pool modes).
-  const staticEntries = buildStaticProviderEntries();
-  const staticPluginIdSet = new Set(staticBundledProviderPlugins.map((plugin) => plugin.id));
+function buildPluginRegistrationContractRegistry(
+  providerEntries: readonly ProviderContractEntry[],
+): PluginRegistrationContractEntry[] {
+  const entries = [
+    ...new Map(
+      providerEntries.map((entry) => [
+        entry.pluginId,
+        {
+          pluginId: entry.pluginId,
+          providerIds: providerEntries
+            .filter((candidate) => candidate.pluginId === entry.pluginId)
+            .map((candidate) => candidate.provider.id),
+          speechProviderIds: [] as string[],
+          mediaUnderstandingProviderIds: [] as string[],
+          imageGenerationProviderIds: [] as string[],
+          webSearchProviderIds: [] as string[],
+          toolNames: [] as string[],
+        },
+      ]),
+    ).values(),
+  ];
 
-  // Supplement with jiti-loaded providers for the remaining bundled plugins
-  // whose runtime contracts do not depend on vi.mock interception.
-  try {
-    providerContractLoadError = undefined;
-    const jitiEntries = resolvePluginProviders({
-      bundledProviderAllowlistCompat: true,
-      bundledProviderVitestCompat: true,
-      cache: false,
-      activate: false,
-    })
-      .filter(
-        (provider): provider is ProviderPlugin & { pluginId: string } =>
-          Boolean(provider.pluginId) && !staticPluginIdSet.has(provider.pluginId as string),
-      )
-      .map((provider) => ({
-        pluginId: provider.pluginId,
-        provider,
-      }));
-    return [...staticEntries, ...jitiEntries];
-  } catch (error) {
-    providerContractLoadError = error instanceof Error ? error : new Error(String(error));
-    return staticEntries;
+  for (const plugin of bundledPluginRegistrationList) {
+    const captured = captureRegistrations(plugin);
+    const existing = entries.find((entry) => entry.pluginId === plugin.id);
+    const next = {
+      pluginId: plugin.id,
+      providerIds: captured.providers.map((provider) => provider.id),
+      speechProviderIds: captured.speechProviders.map((provider) => provider.id),
+      mediaUnderstandingProviderIds: captured.mediaUnderstandingProviders.map(
+        (provider) => provider.id,
+      ),
+      imageGenerationProviderIds: captured.imageGenerationProviders.map((provider) => provider.id),
+      webSearchProviderIds: captured.webSearchProviders.map((provider) => provider.id),
+      toolNames: captured.tools.map((tool) => tool.name),
+    };
+
+    if (!existing) {
+      entries.push(next);
+      continue;
+    }
+
+    existing.providerIds = next.providerIds.length > 0 ? next.providerIds : existing.providerIds;
+    existing.speechProviderIds = next.speechProviderIds;
+    existing.mediaUnderstandingProviderIds = next.mediaUnderstandingProviderIds;
+    existing.imageGenerationProviderIds = next.imageGenerationProviderIds;
+    existing.webSearchProviderIds = next.webSearchProviderIds;
+    existing.toolNames = next.toolNames;
   }
+
+  return entries;
 }
 
-const loadedBundledProviderRegistry: ProviderContractEntry[] = loadBundledProviderRegistry();
+export const providerContractRegistry: ProviderContractEntry[] = [];
+
+export let providerContractLoadError: Error | undefined;
+
+// Keep this loader map aligned with the bundled provider ids discovered from
+// manifest-registry so contract coverage keeps matching the real bundled set.
+const bundledProviderContractPluginLoaders: Record<
+  string,
+  () => Promise<{ default: RegistrablePlugin }>
+> = {
+  "amazon-bedrock": () => import("../../../extensions/amazon-bedrock/index.js"),
+  anthropic: () => import("../../../extensions/anthropic/index.js"),
+  byteplus: () => import("../../../extensions/byteplus/index.js"),
+  chutes: () => import("../../../extensions/chutes/index.js"),
+  "cloudflare-ai-gateway": () => import("../../../extensions/cloudflare-ai-gateway/index.js"),
+  "copilot-proxy": () => import("../../../extensions/copilot-proxy/index.js"),
+  fal: () => import("../../../extensions/fal/index.js"),
+  "github-copilot": () => import("../../../extensions/github-copilot/index.js"),
+  google: () => import("../../../extensions/google/index.js"),
+  huggingface: () => import("../../../extensions/huggingface/index.js"),
+  kilocode: () => import("../../../extensions/kilocode/index.js"),
+  kimi: () => import("../../../extensions/kimi-coding/index.js"),
+  minimax: () => import("../../../extensions/minimax/index.js"),
+  mistral: () => import("../../../extensions/mistral/index.js"),
+  modelstudio: () => import("../../../extensions/modelstudio/index.js"),
+  moonshot: () => import("../../../extensions/moonshot/index.js"),
+  nvidia: () => import("../../../extensions/nvidia/index.js"),
+  ollama: () => import("../../../extensions/ollama/index.js"),
+  openai: () => import("../../../extensions/openai/index.js"),
+  opencode: () => import("../../../extensions/opencode/index.js"),
+  "opencode-go": () => import("../../../extensions/opencode-go/index.js"),
+  openrouter: () => import("../../../extensions/openrouter/index.js"),
+  qianfan: () => import("../../../extensions/qianfan/index.js"),
+  "qwen-portal-auth": () => import("../../../extensions/qwen-portal-auth/index.js"),
+  sglang: () => import("../../../extensions/sglang/index.js"),
+  synthetic: () => import("../../../extensions/synthetic/index.js"),
+  together: () => import("../../../extensions/together/index.js"),
+  venice: () => import("../../../extensions/venice/index.js"),
+  "vercel-ai-gateway": () => import("../../../extensions/vercel-ai-gateway/index.js"),
+  vllm: () => import("../../../extensions/vllm/index.js"),
+  volcengine: () => import("../../../extensions/volcengine/index.js"),
+  xai: () => import("../../../extensions/xai/index.js"),
+  xiaomi: () => import("../../../extensions/xiaomi/index.js"),
+  zai: () => import("../../../extensions/zai/index.js"),
+};
+
+async function loadBundledProviderContractPlugins(): Promise<RegistrablePlugin[]> {
+  const bundledProviderPluginIds = loadPluginManifestRegistry({})
+    .plugins.filter((plugin) => plugin.origin === "bundled" && plugin.providers.length > 0)
+    .map((plugin) => plugin.id)
+    .toSorted((left, right) => left.localeCompare(right));
+
+  const modules = await Promise.all(
+    bundledProviderPluginIds.map((pluginId) => {
+      const load = bundledProviderContractPluginLoaders[pluginId];
+      if (!load) {
+        throw new Error(`missing bundled provider contract loader for ${pluginId}`);
+      }
+      return load();
+    }),
+  );
+
+  return modules.map((mod, index) => {
+    const plugin = mod.default as RegistrablePlugin | undefined;
+    if (!plugin) {
+      throw new Error(
+        `bundled provider contract plugin missing default export for ${bundledProviderPluginIds[index]}`,
+      );
+    }
+    return plugin;
+  });
+}
+
+let loadedBundledProviderRegistry: ProviderContractEntry[] = [];
+
+try {
+  loadedBundledProviderRegistry = buildCapabilityContractRegistry({
+    plugins: await loadBundledProviderContractPlugins(),
+    select: (captured) => captured.providers,
+  });
+  providerContractLoadError = undefined;
+} catch (error) {
+  providerContractLoadError = error instanceof Error ? error : new Error(String(error));
+}
 
 providerContractRegistry.splice(
   0,
@@ -162,55 +260,6 @@ export const providerContractPluginIds = [
 export const providerContractCompatPluginIds = providerContractPluginIds.map((pluginId) =>
   pluginId === "kimi-coding" ? "kimi" : pluginId,
 );
-
-const bundledCapabilityContractPluginIds = [
-  ...new Set([
-    ...providerContractCompatPluginIds,
-    ...resolveBundledWebSearchPluginIds({}),
-    ...BUNDLED_SPEECH_PLUGIN_IDS,
-    ...BUNDLED_MEDIA_UNDERSTANDING_PLUGIN_IDS,
-    ...BUNDLED_IMAGE_GENERATION_PLUGIN_IDS,
-  ]),
-].toSorted((left, right) => left.localeCompare(right));
-
-export let capabilityContractLoadError: Error | undefined;
-
-function loadBundledCapabilityRegistry() {
-  try {
-    capabilityContractLoadError = undefined;
-    return loadOpenClawPlugins({
-      config: withBundledPluginEnablementCompat({
-        config: {
-          plugins: {
-            enabled: true,
-            allow: bundledCapabilityContractPluginIds,
-            slots: {
-              memory: "none",
-            },
-          },
-        },
-        pluginIds: bundledCapabilityContractPluginIds,
-      }),
-      cache: false,
-      activate: false,
-      logger: createPluginLoaderLogger(log),
-    });
-  } catch (error) {
-    capabilityContractLoadError = error instanceof Error ? error : new Error(String(error));
-    return loadOpenClawPlugins({
-      config: {
-        plugins: {
-          enabled: false,
-        },
-      },
-      cache: false,
-      activate: false,
-      logger: createPluginLoaderLogger(log),
-    });
-  }
-}
-
-const loadedBundledCapabilityRegistry = loadBundledCapabilityRegistry();
 
 export function requireProviderContractProvider(providerId: string): ProviderPlugin {
   const provider = uniqueProviderContractProviders.find((entry) => entry.id === providerId);
@@ -251,51 +300,82 @@ export function resolveProviderContractProvidersForPluginIds(
   ];
 }
 
-export const webSearchProviderContractRegistry: WebSearchProviderContractEntry[] =
-  loadedBundledCapabilityRegistry.webSearchProviders
-    .filter((entry) => entry.pluginId in BUNDLED_WEB_SEARCH_CREDENTIAL_VALUES)
-    .map((entry) => ({
-      pluginId: entry.pluginId,
-      provider: entry.provider,
-      credentialValue: BUNDLED_WEB_SEARCH_CREDENTIAL_VALUES[entry.pluginId],
-    }));
-
-export const speechProviderContractRegistry: SpeechProviderContractEntry[] =
-  loadedBundledCapabilityRegistry.speechProviders.map((entry) => ({
-    pluginId: entry.pluginId,
-    provider: entry.provider,
-  }));
-
+export const webSearchProviderContractRegistry: WebSearchProviderContractEntry[] = [];
+export const speechProviderContractRegistry: SpeechProviderContractEntry[] = [];
 export const mediaUnderstandingProviderContractRegistry: MediaUnderstandingProviderContractEntry[] =
-  loadedBundledCapabilityRegistry.mediaUnderstandingProviders.map((entry) => ({
-    pluginId: entry.pluginId,
-    provider: entry.provider,
-  }));
+  [];
+export const imageGenerationProviderContractRegistry: ImageGenerationProviderContractEntry[] = [];
+export const pluginRegistrationContractRegistry: PluginRegistrationContractEntry[] = [];
 
-export const imageGenerationProviderContractRegistry: ImageGenerationProviderContractEntry[] =
-  loadedBundledCapabilityRegistry.imageGenerationProviders.map((entry) => ({
-    pluginId: entry.pluginId,
-    provider: entry.provider,
-  }));
+export let capabilityContractLoadError: Error | undefined;
 
-export const pluginRegistrationContractRegistry: PluginRegistrationContractEntry[] =
-  loadedBundledCapabilityRegistry.plugins
-    .filter(
-      (plugin) =>
-        plugin.origin === "bundled" &&
-        (plugin.providerIds.length > 0 ||
-          plugin.speechProviderIds.length > 0 ||
-          plugin.mediaUnderstandingProviderIds.length > 0 ||
-          plugin.imageGenerationProviderIds.length > 0 ||
-          plugin.webSearchProviderIds.length > 0 ||
-          plugin.toolNames.length > 0),
-    )
-    .map((plugin) => ({
+let loadedWebSearchProviderContractRegistry: WebSearchProviderContractEntry[] = [];
+let loadedSpeechProviderContractRegistry: SpeechProviderContractEntry[] = [];
+let loadedMediaUnderstandingProviderContractRegistry: MediaUnderstandingProviderContractEntry[] =
+  [];
+let loadedImageGenerationProviderContractRegistry: ImageGenerationProviderContractEntry[] = [];
+let loadedPluginRegistrationContractRegistry: PluginRegistrationContractEntry[] = [];
+
+try {
+  loadedWebSearchProviderContractRegistry = bundledWebSearchPlugins.flatMap((plugin) => {
+    const captured = captureRegistrations(plugin);
+    return captured.webSearchProviders.map((provider) => ({
       pluginId: plugin.id,
-      providerIds: plugin.providerIds,
-      speechProviderIds: plugin.speechProviderIds,
-      mediaUnderstandingProviderIds: plugin.mediaUnderstandingProviderIds,
-      imageGenerationProviderIds: plugin.imageGenerationProviderIds,
-      webSearchProviderIds: plugin.webSearchProviderIds,
-      toolNames: plugin.toolNames,
+      provider,
+      credentialValue: plugin.credentialValue,
     }));
+  });
+
+  loadedSpeechProviderContractRegistry = buildCapabilityContractRegistry({
+    plugins: bundledSpeechPlugins,
+    select: (captured) => captured.speechProviders,
+  });
+
+  loadedMediaUnderstandingProviderContractRegistry = buildCapabilityContractRegistry({
+    plugins: bundledMediaUnderstandingPlugins,
+    select: (captured) => captured.mediaUnderstandingProviders,
+  });
+
+  loadedImageGenerationProviderContractRegistry = buildCapabilityContractRegistry({
+    plugins: bundledImageGenerationPlugins,
+    select: (captured) => captured.imageGenerationProviders,
+  });
+
+  loadedPluginRegistrationContractRegistry = buildPluginRegistrationContractRegistry(
+    loadedBundledProviderRegistry,
+  );
+
+  capabilityContractLoadError = undefined;
+} catch (error) {
+  capabilityContractLoadError = error instanceof Error ? error : new Error(String(error));
+}
+
+webSearchProviderContractRegistry.splice(
+  0,
+  webSearchProviderContractRegistry.length,
+  ...loadedWebSearchProviderContractRegistry,
+);
+
+speechProviderContractRegistry.splice(
+  0,
+  speechProviderContractRegistry.length,
+  ...loadedSpeechProviderContractRegistry,
+);
+
+mediaUnderstandingProviderContractRegistry.splice(
+  0,
+  mediaUnderstandingProviderContractRegistry.length,
+  ...loadedMediaUnderstandingProviderContractRegistry,
+);
+
+imageGenerationProviderContractRegistry.splice(
+  0,
+  imageGenerationProviderContractRegistry.length,
+  ...loadedImageGenerationProviderContractRegistry,
+);
+
+pluginRegistrationContractRegistry.splice(
+  0,
+  pluginRegistrationContractRegistry.length,
+  ...loadedPluginRegistrationContractRegistry,
+);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -199,12 +199,24 @@ const resolvePluginSdkAliasFile = (params: {
 const resolvePluginSdkAlias = (): string | null =>
   resolvePluginSdkAliasFile({ srcFile: "root-alias.cjs", distFile: "root-alias.cjs" });
 
+function shouldUseNativePluginLoader(aliasMap: Record<string, string>): boolean {
+  const aliasTargets = Object.values(aliasMap);
+  if (aliasTargets.length === 0) {
+    return true;
+  }
+  return aliasTargets.every((target) => {
+    const normalized = target.replace(/\\/g, "/");
+    return normalized.includes("/dist/") && normalized.endsWith(".js");
+  });
+}
+
 function buildPluginLoaderJitiOptions(aliasMap: Record<string, string>) {
   return {
     interopDefault: true,
-    // Prefer Node's native sync ESM loader for built dist/*.js modules so
-    // bundled plugins and plugin-sdk subpaths stay on the canonical module graph.
-    tryNative: true,
+    // Native ESM works well for built dist/*.js modules, but source-checkout
+    // aliases target .ts entrypoints whose internal relative ".js" imports must
+    // stay on Jiti's TS-aware resolver.
+    tryNative: shouldUseNativePluginLoader(aliasMap),
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
     ...(Object.keys(aliasMap).length > 0
       ? {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -199,24 +199,12 @@ const resolvePluginSdkAliasFile = (params: {
 const resolvePluginSdkAlias = (): string | null =>
   resolvePluginSdkAliasFile({ srcFile: "root-alias.cjs", distFile: "root-alias.cjs" });
 
-function shouldUseNativePluginLoader(aliasMap: Record<string, string>): boolean {
-  const aliasTargets = Object.values(aliasMap);
-  if (aliasTargets.length === 0) {
-    return true;
-  }
-  return aliasTargets.every((target) => {
-    const normalized = target.replace(/\\/g, "/");
-    return normalized.includes("/dist/") && normalized.endsWith(".js");
-  });
-}
-
 function buildPluginLoaderJitiOptions(aliasMap: Record<string, string>) {
   return {
     interopDefault: true,
-    // Native ESM works well for built dist/*.js modules, but source-checkout
-    // aliases target .ts entrypoints whose internal relative ".js" imports must
-    // stay on Jiti's TS-aware resolver.
-    tryNative: shouldUseNativePluginLoader(aliasMap),
+    // Prefer Node's native sync ESM loader for built dist/*.js modules so
+    // bundled plugins and plugin-sdk subpaths stay on the canonical module graph.
+    tryNative: true,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
     ...(Object.keys(aliasMap).length > 0
       ? {

--- a/ui/src/ui/views/usage-metrics.test.ts
+++ b/ui/src/ui/views/usage-metrics.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { buildAggregatesFromSessions, buildPeakErrorHours } from "./usage-metrics.ts";
+import type { UsageSessionEntry } from "./usageTypes.ts";
+
+function makeSession(
+  usage: NonNullable<UsageSessionEntry["usage"]>,
+  overrides: Partial<UsageSessionEntry> = {},
+): UsageSessionEntry {
+  return {
+    key: overrides.key ?? "session-1",
+    label: overrides.label ?? "Session 1",
+    updatedAt: overrides.updatedAt ?? 0,
+    agentId: overrides.agentId ?? "main",
+    channel: overrides.channel ?? "web",
+    usage,
+    ...overrides,
+  } as UsageSessionEntry;
+}
+
+describe("buildAggregatesFromSessions", () => {
+  it("falls back to dailyMessageCounts when messageCounts is missing", () => {
+    const aggregates = buildAggregatesFromSessions([
+      makeSession({
+        totalTokens: 2400,
+        totalCost: 0,
+        input: 1200,
+        output: 1200,
+        cacheRead: 0,
+        cacheWrite: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+        dailyMessageCounts: [
+          {
+            date: "2026-03-01",
+            total: 7,
+            user: 3,
+            assistant: 2,
+            toolCalls: 2,
+            toolResults: 1,
+            errors: 1,
+          },
+          {
+            date: "2026-03-02",
+            total: 5,
+            user: 1,
+            assistant: 1,
+            toolCalls: 1,
+            toolResults: 2,
+            errors: 0,
+          },
+        ],
+      }),
+    ]);
+
+    expect(aggregates.messages.total).toBe(12);
+    expect(aggregates.messages.user).toBe(4);
+    expect(aggregates.messages.assistant).toBe(3);
+    expect(aggregates.messages.toolCalls).toBe(3);
+    expect(aggregates.messages.toolResults).toBe(3);
+    expect(aggregates.messages.errors).toBe(1);
+  });
+
+  it("prefers messageCounts when both messageCounts and dailyMessageCounts exist", () => {
+    const aggregates = buildAggregatesFromSessions([
+      makeSession({
+        totalTokens: 1000,
+        totalCost: 0,
+        input: 400,
+        output: 600,
+        cacheRead: 0,
+        cacheWrite: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+        messageCounts: {
+          total: 4,
+          user: 2,
+          assistant: 2,
+          toolCalls: 1,
+          toolResults: 3,
+          errors: 1,
+        },
+        dailyMessageCounts: [
+          {
+            date: "2026-03-01",
+            total: 9,
+            user: 0,
+            assistant: 0,
+            toolCalls: 5,
+            toolResults: 0,
+            errors: 4,
+          },
+        ],
+      }),
+    ]);
+
+    expect(aggregates.messages.total).toBe(4);
+    expect(aggregates.messages.user).toBe(2);
+    expect(aggregates.messages.assistant).toBe(2);
+    expect(aggregates.messages.toolCalls).toBe(1);
+    expect(aggregates.messages.toolResults).toBe(3);
+    expect(aggregates.messages.errors).toBe(1);
+  });
+});
+
+describe("buildPeakErrorHours", () => {
+  it("uses dailyMessageCounts fallback when messageCounts is missing", () => {
+    const peakHours = buildPeakErrorHours(
+      [
+        makeSession({
+          totalTokens: 1000,
+          totalCost: 0,
+          input: 400,
+          output: 600,
+          cacheRead: 0,
+          cacheWrite: 0,
+          inputCost: 0,
+          outputCost: 0,
+          cacheReadCost: 0,
+          cacheWriteCost: 0,
+          missingCostEntries: 0,
+          firstActivity: Date.UTC(2026, 2, 1, 10, 0, 0),
+          lastActivity: Date.UTC(2026, 2, 1, 10, 30, 0),
+          dailyMessageCounts: [
+            {
+              date: "2026-03-01",
+              total: 10,
+              user: 3,
+              assistant: 4,
+              toolCalls: 2,
+              toolResults: 1,
+              errors: 2,
+            },
+          ],
+        }),
+      ],
+      "utc",
+    );
+
+    expect(peakHours).toHaveLength(1);
+    expect(peakHours[0]?.value).toBe("20.00%");
+    expect(peakHours[0]?.sub).toContain("2");
+    expect(peakHours[0]?.sub).toContain("10");
+  });
+});

--- a/ui/src/ui/views/usage-metrics.ts
+++ b/ui/src/ui/views/usage-metrics.ts
@@ -34,7 +34,8 @@ function buildPeakErrorHours(sessions: UsageSessionEntry[], timeZone: "local" | 
 
   for (const session of sessions) {
     const usage = session.usage;
-    if (!usage?.messageCounts || usage.messageCounts.total === 0) {
+    const messageCounts = getMessageCountsWithFallback(usage);
+    if (!usage || !messageCounts || messageCounts.total === 0) {
       continue;
     }
     const start = usage.firstActivity ?? session.updatedAt;
@@ -55,8 +56,8 @@ function buildPeakErrorHours(sessions: UsageSessionEntry[], timeZone: "local" | 
       const nextMs = Math.min(nextHour.getTime(), endMs);
       const minutes = Math.max((nextMs - cursor) / 60000, 0);
       const share = minutes / totalMinutes;
-      hourErrors[hour] += usage.messageCounts.errors * share;
-      hourMsgs[hour] += usage.messageCounts.total * share;
+      hourErrors[hour] += messageCounts.errors * share;
+      hourMsgs[hour] += messageCounts.total * share;
       cursor = nextMs + 1;
     }
   }
@@ -320,6 +321,30 @@ const mergeUsageTotals = (target: UsageTotals, source: Partial<UsageTotals>) => 
   target.missingCostEntries += source.missingCostEntries ?? 0;
 };
 
+const getMessageCountsWithFallback = (usage: UsageSessionEntry["usage"]) => {
+  if (!usage) {
+    return undefined;
+  }
+  if (usage.messageCounts) {
+    return usage.messageCounts;
+  }
+  if (!usage.dailyMessageCounts?.length) {
+    return undefined;
+  }
+  return usage.dailyMessageCounts.reduce(
+    (counts, day) => {
+      counts.total += day.total ?? 0;
+      counts.user += day.user ?? 0;
+      counts.assistant += day.assistant ?? 0;
+      counts.toolCalls += day.toolCalls ?? 0;
+      counts.toolResults += day.toolResults ?? 0;
+      counts.errors += day.errors ?? 0;
+      return counts;
+    },
+    { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 },
+  );
+};
+
 const buildAggregatesFromSessions = (
   sessions: UsageSessionEntry[],
   fallback?: UsageAggregates | null,
@@ -376,13 +401,14 @@ const buildAggregatesFromSessions = (
     if (!usage) {
       continue;
     }
-    if (usage.messageCounts) {
-      messages.total += usage.messageCounts.total;
-      messages.user += usage.messageCounts.user;
-      messages.assistant += usage.messageCounts.assistant;
-      messages.toolCalls += usage.messageCounts.toolCalls;
-      messages.toolResults += usage.messageCounts.toolResults;
-      messages.errors += usage.messageCounts.errors;
+    const messageCounts = getMessageCountsWithFallback(usage);
+    if (messageCounts) {
+      messages.total += messageCounts.total;
+      messages.user += messageCounts.user;
+      messages.assistant += messageCounts.assistant;
+      messages.toolCalls += messageCounts.toolCalls;
+      messages.toolResults += messageCounts.toolResults;
+      messages.errors += messageCounts.errors;
     }
 
     if (usage.toolUsage) {


### PR DESCRIPTION
## Summary
Fix usage aggregates when usage.messageCounts is missing by falling back to dailyMessageCounts.

This also applies the same fallback to peak error hour calculations so usage insights stay consistent when only daily message counts are present.

## Changes
- add a shared fallback path in usage-metrics.ts for sessions that only have dailyMessageCounts
- preserve user, ssistant, 	oolCalls, 	oolResults, and errors totals in fallback aggregation
- reuse the fallback counts in uildPeakErrorHours
- add regression tests covering fallback aggregation, source precedence, and peak error hours

## Testing
- corepack pnpm --dir E:\Temporary\Github\openclaw-pr\ui exec vitest run src/ui/views/usage-metrics.test.ts
- Result: 3 passed

## Notes
- This supersedes #43047, which was rebuilt cleanly on top of latest main.
- No screenshot included because this is a logic-path fix rather than a layout or styling change.