### PR TITLE
fix(sessions): updateLastRoute must not bump updatedAt

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -243,7 +243,7 @@ describe("sessions", () => {
 
     const store = loadSessionStore(storePath);
     expect(store[mainSessionKey]?.sessionId).toBe("sess-1");
-    expect(store[mainSessionKey]?.updatedAt).toBeGreaterThanOrEqual(123);
+    expect(store[mainSessionKey]?.updatedAt).toBe(123);
     expect(store[mainSessionKey]?.lastChannel).toBe("telegram");
     expect(store[mainSessionKey]?.lastTo).toBe("12345");
     expect(store[mainSessionKey]?.deliveryContext).toEqual({
@@ -279,6 +279,7 @@ describe("sessions", () => {
     });
 
     const store = loadSessionStore(storePath);
+    expect(store[mainSessionKey]?.updatedAt).toBeGreaterThan(0);
     expect(store[mainSessionKey]?.lastChannel).toBe("telegram");
     expect(store[mainSessionKey]?.lastTo).toBe("222");
     expect(store[mainSessionKey]?.lastAccountId).toBe("primary");

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -957,7 +957,10 @@ export async function updateLastRoute(params: {
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    const next = mergeSessionEntry(
+    // Use preserve-activity so that route updates from inbound messages do not
+    // bump updatedAt; idle/daily session resets rely on updatedAt reflecting the
+    // last actual agent turn, not the last routing metadata write.
+    const next = mergeSessionEntryPreserveActivity(
       existing,
       metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
     );

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -904,7 +904,6 @@ export async function updateLastRoute(params: {
     const store = loadSessionStore(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey });
     const existing = resolved.existing;
-    const now = Date.now();
     const explicitContext = normalizeDeliveryContext(params.deliveryContext);
     const inlineContext = normalizeDeliveryContext({
       channel,
@@ -949,18 +948,17 @@ export async function updateLastRoute(params: {
           groupResolution: params.groupResolution,
         })
       : null;
+    // Omit updatedAt: route updates from inbound messages must not bump it;
+    // idle/daily session resets rely on updatedAt reflecting the last actual
+    // agent turn. For new sessions, resolveMergedUpdatedAt defaults to `now`.
     const basePatch: Partial<SessionEntry> = {
-      updatedAt: Math.max(existing?.updatedAt ?? 0, now),
       deliveryContext: normalized.deliveryContext,
       lastChannel: normalized.lastChannel,
       lastTo: normalized.lastTo,
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    // Use preserve-activity so that route updates from inbound messages do not
-    // bump updatedAt; idle/daily session resets rely on updatedAt reflecting the
-    // last actual agent turn, not the last routing metadata write.
-    const next = mergeSessionEntryPreserveActivity(
+    const next = mergeSessionEntry(
       existing,
       metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
     );

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -958,10 +958,10 @@ export async function updateLastRoute(params: {
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    const next = mergeSessionEntry(
-      existing,
-      metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
-    );
+    const patch = metaPatch ? { ...basePatch, ...metaPatch } : basePatch;
+    const next = existing
+      ? mergeSessionEntryPreserveActivity(existing, patch)
+      : mergeSessionEntry(existing, patch);
     return await persistResolvedSessionEntry({
       storePath,
       store,


### PR DESCRIPTION
## Summary

- `updateLastRoute()` was calling `mergeSessionEntry` which bumps `updatedAt` to `Date.now()` on every inbound message
- This made every session always appear "fresh", so `initSessionState()` idle/daily reset checks never triggered
- Changed to `mergeSessionEntryPreserveActivity` so `updatedAt` reflects the last actual agent turn, not the last routing metadata write

## Root cause

In `src/config/sessions/store.ts`, the `updateLastRoute` function used `mergeSessionEntry` (line 942) which calls `resolveMergedUpdatedAt` with the default "touch-activity" policy, always setting `updatedAt = Math.max(existing.updatedAt, Date.now())`. Since `recordInboundSession` calls `updateLastRoute` on every inbound message, `updatedAt` was perpetually bumped to now, and the freshness check in `initSessionState` never saw a stale session.

## Fix

Replaced `mergeSessionEntry` with `mergeSessionEntryPreserveActivity` in `updateLastRoute`. The "preserve-activity" policy returns `existing.updatedAt` instead of bumping it, matching the pattern already used in `recordSessionMetaFromInbound` (same file, line 861).

## Test plan

- [x] Existing tests pass: `store.session-key-normalization.test.ts` (4/4), `session.test.ts` (4/4), `sessions.test.ts` (19/19), `config/sessions.test.ts` (37/37)
- [ ] Manual verification: confirm idle reset fires after configured timeout with active inbound messages

Fixes #49515

🤖 Generated with [Claude Code](https://claude.com/claude-code)