### PR TITLE
fix(feishu): export missing plugin-sdk/feishu subpath symbols

### DIFF
--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -1,5 +1,5 @@
-// Private helper surface for the bundled feishu plugin.
-// Keep this list additive and scoped to symbols used under extensions/feishu.
+// Private helper surface for feishu channel consumers (bundled and standalone).
+// Keep this list additive and scoped to symbols used by feishu channel plugins.
 
 export type { HistoryEntry } from "../auto-reply/reply/history.js";
 export {

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -21,6 +21,7 @@ export {
   setTopLevelChannelAllowFrom,
   setTopLevelChannelDmPolicyWithAllowFrom,
   setTopLevelChannelGroupPolicy,
+  promptAccountId,
   splitSetupEntries,
 } from "../channels/plugins/setup-wizard-helpers.js";
 export { PAIRING_APPROVED_MESSAGE } from "../channels/plugins/pairing-message.js";
@@ -37,6 +38,7 @@ export type {
   ChannelConfiguredBindingMatch,
 } from "../channels/plugins/types.adapters.js";
 export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+export { resolveMentionGatingWithBypass } from "../channels/mention-gating.js";
 export { createReplyPrefixContext } from "../channels/reply-prefix.js";
 export { createChannelReplyPipeline } from "./channel-reply-pipeline.js";
 export type { OpenClawConfig as ClawdbotConfig, OpenClawConfig } from "../config/config.js";


### PR DESCRIPTION
## Summary

Add two missing exports to the `plugin-sdk/feishu` subpath surface:

- **`resolveMentionGatingWithBypass`** — from `../channels/mention-gating.js`
- **`promptAccountId`** — from `../channels/plugins/setup-wizard-helpers.js`

Both symbols are used by the external feishu channel plugin ([`@m1heng-clawd/feishu`](https://github.com/m1heng/clawdbot-feishu)) and were previously importable from the main `openclaw/plugin-sdk` entry. After the recent plugin-sdk subpath restructuring they are no longer reachable from any public surface for feishu consumers.

## Context

The recent refactors that slimmed `plugin-sdk/index.ts` and introduced per-channel subpaths (`plugin-sdk/feishu`, `plugin-sdk/telegram`, etc.) moved most value exports off the main entry. The bundled `extensions/feishu` does not need these two symbols directly, but the standalone npm plugin does — it uses `resolveMentionGatingWithBypass` for group mention policy and `promptAccountId` for the onboarding wizard.

## Test plan

- [ ] `tsc --noEmit` passes
- [ ] Existing tests unaffected (additive change only)