### PR TITLE
fix: normalize mlx-vlm usage token aliases

### DIFF
--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -71,6 +71,21 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("handles mlx-vlm/vLLM input_tokens and output_tokens aliases", () => {
+    const usage = normalizeUsage({
+      input_tokens: 11,
+      output_tokens: 5,
+      total_tokens: 16,
+    });
+    expect(usage).toEqual({
+      input: 11,
+      output: 5,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      total: 16,
+    });
+  });
+
   it("handles Kimi K2 prompt_tokens_details.cached_tokens field", () => {
     // Kimi K2 uses automatic prefix caching and returns cached_tokens in prompt_tokens_details
     const usage = normalizeUsage({

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -15,6 +15,10 @@ export type UsageLike = {
   completion_tokens?: number;
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
+  // OpenAI-compatible servers sometimes emit snake_case input/output aliases.
+  // Examples: mlx-vlm, vLLM.
+  input_tokens?: number;
+  output_tokens?: number;
   // Moonshot/Kimi uses cached_tokens for cache read count (explicit caching API).
   cached_tokens?: number;
   // Kimi K2 uses prompt_tokens_details.cached_tokens for automatic prefix caching.


### PR DESCRIPTION
## Summary
- normalize `input_tokens` / `output_tokens` usage aliases in `normalizeUsage()`
- add a regression test covering mlx-vlm / vLLM-style usage payloads

Fixes #49316.

## Notes
- This keeps the change narrowly scoped to usage normalization so `/status` and related displays can consume mlx-vlm token usage correctly.
- I did not run the full workspace test suite in this fresh shallow clone because dependencies are not installed by default in this cron flow.
