### PR TITLE
fix: clear WS handshake timer early, increase timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/WS handshake: keep valid connect frames from tripping the pre-auth timer while still timing out stalled async auth before registration, and document the shared 10s timeout plus client challenge clamp. Carries forward #49751; related #62060. Thanks @sashakhar1.
 - Agents/approvals: fail restart-interrupted sessions whose transcript tail is still `approval-pending` instead of replaying stale exec approval IDs into the new Gateway process after restart. Fixes #65486. Thanks @mjmai20682068-create.
 - CLI/Gateway: use method-specific least-privilege scopes for classified CLI Gateway calls while preserving legacy broad scopes for unclassified plugin methods, so read-only commands no longer create admin/write/pairing scope-upgrade prompts. Fixes #68634. Thanks @nightmusher.
 - Gateway/sessions: align `chat.history` and `sessions.list` thinking defaults with owning-agent and catalog-aware resolution so Control UI session defaults match backend runtime state. (#63418) Thanks @jpreagan.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -564,6 +564,13 @@ stable across protocol v3 and are the expected baseline for third-party clients.
 | Tick-timeout close                        | code `4000` when silence exceeds `tickIntervalMs * 2` | `src/gateway/client.ts`                                    |
 | `MAX_PAYLOAD_BYTES`                       | `25 * 1024 * 1024` (25 MB)                            | `src/gateway/server-constants.ts`                          |
 
+After a syntactically valid `connect` request arrives, the gateway clears the
+pre-auth challenge timer and uses the same 10 second handshake budget to bound
+async connect/auth work until the client is registered or rejected. The
+`OPENCLAW_HANDSHAKE_TIMEOUT_MS` override applies to both server-side pre-auth
+phases; `OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS` only changes the client
+challenge watchdog and is clamped to the `250`-`10_000` ms range.
+
 The server advertises the effective `policy.tickIntervalMs`, `policy.maxPayload`,
 and `policy.maxBufferedBytes` in `hello-ok`; clients should honor those values
 rather than the pre-handshake defaults.

--- a/src/gateway/handshake-timeouts.test.ts
+++ b/src/gateway/handshake-timeouts.test.ts
@@ -61,4 +61,18 @@ describe("gateway handshake timeouts", () => {
       }
     }
   });
+
+  test("resolveConnectChallengeTimeoutMs clamps env override to the server handshake budget", () => {
+    const original = process.env.OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS;
+    try {
+      process.env.OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS = "15000";
+      expect(resolveConnectChallengeTimeoutMs()).toBe(MAX_CONNECT_CHALLENGE_TIMEOUT_MS);
+    } finally {
+      if (original === undefined) {
+        delete process.env.OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS = original;
+      }
+    }
+  });
 });

--- a/src/gateway/handshake-timeouts.ts
+++ b/src/gateway/handshake-timeouts.ts
@@ -1,5 +1,7 @@
 export const DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 10_000;
 export const MIN_CONNECT_CHALLENGE_TIMEOUT_MS = 250;
+// Keep the client-side connect-challenge watchdog within the server's pre-auth
+// handshake budget so clients fail locally before the gateway's timer expires.
 export const MAX_CONNECT_CHALLENGE_TIMEOUT_MS = DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
 
 export function clampConnectChallengeTimeoutMs(timeoutMs: number): number {

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -200,7 +200,16 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     vi.useFakeTimers();
     const previousHandshakeTimeout = process.env.OPENCLAW_HANDSHAKE_TIMEOUT_MS;
     process.env.OPENCLAW_HANDSHAKE_TIMEOUT_MS = "25";
-    resolveConnectAuthStateMock.mockReturnValue(new Promise(() => {}));
+    let resolveAuth:
+      | ((
+          value: Awaited<ReturnType<typeof import("./auth-context.js").resolveConnectAuthState>>,
+        ) => void)
+      | undefined;
+    resolveConnectAuthStateMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAuth = resolve;
+      }),
+    );
 
     try {
       let onMessage: ((data: string) => void) | undefined;
@@ -216,6 +225,8 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       } as unknown as WebSocket;
       const close = vi.fn();
       const clearHandshakeTimer = vi.fn();
