### PR TITLE
fix(feishu): stop @_all from triggering all bots in group chat

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -248,9 +248,10 @@ export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string):
   if (!botOpenId) {
     return false;
   }
-  if ((event.message.content ?? "").includes("@_all")) {
-    return true;
-  }
+  // @_all (@所有人) is a broadcast to all human members, not a targeted bot
+  // mention. Treating it as mentioning every bot causes all bots in the group
+  // to respond simultaneously (#49761). Skip the @_all shortcut and fall
+  // through to the standard mention-matching logic below.
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
     return mentions.some((mention) => mention.id.open_id === botOpenId);

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -108,6 +108,40 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.mentionedBot).toBe(false);
   });
 
+  it("returns mentionedBot=false for @_all — bots should not respond to broadcast mentions (#49761)", () => {
+    const event = makeEvent("group", [], "@_all hello everyone");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=true when bot is explicitly mentioned alongside @_all", () => {
+    const event = makeEvent(
+      "group",
+      [{ key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } }],
+      "@_all @_user_1 hello",
+    );
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
+  it("returns mentionedBot=false when @_all is present but only other users are mentioned", () => {
+    const event = makeEvent(
+      "group",
+      [{ key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } }],
+      "@_all @_user_1 hello",
+    );
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=false for @_all in DM (p2p) — @_all is not a bot mention in any context", () => {
+    const event = makeEvent("p2p", [], "@_all hello everyone");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    // DM routing is handled separately by the caller (bot.ts), not by
+    // checkBotMentioned. The mention check correctly returns false here.
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
   it("treats mention.name regex metacharacters as literals when stripping", () => {
     const event = makeEvent(
       "group",


### PR DESCRIPTION
## Summary

- **Problem**: `checkBotMentioned()` in `extensions/feishu/src/bot-content.ts` treated `@_all` (`@所有人`) as a targeted mention of every bot. When a user sent `@所有人` in a Feishu group, all bots responded simultaneously, even with `requireMention: true`.
- **Why it matters**: Multi-bot Feishu groups become unusable — every `@所有人` message produces chaotic parallel responses from every bot.
- **What changed**: Removed the `@_all` early-return in `checkBotMentioned()`. The function now falls through to the standard `mentions` array check, which only matches bots whose `open_id` appears in the explicit mention list.
- **What did NOT change**: Bots that are explicitly `@mentioned` by name alongside `@所有人` still respond correctly. No config schema changes.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #49761

## User-visible / Behavior Changes

`@所有人` in Feishu group chats no longer triggers bot responses. Only explicit `@BotName` mentions activate a bot.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] Failing test/log before + passing after

3 new test cases added to `bot.checkBotMentioned.test.ts`:
1. `@_all` alone → `mentionedBot=false`
2. `@_all` + explicit bot mention → `mentionedBot=true`
3. `@_all` + other user mention → `mentionedBot=false`

All 18 tests pass.

## Compatibility / Migration

- Backward compatible? Yes (the old behavior was a bug)
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Users who intentionally relied on `@所有人` to trigger bots will no longer get responses.
  - Mitigation: This was unintended behavior. Users should explicitly `@BotName` to trigger a specific bot. A `respondToAll` config option could be added later if needed.