### PR TITLE
fix: preserve raw WebUI model aliases

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -73,7 +73,7 @@ describe("handleSendChat", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps slash-command model changes in sync with the chat header cache", async () => {
+  it("keeps bare slash-command model changes raw in the chat header cache", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -124,8 +124,8 @@ describe("handleSendChat", () => {
       model: "gpt-5-mini",
     });
     expect(host.chatModelOverrides.main).toEqual({
-      kind: "qualified",
-      value: "openai/gpt-5-mini",
+      kind: "raw",
+      value: "gpt-5-mini",
     });
   });
 });

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -73,7 +73,7 @@ describe("handleSendChat", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps bare slash-command model changes raw in the chat header cache", async () => {
+  it("caches uniquely resolved slash-command model changes as qualified refs", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -124,8 +124,8 @@ describe("handleSendChat", () => {
       model: "gpt-5-mini",
     });
     expect(host.chatModelOverrides.main).toEqual({
-      kind: "raw",
-      value: "gpt-5-mini",
+      kind: "qualified",
+      value: "openai/gpt-5-mini",
     });
   });
 });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -536,17 +536,26 @@ function resolveModelOverrideValue(state: AppViewState): string {
     return "";
   }
   // No local override recorded yet — fall back to server data.
-  // Include provider prefix so the value matches option keys (provider/model).
+  // Only qualify provider/model pairs that exist in the loaded catalog so
+  // raw aliases stay untouched.
   const activeRow = resolveActiveSessionRow(state);
   if (activeRow && typeof activeRow.model === "string" && activeRow.model.trim()) {
-    return resolveServerChatModelValue(activeRow.model, activeRow.modelProvider);
+    return resolveServerChatModelValue(
+      activeRow.model,
+      activeRow.modelProvider,
+      state.chatModelCatalog ?? [],
+    );
   }
   return "";
 }
 
 function resolveDefaultModelValue(state: AppViewState): string {
   const defaults = state.sessionsResult?.defaults;
-  return resolveServerChatModelValue(defaults?.model, defaults?.modelProvider);
+  return resolveServerChatModelValue(
+    defaults?.model,
+    defaults?.modelProvider,
+    state.chatModelCatalog ?? [],
+  );
 }
 
 function buildChatModelOptions(

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -44,7 +44,20 @@ describe("chat-model-ref helpers", () => {
   });
 
   it("resolves server session data to qualified option values", () => {
-    expect(resolveServerChatModelValue("gpt-5-mini", "openai")).toBe("openai/gpt-5-mini");
-    expect(resolveServerChatModelValue("alias-only", null)).toBe("alias-only");
+    expect(resolveServerChatModelValue("gpt-5-mini", "openai", catalog)).toBe(
+      "openai/gpt-5-mini",
+    );
+    expect(resolveServerChatModelValue("alias-only", null, catalog)).toBe("alias-only");
+  });
+
+  it("keeps bare server aliases when the current provider does not own that catalog model", () => {
+    const ambiguousCatalog: ModelCatalogEntry[] = [
+      { id: "glm-5", name: "GLM-5", provider: "zai" },
+      { id: "glm-5", name: "GLM-5", provider: "modelstudio" },
+    ];
+
+    expect(resolveServerChatModelValue("glm-5", "astroncodingplan", ambiguousCatalog)).toBe(
+      "glm-5",
+    );
   });
 });

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -54,6 +54,12 @@ describe("chat-model-ref helpers", () => {
     );
   });
 
