### PR TITLE
fix: suppress reasoning preamble when NO_REPLY in text-only reply

### DIFF
--- a/src/auto-reply/reply/normalize-reply.test.ts
+++ b/src/auto-reply/reply/normalize-reply.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ReplyPayload } from "../types.js";
+import { normalizeReplyPayload } from "./normalize-reply.js";
+
+function makePayload(overrides: Partial<ReplyPayload> = {}): ReplyPayload {
+  return { text: "", ...overrides };
+}
+
+describe("normalizeReplyPayload — NO_REPLY handling", () => {
+  it("suppresses exact NO_REPLY (text-only)", () => {
+    const onSkip = vi.fn();
+    const result = normalizeReplyPayload(makePayload({ text: "NO_REPLY" }), { onSkip });
+    expect(result).toBeNull();
+    expect(onSkip).toHaveBeenCalledWith("silent");
+  });
+
+  it("suppresses NO_REPLY with surrounding whitespace", () => {
+    const result = normalizeReplyPayload(makePayload({ text: "  NO_REPLY  " }));
+    expect(result).toBeNull();
+  });
+
+  // Regression: #XXXXX — reasoning preamble before NO_REPLY must be suppressed,
+  // not posted as the message content.
+  it("suppresses reasoning preamble before trailing NO_REPLY (text-only)", () => {
+    const onSkip = vi.fn();
+    const result = normalizeReplyPayload(makePayload({ text: "not directed at me. NO_REPLY" }), {
+      onSkip,
+    });
+    expect(result).toBeNull();
+    expect(onSkip).toHaveBeenCalledWith("silent");
+  });
+
+  it("suppresses multi-sentence reasoning preamble before NO_REPLY", () => {
+    const result = normalizeReplyPayload(
+      makePayload({ text: "This is a message from @jentic. Not for me. Stay silent.\nNO_REPLY" }),
+    );
+    expect(result).toBeNull();
+  });
+
+  // (#30916, #30955) — emoji alongside channelData: strip token from text,
+  // let non-text content (e.g. channel reaction) send through.
+  it("strips NO_REPLY from text when non-text channelData is present", () => {
+    const result = normalizeReplyPayload(
+      makePayload({
+        text: "😄 NO_REPLY",
+        channelData: { reactions: [{ emoji: "😄" }] } as ReplyPayload["channelData"],
+      }),
+    );
+    // Non-null because channelData carries the reaction
+    expect(result).not.toBeNull();
+    // The NO_REPLY token must not appear in the output text
+    expect(result?.text).not.toContain("NO_REPLY");
+  });
+
+  it("strips NO_REPLY from text when media is present, sends media", () => {
+    const result = normalizeReplyPayload(
+      makePayload({ text: "NO_REPLY", mediaUrl: "https://example.com/image.png" }),
+    );
+    expect(result).not.toBeNull();
+    expect(result?.mediaUrl).toBe("https://example.com/image.png");
+  });
+});

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -63,10 +63,32 @@ export function normalizeReplyPayload(
     }
     text = "";
   }
-  // Strip NO_REPLY from mixed-content messages (e.g. "😄 NO_REPLY") so the
-  // token never leaks to end users.  If stripping leaves nothing, treat it as
-  // silent just like the exact-match path above.  (#30916, #30955)
+  // Handle messages that contain NO_REPLY but aren't an exact match.
+  // (#30916, #30955, #XXXXX)
+  //
+  // Two sub-cases:
+  //
+  // 1. Text-only (no media / interactive / channelData): the agent intended
+  //    full silence. Any text preceding NO_REPLY is internal reasoning that
+  //    must not be posted. Suppress the entire message.
+  //
+  // 2. Non-text content present (media, interactive, channelData): the agent
+  //    wants to send the attachment/reaction but suppress the text portion
+  //    (e.g. "😄 NO_REPLY" alongside a channel reaction). Strip the token
+  //    from the text and let the non-text content through.
   if (text && text.includes(silentToken) && !isSilentReplyText(text, silentToken)) {
+    const hasNonTextContent = hasReplyContent({
+      mediaUrl: payload.mediaUrl,
+      mediaUrls: payload.mediaUrls,
+      interactive: payload.interactive,
+      hasChannelData,
+    });
+    if (!hasNonTextContent) {
+      // Text-only: suppress entirely — never post reasoning preamble.
+      opts.onSkip?.("silent");
+      return null;
+    }
+    // Non-text content exists: strip token from text, send other content.
     text = stripSilentToken(text, silentToken);
     if (
       !hasReplyContent({


### PR DESCRIPTION
## Problem

When an agent outputs a reasoning preamble followed by a trailing `NO_REPLY` token (e.g. `"not directed at me. NO_REPLY"`), the previous behaviour stripped the token and posted the preceding text as the message — leaking internal monologue to the channel.

This affects agents that receive all channel messages (when `requireMention: false`) and have to decide per-message whether to engage. The model outputs `NO_REPLY` to signal silence, but any narration before it would be posted.

## Root Cause

In `normalizeReplyPayload`, the mixed-content path:
```ts
text = stripSilentToken(text, silentToken);
if (!hasReplyContent({ text, ... })) {
  return null; // silent
}
// otherwise, posts stripped text ← BUG when stripped text is reasoning
```

Stripping removes `NO_REPLY` but leaves `"not directed at me."`, which `hasReplyContent` treats as valid content and posts.

## Fix

When `NO_REPLY` appears in a text-only message (no media / interactive / channelData), suppress the **entire** message — the agent intended silence and any preceding text is internal reasoning.

When non-text content is present (e.g. a channel reaction alongside `"😄 NO_REPLY"`), preserve existing behaviour: strip the token from text and let the non-text content send. (refs #30916, #30955)

## Tests

Adds `normalize-reply.test.ts` with 6 cases covering:
- Exact `NO_REPLY` suppression
- Whitespace-padded `NO_REPLY`
- Reasoning preamble suppression (the new case)
- Multi-sentence reasoning preamble
- Emoji + `NO_REPLY` with channelData (non-text content preserved)
- `NO_REPLY` text with media (media preserved)

All 25 tests pass (`tokens.test.ts` + new file).