### PR TITLE
docs: redirect zh-CN to zh-Hans

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -48,6 +48,14 @@
   },
   "redirects": [
     {
+      "source": "/zh-CN",
+      "destination": "/zh-Hans"
+    },
+    {
+      "source": "/zh-CN/:splat",
+      "destination": "/zh-Hans/:splat"
+    },
+    {
       "source": "/messages",
       "destination": "/concepts/messages"
     },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,8 +52,8 @@
       "destination": "/zh-Hans"
     },
     {
-      "source": "/zh-CN/:splat",
-      "destination": "/zh-Hans/:splat"
+      "source": "/zh-CN/:splat*",
+      "destination": "/zh-Hans/:splat*"
     },
     {
       "source": "/messages",

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -190,9 +190,10 @@ Notes:
 
 ## Browserless (hosted remote CDP)
 
-[Browserless](https://browserless.io) is a hosted Chromium service that exposes
-CDP endpoints over HTTPS. You can point an OpenClaw browser profile at a
-Browserless region endpoint and authenticate with your API key.
+[Browserless](https://browserless.io) is a hosted Chromium service whose CDP
+endpoint requires a direct WebSocket (`wss://`) connection. Point an OpenClaw
+browser profile at a Browserless region endpoint and authenticate with your API
+key.
 
 Example:
 
@@ -225,11 +226,12 @@ Notes:
 Some hosted browser services expose a **direct WebSocket** endpoint rather than
 the standard HTTP-based CDP discovery (`/json/version`). OpenClaw supports both:
 
-- **HTTP(S) endpoints** (e.g. Browserless) — OpenClaw calls `/json/version` to
-  discover the WebSocket debugger URL, then connects.
+- **HTTP(S) endpoints** — OpenClaw calls `/json/version` to discover the
+  WebSocket debugger URL, then connects.
 - **WebSocket endpoints** (`ws://` / `wss://`) — OpenClaw connects directly,
   skipping `/json/version`. Use this for services like
-  [Browserbase](https://www.browserbase.com) or any provider that hands you a
+  [Browserless](https://browserless.io),
+  [Browserbase](https://www.browserbase.com), or any provider that hands you a
   WebSocket URL.
 
 ### Browserbase

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -205,7 +205,7 @@ Example:
     remoteCdpHandshakeTimeoutMs: 4000,
     profiles: {
       browserless: {
-        cdpUrl: "https://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
+        cdpUrl: "wss://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
         color: "#00AA00",
       },
     },
@@ -217,6 +217,8 @@ Notes:
 
 - Replace `<BROWSERLESS_API_KEY>` with your real Browserless token.
 - Choose the region endpoint that matches your Browserless account (see their docs).
+
+> Browserless CDP endpoints speak WebSocket only, so keep the `cdpUrl` on `wss://` — `https://` will only reach their REST API and the browser tool will fail to connect.
 
 ## Direct WebSocket CDP providers
 

--- a/docs/zh-CN/tools/browser.md
+++ b/docs/zh-CN/tools/browser.md
@@ -165,7 +165,7 @@ OpenClaw 在调用 `/json/*` 端点和连接 CDP WebSocket 时会保留认证信
     remoteCdpHandshakeTimeoutMs: 4000,
     profiles: {
       browserless: {
-        cdpUrl: "https://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
+        cdpUrl: "wss://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
         color: "#00AA00",
       },
     },
@@ -177,6 +177,8 @@ OpenClaw 在调用 `/json/*` 端点和连接 CDP WebSocket 时会保留认证信
 
 - 将 `<BROWSERLESS_API_KEY>` 替换为你真实的 Browserless 令牌。
 - 选择与你的 Browserless 账户匹配的区域端点（请参阅其文档）。
+
+> Browserless 的 CDP 端点只接受 WebSocket (`wss://`) 连接；`https://` 只能访问它的 REST API，浏览器工具会直接报 Remote CDP websocket not reachable。
 
 ## 安全性
 

--- a/docs/zh-CN/tools/browser.md
+++ b/docs/zh-CN/tools/browser.md
@@ -152,7 +152,7 @@ OpenClaw 在调用 `/json/*` 端点和连接 CDP WebSocket 时会保留认证信
 
 ## Browserless（托管远程 CDP）
 
-[Browserless](https://browserless.io) 是一个托管的 Chromium 服务，通过 HTTPS 暴露 CDP 端点。你可以将 OpenClaw 浏览器配置文件指向 Browserless 区域端点，并使用你的 API 密钥进行认证。
+[Browserless](https://browserless.io) 是一个托管的 Chromium 服务，其 CDP 端点需要直接的 WebSocket (`wss://`) 连接。你可以将 OpenClaw 浏览器配置文件指向 Browserless 区域端点，并使用你的 API 密钥进行认证。
 
 示例：
 


### PR DESCRIPTION
## Summary
- add explicit redirects so /zh-CN and nested paths forward to /zh-Hans equivalents
- fixes #43598 where https://docs.openclaw.ai/zh-CN returned 404 after the locale rename

## Testing
- not applicable (config-only)
