### PR TITLE
fix(ui): add .catch() handler to createLazy — prevents permanent blank Control UI views

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -111,11 +111,18 @@ function createLazy<T>(loader: () => Promise<T>): () => T | null {
       return s.mod;
     }
     if (!s.promise) {
-      s.promise = loader().then((m) => {
-        s.mod = m;
-        _pendingUpdate?.();
-        return m;
-      });
+      s.promise = loader()
+        .then((m) => {
+          s.mod = m;
+          _pendingUpdate?.();
+          return m;
+        })
+        .catch((err) => {
+          console.error("[openclaw] Failed to load lazy view module:", err);
+          s.promise = null; // reset so the view can retry on next render
+          _pendingUpdate?.();
+          return null as any;
+        });
     }
     return null;
   };


### PR DESCRIPTION
## Problem

When a lazy-loaded view module fails to import (e.g. due to a JavaScript evaluation error during module load), the rejected promise in `createLazy()` is not caught. This causes:

- `s.mod` stays `null` permanently
- Every subsequent render returns `null` (blank view)
- No error appears in the console — completely silent failure

All 9 lazy-loaded Control UI views share this vulnerability:
`lazyAgents`, `lazyChannels`, `lazyCron`, `lazyDebug`, `lazyInstances`, `lazyLogs`, `lazyNodes`, `lazySessions`, `lazySkills`

The most commonly reported symptom is the **Channels page rendering completely empty** even though `channels.status` WebSocket RPC returns data successfully — the page header renders but no channel cards appear.

Reported in #49665.

## Fix

Added a `.catch()` handler to `createLazy()` that:

1. **Logs the error** to `console.error` so failures are visible during debugging instead of silently disappearing
2. **Resets `s.promise` to `null`** so the view can retry loading on the next render cycle rather than staying blank permanently
3. **Calls `_pendingUpdate()`** to trigger an immediate re-render attempt after the failure is recorded

```typescript
// Before: no .catch() — import failure silently leaves s.mod = null forever
s.promise = loader().then((m) => { s.mod = m; _pendingUpdate?.(); return m; });

// After: failure is logged and state is reset for retry
s.promise = loader()
  .then((m) => { s.mod = m; _pendingUpdate?.(); return m; })
  .catch((err) => {
    console.error('[openclaw] Failed to load lazy view module:', err);
    s.promise = null; // reset so the view can retry on next render
    _pendingUpdate?.();
    return null as any;
  });
```

## Testing

To reproduce the original bug: intercept `import('./views/channels.ts')` to throw, observe blank Channels page with no console output. With this fix, the error is logged and the view retries on next render.

Fixes #49665