### PR TITLE
fix(ui): add .catch() to createLazy() to prevent silent blank views

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -111,11 +111,18 @@ function createLazy<T>(loader: () => Promise<T>): () => T | null {
       return s.mod;
     }
     if (!s.promise) {
-      s.promise = loader().then((m) => {
-        s.mod = m;
-        _pendingUpdate?.();
-        return m;
-      });
+      s.promise = loader()
+        .then((m) => {
+          s.mod = m;
+          _pendingUpdate?.();
+          return m;
+        })
+        .catch((err) => {
+          console.error("[openclaw] Failed to load lazy module:", err);
+          s.promise = null; // allow retry on next render
+          _pendingUpdate?.();
+          return null as unknown as T;
+        });
     }
     return null;
   };


### PR DESCRIPTION
## Problem

When a lazy-loaded view module (e.g. `channels.ts`) fails to import, `createLazy()` in `app-render.ts` had no `.catch()` handler. The promise rejected silently, `s.mod` stayed `null` forever, and the view rendered blank permanently — no error in console, no recovery, no retry.

All 9 lazy views share this vulnerability: `lazyAgents`, `lazyChannels`, `lazyCron`, `lazyDebug`, `lazyInstances`, `lazyLogs`, `lazyNodes`, `lazySessions`, `lazySkills`.

## Fix

Add a `.catch()` handler that:
- Logs the error to `console.error` for visibility
- Resets `s.promise = null` so the next render retries the import
- Calls `_pendingUpdate()` to trigger a re-render

```typescript
s.promise = loader()
  .then((m) => {
    s.mod = m;
    _pendingUpdate?.();
    return m;
  })
  .catch((err) => {
    console.error('[openclaw] Failed to load lazy module:', err);
    s.promise = null; // allow retry on next render
    _pendingUpdate?.();
    return null as unknown as T;
  });
```

## Testing

Reproduce: throw inside a lazy-loaded view module. Before: blank page, no console output. After: error logged, page retries on next render.

Fixes #49665