### PR TITLE
ui: show tool call request arguments in sidebar

### DIFF
--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildToolCardSidebarContent, extractToolCards } from "./tool-cards.ts";
+
+describe("tool-cards", () => {
+  it("extracts tool call arguments from message content", () => {
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [{ type: "tool_call", name: "sessions_spawn", arguments: { runtime: "acp", task: "fix it" } }],
+    });
+
+    expect(cards).toEqual([
+      { kind: "call", name: "sessions_spawn", args: { runtime: "acp", task: "fix it" } },
+    ]);
+  });
+
+  it("includes pretty-printed request arguments in sidebar content for completed tool calls", () => {
+    const content = buildToolCardSidebarContent({
+      kind: "call",
+      name: "sessions_spawn",
+      args: { runtime: "acp", task: "fix it" },
+    });
+
+    expect(content).toContain("## Sessions Spawn");
+    expect(content).toContain("**Arguments:**");
+    expect(content).toContain('"runtime": "acp"');
+    expect(content).toContain('"task": "fix it"');
+    expect(content).toContain("No output — tool completed successfully.");
+  });
+
+  it("prefers tool output when present", () => {
+    const content = buildToolCardSidebarContent({
+      kind: "result",
+      name: "exec",
+      args: { command: "echo ok" },
+      text: "ok",
+    });
+
+    expect(content).toContain("ok");
+    expect(content).not.toContain("**Arguments:**");
+  });
+});

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -48,6 +48,18 @@ export function extractToolCards(message: unknown): ToolCard[] {
   return cards;
 }
 
+export function buildToolCardSidebarContent(card: ToolCard): string {
+  const display = resolveToolDisplay({ name: card.name, args: card.args });
+  const detail = formatToolDetail(display);
+  const hasText = Boolean(card.text?.trim());
+  if (hasText) {
+    return formatToolOutputForSidebar(card.text!);
+  }
+
+  const argsBlock = formatToolArgsBlock(card.args);
+  return `## ${display.label}\n\n${detail ? `**Command:** \`${detail}\`\n\n` : ""}${argsBlock}*No output — tool completed successfully.*`;
+}
+
 export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: string) => void) {
   const display = resolveToolDisplay({ name: card.name, args: card.args });
   const detail = formatToolDetail(display);
@@ -56,14 +68,7 @@ export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: 
   const canClick = Boolean(onOpenSidebar);
   const handleClick = canClick
     ? () => {
-        if (hasText) {
-          onOpenSidebar!(formatToolOutputForSidebar(card.text!));
-          return;
-        }
-        const info = `## ${display.label}\n\n${
-          detail ? `**Command:** \`${detail}\`\n\n` : ""
-        }*No output — tool completed successfully.*`;
-        onOpenSidebar!(info);
+        onOpenSidebar!(buildToolCardSidebarContent(card));
       }
     : undefined;
 
@@ -153,4 +158,22 @@ function extractToolText(item: Record<string, unknown>): string | undefined {
     return item.content;
   }
   return undefined;
+}
+
+function formatToolArgsBlock(args: unknown): string {
+  if (args == null) {
+    return "";
+  }
+  if (typeof args === "string") {
+    const trimmed = args.trim();
+    if (!trimmed) {
+      return "";
+    }
+    return `**Arguments:**\n\n\`\`\`json\n${trimmed}\n\`\`\`\n\n`;
+  }
+  try {
+    return `**Arguments:**\n\n\`\`\`json\n${JSON.stringify(args, null, 2)}\n\`\`\`\n\n`;
+  } catch {
+    return `**Arguments:** \`${String(args)}\`\n\n`;
+  }
 }


### PR DESCRIPTION
## Summary
- show pretty-printed tool call request arguments in the Control UI sidebar for completed tool calls without output
- add focused UI tests covering tool-call argument extraction and sidebar rendering

## Validation
- node C:/Users/Administrator/.openclaw/workspace/openclaw/node_modules/vitest/vitest.mjs run --config vitest.config.ts src/ui/chat/tool-cards.test.ts src/ui/chat-model-ref.test.ts

Fixes #49424