### PR TITLE
fix: regenerate models.json on config hot reload

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -14,6 +14,7 @@ export type GatewayReloadPlan = {
   restartCron: boolean;
   restartHeartbeat: boolean;
   restartHealthMonitor: boolean;
+  regenerateModelsJson: boolean;
   restartChannels: Set<ChannelKind>;
   noopPaths: string[];
 };
@@ -31,6 +32,7 @@ type ReloadAction =
   | "restart-cron"
   | "restart-heartbeat"
   | "restart-health-monitor"
+  | "regenerate-models-json"
   | `restart-channel:${ChannelId}`;
 
 const BASE_RELOAD_RULES: ReloadRule[] = [
@@ -73,7 +75,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   {
     prefix: "models",
     kind: "hot",
-    actions: ["restart-heartbeat"],
+    actions: ["restart-heartbeat", "regenerate-models-json"],
   },
   { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
@@ -161,6 +163,7 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
     restartCron: false,
     restartHeartbeat: false,
     restartHealthMonitor: false,
+    regenerateModelsJson: false,
     restartChannels: new Set(),
     noopPaths: [],
   };
@@ -189,6 +192,9 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
         break;
       case "restart-health-monitor":
         plan.restartHealthMonitor = true;
+        break;
+      case "regenerate-models-json":
+        plan.regenerateModelsJson = true;
         break;
       default:
         break;

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -154,6 +154,8 @@ export function createGatewayReloadHandlers(params: {
         const result = await ensureOpenClawModelsJson(nextConfig);
         if (result.wrote) {
           params.logReload.info("models.json regenerated from updated config");
+        } else {
+          params.logReload.info("models.json already up-to-date, no write needed");
         }
       } catch (err) {
         params.logReload.warn(`models.json regeneration failed: ${String(err)}`);

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,4 +1,5 @@
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
+import { ensureOpenClawModelsJson } from "../agents/models-config.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.js";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
@@ -145,6 +146,17 @@ export function createGatewayReloadHandlers(params: {
         for (const channel of plan.restartChannels) {
           await restartChannel(channel);
         }
+      }
+    }
+
+    if (plan.regenerateModelsJson) {
+      try {
+        const result = await ensureOpenClawModelsJson(nextConfig);
+        if (result.wrote) {
+          params.logReload.info("models.json regenerated from updated config");
+        }
+      } catch (err) {
+        params.logReload.warn(`models.json regeneration failed: ${String(err)}`);
       }
     }
 


### PR DESCRIPTION
## Summary

When models are added or modified in `openclaw.json`, the config hot reload path updates in-memory provider configuration but does **not** regenerate the per-agent `models.json` files. New models don't appear in the Telegram `/model` menu until a full gateway restart.

## Changes

- Added `regenerate-models-json` reload action to `config-reload-plan.ts`
- Added `regenerateModelsJson` flag to `GatewayReloadPlan` type
- Call `ensureOpenClawModelsJson()` in `applyHotReload()` when model-related config paths change
- Wrapped in try/catch — failure logs a warning but doesn't break hot reload

## Root Cause

`ensureOpenClawModelsJson()` is only called during gateway startup. The hot reload path for `models.*` config changes only triggers `restart-heartbeat`, missing the models.json regeneration step.

## Test Plan

- [x] Verified the issue: adding a model to `openclaw.json` → hot reload fires → `/model` still shows old list
- [x] After this fix: hot reload regenerates `models.json` → new model appears without restart
- [ ] CI tests should pass (no existing behavior changed, only additive)

Fixes #49568