### PR TITLE
fix(feishu): @所有人 (@all) no longer triggers every bot unconditionally

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -15815,6 +15815,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.feishu.accounts.*.groups.*.respondToAtAll",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.feishu.accounts.*.groups.*.skills",
       "kind": "channel",
       "type": "array",
@@ -16117,6 +16127,16 @@
     },
     {
       "path": "channels.feishu.accounts.*.resolveSenderNames",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.respondToAtAll",
       "kind": "channel",
       "type": "boolean",
       "required": false,
@@ -16832,6 +16852,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.feishu.groups.*.respondToAtAll",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.feishu.groups.*.skills",
       "kind": "channel",
       "type": "array",
@@ -17129,6 +17159,16 @@
       "type": "boolean",
       "required": true,
       "defaultValue": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.respondToAtAll",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5631}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5635}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1403,6 +1403,7 @@
 {"recordType":"path","path":"channels.feishu.accounts.*.groups.*.groupSessionScope","kind":"channel","type":"string","required":false,"enumValues":["group","group_sender","group_topic","group_topic_sender"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.groups.*.replyInThread","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.groups.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.groups.*.respondToAtAll","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.groups.*.skills","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.groups.*.skills.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1430,6 +1431,7 @@
 {"recordType":"path","path":"channels.feishu.accounts.*.replyInThread","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.resolveSenderNames","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.respondToAtAll","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.streaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1495,6 +1497,7 @@
 {"recordType":"path","path":"channels.feishu.groups.*.groupSessionScope","kind":"channel","type":"string","required":false,"enumValues":["group","group_sender","group_topic","group_topic_sender"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.groups.*.replyInThread","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.groups.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.groups.*.respondToAtAll","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.groups.*.skills","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.groups.*.skills.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1521,6 +1524,7 @@
 {"recordType":"path","path":"channels.feishu.replyInThread","kind":"channel","type":"string","required":false,"enumValues":["disabled","enabled"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.resolveSenderNames","kind":"channel","type":"boolean","required":true,"defaultValue":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.respondToAtAll","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.streaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -231,9 +231,11 @@ export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string):
   if (!botOpenId) {
     return false;
   }
-  if ((event.message.content ?? "").includes("@_all")) {
-    return true;
-  }
+  // @_all (@所有人) is intentionally NOT treated as mentioning every bot here.
+  // Whether to respond to @所有人 is an opt-in decision controlled by the
+  // respondToAtAll config flag; the check is applied in handleFeishuMessage
+  // after the group config is resolved so that per-group and per-account
+  // settings are both honoured.
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
     return mentions.some((mention) => mention.id.open_id === botOpenId);

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -246,6 +246,22 @@ export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string):
   return false;
 }
 
+/**
+ * Returns true when the Feishu message contains a real @所有人 (@_all) mention
+ * according to the structured mention metadata in `event.message.mentions`.
+ *
+ * Using the `mentions` array (rather than a raw substring search on
+ * `message.content`) prevents spoofing: a user can type the literal text
+ * "@_all" in a normal message without triggering an @所有人 broadcast — the
+ * Feishu server only inserts a `mentions` entry with `key === "@_all"` when
+ * the sender actually used the @所有人 mention (CWE-807).
+ */
+export function hasAtAllMention(event: FeishuMessageLike): boolean {
+  return (event.message.mentions ?? []).some(
+    (m) => m.key === "@_all" || m.id?.user_id === "all" || m.id?.open_id === "all",
+  );
+}
+
 export function normalizeMentions(
   text: string,
   mentions?: FeishuMention[],

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -201,15 +201,15 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.mentionedBot).toBe(false);
   });
 
-  it("returns mentionedBot=false for @_all even when bot is also in mentions list (opt-in path takes precedence)", () => {
-    // Explicit bot mention still wins via the mentions array path
+  it("returns mentionedBot=true for @_all when bot is also explicitly mentioned (direct mention takes precedence)", () => {
+    // Bot IS in the mentions array; the direct-mention path returns true
+    // regardless of the respondToAtAll opt-in flag.
     const event = makeEvent(
       "group",
       [{ key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } }],
       "@_all hello",
     );
     const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
-    // Bot IS in the mentions array, so it should still be true via that path
     expect(ctx.mentionedBot).toBe(true);
   });
 });

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { hasAtAllMention } from "./bot-content.js";
 import { parseFeishuMessageEvent } from "./bot.js";
 
 // Helper to build a minimal FeishuMessageEvent for testing
@@ -210,5 +211,44 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
     // Bot IS in the mentions array, so it should still be true via that path
     expect(ctx.mentionedBot).toBe(true);
+  });
+});
+
+// hasAtAllMention — structured @所有人 detection (CWE-807 spoofing prevention)
+describe("hasAtAllMention", () => {
+  function makeRawEvent(
+    mentions: Array<{ key: string; name: string; id: Record<string, string> }>,
+  ) {
+    return {
+      message: {
+        content: '{"text":"hello"}',
+        message_type: "text",
+        mentions,
+        chat_id: "oc_group1",
+        message_id: "om_msg1",
+      },
+      sender: { sender_id: { open_id: "ou_sender1", user_id: "u_sender1" }, sender_type: "user" },
+    };
+  }
+
+  it("returns true when mentions contains key @_all", () => {
+    const event = makeRawEvent([{ key: "@_all", name: "所有人", id: {} }]);
+    expect(hasAtAllMention(event as any)).toBe(true);
+  });
+
+  it("returns true when mentions contains id.user_id === 'all'", () => {
+    const event = makeRawEvent([{ key: "@_all", name: "所有人", id: { user_id: "all" } }]);
+    expect(hasAtAllMention(event as any)).toBe(true);
+  });
+
+  it("returns false when mentions is empty (raw @_all text does NOT trigger)", () => {
+    // A user typing the literal text "@_all" should not be detected as @所有人
+    const event = makeRawEvent([]);
+    expect(hasAtAllMention(event as any)).toBe(false);
+  });
+
+  it("returns false when mentions only contain regular user mentions", () => {
+    const event = makeRawEvent([{ key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } }]);
+    expect(hasAtAllMention(event as any)).toBe(false);
   });
 });

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -190,4 +190,25 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     const ctx = parseFeishuMessageEvent(event as any, "ou_bot_123");
     expect(ctx.content).toBe("[Forwarded message: sc_abc123]");
   });
