### PR TITLE
Gateway: rebind plugin registry before channel lifecycle

### DIFF
--- a/src/channels/plugins/index.ts
+++ b/src/channels/plugins/index.ts
@@ -1,4 +1,9 @@
-export { getChannelPlugin, listChannelPlugins, normalizeChannelId } from "./registry.js";
+export {
+  getChannelPlugin,
+  listChannelPlugins,
+  listChannelPluginsFromRegistry,
+  normalizeChannelId,
+} from "./registry.js";
 export {
   applyChannelMatchMeta,
   buildChannelKeyCandidates,

--- a/src/channels/plugins/registry.ts
+++ b/src/channels/plugins/registry.ts
@@ -1,3 +1,4 @@
+import type { PluginRegistry } from "../../plugins/registry.js";
 import {
   getActivePluginRegistryVersion,
   requireActivePluginRegistry,
@@ -17,6 +18,21 @@ function dedupeChannels(channels: ChannelPlugin[]): ChannelPlugin[] {
     resolved.push(plugin);
   }
   return resolved;
+}
+
+export function listChannelPluginsFromRegistry(
+  registry: Pick<PluginRegistry, "channels">,
+): ChannelPlugin[] {
+  return dedupeChannels(registry.channels.map((entry) => entry.plugin)).toSorted((a, b) => {
+    const indexA = CHAT_CHANNEL_ORDER.indexOf(a.id as ChatChannelId);
+    const indexB = CHAT_CHANNEL_ORDER.indexOf(b.id as ChatChannelId);
+    const orderA = a.meta.order ?? (indexA === -1 ? 999 : indexA);
+    const orderB = b.meta.order ?? (indexB === -1 ? 999 : indexB);
+    if (orderA !== orderB) {
+      return orderA - orderB;
+    }
+    return a.id.localeCompare(b.id);
+  });
 }
 
 type CachedChannelPlugins = {
@@ -41,16 +57,7 @@ function resolveCachedChannelPlugins(): CachedChannelPlugins {
     return cached;
   }
 
-  const sorted = dedupeChannels(registry.channels.map((entry) => entry.plugin)).toSorted((a, b) => {
-    const indexA = CHAT_CHANNEL_ORDER.indexOf(a.id as ChatChannelId);
-    const indexB = CHAT_CHANNEL_ORDER.indexOf(b.id as ChatChannelId);
-    const orderA = a.meta.order ?? (indexA === -1 ? 999 : indexA);
-    const orderB = b.meta.order ?? (indexB === -1 ? 999 : indexB);
-    if (orderA !== orderB) {
-      return orderA - orderB;
-    }
-    return a.id.localeCompare(b.id);
-  });
+  const sorted = listChannelPluginsFromRegistry(registry);
   const byId = new Map<string, ChannelPlugin>();
   for (const plugin of sorted) {
     byId.set(plugin.id, plugin);

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -557,4 +557,55 @@ describe("server-channels auto restart", () => {
     expect(getActivePluginRegistryKey()).toBe("bootstrapped-registry");
     expect(getGlobalPluginRegistry()).toBe(bootstrappedRegistry);
   });
+
+  it("promotes live channel runtime state when the active registry changes but channel IDs stay the same", async () => {
+    const startupStartAccount = vi.fn(async () => {});
+    const upgradedStartAccount = vi.fn(async () => {
+      registerPluginHttpRoute({
+        path: "/upgraded-webhook",
+        auth: "plugin",
+        pluginId: "discord",
+        source: "test-webhook",
+        handler: () => true,
+      });
+    });
+    const startupRegistry = createTestRegistry(
+      createTestPlugin({
+        startAccount: startupStartAccount,
+      }),
+    );
+    const upgradedRegistry = createTestRegistry(
+      createTestPlugin({
+        startAccount: upgradedStartAccount,
+      }),
+    );
+
+    setActivePluginRegistry(startupRegistry, "startup-registry");
+    initializeGlobalHookRunner(startupRegistry);
+    let runtimeState: ChannelLifecyclePluginRuntimeState = {
+      registry: startupRegistry,
+      cacheKey: "startup-registry",
+    };
+    const manager = createManager({
+      resolvePluginRuntimeState: () => {
+        runtimeState = resolveChannelLifecyclePluginRuntimeState(runtimeState);
+        return runtimeState;
+      },
+    });
+
+    // Simulate an upgrade that activates a new registry with same channel IDs.
+    setActivePluginRegistry(upgradedRegistry, "upgraded-registry");
+    initializeGlobalHookRunner(upgradedRegistry);
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    expect(upgradedStartAccount).toHaveBeenCalledTimes(1);
+    expect(startupStartAccount).not.toHaveBeenCalled();
+    expect(upgradedRegistry.httpRoutes).toHaveLength(1);
+    expect(upgradedRegistry.httpRoutes[0]?.path).toBe("/upgraded-webhook");
+    expect(startupRegistry.httpRoutes).toHaveLength(0);
+    expect(getActivePluginRegistry()).toBe(upgradedRegistry);
+    expect(getActivePluginRegistryKey()).toBe("upgraded-registry");
+    expect(getGlobalPluginRegistry()).toBe(upgradedRegistry);
+  });
 });

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -21,6 +21,10 @@ import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createChannelManager } from "./server-channels.js";
+import {
+  ChannelLifecyclePluginRuntimeState,
+  resolveChannelLifecyclePluginRuntimeState,
+} from "./server-plugin-runtime-state.js";
 
 const hoisted = vi.hoisted(() => {
   const computeBackoff = vi.fn(() => 10);
@@ -51,12 +55,14 @@ type TestAccount = {
 };
 
 function createTestPlugin(params?: {
+  id?: ChannelId;
   account?: TestAccount;
   startAccount?: NonNullable<ChannelPlugin<TestAccount>["gateway"]>["startAccount"];
   includeDescribeAccount?: boolean;
   resolveAccount?: ChannelPlugin<TestAccount>["config"]["resolveAccount"];
   isConfigured?: ChannelPlugin<TestAccount>["config"]["isConfigured"];
 }): ChannelPlugin<TestAccount> {
+  const id = params?.id ?? "discord";
   const account = params?.account ?? { enabled: true, configured: true };
   const includeDescribeAccount = params?.includeDescribeAccount !== false;
   const config: ChannelPlugin<TestAccount>["config"] = {
@@ -77,12 +83,12 @@ function createTestPlugin(params?: {
     gateway.startAccount = params.startAccount;
   }
   return {
-    id: "discord",
+    id,
     meta: {
-      id: "discord",
-      label: "Discord",
-      selectionLabel: "Discord",
-      docsPath: "/channels/discord",
+      id,
+      label: id,
+      selectionLabel: id,
+      docsPath: `/channels/${id}`,
       blurb: "test stub",
     },
     capabilities: { chatTypes: ["direct"] },
@@ -99,13 +105,20 @@ function createDeferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve: resolvePromise };
 }
 
-function installTestRegistry(plugin: ChannelPlugin<TestAccount>) {
+function createTestRegistry(...plugins: ChannelPlugin<TestAccount>[]): PluginRegistry {
   const registry = createEmptyPluginRegistry();
-  registry.channels.push({
-    pluginId: plugin.id,
-    source: "test",
-    plugin,
-  });
+  for (const plugin of plugins) {
+    registry.channels.push({
+      pluginId: plugin.id,
+      source: "test",
+      plugin,
+    });
+  }
+  return registry;
+}
+
+function installTestRegistry(plugin: ChannelPlugin<TestAccount>) {
+  const registry = createTestRegistry(plugin);
   setActivePluginRegistry(registry);
 }
 
@@ -482,5 +495,66 @@ describe("server-channels auto restart", () => {
     expect(driftedRegistry.httpRoutes).toHaveLength(0);
     expect(getActivePluginRegistryKey()).toBe("startup-registry");
     expect(getGlobalPluginRegistry()).toBe(startupRegistry);
+  });
+
+  it("promotes live channel runtime state when the active registry gains channels", async () => {
+    const startupStartAccount = vi.fn(async () => {
+      registerPluginHttpRoute({
+        path: "/startup-webhook",
+        auth: "plugin",
+        pluginId: "discord",
+        source: "test-webhook",
+        handler: () => true,
+      });
+    });
+    const bootstrappedStartAccount = vi.fn(async () => {
+      registerPluginHttpRoute({
+        path: "/bootstrapped-webhook",
+        auth: "plugin",
+        pluginId: "discord",
+        source: "test-webhook",
+        handler: () => true,
+      });
+    });
+    const startupRegistry = createTestRegistry(
+      createTestPlugin({
+        startAccount: startupStartAccount,
+      }),
+    );
+    const bootstrappedRegistry = createTestRegistry(
+      createTestPlugin({
+        startAccount: bootstrappedStartAccount,
+      }),
+      createTestPlugin({
+        id: "telegram",
+      }),
+    );
+
+    setActivePluginRegistry(startupRegistry, "startup-registry");
+    initializeGlobalHookRunner(startupRegistry);
+    let runtimeState: ChannelLifecyclePluginRuntimeState = {
+      registry: startupRegistry,
+      cacheKey: "startup-registry",
+    };
+    const manager = createManager({
+      resolvePluginRuntimeState: () => {
+        runtimeState = resolveChannelLifecyclePluginRuntimeState(runtimeState);
+        return runtimeState;
+      },
+    });
+
+    setActivePluginRegistry(bootstrappedRegistry, "bootstrapped-registry");
+    initializeGlobalHookRunner(bootstrappedRegistry);
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    expect(bootstrappedStartAccount).toHaveBeenCalledTimes(1);
+    expect(startupStartAccount).not.toHaveBeenCalled();
+    expect(bootstrappedRegistry.httpRoutes).toHaveLength(1);
+    expect(bootstrappedRegistry.httpRoutes[0]?.path).toBe("/bootstrapped-webhook");
+    expect(startupRegistry.httpRoutes).toHaveLength(0);
+    expect(getActivePluginRegistry()).toBe(bootstrappedRegistry);
+    expect(getActivePluginRegistryKey()).toBe("bootstrapped-registry");
+    expect(getGlobalPluginRegistry()).toBe(bootstrappedRegistry);
   });
 });

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -5,8 +5,18 @@ import {
   type SubsystemLogger,
   runtimeForLogger,
 } from "../logging/subsystem.js";
+import {
+  getGlobalPluginRegistry,
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { registerPluginHttpRoute } from "../plugins/http-registry.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "../plugins/registry.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  getActivePluginRegistry,
+  getActivePluginRegistryKey,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -103,6 +113,9 @@ function createManager(options?: {
   channelRuntime?: PluginRuntime["channel"];
   resolveChannelRuntime?: () => PluginRuntime["channel"];
   loadConfig?: () => Record<string, unknown>;
+  pluginRegistry?: PluginRegistry;
+  pluginRegistryCacheKey?: string | null;
+  resolvePluginRuntimeState?: () => { registry: PluginRegistry; cacheKey?: string | null } | null;
 }) {
   const log = createSubsystemLogger("gateway/server-channels-test");
   const channelLogs = { discord: log } as Record<ChannelId, SubsystemLogger>;
@@ -112,18 +125,29 @@ function createManager(options?: {
     loadConfig: () => options?.loadConfig?.() ?? {},
     channelLogs,
     channelRuntimeEnvs,
+    ...(options?.pluginRegistry ? { pluginRegistry: options.pluginRegistry } : {}),
+    ...(options && "pluginRegistryCacheKey" in options
+      ? { pluginRegistryCacheKey: options.pluginRegistryCacheKey }
+      : {}),
     ...(options?.channelRuntime ? { channelRuntime: options.channelRuntime } : {}),
     ...(options?.resolveChannelRuntime
       ? { resolveChannelRuntime: options.resolveChannelRuntime }
+      : {}),
+    ...(options?.resolvePluginRuntimeState
+      ? { resolvePluginRuntimeState: options.resolvePluginRuntimeState }
       : {}),
   });
 }
 
 describe("server-channels auto restart", () => {
   let previousRegistry: PluginRegistry | null = null;
+  let previousRegistryKey: string | null = null;
+  let previousHookRegistry: PluginRegistry | null = null;
 
   beforeEach(() => {
     previousRegistry = getActivePluginRegistry();
+    previousRegistryKey = getActivePluginRegistryKey();
+    previousHookRegistry = getGlobalPluginRegistry();
     vi.useFakeTimers();
     hoisted.computeBackoff.mockClear();
     hoisted.sleepWithAbort.mockClear();
@@ -131,7 +155,15 @@ describe("server-channels auto restart", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    setActivePluginRegistry(previousRegistry ?? createEmptyPluginRegistry());
+    setActivePluginRegistry(
+      previousRegistry ?? createEmptyPluginRegistry(),
+      previousRegistryKey ?? undefined,
+    );
+    if (previousHookRegistry) {
+      initializeGlobalHookRunner(previousHookRegistry);
+    } else {
+      resetGlobalHookRunner();
+    }
   });
 
   it("caps crash-loop restarts after max attempts", async () => {
@@ -408,5 +440,47 @@ describe("server-channels auto restart", () => {
     });
 
     expect(manager.isHealthMonitorEnabled("discord", "")).toBe(true);
+  });
+
+  it("rebinds the active plugin registry and hook runner before channel startup", async () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    startupRegistry.channels.push({
+      pluginId: "discord",
+      source: "test",
+      plugin: createTestPlugin({
+        startAccount: async () => {
+          registerPluginHttpRoute({
+            path: "/probe-webhook",
+            auth: "plugin",
+            pluginId: "discord",
+            source: "test-webhook",
+            handler: () => true,
+          });
+        },
+      }),
+    });
+    // Drift to an empty registry to verify bulk startup rebinds before listing channels.
+    const driftedRegistry = createEmptyPluginRegistry();
+
+    setActivePluginRegistry(startupRegistry, "startup-registry");
+    initializeGlobalHookRunner(startupRegistry);
+    const manager = createManager({
+      resolvePluginRuntimeState: () => ({
+        registry: startupRegistry,
+        cacheKey: "startup-registry",
+      }),
+    });
+
+    // Simulate registry drift before a hot-reload channel restart.
+    setActivePluginRegistry(driftedRegistry, "drifted-registry");
+    initializeGlobalHookRunner(driftedRegistry);
+
+    await manager.startChannels();
+
+    expect(startupRegistry.httpRoutes).toHaveLength(1);
+    expect(startupRegistry.httpRoutes[0]?.path).toBe("/probe-webhook");
+    expect(driftedRegistry.httpRoutes).toHaveLength(0);
+    expect(getActivePluginRegistryKey()).toBe("startup-registry");
+    expect(getGlobalPluginRegistry()).toBe(startupRegistry);
   });
 });

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type ChannelId, type ChannelPlugin } from "../channels/plugins/types.js";
 import {
@@ -15,6 +16,8 @@ import { createEmptyPluginRegistry, type PluginRegistry } from "../plugins/regis
 import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
   setActivePluginRegistry,
 } from "../plugins/runtime.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
@@ -25,6 +28,8 @@ import {
   ChannelLifecyclePluginRuntimeState,
   resolveChannelLifecyclePluginRuntimeState,
 } from "./server-plugin-runtime-state.js";
+import { createGatewayPluginRequestHandler } from "./server/plugins-http.js";
+import { makeMockHttpResponse } from "./test-http-response.js";
 
 const hoisted = vi.hoisted(() => {
   const computeBackoff = vi.fn(() => 10);
@@ -58,6 +63,7 @@ function createTestPlugin(params?: {
   id?: ChannelId;
   account?: TestAccount;
   startAccount?: NonNullable<ChannelPlugin<TestAccount>["gateway"]>["startAccount"];
+  stopAccount?: NonNullable<ChannelPlugin<TestAccount>["gateway"]>["stopAccount"];
   includeDescribeAccount?: boolean;
   resolveAccount?: ChannelPlugin<TestAccount>["config"]["resolveAccount"];
   isConfigured?: ChannelPlugin<TestAccount>["config"]["isConfigured"];
@@ -81,6 +87,9 @@ function createTestPlugin(params?: {
   const gateway: NonNullable<ChannelPlugin<TestAccount>["gateway"]> = {};
   if (params?.startAccount) {
     gateway.startAccount = params.startAccount;
+  }
+  if (params?.stopAccount) {
+    gateway.stopAccount = params.stopAccount;
   }
   return {
     id,
@@ -168,6 +177,7 @@ describe("server-channels auto restart", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    releasePinnedPluginHttpRouteRegistry();
     setActivePluginRegistry(
       previousRegistry ?? createEmptyPluginRegistry(),
       previousRegistryKey ?? undefined,
@@ -607,5 +617,90 @@ describe("server-channels auto restart", () => {
     expect(getActivePluginRegistry()).toBe(upgradedRegistry);
     expect(getActivePluginRegistryKey()).toBe("upgraded-registry");
     expect(getGlobalPluginRegistry()).toBe(upgradedRegistry);
+  });
+
+  it("keeps webhook dispatch reachable through the pinned route registry after channel restart", async () => {
+    let unregisterWebhook = () => {};
+    const initialWebhookHandler = vi.fn(async (_req, res) => {
+      res.statusCode = 202;
+      res.end("initial");
+      return true;
+    });
+    const restartedWebhookHandler = vi.fn(async (_req, res) => {
+      res.statusCode = 400;
+      res.end("invalid payload");
+      return true;
+    });
+    const startAccount = vi
+      .fn<NonNullable<ChannelPlugin<TestAccount>["gateway"]>["startAccount"]>()
+      .mockImplementationOnce(async () => {
+        unregisterWebhook = registerPluginHttpRoute({
+          path: "/bluebubbles-webhook",
+          auth: "plugin",
+          pluginId: "discord",
+          source: "test-webhook",
+          handler: initialWebhookHandler,
+          replaceExisting: true,
+        });
+      })
+      .mockImplementationOnce(async () => {
+        unregisterWebhook = registerPluginHttpRoute({
+          path: "/bluebubbles-webhook",
+          auth: "plugin",
+          pluginId: "discord",
+          source: "test-webhook",
+          handler: restartedWebhookHandler,
+          replaceExisting: true,
+        });
+      });
+    const stopAccount = vi.fn(async () => {
+      unregisterWebhook();
+      unregisterWebhook = () => {};
+    });
+
+    const startupRegistry = createTestRegistry(
+      createTestPlugin({
+        startAccount,
+        stopAccount,
+      }),
+    );
+    const driftedRegistry = createEmptyPluginRegistry();
+
+    setActivePluginRegistry(startupRegistry, "startup-registry");
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+    initializeGlobalHookRunner(startupRegistry);
+    const manager = createManager({
+      resolvePluginRuntimeState: () => ({
+        registry: startupRegistry,
+        cacheKey: "startup-registry",
+      }),
+    });
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    expect(initialWebhookHandler).not.toHaveBeenCalled();
+
+    setActivePluginRegistry(driftedRegistry, "drifted-registry");
+    initializeGlobalHookRunner(driftedRegistry);
+
+    await manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    const handler = createGatewayPluginRequestHandler({
+      registry: startupRegistry,
+      log: createSubsystemLogger("gateway/server-channels-test/plugin-http"),
+    });
+    const { res, end } = makeMockHttpResponse();
+    const handled = await handler({ url: "/bluebubbles-webhook" } as IncomingMessage, res);
+
+    expect(handled).toBe(true);
+    expect(stopAccount).toHaveBeenCalledTimes(1);
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(initialWebhookHandler).not.toHaveBeenCalled();
+    expect(restartedWebhookHandler).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(400);
+    expect(end).toHaveBeenCalledWith("invalid payload");
+    expect(startupRegistry.httpRoutes).toHaveLength(1);
+    expect(startupRegistry.httpRoutes[0]?.path).toBe("/bluebubbles-webhook");
+    expect(driftedRegistry.httpRoutes).toHaveLength(0);
   });
 });

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -6,6 +6,9 @@ import { type BackoffPolicy, computeBackoff, sleepWithAbort } from "../infra/bac
 import { formatErrorMessage } from "../infra/errors.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
+import { initializeGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type { PluginRegistry } from "../plugins/registry.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import {
@@ -77,6 +80,8 @@ type ChannelManagerOptions = {
   loadConfig: () => OpenClawConfig;
   channelLogs: Record<ChannelId, SubsystemLogger>;
   channelRuntimeEnvs: Record<ChannelId, RuntimeEnv>;
+  pluginRegistry?: PluginRegistry;
+  pluginRegistryCacheKey?: string | null;
   /**
    * Optional channel runtime helpers for external channel plugins.
    *
@@ -115,6 +120,7 @@ type ChannelManagerOptions = {
    * a channel account actually starts.
    */
   resolveChannelRuntime?: () => PluginRuntime["channel"];
+  resolvePluginRuntimeState?: () => { registry: PluginRegistry; cacheKey?: string | null } | null;
 };
 
 type StartChannelOptions = {
@@ -135,8 +141,16 @@ export type ChannelManager = {
 
 // Channel docking: lifecycle hooks (`plugin.gateway`) flow through this manager.
 export function createChannelManager(opts: ChannelManagerOptions): ChannelManager {
-  const { loadConfig, channelLogs, channelRuntimeEnvs, channelRuntime, resolveChannelRuntime } =
-    opts;
+  const {
+    loadConfig,
+    channelLogs,
+    channelRuntimeEnvs,
+    channelRuntime,
+    resolveChannelRuntime,
+    pluginRegistry,
+    pluginRegistryCacheKey,
+    resolvePluginRuntimeState,
+  } = opts;
 
   const channelStores = new Map<ChannelId, ChannelRuntimeStore>();
   // Tracks restart attempts per channel:account. Reset on successful start.
@@ -145,6 +159,17 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   const manuallyStopped = new Set<string>();
 
   const restartKey = (channelId: ChannelId, accountId: string) => `${channelId}:${accountId}`;
+
+  const syncPluginRuntimeState = () => {
+    const resolved =
+      resolvePluginRuntimeState?.() ??
+      (pluginRegistry ? { registry: pluginRegistry, cacheKey: pluginRegistryCacheKey } : null);
+    if (!resolved?.registry) {
+      return;
+    }
+    setActivePluginRegistry(resolved.registry, resolved.cacheKey ?? undefined);
+    initializeGlobalHookRunner(resolved.registry);
+  };
 
   const resolveAccountHealthMonitorOverride = (
     channelConfig: ChannelHealthMonitorConfig | undefined,
@@ -239,6 +264,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     accountId?: string,
     opts: StartChannelOptions = {},
   ) => {
+    syncPluginRuntimeState();
     const plugin = getChannelPlugin(channelId);
     const startAccount = plugin?.gateway?.startAccount;
     if (!startAccount) {
@@ -435,6 +461,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   };
 
   const stopChannel = async (channelId: ChannelId, accountId?: string) => {
+    syncPluginRuntimeState();
     const plugin = getChannelPlugin(channelId);
     const store = getStore(channelId);
     // Fast path: nothing running and no explicit plugin shutdown hook to run.
@@ -493,12 +520,15 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   };
 
   const startChannels = async () => {
+    // Bulk startup enumerates plugins from the active registry, so rebind before listing them.
+    syncPluginRuntimeState();
     for (const plugin of listChannelPlugins()) {
       await startChannel(plugin.id);
     }
   };
 
   const markChannelLoggedOut = (channelId: ChannelId, cleared: boolean, accountId?: string) => {
+    syncPluginRuntimeState();
     const plugin = getChannelPlugin(channelId);
     if (!plugin) {
       return;

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -247,7 +247,10 @@ function loadSchemaWithPlugins(): ConfigSchemaResponse {
   const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
   const pluginRegistry = loadOpenClawPlugins({
     config: cfg,
-    cache: true,
+    // Config schema reads need a snapshot registry only; they must not replace the
+    // live gateway plugin runtime while the process is serving channel traffic.
+    cache: false,
+    activate: false,
     workspaceDir,
     runtimeOptions: {
       allowGatewaySubagentBinding: true,

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,6 +1,6 @@
 import { exec } from "node:child_process";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { listChannelPlugins } from "../../channels/plugins/index.js";
+import { listChannelPluginsFromRegistry } from "../../channels/plugins/index.js";
 import {
   createConfigIO,
   loadConfig,
@@ -273,7 +273,7 @@ function loadSchemaWithPlugins(): ConfigSchemaResponse {
       configUiHints: plugin.configUiHints,
       configSchema: plugin.configJsonSchema,
     })),
-    channels: listChannelPlugins().map((entry) => ({
+    channels: listChannelPluginsFromRegistry(pluginRegistry).map((entry) => ({
       id: entry.id,
       label: entry.meta.label,
       description: entry.meta.blurb,

--- a/src/gateway/server-plugin-runtime-state.ts
+++ b/src/gateway/server-plugin-runtime-state.ts
@@ -1,0 +1,45 @@
+import { listChannelPluginsFromRegistry } from "../channels/plugins/index.js";
+import type { PluginRegistry } from "../plugins/registry.js";
+import { getActivePluginRegistry, getActivePluginRegistryKey } from "../plugins/runtime.js";
+
+export type ChannelLifecyclePluginRuntimeState = {
+  registry: PluginRegistry;
+  cacheKey: string | null;
+};
+
+function collectChannelIds(registry: PluginRegistry): Set<string> {
+  return new Set(listChannelPluginsFromRegistry(registry).map((plugin) => plugin.id));
+}
+
+export function resolveChannelLifecyclePluginRuntimeState(
+  current: ChannelLifecyclePluginRuntimeState,
+): ChannelLifecyclePluginRuntimeState {
+  const activeRegistry = getActivePluginRegistry();
+  if (!activeRegistry) {
+    return current;
+  }
+
+  const activeCacheKey = getActivePluginRegistryKey();
+  if (activeRegistry === current.registry) {
+    return current.cacheKey === activeCacheKey
+      ? current
+      : { registry: activeRegistry, cacheKey: activeCacheKey };
+  }
+
+  const currentChannelIds = collectChannelIds(current.registry);
+  const activeChannelIds = collectChannelIds(activeRegistry);
+
+  // Channel lifecycle rebinds must follow legitimate live upgrades such as
+  // lazy outbound bootstrap, but should refuse active snapshots that would
+  // drop channel plugins the gateway already knows about.
+  if (activeChannelIds.size <= currentChannelIds.size) {
+    return current;
+  }
+  for (const channelId of currentChannelIds) {
+    if (!activeChannelIds.has(channelId)) {
+      return current;
+    }
+  }
+
+  return { registry: activeRegistry, cacheKey: activeCacheKey };
+}

--- a/src/gateway/server-plugin-runtime-state.ts
+++ b/src/gateway/server-plugin-runtime-state.ts
@@ -29,12 +29,9 @@ export function resolveChannelLifecyclePluginRuntimeState(
   const currentChannelIds = collectChannelIds(current.registry);
   const activeChannelIds = collectChannelIds(activeRegistry);
 
-  // Channel lifecycle rebinds must follow legitimate live upgrades such as
-  // lazy outbound bootstrap, but should refuse active snapshots that would
-  // drop channel plugins the gateway already knows about.
-  if (activeChannelIds.size <= currentChannelIds.size) {
-    return current;
-  }
+  // Channel lifecycle rebinds must follow legitimate live registry upgrades,
+  // including same-channel replacements that add tools/providers/hooks, but
+  // should still refuse active snapshots that would drop known channels.
   for (const channelId of currentChannelIds) {
     if (!activeChannelIds.has(channelId)) {
       return current;

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -3,6 +3,17 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  getGlobalPluginRegistry,
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import {
+  getActivePluginRegistry,
+  getActivePluginRegistryKey,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
+import {
   connectOk,
   installGatewayTestHooks,
   rpcReq,
@@ -85,6 +96,42 @@ describe("gateway config methods", () => {
     expect(res.ok).toBe(true);
     expect(res.payload?.path).toBe(createConfigIO().configPath);
     expect(res.payload?.config).toBeTruthy();
+  });
+
+  it("does not replace the live plugin runtime when reading config schema", async () => {
+    const previousRegistry = getActivePluginRegistry();
+    const previousRegistryKey = getActivePluginRegistryKey();
+    const previousHookRegistry = getGlobalPluginRegistry();
+    const liveRegistry = createEmptyPluginRegistry();
+
+    setActivePluginRegistry(liveRegistry, "live-registry");
+    initializeGlobalHookRunner(liveRegistry);
+
+    try {
+      const current = await rpcReq<{ ok?: boolean }>(requireWs(), "config.get", {});
+      expect(current.ok).toBe(true);
+      expect(getActivePluginRegistry()).toBe(liveRegistry);
+      expect(getActivePluginRegistryKey()).toBe("live-registry");
+      expect(getGlobalPluginRegistry()).toBe(liveRegistry);
+
+      const lookup = await rpcReq<{ ok?: boolean }>(requireWs(), "config.schema.lookup", {
+        path: "gateway.auth",
+      });
+      expect(lookup.ok).toBe(true);
+      expect(getActivePluginRegistry()).toBe(liveRegistry);
+      expect(getActivePluginRegistryKey()).toBe("live-registry");
+      expect(getGlobalPluginRegistry()).toBe(liveRegistry);
+    } finally {
+      setActivePluginRegistry(
+        previousRegistry ?? createEmptyPluginRegistry(),
+        previousRegistryKey ?? undefined,
+      );
+      if (previousHookRegistry) {
+        initializeGlobalHookRunner(previousHookRegistry);
+      } else {
+        resetGlobalHookRunner();
+      }
+    }
   });
 
   it("returns config.set validation details in the top-level error message", async () => {

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.js";
 import {
   getGlobalPluginRegistry,
   initializeGlobalHookRunner,
@@ -17,6 +18,8 @@ import {
   connectOk,
   installGatewayTestHooks,
   rpcReq,
+  resetTestPluginRegistry,
+  setTestPluginRegistry,
   startServerWithClient,
   testState,
   writeSessionStore,
@@ -72,6 +75,35 @@ async function expectSchemaLookupInvalid(path: unknown) {
   expect(res.error?.message ?? "").toContain("invalid config.schema.lookup params");
 }
 
+function createConfigSchemaTestChannelPlugin(): ChannelPlugin {
+  return {
+    id: "discord",
+    meta: {
+      id: "discord",
+      label: "Discord",
+      selectionLabel: "Discord",
+      docsPath: "/channels/discord",
+      blurb: "test stub",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => [],
+      resolveAccount: () => ({}),
+    },
+    configSchema: {
+      schema: {
+        type: "object",
+        properties: {
+          token: { type: "string" },
+        },
+      },
+      uiHints: {
+        token: { label: "Discord token" },
+      },
+    },
+  };
+}
+
 describe("gateway config methods", () => {
   it("round-trips config.set and returns the live config path", async () => {
     const { createConfigIO } = await import("../config/config.js");
@@ -122,6 +154,50 @@ describe("gateway config methods", () => {
       expect(getActivePluginRegistryKey()).toBe("live-registry");
       expect(getGlobalPluginRegistry()).toBe(liveRegistry);
     } finally {
+      setActivePluginRegistry(
+        previousRegistry ?? createEmptyPluginRegistry(),
+        previousRegistryKey ?? undefined,
+      );
+      if (previousHookRegistry) {
+        initializeGlobalHookRunner(previousHookRegistry);
+      } else {
+        resetGlobalHookRunner();
+      }
+    }
+  });
+
+  it("builds channels.* schema from the snapshot registry instead of the live registry", async () => {
+    const previousRegistry = getActivePluginRegistry();
+    const previousRegistryKey = getActivePluginRegistryKey();
+    const previousHookRegistry = getGlobalPluginRegistry();
+    const liveRegistry = createEmptyPluginRegistry();
+    const snapshotRegistry = createEmptyPluginRegistry();
+    snapshotRegistry.channels.push({
+      pluginId: "discord",
+      source: "test",
+      plugin: createConfigSchemaTestChannelPlugin(),
+    });
+
+    setTestPluginRegistry(snapshotRegistry);
+    setActivePluginRegistry(liveRegistry, "live-registry");
+    initializeGlobalHookRunner(liveRegistry);
+
+    try {
+      const lookup = await rpcReq<{
+        path?: string;
+        hintPath?: string;
+      }>(requireWs(), "config.schema.lookup", {
+        path: "channels.discord.token",
+      });
+
+      expect(lookup.ok).toBe(true);
+      expect(lookup.payload?.path).toBe("channels.discord.token");
+      expect(lookup.payload?.hintPath).toBe("channels.discord.token");
+      expect(getActivePluginRegistry()).toBe(liveRegistry);
+      expect(getActivePluginRegistryKey()).toBe("live-registry");
+      expect(getGlobalPluginRegistry()).toBe(liveRegistry);
+    } finally {
+      resetTestPluginRegistry();
       setActivePluginRegistry(
         previousRegistry ?? createEmptyPluginRegistry(),
         previousRegistryKey ?? undefined,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -100,6 +100,7 @@ import { createSecretsHandlers } from "./server-methods/secrets.js";
 import { hasConnectedMobileNode } from "./server-mobile-nodes.js";
 import { loadGatewayModelCatalog } from "./server-model-catalog.js";
 import { createNodeSubscriptionManager } from "./server-node-subscriptions.js";
+import { resolveChannelLifecyclePluginRuntimeState } from "./server-plugin-runtime-state.js";
 import { loadGatewayPlugins, setFallbackGatewayContext } from "./server-plugins.js";
 import { createGatewayReloadHandlers } from "./server-reload-handlers.js";
 import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
@@ -535,6 +536,24 @@ export async function startGatewayServer(
   const emptyPluginRegistry = createEmptyPluginRegistry();
   let pluginRegistry = emptyPluginRegistry;
   let pluginRegistryCacheKey: string | null = null;
+  let channelLifecyclePluginRuntimeState = {
+    registry: pluginRegistry,
+    cacheKey: pluginRegistryCacheKey,
+  };
+  const updateChannelLifecyclePluginRuntimeState = () => {
+    channelLifecyclePluginRuntimeState = {
+      registry: pluginRegistry,
+      cacheKey: pluginRegistryCacheKey,
+    };
+  };
+  const resolvePluginRuntimeStateForChannels = () => {
+    channelLifecyclePluginRuntimeState = resolveChannelLifecyclePluginRuntimeState(
+      channelLifecyclePluginRuntimeState,
+    );
+    pluginRegistry = channelLifecyclePluginRuntimeState.registry;
+    pluginRegistryCacheKey = channelLifecyclePluginRuntimeState.cacheKey;
+    return channelLifecyclePluginRuntimeState;
+  };
   let baseGatewayMethods = baseMethods;
   if (!minimalTestGateway) {
     ({ pluginRegistry, gatewayMethods: baseGatewayMethods } = loadGatewayPlugins({
@@ -546,6 +565,7 @@ export async function startGatewayServer(
       preferSetupRuntimeForChannelPlugins: deferredConfiguredChannelPluginIds.length > 0,
     }));
     pluginRegistryCacheKey = getActivePluginRegistryKey();
+    updateChannelLifecyclePluginRuntimeState();
   }
   const channelLogs = Object.fromEntries(
     listChannelPlugins().map((plugin) => [plugin.id, logChannels.child(plugin.id)]),
@@ -646,10 +666,7 @@ export async function startGatewayServer(
     channelLogs,
     channelRuntimeEnvs,
     resolveChannelRuntime: getChannelRuntime,
-    resolvePluginRuntimeState: () => ({
-      registry: pluginRegistry,
-      cacheKey: pluginRegistryCacheKey,
-    }),
+    resolvePluginRuntimeState: resolvePluginRuntimeStateForChannels,
   });
   const getReadiness = createReadinessChecker({
     channelManager,
@@ -1174,6 +1191,7 @@ export async function startGatewayServer(
         logDiagnostics: false,
       }));
       pluginRegistryCacheKey = getActivePluginRegistryKey();
+      updateChannelLifecyclePluginRuntimeState();
     }
     ({ browserControl, pluginServices } = await startGatewaySidecars({
       cfg: cfgAtStart,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -49,6 +49,7 @@ import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js
 import { resolveConfiguredDeferredChannelPluginIds } from "../plugins/channel-plugin-ids.js";
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { getActivePluginRegistryKey } from "../plugins/runtime.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
@@ -533,6 +534,7 @@ export async function startGatewayServer(
   const baseMethods = listGatewayMethods();
   const emptyPluginRegistry = createEmptyPluginRegistry();
   let pluginRegistry = emptyPluginRegistry;
+  let pluginRegistryCacheKey: string | null = null;
   let baseGatewayMethods = baseMethods;
   if (!minimalTestGateway) {
     ({ pluginRegistry, gatewayMethods: baseGatewayMethods } = loadGatewayPlugins({
@@ -543,6 +545,7 @@ export async function startGatewayServer(
       baseMethods,
       preferSetupRuntimeForChannelPlugins: deferredConfiguredChannelPluginIds.length > 0,
     }));
+    pluginRegistryCacheKey = getActivePluginRegistryKey();
   }
   const channelLogs = Object.fromEntries(
     listChannelPlugins().map((plugin) => [plugin.id, logChannels.child(plugin.id)]),
@@ -643,6 +646,10 @@ export async function startGatewayServer(
     channelLogs,
     channelRuntimeEnvs,
     resolveChannelRuntime: getChannelRuntime,
+    resolvePluginRuntimeState: () => ({
+      registry: pluginRegistry,
+      cacheKey: pluginRegistryCacheKey,
+    }),
   });
   const getReadiness = createReadinessChecker({
     channelManager,
@@ -1166,6 +1173,7 @@ export async function startGatewayServer(
         baseMethods,
         logDiagnostics: false,
       }));
+      pluginRegistryCacheKey = getActivePluginRegistryKey();
     }
     ({ browserControl, pluginServices } = await startGatewaySidecars({
       cfg: cfgAtStart,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: changing `channels.bluebubbles.*` could hot-reload the BlueBubbles channel after plugin runtime state had drifted, so the restart path could lose the live webhook registration and BlueBubbles webhook deliveries would fall through to `404 Not Found`.
- Why it matters: BlueBubbles could log that its webhook was listening, while `http://localhost:18789/bluebubbles-webhook?...` still behaved as if the route was missing after channel restart / hot reload.
- What changed: gateway channel lifecycle calls now resolve and rebind the current channel-lifecycle plugin runtime state before start/stop/logout work, and config schema reads use snapshot plugin registries instead of mutating the live registry/hook-runner state.
- What did NOT change (scope boundary): this does not change BlueBubbles webhook URLs, passwords, payload parsing, or webhook auth semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #48624
- Fixes #48734
- Fixes #49395

## User-visible / Behavior Changes

In the verified local BlueBubbles hot-reload path, the webhook stays reachable after a `channels.bluebubbles.*` config change and channel restart instead of falling through to `404 Not Found`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local gateway build / restart
- Model/provider: N/A
- Integration/channel (if any): BlueBubbles
- Relevant config (redacted): `channels.bluebubbles.*` with a local webhook URL at `http://localhost:18789/bluebubbles-webhook?...`

### Steps

1. Start the local gateway with BlueBubbles configured.
2. Change `channels.bluebubbles.*` in the local config so the BlueBubbles channel hot-reloads / restarts.
3. Replay a webhook request to the existing BlueBubbles webhook URL.

### Expected

- The webhook route remains reachable after the config-triggered BlueBubbles restart, so the request reaches the BlueBubbles webhook handler.

### Actual

- Before this fix, the same replay could return `404 Not Found` after channel restart / hot reload.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Manual replay evidence from the current local verification:

- Config edit triggered: `config change detected; evaluating reload (channels.bluebubbles.allowFrom, channels.bluebubbles.accounts.default.allowFrom)`
- Gateway restart path triggered: `restarting bluebubbles channel`
- BlueBubbles re-registered: `BlueBubbles webhook listening on /bluebubbles-webhook`
- Replay result after hot reload: `400 invalid payload`

That `400 invalid payload` is intentional from an incomplete test payload and shows the request now reaches the BlueBubbles webhook handler instead of missing the route.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: on a local macOS gateway run, edited `channels.bluebubbles.allowFrom` / `channels.bluebubbles.accounts.default.allowFrom`, observed the config watcher trigger a BlueBubbles restart, and replayed the same webhook URL after restart.
- Edge cases checked: the replay after hot reload returned `400 invalid payload` instead of `404 Not Found`, confirming handler reachability after the config-triggered restart.
- What you did **not** verify: a full end-to-end live BlueBubbles conversation round-trip from a real inbound message through final OpenClaw reply delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/gateway/server-channels.ts`, `src/gateway/server-plugin-runtime-state.ts`, `src/gateway/server.impl.ts`, `src/gateway/server-methods/config.ts`, `src/channels/plugins/index.ts`, `src/channels/plugins/registry.ts`, `src/gateway/server-channels.test.ts`, `src/gateway/server.config-patch.test.ts`
- Known bad symptoms reviewers should watch for: missing or duplicated plugin HTTP routes during channel restart / hot reload, or config schema reads mutating live plugin runtime state.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: channel lifecycle runtime rebinding now tracks more live plugin runtime state than the original narrow fix, so unsupported plugin runtime mutation paths may still surface edge cases outside the BlueBubbles repro.
  - Mitigation: regression coverage now covers stale-registry startup, same-channel live registry upgrades, and snapshot-only config schema loads; manual verification also confirms the local BlueBubbles hot-reload path no longer returns `404`.
