### PR TITLE
feat: accept optional tools.allow/deny in route bindings

### DIFF
--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -41,6 +41,10 @@ export type AgentRouteBinding = {
   agentId: string;
   comment?: string;
   match: AgentBindingMatch;
+  tools?: {
+    allow?: string[];
+    deny?: string[];
+  };
 };
 
 export type AgentAcpBinding = {

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -34,12 +34,21 @@ const BindingMatchSchema = z
   })
   .strict();
 
+const BindingToolsSchema = z
+  .object({
+    allow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
+  })
+  .strict()
+  .optional();
+
 const RouteBindingSchema = z
   .object({
     type: z.literal("route").optional(),
     agentId: z.string(),
     comment: z.string().optional(),
     match: BindingMatchSchema,
+    tools: BindingToolsSchema,
   })
   .strict();
 


### PR DESCRIPTION
## Summary

`RouteBindingSchema` uses `.strict()` which rejects any fields beyond `agentId`, `comment`, and `match`. This makes it impossible to declare per-binding tool restrictions in `openclaw.json` — the Gateway fails with `must NOT have additional properties`.

## Changes

Added `BindingToolsSchema` (optional `tools.allow` / `tools.deny` string arrays) to `RouteBindingSchema`, so the following config is accepted without validation errors:

```json
{
  "bindings": [
    {
      "agentId": "main",
      "match": { "channel": "telegram", "accountId": "default" },
      "tools": {
        "deny": ["sessions_spawn"]
      }
    }
  ]
}
```

## Scope

This PR only extends the **schema** to accept the `tools` field. The actual runtime filtering (wiring `tools.deny` into `filterToolsByPolicy()`) is left for a follow-up PR to keep this change minimal and easy to review.

## Use Case

Multi-agent Telegram setups where certain tools should be restricted in specific groups while remaining available in DMs. Currently the only workaround is filtering at the MCP server level, which is fragile and invisible to the Gateway.

Refs #49567