### PR TITLE
fix(config): accept sandbox browser evaluateEnabled

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -175,6 +175,22 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts agents.defaults.sandbox.browser.evaluateEnabled", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            browser: {
+              evaluateEnabled: false,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects browser.extraArgs with non-array value", () => {
     const res = validateConfigObject({
       browser: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -216,6 +216,7 @@ export const SandboxBrowserSchema = z
     noVncPort: z.number().int().positive().optional(),
     headless: z.boolean().optional(),
     enableNoVnc: z.boolean().optional(),
+    evaluateEnabled: z.boolean().optional(),
     allowHostControl: z.boolean().optional(),
     autoStart: z.boolean().optional(),
     autoStartTimeoutMs: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary
- add the missing `evaluateEnabled` field to `SandboxBrowserSchema`
- add a regression test covering `agents.defaults.sandbox.browser.evaluateEnabled`

## Validation
- `node --import tsx --eval "import { validateConfigObject } from './src/config/config.ts'; const res = validateConfigObject({ agents: { defaults: { sandbox: { browser: { evaluateEnabled: false } } } } }); if (!res.ok) { console.error(JSON.stringify(res.issues, null, 2)); process.exit(1); } console.log('config-validation-ok');"`

Closes #49808.
