### PR TITLE
Agents: suppress transcript-only gateway-injected messages

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -33,6 +33,21 @@ const stripTrailingDirective = (text: string): string => {
   return text.slice(0, openIndex);
 };
 
+const TRANSCRIPT_ONLY_ASSISTANT_MODELS = new Set(["gateway-injected"]);
+
+function isTranscriptOnlyAssistantMessage(message: AgentMessage | undefined): boolean {
+  if (!message || message.role !== "assistant") {
+    return false;
+  }
+  const provider = (message as { provider?: unknown }).provider;
+  const model = (message as { model?: unknown }).model;
+  return (
+    provider === "openclaw" &&
+    typeof model === "string" &&
+    TRANSCRIPT_ONLY_ASSISTANT_MODELS.has(model)
+  );
+}
+
 function emitReasoningEnd(ctx: EmbeddedPiSubscribeContext) {
   if (!ctx.state.reasoningStreamOpen) {
     return;
@@ -61,7 +76,7 @@ export function handleMessageStart(
   evt: AgentEvent & { message: AgentMessage },
 ) {
   const msg = evt.message;
-  if (msg?.role !== "assistant") {
+  if (msg?.role !== "assistant" || isTranscriptOnlyAssistantMessage(msg)) {
     return;
   }
 
@@ -80,7 +95,7 @@ export function handleMessageUpdate(
   evt: AgentEvent & { message: AgentMessage; assistantMessageEvent?: unknown },
 ) {
   const msg = evt.message;
-  if (msg?.role !== "assistant") {
+  if (msg?.role !== "assistant" || isTranscriptOnlyAssistantMessage(msg)) {
     return;
   }
 
@@ -257,7 +272,7 @@ export function handleMessageEnd(
   evt: AgentEvent & { message: AgentMessage },
 ) {
   const msg = evt.message;
-  if (msg?.role !== "assistant") {
+  if (msg?.role !== "assistant" || isTranscriptOnlyAssistantMessage(msg)) {
     return;
   }
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -293,6 +293,38 @@ describe("subscribeEmbeddedPiSession", () => {
     expectSingleAgentEventText(onAgentEvent.mock.calls, "Hello world");
   });
 
+  it("does not emit external replies for transcript-only openclaw assistant messages", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    emitMessageStartAndEndForAssistantText({ emit, text: "Normal summary" });
+
+    const injectedAssistantMessage = {
+      role: "assistant",
+      provider: "openclaw",
+      model: "gateway-injected",
+      content: [{ type: "text", text: "[Stopped]\n\nInternal banner" }],
+    } as AssistantMessage;
+
+    emit({ type: "message_start", message: injectedAssistantMessage });
+    emit({
+      type: "message_update",
+      message: injectedAssistantMessage,
+      assistantMessageEvent: { type: "text_delta", delta: "[Stopped]\n\nInternal banner" },
+    });
+    emit({ type: "message_end", message: injectedAssistantMessage });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Normal summary");
+  });
+
   it("does not emit duplicate agent events when message_end repeats", () => {
     const { emit, onAgentEvent } = createAgentEventHarness();
 


### PR DESCRIPTION
## Summary

This fixes a transcript-only assistant message leak in embedded session delivery.

When OpenClaw appends an internal `provider=openclaw` / `model=gateway-injected` assistant message to the transcript, the embedded subscribe handlers currently treat it like a normal user-visible assistant reply. That can cause external channels to receive an extra assistant message even though the actual business reply was only generated once.

## What happens today

1. A normal assistant reply is generated and delivered to the external channel.
2. OpenClaw later appends a transcript-only internal assistant message with `model=gateway-injected`.
3. `handleMessageStart`, `handleMessageUpdate`, and `handleMessageEnd` in `src/agents/pi-embedded-subscribe.handlers.messages.ts` only check `role === "assistant"`, so the injected message enters the same outward delivery pipeline.
4. Channels can therefore receive a second reply that should have remained transcript-only.

This surfaced in Feishu, but the bug is channel-agnostic because the leak happens before channel-specific delivery.

## Fix

Add a centralized helper that classifies `openclaw/gateway-injected` assistant messages as transcript-only and short-circuits them in all three embedded subscribe assistant-message entry points:

- `handleMessageStart`
- `handleMessageUpdate`
- `handleMessageEnd`

The transcript entry is still preserved for debugging and audit purposes; it just no longer becomes an outward-facing assistant reply.

## Tests

Add a regression test that verifies:

- a normal assistant message still emits a user-visible agent event
- a subsequent `openclaw/gateway-injected` assistant message in the same session does not emit an additional outward event
