### PR TITLE
fix(installer): load nvm before Node.js version check

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1395,6 +1395,21 @@ ensure_default_node_active_shell() {
     return 1
 }
 
+try_load_nvm() {
+    # Source nvm before checking Node.js so the installer uses the nvm-managed
+    # version rather than a system-installed Node that may be too old.
+    # This is a no-op if nvm is not installed or already loaded.
+    local nvm_dir="${NVM_DIR:-$HOME/.nvm}"
+    if [[ -s "${nvm_dir}/nvm.sh" ]]; then
+        # shellcheck source=/dev/null
+        . "${nvm_dir}/nvm.sh" --no-use
+        # Activate the default/current nvm Node version if one is set
+        if command -v nvm >/dev/null 2>&1; then
+            nvm use default --silent 2>/dev/null || nvm use node --silent 2>/dev/null || true
+        fi
+    fi
+}
+
 check_node() {
     if command -v node &> /dev/null; then
         NODE_VERSION="$(node_major_version || true)"
@@ -2340,6 +2355,11 @@ main() {
     install_homebrew
 
     # Step 2: Node.js
+    # Proactively load nvm if available so the installer picks up the nvm-managed
+    # Node instead of a stale system Node (e.g. /usr/bin/node v8) that appears
+    # earlier on PATH. Without this, check_node() fails on the system binary and
+    # install_node() runs unnecessarily, overwriting the user's nvm environment.
+    try_load_nvm
     if ! check_node; then
         install_node
     fi


### PR DESCRIPTION
## Problem

On systems where nvm manages Node.js, the installer runs in a non-interactive shell (e.g. `curl ... | bash`) where nvm is not loaded. The system-installed Node (e.g. `/usr/bin/node` v8) appeared earlier on PATH, causing `check_node()` to fail on the stale binary and trigger `install_node()` — overwriting the user's nvm environment unnecessarily.

## Fix

Add a `try_load_nvm()` helper that sources `${NVM_DIR:-$HOME/.nvm}/nvm.sh` with `--no-use` before `check_node` runs, then activates the nvm default alias. If nvm is not installed, it is a no-op.

```bash
try_load_nvm() {
    local nvm_dir="${NVM_DIR:-$HOME/.nvm}"
    if [[ -s "${nvm_dir}/nvm.sh" ]]; then
        . "${nvm_dir}/nvm.sh" --no-use
        if command -v nvm >/dev/null 2>&1; then
            nvm use default --silent 2>/dev/null || nvm use node --silent 2>/dev/null || true
        fi
    fi
}
```

## Testing

- System with nvm + Node 24 via nvm, Node 18 at `/usr/bin/node`: before fix → installs Node again; after fix → detects v24 correctly and skips install
- System without nvm: `try_load_nvm` is a no-op, no behavior change

Fixes #49556