### PR TITLE
Avoid memory CLI watcher EMFILE

### DIFF
--- a/src/cli/memory-cli.test.ts
+++ b/src/cli/memory-cli.test.ts
@@ -338,6 +338,9 @@ describe("memory cli", () => {
     await runMemoryCli(["status", "--index"]);
 
     expectCliSync(sync);
+    expect(getMemorySearchManager).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", purpose: "cli" }),
+    );
     expect(probeEmbeddingAvailability).toHaveBeenCalled();
     expect(close).toHaveBeenCalled();
   });
@@ -351,6 +354,9 @@ describe("memory cli", () => {
     await runMemoryCli(["index"]);
 
     expectCliSync(sync);
+    expect(getMemorySearchManager).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", purpose: "cli" }),
+    );
     expect(close).toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith("Memory index updated (main).");
   });

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -346,7 +346,7 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
   }> = [];
 
   for (const agentId of agentIds) {
-    const managerPurpose = opts.index ? "default" : "status";
+    const managerPurpose = opts.index ? "cli" : "status";
     await withMemoryManagerForAgent({
       cfg,
       agentId,
@@ -620,6 +620,7 @@ export function registerMemoryCli(program: Command) {
         await withMemoryManagerForAgent({
           cfg,
           agentId,
+          purpose: "cli",
           run: async (manager) => {
             try {
               const syncFn = manager.sync ? manager.sync.bind(manager) : undefined;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -135,7 +135,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   static async get(params: {
     cfg: OpenClawConfig;
     agentId: string;
-    purpose?: "default" | "status";
+    purpose?: "default" | "status" | "cli";
   }): Promise<MemoryIndexManager | null> {
     const { cfg, agentId } = params;
     const settings = resolveMemorySearchConfig(cfg, agentId);
@@ -196,7 +196,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     workspaceDir: string;
     settings: ResolvedMemorySearchConfig;
     providerResult: EmbeddingProviderResult;
-    purpose?: "default" | "status";
+    purpose?: "default" | "status" | "cli";
   }) {
     super();
     this.cacheKey = params.cacheKey;
@@ -232,10 +232,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (meta?.vectorDims) {
       this.vector.dims = meta.vectorDims;
     }
-    this.ensureWatcher();
-    this.ensureSessionListener();
-    this.ensureIntervalSync();
     const statusOnly = params.purpose === "status";
+    const cliOnly = params.purpose === "cli";
+    if (!statusOnly && !cliOnly) {
+      this.ensureWatcher();
+      this.ensureSessionListener();
+      this.ensureIntervalSync();
+    }
     this.dirty = this.sources.has("memory") && (statusOnly ? !meta : true);
     this.batch = this.resolveBatchConfig();
   }

--- a/src/memory/manager.watcher-config.test.ts
+++ b/src/memory/manager.watcher-config.test.ts
@@ -153,4 +153,26 @@ describe("memory watcher config", () => {
       ]),
     );
   });
+
+  it("skips chokidar watcher for status-only managers", async () => {
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const cfg = createWatcherConfig();
+
+    const result = await getMemorySearchManager({ cfg, agentId: "main", purpose: "status" });
+    expect(result.manager).not.toBeNull();
+    manager = result.manager as unknown as MemoryIndexManager;
+
+    expect(watchMock).not.toHaveBeenCalled();
+  });
+
+  it("skips chokidar watcher for one-shot cli managers", async () => {
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const cfg = createWatcherConfig();
+
+    const result = await getMemorySearchManager({ cfg, agentId: "main", purpose: "cli" });
+    expect(result.manager).not.toBeNull();
+    manager = result.manager as unknown as MemoryIndexManager;
+
+    expect(watchMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -25,7 +25,7 @@ export type MemorySearchManagerResult = {
 export async function getMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
-  purpose?: "default" | "status";
+  purpose?: "default" | "status" | "cli";
 }): Promise<MemorySearchManagerResult> {
   const resolved = resolveMemoryBackendConfig(params);
   if (resolved.backend === "qmd" && resolved.qmd) {


### PR DESCRIPTION
## Summary
- add a one-shot CLI memory manager purpose that skips watcher/session/interval startup
- route memory status --index and memory index through the CLI purpose
- add regression coverage for watcher-free status/cli managers

## Testing
- ./node_modules/.bin/vitest run --config vitest.unit.config.ts src/memory/manager.watcher-config.test.ts
- ./node_modules/.bin/vitest run --config vitest.unit.config.ts src/cli/memory-cli.test.ts