### PR TITLE
fix(sandbox): use container IP for browser CDP when gateway runs in Docker

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import os from "node:os";
 import { startBrowserBridgeServer, stopBrowserBridgeServer } from "../../browser/bridge-server.js";
 import { type ResolvedBrowserConfig, resolveProfile } from "../../browser/config.js";
 import {
@@ -16,7 +17,9 @@ import {
   buildSandboxCreateArgs,
   dockerContainerState,
   execDocker,
+  isRunningInContainer,
   readDockerContainerEnvVar,
+  readDockerContainerIP,
   readDockerContainerLabel,
   readDockerPort,
 } from "./docker.js";
@@ -38,9 +41,13 @@ import { appendWorkspaceMountArgs } from "./workspace-mounts.js";
 const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 const CDP_SOURCE_RANGE_ENV_KEY = "OPENCLAW_BROWSER_CDP_SOURCE_RANGE";
 
-async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number }): Promise<boolean> {
+async function waitForSandboxCdp(params: {
+  cdpHost: string;
+  cdpPort: number;
+  timeoutMs: number;
+}): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, params.timeoutMs);
-  const url = `http://127.0.0.1:${params.cdpPort}/json/version`;
+  const url = `http://${params.cdpHost}:${params.cdpPort}/json/version`;
   while (Date.now() < deadline) {
     try {
       const ctrl = new AbortController();
@@ -63,19 +70,21 @@ async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number })
 
 function buildSandboxBrowserResolvedConfig(params: {
   controlPort: number;
+  cdpHost: string;
   cdpPort: number;
   headless: boolean;
   evaluateEnabled: boolean;
 }): ResolvedBrowserConfig {
-  const cdpHost = "127.0.0.1";
+  const cdpHost = params.cdpHost;
   const cdpPortRange = deriveDefaultBrowserCdpPortRange(params.controlPort);
+  const cdpIsLoopback = cdpHost === "127.0.0.1" || cdpHost === "::1" || cdpHost === "localhost";
   return {
     enabled: true,
     evaluateEnabled: params.evaluateEnabled,
     controlPort: params.controlPort,
     cdpProtocol: "http",
     cdpHost,
-    cdpIsLoopback: true,
+    cdpIsLoopback,
     cdpPortRangeStart: cdpPortRange.start,
     cdpPortRangeEnd: cdpPortRange.end,
     remoteCdpTimeoutMs: 1500,
@@ -280,6 +289,31 @@ export async function ensureSandboxBrowser(params: {
   const mappedNoVnc = noVncEnabled
     ? await readDockerPort(containerName, params.cfg.browser.noVncPort)
     : null;
+
+  // When gateway runs inside a container, 127.0.0.1:hostMappedPort is unreachable.
+  // Use browser container's IP on shared Docker network + internal CDP port instead.
+  let cdpHost = "127.0.0.1";
+  let cdpPort = mappedCdp;
+
+  if (isRunningInContainer()) {
+    // Auto-connect gateway to browser network (idempotent, no-op if already connected)
+    const hostname = os.hostname();
+    await execDocker(["network", "connect", browserDockerCfg.network, hostname], {
+      allowFailure: true,
+    });
+
+    const containerIP = await readDockerContainerIP(containerName, browserDockerCfg.network);
+    if (containerIP) {
+      cdpHost = containerIP;
+      cdpPort = params.cfg.browser.cdpPort; // internal port (e.g. 9222)
+    }
+    // Fall through to host-mapped port if IP lookup fails
+  }
+
+  let resolvedNoVncPort = mappedNoVnc;
+  if (isRunningInContainer() && cdpHost !== "127.0.0.1" && mappedNoVnc) {
+    resolvedNoVncPort = params.cfg.browser.noVncPort; // internal port
+  }
   if (noVncEnabled && !noVncPassword) {
     noVncPassword =
       (await readDockerContainerEnvVar(containerName, NOVNC_PASSWORD_ENV_KEY)) ?? undefined;
@@ -304,7 +338,7 @@ export async function ensureSandboxBrowser(params: {
   }
 
   const shouldReuse =
-    existing && existing.containerName === containerName && existingProfile?.cdpPort === mappedCdp;
+    existing && existing.containerName === containerName && existingProfile?.cdpPort === cdpPort;
   const authMatches =
     !existing ||
     (existing.authToken === desiredAuthToken && existing.authPassword === desiredAuthPassword);
@@ -336,12 +370,13 @@ export async function ensureSandboxBrowser(params: {
             await execDocker(["start", containerName]);
           }
           const ok = await waitForSandboxCdp({
-            cdpPort: mappedCdp,
+            cdpHost,
+            cdpPort,
             timeoutMs: params.cfg.browser.autoStartTimeoutMs,
           });
           if (!ok) {
             throw new Error(
-              `Sandbox browser CDP did not become reachable on 127.0.0.1:${mappedCdp} within ${params.cfg.browser.autoStartTimeoutMs}ms.`,
+              `Sandbox browser CDP did not become reachable on ${cdpHost}:${cdpPort} within ${params.cfg.browser.autoStartTimeoutMs}ms.`,
             );
           }
         }
@@ -350,7 +385,8 @@ export async function ensureSandboxBrowser(params: {
     return await startBrowserBridgeServer({
       resolved: buildSandboxBrowserResolvedConfig({
         controlPort: 0,
-        cdpPort: mappedCdp,
+        cdpHost,
+        cdpPort,
         headless: params.cfg.browser.headless,
         evaluateEnabled: params.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED,
       }),
@@ -378,15 +414,15 @@ export async function ensureSandboxBrowser(params: {
     lastUsedAtMs: now,
     image: browserImage,
     configHash: hashMismatch && running ? (currentHash ?? undefined) : expectedHash,
-    cdpPort: mappedCdp,
-    noVncPort: mappedNoVnc ?? undefined,
+    cdpPort: cdpPort,
+    noVncPort: resolvedNoVncPort ?? undefined,
   });
 
   const noVncUrl =
-    mappedNoVnc && noVncEnabled
+    resolvedNoVncPort && noVncEnabled
       ? (() => {
           const token = issueNoVncObserverToken({
-            noVncPort: mappedNoVnc,
+            noVncPort: resolvedNoVncPort,
             password: noVncPassword,
           });
           return buildNoVncObserverTokenUrl(resolvedBridge.baseUrl, token);

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   materializeWindowsSpawnProgram,
@@ -238,6 +239,34 @@ export async function readDockerPort(containerName: string, port: number) {
   }
   const mapped = Number.parseInt(match[1] ?? "", 10);
   return Number.isFinite(mapped) ? mapped : null;
+}
+
+let _isInContainer: boolean | null = null;
+export function isRunningInContainer(): boolean {
+  if (_isInContainer !== null) {
+    return _isInContainer;
+  }
+  try {
+    _isInContainer = fs.existsSync("/.dockerenv") || fs.existsSync("/run/.containerenv");
+  } catch {
+    _isInContainer = false;
+  }
+  return _isInContainer;
+}
+
+export async function readDockerContainerIP(
+  containerName: string,
+  networkName: string,
+): Promise<string | null> {
+  const fmt = `{{.NetworkSettings.Networks.${networkName}.IPAddress}}`;
+  const result = await execDocker(["inspect", "-f", fmt, containerName], {
+    allowFailure: true,
+  });
+  if (result.code !== 0) {
+    return null;
+  }
+  const ip = result.stdout.trim();
+  return ip && ip !== "<no value>" ? ip : null;
 }
 
 async function dockerImageExists(image: string) {


### PR DESCRIPTION
## Summary

- When the OpenClaw gateway runs inside a Docker container (bridge mode), the sandbox browser container's CDP port is unreachable because `browser.ts` hardcodes `127.0.0.1` as the CDP host and uses the host-mapped port. Inside the gateway container, `127.0.0.1` refers to itself, not the host.
- This PR detects when the gateway is running in a container, auto-connects it to the sandbox browser Docker network, and uses the browser container's IP + internal CDP port instead.
- Falls back to existing `127.0.0.1` + host-mapped port behavior when running on the host — zero regression risk.

## Changes

**`src/agents/sandbox/docker.ts`:**
- `isRunningInContainer()` — detects Docker (`/.dockerenv`) and Podman (`/run/.containerenv`), cached
- `readDockerContainerIP()` — gets container IP on a specific Docker network via `docker inspect`

**`src/agents/sandbox/browser.ts`:**
- `waitForSandboxCdp` and `buildSandboxBrowserResolvedConfig` accept dynamic `cdpHost` instead of hardcoding `127.0.0.1`
- `ensureSandboxBrowser` resolves CDP host/port based on gateway environment:
  - Host gateway: `127.0.0.1:hostMappedPort` (unchanged)
  - Containerized gateway: `containerIP:internalCdpPort` (e.g. `172.20.0.2:9222`)
- Auto-connects gateway container to browser sandbox network (idempotent)
- Same pattern applied to noVNC port resolution

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test -- src/agents/sandbox/browser` — all 9 tests pass
- [ ] Manual: Docker bridge mode — send browser task to sandboxed agent, verify CDP connects via container IP
- [ ] Manual: Host gateway — verify existing behavior unchanged