### PR TITLE
fix: use async fs APIs in export-session command

### DIFF
--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -25,16 +25,18 @@ interface SessionData {
   tools?: Array<{ name: string; description?: string; parameters?: unknown }>;
 }
 
-function loadTemplate(fileName: string): string {
-  return fs.readFileSync(path.join(EXPORT_HTML_DIR, fileName), "utf-8");
+async function loadTemplate(fileName: string): Promise<string> {
+  return await fs.promises.readFile(path.join(EXPORT_HTML_DIR, fileName), "utf-8");
 }
 
-function generateHtml(sessionData: SessionData): string {
-  const template = loadTemplate("template.html");
-  const templateCss = loadTemplate("template.css");
-  const templateJs = loadTemplate("template.js");
-  const markedJs = loadTemplate(path.join("vendor", "marked.min.js"));
-  const hljsJs = loadTemplate(path.join("vendor", "highlight.min.js"));
+async function generateHtml(sessionData: SessionData): Promise<string> {
+  const [template, templateCss, templateJs, markedJs, hljsJs] = await Promise.all([
+    loadTemplate("template.html"),
+    loadTemplate("template.css"),
+    loadTemplate("template.js"),
+    loadTemplate(path.join("vendor", "marked.min.js")),
+    loadTemplate(path.join("vendor", "highlight.min.js")),
+  ]);
 
   // Use pi-mono dark theme colors (matching their theme/dark.json)
   const themeVars = `
@@ -138,7 +140,9 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
     };
   }
 
-  if (!fs.existsSync(sessionFile)) {
+  try {
+    await fs.promises.access(sessionFile);
+  } catch {
     return { text: `❌ Session file not found: ${sessionFile}` };
   }
 
@@ -165,7 +169,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   };
 
   // 5. Generate HTML
-  const html = generateHtml(sessionData);
+  const html = await generateHtml(sessionData);
 
   // 6. Determine output path
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
@@ -180,12 +184,14 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
 
   // Ensure directory exists
   const outputDir = path.dirname(outputPath);
-  if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true });
+  try {
+    await fs.promises.access(outputDir);
+  } catch {
+    await fs.promises.mkdir(outputDir, { recursive: true });
   }
 
   // 7. Write file
-  fs.writeFileSync(outputPath, html, "utf-8");
+  await fs.promises.writeFile(outputPath, html, "utf-8");
 
   const relativePath = path.relative(params.workspaceDir, outputPath);
   const displayPath = relativePath.startsWith("..") ? outputPath : relativePath;


### PR DESCRIPTION
### Summary

This change updates the export-session command to use async fs APIs consistently with the rest of the codebase, instead of mixing sync and async APIs.

### Changes

- Replace `fs.readFileSync` with `fs.promises.readFile`
- Replace `fs.existsSync` with `fs.promises.access`
- Replace `fs.mkdirSync` with `fs.promises.mkdir`
- Replace `fs.writeFileSync` with `fs.promises.writeFile`
- Load templates in parallel with `Promise.all` for better performance
- Keep the same functionality, just use async APIs consistently

### Testing

The functionality remains identical - this is just a code hygiene change to use async APIs consistently throughout the codebase.