### PR TITLE
fix(google-vertex): prevent ADC sentinel from leaking as literal API key

### DIFF
--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -6,6 +6,7 @@ export const OAUTH_API_KEY_MARKER_PREFIX = "oauth:";
 export const QWEN_OAUTH_MARKER = "qwen-oauth";
 export const OLLAMA_LOCAL_AUTH_MARKER = "ollama-local";
 export const CUSTOM_LOCAL_AUTH_MARKER = "custom-local";
+export const VERTEX_ADC_AUTH_MARKER = "vertex-adc";
 export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
 export const SECRETREF_ENV_HEADER_MARKER_PREFIX = "secretref-env:"; // pragma: allowlist secret
 
@@ -83,6 +84,7 @@ export function isNonSecretApiKeyMarker(
     isOAuthApiKeyMarker(trimmed) ||
     trimmed === OLLAMA_LOCAL_AUTH_MARKER ||
     trimmed === CUSTOM_LOCAL_AUTH_MARKER ||
+    trimmed === VERTEX_ADC_AUTH_MARKER ||
     trimmed === NON_ENV_SECRETREF_MARKER ||
     isAwsSdkAuthMarker(trimmed);
   if (isKnownMarker) {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -24,6 +24,7 @@ import {
   isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
   OLLAMA_LOCAL_AUTH_MARKER,
+  VERTEX_ADC_AUTH_MARKER,
 } from "./model-auth-markers.js";
 import { normalizeProviderId, normalizeProviderIdForAuth } from "./model-selection.js";
 
@@ -425,6 +426,14 @@ export function resolveEnvApiKey(
     const envKey = getEnvApiKey(normalized);
     if (!envKey) {
       return null;
+    }
+    // getEnvApiKey returns "<authenticated>" when ADC credentials are detected
+    // (gcloud ADC file + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION).
+    // Use the VERTEX_ADC_AUTH_MARKER so downstream consumers (pi-ai) recognize
+    // this as a non-secret marker and fall through to ADC-based auth (OAuth2
+    // access token) instead of sending the sentinel as a literal API key.
+    if (envKey === "<authenticated>") {
+      return { apiKey: VERTEX_ADC_AUTH_MARKER, source: "gcloud adc" };
     }
     return { apiKey: envKey, source: "gcloud adc" };
   }


### PR DESCRIPTION
## Problem

When `google-vertex` ADC credentials are detected (gcloud ADC file + `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION`), `getEnvApiKey()` from pi-ai returns `"<authenticated>"` as a sentinel string. This sentinel leaks through `resolveEnvApiKey()` in `model-auth.ts` as a literal `apiKey` value.

The downstream pi-ai google-vertex provider sees a truthy `apiKey`, chooses `createClientWithApiKey()` mode, and sends the sentinel string as an `x-goog-api-key` header. Vertex AI rejects this with:

```
401 UNAUTHENTICATED: API keys are not supported by this API.
Expected OAuth2 access token or other authentication credentials.
```

This breaks all `google-vertex/*` models on GCP VMs and any environment using gcloud ADC.

## Root Cause

The `"<authenticated>"` sentinel from pi-ai `getEnvApiKey()` is not recognized by `isNonSecretApiKeyMarker()`, so it gets treated as a real API key and passed through to the provider.

## Fix

1. Add a new `VERTEX_ADC_AUTH_MARKER` (`"vertex-adc"`) constant in `model-auth-markers.ts`
2. Register it in `isNonSecretApiKeyMarker()` so it is recognized as a non-secret marker
3. In `resolveEnvApiKey()` (`model-auth.ts`), replace the `"<authenticated>"` sentinel with `VERTEX_ADC_AUTH_MARKER` before returning

This prevents the marker from being used as a real API key in request headers, allowing the pi-ai provider to fall through to its ADC-based auth path (OAuth2 access token via VM metadata or gcloud application-default credentials).

## Testing

Verified on a GCP VM (e2-medium, us-east1) running OpenClaw 2026.3.13:
- Before fix: `google-vertex/gemini-3.1-pro-preview` returns 401 "API keys are not supported"
- After fix: `google-vertex/gemini-3.1-pro-preview` responds successfully via VM metadata ADC

## Files Changed

- `src/agents/model-auth-markers.ts` — add `VERTEX_ADC_AUTH_MARKER`, register in `isNonSecretApiKeyMarker()`
- `src/agents/model-auth.ts` — intercept `"<authenticated>"` sentinel, replace with marker