### PR TITLE
Fix device-pairing key mismatch and regex escape bugs

### DIFF
--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -470,7 +470,7 @@ export async function updatePairedDeviceMetadata(
     }
     const roles = mergeRoles(existing.roles, existing.role, patch.role);
     const scopes = mergeScopes(existing.scopes, patch.scopes);
-    state.pairedByDeviceId[deviceId] = {
+    state.pairedByDeviceId[existing.deviceId] = {
       ...existing,
       ...patch,
       deviceId: existing.deviceId,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -740,7 +740,7 @@ export function resolveSessionDisplayName(
     if (!prefix) {
       return name;
     }
-    const prefixPattern = new RegExp(`^${prefix.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}\\s*`, "i");
+    const prefixPattern = new RegExp(`^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*`, "i");
     return prefixPattern.test(name) ? name : `${prefix} ${name}`;
   };
 

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -604,7 +604,7 @@ function compilePattern(pattern: string): CompiledPattern {
   if (!normalized.includes("*")) {
     return { kind: "exact", value: normalized };
   }
-  const escaped = normalized.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
+  const escaped = normalized.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return { kind: "regex", value: new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`) };
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** Two categories of bugs found during code audit: (1) `updatePairedDeviceMetadata` uses raw `deviceId` as the map write key while using `normalizeDeviceId(deviceId)` for lookup, which can create duplicate entries if the input has leading/trailing whitespace; (2) Two UI files have a malformed regex escape pattern where `[\]` was mistyped as `[\\]`, causing the `]` character to fall outside the character class and not be properly escaped.
- **Why it matters:** The device-pairing bug could cause metadata updates to be lost (written to a new key while the old key retains stale data). The regex bugs mean `]` characters in tool patterns or prefixes won't be escaped, potentially causing incorrect regex construction.
- **What changed:** Used `existing.deviceId` (the already-normalized stored key) for the map write in `updatePairedDeviceMetadata`. Fixed the regex character class in both UI files to match the correct pattern used elsewhere in the codebase (`src/utils.ts`, `src/agents/glob-pattern.ts`).
- **What did NOT change (scope boundary):** No behavioral changes beyond correcting the identified bugs. No new features, no refactoring.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Auth / tokens
- [x] UI / DX

## Linked Issue/PR

- N/A — discovered during code audit

## User-visible / Behavior Changes

None — these fixes correct edge-case bugs that don't change normal operation.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Device-pairing bug

**Steps:**
1. Call `updatePairedDeviceMetadata` with a `deviceId` that has leading/trailing whitespace (e.g., `"  device-123  "`)
2. The lookup via `normalizeDeviceId()` finds the existing entry at key `"device-123"`
3. The write goes to key `"  device-123  "` — creating a duplicate

**Expected:** Update should be written to the same key that was looked up.

**Actual (before fix):** A new entry is created at the raw key; the original entry retains stale data.

### Regex escape bug

**Steps:**
1. In the UI, have a tool pattern or prefix containing `]`
2. The `]` is not escaped before being used in `new RegExp()`

**Expected:** `]` should be escaped to `\]` like all other special regex characters.

**Actual (before fix):** `]` passes through unescaped because the regex character class `[\\]` prematurely closes at `\\` + `]`, leaving `]` outside the class.

## Evidence

- The correct regex pattern `/[.*+?^${}()|[\]\\]/g` exists in `src/utils.ts:44`, `src/agents/glob-pattern.ts:8`, and `src/tui/components/searchable-select-list.ts:132`
- The buggy pattern `/[.*+?^${}()|[\\]\\]/g` only appears in the two UI files fixed here
- Other write operations in `device-pairing.ts` consistently use `device.deviceId` (the stored normalized form) as the map key (lines 417, 551, 608, 680, 708)

## Human Verification (required)

- Verified scenarios: Compared regex patterns across codebase; confirmed write key inconsistency against all other map writes in device-pairing.ts
- Edge cases checked: Verified `normalizeDeviceId` is `trim()` only; confirmed `existing.deviceId` is always the normalized form
- What I did **not** verify: Did not run full test suite (CI should cover this)

## AI/Vibe-Coded PR

- [x] AI-assisted (found and fixed with Claude code audit)
- [x] Lightly tested (lint clean, logic verified by code review)
- [x] I understand what the code does

## Review Conversations

- [x] I will reply to or resolve every bot review conversation I address in this PR.
- [x] I will leave unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the two commits
- Known bad symptoms: None expected — both fixes are strictly more correct than the originals

## Risks and Mitigations

- Risk: Device-pairing fix changes which map key is written to
  - Mitigation: `existing.deviceId` is the canonical normalized key, matching all other write sites in the same file