### PR TITLE
fix(ui): context % uses full token footprint instead of uncached input only

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -235,8 +235,13 @@ function extractGroupMeta(group: MessageGroup, contextWindow: number | null): Gr
     return null;
   }
 
+  // Context occupancy = input (uncached) + cacheRead + cacheWrite — the full
+  // token footprint sent to the model, not just the uncached portion.
+  const contextTotal = input + cacheRead + cacheWrite;
   const contextPercent =
-    contextWindow && input > 0 ? Math.min(Math.round((input / contextWindow) * 100), 100) : null;
+    contextWindow && contextTotal > 0
+      ? Math.min(Math.round((contextTotal / contextWindow) * 100), 100)
+      : null;
 
   return { input, output, cacheRead, cacheWrite, cost, model, contextPercent };
 }

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -315,9 +315,13 @@ async function executeUsage(
     }
     const input = session.inputTokens ?? 0;
     const output = session.outputTokens ?? 0;
+    // totalTokens is a prompt/context snapshot (input + cacheRead + cacheWrite).
     const total = session.totalTokens ?? input + output;
     const ctx = session.contextTokens ?? 0;
-    const pct = ctx > 0 ? Math.round((input / ctx) * 100) : null;
+    // Use totalTokens (full context occupancy) for the percentage when
+    // available; fall back to input for stale sessions.
+    const contextUsed = session.totalTokens ?? input;
+    const pct = ctx > 0 ? Math.round((contextUsed / ctx) * 100) : null;
 
     const lines = [
       "**Session Usage**",


### PR DESCRIPTION
## Problem

The control dashboard footer shows **0-1% context usage** when \/status\ reports **21%** for the same session.

**Dashboard footer:** \↑3 ↓505 R26.1k W309 0% ctx\
**\/status\:** \Context: 26k/128k (21%)\

## Root Cause

\extractGroupMeta\ in \grouped-render.ts\ computes \contextPercent\ by dividing only the **uncached input tokens** (\input\) by the context window. For a session with 26k total tokens where only 309 were uncached (new), this produces \309 / 128000 = 0%\ instead of the correct \26000 / 128000 ≈ 21%\.

The backend already computes this correctly via \derivePromptTokens\ (\input + cacheRead + cacheWrite\), but three UI surfaces weren't using the same formula.

## Fix

**\grouped-render.ts\** (footer \% ctx\):
- Compute \contextTotal = input + cacheRead + cacheWrite\ and use that as the numerator, matching \derivePromptTokens\ in \src/agents/usage.ts\.

**\chat.ts\** (\enderContextNotice\, the 85%+ warning bar):
- Use \	otalTokens\ (which is already \input + cacheRead + cacheWrite\ per \session-store.ts\) instead of \inputTokens\.

**\slash-command-executor.ts\** (\/usage\ command):
- Use \	otalTokens\ for the context percentage instead of \inputTokens\.

## Repro

1. Open a session with prompt caching active (most Anthropic/OpenAI models)
2. Send a few messages to build context
3. Compare footer \% ctx\ with \/status\ output
4. Footer shows near-0%, \/status\ shows the correct percentage

Observed with \github-copilot/claude-opus-4.6\ on OpenClaw 2026.3.13.

Fixes #49824