### PR TITLE
fix: restore compact JS placeholders in session export template

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 docs/.generated/
+src/auto-reply/reply/export-html/template.html

--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -60,29 +60,17 @@
 
     <!-- Vendored libraries -->
     <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
+      {{MARKED_JS}}
     </script>
 
     <!-- highlight.js -->
     <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
+      {{HIGHLIGHT_JS}}
     </script>
 
     <!-- Main application code -->
     <script>
-      {
-        {
-          JS;
-        }
-      }
+      {{JS}}
     </script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #49957

The session export template at `src/auto-reply/reply/export-html/template.html` had its JS placeholders reformatted into multi-line blocks. This prevented the `.replace()` calls in the export logic from finding and injecting the vendored JS, resulting in empty exports in the browser.

This PR restores the single-line format.