### PR TITLE
fix(ui): use selected model's provider prefix in webchat model switcher

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -146,9 +146,10 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
+    // Bare model name is now qualified with the catalog provider before sending.
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
-      model: "gpt-5-mini",
+      model: "openai/gpt-5-mini",
     });
     expect(host.chatModelOverrides.main).toEqual({
       kind: "qualified",

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -243,12 +243,6 @@ describe("executeSlashCommand directives", () => {
       if (method === "sessions.patch") {
         return createResolvedModelPatch("gpt-5-mini", "openai");
       }
-      if (method === "models.list") {
-        return { models: createModelCatalog(OPENAI_GPT5_MINI_MODEL) };
-      }
-      if (method === "models.list") {
-        return { models: [{ id: "gpt-5-mini", name: "gpt-5-mini", provider: "openai" }] };
-      }
       throw new Error(`unexpected method: ${method}`);
     });
 
@@ -264,7 +258,7 @@ describe("executeSlashCommand directives", () => {
 
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
-      model: "gpt-5-mini",
+      model: "openai/gpt-5-mini",
     });
     expect(result.sessionPatch?.modelOverride).toEqual({
       kind: "qualified",
@@ -296,9 +290,44 @@ describe("executeSlashCommand directives", () => {
       },
     );
 
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "openai/gpt-5-mini",
+    });
     expect(result.sessionPatch?.modelOverride).toEqual({
       kind: "qualified",
       value: "openai/gpt-5-mini",
+    });
+  });
+
+  it("uses the selected model's own provider when switching between providers", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.patch") {
+        return createResolvedModelPatch("gemini-2.5-pro", "google");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "gemini-2.5-pro",
+      {
+        chatModelCatalog: [
+          { id: "claude-opus-4-6", provider: "anthropic", name: "Claude Opus" },
+          { id: "gemini-2.5-pro", provider: "google", name: "Gemini 2.5 Pro" },
+        ],
+      },
+    );
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "google/gemini-2.5-pro",
+    });
+    expect(result.sessionPatch?.modelOverride).toEqual({
+      kind: "qualified",
+      value: "google/gemini-2.5-pro",
     });
   });
 