+
+  // @_all (@所有人) behaviour — opt-in is controlled by respondToAtAll config
+  // and resolved later in handleFeishuMessage; parseFeishuMessageEvent itself
+  // no longer unconditionally sets mentionedBot=true for @_all.
+  it("returns mentionedBot=false for @_all message (respondToAtAll opt-in not yet applied)", () => {
+    const event = makeEvent("group", [], "@_all hello everyone");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=false for @_all even when bot is also in mentions list (opt-in path takes precedence)", () => {
+    // Explicit bot mention still wins via the mentions array path
+    const event = makeEvent(
+      "group",
+      [{ key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } }],
+      "@_all hello",
+    );
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    // Bot IS in the mentions array, so it should still be true via that path
+    expect(ctx.mentionedBot).toBe(true);
+  });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -428,6 +428,17 @@ export async function handleFeishuMessage(params: {
       groupPolicy,
     }));
 
+    // @_all (@所有人) opt-in: if the message targets all group members and the
+    // account or group is explicitly configured with respondToAtAll:true, treat
+    // it as mentioning this bot.  Default is false so bots that do not opt in
+    // stay silent when a user broadcasts to the whole group.
+    if (!ctx.mentionedBot && (event.message.content ?? "").includes("@_all")) {
+      const respondToAtAll = groupConfig?.respondToAtAll ?? feishuCfg?.respondToAtAll ?? false;
+      if (respondToAtAll) {
+        ctx = { ...ctx, mentionedBot: true };
+      }
+    }
+
     if (requireMention && !ctx.mentionedBot) {
       log(`feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot`);
       // Record to pending history for non-broadcast groups only. For broadcast groups,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -23,6 +23,7 @@ import {
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import {
   checkBotMentioned,
+  hasAtAllMention,
   normalizeFeishuCommandProbeBody,
   normalizeMentions,
   parseMergeForwardContent,
@@ -432,7 +433,12 @@ export async function handleFeishuMessage(params: {
     // account or group is explicitly configured with respondToAtAll:true, treat
     // it as mentioning this bot.  Default is false so bots that do not opt in
     // stay silent when a user broadcasts to the whole group.
-    if (!ctx.mentionedBot && (event.message.content ?? "").includes("@_all")) {
+    //
+    // Detection uses the structured mention metadata (event.message.mentions)
+    // rather than a raw substring check on message.content to prevent spoofing
+    // (a user typing the literal text "@_all" in a normal message would otherwise
+    // bypass the requireMention gate — CWE-807).
+    if (!ctx.mentionedBot && hasAtAllMention(event)) {
       const respondToAtAll = groupConfig?.respondToAtAll ?? feishuCfg?.respondToAtAll ?? false;
       if (respondToAtAll) {
         ctx = { ...ctx, mentionedBot: true };

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -141,6 +141,7 @@ const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    respondToAtAll: z.boolean().optional(),
     tools: ToolPolicySchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
@@ -164,6 +165,7 @@ const FeishuSharedConfigShape = {
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
+  respondToAtAll: z.boolean().optional(),
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),


### PR DESCRIPTION
## Problem

Closes #49761

When a user sends `@所有人` (@all) in a Feishu group chat, **all bots** in the group responded simultaneously — even with `requireMention: true` set. The root cause was an unconditional early-return in `checkBotMentioned()`:

```typescript
// bot-content.ts (before)
if ((event.message.content ?? '').includes('@_all')) {
  return true; // ← every bot, no exceptions
}
```

## Fix

Remove the unconditional `@_all → true` path from `checkBotMentioned()` and replace it with an explicit **opt-in** config flag.

### New config option: `respondToAtAll` (default: `false`)

Can be set at three levels (resolved in order: group → account → global):

```json
// channels.feishu — global default for all accounts
{ "respondToAtAll": true }

// channels.feishu.accounts.<id> — per-account
{ "accounts": { "mybot": { "respondToAtAll": true } } }

// channels.feishu.groups.<chatId> — per-group
{ "groups": { "oc_abc123": { "respondToAtAll": true } } }
```

Bots that do **not** opt in remain silent when `@所有人` is used, which:
- Preserves existing behaviour for single-bot deployments
- Allows multi-bot groups to decide per-account which bot(s) handle broadcast messages

### Implementation

The opt-in check is applied inside `handleFeishuMessage` **after** `groupConfig` is resolved (not inside `checkBotMentioned`) so that per-group and per-account settings are both honoured.

## Files changed

| File | Change |
|---|---|
| `extensions/feishu/src/bot-content.ts` | Drop `@_all → true` early-return, add explanatory comment |
| `extensions/feishu/src/bot.ts` | Add `respondToAtAll` opt-in check after `groupConfig` is resolved |
| `extensions/feishu/src/config-schema.ts` | Add `respondToAtAll?: boolean` to `FeishuSharedConfigShape` and `FeishuGroupSchema` |
| `extensions/feishu/src/bot.checkBotMentioned.test.ts` | Two new tests: `@_all` → `mentionedBot=false` via `parseFeishuMessageEvent` |

## Tests

```
pnpm vitest run extensions/feishu/src/bot.checkBotMentioned.test.ts  → 17/17 ✅
pnpm vitest run extensions/feishu/src/config-schema.test.ts          → 22/22 ✅
pnpm build                                                             → ✅
pnpm check                                                             → ✅
```