+      const send = vi.fn();
+      const setClient = vi.fn(() => true);
       const resolvedAuth: ResolvedGatewayAuth = {
         mode: "none",
         allowTailscale: false,
@@ -239,12 +250,12 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
         extraHandlers: {},
         buildRequestContext: () => ({}) as GatewayRequestContext,
         refreshHealthSnapshot: vi.fn() as GatewayRequestContext["refreshHealthSnapshot"],
-        send: vi.fn(),
+        send,
         close,
         isClosed: () => false,
         clearHandshakeTimer,
         getClient: () => null,
-        setClient: vi.fn(() => true),
+        setClient,
         setHandshakeState: vi.fn(),
         setCloseCause: vi.fn(),
         setLastFrameMeta: vi.fn(),
@@ -278,6 +289,17 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       await vi.advanceTimersByTimeAsync(25);
 
       expect(close).toHaveBeenCalledWith(1008, "connect auth timeout");
+      resolveAuth?.({
+        authResult: { ok: true, method: "none" },
+        authOk: true,
+        authMethod: "none",
+        sharedAuthOk: false,
+        sharedAuthProvided: false,
+      });
+      await vi.runAllTimersAsync();
+
+      expect(setClient).not.toHaveBeenCalled();
+      expect(send).not.toHaveBeenCalled();
     } finally {
       if (previousHandshakeTimeout === undefined) {
         delete process.env.OPENCLAW_HANDSHAKE_TIMEOUT_MS;

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -11,6 +11,7 @@ const {
   getHealthVersionMock,
   incrementPresenceVersionMock,
   loadConfigMock,
+  resolveConnectAuthStateMock,
   upsertPresenceMock,
 } = vi.hoisted(() => ({
   buildGatewaySnapshotMock: vi.fn(() => ({
@@ -37,6 +38,7 @@ const {
       },
     },
   })),
+  resolveConnectAuthStateMock: vi.fn(),
   upsertPresenceMock: vi.fn(),
 }));
 
@@ -63,6 +65,14 @@ vi.mock("../health-state.js", () => ({
   incrementPresenceVersion: incrementPresenceVersionMock,
 }));
 
+vi.mock("./auth-context.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./auth-context.js")>();
+  return {
+    ...actual,
+    resolveConnectAuthState: resolveConnectAuthStateMock,
+  };
+});
+
 import { attachGatewayWsMessageHandler } from "./message-handler.js";
 
 function createLogger() {
@@ -77,6 +87,13 @@ function createLogger() {
 describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resolveConnectAuthStateMock.mockResolvedValue({
+      authResult: { ok: true, method: "none" },
+      authOk: true,
+      authMethod: "none",
+      sharedAuthOk: false,
+      sharedAuthProvided: false,
+    });
   });
 
   it("uses the injected runtime-aware health refresh after hello", async () => {
@@ -177,5 +194,97 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       expect(refreshHealthSnapshot).toHaveBeenCalledWith({ probe: true });
     });
     resolveRefresh?.();
