### PR TITLE
Slack: respect HTTPS_PROXY env var for WebClient

### DIFF
--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@slack/web-api", () => {
   const WebClient = vi.fn(function WebClientMock(
@@ -13,8 +14,12 @@ vi.mock("@slack/web-api", () => {
 });
 
 const slackWebApi = await import("@slack/web-api");
-const { createSlackWebClient, resolveSlackWebClientOptions, SLACK_DEFAULT_RETRY_OPTIONS } =
-  await import("./client.js");
+const {
+  createSlackWebClient,
+  resolveSlackWebClientOptions,
+  setSlackClientRuntimeForTest,
+  SLACK_DEFAULT_RETRY_OPTIONS,
+} = await import("./client.js");
 
 const WebClient = slackWebApi.WebClient as unknown as ReturnType<typeof vi.fn>;
 
@@ -42,5 +47,47 @@ describe("slack web client config", () => {
         retryConfig: SLACK_DEFAULT_RETRY_OPTIONS,
       }),
     );
+  });
+});
+
+describe("slack proxy agent", () => {
+  afterEach(() => {
+    delete process.env.HTTPS_PROXY;
+    delete process.env.https_proxy;
+    delete process.env.HTTP_PROXY;
+    delete process.env.http_proxy;
+    setSlackClientRuntimeForTest();
+  });
+
+  it("includes an HttpsProxyAgent when HTTPS_PROXY is set", () => {
+    process.env.HTTPS_PROXY = "http://proxy.test:8080";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeInstanceOf(HttpsProxyAgent);
+  });
+
+  it("does not include agent when no proxy env is set", () => {
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeUndefined();
+  });
+
+  it("does not override an explicit agent option", () => {
+    process.env.HTTPS_PROXY = "http://proxy.test:8080";
+    const customAgent = new HttpsProxyAgent("http://custom.test:9090");
+    const options = resolveSlackWebClientOptions({ agent: customAgent });
+
+    expect(options.agent).toBe(customAgent);
+  });
+
+  it("silently falls back when proxy agent constructor throws", () => {
+    process.env.HTTPS_PROXY = "http://proxy.test:8080";
+    const ThrowingCtor = function () {
+      throw new Error("boom");
+    } as unknown as typeof HttpsProxyAgent;
+    setSlackClientRuntimeForTest({ HttpsProxyAgent: ThrowingCtor });
+
+    const options = resolveSlackWebClientOptions();
+    expect(options.agent).toBeUndefined();
   });
 });

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -1,4 +1,8 @@
 import { type RetryOptions, type WebClientOptions, WebClient } from "@slack/web-api";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { resolveEnvHttpProxyUrl } from "openclaw/plugin-sdk/infra-runtime";
+
+let httpsProxyAgentCtor: typeof HttpsProxyAgent = HttpsProxyAgent;
 
 export const SLACK_DEFAULT_RETRY_OPTIONS: RetryOptions = {
   retries: 2,
@@ -8,11 +12,29 @@ export const SLACK_DEFAULT_RETRY_OPTIONS: RetryOptions = {
   randomize: true,
 };
 
+function resolveProxyAgent(): HttpsProxyAgent<string> | undefined {
+  const proxyUrl = resolveEnvHttpProxyUrl("https");
+  if (!proxyUrl) return undefined;
+  try {
+    return new httpsProxyAgentCtor(proxyUrl);
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveSlackWebClientOptions(options: WebClientOptions = {}): WebClientOptions {
+  const agent = options.agent ?? resolveProxyAgent();
   return {
     ...options,
     retryConfig: options.retryConfig ?? SLACK_DEFAULT_RETRY_OPTIONS,
+    ...(agent ? { agent } : {}),
   };
+}
+
+export function setSlackClientRuntimeForTest(overrides?: {
+  HttpsProxyAgent?: typeof HttpsProxyAgent;
+}): void {
+  httpsProxyAgentCtor = overrides?.HttpsProxyAgent ?? HttpsProxyAgent;
 }
 
 export function createSlackWebClient(token: string, options: WebClientOptions = {}) {


### PR DESCRIPTION
When trying to lock down network access for OpenClaw, it can be helpful to use a proxy. This change makes it so Slack access respects `HTTPS_PROXY` so such a set up is possible.

## Summary

- Read `HTTPS_PROXY`/`https_proxy`/`HTTP_PROXY`/`http_proxy` env vars and pass an `HttpsProxyAgent` as the `agent` option in Slack `WebClientOptions`
- Reuses the existing `resolveEnvHttpProxyUrl` helper from `openclaw/plugin-sdk/infra-runtime` for correct env var precedence
- Follows the same pattern as `extensions/feishu/src/client.ts` (module-level constructor override for tests, silent fallback on invalid proxy URL)
- Does not override an explicitly provided `agent` option

## Test plan

- [x] `pnpm tsgo` — no type errors
- [x] `pnpm test -- extensions/slack/src/client.test.ts` — 7/7 pass (4 new proxy tests)
- [x] `pnpm check` — lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)