### PR TITLE
docs: add bamdra-openclaw-memory to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -59,6 +59,18 @@ while reducing token usage.
 openclaw plugins install @martian-engineering/lossless-claw
 ```
 
+### OpenClaw Memory
+
+Continuity-first memory runtime for OpenClaw with durable SQLite recall,
+user-aware identity binding, and optional local Markdown knowledge retrieval.
+
+- **npm:** `@bamdra/bamdra-openclaw-memory`
+- **repo:** [github.com/bamdra/bamdra-openclaw-memory](https://github.com/bamdra/bamdra-openclaw-memory)
+
+```bash
+openclaw plugins install @bamdra/bamdra-openclaw-memory
+```
+
 ### Opik
 
 Official plugin that exports agent traces to Opik. Monitor agent behavior,


### PR DESCRIPTION
## Summary

- Adds **bamdra-openclaw-memory** to the community plugins listing
- Plugin provides a continuity-first memory runtime for OpenClaw with durable SQLite recall, user-aware identity binding, and optional local Markdown knowledge retrieval

## Plugin details

- **npm**: `@bamdra/bamdra-openclaw-memory`
- **repo**: https://github.com/bamdra/bamdra-openclaw-memory
- **license**: MIT
- **runtime dependencies**: auto-provisions `@bamdra/bamdra-user-bind` and stages `@bamdra/bamdra-memory-vector`

## How it works

1. Restores topic continuity and durable fact recall for OpenClaw
2. Keeps prompt context compact enough for production use
3. Auto-provisions the user identity/profile layer when needed
4. Can stage a local Markdown knowledge base for semantic recall

## Checklist

- [x] Public GitHub repository
- [x] README with installation, configuration, and usage docs
- [x] MIT license
- [x] Issue tracker enabled
- [x] Published on npmjs
