### PR TITLE
fix(sessions): updateLastRoute must not bump updatedAt (#49515)

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -243,7 +243,8 @@ describe("sessions", () => {
 
     const store = loadSessionStore(storePath);
     expect(store[mainSessionKey]?.sessionId).toBe("sess-1");
-    expect(store[mainSessionKey]?.updatedAt).toBeGreaterThanOrEqual(123);
+    // updateLastRoute must preserve existing updatedAt (activity timestamp)
+    expect(store[mainSessionKey]?.updatedAt).toBe(123);
     expect(store[mainSessionKey]?.lastChannel).toBe("telegram");
     expect(store[mainSessionKey]?.lastTo).toBe("12345");
     expect(store[mainSessionKey]?.deliveryContext).toEqual({
@@ -353,6 +354,36 @@ describe("sessions", () => {
     expect(store[sessionKey]?.origin?.label).toBe("Family id:123@g.us");
     expect(store[sessionKey]?.origin?.provider).toBe("whatsapp");
     expect(store[sessionKey]?.origin?.chatType).toBe("group");
+  });
+
+  it("updateLastRoute does not bump updatedAt on existing sessions (#49515)", async () => {
+    const mainSessionKey = "agent:main:main";
+    const frozenUpdatedAt = 1000;
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "updateLastRoute-preserve-activity",
+      entries: {
+        [mainSessionKey]: buildMainSessionEntry({
+          updatedAt: frozenUpdatedAt,
+        }),
+      },
+    });
+
+    await updateLastRoute({
+      storePath,
+      sessionKey: mainSessionKey,
+      deliveryContext: {
+        channel: "telegram",
+        to: "99999",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    // Route updates must not refresh activity timestamps; idle/daily reset
+    // evaluation relies on updatedAt from actual session turns.
+    expect(store[mainSessionKey]?.updatedAt).toBe(frozenUpdatedAt);
+    // Routing fields should still be updated
+    expect(store[mainSessionKey]?.lastChannel).toBe("telegram");
+    expect(store[mainSessionKey]?.lastTo).toBe("99999");
   });
 
   it("updateSessionStoreEntry preserves existing fields when patching", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -932,14 +932,15 @@ export async function updateLastRoute(params: {
         })
       : null;
     const basePatch: Partial<SessionEntry> = {
-      updatedAt: Math.max(existing?.updatedAt ?? 0, now),
       deliveryContext: normalized.deliveryContext,
       lastChannel: normalized.lastChannel,
       lastTo: normalized.lastTo,
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    const next = mergeSessionEntry(
+    // Route updates must not refresh activity timestamps; idle/daily reset
+    // evaluation relies on updatedAt from actual session turns (#49515).
+    const next = mergeSessionEntryPreserveActivity(
       existing,
       metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
     );


### PR DESCRIPTION
Fixes #49515

## Problem

`updateLastRoute()` used `mergeSessionEntry` which bumps `updatedAt` to `Date.now()` on every inbound message. This prevented session idle and daily reset from ever firing, since `evaluateSessionFreshness()` always saw a fresh `updatedAt`.

The fix from #32379 patched `recordSessionMetaFromInbound` to use `mergeSessionEntryPreserveActivity`, but missed `updateLastRoute()` in the same inbound pipeline.

## Fix

- Remove explicit `updatedAt` from `updateLastRoute` basePatch (routing should not write activity timestamps)
- Switch from `mergeSessionEntry` to `mergeSessionEntryPreserveActivity` (belt-and-suspenders: `resolveMergedUpdatedAt` has a `Date.now()` fallback that would still bump activity without the preserve-activity policy)
- Add regression test verifying `updatedAt` is preserved across route updates
- Update existing test assertion to match corrected behavior

## Context

The comment at line 860 of `store.ts` already documents the principle:
> Inbound metadata updates must not refresh activity timestamps; idle reset evaluation relies on updatedAt from actual session turns.

This PR applies the same principle to `updateLastRoute()`, completing the fix started in #32379.

## Testing

- New test: `updateLastRoute does not bump updatedAt on existing sessions (#49515)`
- Updated existing test: `updateLastRoute persists channel and target` — assertion changed from `toBeGreaterThanOrEqual(123)` to `toBe(123)`