### PR TITLE
Fix/slack http webhook module split

### DIFF
--- a/extensions/slack/src/http/registry.test.ts
+++ b/extensions/slack/src/http/registry.test.ts
@@ -85,4 +85,19 @@ describe("registerSlackHttpHandler", () => {
       'slack: webhook path /slack/events already registered for account "duplicate"',
     );
   });
+
+  it("shares the route map via globalThis singleton", () => {
+    const key = Symbol.for("openclaw.slack.httpRoutes");
+    const globalMap = (globalThis as Record<PropertyKey, unknown>)[key] as Map<string, unknown>;
+    expect(globalMap).toBeInstanceOf(Map);
+
+    const handler = vi.fn();
+    const unregister = registerSlackHttpHandler({ path: "/test-global", handler });
+    unregisters.push(unregister);
+
+    expect(globalMap.has("/test-global")).toBe(true);
+
+    unregister();
+    expect(globalMap.has("/test-global")).toBe(false);
+  });
 });

--- a/extensions/slack/src/http/registry.ts
+++ b/extensions/slack/src/http/registry.ts
@@ -16,9 +16,12 @@ type RegisterSlackHttpHandlerArgs = {
 // Without this, the bundler may duplicate this module into multiple chunks, causing
 // registerSlackHttpHandler and handleSlackHttpRequest to operate on different Maps.
 const GLOBAL_KEY = Symbol.for("openclaw.slack.httpRoutes");
-const slackHttpRoutes: Map<string, SlackHttpRequestHandler> =
-  ((globalThis as any)[GLOBAL_KEY] as Map<string, SlackHttpRequestHandler>) ??
-  ((globalThis as any)[GLOBAL_KEY] = new Map<string, SlackHttpRequestHandler>());
+type GlobalWithRoutes = typeof globalThis & {
+  [GLOBAL_KEY]?: Map<string, SlackHttpRequestHandler>;
+};
+const slackHttpRoutes: Map<string, SlackHttpRequestHandler> = ((globalThis as GlobalWithRoutes)[
+  GLOBAL_KEY
+] ??= new Map());
 
 export function normalizeSlackWebhookPath(path?: string | null): string {
   const trimmed = path?.trim();

--- a/extensions/slack/src/http/registry.ts
+++ b/extensions/slack/src/http/registry.ts
@@ -12,7 +12,13 @@ type RegisterSlackHttpHandlerArgs = {
   accountId?: string;
 };
 
-const slackHttpRoutes = new Map<string, SlackHttpRequestHandler>();
+// Use globalThis to ensure a single shared Map across all bundled module instances.
+// Without this, the bundler may duplicate this module into multiple chunks, causing
+// registerSlackHttpHandler and handleSlackHttpRequest to operate on different Maps.
+const GLOBAL_KEY = Symbol.for("openclaw.slack.httpRoutes");
+const slackHttpRoutes: Map<string, SlackHttpRequestHandler> =
+  ((globalThis as any)[GLOBAL_KEY] as Map<string, SlackHttpRequestHandler>) ??
+  ((globalThis as any)[GLOBAL_KEY] = new Map<string, SlackHttpRequestHandler>());
 
 export function normalizeSlackWebhookPath(path?: string | null): string {
   const trimmed = path?.trim();


### PR DESCRIPTION
## Summary

- **Problem**: When OpenClaw is built with tsdown, `extensions/slack/src/http/registry.ts` is inlined into multiple output chunks. The module-level `slackHttpRoutes` Map gets duplicated — `registerSlackHttpHandler` (called by the Slack monitor/provider) writes to one instance, while `handleSlackHttpRequest` (called by the gateway HTTP pipeline) reads from a different, empty instance. All HTTP webhook requests return 404.
- **Why it matters**: HTTP webhook mode (`channels.slack.mode: "http"`) is completely non-functional in the compiled Docker image. The gateway logs `[slack] http mode listening at /slack/events` but no route is registered on the HTTP server.
- **What changed**: Replaced the module-level `Map` with a `globalThis`-backed singleton using `Symbol.for()`, ensuring all bundled copies share the same Map instance.
- **What did NOT change**: No build config, import path, or API changes. The fix is entirely internal to `registry.ts`.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Integrations

## User-visible / Behavior Changes

HTTP webhook mode for Slack (`channels.slack.mode: "http"`) now works correctly. Previously, all POST requests to the configured `webhookPath` returned 404 despite the config being valid.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Amazon Linux 2023 (arm64)
- Runtime/container: Docker, `ghcr.io/openclaw/openclaw:latest` (v2026.3.13)
- Integration/channel: Slack (HTTP webhook mode)
- Config:
  ```json
  {
    "channels": {
      "slack": {
        "mode": "http",
        "botToken": "xoxb-...",
        "signingSecret": "...",
        "webhookPath": "/slack/events"
      }
    }
  }
  ```

### Steps

1. Configure OpenClaw with `channels.slack.mode: "http"` and valid `botToken` + `signingSecret`
2. Start the gateway
3. Observe log: `[slack] http mode listening at /slack/events`
4. POST to `http://localhost:18789/slack/events` with valid Slack signature headers

### Expected

- Request is processed by the Slack HTTP handler

### Actual

- 404 Not Found (before fix)
- Request processed correctly (after fix)

## Evidence

- Verified by deploying patched image to EC2, sending Slack messages through a Socket Mode router to the container's HTTP webhook endpoint. Messages delivered successfully: `[slack] delivered reply to channel:C0ALL****V8`

## Human Verification

- Verified: HTTP webhook endpoint responds (400 for bad signatures, 200 for valid requests) instead of 404
- Verified: Full end-to-end Slack message flow works with patched image
- Edge cases checked: Multiple containers with separate webhook paths on the same host
- Not verified: Whether `tsdown` config changes could achieve the same result without the globalThis pattern

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert this single commit to restore previous behavior
- The fix is additive — if `globalThis` already has the Map, it reuses it; otherwise creates a new one (same behavior as before for single-instance scenarios)

## Risks and Mitigations

- Risk: `globalThis` pollution in environments where multiple OpenClaw instances share a process
  - Mitigation: The `Symbol.for()` key is namespaced (`openclaw.slack.httpRoutes`), and multiple OpenClaw instances in one process is not a supported configuration