### PR TITLE
fix(plugin-loader): disable tryNative to fix channel runtime crash on Node 22.6+

### DIFF
--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -69,8 +69,11 @@ function getJiti() {
   const { createJiti } = require("jiti");
   jitiLoader = createJiti(__filename, {
     interopDefault: true,
-    // Prefer Node's native sync ESM loader for built dist/plugin-sdk/*.js files
-    // so local plugins do not create a second transpiled OpenClaw core graph.
+    // tryNative: true is safe here because this loader is only ever called
+    // synchronously (jiti(), not jiti.import()). The async tryNative path that
+    // is broken on Node 22.6+ (native TS loading bypasses .js->.ts remapping)
+    // is never triggered. compat.ts also has no dynamic import() calls that
+    // would reach the async path via jitiImport.
     tryNative: true,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
   });

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3331,10 +3331,10 @@ module.exports = {
     expect(subpaths).not.toContain("root-alias");
   });
 
-  it("configures the plugin loader jiti boundary to prefer native dist modules", () => {
+  it("configures the plugin loader jiti boundary to use jiti's own transform for Node 22.6+ compatibility", () => {
     const options = __testing.buildPluginLoaderJitiOptions({});
 
-    expect(options.tryNative).toBe(true);
+    expect(options.tryNative).toBe(false);
     expect(options.interopDefault).toBe(true);
     expect(options.extensions).toContain(".js");
     expect(options.extensions).toContain(".ts");

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -202,9 +202,15 @@ const resolvePluginSdkAlias = (): string | null =>
 function buildPluginLoaderJitiOptions(aliasMap: Record<string, string>) {
   return {
     interopDefault: true,
-    // Prefer Node's native sync ESM loader for built dist/*.js modules so
-    // bundled plugins and plugin-sdk subpaths stay on the canonical module graph.
-    tryNative: true,
+    // Do NOT set tryNative: true here. Node 22+ has native TypeScript support
+    // (type stripping), so jiti's tryNative path loads .ts files via the native
+    // ESM dynamic import(), which succeeds for the file itself but then fails to
+    // resolve its .js-extension sub-imports (ESM convention) because the native
+    // ESM resolver does not remap .js→.ts. jiti's async tryNative path has no
+    // .catch() fallback, so the error propagates instead of falling back to
+    // jiti's own CJS transform. Singleton coherence for pre-loaded dist/*.js
+    // modules is preserved by jiti's moduleCache (shares nativeRequire.cache).
+    tryNative: false,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
     ...(Object.keys(aliasMap).length > 0
       ? {


### PR DESCRIPTION
## Summary

- Problem: Channel runtimes (Discord voice, WhatsApp, and any extension that lazy-loads a `.runtime.ts` file via `import()`) crash immediately on Node 22.6+ with `Cannot find module '...manager.js' imported from ...manager.runtime.ts`.
- Why it matters: Node 22 is current LTS. All users on Node 22.6+ (including 22.12+ stable LTS) are affected. Channels enter an auto-restart loop and never recover.
- What changed: `tryNative: true` -> `tryNative: false` in `buildPluginLoaderJitiOptions` (`src/plugins/loader.ts`). Updated stale test assertion and description in `loader.test.ts`. Added a comment to `root-alias.cjs` confirming its `tryNative: true` is safe (it only uses the synchronous jiti path).
- What did NOT change: All other jiti options, alias resolution, module cache behaviour, singleton coherence. `root-alias.cjs` is unaffected -- see note below.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #49744

## User-visible / Behavior Changes

Channel runtimes that previously crashed on Node 22.6+ now load correctly.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Root Cause

`src/plugins/loader.ts` configures jiti with `tryNative: true`. In jiti v2, the async import path (`jiti.import()`) with `tryNative: true` does:

1. Resolve `./manager.runtime.js` -> `./manager.runtime.ts` (correct)
2. Call `nativeImport('./manager.runtime.ts')` -- native ESM `import()`

Node 22.6+ ships with native TypeScript type stripping, so step 2 **succeeds** -- the `.ts` file loads. But then Node's ESM resolver encounters the static import `import { ... } from './manager.js'` inside `manager.runtime.ts` and throws, because the native ESM resolver does not remap `.js` extensions to `.ts`.

jiti v2's async `tryNative` path has no `.catch()` fallback (unlike the non-`tryNative` async path which does), so the Node ESM error propagates directly to the caller instead of falling back to jiti's own CJS transform.

The synchronous `jiti(path)` path is unaffected: `nativeRequire()` on a `.ts` file with ESM `import` syntax throws immediately (before loading sub-imports), jiti catches that synchronous error, and falls back to its own transform correctly.

**Singleton coherence is preserved** with `tryNative: false`: jiti defaults to `moduleCache: true`, sharing Node's `nativeRequire.cache`. Modules already loaded natively by the core (e.g. `dist/plugin-sdk/cli-runtime.js`) are returned from the shared cache -- no duplicate instances.

**`root-alias.cjs` is not affected**: it only uses synchronous `jiti()` calls (never `jiti.import()`), and `compat.ts` has no dynamic `import()` calls, so the async tryNative code path is never reached. Its `tryNative: true` is left unchanged with a comment confirming the safety analysis.

## Repro + Verification

### Environment

- OS: Linux (also affects macOS with Node 22.6+)
- Runtime: Node 22.6+ (type stripping experimental), Node 22.12+ (stable), Node 23+, Node 24+, Node 25+
- Integration/channel: Discord (voice), WhatsApp -- any channel with a `.runtime.ts` that is lazy-loaded via `import()`

### Steps

1. Install openclaw, configure Discord or WhatsApp.
2. Run `openclaw gateway run` on Node 22.6+.
3. Observe channel immediately exiting with `Cannot find module '...manager.js' imported from ...manager.runtime.ts`.

Programmatic repro:

```js
import { createJiti } from 'jiti';
const jiti = createJiti(import.meta.url, { tryNative: true, extensions: ['.ts', '.js'] });
// Fails on Node 22.6+ -- native ESM loads .ts but then cannot find .js sub-import:
await jiti.import('./extensions/discord/src/voice/manager.runtime.ts');
```

With `tryNative: false` the above resolves correctly (`.js` -> `.ts` remapping handled by jiti).

### Expected

Channel runtimes load and channels connect normally.

### Actual

```
[discord] channel exited: Cannot find module '/path/to/extensions/discord/src/voice/manager.js'
imported from /path/to/extensions/discord/src/voice/manager.runtime.ts
[discord] auto-restart attempt 1/10 in Xs
```

## Evidence

- [x] Trace/log snippets (above)
- [x] Programmatic repro confirms `tryNative: false` resolves the failure

## Human Verification (required)

- Verified scenarios: Gateway started cleanly on Node 22.22.1 with this patch; Discord voice and WhatsApp channels connected without errors. Confirmed channels that were previously in auto-restart loop are stable.
- Edge cases checked: Singleton coherence verified -- `dist/plugin-sdk` modules found in shared `nativeRequire.cache` by jiti, not re-transformed. `root-alias.cjs` confirmed safe (sync-only path, no dynamic imports in compat.ts).
- What you did not verify: Behaviour on Node versions below 22.6 (where `tryNative: true` was fine and this change is a no-op in terms of observable behaviour).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert `tryNative: false` back to `tryNative: true` in `src/plugins/loader.ts` (only safe on Node < 22.6)
- Files/config to restore: `src/plugins/loader.ts`
- Known bad symptoms reviewers should watch for: plugin-sdk singleton split (two instances of the same module) -- would manifest as unexpected `instanceof` failures or shared state not being shared between core and plugin

## Risks and Mitigations

- Risk: `tryNative: false` causes jiti to go through its own transform for `.js` dist files that were previously loaded natively, potentially creating duplicate module instances for modules NOT yet in `nativeRequire.cache`.
  - Mitigation: `moduleCache: true` (jiti default) shares `nativeRequire.cache`. Any module the core has already loaded natively is returned from cache. In practice, all plugin-sdk subpaths used by extensions are loaded during gateway startup before any plugin runs, so they are already cached.