### PR TITLE
fix(cron): preserve nested object properties in payload normalization

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -450,6 +450,96 @@ describe("normalizeCronJobCreate", () => {
 
     expect(normalized.sessionTarget).toBe("session:MySessionID");
   });
+
+  it("preserves nested object properties in payload", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "nested-payload",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "hello",
+        options: { model: "gpt-4", temperature: 0.5 },
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.message).toBe("hello");
+    const options = payload.options as Record<string, unknown>;
+    expect(options).toEqual({ model: "gpt-4", temperature: 0.5 });
+  });
+
+  it("does not mutate the original input object (deep clone)", () => {
+    const input = {
+      name: "mutation-check",
+      schedule: { kind: "cron" as const, expr: "* * * * *" },
+      sessionTarget: "isolated" as const,
+      wakeMode: "now" as const,
+      payload: {
+        kind: "agentTurn" as const,
+        message: "  hello  ",
+        options: { nested: { deep: true } },
+      },
+    };
+    const inputCopy = structuredClone(input);
+    normalizeCronJobCreate(input);
+    // The original input must remain untouched
+    expect(input).toEqual(inputCopy);
+  });
+
+  it("preserves nested objects in delivery config", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "delivery-nested",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "hi" },
+      delivery: {
+        mode: "webhook",
+        to: "https://example.invalid/hook",
+        headers: { Authorization: "Bearer abc", "X-Custom": "value" },
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const delivery = normalized.delivery as Record<string, unknown>;
+    expect(delivery.mode).toBe("webhook");
+    expect(delivery.headers).toEqual({
+      Authorization: "Bearer abc",
+      "X-Custom": "value",
+    });
+  });
+
+  it("preserves deeply nested structures (3+ levels) through normalization", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "deep-nesting",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+        config: {
+          level1: {
+            level2: {
+              level3: { value: 42, tags: ["a", "b"] },
+            },
+          },
+        },
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    const config = payload.config as Record<string, unknown>;
+    expect(config).toEqual({
+      level1: {
+        level2: {
+          level3: { value: 42, tags: ["a", "b"] },
+        },
+      },
+    });
+  });
 });
 
 describe("normalizeCronJobPatch", () => {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -20,7 +20,7 @@ const DEFAULT_OPTIONS: NormalizeOptions = {
 };
 
 function coerceSchedule(schedule: UnknownRecord) {
-  const next: UnknownRecord = { ...schedule };
+  const next: UnknownRecord = structuredClone(schedule);
   const rawKind = typeof schedule.kind === "string" ? schedule.kind.trim().toLowerCase() : "";
   const kind = rawKind === "at" || rawKind === "every" || rawKind === "cron" ? rawKind : undefined;
   const exprRaw = typeof schedule.expr === "string" ? schedule.expr.trim() : "";
@@ -83,7 +83,7 @@ function coerceSchedule(schedule: UnknownRecord) {
 }
 
 function coercePayload(payload: UnknownRecord) {
-  const next: UnknownRecord = { ...payload };
+  const next: UnknownRecord = structuredClone(payload);
   // Back-compat: older configs used `provider` for delivery channel.
   migrateLegacyCronPayload(next);
   const kindRaw = typeof next.kind === "string" ? next.kind.trim().toLowerCase() : "";
@@ -164,7 +164,7 @@ function coercePayload(payload: UnknownRecord) {
 }
 
 function coerceDelivery(delivery: UnknownRecord) {
-  const next: UnknownRecord = { ...delivery };
+  const next: UnknownRecord = structuredClone(delivery);
   if (typeof delivery.mode === "string") {
     const mode = delivery.mode.trim().toLowerCase();
     if (mode === "deliver") {
@@ -321,7 +321,7 @@ export function normalizeCronJobInput(
     return null;
   }
   const base = unwrapJob(raw);
-  const next: UnknownRecord = { ...base };
+  const next: UnknownRecord = structuredClone(base);
 
   if ("agentId" in base) {
     const agentId = base.agentId;


### PR DESCRIPTION
## Summary

Cron job payloads with nested objects lose their nested properties during normalization because `coercePayload()`, `coerceSchedule()`, `coerceDelivery()`, and `normalizeCronJobInput()` use shallow spread (`{ ...obj }`) instead of deep cloning.

Fixes #49780

## Problem

When a cron job is created with a payload containing nested objects (e.g., `payload.options = { model: 'gpt-4', temperature: 0.5 }`), the nested structure is lost during the normalize → store → retrieve cycle because shallow spread only copies top-level properties by reference. The original input object can also be mutated since nested objects share references.

## Solution

Replace `{ ...obj }` with `structuredClone(obj)` in four locations:

1. `normalizeCronJobInput()` — deep-clones the base job object
2. `coercePayload()` — deep-clones the payload
3. `coerceSchedule()` — deep-clones the schedule
4. `coerceDelivery()` — deep-clones the delivery config

## Testing

Added 4 new tests verifying:
- Payload with nested objects survives normalization
- Original input is not mutated (deep clone verification)
- Nested objects in delivery config are preserved
- Deeply nested structures (3+ levels) survive round-trip

All 34 tests pass.

Made-with: Claude Code (Claude Opus 4.6)