### PR TITLE
fix(tui): prioritize modelOverride over runtime model in status bar

### DIFF
--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -199,6 +199,215 @@ describe("tui session actions", () => {
     expect(state.sessionInfo.updatedAt).toBe(200);
   });
 
+  it("preserves modelOverride when session entry has a different runtime model", async () => {
+    // Scenario: user sets model override to opus, then a heartbeat runs on flash-lite.
+    // The session entry now has model=flash-lite but modelOverride=opus.
+    // The TUI status bar should show opus, not flash-lite.
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [
+        {
+          key: "agent:main:main",
+          // Runtime model from last turn (heartbeat ran on flash-lite)
+          model: "gemini-2.5-flash-lite",
+          modelProvider: "google",
+          // User's explicit override (set via /status model=opus)
+          modelOverride: "claude-opus-4-6",
+          providerOverride: "anthropic",
+          updatedAt: 200,
+        },
+      ],
+    });
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {
+        model: "claude-opus-4-6",
+        modelProvider: "anthropic",
+        updatedAt: 100,
+      },
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { refreshSessionInfo } = createSessionActions({
+      client: { listSessions } as unknown as GatewayChatClient,
+      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      btw: createBtwPresenter(),
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await refreshSessionInfo();
+
+    // modelOverride should take priority over the runtime model
+    expect(state.sessionInfo.model).toBe("claude-opus-4-6");
+    expect(state.sessionInfo.modelProvider).toBe("anthropic");
+  });
+
+  it("falls back to entry.model when no modelOverride is set", async () => {
+    // When there's no user override, the runtime model should display normally
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [
+        {
+          key: "agent:main:main",
+          model: "claude-sonnet-4-6",
+          modelProvider: "anthropic",
+          // No modelOverride set
+          updatedAt: 200,
+        },
+      ],
+    });
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {
+        model: "claude-sonnet-4-6",
+        modelProvider: "anthropic",
+        updatedAt: 100,
+      },
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { refreshSessionInfo } = createSessionActions({
+      client: { listSessions } as unknown as GatewayChatClient,
+      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      btw: createBtwPresenter(),
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await refreshSessionInfo();
+
+    // Without an override, the runtime model should be used
+    expect(state.sessionInfo.model).toBe("claude-sonnet-4-6");
+    expect(state.sessionInfo.modelProvider).toBe("anthropic");
+  });
+
+  it("clears override when modelOverride is reset to empty string", async () => {
+    // When user resets override (e.g. /status model=default), modelOverride is ""
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [
+        {
+          key: "agent:main:main",
+          model: "claude-sonnet-4-6",
+          modelProvider: "anthropic",
+          modelOverride: "",
+          updatedAt: 200,
+        },
+      ],
+    });
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {
+        model: "claude-opus-4-6",
+        modelProvider: "anthropic",
+        updatedAt: 100,
+      },
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { refreshSessionInfo } = createSessionActions({
+      client: { listSessions } as unknown as GatewayChatClient,
+      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      btw: createBtwPresenter(),
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await refreshSessionInfo();
+
+    // Empty modelOverride should fall through to entry.model
+    expect(state.sessionInfo.model).toBe("claude-sonnet-4-6");
+    expect(state.sessionInfo.modelProvider).toBe("anthropic");
+  });
+
   it("accepts older session snapshots after switching session keys", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -121,16 +121,19 @@ export function createSessionActions(context: SessionActionContext) {
   };
 
   const resolveModelSelection = (entry?: SessionInfoEntry) => {
+    // User-set model override always takes priority over the session's
+    // last-resolved model (which reflects whatever model ran the most recent
+    // turn — heartbeat flash-lite, compaction sonnet, etc.).
+    const overrideModel = entry?.modelOverride?.trim();
+    if (overrideModel) {
+      const overrideProvider = entry?.providerOverride?.trim() || state.sessionInfo.modelProvider;
+      return { modelProvider: overrideProvider, model: overrideModel };
+    }
     if (entry?.modelProvider || entry?.model) {
       return {
         modelProvider: entry.modelProvider ?? state.sessionInfo.modelProvider,
         model: entry.model ?? state.sessionInfo.model,
       };
-    }
-    const overrideModel = entry?.modelOverride?.trim();
-    if (overrideModel) {
-      const overrideProvider = entry?.providerOverride?.trim() || state.sessionInfo.modelProvider;
-      return { modelProvider: overrideProvider, model: overrideModel };
     }
     return {
       modelProvider: state.sessionInfo.modelProvider,


### PR DESCRIPTION
## Problem

When a user sets a per-session model override (e.g. via `session_status` tool or `/status model=opus`), the TUI status bar reverts to the default or heartbeat model after certain system events:

- **Heartbeats** run on a lightweight model (e.g. `gemini-2.5-flash-lite`)
- **Compactions** run on the agent default model (e.g. `claude-sonnet-4-6`)
- **Cron jobs** may run on any configured model

After these events complete, the session store updates `entry.model` to reflect the model that actually ran the last turn. When the TUI next calls `refreshSessionInfo()`, it picks up this runtime model and displays it in the status bar — overwriting the user's explicit override.

## Root Cause

In `src/tui/tui-session-actions.ts`, `resolveModelSelection()` checked `entry.model` / `entry.modelProvider` **before** `entry.modelOverride`:

```ts
// OLD — entry.model wins over modelOverride
if (entry?.modelProvider || entry?.model) {
  return { modelProvider: entry.modelProvider, model: entry.model };
}
const overrideModel = entry?.modelOverride?.trim();
if (overrideModel) { ... }
```

Since `entry.model` is always populated (from the last turn's runtime model), the `modelOverride` branch was unreachable whenever `entry.model` was set.

## Fix

Reorder the checks so `modelOverride` is evaluated first:

```ts
// NEW — user override wins
const overrideModel = entry?.modelOverride?.trim();
if (overrideModel) {
  return { modelProvider: overrideProvider, model: overrideModel };
}
if (entry?.modelProvider || entry?.model) {
  return { modelProvider: entry.modelProvider, model: entry.model };
}
```

When `modelOverride` is set and non-empty, it takes priority. When absent or empty (e.g. after `/status model=default` reset), the existing `entry.model` logic applies unchanged.

## Tests Added

Three new test cases in `tui-session-actions.test.ts`:

1. **`preserves modelOverride when session entry has a different runtime model`** — simulates heartbeat running on flash-lite while user has opus override; verifies status bar shows opus
2. **`falls back to entry.model when no modelOverride is set`** — verifies normal behavior when no override exists
3. **`clears override when modelOverride is reset to empty string`** — verifies that resetting the override correctly falls through to the runtime model

All existing tests continue to pass (6/6).

## Reproduction Steps

1. Start OpenClaw TUI
2. Set a model override: `/status model=opus`
3. Wait for a heartbeat to fire (runs on flash-lite)
4. Observe status bar now shows `google/gemini-2.5-flash-lite` instead of `anthropic/claude-opus-4-6`

After this fix, the status bar correctly shows `anthropic/claude-opus-4-6` after the heartbeat.