### PR TITLE
Fix: Preserve Anthropic thinking blocks during compaction

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -734,6 +734,18 @@ export function formatAssistantErrorText(
     );
   }
 
+  // Catch Anthropic thinking blocks error specifically
+  if (
+    raw.includes("thinking") &&
+    raw.includes("redacted_thinking") &&
+    raw.includes("cannot be modified")
+  ) {
+    return (
+      "Context compaction encountered an issue with Anthropic's thinking blocks. " +
+      "Try running /compact again, or use /new to start a fresh session."
+    );
+  }
+
   const invalidRequest = raw.match(/"type":"invalid_request_error".*?"message":"([^"]+)"/);
   if (invalidRequest?.[1]) {
     return `LLM request rejected: ${invalidRequest[1]}`;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -243,6 +243,79 @@ function summarizeCompactionMessages(messages: AgentMessage[]): CompactionMessag
   };
 }
 
+/**
+ * Extract thinking and redacted_thinking blocks from the latest assistant message.
+ * Anthropic's API requires these blocks to remain unmodified in the latest assistant message.
+ */
+function extractThinkingBlocksFromLatestAssistant(
+  messages: AgentMessage[],
+): { blocks: unknown[]; messageIndex: number } | null {
+  // Find the latest assistant message
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (
+      msg &&
+      typeof msg === "object" &&
+      msg.role === "assistant" &&
+      Array.isArray((msg as { content?: unknown }).content)
+    ) {
+      const content = (msg as { content: unknown[] }).content;
+      const thinkingBlocks = content.filter(
+        (block) =>
+          block &&
+          typeof block === "object" &&
+          ((block as { type?: unknown }).type === "thinking" ||
+            (block as { type?: unknown }).type === "redacted_thinking"),
+      );
+      if (thinkingBlocks.length > 0) {
+        return { blocks: thinkingBlocks, messageIndex: i };
+      }
+      // Found latest assistant message but it has no thinking blocks
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Restore thinking blocks to the latest assistant message after compaction.
+ * This ensures Anthropic's API requirement is met.
+ */
+function restoreThinkingBlocksToLatestAssistant(
+  messages: AgentMessage[],
+  preserved: { blocks: unknown[]; messageIndex: number } | null,
+): void {
+  if (!preserved || preserved.blocks.length === 0) {
+    return;
+  }
+
+  // Find the latest assistant message after compaction
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (
+      msg &&
+      typeof msg === "object" &&
+      msg.role === "assistant" &&
+      Array.isArray((msg as { content?: unknown }).content)
+    ) {
+      const content = (msg as { content: unknown[] }).content;
+      // Remove any existing thinking blocks that may have been added during compaction
+      const nonThinkingContent = content.filter(
+        (block) =>
+          !(
+            block &&
+            typeof block === "object" &&
+            ((block as { type?: unknown }).type === "thinking" ||
+              (block as { type?: unknown }).type === "redacted_thinking")
+          ),
+      );
+      // Prepend the preserved thinking blocks (they should come first)
+      (msg as { content: unknown[] }).content = [...preserved.blocks, ...nonThinkingContent];
+      return;
+    }
+  }
+}
+
 function classifyCompactionReason(reason?: string): string {
   const text = (reason ?? "").trim().toLowerCase();
   if (!text) {
@@ -986,6 +1059,11 @@ export async function compactEmbeddedPiSessionDirect(
           // If token estimation throws on a malformed message, fall back to 0 so
           // the sanity check below becomes a no-op instead of crashing compaction.
         }
+
+        // ANTHROPIC FIX: Preserve thinking/redacted_thinking blocks from latest assistant message.
+        // Anthropic's API strictly requires these blocks to remain unmodified.
+        const preservedThinkingBlocks = extractThinkingBlocksFromLatestAssistant(session.messages);
+
         const result = await compactWithSafetyTimeout(
           () => session.compact(params.customInstructions),
           compactionTimeoutMs,
@@ -1001,6 +1079,9 @@ export async function compactEmbeddedPiSessionDirect(
           sessionKey: params.sessionKey,
           sessionFile: params.sessionFile,
         });
+
+        // ANTHROPIC FIX: Restore preserved thinking blocks to latest assistant message.
+        restoreThinkingBlocksToLatestAssistant(session.messages, preservedThinkingBlocks);
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
         try {


### PR DESCRIPTION
## The Bug

When OpenClaw compacts conversation context, it modifies messages that contain Anthropic's `thinking` or `redacted_thinking` content blocks. Anthropic's API strictly requires these blocks in the latest assistant message to remain exactly as they were in the original response.

When compaction alters them, the API returns:
```
LLM request rejected: messages.15.content.13: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.
```

This error then leaks to the end user via Telegram instead of being caught.

## How to Reproduce

1. Have a conversation with Anthropic models (Claude) with thinking enabled
2. Let the context grow until compaction is triggered
3. After compaction, the next API call fails with the thinking blocks error
4. User sees the raw API error in chat

## The Fix

Two-part fix:

### Part 1: Preserve thinking blocks during compaction
- Before calling `session.compact()`, extract any `thinking` or `redacted_thinking` blocks from the latest assistant message
- After compaction completes, restore those exact blocks to the latest assistant message
- Ensures Anthropic's immutability requirement is met

### Part 2: Error handling (defense in depth)
- Added specific detection for the Anthropic thinking blocks error in error formatting
- Provides a user-friendly message suggesting `/compact` retry or `/new`
- Prevents raw API error from leaking to chat

## Code Changes

- `src/agents/pi-embedded-runner/compact.ts`: Added helper functions to extract and restore thinking blocks around the compaction call
- `src/agents/pi-embedded-helpers/errors.ts`: Added specific error handling for the thinking blocks API error

## Testing

The fix has been reviewed for logic correctness. It:
- Only touches messages when thinking blocks are present in the latest assistant message
- Preserves all other message content unchanged
- Uses defensive coding (null checks, array bounds checks)
- Falls back gracefully if no thinking blocks are found

## Impact

- Fixes a crash that blocks continued conversation after compaction
- Maintains compatibility with Anthropic's API requirements
- No impact on non-Anthropic providers or messages without thinking blocks
- Minimal, surgical change to core compaction logic