### PR TITLE
fix(installer): source nvm before Node detection (#49556)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2340,6 +2340,16 @@ main() {
     install_homebrew
 
     # Step 2: Node.js
+    # Source nvm if available so its managed Node appears on PATH.
+    # In a curl|bash context, .bashrc/.zshrc are not sourced, so nvm's
+    # PATH modifications are missing and the system Node is found instead.
+    if [[ -z "${NVM_DIR:-}" && -d "${HOME}/.nvm" ]]; then
+        export NVM_DIR="${HOME}/.nvm"
+    fi
+    if [[ -n "${NVM_DIR:-}" && -s "${NVM_DIR}/nvm.sh" ]]; then
+        . "${NVM_DIR}/nvm.sh" 2>/dev/null || true
+    fi
+
     if ! check_node; then
         install_node
     fi


### PR DESCRIPTION
## Problem

When the installer runs via `curl -fsSL https://openclaw.ai/install.sh | bash`, shell profile files (`.bashrc`, `.zshrc`) are not sourced. This means nvm's PATH modifications are missing and `command -v node` finds the system Node (e.g. v8 at `/usr/local/bin/node`) instead of the nvm-managed version (e.g. v22 at `~/.nvm/versions/node/v22.x/bin/node`).

The installer then unnecessarily tries to install/upgrade Node, or errors out telling the user to fix their PATH manually.

## Fix

Source `nvm.sh` before `check_node()` is called, so nvm-managed Node versions appear on PATH:

```bash
if [[ -z "${NVM_DIR:-}" && -d "${HOME}/.nvm" ]]; then
    export NVM_DIR="${HOME}/.nvm"
fi
if [[ -n "${NVM_DIR:-}" && -s "${NVM_DIR}/nvm.sh" ]]; then
    . "${NVM_DIR}/nvm.sh" 2>/dev/null || true
fi
```

- Respects `NVM_DIR` if already set
- Falls back to `~/.nvm` (the default nvm install location)
- Suppresses any nvm output with `2>/dev/null`
- Failure is non-fatal (`|| true`)

## Scope

This PR only addresses nvm. Other version managers (fnm, volta, asdf, mise) are not handled — that could be a follow-up if needed.

Fixes #49556