### PR TITLE
fix: suppress drain error replies to prevent chat flooding

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -23,6 +23,7 @@ import {
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import { GatewayDrainingError } from "../../process/command-queue.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
   isMarkdownCapableMessageChannel,
@@ -527,6 +528,16 @@ export async function runAgentTurnWithFallback(params: {
 
       break;
     } catch (err) {
+      // Suppress drain errors silently — the gateway is about to restart and
+      // the message will be retried on the next boot.  Sending an error reply
+      // for every rejected task during drain floods the user's chat (#30643).
+      if (err instanceof GatewayDrainingError) {
+        defaultRuntime.log(
+          `Suppressed drain error reply for session ${params.sessionKey ?? "unknown"}`,
+        );
+        return { kind: "final", payload: { text: "" } };
+      }
+
       const message = err instanceof Error ? err.message : String(err);
       const isBilling = isBillingErrorMessage(message);
       const isContextOverflow = !isBilling && isLikelyContextOverflowError(message);


### PR DESCRIPTION
## Problem

During a gateway restart (SIGUSR1), every rejected task sends an individual error message to the user's chat:

> ⚠️ Agent failed before reply: Gateway is draining for restart; new tasks are not accepted.

With multiple agents and pending/heartbeat tasks, this floods the channel with dozens of identical error messages within seconds (see #30643 — one user received **199 identical messages** in ~3 seconds).

## Root Cause

`GatewayDrainingError` thrown by `enqueueCommandInLane()` is caught by the generic error handler in `runAgentTurnWithFallback()` (`agent-runner-execution.ts`), which treats it as a regular agent failure and sends an error reply for **every** rejected task.

## Fix

Catch `GatewayDrainingError` explicitly in the agent runner execution loop and return an empty payload instead of an error message. The existing `normalizeReplyPayload()` layer already skips empty payloads (returns `null`, triggering the `onSkip('empty')` path), so no message is sent to the user.

This is the correct UX because:
- The gateway restarts within seconds
- Pending messages are retried on the next boot
- Users should not see transient infrastructure errors for a brief restart window

## Changes

- `src/auto-reply/reply/agent-runner-execution.ts`: Add `GatewayDrainingError` check before the generic error handling, returning `{ kind: 'final', payload: { text: '' } }` with a diagnostic log

## Testing

- TypeScript compilation: zero errors on the modified file
- Follows the same empty-payload pattern already used at line 538 for other silent-return cases
- `normalizeReplyPayload()` confirmed to return `null` for `{ text: '' }` payloads with no media

Fixes #30643