### PR TITLE
fix(telegram): retry setMyCommands on 429 rate-limit with retry_after backoff

### DIFF
--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -349,4 +349,72 @@ describe("bot-native-command-menu", () => {
       "Telegram rejected 10 commands (BOT_COMMANDS_TOO_MUCH); retrying with 8.",
     );
   });
+
+  it("retries setMyCommands after a 429 rate-limit using the retry_after delay", async () => {
+    vi.useFakeTimers();
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const rateLimitError = Object.assign(new Error("429: Too Many Requests: retry after 5"), {
+      error_code: 429,
+      description: "Too Many Requests: retry after 5",
+    });
+    const setMyCommands = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValue(undefined);
+    const runtimeLog = vi.fn();
+    const runtimeError = vi.fn();
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      runtimeError,
+      commandsToRegister: [{ command: "help", description: "Help" }],
+      accountId: `test-ratelimit-${Date.now()}`,
+      botIdentity: "bot-ratelimit",
+    });
+
+    // Advance past the 5-second retry_after delay.
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(2));
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("rate-limited (retry after 5s)"),
+    );
+    expect(runtimeError).not.toHaveBeenCalled();
+  });
+
+  it("gives up setMyCommands after exhausting 429 rate-limit retries", async () => {
+    vi.useFakeTimers();
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const rateLimitError = Object.assign(new Error("429: Too Many Requests: retry after 2"), {
+      error_code: 429,
+      description: "Too Many Requests: retry after 2",
+    });
+    const setMyCommands = vi.fn().mockRejectedValue(rateLimitError);
+    const runtimeLog = vi.fn();
+    const runtimeError = vi.fn();
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      runtimeError,
+      commandsToRegister: [{ command: "help", description: "Help" }],
+      accountId: `test-ratelimit-exhaust-${Date.now()}`,
+      botIdentity: "bot-exhaust",
+    });
+
+    // Each retry schedules a new timer; drain multiple rounds to exhaust all retries.
+    for (let i = 0; i < 4; i++) {
+      await vi.runAllTimersAsync();
+    }
+    vi.useRealTimers();
+
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("rate-limited after 3 retries"),
+    );
+  });
 });

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -407,9 +407,11 @@ describe("bot-native-command-menu", () => {
       botIdentity: "bot-exhaust",
     });
 
-    // Each retry schedules a new timer; drain multiple rounds to exhaust all retries.
-    for (let i = 0; i < 4; i++) {
-      await vi.runAllTimersAsync();
+    // The first call happens before any retry timer is scheduled.
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(1));
+    // Each retry schedules one timer; drain them one round at a time.
+    for (let i = 0; i < 3; i++) {
+      await vi.runOnlyPendingTimersAsync();
     }
     vi.useRealTimers();
 

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -374,15 +374,16 @@ describe("bot-native-command-menu", () => {
       botIdentity: "bot-ratelimit",
     });
 
