### PR TITLE
fix: suppress leaked ANNOUNCE_SKIP payloads

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -146,6 +146,15 @@ describe("resolveSilentReplyFallbackText", () => {
     ).toBe("NO_REPLY");
   });
 
+  it("replaces ANNOUNCE_SKIP with latest messaging tool text when available", () => {
+    expect(
+      resolveSilentReplyFallbackText({
+        text: "ANNOUNCE_SKIP",
+        messagingToolSentTexts: ["first", "final delivered text"],
+      }),
+    ).toBe("final delivered text");
+  });
+
   it("tolerates malformed text payloads without throwing", () => {
     expect(
       resolveSilentReplyFallbackText({

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -155,6 +155,15 @@ describe("resolveSilentReplyFallbackText", () => {
     ).toBe("final delivered text");
   });
 
+  it("keeps ANNOUNCE_SKIP when there is no messaging tool text to mirror", () => {
+    expect(
+      resolveSilentReplyFallbackText({
+        text: "ANNOUNCE_SKIP",
+        messagingToolSentTexts: [],
+      }),
+    ).toBe("ANNOUNCE_SKIP");
+  });
+
   it("tolerates malformed text payloads without throwing", () => {
     expect(
       resolveSilentReplyFallbackText({

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { isAnnounceSkip } from "./tools/sessions-send-helpers.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
@@ -191,7 +192,7 @@ export function resolveSilentReplyFallbackText(params: {
 }): string {
   const text = coerceText(params.text);
   const trimmed = text.trim();
-  if (trimmed !== SILENT_REPLY_TOKEN) {
+  if (!isSilentReplyText(trimmed, SILENT_REPLY_TOKEN) && !isAnnounceSkip(trimmed)) {
     return text;
   }
   const fallback = coerceText(params.messagingToolSentTexts.at(-1)).trim();

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -55,6 +55,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     expect(
       normalizeReplyPayloadsForDelivery([
         { text: "NO_REPLY" },
+        { text: "ANNOUNCE_SKIP" },
         { text: "Reasoning:\n_step_", isReasoning: true },
         { text: "final answer" },
       ]),

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -12,6 +12,7 @@ import {
   hasReplyPayloadContent,
   type InteractiveReply,
 } from "../../interactive/payload.js";
+import { isAnnounceSkip } from "../../agents/tools/sessions-send-helpers.js";
 
 export type NormalizedOutboundPayload = {
   text: string;
@@ -104,7 +105,7 @@ function createOutboundPayloadPlanEntry(payload: ReplyPayload): OutboundPayloadP
   if (isSuppressedRelayStatusText(parsedText) && mergedMedia.length === 0) {
     return null;
   }
-  if (parsed.isSilent && mergedMedia.length === 0) {
+  if ((parsed.isSilent || isAnnounceSkip(parsedText)) && mergedMedia.length === 0) {
     return null;
   }
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;


### PR DESCRIPTION
## Summary
- suppress leaked `ANNOUNCE_SKIP` outbound payloads
- retarget hook dispatch session keys to the target hook agent instead of preserving the original agent scope
- add regression coverage for payload filtering and hook retargeting

## Why this change
These fixes address output/routing leakage directly:
- `ANNOUNCE_SKIP` should not leak into user-visible delivery flows
- hook dispatch should respect the target hook agent when normalizing an already agent-scoped session key

## Testing
- `npm exec --yes vitest run src/gateway/hooks.test.ts`