### PR TITLE
Wire runInboundClaim into general dispatch path

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -414,6 +414,18 @@ export async function dispatchReplyFromConfig(params: {
     );
   }
 
+  // General inbound_claim: let plugins (e.g. speedtrap) claim a message
+  // before it triggers agent dispatch. If claimed, the message is buffered
+  // by the plugin and never reaches the agent runner.
+  if (hookRunner?.hasHooks("inbound_claim")) {
+    const claimResult = await hookRunner.runInboundClaim(inboundClaimEvent, inboundClaimContext);
+    if (claimResult?.handled) {
+      logVerbose("dispatch-from-config: inbound claimed by plugin, skipping agent dispatch");
+      recordProcessed("completed", { reason: "inbound_claimed" });
+      return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
+    }
+  }
+
   markProcessing();
 
   try {


### PR DESCRIPTION
## Summary

Add a broadcast `runInboundClaim()` call in the general dispatch path so plugins can claim inbound messages before agent dispatch, not just for plugin-bound conversations.

Fixes #49748

## Motivation

The `inbound_claim` hook type, runner methods, and event mappers all exist in core. But `runInboundClaim` is only called for plugin-bound conversations via `runInboundClaimForPluginOutcome`. Plugins registering global `api.on("inbound_claim", ...)` handlers are never invoked for regular channel messages.

This prevents plugins from intercepting inbound messages before agent dispatch (e.g. to buffer overlapping messages while an agent run is active).

## Changes

**`src/auto-reply/reply/dispatch-from-config.ts`**: Add `runInboundClaim` call between `message_received` (fire-and-forget) and `markProcessing()`. If a plugin returns `{ handled: true }`, dispatch returns early without starting agent runs.

## Why this is safe

- `handled: true` is opt-in. Existing plugins that do not register `inbound_claim` handlers are unaffected.
- The insertion is after `message_received` (plugins already notified) but before `markProcessing` (no agent work started).
- Uses the same `inboundClaimEvent` and `inboundClaimContext` already constructed for the plugin-bound path.
- The general `runInboundClaim` and plugin-bound `runInboundClaimForPluginOutcome` are separate call sites with separate semantics (broadcast vs targeted).

## Test plan

- [ ] Existing `inbound_claim` tests pass (wired-hooks-inbound-claim.test.ts)
- [ ] Manual testing confirms plugins can claim regular channel messages
- [ ] Verify plugin-bound claim path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)