### PR TITLE
fix(responses): pass clientTools to runEmbeddedAttempt

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -960,6 +960,7 @@ export async function runEmbeddedPiAgent(
             skillsSnapshot: params.skillsSnapshot,
             prompt,
             images: params.images,
+            clientTools: params.clientTools,
             disableTools: params.disableTools,
             provider,
             modelId,


### PR DESCRIPTION
## Problem

When client-side function tools are provided via the `/v1/responses` API:

```json
{
  "tools": [{"type": "function", "function": {"name": "my_tool", ...}}]
}
```

The tools are correctly extracted and forwarded through the full chain:

```
/v1/responses (gateway)
  → extractClientTools       ✅ tools present
  → agentCommandFromIngress  ✅ opts.clientTools
  → agentCommandInternal     ✅ opts.clientTools
  → runAgentAttempt           ✅ params.opts.clientTools
  → runEmbeddedPiAgent        ✅ params.clientTools
  → runEmbeddedAttempt        ❌ params.clientTools is undefined
  → model API call            ❌ client tools missing
```

`runEmbeddedPiAgent` receives `clientTools` correctly but does **not** pass it through to the inner `runEmbeddedAttempt` call. As a result, client tools are silently dropped and the model never sees them — any attempt to use a client tool results in a "tool not available" text response instead of a proper `function_call` output.

## Fix

Add the missing `clientTools: params.clientTools` to the `runEmbeddedAttempt({...})` call in `run.ts`, consistent with how `images`, `disableTools`, and other pass-through parameters are already handled.

## How I found it

Injected `console.error` debug logs at key points in the call chain (gateway → agentCommandInternal → runEmbeddedPiAgent → runEmbeddedAttempt) and observed that `clientTools` was present up to `runEmbeddedPiAgent` but became `null`/`undefined` inside `runEmbeddedAttempt`.