### PR TITLE
fix(channels): treat Feishu p2p chats as direct messages

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -1,6 +1,6 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
-import type { OpenClawConfig } from "../../../config/config.js";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/config.js";
 import { formatBillingErrorMessage } from "../../pi-embedded-helpers.js";
 import { makeAssistantMessageFixture } from "../../test-helpers/assistant-message-fixtures.js";
 import {
@@ -103,6 +103,7 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).toBe("A");
     expect(payloads[1]?.text).toBe("B");
   });
+
   it("suppresses pretty-printed error JSON that differs from the errorMessage", () => {
     const payloads = buildPayloads({
       assistantTexts: [errorJsonPretty],

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
+import type { OpenClawConfig } from "../../../config/config.js";
 import { describe, expect, it } from "vitest";
 import { formatBillingErrorMessage } from "../../pi-embedded-helpers.js";
 import { makeAssistantMessageFixture } from "../../test-helpers/assistant-message-fixtures.js";
@@ -80,6 +81,28 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads.some((payload) => payload.text === errorJson)).toBe(false);
   });
 
+  it("keeps feishu p2p multi-text payloads when block_deliver.dm_enable is true", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          block_deliver: {
+            block_disable: true,
+            dm_enable: true,
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const payloads = buildPayloads({
+      assistantTexts: ["A", "B"],
+      config: cfg,
+      messageProvider: "feishu",
+      chatType: "p2p",
+    });
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.text).toBe("A");
+    expect(payloads[1]?.text).toBe("B");
+  });
   it("suppresses pretty-printed error JSON that differs from the errorMessage", () => {
     const payloads = buildPayloads({
       assistantTexts: [errorJsonPretty],

--- a/src/channels/channels-misc.test.ts
+++ b/src/channels/channels-misc.test.ts
@@ -19,6 +19,7 @@ describe("normalizeChatType", () => {
   const cases: Array<{ name: string; value: string | undefined; expected: string | undefined }> = [
     { name: "normalizes direct", value: "direct", expected: "direct" },
     { name: "normalizes dm alias", value: "dm", expected: "direct" },
+    { name: "normalizes p2p alias", value: "p2p", expected: "direct" },
     { name: "normalizes group", value: "group", expected: "group" },
     { name: "normalizes channel", value: "channel", expected: "channel" },
     { name: "returns undefined for undefined", value: undefined, expected: undefined },
@@ -38,6 +39,7 @@ describe("normalizeChatType", () => {
       // Legacy config/input may use "dm" with non-canonical casing/spacing.
       expect(normalizeChatType("DM")).toBe("direct");
       expect(normalizeChatType(" dm ")).toBe("direct");
+      expect(normalizeChatType(" P2P ")).toBe("direct");
     });
   });
 });

--- a/src/channels/chat-type.ts
+++ b/src/channels/chat-type.ts
@@ -5,7 +5,8 @@ export function normalizeChatType(raw?: string): ChatType | undefined {
   if (!value) {
     return undefined;
   }
-  if (value === "direct" || value === "dm") {
+  // Feishu reports 1:1 chats as "p2p".
+  if (value === "direct" || value === "dm" || value === "p2p") {
     return "direct";
   }
   if (value === "group") {


### PR DESCRIPTION
## Summary
- normalize Feishu `p2p` chat types to `direct` in shared chat-type normalization
- cover the alias in chat-type tests
- add a payload regression test showing `block_deliver.dm_enable` now applies to Feishu DMs

## Problem
Feishu reports 1:1 chats as `p2p`. The shared chat-type normalizer only treated `direct` and `dm` as direct-message aliases, so downstream logic that relies on direct chat detection did not recognize Feishu DMs.

One visible symptom is `block_deliver.dm_enable=true`: Feishu DMs were still handled like non-DM chats and block-delivery filtering stayed enabled.

## Testing
- `pnpm test -- src/channels/channels-misc.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts`