### PR TITLE
fix(acp): dispatch abort signal with timeout to prevent ghost turns and stuck sessions

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -702,6 +702,10 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
+    // Pass input.signal so throwIfAborted() fires before any work starts when
+    // the queue drains for a turn whose caller already timed out (ghost turn
+    // prevention). Without this, the queued runTurn executes fully even after
+    // withTimeout() has already rejected the caller. refs #17258
     await this.withSessionActor(
       sessionKey,
       async () => {
@@ -761,7 +765,11 @@ export class AcpSessionManager {
 
             internalAbortController = new AbortController();
             onCallerAbort = () => {
-              internalAbortController?.abort();
+              try {
+                internalAbortController?.abort();
+              } catch (err) {
+                logVerbose(`acp-manager: onCallerAbort threw for ${sessionKey}: ${String(err)}`);
+              }
             };
             if (input.signal?.aborted) {
               internalAbortController.abort();
@@ -937,6 +945,7 @@ export class AcpSessionManager {
                 handle,
                 meta,
                 failOnStatusError: false,
+                signal: input.signal,
               }));
             }
             if (
@@ -1943,6 +1952,7 @@ export class AcpSessionManager {
     meta: SessionAcpMeta;
     runtimeStatus?: AcpRuntimeStatus;
     failOnStatusError: boolean;
+    signal?: AbortSignal;
   }): Promise<{
     handle: AcpRuntimeHandle;
     meta: SessionAcpMeta;

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -766,13 +766,13 @@ export class AcpSessionManager {
             internalAbortController = new AbortController();
             onCallerAbort = () => {
               try {
-                internalAbortController?.abort();
+                internalAbortController?.abort(input.signal?.reason);
               } catch (err) {
                 logVerbose(`acp-manager: onCallerAbort threw for ${sessionKey}: ${String(err)}`);
               }
             };
             if (input.signal?.aborted) {
-              internalAbortController.abort();
+              internalAbortController.abort(input.signal.reason);
             } else if (input.signal) {
               input.signal.addEventListener("abort", onCallerAbort, { once: true });
             }

--- a/src/acp/control-plane/manager.identity-reconcile.ts
+++ b/src/acp/control-plane/manager.identity-reconcile.ts
@@ -21,6 +21,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
   meta: SessionAcpMeta;
   runtimeStatus?: AcpRuntimeStatus;
   failOnStatusError: boolean;
+  signal?: AbortSignal;
   setCachedHandle: (sessionKey: string, handle: AcpRuntimeHandle) => void;
   writeSessionMeta: (params: {
     cfg: OpenClawConfig;
@@ -43,6 +44,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
         run: async () =>
           await params.runtime.getStatus!({
             handle: params.handle,
+            ...(params.signal ? { signal: params.signal } : {}),
           }),
         fallbackCode: "ACP_TURN_FAILED",
         fallbackMessage: "Could not read ACP runtime status.",
@@ -98,13 +100,20 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
           : {}),
       }
     : params.handle;
-  if (handleChanged) {
+  if (handleChanged && !params.signal?.aborted) {
     params.setCachedHandle(params.sessionKey, nextHandle);
   }
 
   const metaChanged =
     !identityEquals(currentIdentity, nextIdentity) || hasLegacyAcpIdentityProjection(params.meta);
   if (!metaChanged) {
+    return {
+      handle: nextHandle,
+      meta: params.meta,
+      runtimeStatus,
+    };
+  }
+  if (params.signal?.aborted) {
     return {
       handle: nextHandle,
       meta: params.meta,
@@ -143,6 +152,14 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
     mutate: (current, entry) => {
       if (!entry) {
         return null;
+      }
+      // Re-check abort *inside* the mutator so that if the signal fires while
+      // waiting on the updateSessionStore lock, we still no-op instead of
+      // overwriting newer session state with stale reconcile data.
+      // Return undefined (not null) so upsertAcpSessionMeta treats this as a
+      // no-op rather than a delete operation.
+      if (params.signal?.aborted) {
+        return undefined;
       }
       const base = current ?? entry.acp;
       if (!base) {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -6,6 +6,7 @@ import {
   isSessionIdentityPending,
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
+import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
@@ -13,6 +14,7 @@ import { emitAgentEvent } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
+import { withTimeout } from "../../node-host/with-timeout.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -417,16 +419,25 @@ export async function tryDispatchAcpReply(params: {
       logVerbose(`dispatch-acp: start reply lifecycle failed: ${formatErrorMessage(error)}`);
     }
 
-    await acpManager.runTurn({
-      cfg: params.cfg,
-      sessionKey: canonicalSessionKey,
-      text: promptText,
-      attachments: attachments.length > 0 ? attachments : undefined,
-      mode: "prompt",
-      requestId: resolveAcpRequestId(params.ctx),
-      ...(params.abortSignal ? { signal: params.abortSignal } : {}),
-      onEvent: async (event) => await projector.onEvent(event),
-    });
+    // Guard against stalled upstream streams: abort the turn after the configured
+    // agent timeout (agents.defaults.timeoutSeconds, default 600s). Without this,
+    // a silently hung SSE connection blocks the session queue forever. refs #17258
+    const turnTimeoutMs = resolveAgentTimeoutMs({ cfg: params.cfg, minMs: 30_000 });
+    await withTimeout(
+      (signal) =>
+        acpManager.runTurn({
+          cfg: params.cfg,
+          sessionKey: canonicalSessionKey,
+          text: promptText,
+          attachments: attachments.length > 0 ? attachments : undefined,
+          mode: "prompt",
+          requestId: resolveAcpRequestId(params.ctx),
+          onEvent: (event) => projector.onEvent(event),
+          signal,
+        }),
+      turnTimeoutMs,
+      "ACP turn",
+    );
 
     await projector.flush(true);
     queuedFinal =

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -425,18 +425,20 @@ export async function tryDispatchAcpReply(params: {
     // agent timeout (agents.defaults.timeoutSeconds, default 600s). Without this,
     // a silently hung SSE connection blocks the session queue forever. refs #17258
     //
-    // P2: Align the wrapper timeout with the session-aware source so the dispatch
-    // timeout matches what AcpSessionManager.runTurn uses internally.
-    // runtimeOptions.timeoutSeconds takes priority over the global default.
-    const sessionRuntimeTimeoutSeconds =
-      acpResolution.kind === "ready"
-        ? resolveRuntimeOptionsFromMeta(acpResolution.meta).timeoutSeconds
-        : undefined;
+    // P2 (rev): Re-resolve session state immediately before runTurn so the wrapper
+    // timeout reflects the most current runtimeOptions — not the stale snapshot
+    // captured at the top of tryDispatchAcpReply (before media work and before
+    // runTurn acquires the session actor). If the session was updated in that window,
+    // this ensures dispatch and AcpSessionManager.runTurn share the same budget.
+    const liveAcpMeta = readAcpSessionEntry({ cfg: params.cfg, sessionKey })?.acp ?? undefined;
+    const liveTimeoutSeconds = liveAcpMeta
+      ? resolveRuntimeOptionsFromMeta(liveAcpMeta).timeoutSeconds
+      : undefined;
     const turnTimeoutMs =
-      typeof sessionRuntimeTimeoutSeconds === "number" &&
-      Number.isFinite(sessionRuntimeTimeoutSeconds) &&
-      sessionRuntimeTimeoutSeconds > 0
-        ? Math.max(30_000, Math.round(sessionRuntimeTimeoutSeconds * 1_000))
+      typeof liveTimeoutSeconds === "number" &&
+      Number.isFinite(liveTimeoutSeconds) &&
+      liveTimeoutSeconds > 0
+        ? Math.max(30_000, Math.round(liveTimeoutSeconds * 1_000))
         : resolveAgentTimeoutMs({ cfg: params.cfg, minMs: 30_000 });
 
     // P1b: Track the runTurn promise so that when the dispatch-level timeout fires

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -429,7 +429,8 @@ export async function tryDispatchAcpReply(params: {
     // captured at the top of tryDispatchAcpReply (before media work and before
     // runTurn acquires the session actor). If the session was updated in that window,
     // this ensures dispatch and AcpSessionManager.runTurn share the same budget.
-    const liveAcpMeta = readAcpSessionEntry({ cfg: params.cfg, sessionKey })?.acp ?? undefined;
+    const { readAcpSessionEntry: readLiveAcpSessionEntry } = await loadDispatchAcpSessionRuntime();
+    const liveAcpMeta = readLiveAcpSessionEntry({ cfg: params.cfg, sessionKey })?.acp ?? undefined;
     const liveTimeoutSeconds = liveAcpMeta
       ? resolveRuntimeOptionsFromMeta(liveAcpMeta).timeoutSeconds
       : undefined;

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -430,7 +430,9 @@ export async function tryDispatchAcpReply(params: {
     // runTurn acquires the session actor). If the session was updated in that window,
     // this ensures dispatch and AcpSessionManager.runTurn share the same budget.
     const { readAcpSessionEntry: readLiveAcpSessionEntry } = await loadDispatchAcpSessionRuntime();
-    const liveAcpMeta = readLiveAcpSessionEntry({ cfg: params.cfg, sessionKey })?.acp ?? undefined;
+    const liveAcpMeta =
+      readLiveAcpSessionEntry({ cfg: params.cfg, sessionKey: canonicalSessionKey })?.acp ??
+      undefined;
     const liveTimeoutSeconds = liveAcpMeta
       ? resolveRuntimeOptionsFromMeta(liveAcpMeta).timeoutSeconds
       : undefined;
@@ -453,10 +455,26 @@ export async function tryDispatchAcpReply(params: {
         // so that either cancellation path (caller abort OR dispatch timeout)
         // reaches runTurn. Previously only the timeout signal was forwarded,
         // dropping params.abortSignal entirely.
-        const signal =
-          params.abortSignal != null && typeof AbortSignal.any === "function"
-            ? AbortSignal.any([timeoutSignal!, params.abortSignal])
-            : timeoutSignal;
+        let signal: AbortSignal | undefined;
+        if (params.abortSignal != null && typeof AbortSignal.any === "function") {
+          signal = AbortSignal.any([timeoutSignal!, params.abortSignal]);
+        } else if (params.abortSignal != null && timeoutSignal != null) {
+          // Fallback for runtimes without AbortSignal.any: relay params.abortSignal
+          // into a local controller that also listens to the timeout signal.
+          const controller = new AbortController();
+          const relayAbort = (source: AbortSignal) => () => {
+            if (!controller.signal.aborted) {
+              controller.abort(source.reason);
+            }
+          };
+          timeoutSignal.addEventListener("abort", relayAbort(timeoutSignal), { once: true });
+          params.abortSignal.addEventListener("abort", relayAbort(params.abortSignal), {
+            once: true,
+          });
+          signal = controller.signal;
+        } else {
+          signal = timeoutSignal;
+        }
         runTurnSettlePromise = acpManager.runTurn({
           cfg: params.cfg,
           sessionKey: canonicalSessionKey,

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -483,7 +483,7 @@ export async function tryDispatchAcpReply(params: {
           }),
           new Promise<void>((resolve) => {
             const t = setTimeout(resolve, DRAIN_GRACE_MS);
-            (t as NodeJS.Timeout).unref?.();
+            t.unref?.();
           }),
         ]);
       }

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -1,3 +1,5 @@
+import type { AcpTurnAttachment } from "../../acp/control-plane/manager.types.js";
+import { resolveRuntimeOptionsFromMeta } from "../../acp/control-plane/runtime-options.js";
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../../acp/policy.js";
 import { formatAcpRuntimeErrorText } from "../../acp/runtime/error-text.js";
 import { toAcpRuntimeError } from "../../acp/runtime/errors.js";
@@ -422,10 +424,38 @@ export async function tryDispatchAcpReply(params: {
     // Guard against stalled upstream streams: abort the turn after the configured
     // agent timeout (agents.defaults.timeoutSeconds, default 600s). Without this,
     // a silently hung SSE connection blocks the session queue forever. refs #17258
-    const turnTimeoutMs = resolveAgentTimeoutMs({ cfg: params.cfg, minMs: 30_000 });
+    //
+    // P2: Align the wrapper timeout with the session-aware source so the dispatch
+    // timeout matches what AcpSessionManager.runTurn uses internally.
+    // runtimeOptions.timeoutSeconds takes priority over the global default.
+    const sessionRuntimeTimeoutSeconds =
+      acpResolution.kind === "ready"
+        ? resolveRuntimeOptionsFromMeta(acpResolution.meta).timeoutSeconds
+        : undefined;
+    const turnTimeoutMs =
+      typeof sessionRuntimeTimeoutSeconds === "number" &&
+      Number.isFinite(sessionRuntimeTimeoutSeconds) &&
+      sessionRuntimeTimeoutSeconds > 0
+        ? Math.max(30_000, Math.round(sessionRuntimeTimeoutSeconds * 1_000))
+        : resolveAgentTimeoutMs({ cfg: params.cfg, minMs: 30_000 });
+
+    // P1b: Track the runTurn promise so that when the dispatch-level timeout fires
+    // we can wait for runTurn to settle before surfacing the error. Without this,
+    // withTimeout() returns while runTurn drains in the background, causing late
+    // events and keeping the session actor queue locked.
+    const DRAIN_GRACE_MS = 5_000;
+    let runTurnSettlePromise: Promise<void> | undefined;
     await withTimeout(
-      (signal) =>
-        acpManager.runTurn({
+      (timeoutSignal) => {
+        // P1a: Combine the caller's upstream abort signal with the timeout signal
+        // so that either cancellation path (caller abort OR dispatch timeout)
+        // reaches runTurn. Previously only the timeout signal was forwarded,
+        // dropping params.abortSignal entirely.
+        const signal =
+          params.abortSignal != null && typeof AbortSignal.any === "function"
+            ? AbortSignal.any([timeoutSignal!, params.abortSignal])
+            : timeoutSignal;
+        runTurnSettlePromise = acpManager.runTurn({
           cfg: params.cfg,
           sessionKey: canonicalSessionKey,
           text: promptText,
@@ -434,10 +464,29 @@ export async function tryDispatchAcpReply(params: {
           requestId: resolveAcpRequestId(params.ctx),
           onEvent: (event) => projector.onEvent(event),
           signal,
-        }),
+        });
+        return runTurnSettlePromise;
+      },
       turnTimeoutMs,
       "ACP turn",
-    );
+    ).catch(async (err: unknown) => {
+      // P1b: On timeout (or upstream abort), wait for runTurn to drain before
+      // re-throwing. runTurn's own internal cleanup (cleanupTimedOutTurn) will
+      // abort and close the runtime, but we need to wait for that to finish
+      // so the session actor queue is fully released before we hand back control.
+      if (runTurnSettlePromise !== undefined) {
+        await Promise.race([
+          runTurnSettlePromise.catch(() => {
+            /* runTurn's own error is irrelevant here — we already have err */
+          }),
+          new Promise<void>((resolve) => {
+            const t = setTimeout(resolve, DRAIN_GRACE_MS);
+            (t as NodeJS.Timeout).unref?.();
+          }),
+        ]);
+      }
+      throw err;
+    });
 
     await projector.flush(true);
     queuedFinal =

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -1,4 +1,3 @@
-import type { AcpTurnAttachment } from "../../acp/control-plane/manager.types.js";
 import { resolveRuntimeOptionsFromMeta } from "../../acp/control-plane/runtime-options.js";
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../../acp/policy.js";
 import { formatAcpRuntimeErrorText } from "../../acp/runtime/error-text.js";


### PR DESCRIPTION
Supersedes #36860 (clean rebase onto current upstream/main, all review feedback addressed).

Adds ghost turn prevention, abort-aware delivery guards, and cleanup timeouts to the ACP dispatch path.

**dispatch-acp.ts:** Wrap runTurn with withTimeout using agent-configured timeout. Add turnAbortFired flag + lastDeliveryPromise tracking to prevent contradictory responses when abort fires mid-delivery. Add onCombinedAbort callback for cancelSession coverage.

**manager.core.ts:** Pass input.signal to withSessionActor for ghost turn prevention. Fire onCombinedAbort on combined signal abort. Add 5s cleanup timeouts for reconcile/close. Add reconcileAbortController.

**manager.types.ts:** Add onCombinedAbort to AcpRunTurnInput.

**manager.identity-reconcile.ts:** Forward abort signal to runtime.getStatus.

**Tests:** Coverage for ghost turn prevention, turnAbortFired suppression, timeout path, cleanup timeout.