+  it("preserves same-provider prefixes for native slash-containing model ids", () => {
+    expect(resolveServerChatModelValue("openrouter/auto", "openrouter", catalog)).toBe(
+      "openrouter/openrouter/auto",
+    );
+  });
+
   it("keeps bare server aliases when the current provider does not own that catalog model", () => {
     const ambiguousCatalog: ModelCatalogEntry[] = [
       { id: "glm-5", name: "GLM-5", provider: "zai" },

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -44,10 +44,14 @@ describe("chat-model-ref helpers", () => {
   });
 
   it("resolves server session data to qualified option values", () => {
-    expect(resolveServerChatModelValue("gpt-5-mini", "openai", catalog)).toBe(
-      "openai/gpt-5-mini",
-    );
+    expect(resolveServerChatModelValue("gpt-5-mini", "openai", catalog)).toBe("openai/gpt-5-mini");
     expect(resolveServerChatModelValue("alias-only", null, catalog)).toBe("alias-only");
+  });
+
+  it("preserves a distinct provider for slash-containing server model ids", () => {
+    expect(resolveServerChatModelValue("anthropic/claude-haiku-4.5", "openrouter", catalog)).toBe(
+      "openrouter/anthropic/claude-haiku-4.5",
+    );
   });
 
   it("keeps bare server aliases when the current provider does not own that catalog model", () => {

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -19,6 +19,25 @@ export function buildQualifiedChatModelValue(model: string, provider?: string | 
   return trimmedProvider ? `${trimmedProvider}/${trimmedModel}` : trimmedModel;
 }
 
+export function buildResolvedChatModelValue(model: string, provider?: string | null): string {
+  const trimmedModel = model.trim();
+  if (!trimmedModel) {
+    return "";
+  }
+  const trimmedProvider = provider?.trim();
+  if (!trimmedProvider) {
+    return trimmedModel;
+  }
+  const separator = trimmedModel.indexOf("/");
+  if (separator <= 0) {
+    return buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
+  }
+  const embeddedProvider = trimmedModel.slice(0, separator).trim();
+  return embeddedProvider.toLowerCase() === trimmedProvider.toLowerCase()
+    ? trimmedModel
+    : buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
+}
+
 export function createChatModelOverride(value: string): ChatModelOverride | null {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -75,7 +94,7 @@ export function resolveServerChatModelValue(
     return "";
   }
   if (trimmedModel.includes("/")) {
-    return trimmedModel;
+    return buildResolvedChatModelValue(trimmedModel, provider);
   }
   const trimmedProvider = provider?.trim();
   if (!trimmedProvider) {
@@ -87,7 +106,7 @@ export function resolveServerChatModelValue(
       entry.provider?.trim().toLowerCase() === trimmedProvider.toLowerCase(),
   );
   return hasExactCatalogMatch
-    ? buildQualifiedChatModelValue(trimmedModel, trimmedProvider)
+    ? buildResolvedChatModelValue(trimmedModel, trimmedProvider)
     : trimmedModel;
 }
 

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -65,11 +65,30 @@ export function normalizeChatModelOverrideValue(
 export function resolveServerChatModelValue(
   model?: string | null,
   provider?: string | null,
+  catalog: ModelCatalogEntry[] = [],
 ): string {
   if (typeof model !== "string") {
     return "";
   }
-  return buildQualifiedChatModelValue(model, provider);
+  const trimmedModel = model.trim();
+  if (!trimmedModel) {
+    return "";
+  }
+  if (trimmedModel.includes("/")) {
+    return trimmedModel;
+  }
+  const trimmedProvider = provider?.trim();
+  if (!trimmedProvider) {
+    return trimmedModel;
+  }
+  const hasExactCatalogMatch = catalog.some(
+    (entry) =>
+      entry.id.trim().toLowerCase() === trimmedModel.toLowerCase() &&
+      entry.provider?.trim().toLowerCase() === trimmedProvider.toLowerCase(),
+  );
+  return hasExactCatalogMatch
+    ? buildQualifiedChatModelValue(trimmedModel, trimmedProvider)
+    : trimmedModel;
 }
 
 export function formatChatModelDisplay(value: string): string {

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -28,14 +28,7 @@ export function buildResolvedChatModelValue(model: string, provider?: string | n
   if (!trimmedProvider) {
     return trimmedModel;
   }
-  const separator = trimmedModel.indexOf("/");
-  if (separator <= 0) {
-    return buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
-  }
-  const embeddedProvider = trimmedModel.slice(0, separator).trim();
-  return embeddedProvider.toLowerCase() === trimmedProvider.toLowerCase()
-    ? trimmedModel
-    : buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
+  return buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
 }
 
 export function createChatModelOverride(value: string): ChatModelOverride | null {

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -265,7 +265,7 @@ describe("executeSlashCommand directives", () => {
     expect(request).toHaveBeenNthCalledWith(2, "models.list", {});
   });
 
-  it("keeps ambiguous bare /model aliases raw after successful changes", async () => {
+  it("caches the resolved provider for ambiguous bare /model aliases", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "sessions.patch") {
         return {
@@ -292,8 +292,8 @@ describe("executeSlashCommand directives", () => {
       model: "glm-5",
     });
     expect(result.sessionPatch?.modelOverride).toEqual({
-      kind: "raw",
-      value: "glm-5",
+      kind: "qualified",
+      value: "astroncodingplan/glm-5",
     });
   });
 

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -265,7 +265,7 @@ describe("executeSlashCommand directives", () => {
     expect(request).toHaveBeenNthCalledWith(2, "models.list", {});
   });
 
-  it("mirrors resolved provider-qualified model refs after /model changes", async () => {
+  it("keeps bare /model arguments raw after successful changes", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "sessions.patch") {
         return {
@@ -290,6 +290,38 @@ describe("executeSlashCommand directives", () => {
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
       model: "gpt-5-mini",
+    });
+    expect(result.sessionPatch?.modelOverride).toEqual({
+      kind: "raw",
+      value: "gpt-5-mini",
+    });
+  });
+
+  it("preserves explicit provider/model refs after successful /model changes", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          key: "main",
+          resolved: {
+            modelProvider: "openai",
+            model: "gpt-5-mini",
+          },
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "openai/gpt-5-mini",
+    );
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "openai/gpt-5-mini",
     });
     expect(result.sessionPatch?.modelOverride).toEqual({
       kind: "qualified",

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -265,15 +265,15 @@ describe("executeSlashCommand directives", () => {
     expect(request).toHaveBeenNthCalledWith(2, "models.list", {});
   });
 
-  it("keeps bare /model arguments raw after successful changes", async () => {
+  it("keeps ambiguous bare /model aliases raw after successful changes", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "sessions.patch") {
         return {
           ok: true,
           key: "main",
           resolved: {
-            modelProvider: "openai",
-            model: "gpt-5-mini",
+            modelProvider: "astroncodingplan",
+            model: "glm-5",
           },
         };
       }
@@ -284,16 +284,48 @@ describe("executeSlashCommand directives", () => {
       { request } as unknown as GatewayBrowserClient,
       "main",
       "model",
-      "gpt-5-mini",
+      "glm-5",
     );
 
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "main",
-      model: "gpt-5-mini",
+      model: "glm-5",
     });
     expect(result.sessionPatch?.modelOverride).toEqual({
       kind: "raw",
-      value: "gpt-5-mini",
+      value: "glm-5",
+    });
+  });
+
+  it("caches canonicalized /model shorthands as resolved provider/model refs", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          key: "main",
+          resolved: {
+            modelProvider: "anthropic",
+            model: "claude-sonnet-4-5",
+          },
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "sonnet",
+    );
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "sonnet",
+    });
+    expect(result.sessionPatch?.modelOverride).toEqual({
+      kind: "qualified",
+      value: "anthropic/claude-sonnet-4-5",
     });
   });
 

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -361,6 +361,38 @@ describe("executeSlashCommand directives", () => {
     });
   });
 
+  it("keeps same-provider slash model ids aligned with picker values after /model", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          key: "main",
+          resolved: {
+            modelProvider: "openrouter",
+            model: "openrouter/auto",
+          },
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "openrouter/auto",
+    );
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "openrouter/auto",
+    });
+    expect(result.sessionPatch?.modelOverride).toEqual({
+      kind: "qualified",
+      value: "openrouter/openrouter/auto",
+    });
+  });
+
   it("resolves the legacy main alias for /usage", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "sessions.list") {

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -16,7 +16,10 @@ import {
   isSubagentSessionKey,
   parseAgentSessionKey,
 } from "../../../../src/routing/session-key.js";
-import { createChatModelOverride } from "../chat-model-ref.ts";
+import {
+  buildQualifiedChatModelValue,
+  createChatModelOverride,
+} from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
   AgentsListResult,
@@ -151,18 +154,40 @@ async function executeModel(
   }
 
   try {
-    await client.request<SessionsPatchResult>("sessions.patch", {
+    const requestedModel = args.trim();
+    const patched = await client.request<SessionsPatchResult>("sessions.patch", {
       key: sessionKey,
-      model: args.trim(),
+      model: requestedModel,
     });
     return {
-      content: `Model set to \`${args.trim()}\`.`,
+      content: `Model set to \`${requestedModel}\`.`,
       action: "refresh",
-      sessionPatch: { modelOverride: createChatModelOverride(args.trim()) },
+      sessionPatch: {
+        modelOverride: resolvePatchedModelOverride(requestedModel, patched.resolved),
+      },
     };
   } catch (err) {
     return { content: `Failed to set model: ${String(err)}` };
   }
+}
+
+function resolvePatchedModelOverride(
+  requestedModel: string,
+  resolved?: SessionsPatchResult["resolved"],
+): ChatModelOverride | null {
+  const requestedOverride = createChatModelOverride(requestedModel);
+  const resolvedModel = resolved?.model?.trim();
+  if (!requestedOverride || !resolvedModel) {
+    return requestedOverride;
+  }
+  if (requestedOverride.kind === "raw" && requestedOverride.value === resolvedModel) {
+    return requestedOverride;
+  }
+  return (
+    createChatModelOverride(
+      buildQualifiedChatModelValue(resolvedModel, resolved?.modelProvider),
+    ) ?? requestedOverride
+  );
 }
 
 async function executeThink(

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -16,10 +16,7 @@ import {
   isSubagentSessionKey,
   parseAgentSessionKey,
 } from "../../../../src/routing/session-key.js";
-import {
-  buildQualifiedChatModelValue,
-  createChatModelOverride,
-} from "../chat-model-ref.ts";
+import { buildResolvedChatModelValue, createChatModelOverride } from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
   AgentsListResult,
@@ -180,14 +177,15 @@ function resolvePatchedModelOverride(
   if (!requestedOverride || !resolvedModel) {
     return requestedOverride;
   }
-  if (requestedOverride.kind === "raw" && requestedOverride.value === resolvedModel) {
+  const resolvedValue = buildResolvedChatModelValue(resolvedModel, resolved?.modelProvider);
+  if (
+    requestedOverride.kind === "raw" &&
+    requestedOverride.value === resolvedModel &&
+    resolvedValue === resolvedModel
+  ) {
     return requestedOverride;
   }
-  return (
-    createChatModelOverride(
-      buildQualifiedChatModelValue(resolvedModel, resolved?.modelProvider),
-    ) ?? requestedOverride
-  );
+  return createChatModelOverride(resolvedValue) ?? requestedOverride;
 }
 
 async function executeThink(

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -16,7 +16,7 @@ import {
   isSubagentSessionKey,
   parseAgentSessionKey,
 } from "../../../../src/routing/session-key.js";
-import { createChatModelOverride, resolveServerChatModelValue } from "../chat-model-ref.ts";
+import { createChatModelOverride } from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
   AgentsListResult,
@@ -151,18 +151,14 @@ async function executeModel(
   }
 
   try {
-    const patched = await client.request<SessionsPatchResult>("sessions.patch", {
+    await client.request<SessionsPatchResult>("sessions.patch", {
       key: sessionKey,
       model: args.trim(),
     });
-    const resolvedValue = resolveServerChatModelValue(
-      patched.resolved?.model ?? args.trim(),
-      patched.resolved?.modelProvider,
-    );
     return {
       content: `Model set to \`${args.trim()}\`.`,
       action: "refresh",
-      sessionPatch: { modelOverride: createChatModelOverride(resolvedValue) },
+      sessionPatch: { modelOverride: createChatModelOverride(args.trim()) },
     };
   } catch (err) {
     return { content: `Failed to set model: ${String(err)}` };

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -25,12 +25,14 @@ function createSessions(): SessionsListResult {
 function createChatHeaderState(
   overrides: {
     model?: string | null;
+    modelProvider?: string | null;
     models?: ModelCatalogEntry[];
     omitSessionFromList?: boolean;
   } = {},
 ): { state: AppViewState; request: ReturnType<typeof vi.fn> } {
   let currentModel = overrides.model ?? null;
-  let currentModelProvider = currentModel ? "openai" : null;
+  let currentModelProvider =
+    overrides.modelProvider ?? (currentModel ? "openai" : null);
   const omitSessionFromList = overrides.omitSessionFromList ?? false;
   const catalog = overrides.models ?? [
     { id: "gpt-5", name: "GPT-5", provider: "openai" },
@@ -795,6 +797,33 @@ describe("chat view", () => {
     );
     expect(optionValues).toContain("openai/gpt-5-mini");
     expect(optionValues).not.toContain("gpt-5-mini");
+  });
+
+  it("keeps bare session aliases instead of prefixing the active provider", () => {
+    const { state } = createChatHeaderState({
+      model: "glm-5",
+      modelProvider: "astroncodingplan",
+      models: [
+        { id: "claude-sonnet", name: "Claude Sonnet", provider: "astroncodingplan" },
+        { id: "glm-5", name: "GLM-5", provider: "zai" },
+        { id: "glm-5", name: "GLM-5", provider: "modelstudio" },
+      ],
+    });
+
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect).not.toBeNull();
+    expect(modelSelect?.value).toBe("glm-5");
+
+    const optionValues = Array.from(modelSelect?.querySelectorAll("option") ?? []).map(
+      (option) => option.value,
+    );
+    expect(optionValues).toContain("glm-5");
+    expect(optionValues).not.toContain("astroncodingplan/glm-5");
   });
 
   it("prefers the session label over displayName in the grouped chat session selector", () => {


### PR DESCRIPTION
## Summary
- preserve raw model aliases in the Control UI when the current session provider does not uniquely identify the selected model
- cache the server-resolved provider/model when `/model` canonicalizes an alias or shorthand ref
- add regression tests for ambiguous aliases, canonicalized `/model` inputs, and related chat view behavior

## Reproduction
Before this change, the source-level helper rewrote a bare alias like `glm-5` with the current provider, producing `astroncodingplan/glm-5` and causing the reported `model not allowed` failure.

## Validation
- source-level repro before the fix showed `resolveServerChatModelValue("glm-5", "astroncodingplan")` returning `astroncodingplan/glm-5`
- follow-up coverage verifies ambiguous aliases still stay raw while canonicalized `/model` inputs cache the resolved provider/model
- added regression coverage in `ui/src/ui/chat-model-ref.test.ts`, `ui/src/ui/views/chat.test.ts`, `ui/src/ui/app-chat.test.ts`, and `ui/src/ui/chat/slash-command-executor.node.test.ts`

## AI Assistance
- AI-assisted: yes (implemented with Codex plus manual verification and follow-up fixes)
- Testing degree: targeted/source-level validation plus focused regression tests in the changed UI modules; full local `pnpm build && pnpm check && pnpm test` was not available in the initial sandbox, so broader validation is currently delegated to repository CI

Fixes #49718
