### PR TITLE
fix: classify Z.ai error codes 1311 (billing) and 1113 (auth)

### DIFF
--- a/src/agents/pi-embedded-helpers/failover-matches.test.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAuthErrorMessage,
+  isBillingErrorMessage,
+  isRateLimitErrorMessage,
+} from "./failover-matches.js";
+
+describe("Z.ai vendor error codes (#48988)", () => {
+  describe("error 1311 — model not included in subscription plan", () => {
+    it("classifies Z.ai 1311 JSON body as billing", () => {
+      const raw =
+        '{"code":1311,"message":"The model you requested is not available in your current plan"}';
+      expect(isBillingErrorMessage(raw)).toBe(true);
+    });
+
+    it("classifies Z.ai 1311 with spaces as billing", () => {
+      const raw = '{"code": 1311, "message": "model not on plan"}';
+      expect(isBillingErrorMessage(raw)).toBe(true);
+    });
+
+    it("does not misclassify 1311 as rate_limit", () => {
+      const raw =
+        '{"code":1311,"message":"The model you requested is not available in your current plan"}';
+      expect(isRateLimitErrorMessage(raw)).toBe(false);
+    });
+
+    it("does not misclassify 1311 as auth", () => {
+      const raw =
+        '{"code":1311,"message":"The model you requested is not available in your current plan"}';
+      expect(isAuthErrorMessage(raw)).toBe(false);
+    });
+  });
+
+  describe("error 1113 — wrong endpoint or invalid credentials", () => {
+    it("classifies Z.ai 1113 JSON body as auth", () => {
+      const raw = '{"code":1113,"message":"invalid api endpoint or credentials"}';
+      expect(isAuthErrorMessage(raw)).toBe(true);
+    });
+
+    it("classifies Z.ai 1113 with spaces as auth", () => {
+      const raw = '{"code": 1113, "message": "authentication failed"}';
+      expect(isAuthErrorMessage(raw)).toBe(true);
+    });
+
+    it("does not misclassify 1113 as rate_limit", () => {
+      const raw = '{"code":1113,"message":"invalid api endpoint or credentials"}';
+      expect(isRateLimitErrorMessage(raw)).toBe(false);
+    });
+
+    it("does not misclassify 1113 as billing", () => {
+      const raw = '{"code":1113,"message":"invalid api endpoint or credentials"}';
+      expect(isBillingErrorMessage(raw)).toBe(false);
+    });
+  });
+
+  describe("existing patterns are unaffected", () => {
+    it("rate limit still classified correctly", () => {
+      expect(isRateLimitErrorMessage("rate limit exceeded")).toBe(true);
+    });
+
+    it("billing still classified correctly", () => {
+      expect(isBillingErrorMessage("insufficient credits")).toBe(true);
+    });
+
+    it("auth still classified correctly", () => {
+      expect(isAuthErrorMessage("invalid api key provided")).toBe(true);
+    });
+  });
+});

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -74,6 +74,8 @@ const ERROR_PATTERNS = {
     "insufficient balance",
     "insufficient usd or diem balance",
     /requires?\s+more\s+credits/i,
+    // Z.ai: error 1311 = model not included in current subscription plan (#48988)
+    /"code"\s*:\s*1311\b/,
   ],
   authPermanent: [
     /api[_ ]?key[_ ]?(?:revoked|invalid|deactivated|deleted)/i,
@@ -105,6 +107,8 @@ const ERROR_PATTERNS = {
     "no credentials found",
     "no api key found",
     /\bfailed to (?:extract|parse|validate|decode)\b.*\btoken\b/,
+    // Z.ai: error 1113 = wrong endpoint or invalid credentials (#48988)
+    /"code"\s*:\s*1113\b/,
   ],
   format: [
     "string should match pattern",


### PR DESCRIPTION
## Summary
- Classifies Z.ai error code 1311 as a billing error for proper failover handling
- Classifies Z.ai error code 1113 as an auth error

## Test plan
- [x] Unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)