### PR TITLE
fix: ignore empty/default poll params for message(action=send)

### DIFF
--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -339,6 +339,23 @@ describe("runMessageAction context isolation", () => {
     expect(result.kind).toBe("send");
   });
 
+  it("allows send when poll fields are empty defaults", async () => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "slack",
+        target: "#C12345678",
+        message: "hi",
+        pollQuestion: "",
+        pollOption: [],
+        pollDurationHours: 0,
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    });
+
+    expect(result.kind).toBe("send");
+  });
+
   it.each([
     {
       name: "structured poll params",


### PR DESCRIPTION
## Summary
- Fixes `hasPollCreationParams()` to treat `0` and `"0"` poll field values as empty/default rather than poll creation intent
- Prevents false-positive poll detection that was blocking normal message sends

## Test plan
- [x] Unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)