### PR TITLE
docs: make format check PowerShell-friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -580,7 +580,7 @@
     "format:check": "oxfmt --check",
     "format:diff": "oxfmt --write && git --no-pager diff",
     "format:docs": "git ls-files 'docs/**/*.md' 'docs/**/*.mdx' 'README.md' | xargs oxfmt --write",
-    "format:docs:check": "git ls-files 'docs/**/*.md' 'docs/**/*.mdx' 'README.md' | xargs oxfmt --check",
+    "format:docs:check": "node scripts/check-docs-format.mjs",
     "format:fix": "oxfmt --write",
     "format:swift": "swiftformat --lint --config .swiftformat apps/macos/Sources apps/ios/Sources apps/shared/OpenClawKit/Sources",
     "gateway:dev": "OPENCLAW_SKIP_CHANNELS=1 CLAWDBOT_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway",

--- a/scripts/check-docs-format.mjs
+++ b/scripts/check-docs-format.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { execFile as execFileCb, spawn } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+const DOC_GLOBS = ["docs/**/*.md", "docs/**/*.mdx", "README.md"];
+const CHUNK_SIZE = 100;
+
+async function listTrackedDocs() {
+  const { stdout } = await execFile("git", ["ls-files", ...DOC_GLOBS], {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return stdout.split(/\r?\n/).filter(Boolean);
+}
+
+function chunk(array, size) {
+  const result = [];
+  for (let i = 0; i < array.length; i += size) {
+    result.push(array.slice(i, i + size));
+  }
+  return result;
+}
+
+function runOxfmt(files) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("oxfmt", ["--check", ...files], {
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`oxfmt exited with code ${code}`));
+      }
+    });
+  });
+}
+
+async function main() {
+  const files = await listTrackedDocs();
+  if (files.length === 0) {
+    console.log("No tracked docs found, skipping oxfmt check.");
+    return;
+  }
+  for (const group of chunk(files, CHUNK_SIZE)) {
+    await runOxfmt(group);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- replace the Unix-only `xargs` pipeline in `format:docs:check` with a cross-platform Node script that enumerates tracked docs files and calls oxfmt directly
- chunk file lists so Windows command-line limits aren’t hit, keeping the formatting check consistent across shells
- fixes #44293

## Testing
- pnpm format:docs:check
