### PR TITLE
Discord: make exec approval timeout configurable

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -944,10 +944,13 @@ Default slash command settings:
 
     - `channels.discord.execApprovals.enabled`
     - `channels.discord.execApprovals.approvers`
+    - `channels.discord.execApprovals.timeoutMs` (default: `120000`)
     - `channels.discord.execApprovals.target` (`dm` | `channel` | `both`, default: `dm`)
     - `agentFilter`, `sessionFilter`, `cleanupAfterResolve`
 
     When `target` is `channel` or `both`, the approval prompt is visible in the channel. Only configured approvers can use the buttons; other users receive an ephemeral denial. Approval prompts include the command text, so only enable channel delivery in trusted channels. If the channel ID cannot be derived from the session key, OpenClaw falls back to DM delivery.
+
+    Increase `timeoutMs` when approvers commonly respond from mobile push notifications or other slower workflows. For example, `600000` gives Discord approvers 10 minutes instead of the default 2 minutes.
 
     Gateway auth for this handler uses the same shared credential resolution contract as other Gateway clients:
 

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -36,6 +36,7 @@ import {
 import { auditDiscordChannelPermissions, collectDiscordAuditChannelIds } from "./audit.js";
 import {
   isDiscordExecApprovalClientEnabled,
+  resolveDiscordExecApprovalTimeoutMs,
   shouldSuppressLocalDiscordExecApprovalPrompt,
 } from "./exec-approvals.js";
 import { monitorDiscordProvider } from "./monitor.js";
@@ -375,6 +376,8 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       isDiscordExecApprovalClientEnabled({ cfg, accountId })
         ? { kind: "enabled" }
         : { kind: "disabled" },
+    resolveApprovalTimeoutMs: ({ cfg, accountId, defaultTimeoutMs }) =>
+      resolveDiscordExecApprovalTimeoutMs({ cfg, accountId, defaultTimeoutMs }),
     shouldSuppressLocalPrompt: ({ cfg, accountId, payload }) =>
       shouldSuppressLocalDiscordExecApprovalPrompt({
         cfg,

--- a/extensions/discord/src/exec-approvals.ts
+++ b/extensions/discord/src/exec-approvals.ts
@@ -1,7 +1,17 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { getExecApprovalReplyMetadata } from "openclaw/plugin-sdk/infra-runtime";
+import {
+  DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  getExecApprovalReplyMetadata,
+} from "openclaw/plugin-sdk/infra-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveDiscordAccount } from "./accounts.js";
+
+function normalizeExecApprovalTimeoutMs(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(value));
+}
 
 export function isDiscordExecApprovalClientEnabled(params: {
   cfg: OpenClawConfig;
@@ -9,6 +19,25 @@ export function isDiscordExecApprovalClientEnabled(params: {
 }): boolean {
   const config = resolveDiscordAccount(params).config.execApprovals;
   return Boolean(config?.enabled && (config.approvers?.length ?? 0) > 0);
+}
+
+export function resolveDiscordExecApprovalTimeoutMs(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  defaultTimeoutMs?: number;
+}): number {
+  const fallback = normalizeExecApprovalTimeoutMs(
+    params.defaultTimeoutMs,
+    DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  );
+  if (!isDiscordExecApprovalClientEnabled(params)) {
+    return fallback;
+  }
+  return normalizeExecApprovalTimeoutMs(
+    resolveDiscordAccount({ cfg: params.cfg, accountId: params.accountId }).config.execApprovals
+      ?.timeoutMs,
+    fallback,
+  );
 }
 
 export function shouldSuppressLocalDiscordExecApprovalPrompt(params: {

--- a/extensions/discord/src/exec-approvals.ts
+++ b/extensions/discord/src/exec-approvals.ts
@@ -2,16 +2,10 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
   getExecApprovalReplyMetadata,
+  normalizeExecApprovalTimeoutMs,
 } from "openclaw/plugin-sdk/infra-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveDiscordAccount } from "./accounts.js";
-
-function normalizeExecApprovalTimeoutMs(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return fallback;
-  }
-  return Math.max(1, Math.floor(value));
-}
 
 export function isDiscordExecApprovalClientEnabled(params: {
   cfg: OpenClawConfig;

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -224,4 +224,33 @@ describe("requestExecApprovalDecision", () => {
       vi.useRealTimers();
     }
   });
+
+  it("extends waitDecision timeout to match longer approval windows", async () => {
+    vi.mocked(callGatewayTool)
+      .mockResolvedValueOnce({
+        status: "accepted",
+        id: "approval-id",
+        expiresAtMs: 600_000,
+      })
+      .mockResolvedValueOnce({ decision: "allow-once" });
+
+    await expect(
+      requestExecApprovalDecision({
+        id: "approval-id",
+        command: "echo hi",
+        cwd: "/tmp",
+        host: "gateway",
+        security: "allowlist",
+        ask: "always",
+        timeoutMs: 600_000,
+      }),
+    ).resolves.toBe("allow-once");
+
+    expect(callGatewayTool).toHaveBeenNthCalledWith(
+      2,
+      "exec.approval.waitDecision",
+      { timeoutMs: 610_000 },
+      { id: "approval-id" },
+    );
+  });
 });

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -9,12 +9,14 @@ vi.mock("./tools/gateway.js", () => ({
 }));
 
 let callGatewayTool: typeof import("./tools/gateway.js").callGatewayTool;
+let registerExecApprovalRequest: typeof import("./bash-tools.exec-approval-request.js").registerExecApprovalRequest;
 let requestExecApprovalDecision: typeof import("./bash-tools.exec-approval-request.js").requestExecApprovalDecision;
 
 describe("requestExecApprovalDecision", () => {
   beforeAll(async () => {
     ({ callGatewayTool } = await import("./tools/gateway.js"));
-    ({ requestExecApprovalDecision } = await import("./bash-tools.exec-approval-request.js"));
+    ({ registerExecApprovalRequest, requestExecApprovalDecision } =
+      await import("./bash-tools.exec-approval-request.js"));
   });
 
   beforeEach(() => {
@@ -173,5 +175,53 @@ describe("requestExecApprovalDecision", () => {
 
     expect(result).toBe("deny");
     expect(vi.mocked(callGatewayTool).mock.calls).toHaveLength(1);
+  });
+
+  it("passes through caller-provided timeoutMs and uses it for fallback expiry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-17T12:00:00Z"));
+    vi.mocked(callGatewayTool).mockResolvedValueOnce({ status: "accepted", id: "approval-id" });
+
+    try {
+      const result = await registerExecApprovalRequest({
+        id: "approval-id",
+        command: "echo hi",
+        cwd: "/tmp",
+        host: "gateway",
+        security: "allowlist",
+        ask: "always",
+        timeoutMs: 600_000,
+      });
+
+      expect(result).toEqual({
+        id: "approval-id",
+        expiresAtMs: Date.now() + 600_000,
+      });
+      expect(callGatewayTool).toHaveBeenCalledWith(
+        "exec.approval.request",
+        { timeoutMs: DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS },
+        {
+          id: "approval-id",
+          command: "echo hi",
+          cwd: "/tmp",
+          nodeId: undefined,
+          host: "gateway",
+          security: "allowlist",
+          ask: "always",
+          agentId: undefined,
+          resolvedPath: undefined,
+          sessionKey: undefined,
+          turnSourceChannel: undefined,
+          turnSourceTo: undefined,
+          turnSourceAccountId: undefined,
+          turnSourceThreadId: undefined,
+          timeoutMs: 600_000,
+          twoPhase: true,
+        },
+        { expectFinal: false },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -23,6 +23,7 @@ export type RequestExecApprovalDecisionParams = {
   turnSourceTo?: string;
   turnSourceAccountId?: string;
   turnSourceThreadId?: string | number;
+  timeoutMs?: number;
 };
 
 type ExecApprovalRequestToolParams = RequestExecApprovalDecisionParams & {
@@ -33,6 +34,10 @@ type ExecApprovalRequestToolParams = RequestExecApprovalDecisionParams & {
 function buildExecApprovalRequestToolParams(
   params: RequestExecApprovalDecisionParams,
 ): ExecApprovalRequestToolParams {
+  const timeoutMs =
+    typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+      ? Math.max(1, Math.floor(params.timeoutMs))
+      : DEFAULT_APPROVAL_TIMEOUT_MS;
   return {
     id: params.id,
     ...(params.command ? { command: params.command } : {}),
@@ -51,7 +56,7 @@ function buildExecApprovalRequestToolParams(
     turnSourceTo: params.turnSourceTo,
     turnSourceAccountId: params.turnSourceAccountId,
     turnSourceThreadId: params.turnSourceThreadId,
-    timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    timeoutMs,
     twoPhase: true,
   };
 }
@@ -88,22 +93,20 @@ export type ExecApprovalRegistration = {
 export async function registerExecApprovalRequest(
   params: RequestExecApprovalDecisionParams,
 ): Promise<ExecApprovalRegistration> {
+  const requestParams = buildExecApprovalRequestToolParams(params);
   // Two-phase registration is critical: the ID must be registered server-side
   // before exec returns `approval-pending`, otherwise `/approve` can race and orphan.
   const registrationResult = await callGatewayTool<{
     id?: string;
     expiresAtMs?: number;
     decision?: string;
-  }>(
-    "exec.approval.request",
-    { timeoutMs: DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS },
-    buildExecApprovalRequestToolParams(params),
-    { expectFinal: false },
-  );
+  }>("exec.approval.request", { timeoutMs: DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS }, requestParams, {
+    expectFinal: false,
+  });
   const decision = parseDecision(registrationResult);
   const id = parseString(registrationResult?.id) ?? params.id;
   const expiresAtMs =
-    parseExpiresAtMs(registrationResult?.expiresAtMs) ?? Date.now() + DEFAULT_APPROVAL_TIMEOUT_MS;
+    parseExpiresAtMs(registrationResult?.expiresAtMs) ?? Date.now() + requestParams.timeoutMs;
   if (decision.present) {
     return { id, expiresAtMs, finalDecision: decision.value };
   }
@@ -166,6 +169,7 @@ type HostExecApprovalParams = {
   turnSourceTo?: string;
   turnSourceAccountId?: string;
   turnSourceThreadId?: string | number;
+  timeoutMs?: number;
 };
 
 type ExecApprovalRequesterContext = {
@@ -221,6 +225,7 @@ function buildHostApprovalDecisionParams(
     }),
     resolvedPath: params.resolvedPath,
     ...buildExecApprovalTurnSourceContext(params),
+    timeoutMs: params.timeoutMs,
   };
 }
 

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -1,9 +1,19 @@
-import type { ExecAsk, ExecSecurity, SystemRunApprovalPlan } from "../infra/exec-approvals.js";
+import {
+  normalizeExecApprovalTimeoutMs,
+  type ExecAsk,
+  type ExecSecurity,
+  type SystemRunApprovalPlan,
+} from "../infra/exec-approvals.js";
 import {
   DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS,
   DEFAULT_APPROVAL_TIMEOUT_MS,
 } from "./bash-tools.exec-runtime.js";
 import { callGatewayTool } from "./tools/gateway.js";
+
+const APPROVAL_WAIT_TIMEOUT_BUFFER_MS = Math.max(
+  0,
+  DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS - DEFAULT_APPROVAL_TIMEOUT_MS,
+);
 
 export type RequestExecApprovalDecisionParams = {
   id: string;
@@ -34,10 +44,7 @@ type ExecApprovalRequestToolParams = RequestExecApprovalDecisionParams & {
 function buildExecApprovalRequestToolParams(
   params: RequestExecApprovalDecisionParams,
 ): ExecApprovalRequestToolParams {
-  const timeoutMs =
-    typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
-      ? Math.max(1, Math.floor(params.timeoutMs))
-      : DEFAULT_APPROVAL_TIMEOUT_MS;
+  const timeoutMs = normalizeExecApprovalTimeoutMs(params.timeoutMs, DEFAULT_APPROVAL_TIMEOUT_MS);
   return {
     id: params.id,
     ...(params.command ? { command: params.command } : {}),
@@ -59,6 +66,14 @@ function buildExecApprovalRequestToolParams(
     timeoutMs,
     twoPhase: true,
   };
+}
+
+function resolveExecApprovalWaitTimeoutMs(timeoutMs: number | undefined): number {
+  const approvalTimeoutMs = normalizeExecApprovalTimeoutMs(timeoutMs, DEFAULT_APPROVAL_TIMEOUT_MS);
+  return Math.max(
+    DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS,
+    approvalTimeoutMs + APPROVAL_WAIT_TIMEOUT_BUFFER_MS,
+  );
 }
 
 type ParsedDecision = { present: boolean; value: string | null };
@@ -113,11 +128,14 @@ export async function registerExecApprovalRequest(
   return { id, expiresAtMs };
 }
 
-export async function waitForExecApprovalDecision(id: string): Promise<string | null> {
+export async function waitForExecApprovalDecision(
+  id: string,
+  timeoutMs?: number,
+): Promise<string | null> {
   try {
     const decisionResult = await callGatewayTool<{ decision: string }>(
       "exec.approval.waitDecision",
-      { timeoutMs: DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS },
+      { timeoutMs: resolveExecApprovalWaitTimeoutMs(timeoutMs) },
       { id },
     );
     return parseDecision(decisionResult).value;
@@ -134,21 +152,23 @@ export async function waitForExecApprovalDecision(id: string): Promise<string | 
 export async function resolveRegisteredExecApprovalDecision(params: {
   approvalId: string;
   preResolvedDecision: string | null | undefined;
+  timeoutMs?: number;
 }): Promise<string | null> {
   if (params.preResolvedDecision !== undefined) {
     return params.preResolvedDecision ?? null;
   }
-  return await waitForExecApprovalDecision(params.approvalId);
+  return await waitForExecApprovalDecision(params.approvalId, params.timeoutMs);
 }
 
 export async function requestExecApprovalDecision(
   params: RequestExecApprovalDecisionParams,
 ): Promise<string | null> {
+  const requestParams = buildExecApprovalRequestToolParams(params);
   const registration = await registerExecApprovalRequest(params);
   if (Object.hasOwn(registration, "finalDecision")) {
     return registration.finalDecision ?? null;
   }
-  return await waitForExecApprovalDecision(registration.id);
+  return await waitForExecApprovalDecision(registration.id, requestParams.timeoutMs);
 }
 
 type HostExecApprovalParams = {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -29,6 +29,7 @@ import {
   sendExecApprovalFollowupResult,
 } from "./bash-tools.exec-host-shared.js";
 import {
+  DEFAULT_APPROVAL_TIMEOUT_MS,
   DEFAULT_NOTIFY_TAIL_CHARS,
   createApprovalSlug,
   normalizeNotifyOutput,
@@ -144,6 +145,7 @@ export async function processGatewayAllowlist(
   if (requiresAsk) {
     const requestArgs = buildDefaultExecApprovalRequestArgs({
       warnings: params.warnings,
+      timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
       approvalRunningNoticeMs: params.approvalRunningNoticeMs,
       createApprovalSlug,
       turnSourceChannel: params.turnSourceChannel,
@@ -158,6 +160,7 @@ export async function processGatewayAllowlist(
         host: "gateway",
         security: hostSecurity,
         ask: hostAsk,
+        timeoutMs: requestArgs.timeoutMs,
         ...buildExecApprovalRequesterContext({
           agentId: params.agentId,
           sessionKey: params.sessionKey,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -197,6 +197,7 @@ export async function processGatewayAllowlist(
       const decision = await resolveApprovalDecisionOrUndefined({
         approvalId,
         preResolvedDecision,
+        timeoutMs: requestArgs.timeoutMs,
         onFailure: () =>
           void sendExecApprovalFollowupResult(
             followupTarget,

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -19,6 +19,7 @@ import {
 } from "./bash-tools.exec-approval-request.js";
 import * as execHostShared from "./bash-tools.exec-host-shared.js";
 import {
+  DEFAULT_APPROVAL_TIMEOUT_MS,
   DEFAULT_NOTIFY_TAIL_CHARS,
   createApprovalSlug,
   normalizeNotifyOutput,
@@ -210,6 +211,7 @@ export async function executeNodeHostCommand(
   if (requiresAsk) {
     const requestArgs = execHostShared.buildDefaultExecApprovalRequestArgs({
       warnings: params.warnings,
+      timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
       approvalRunningNoticeMs: params.approvalRunningNoticeMs,
       createApprovalSlug,
       turnSourceChannel: params.turnSourceChannel,
@@ -225,6 +227,7 @@ export async function executeNodeHostCommand(
         nodeId,
         security: hostSecurity,
         ask: hostAsk,
+        timeoutMs: requestArgs.timeoutMs,
         ...buildExecApprovalRequesterContext({
           agentId: runAgentId,
           sessionKey: runSessionKey,

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -260,6 +260,7 @@ export async function executeNodeHostCommand(
       const decision = await execHostShared.resolveApprovalDecisionOrUndefined({
         approvalId,
         preResolvedDecision,
+        timeoutMs: requestArgs.timeoutMs,
         onFailure: () =>
           void execHostShared.sendExecApprovalFollowupResult(
             followupTarget,

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadConfigMock = vi.hoisted(() => vi.fn());
+const resolveExecApprovalTimeoutMsMock = vi.hoisted(() => vi.fn());
+
+let buildDefaultExecApprovalRequestArgs: typeof import("./bash-tools.exec-host-shared.js").buildDefaultExecApprovalRequestArgs;
+
+describe("buildDefaultExecApprovalRequestArgs", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    loadConfigMock.mockReset();
+    resolveExecApprovalTimeoutMsMock.mockReset();
+    resolveExecApprovalTimeoutMsMock.mockReturnValue(600_000);
+
+    vi.doMock("../config/config.js", () => ({
+      loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+    }));
+    vi.doMock("../infra/exec-approval-surface.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../infra/exec-approval-surface.js")>();
+      return {
+        ...actual,
+        resolveExecApprovalTimeoutMs: (...args: unknown[]) =>
+          resolveExecApprovalTimeoutMsMock(...args),
+      };
+    });
+
+    ({ buildDefaultExecApprovalRequestArgs } = await import("./bash-tools.exec-host-shared.js"));
+  });
+
+  it("lets surface timeout resolution load config lazily", () => {
+    const createApprovalSlug = (approvalId: string) => approvalId;
+
+    expect(
+      buildDefaultExecApprovalRequestArgs({
+        warnings: [],
+        timeoutMs: 120_000,
+        approvalRunningNoticeMs: 10_000,
+        createApprovalSlug,
+        turnSourceChannel: "web",
+        turnSourceAccountId: "main",
+      }),
+    ).toEqual({
+      warnings: [],
+      timeoutMs: 600_000,
+      approvalRunningNoticeMs: 10_000,
+      createApprovalSlug,
+      turnSourceChannel: "web",
+      turnSourceAccountId: "main",
+    });
+
+    expect(resolveExecApprovalTimeoutMsMock).toHaveBeenCalledWith({
+      channel: "web",
+      accountId: "main",
+      defaultTimeoutMs: 120_000,
+    });
+    expect(loadConfigMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -196,12 +196,14 @@ export function resolveExecHostApprovalContext(params: {
 export async function resolveApprovalDecisionOrUndefined(params: {
   approvalId: string;
   preResolvedDecision: string | null | undefined;
+  timeoutMs?: number;
   onFailure: () => void;
 }): Promise<string | null | undefined> {
   try {
     return await resolveRegisteredExecApprovalDecision({
       approvalId: params.approvalId,
       preResolvedDecision: params.preResolvedDecision,
+      timeoutMs: params.timeoutMs,
     });
   } catch {
     params.onFailure();
@@ -289,7 +291,6 @@ export function buildDefaultExecApprovalRequestArgs(
   params: DefaultExecApprovalRequestArgs,
 ): DefaultExecApprovalRequestArgs {
   const timeoutMs = resolveExecApprovalTimeoutMs({
-    cfg: loadConfig(),
     channel: params.turnSourceChannel,
     accountId: params.turnSourceAccountId,
     defaultTimeoutMs: params.timeoutMs,

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -6,6 +6,7 @@ import {
   hasConfiguredExecApprovalDmRoute,
   type ExecApprovalInitiatingSurfaceState,
   resolveExecApprovalInitiatingSurfaceState,
+  resolveExecApprovalTimeoutMs,
 } from "../infra/exec-approval-surface.js";
 import {
   maxAsk,
@@ -69,6 +70,7 @@ export type ExecApprovalFollowupTarget = {
 
 export type DefaultExecApprovalRequestArgs = {
   warnings: string[];
+  timeoutMs: number;
   approvalRunningNoticeMs: number;
   createApprovalSlug: (approvalId: string) => string;
   turnSourceChannel?: string;
@@ -127,12 +129,13 @@ export function createExecApprovalRequestContext(params: {
 
 export function createDefaultExecApprovalRequestContext(params: {
   warnings: string[];
+  timeoutMs?: number;
   approvalRunningNoticeMs: number;
   createApprovalSlug: (approvalId: string) => string;
 }) {
   return createExecApprovalRequestContext({
     warnings: params.warnings,
-    timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    timeoutMs: params.timeoutMs ?? DEFAULT_APPROVAL_TIMEOUT_MS,
     approvalRunningNoticeMs: params.approvalRunningNoticeMs,
     createApprovalSlug: params.createApprovalSlug,
   });
@@ -239,6 +242,7 @@ export function resolveExecApprovalUnavailableState(params: {
 
 export async function createAndRegisterDefaultExecApprovalRequest(params: {
   warnings: string[];
+  timeoutMs: number;
   approvalRunningNoticeMs: number;
   createApprovalSlug: (approvalId: string) => string;
   turnSourceChannel?: string;
@@ -253,6 +257,7 @@ export async function createAndRegisterDefaultExecApprovalRequest(params: {
     preResolvedDecision: defaultPreResolvedDecision,
   } = createDefaultExecApprovalRequestContext({
     warnings: params.warnings,
+    timeoutMs: params.timeoutMs,
     approvalRunningNoticeMs: params.approvalRunningNoticeMs,
     createApprovalSlug: params.createApprovalSlug,
   });
@@ -283,8 +288,15 @@ export async function createAndRegisterDefaultExecApprovalRequest(params: {
 export function buildDefaultExecApprovalRequestArgs(
   params: DefaultExecApprovalRequestArgs,
 ): DefaultExecApprovalRequestArgs {
+  const timeoutMs = resolveExecApprovalTimeoutMs({
+    cfg: loadConfig(),
+    channel: params.turnSourceChannel,
+    accountId: params.turnSourceAccountId,
+    defaultTimeoutMs: params.timeoutMs,
+  });
   return {
     warnings: params.warnings,
+    timeoutMs,
     approvalRunningNoticeMs: params.approvalRunningNoticeMs,
     createApprovalSlug: params.createApprovalSlug,
     turnSourceChannel: params.turnSourceChannel,

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -460,6 +460,11 @@ export type ChannelExecApprovalAdapter = {
     cfg: OpenClawConfig;
     accountId?: string | null;
   }) => ChannelExecApprovalInitiatingSurfaceState;
+  resolveApprovalTimeoutMs?: (params: {
+    cfg: OpenClawConfig;
+    accountId?: string | null;
+    defaultTimeoutMs: number;
+  }) => number | undefined;
   shouldSuppressLocalPrompt?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;

--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -102,4 +102,18 @@ describe("config discord", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("rejects discord exec approval timeoutMs values above 24 hours", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          execApprovals: {
+            timeoutMs: 86_400_001,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -86,4 +86,20 @@ describe("config discord", () => {
       ).toBe(true);
     }
   });
+
+  it("accepts positive discord exec approval timeoutMs values", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          execApprovals: {
+            enabled: true,
+            approvers: ["555"],
+            timeoutMs: 600000,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1478,6 +1478,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Allow bot-authored messages to trigger Discord replies (default: false). Set "mentions" to only accept bot messages that mention the bot.',
   "channels.discord.proxy":
     "Proxy URL for Discord gateway + API requests (app-id lookup and allowlist resolution). Set per account via channels.discord.accounts.<id>.proxy.",
+  "channels.discord.execApprovals.timeoutMs":
+    "Timeout in milliseconds before Discord exec approval requests expire. Default: 120000 (2 minutes); increase this for approvers who respond from mobile notifications or slower workflows.",
   "channels.whatsapp.configWrites":
     "Allow WhatsApp to write config in response to channel events/commands (default: true).",
   "channels.signal.configWrites":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -772,6 +772,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.discord.dm.policy": "Discord DM Policy",
   "channels.discord.configWrites": "Discord Config Writes",
   "channels.discord.proxy": "Discord Proxy URL",
+  "channels.discord.execApprovals.timeoutMs": "Discord Exec Approval Timeout (ms)",
   "channels.discord.commands.native": "Discord Native Commands",
   "channels.discord.commands.nativeSkills": "Discord Native Skill Commands",
   "channels.discord.streaming": "Discord Streaming Mode",

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -136,6 +136,8 @@ export type DiscordExecApprovalConfig = {
   enabled?: boolean;
   /** Discord user IDs to receive approval prompts. Required if enabled. */
   approvers?: string[];
+  /** Approval timeout in milliseconds before requests expire. Default: 120000 (2 minutes). */
+  timeoutMs?: number;
   /** Only forward approvals for these agent IDs. Omit = all agents. */
   agentFilter?: string[];
   /** Only forward approvals matching these session key patterns (substring or regex). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -522,6 +522,7 @@ export const DiscordAccountSchema = z
       .object({
         enabled: z.boolean().optional(),
         approvers: DiscordIdListSchema.optional(),
+        timeoutMs: z.number().int().positive().optional(),
         agentFilter: z.array(z.string()).optional(),
         sessionFilter: z.array(z.string()).optional(),
         cleanupAfterResolve: z.boolean().optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -522,7 +522,7 @@ export const DiscordAccountSchema = z
       .object({
         enabled: z.boolean().optional(),
         approvers: DiscordIdListSchema.optional(),
-        timeoutMs: z.number().int().positive().optional(),
+        timeoutMs: z.number().int().positive().max(86_400_000).optional(),
         agentFilter: z.array(z.string()).optional(),
         sessionFilter: z.array(z.string()).optional(),
         cleanupAfterResolve: z.boolean().optional(),

--- a/src/infra/exec-approval-surface.test.ts
+++ b/src/infra/exec-approval-surface.test.ts
@@ -9,6 +9,7 @@ type ExecApprovalSurfaceModule = typeof import("./exec-approval-surface.js");
 
 let hasConfiguredExecApprovalDmRoute: ExecApprovalSurfaceModule["hasConfiguredExecApprovalDmRoute"];
 let resolveExecApprovalInitiatingSurfaceState: ExecApprovalSurfaceModule["resolveExecApprovalInitiatingSurfaceState"];
+let resolveExecApprovalTimeoutMs: ExecApprovalSurfaceModule["resolveExecApprovalTimeoutMs"];
 
 describe("resolveExecApprovalInitiatingSurfaceState", () => {
   beforeEach(async () => {
@@ -49,8 +50,11 @@ describe("resolveExecApprovalInitiatingSurfaceState", () => {
       INTERNAL_MESSAGE_CHANNEL: "web",
       normalizeMessageChannel: (...args: unknown[]) => normalizeMessageChannelMock(...args),
     }));
-    ({ hasConfiguredExecApprovalDmRoute, resolveExecApprovalInitiatingSurfaceState } =
-      await import("./exec-approval-surface.js"));
+    ({
+      hasConfiguredExecApprovalDmRoute,
+      resolveExecApprovalInitiatingSurfaceState,
+      resolveExecApprovalTimeoutMs,
+    } = await import("./exec-approval-surface.js"));
   });
 
   it("treats web UI, terminal UI, and missing channels as enabled", () => {
@@ -147,6 +151,87 @@ describe("resolveExecApprovalInitiatingSurfaceState", () => {
   });
 });
 
+describe("resolveExecApprovalTimeoutMs", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    loadConfigMock.mockReset();
+    getChannelPluginMock.mockReset();
+    listChannelPluginsMock.mockReset();
+    normalizeMessageChannelMock.mockReset();
+    normalizeMessageChannelMock.mockImplementation((value?: string | null) =>
+      typeof value === "string" ? value.trim().toLowerCase() : undefined,
+    );
+    vi.doMock("../config/config.js", () => ({
+      loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+    }));
+    vi.doMock("../channels/plugins/index.js", () => ({
+      getChannelPlugin: (...args: unknown[]) => getChannelPluginMock(...args),
+      listChannelPlugins: (...args: unknown[]) => listChannelPluginsMock(...args),
+    }));
+    vi.doMock("../../extensions/discord/src/channel.js", () => ({
+      discordPlugin: {},
+    }));
+    vi.doMock("../../extensions/telegram/src/channel.js", () => ({
+      telegramPlugin: {},
+    }));
+    vi.doMock("../../extensions/slack/src/channel.js", () => ({
+      slackPlugin: {},
+    }));
+    vi.doMock("../../extensions/whatsapp/src/channel.js", () => ({
+      whatsappPlugin: {},
+    }));
+    vi.doMock("../../extensions/signal/src/channel.js", () => ({
+      signalPlugin: {},
+    }));
+    vi.doMock("../../extensions/imessage/src/channel.js", () => ({
+      imessagePlugin: {},
+    }));
+    vi.doMock("../utils/message-channel.js", () => ({
+      INTERNAL_MESSAGE_CHANNEL: "web",
+      normalizeMessageChannel: (...args: unknown[]) => normalizeMessageChannelMock(...args),
+    }));
+    ({
+      hasConfiguredExecApprovalDmRoute,
+      resolveExecApprovalInitiatingSurfaceState,
+      resolveExecApprovalTimeoutMs,
+    } = await import("./exec-approval-surface.js"));
+  });
+
+  it("uses plugin-specific timeout overrides when available", () => {
+    getChannelPluginMock.mockImplementation((channel: string) =>
+      channel === "discord"
+        ? {
+            execApprovals: {
+              resolveApprovalTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
+                defaultTimeoutMs * 5,
+            },
+          }
+        : undefined,
+    );
+
+    expect(
+      resolveExecApprovalTimeoutMs({
+        channel: "discord",
+        accountId: "main",
+        cfg: {} as never,
+        defaultTimeoutMs: 30_000,
+      }),
+    ).toBe(150_000);
+    expect(loadConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default timeout for web UI and unsupported channels", () => {
+    expect(resolveExecApprovalTimeoutMs({ channel: "web", defaultTimeoutMs: 45_000 })).toBe(45_000);
+    expect(loadConfigMock).not.toHaveBeenCalled();
+
+    loadConfigMock.mockReturnValueOnce({ loaded: true });
+    expect(resolveExecApprovalTimeoutMs({ channel: "signal", defaultTimeoutMs: 45_000 })).toBe(
+      45_000,
+    );
+    expect(loadConfigMock).toHaveBeenCalledOnce();
+  });
+});
+
 describe("hasConfiguredExecApprovalDmRoute", () => {
   beforeEach(async () => {
     vi.resetModules();
@@ -186,8 +271,11 @@ describe("hasConfiguredExecApprovalDmRoute", () => {
       INTERNAL_MESSAGE_CHANNEL: "web",
       normalizeMessageChannel: (...args: unknown[]) => normalizeMessageChannelMock(...args),
     }));
-    ({ hasConfiguredExecApprovalDmRoute, resolveExecApprovalInitiatingSurfaceState } =
-      await import("./exec-approval-surface.js"));
+    ({
+      hasConfiguredExecApprovalDmRoute,
+      resolveExecApprovalInitiatingSurfaceState,
+      resolveExecApprovalTimeoutMs,
+    } = await import("./exec-approval-surface.js"));
   });
 
   it("returns true when any enabled account routes approvals to DM or both", () => {

--- a/src/infra/exec-approval-surface.ts
+++ b/src/infra/exec-approval-surface.ts
@@ -1,6 +1,7 @@
 import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../utils/message-channel.js";
+import { DEFAULT_EXEC_APPROVAL_TIMEOUT_MS } from "./exec-approvals.js";
 
 export type ExecApprovalInitiatingSurfaceState =
   | { kind: "enabled"; channel: string | undefined; channelLabel: string }
@@ -20,6 +21,13 @@ function labelForChannel(channel?: string): string {
     default:
       return channel ? channel[0]?.toUpperCase() + channel.slice(1) : "this platform";
   }
+}
+
+function normalizeTimeoutMs(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(value));
 }
 
 export function resolveExecApprovalInitiatingSurfaceState(params: {
@@ -42,6 +50,32 @@ export function resolveExecApprovalInitiatingSurfaceState(params: {
     return { ...state, channel, channelLabel };
   }
   return { kind: "unsupported", channel, channelLabel };
+}
+
+export function resolveExecApprovalTimeoutMs(params: {
+  channel?: string | null;
+  accountId?: string | null;
+  cfg?: OpenClawConfig;
+  defaultTimeoutMs?: number;
+}): number {
+  const defaultTimeoutMs = normalizeTimeoutMs(
+    params.defaultTimeoutMs,
+    DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  );
+  const channel = normalizeMessageChannel(params.channel);
+  if (!channel || channel === INTERNAL_MESSAGE_CHANNEL || channel === "tui") {
+    return defaultTimeoutMs;
+  }
+
+  const cfg = params.cfg ?? loadConfig();
+  return normalizeTimeoutMs(
+    getChannelPlugin(channel)?.execApprovals?.resolveApprovalTimeoutMs?.({
+      cfg,
+      accountId: params.accountId,
+      defaultTimeoutMs,
+    }),
+    defaultTimeoutMs,
+  );
 }
 
 export function hasConfiguredExecApprovalDmRoute(cfg: OpenClawConfig): boolean {

--- a/src/infra/exec-approval-surface.ts
+++ b/src/infra/exec-approval-surface.ts
@@ -1,7 +1,10 @@
 import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../utils/message-channel.js";
-import { DEFAULT_EXEC_APPROVAL_TIMEOUT_MS } from "./exec-approvals.js";
+import {
+  DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  normalizeExecApprovalTimeoutMs,
+} from "./exec-approvals.js";
 
 export type ExecApprovalInitiatingSurfaceState =
   | { kind: "enabled"; channel: string | undefined; channelLabel: string }
@@ -21,13 +24,6 @@ function labelForChannel(channel?: string): string {
     default:
       return channel ? channel[0]?.toUpperCase() + channel.slice(1) : "this platform";
   }
-}
-
-function normalizeTimeoutMs(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return fallback;
-  }
-  return Math.max(1, Math.floor(value));
 }
 
 export function resolveExecApprovalInitiatingSurfaceState(params: {
@@ -58,7 +54,7 @@ export function resolveExecApprovalTimeoutMs(params: {
   cfg?: OpenClawConfig;
   defaultTimeoutMs?: number;
 }): number {
-  const defaultTimeoutMs = normalizeTimeoutMs(
+  const defaultTimeoutMs = normalizeExecApprovalTimeoutMs(
     params.defaultTimeoutMs,
     DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
   );
@@ -68,7 +64,7 @@ export function resolveExecApprovalTimeoutMs(params: {
   }
 
   const cfg = params.cfg ?? loadConfig();
-  return normalizeTimeoutMs(
+  return normalizeExecApprovalTimeoutMs(
     getChannelPlugin(channel)?.execApprovals?.resolveApprovalTimeoutMs?.({
       cfg,
       accountId: params.accountId,

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -146,6 +146,13 @@ export type ExecApprovalsResolved = {
 // Keep CLI + gateway defaults in sync.
 export const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 120_000;
 
+export function normalizeExecApprovalTimeoutMs(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
 const DEFAULT_SECURITY: ExecSecurity = "deny";
 const DEFAULT_ASK: ExecAsk = "on-miss";
 const DEFAULT_ASK_FALLBACK: ExecSecurity = "deny";


### PR DESCRIPTION
## Summary

- Problem: Discord exec approvals always expired after 2 minutes, even for operators approving from mobile notifications or slower workflows.
- Why it matters: the timeout was hardcoded in the exec approval request path, so Discord config had no way to extend it.
- What changed: added `channels.discord.execApprovals.timeoutMs`, wired channel-owned timeout resolution into approval registration, updated schema/docs, and added focused tests.
- What did NOT change (scope boundary): this PR does not address the separate async follow-up `entry.factory is not a function` failure also mentioned in #49282.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #49282

## User-visible / Behavior Changes

- New optional config: `channels.discord.execApprovals.timeoutMs`
- Discord exec approval requests now honor the configured timeout instead of always using `120000ms`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: n/a
- Integration/channel (if any): Discord
- Relevant config (redacted): `channels.discord.execApprovals.timeoutMs: 600000`

### Steps

1. Configure Discord exec approvals with a longer `timeoutMs`.
2. Trigger an exec request that requires approval.
3. Observe that the approval stays pending for the configured interval instead of expiring after 2 minutes.

### Expected

- Discord exec approval timeout is configurable per account.

### Actual

- Before this change, the approval request path always used `120000ms`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace/log summary:
- `pnpm exec oxfmt --check ...` passed on touched files
- `pnpm exec oxlint ...` reported 0 warnings/errors on touched TS files
- `pnpm tsgo` still reports unrelated pre-existing repo failures outside this diff
- local `vitest` / `codex review` did not complete cleanly in this environment, so this PR does not claim a passing runtime test run here

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: traced the request path from Discord config -> channel adapter -> exec approval registration payload and confirmed the configured timeout is threaded through to `exec.approval.request`
- Edge cases checked: missing/invalid timeout falls back to the default; non-Discord surfaces continue using the default timeout
- What you did **not** verify: a successful end-to-end Vitest or live Discord run in this local environment

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove `channels.discord.execApprovals.timeoutMs` or revert this commit
- Files/config to restore: Discord exec approval config and the touched exec approval request plumbing
- Known bad symptoms reviewers should watch for: approval requests ignoring the configured timeout or expiring immediately

## Risks and Mitigations

- Risk: a non-Discord channel could accidentally inherit Discord-specific timeout behavior
- Mitigation: timeout resolution goes through the generic channel adapter and falls back to the default

AI-assisted: yes (Codex)