+  });
+
+  it("bounds stalled connect auth after clearing the pre-auth timer", async () => {
+    vi.useFakeTimers();
+    const previousHandshakeTimeout = process.env.OPENCLAW_HANDSHAKE_TIMEOUT_MS;
+    process.env.OPENCLAW_HANDSHAKE_TIMEOUT_MS = "25";
+    resolveConnectAuthStateMock.mockReturnValue(new Promise(() => {}));
+
+    try {
+      let onMessage: ((data: string) => void) | undefined;
+      const socket = {
+        _receiver: {},
+        send: vi.fn(),
+        on: vi.fn((event: string, handler: (data: string) => void) => {
+          if (event === "message") {
+            onMessage = handler;
+          }
+          return socket;
+        }),
+      } as unknown as WebSocket;
+      const close = vi.fn();
+      const clearHandshakeTimer = vi.fn();
+      const resolvedAuth: ResolvedGatewayAuth = {
+        mode: "none",
+        allowTailscale: false,
+      };
+
+      attachGatewayWsMessageHandler({
+        socket,
+        upgradeReq: {
+          headers: { host: "127.0.0.1:19001", origin: "http://127.0.0.1:19001" },
+          socket: { localAddress: "127.0.0.1", remoteAddress: "127.0.0.1" },
+        } as unknown as IncomingMessage,
+        connId: "conn-stalled-auth",
+        remoteAddr: "127.0.0.1",
+        localAddr: "127.0.0.1",
+        requestHost: "127.0.0.1:19001",
+        requestOrigin: "http://127.0.0.1:19001",
+        connectNonce: "nonce-stalled-auth",
+        getResolvedAuth: () => resolvedAuth,
+        gatewayMethods: [],
+        events: [],
+        extraHandlers: {},
+        buildRequestContext: () => ({}) as GatewayRequestContext,
+        refreshHealthSnapshot: vi.fn() as GatewayRequestContext["refreshHealthSnapshot"],
+        send: vi.fn(),
+        close,
+        isClosed: () => false,
+        clearHandshakeTimer,
+        getClient: () => null,
+        setClient: vi.fn(() => true),
+        setHandshakeState: vi.fn(),
+        setCloseCause: vi.fn(),
+        setLastFrameMeta: vi.fn(),
+        originCheckMetrics: { hostHeaderFallbackAccepted: 0 },
+        logGateway: createLogger() as never,
+        logHealth: createLogger() as never,
+        logWsControl: createLogger() as never,
+      });
+
+      onMessage?.(
+        JSON.stringify({
+          type: "req",
+          id: "connect-stalled-auth",
+          method: "connect",
+          params: {
+            minProtocol: PROTOCOL_VERSION,
+            maxProtocol: PROTOCOL_VERSION,
+            client: {
+              id: "openclaw-control-ui",
+              version: "dev",
+              platform: "test",
+              mode: "ui",
+            },
+            role: "operator",
+            caps: [],
+          },
+        }),
+      );
+
+      expect(clearHandshakeTimer).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(25);
+
+      expect(close).toHaveBeenCalledWith(1008, "connect auth timeout");
+    } finally {
+      if (previousHandshakeTimeout === undefined) {
+        delete process.env.OPENCLAW_HANDSHAKE_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_HANDSHAKE_TIMEOUT_MS = previousHandshakeTimeout;
+      }
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -325,6 +325,7 @@ export function attachGatewayWsMessageHandler(params: {
     rateLimitClientIp: browserRateLimitClientIp,
     authRateLimiter,
   } = browserSecurity;
+  let clearPendingConnectAuthTimer: (() => void) | undefined;
 
   const handleMessage = async (data: RawData) => {
     if (isClosed()) {
@@ -434,6 +435,7 @@ export function attachGatewayWsMessageHandler(params: {
         const connectAuthStartedAt = Date.now();
         const connectAuthTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv();
         const connectAuthTimer = setTimeout(() => {
+          clearConnectAuthTimer();
           if (isClosed() || getClient()) {
             return;
           }
@@ -449,7 +451,17 @@ export function attachGatewayWsMessageHandler(params: {
           close(1008, "connect auth timeout");
         }, connectAuthTimeoutMs);
         connectAuthTimer.unref?.();
-        const clearConnectAuthTimer = () => clearTimeout(connectAuthTimer);
+        const clearConnectAuthTimer = () => {
+          clearTimeout(connectAuthTimer);
+          if (clearPendingConnectAuthTimer === clearConnectAuthTimer) {
+            clearPendingConnectAuthTimer = undefined;
+          }
+        };
+        clearPendingConnectAuthTimer = clearConnectAuthTimer;
+        const closeConnectAuth = (code?: number, reason?: string) => {
+          clearConnectAuthTimer();
+          close(code, reason);
+        };
 
         // Clear the pre-auth challenge timer once the client has sent a valid
         // connect request. The connect auth timer above still bounds stalled
@@ -486,7 +498,7 @@ export function attachGatewayWsMessageHandler(params: {
           sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, "protocol mismatch", {
             details: { expectedProtocol: PROTOCOL_VERSION },
           });
-          close(1002, "protocol mismatch");
+          closeConnectAuth(1002, "protocol mismatch");
           return;
         }
 
@@ -497,7 +509,7 @@ export function attachGatewayWsMessageHandler(params: {
             role: roleRaw,
           });
           sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, "invalid role");
-          close(1008, "invalid role");
+          closeConnectAuth(1008, "invalid role");
           return;
         }
         // Default-deny: scopes must be explicit. Empty/missing scopes means no permissions.
@@ -539,7 +551,7 @@ export function attachGatewayWsMessageHandler(params: {
                 reason: originCheck.reason,
               },
             });
-            close(1008, truncateCloseReason(errorMessage));
+            closeConnectAuth(1008, truncateCloseReason(errorMessage));
             return;
           }
           if (originCheck.matchedBy === "host-header-fallback") {
@@ -624,7 +636,7 @@ export function attachGatewayWsMessageHandler(params: {
               recommendedNextStep,
             },
           });
-          close(1008, truncateCloseReason(authMessage));
+          closeConnectAuth(1008, truncateCloseReason(authMessage));
         };
         const clearUnboundScopes = () => {
           if (scopes.length > 0) {
@@ -704,7 +716,7 @@ export function attachGatewayWsMessageHandler(params: {
             sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, errorMessage, {
               details: { code: ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED },
             });
-            close(1008, errorMessage);
+            closeConnectAuth(1008, errorMessage);
             return false;
           }
 
@@ -717,7 +729,7 @@ export function attachGatewayWsMessageHandler(params: {
           sendHandshakeErrorResponse(ErrorCodes.NOT_PAIRED, "device identity required", {
             details: { code: ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED },
           });
-          close(1008, "device identity required");
+          closeConnectAuth(1008, "device identity required");
           return false;
         };
         if (!handleMissingDeviceIdentity()) {
@@ -742,7 +754,7 @@ export function attachGatewayWsMessageHandler(params: {
                 },
               }),
             });
-            close(1008, message);
+            closeConnectAuth(1008, message);
           };
           const derivedId = deriveDeviceIdFromPublicKey(device.publicKey);
           if (!derivedId || derivedId !== device.id) {
@@ -850,7 +862,7 @@ export function attachGatewayWsMessageHandler(params: {
             setCloseCause("gateway-auth-rotated", {
               authGenerationStale: true,
             });
-            close(4001, "gateway auth changed");
+            closeConnectAuth(4001, "gateway auth changed");
             return;
           }
         }
@@ -1063,7 +1075,9 @@ export function attachGatewayWsMessageHandler(params: {
                   requestStillPending = recoveryRequestId === pairing.request.requestId;
                 }
                 if (requestStillPending) {
-                  context.broadcast("device.pair.requested", pairing.request, { dropIfSlow: true });
+                  context.broadcast("device.pair.requested", pairing.request, {
+                    dropIfSlow: true,
+                  });
                 }
               }
             } else if (pairing.created) {
@@ -1112,7 +1126,7 @@ export function attachGatewayWsMessageHandler(params: {
                   details: pairingErrorDetails,
                 }),
               });
-              close(
+              closeConnectAuth(
                 1008,
                 truncateCloseReason(
                   buildPairingConnectCloseReason({
@@ -1293,6 +1307,7 @@ export function attachGatewayWsMessageHandler(params: {
         const presenceKey = shouldTrackPresence ? (device?.id ?? instanceId ?? connId) : undefined;
 
         if (isClosed()) {
+          clearConnectAuthTimer();
           setCloseCause("connect-aborted-before-register", {
             ...clientMeta,
             auth: authMethod,
@@ -1473,7 +1488,7 @@ export function attachGatewayWsMessageHandler(params: {
           await sendFrame({ type: "res", id: frame.id, ok: true, payload: helloOk });
         } catch (err) {
           setCloseCause("hello-send-failed", { error: formatForLog(err) });
-          close();
+          closeConnectAuth();
           return;
         }
         if (authMethod === "bootstrap-token" && bootstrapTokenCandidate && device) {
@@ -1616,6 +1631,7 @@ export function attachGatewayWsMessageHandler(params: {
       logGateway.error(`parse/handle error: ${String(err)}`);
       logWs("out", "parse-error", { connId, error: formatForLog(err) });
       if (!getClient()) {
+        clearPendingConnectAuthTimer?.();
         close();
       }
     }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -434,7 +434,9 @@ export function attachGatewayWsMessageHandler(params: {
         };
         const connectAuthStartedAt = Date.now();
         const connectAuthTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv();
+        let connectAuthTimedOut = false;
         const connectAuthTimer = setTimeout(() => {
+          connectAuthTimedOut = true;
           clearConnectAuthTimer();
           if (isClosed() || getClient()) {
             return;
@@ -1306,12 +1308,14 @@ export function attachGatewayWsMessageHandler(params: {
         const instanceId = connectParams.client.instanceId;
         const presenceKey = shouldTrackPresence ? (device?.id ?? instanceId ?? connId) : undefined;
 
-        if (isClosed()) {
+        if (connectAuthTimedOut || isClosed()) {
           clearConnectAuthTimer();
-          setCloseCause("connect-aborted-before-register", {
-            ...clientMeta,
-            auth: authMethod,
-          });
+          if (!connectAuthTimedOut) {
+            setCloseCause("connect-aborted-before-register", {
+              ...clientMeta,
+              auth: authMethod,
+            });
+          }
           return;
         }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -63,6 +63,7 @@ import {
   mintCanvasCapabilityToken,
 } from "../../canvas-capability.js";
 import { normalizeDeviceMetadataForAuth } from "../../device-auth.js";
+import { getPreauthHandshakeTimeoutMsFromEnv } from "../../handshake-timeouts.js";
 import { ADMIN_SCOPE } from "../../method-scopes.js";
 import {
   isLocalishHost,
@@ -430,6 +431,30 @@ export function attachGatewayWsMessageHandler(params: {
           modelIdentifier: connectParams.client.modelIdentifier,
           instanceId: connectParams.client.instanceId,
         };
+        const connectAuthStartedAt = Date.now();
+        const connectAuthTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv();
+        const connectAuthTimer = setTimeout(() => {
+          if (isClosed() || getClient()) {
+            return;
+          }
+          setHandshakeState("failed");
+          setCloseCause("connect-auth-timeout", {
+            ...clientMeta,
+            handshakeMs: Date.now() - connectAuthStartedAt,
+            endpoint,
+          });
+          logWsControl.warn(
+            `connect auth timeout conn=${connId} peer=${formatForLog(peerLabel)} remote=${remoteAddr ?? "?"}`,
+          );
+          close(1008, "connect auth timeout");
+        }, connectAuthTimeoutMs);
+        connectAuthTimer.unref?.();
+        const clearConnectAuthTimer = () => clearTimeout(connectAuthTimer);
+
+        // Clear the pre-auth challenge timer once the client has sent a valid
+        // connect request. The connect auth timer above still bounds stalled
+        // async auth work before the client is registered.
+        clearHandshakeTimer();
         const markHandshakeFailure = (cause: string, meta?: Record<string, unknown>) => {
           setHandshakeState("failed");
           setCloseCause(cause, { ...meta, ...clientMeta });
@@ -1287,7 +1312,7 @@ export function attachGatewayWsMessageHandler(params: {
           canvasHostUrl && canvasCapability
             ? (buildCanvasScopedHostUrl(canvasHostUrl, canvasCapability) ?? canvasHostUrl)
             : canvasHostUrl;
-        clearHandshakeTimer();
+        clearConnectAuthTimer();
         const nextClient: GatewayWsClient = {
           socket,
           connect: connectParams,


### PR DESCRIPTION
## Summary

- **Move `clearHandshakeTimer()` earlier** in the gateway connect handler — right after validating the connect request, before any async auth work (device verification, token resolution, etc.)
- **Raise default timeouts**: server handshake 3s->10s, client challenge 2s->10s

## Problem

On resource-constrained hosts (small VPS, busy Node.js event loop), the gateway async auth flow (`resolveConnectAuthState`, device signature verification, token grant) can take longer than the 3-second `DEFAULT_HANDSHAKE_TIMEOUT_MS`. Because `clearHandshakeTimer()` is only called *after* the entire auth flow completes, the timer fires mid-auth and kills a legitimate in-progress connection with code 1000.

The client sends a valid `connect` request within ~50ms of WS open, the gateway receives it, starts processing auth — then the handshake timer fires 3 seconds after WS opened and closes the connection before auth finishes.

Gateway logs show:
```
[ws] handshake timeout conn=... remote=127.0.0.1
[ws] closed before connect conn=... code=1000 reason=n/a
```

Client sees:
```
Error: gateway closed (1000 normal closure): no close reason
```

## Root cause

The handshake timer starts on WS open and races against the full async auth resolution. When auth takes >3s (due to event loop pressure, slow I/O, or heavy GC), the timer wins.

```
Timeline (broken):
  0ms    WS open -> handshake timer starts (3s)
  ~15ms  gateway sends connect.challenge
  ~50ms  client sends connect request -> gateway starts async auth
  3000ms handshake timer fires -> gateway sees !client -> close()
  ???ms  auth would have completed -> too late, connection dead
```

## Fix

Separate "did the client send a valid connect request?" from "is the auth valid?". Clear the timer as soon as the connect request parses and validates, before entering async auth:

```
Timeline (fixed):
  0ms    WS open -> handshake timer starts (10s)
  ~15ms  gateway sends connect.challenge
  ~50ms  client sends connect request -> clearHandshakeTimer() -> async auth begins
  ???ms  auth completes -> session established
```

If auth fails, the connection is closed by the auth handler itself (with a proper error code), not by the handshake timer.

## Files changed

| File | Change |
|---|---|
| `src/gateway/server/ws-connection/message-handler.ts` | Move `clearHandshakeTimer()` from post-auth to pre-auth |
| `src/gateway/server-constants.ts` | `DEFAULT_HANDSHAKE_TIMEOUT_MS`: 3s -> 10s |
| `src/gateway/client.ts` | Client challenge timeout default: 2s -> 10s |

## Test plan

- [ ] Existing gateway WS tests pass (timer moved, not removed — invalid/missing connect still times out)
- [ ] `openclaw gateway health` succeeds on a resource-constrained host (2GB VPS, loopback + token auth)
- [ ] `openclaw cron list` succeeds (requires operator.read scope via device identity)
- [ ] Invalid handshake (malformed frame, wrong method) still closes promptly
- [ ] Unauthenticated connect still rejected by auth handler (not the timer)

Fixes #46650
Fixes #48167
