### PR TITLE
fix: keep slack block streaming replies in thread

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -51,11 +51,21 @@ describe("slack native streaming thread hint", () => {
 });
 
 describe("slack block delivery thread reuse", () => {
-  it("reuses the established thread when first-mode planning is exhausted", () => {
+  it("does not reuse the established thread unless block delivery opts in", () => {
     expect(
       resolveSlackDeliveryThreadTs({
         plannedThreadTs: undefined,
         usedReplyThreadTs: "3000.1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("reuses the established thread when first-mode block planning is exhausted", () => {
+    expect(
+      resolveSlackDeliveryThreadTs({
+        plannedThreadTs: undefined,
+        usedReplyThreadTs: "3000.1",
+        allowUsedReplyThreadTs: true,
       }),
     ).toBe("3000.1");
   });
@@ -66,6 +76,7 @@ describe("slack block delivery thread reuse", () => {
         forcedThreadTs: "3000.2",
         plannedThreadTs: "3000.3",
         usedReplyThreadTs: "3000.1",
+        allowUsedReplyThreadTs: true,
       }),
     ).toBe("3000.2");
 
@@ -73,6 +84,7 @@ describe("slack block delivery thread reuse", () => {
       resolveSlackDeliveryThreadTs({
         plannedThreadTs: "3000.3",
         usedReplyThreadTs: "3000.1",
+        allowUsedReplyThreadTs: true,
       }),
     ).toBe("3000.3");
   });

--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -3,6 +3,7 @@ import {
   isSlackStreamingEnabled,
   resolveSlackDeliveryThreadTs,
   resolveSlackStreamingThreadHint,
+  resolveTrackedSlackBlockReplyThreadTs,
 } from "./dispatch.js";
 
 describe("slack native streaming defaults", () => {
@@ -87,5 +88,25 @@ describe("slack block delivery thread reuse", () => {
         allowUsedReplyThreadTs: true,
       }),
     ).toBe("3000.3");
+  });
+
+  it("refreshes the cached block thread when a delivered block uses an explicit thread", () => {
+    expect(
+      resolveTrackedSlackBlockReplyThreadTs({
+        deliveredThreadTs: "reply-tag.1",
+        usedBlockReplyThreadTs: "3000.1",
+        trackBlockReplyThreadTs: true,
+      }),
+    ).toBe("reply-tag.1");
+  });
+
+  it("keeps the cached block thread when the delivery should not retarget block reuse", () => {
+    expect(
+      resolveTrackedSlackBlockReplyThreadTs({
+        deliveredThreadTs: "reply-tag.1",
+        usedBlockReplyThreadTs: "3000.1",
+        trackBlockReplyThreadTs: false,
+      }),
+    ).toBe("3000.1");
   });
 });

--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isSlackStreamingEnabled, resolveSlackStreamingThreadHint } from "./dispatch.js";
+import {
+  isSlackStreamingEnabled,
+  resolveSlackDeliveryThreadTs,
+  resolveSlackStreamingThreadHint,
+} from "./dispatch.js";
 
 describe("slack native streaming defaults", () => {
   it("is enabled for partial mode when native streaming is on", () => {
@@ -43,5 +47,33 @@ describe("slack native streaming thread hint", () => {
         messageTs: "1000.3",
       }),
     ).toBe("2000.1");
+  });
+});
+
+describe("slack block delivery thread reuse", () => {
+  it("reuses the established thread when first-mode planning is exhausted", () => {
+    expect(
+      resolveSlackDeliveryThreadTs({
+        plannedThreadTs: undefined,
+        usedReplyThreadTs: "3000.1",
+      }),
+    ).toBe("3000.1");
+  });
+
+  it("still prefers an explicit or newly planned thread over the reused thread", () => {
+    expect(
+      resolveSlackDeliveryThreadTs({
+        forcedThreadTs: "3000.2",
+        plannedThreadTs: "3000.3",
+        usedReplyThreadTs: "3000.1",
+      }),
+    ).toBe("3000.2");
+
+    expect(
+      resolveSlackDeliveryThreadTs({
+        plannedThreadTs: "3000.3",
+        usedReplyThreadTs: "3000.1",
+      }),
+    ).toBe("3000.3");
   });
 });