-    // Advance past the 5-second retry_after delay.
-    await vi.runAllTimersAsync();
-    vi.useRealTimers();
+    await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(1));
+    // Advance past the 5-second retry_after delay after the retry timer is actually scheduled.
+    await vi.runOnlyPendingTimersAsync();
 
     await vi.waitFor(() => expect(setMyCommands).toHaveBeenCalledTimes(2));
     expect(runtimeLog).toHaveBeenCalledWith(
       expect.stringContaining("rate-limited (retry after 5s)"),
     );
     expect(runtimeError).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it("gives up setMyCommands after exhausting 429 rate-limit retries", async () => {

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -106,12 +106,18 @@ function readErrorTextField(value: unknown, key: "description" | "message"): str
  * Returns undefined if the error is not a 429 or the delay cannot be parsed.
  */
 function extractRateLimitRetryAfterSeconds(err: unknown): number | undefined {
-  if (!err || typeof err !== "object") return undefined;
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
   const maybe = err as { error_code?: unknown; description?: unknown };
-  if (maybe.error_code !== 429) return undefined;
+  if (maybe.error_code !== 429) {
+    return undefined;
+  }
   const desc = typeof maybe.description === "string" ? maybe.description : "";
   const match = /retry after (\d+)/i.exec(desc);
-  if (match?.[1]) return parseInt(match[1], 10);
+  if (match?.[1]) {
+    return parseInt(match[1], 10);
+  }
   return undefined;
 }
 

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -14,6 +14,8 @@ export const TELEGRAM_MAX_COMMANDS = 100;
 export const TELEGRAM_TOTAL_COMMAND_TEXT_BUDGET = 5700;
 const TELEGRAM_COMMAND_RETRY_RATIO = 0.8;
 const TELEGRAM_MIN_COMMAND_DESCRIPTION_LENGTH = 1;
+/** Maximum number of times to retry a rate-limited command sync operation. */
+const TELEGRAM_COMMAND_SYNC_RATE_LIMIT_RETRIES = 3;
 
 export type TelegramMenuCommand = {
   command: string;
@@ -97,6 +99,20 @@ function readErrorTextField(value: unknown, key: "description" | "message"): str
     return undefined;
   }
   return readStringValue((value as Record<"description" | "message", unknown>)[key]);
+}
+
+/**
+ * Extract the retry-after delay in seconds from a Telegram 429 rate-limit error.
+ * Returns undefined if the error is not a 429 or the delay cannot be parsed.
+ */
+function extractRateLimitRetryAfterSeconds(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const maybe = err as { error_code?: unknown; description?: unknown };
+  if (maybe.error_code !== 429) return undefined;
+  const desc = typeof maybe.description === "string" ? maybe.description : "";
+  const match = /retry after (\d+)/i.exec(desc);
+  if (match?.[1]) return parseInt(match[1], 10);
+  return undefined;
 }
 
 function isBotCommandsTooMuchError(err: unknown): boolean {
@@ -299,12 +315,15 @@ export function syncTelegramMenuCommands(params: {
 
     let retryCommands = commandsToRegister;
     const initialCommandCount = commandsToRegister.length;
+    // Track 429 retry attempts separately from BOT_COMMANDS_TOO_MUCH shrink retries.
+    let rateLimitRetries = 0;
     while (retryCommands.length > 0) {
       try {
         await withTelegramApiErrorLogging({
           operation: "setMyCommands",
           runtime,
-          shouldLog: (err) => !isBotCommandsTooMuchError(err),
+          shouldLog: (err) =>
+            !isBotCommandsTooMuchError(err) && extractRateLimitRetryAfterSeconds(err) === undefined,
           fn: () => bot.api.setMyCommands(retryCommands),
         });
         if (retryCommands.length < initialCommandCount) {
@@ -318,6 +337,25 @@ export function syncTelegramMenuCommands(params: {
         await writeCachedCommandHash(accountId, botIdentity, currentHash);
         return;
       } catch (err) {
+        // Handle 429 rate-limit: wait for the server-specified delay then retry.
+        const rateLimitDelaySecs = extractRateLimitRetryAfterSeconds(err);
+        if (rateLimitDelaySecs !== undefined) {
+          if (rateLimitRetries >= TELEGRAM_COMMAND_SYNC_RATE_LIMIT_RETRIES) {
+            runtime.error?.(
+              `Telegram setMyCommands rate-limited after ${rateLimitRetries} retries; giving up. ` +
+                "The command menu will be synced on the next gateway restart.",
+            );
+            return;
+          }
+          rateLimitRetries++;
+          runtime.log?.(
+            `Telegram setMyCommands rate-limited (retry after ${rateLimitDelaySecs}s); ` +
+              `will retry in ${rateLimitDelaySecs}s (attempt ${rateLimitRetries}/${TELEGRAM_COMMAND_SYNC_RATE_LIMIT_RETRIES}).`,
+          );
+          await new Promise<void>((resolve) => setTimeout(resolve, rateLimitDelaySecs * 1000));
+          continue;
+        }
+
         if (!isBotCommandsTooMuchError(err)) {
           throw err;
         }


### PR DESCRIPTION
## Problem

When the gateway restarts, `syncTelegramMenuCommands` calls `setMyCommands` / `deleteMyCommands` on each bot. Under rapid restarts (e.g., config changes during debugging), Telegram rate-limits these calls with `429 Too Many Requests: retry after N`. The current code catches this error, logs it, and silently drops the sync — but the **command hash is never written**, so every subsequent restart retries the call, hitting 429 again and again in a compounding loop.

The existing hash-caching defence (see #32017) prevents redundant syncs when commands are unchanged, but it only writes the hash after a **successful** `setMyCommands`. A 429 breaks this invariant.

## Root cause

`extensions/telegram/src/bot-native-command-menu.ts`, inside `syncTelegramMenuCommands`:

```typescript
} catch (err) {
  if (!isBotCommandsTooMuchError(err)) {
    throw err;   // ← 429 is thrown here, propagates to outer .catch which only logs
  }
  // BOT_COMMANDS_TOO_MUCH shrink logic...
}
```

No retry-after handling → the hash never gets cached → infinite 429 loop on next restart.

## Fix

Add `extractRateLimitRetryAfterSeconds` that parses the `retry_after` value from a GrammyError with `error_code === 429`. When detected:

1. Log a message including the delay.
2. `await` the specified delay via `setTimeout`.
3. Re-enter the loop (`continue`).
4. Give up after `TELEGRAM_COMMAND_SYNC_RATE_LIMIT_RETRIES` (3) attempts with an explanatory error log.

This mirrors the correct pattern: **wait the server-specified time, then retry**; never immediately re-throw and let systemd restart do it (that would call setMyCommands again immediately, re-triggering the 429).

## Changes

- `extensions/telegram/src/bot-native-command-menu.ts` — adds `extractRateLimitRetryAfterSeconds` helper and 429-aware retry loop inside `syncTelegramMenuCommands`
- `extensions/telegram/src/bot-native-command-menu.test.ts` — two new test cases:
  - successful retry after a single 429
  - exhaustion of all retries with error log

## Tests

```
✓ retries setMyCommands after a 429 rate-limit using the retry_after delay
✓ gives up setMyCommands after exhausting 429 rate-limit retries
13 tests passed (0 failed)
```

Fixes the self-compounding 429 loop that occurs when the gateway is restarted multiple times in quick succession (e.g., during config changes or debugging sessions).