@@ -320,6 +349,10 @@ describe("executeSlashCommand directives", () => {
       "deepseek-chat",
     );
 
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "deepseek/deepseek-chat",
+    });
     expect(result.sessionPatch?.modelOverride).toEqual({
       kind: "qualified",
       value: "deepseek/deepseek-chat",
@@ -344,6 +377,10 @@ describe("executeSlashCommand directives", () => {
       "gpt-5-mini",
     );
 
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "gpt-5-mini",
+    });
     expect(result.sessionPatch?.modelOverride).toEqual({
       kind: "qualified",
       value: "openai/gpt-5-mini",
@@ -366,12 +403,47 @@ describe("executeSlashCommand directives", () => {
       { modelCatalog: createModelCatalog(OPENAI_GPT5_MINI_MODEL) },
     );
 
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "openai/gpt-5-mini",
+    });
     expect(result.sessionPatch?.modelOverride).toEqual({
       kind: "qualified",
       value: "openai/gpt-5-mini",
     });
     expect(request).toHaveBeenCalledTimes(1);
     expect(request).not.toHaveBeenCalledWith("models.list", {});
+  });
+
+  it("falls back to the bare model when the catalog is ambiguous", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.patch") {
+        return createResolvedModelPatch("gpt-5-mini", "openai");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "gpt-5-mini",
+      {
+        chatModelCatalog: [
+          { id: "gpt-5-mini", provider: "openai", name: "GPT-5 Mini" },
+          { id: "gpt-5-mini", provider: "azure-openai", name: "GPT-5 Mini" },
+        ],
+      },
+    );
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "gpt-5-mini",
+    });
+    expect(result.sessionPatch?.modelOverride).toEqual({
+      kind: "qualified",
+      value: "openai/gpt-5-mini",
+    });
   });
   it("resolves the legacy main alias for /usage", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -136,12 +136,13 @@ async function executeModel(
   args: string,
   context: SlashCommandContext,
 ): Promise<SlashCommandResult> {
-  const modelCatalog = context.chatModelCatalog ?? context.modelCatalog;
+  const modelCatalog = context.chatModelCatalog ?? context.modelCatalog ?? [];
+  const hasModelCatalog = modelCatalog.length > 0;
   if (!args) {
     try {
       const [sessions, models] = await Promise.all([
         client.request<SessionsListResult>("sessions.list", {}),
-        modelCatalog ? Promise.resolve(modelCatalog) : loadModelCatalog(client),
+        hasModelCatalog ? Promise.resolve(modelCatalog) : loadModelCatalog(client),
       ]);
       const session = resolveCurrentSession(sessions, sessionKey);
       const model = session?.model || sessions?.defaults?.model || "default";
@@ -164,7 +165,9 @@ async function executeModel(
   try {
     const modelArg = args.trim();
     const resolvedModelCatalog =
-      modelCatalog ??
+      hasModelCatalog
+        ? modelCatalog
+        :
       (modelArg.includes("/") ? [] : await loadModelCatalog(client, { allowFailure: true }));
     const requestedValue =
       resolveChatModelOverride(createChatModelOverride(modelArg), resolvedModelCatalog).value ||

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -15,7 +15,11 @@ import {
   isSubagentSessionKey,
   parseAgentSessionKey,
 } from "../../../../src/routing/session-key.js";
-import { createChatModelOverride, resolvePreferredServerChatModel } from "../chat-model-ref.ts";
+import {
+  createChatModelOverride,
+  resolveChatModelOverride,
+  resolvePreferredServerChatModel,
+} from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
   AgentsListResult,
@@ -158,22 +162,24 @@ async function executeModel(
   }
 
   try {
-    const [patched, resolvedModelCatalog] = await Promise.all([
-      client.request<SessionsPatchResult>("sessions.patch", {
-        key: sessionKey,
-        model: args.trim(),
-      }),
-      modelCatalog
-        ? Promise.resolve(modelCatalog)
-        : loadModelCatalog(client, { allowFailure: true }),
-    ]);
+    const modelArg = args.trim();
+    const resolvedModelCatalog =
+      modelCatalog ??
+      (modelArg.includes("/") ? [] : await loadModelCatalog(client, { allowFailure: true }));
+    const requestedValue =
+      resolveChatModelOverride(createChatModelOverride(modelArg), resolvedModelCatalog).value ||
+      modelArg;
+    const patched = await client.request<SessionsPatchResult>("sessions.patch", {
+      key: sessionKey,
+      model: requestedValue,
+    });
     const resolvedValue = resolvePreferredServerChatModel(
-      patched.resolved?.model ?? args.trim(),
+      patched.resolved?.model ?? requestedValue,
       patched.resolved?.modelProvider,
       resolvedModelCatalog,
     ).value;
     return {
-      content: `Model set to \`${args.trim()}\`.`,
+      content: `Model set to \`${modelArg}\`.`,
       action: "refresh",
       sessionPatch: { modelOverride: createChatModelOverride(resolvedValue) },
     };


### PR DESCRIPTION
## Summary
- When switching between providers in the webchat UI dropdown, the model switcher incorrectly used the current session's provider prefix instead of the selected model's own provider
- Now looks up the model catalog to resolve the correct `provider/model` string before sending to the server
- Includes regression tests for cross-provider model switching

## Test plan
- [ ] Switch from anthropic/claude to google/gemini in webchat dropdown
- [ ] Verify the correct provider prefix is sent (google/gemini-2.5-pro, not anthropic/gemini-2.5-pro)
- [ ] Verify same-provider switching still works

Fixes #49544

🤖 Generated with [Claude Code](https://claude.com/claude-code)