--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isSlackStreamingEnabled,
+  resolveSlackDraftPreviewThreadTs,
   resolveSlackDeliveryThreadTs,
   resolveSlackStreamingThreadHint,
   resolveTrackedSlackBlockReplyThreadTs,
@@ -106,6 +107,28 @@ describe("slack block delivery thread reuse", () => {
         deliveredThreadTs: "reply-tag.1",
         usedBlockReplyThreadTs: "3000.1",
         trackBlockReplyThreadTs: false,
+      }),
+    ).toBe("3000.1");
+  });
+});
+
+describe("slack draft preview thread reuse", () => {
+  it("does not reuse the cached thread in first mode once planning is exhausted", () => {
+    expect(
+      resolveSlackDraftPreviewThreadTs({
+        replyToMode: "first",
+        plannedThreadTs: undefined,
+        usedReplyThreadTs: "3000.1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("can reuse the cached thread in all mode when planning is exhausted", () => {
+    expect(
+      resolveSlackDraftPreviewThreadTs({
+        replyToMode: "all",
+        plannedThreadTs: undefined,
+        usedReplyThreadTs: "3000.1",
       }),
     ).toBe("3000.1");
   });

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -75,6 +75,17 @@ export function resolveSlackDeliveryThreadTs(params: {
   );
 }
 
+export function resolveTrackedSlackBlockReplyThreadTs(params: {
+  deliveredThreadTs?: string;
+  usedBlockReplyThreadTs?: string;
+  trackBlockReplyThreadTs?: boolean;
+}): string | undefined {
+  if (params.trackBlockReplyThreadTs && params.deliveredThreadTs) {
+    return params.deliveredThreadTs;
+  }
+  return params.usedBlockReplyThreadTs;
+}
+
 function shouldUseStreaming(params: {
   streamingEnabled: boolean;
   threadTs: string | undefined;
@@ -278,10 +289,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     // Record the thread ts only after confirmed delivery success.
     if (effectiveReplyThreadTs) {
       usedReplyThreadTs ??= effectiveReplyThreadTs;
-      if (options?.trackBlockReplyThreadTs) {
-        usedBlockReplyThreadTs ??= effectiveReplyThreadTs;
-      }
     }
+    usedBlockReplyThreadTs = resolveTrackedSlackBlockReplyThreadTs({
+      deliveredThreadTs: effectiveReplyThreadTs,
+      usedBlockReplyThreadTs,
+      trackBlockReplyThreadTs: options?.trackBlockReplyThreadTs,
+    });
     replyPlan.markSent();
   };
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -86,6 +86,18 @@ export function resolveTrackedSlackBlockReplyThreadTs(params: {
   return params.usedBlockReplyThreadTs;
 }
 
+export function resolveSlackDraftPreviewThreadTs(params: {
+  replyToMode: "off" | "first" | "all";
+  plannedThreadTs?: string;
+  usedReplyThreadTs?: string;
+}): string | undefined {
+  return resolveSlackDeliveryThreadTs({
+    plannedThreadTs: params.plannedThreadTs,
+    usedReplyThreadTs: params.usedReplyThreadTs,
+    allowUsedReplyThreadTs: params.replyToMode === "all",
+  });
+}
+
 function shouldUseStreaming(params: {
   streamingEnabled: boolean;
   threadTs: string | undefined;
@@ -450,10 +462,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     accountId: account.accountId,
     maxChars: Math.min(ctx.textLimit, 4000),
     resolveThreadTs: () => {
-      const ts = resolveSlackDeliveryThreadTs({
+      const ts = resolveSlackDraftPreviewThreadTs({
+        replyToMode: prepared.replyToMode,
         plannedThreadTs: replyPlan.nextThreadTs(),
         usedReplyThreadTs: usedBlockReplyThreadTs,
-        allowUsedReplyThreadTs: true,
       });
       if (ts) {
         usedReplyThreadTs ??= ts;

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -61,6 +61,14 @@ export function resolveSlackStreamingThreadHint(params: {
   });
 }
 
+export function resolveSlackDeliveryThreadTs(params: {
+  forcedThreadTs?: string;
+  plannedThreadTs?: string;
+  usedReplyThreadTs?: string;
+}): string | undefined {
+  return params.forcedThreadTs ?? params.plannedThreadTs ?? params.usedReplyThreadTs;
+}
+
 function shouldUseStreaming(params: {
   streamingEnabled: boolean;
   threadTs: string | undefined;
@@ -230,7 +238,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let usedReplyThreadTs: string | undefined;
 
   const deliverNormally = async (payload: ReplyPayload, forcedThreadTs?: string): Promise<void> => {
-    const replyThreadTs = forcedThreadTs ?? replyPlan.nextThreadTs();
+    const replyThreadTs = resolveSlackDeliveryThreadTs({
+      forcedThreadTs,
+      plannedThreadTs: replyPlan.nextThreadTs(),
+      usedReplyThreadTs,
+    });
     await deliverReplies({
       replies: [payload],
       target: prepared.replyTarget,
@@ -380,7 +392,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     accountId: account.accountId,
     maxChars: Math.min(ctx.textLimit, 4000),
     resolveThreadTs: () => {
-      const ts = replyPlan.nextThreadTs();
+      const ts = resolveSlackDeliveryThreadTs({
+        plannedThreadTs: replyPlan.nextThreadTs(),
+        usedReplyThreadTs,
+      });
       if (ts) {
         usedReplyThreadTs ??= ts;
       }

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -65,8 +65,13 @@ export function resolveSlackDeliveryThreadTs(params: {
   forcedThreadTs?: string;
   plannedThreadTs?: string;
   usedReplyThreadTs?: string;
+  allowUsedReplyThreadTs?: boolean;
 }): string | undefined {
-  return params.forcedThreadTs ?? params.plannedThreadTs ?? params.usedReplyThreadTs;
+  return (
+    params.forcedThreadTs ??
+    params.plannedThreadTs ??
+    (params.allowUsedReplyThreadTs ? params.usedReplyThreadTs : undefined)
+  );
 }
 
 function shouldUseStreaming(params: {
@@ -237,11 +242,19 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let streamFailed = false;
   let usedReplyThreadTs: string | undefined;
 
-  const deliverNormally = async (payload: ReplyPayload, forcedThreadTs?: string): Promise<void> => {
+  const deliverNormally = async (
+    payload: ReplyPayload,
+    options?: {
+      forcedThreadTs?: string;
+      allowUsedReplyThreadTs?: boolean;
+    },
+  ): Promise<void> => {
+    const plannedThreadTs = options?.forcedThreadTs ? undefined : replyPlan.nextThreadTs();
     const replyThreadTs = resolveSlackDeliveryThreadTs({
-      forcedThreadTs,
-      plannedThreadTs: replyPlan.nextThreadTs(),
+      forcedThreadTs: options?.forcedThreadTs,
+      plannedThreadTs,
       usedReplyThreadTs,
+      allowUsedReplyThreadTs: options?.allowUsedReplyThreadTs,
     });
     await deliverReplies({
       replies: [payload],
@@ -261,14 +274,21 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     replyPlan.markSent();
   };
 
-  const deliverWithStreaming = async (payload: ReplyPayload): Promise<void> => {
+  const deliverWithStreaming = async (
+    payload: ReplyPayload,
+    kind: "tool" | "block" | "final",
+  ): Promise<void> => {
+    const allowUsedReplyThreadTs = kind === "block";
     if (
       streamFailed ||
       hasMedia(payload) ||
       readSlackReplyBlocks(payload)?.length ||
       !payload.text?.trim()
     ) {
-      await deliverNormally(payload, streamSession?.threadTs);
+      await deliverNormally(payload, {
+        forcedThreadTs: streamSession?.threadTs,
+        allowUsedReplyThreadTs,
+      });
       return;
     }
 
@@ -283,7 +303,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             "slack-stream: no reply thread target for stream start, falling back to normal delivery",
           );
           streamFailed = true;
-          await deliverNormally(payload);
+          await deliverNormally(payload, { allowUsedReplyThreadTs });
           return;
         }
 
@@ -309,7 +329,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         danger(`slack-stream: streaming API call failed: ${String(err)}, falling back`),
       );
       streamFailed = true;
-      await deliverNormally(payload, streamSession?.threadTs ?? plannedThreadTs);
+      await deliverNormally(payload, {
+        forcedThreadTs: streamSession?.threadTs ?? plannedThreadTs,
+        allowUsedReplyThreadTs,
+      });
     }
   };
 
@@ -317,9 +340,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     ...prefixOptions,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     typingCallbacks,
-    deliver: async (payload) => {
+    deliver: async (payload, info) => {
       if (useStreaming) {
-        await deliverWithStreaming(payload);
+        await deliverWithStreaming(payload, info.kind);
         return;
       }
 
@@ -378,7 +401,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         hasStreamedMessage = false;
       }
 
-      await deliverNormally(payload);
+      await deliverNormally(payload, {
+        allowUsedReplyThreadTs: info.kind === "block",
+      });
     },
     onError: (err, info) => {
       runtime.error?.(danger(`slack ${info.kind} reply failed: ${String(err)}`));
@@ -395,6 +420,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       const ts = resolveSlackDeliveryThreadTs({
         plannedThreadTs: replyPlan.nextThreadTs(),
         usedReplyThreadTs,
+        allowUsedReplyThreadTs: true,
       });
       if (ts) {
         usedReplyThreadTs ??= ts;

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -28,6 +28,7 @@ import {
   createSlackReplyDeliveryPlan,
   deliverReplies,
   readSlackReplyBlocks,
+  resolveDeliveredSlackReplyThreadTs,
   resolveSlackThreadTs,
 } from "../replies.js";
 import type { PreparedSlackMessage } from "./types.js";
@@ -241,19 +242,21 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let streamSession: SlackStreamSession | null = null;
   let streamFailed = false;
   let usedReplyThreadTs: string | undefined;
+  let usedBlockReplyThreadTs: string | undefined;
 
   const deliverNormally = async (
     payload: ReplyPayload,
     options?: {
       forcedThreadTs?: string;
       allowUsedReplyThreadTs?: boolean;
+      trackBlockReplyThreadTs?: boolean;
     },
   ): Promise<void> => {
     const plannedThreadTs = options?.forcedThreadTs ? undefined : replyPlan.nextThreadTs();
     const replyThreadTs = resolveSlackDeliveryThreadTs({
       forcedThreadTs: options?.forcedThreadTs,
       plannedThreadTs,
-      usedReplyThreadTs,
+      usedReplyThreadTs: usedBlockReplyThreadTs,
       allowUsedReplyThreadTs: options?.allowUsedReplyThreadTs,
     });
     await deliverReplies({
@@ -267,9 +270,17 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       replyToMode: prepared.replyToMode,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
     });
+    const effectiveReplyThreadTs = resolveDeliveredSlackReplyThreadTs({
+      replyToMode: prepared.replyToMode,
+      payloadReplyToId: payload.replyToId,
+      replyThreadTs,
+    });
     // Record the thread ts only after confirmed delivery success.
-    if (replyThreadTs) {
-      usedReplyThreadTs ??= replyThreadTs;
+    if (effectiveReplyThreadTs) {
+      usedReplyThreadTs ??= effectiveReplyThreadTs;
+      if (options?.trackBlockReplyThreadTs) {
+        usedBlockReplyThreadTs ??= effectiveReplyThreadTs;
+      }
     }
     replyPlan.markSent();
   };
@@ -278,7 +289,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     payload: ReplyPayload,
     kind: "tool" | "block" | "final",
   ): Promise<void> => {
-    const allowUsedReplyThreadTs = kind === "block";
+    const trackBlockReplyThreadTs = kind === "block";
     if (
       streamFailed ||
       hasMedia(payload) ||
@@ -287,7 +298,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     ) {
       await deliverNormally(payload, {
         forcedThreadTs: streamSession?.threadTs,
-        allowUsedReplyThreadTs,
+        allowUsedReplyThreadTs: trackBlockReplyThreadTs,
+        trackBlockReplyThreadTs,
       });
       return;
     }
@@ -303,7 +315,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             "slack-stream: no reply thread target for stream start, falling back to normal delivery",
           );
           streamFailed = true;
-          await deliverNormally(payload, { allowUsedReplyThreadTs });
+          await deliverNormally(payload, {
+            allowUsedReplyThreadTs: trackBlockReplyThreadTs,
+            trackBlockReplyThreadTs,
+          });
           return;
         }
 
@@ -316,6 +331,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           userId: message.user,
         });
         usedReplyThreadTs ??= streamThreadTs;
+        if (trackBlockReplyThreadTs) {
+          usedBlockReplyThreadTs ??= streamThreadTs;
+        }
         replyPlan.markSent();
         return;
       }
@@ -331,7 +349,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       streamFailed = true;
       await deliverNormally(payload, {
         forcedThreadTs: streamSession?.threadTs ?? plannedThreadTs,
-        allowUsedReplyThreadTs,
+        allowUsedReplyThreadTs: trackBlockReplyThreadTs,
+        trackBlockReplyThreadTs,
       });
     }
   };
@@ -403,6 +422,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
       await deliverNormally(payload, {
         allowUsedReplyThreadTs: info.kind === "block",
+        trackBlockReplyThreadTs: info.kind === "block",
       });
     },
     onError: (err, info) => {
@@ -419,11 +439,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     resolveThreadTs: () => {
       const ts = resolveSlackDeliveryThreadTs({
         plannedThreadTs: replyPlan.nextThreadTs(),
-        usedReplyThreadTs,
+        usedReplyThreadTs: usedBlockReplyThreadTs,
         allowUsedReplyThreadTs: true,
       });
       if (ts) {
         usedReplyThreadTs ??= ts;
+        usedBlockReplyThreadTs ??= ts;
       }
       return ts;
     },

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -5,7 +5,7 @@ vi.mock("../send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMock(...args),
 }));
 
-import { deliverReplies } from "./replies.js";
+import { deliverReplies, resolveDeliveredSlackReplyThreadTs } from "./replies.js";
 
 function baseParams(overrides?: Record<string, unknown>) {
   return {
@@ -93,5 +93,27 @@ describe("deliverReplies identity passthrough", () => {
         blocks,
       }),
     );
+  });
+});
+
+describe("resolveDeliveredSlackReplyThreadTs", () => {
+  it("prefers explicit reply targets when reply threading is enabled", () => {
+    expect(
+      resolveDeliveredSlackReplyThreadTs({
+        replyToMode: "first",
+        payloadReplyToId: "reply-tag.1",
+        replyThreadTs: "planned.1",
+      }),
+    ).toBe("reply-tag.1");
+  });
+
+  it("ignores explicit reply targets when reply threading is off", () => {
+    expect(
+      resolveDeliveredSlackReplyThreadTs({
+        replyToMode: "off",
+        payloadReplyToId: "reply-tag.1",
+        replyThreadTs: "planned.1",
+      }),
+    ).toBe("planned.1");
   });
 });

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -33,10 +33,11 @@ export async function deliverReplies(params: {
   identity?: SlackSendIdentity;
 }) {
   for (const payload of params.replies) {
-    // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
-    // must not force threading.
-    const inlineReplyToId = params.replyToMode === "off" ? undefined : payload.replyToId;
-    const threadTs = inlineReplyToId ?? params.replyThreadTs;
+    const threadTs = resolveDeliveredSlackReplyThreadTs({
+      replyToMode: params.replyToMode,
+      payloadReplyToId: payload.replyToId,
+      replyThreadTs: params.replyThreadTs,
+    });
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const text = payload.text ?? "";
     const slackBlocks = readSlackReplyBlocks(payload);
@@ -75,6 +76,17 @@ export async function deliverReplies(params: {
     }
     params.runtime.log?.(`delivered reply to ${params.target}`);
   }
+}
+
+export function resolveDeliveredSlackReplyThreadTs(params: {
+  replyToMode: "off" | "first" | "all";
+  payloadReplyToId?: string;
+  replyThreadTs?: string;
+}): string | undefined {
+  // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
+  // must not force threading.
+  const inlineReplyToId = params.replyToMode === "off" ? undefined : params.payloadReplyToId;
+  return inlineReplyToId ?? params.replyThreadTs;
 }
 
 export type SlackRespondFn = (payload: {


### PR DESCRIPTION
## Summary

- Problem: with Slack `blockStreaming: true` and `replyToModeByChatType.channel: "first"`, the first block replies in-thread but later blocks can fall back to the main channel.
- Root cause: the block delivery path consumes `replyPlan.nextThreadTs()` once, but does not reuse the already-established `usedReplyThreadTs` when later block deliveries or draft-stream thread resolution run after the planner is exhausted.
- What changed: added a small thread-resolution helper in the Slack dispatch path and reused the established thread for normal block delivery and draft-stream thread lookup once the first reply has already established the thread.
- Why this fix: it preserves the existing precedence order (`forced thread` > `newly planned thread` > `already established thread`) and keeps behavior unchanged for `replyToMode: "off"` / `"all"` while fixing the `first` + `blockStreaming` regression.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] UI / DX
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49341

## User-visible / Behavior Changes

Slack replies that use `blockStreaming: true` together with `replyToModeByChatType.channel: "first"` now keep later blocks in the same thread once the first block has established that thread.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No

## Repro + Verification

### Environment

- OS: Windows 11 (development environment)
- Integration/channel: Slack block delivery path
- Relevant config: `blockStreaming: true`, `replyToModeByChatType.channel: "first"`

### Steps

1. Configure Slack with block streaming enabled and channel replies in `first` mode.
2. Trigger a response that emits multiple blocks.
3. Observe thread selection across later block deliveries.

### Expected

All blocks after the first reply should continue using the thread that the first reply established.

### Actual

Before this change, later blocks could fall back to the main channel once `replyPlan.nextThreadTs()` had been consumed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted local test command:

`pnpm exec vitest run extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts`

Result observed locally:

- Vitest reported `1` passed file and `7` passed tests for the targeted Slack dispatch test file.
- In this Windows environment, the Vitest wrapper process lingered past a 10-second watchdog after printing the passing result, so the wrapper was terminated after confirming the pass output and verifying no lingering Vitest worker processes remained.

## Human Verification (required)

What you personally verified:

- The new helper preserves precedence as `forced thread` > `planned thread` > `established thread`.
- The new regression tests cover both the reuse case and the precedence case.
- `git diff --check` passed on the changed files.
- `oxfmt --check` passed on the changed files.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore the previous Slack block delivery thread-selection behavior.
- Files/config to restore: `extensions/slack/src/monitor/message-handler/dispatch.ts`, `extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts`
- Known bad symptoms reviewers should watch for: replies unexpectedly staying in a thread when an explicit forced thread or a newly planned thread should have won precedence.

## Risks and Mitigations

- Risk: later block deliveries could accidentally override an explicit thread target.
- Mitigation: the helper keeps explicit `forcedThreadTs` first, planned thread second, and only falls back to the stored thread when both are absent.
