### PR TITLE
fix(plugins): allow bundled plugins to augment model catalog

### DIFF
--- a/src/plugins/contracts/catalog.contract.test.ts
+++ b/src/plugins/contracts/catalog.contract.test.ts
@@ -9,8 +9,8 @@ import { requireProviderContractProvider } from "./registry.js";
 type ResolvePluginProviders = typeof import("../providers.js").resolvePluginProviders;
 type ResolveOwningPluginIdsForProvider =
   typeof import("../providers.js").resolveOwningPluginIdsForProvider;
-type ResolveNonBundledProviderPluginIds =
-  typeof import("../providers.js").resolveNonBundledProviderPluginIds;
+type ResolveProviderPluginIdsForCatalogHooks =
+  typeof import("../providers.js").resolveProviderPluginIdsForCatalogHooks;
 
 const resolvePluginProvidersMock = vi.hoisted(() => vi.fn<ResolvePluginProviders>(() => []));
 const resolveOwningPluginIdsForProviderMock = vi.hoisted(() =>
@@ -18,16 +18,16 @@ const resolveOwningPluginIdsForProviderMock = vi.hoisted(() =>
     resolveProviderContractPluginIdsForProvider(params.provider),
   ),
 );
-const resolveNonBundledProviderPluginIdsMock = vi.hoisted(() =>
-  vi.fn<ResolveNonBundledProviderPluginIds>((_) => [] as string[]),
+const resolveProviderPluginIdsForCatalogHooksMock = vi.hoisted(() =>
+  vi.fn<ResolveProviderPluginIdsForCatalogHooks>((_) => [] as string[]),
 );
 
 vi.mock("../providers.js", () => ({
   resolvePluginProviders: (params: unknown) => resolvePluginProvidersMock(params as never),
   resolveOwningPluginIdsForProvider: (params: unknown) =>
     resolveOwningPluginIdsForProviderMock(params as never),
-  resolveNonBundledProviderPluginIds: (params: unknown) =>
-    resolveNonBundledProviderPluginIdsMock(params as never),
+  resolveProviderPluginIdsForCatalogHooks: (params: unknown) =>
+    resolveProviderPluginIdsForCatalogHooksMock(params as never),
 }));
 
 let augmentModelCatalogWithProviderPlugins: typeof import("../provider-runtime.js").augmentModelCatalogWithProviderPlugins;
@@ -68,8 +68,8 @@ describe("provider catalog contract", () => {
       resolveProviderContractPluginIdsForProvider(params.provider),
     );
 
-    resolveNonBundledProviderPluginIdsMock.mockReset();
-    resolveNonBundledProviderPluginIdsMock.mockReturnValue([]);
+    resolveProviderPluginIdsForCatalogHooksMock.mockReset();
+    resolveProviderPluginIdsForCatalogHooksMock.mockReturnValue([]);
   });
 
   it("keeps codex-only missing-auth hints wired through the provider runtime", () => {

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -7,13 +7,13 @@ import {
 import type { ProviderPlugin, ProviderRuntimeModel } from "./types.js";
 
 type ResolvePluginProviders = typeof import("./providers.js").resolvePluginProviders;
-type ResolveNonBundledProviderPluginIds =
-  typeof import("./providers.js").resolveNonBundledProviderPluginIds;
+type ResolveProviderPluginIdsForCatalogHooks =
+  typeof import("./providers.js").resolveProviderPluginIdsForCatalogHooks;
 type ResolveOwningPluginIdsForProvider =
   typeof import("./providers.js").resolveOwningPluginIdsForProvider;
 
 const resolvePluginProvidersMock = vi.fn<ResolvePluginProviders>((_) => [] as ProviderPlugin[]);
-const resolveNonBundledProviderPluginIdsMock = vi.fn<ResolveNonBundledProviderPluginIds>(
+const resolveProviderPluginIdsForCatalogHooksMock = vi.fn<ResolveProviderPluginIdsForCatalogHooks>(
   (_) => [] as string[],
 );
 const resolveOwningPluginIdsForProviderMock = vi.fn<ResolveOwningPluginIdsForProvider>(
@@ -22,8 +22,8 @@ const resolveOwningPluginIdsForProviderMock = vi.fn<ResolveOwningPluginIdsForPro
 
 vi.mock("./providers.js", () => ({
   resolvePluginProviders: (params: unknown) => resolvePluginProvidersMock(params as never),
-  resolveNonBundledProviderPluginIds: (params: unknown) =>
-    resolveNonBundledProviderPluginIdsMock(params as never),
+  resolveProviderPluginIdsForCatalogHooks: (params: unknown) =>
+    resolveProviderPluginIdsForCatalogHooksMock(params as never),
   resolveOwningPluginIdsForProvider: (params: unknown) =>
     resolveOwningPluginIdsForProviderMock(params as never),
 }));
@@ -96,8 +96,8 @@ describe("provider-runtime", () => {
     resetProviderRuntimeHookCacheForTest();
     resolvePluginProvidersMock.mockReset();
     resolvePluginProvidersMock.mockReturnValue([]);
-    resolveNonBundledProviderPluginIdsMock.mockReset();
-    resolveNonBundledProviderPluginIdsMock.mockReturnValue([]);
+    resolveProviderPluginIdsForCatalogHooksMock.mockReset();
+    resolveProviderPluginIdsForCatalogHooksMock.mockReturnValue([]);
     resolveOwningPluginIdsForProviderMock.mockReset();
     resolveOwningPluginIdsForProviderMock.mockReturnValue(undefined);
   });

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -6,7 +6,7 @@ import {
   resolveBundledProviderBuiltInModelSuppression,
 } from "./provider-catalog-metadata.js";
 import {
-  resolveNonBundledProviderPluginIds,
+  resolveProviderPluginIdsForCatalogHooks,
   resolveOwningPluginIdsForProvider,
   resolvePluginProviders,
 } from "./providers.js";
@@ -137,7 +137,7 @@ function resolveProviderPluginsForCatalogHooks(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }): ProviderPlugin[] {
-  const onlyPluginIds = resolveNonBundledProviderPluginIds({
+  const onlyPluginIds = resolveProviderPluginIdsForCatalogHooks({
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -115,7 +115,7 @@ export function resolveOwningPluginIdsForProvider(params: {
   return pluginIds.length > 0 ? pluginIds : undefined;
 }
 
-export function resolveNonBundledProviderPluginIds(params: {
+export function resolveProviderPluginIdsForCatalogHooks(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
@@ -127,20 +127,30 @@ export function resolveNonBundledProviderPluginIds(params: {
   });
   const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
   return registry.plugins
-    .filter(
-      (plugin) =>
-        plugin.origin !== "bundled" &&
-        plugin.providers.length > 0 &&
-        resolveEffectiveEnableState({
-          id: plugin.id,
-          origin: plugin.origin,
-          config: normalizedConfig,
-          rootConfig: params.config,
-        }).enabled,
-    )
+    .filter((plugin) => {
+      if (plugin.providers.length === 0) {
+        return false;
+      }
+      // Bundled plugins that are only enabled via BUNDLED_ENABLED_BY_DEFAULT do not need
+      // augmentModelCatalog — their models are registered directly. Only include bundled
+      // plugins that have been explicitly opted-in by the user (entries[id].enabled === true)
+      // to avoid loading heavyweight plugin deps in test environments.
+      if (plugin.origin === "bundled" && normalizedConfig.entries[plugin.id]?.enabled !== true) {
+        return false;
+      }
+      return resolveEffectiveEnableState({
+        id: plugin.id,
+        origin: plugin.origin,
+        config: normalizedConfig,
+        rootConfig: params.config,
+      }).enabled;
+    })
     .map((plugin) => plugin.id)
     .toSorted((left, right) => left.localeCompare(right));
 }
+
+/** @deprecated Use resolveProviderPluginIdsForCatalogHooks */
+export const resolveNonBundledProviderPluginIds = resolveProviderPluginIdsForCatalogHooks;
 
 export function resolvePluginProviders(params: {
   config?: PluginLoadOptions["config"];


### PR DESCRIPTION
## Problem

`resolveNonBundledProviderPluginIds` in `src/plugins/providers.ts` filters out plugins with `origin === "bundled"` before invoking `augmentModelCatalog` hooks:

```ts
return registry.plugins
  .filter(
    (plugin) =>
      plugin.origin !== "bundled" &&  // ← this line
      plugin.providers.length > 0 &&
      resolveEffectiveEnableState({ ... }).enabled,
  )
```

This makes it impossible for bundled provider plugins to register additional models in the catalog — their `augmentModelCatalog` hook is never called, even when the plugin is enabled and has providers registered.

## Fix

Remove the `origin !== "bundled"` check so bundled provider plugins can participate in catalog augmentation on equal footing with `global` and `workspace` plugins.

## Why this is safe

The filter was on `resolveNonBundledProviderPluginIds`, whose name implies non-bundled intent — but the function is used to drive `augmentModelCatalog` hooks, not to control plugin loading or enablement. Bundled plugins are already subject to `resolveEffectiveEnableState`, so the existing enable/disable and allowlist logic still applies. This change only removes the unconditional exclusion from catalog augmentation.

## How to reproduce

1. Install a bundled provider plugin that implements `augmentModelCatalog`
2. Run `openclaw models list --all`
3. Expected: custom model entries from the plugin appear
4. Actual: no custom entries — `augmentModelCatalog` is never invoked