### PR TITLE
fix: restore export HTML template placeholders broken by Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 docs/.generated/
+src/auto-reply/reply/export-html/template.html

--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -60,29 +60,17 @@
 
     <!-- Vendored libraries -->
     <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
+      {{MARKED_JS}}
     </script>
 
     <!-- highlight.js -->
     <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
+      {{HIGHLIGHT_JS}}
     </script>
 
     <!-- Main application code -->
     <script>
-      {
-        {
-          JS;
-        }
-      }
+      {{JS}}
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Problem

Session exports via `/export_session` render as empty pages in the browser (#49957).

Prettier reformatted the `{{MARKED_JS}}`, `{{HIGHLIGHT_JS}}`, and `{{JS}}` placeholders in `template.html` into multi-line blocks with semicolons:

```html
<script>
  {
    {
      MARKED_JS;
    }
  }
</script>
```

The `.replace("{{MARKED_JS}}", ...)` calls in `commands-export-session.ts` no longer match, so no JavaScript is injected into the export.

## Fix

- Restored compact `{{PLACEHOLDER}}` format in the template
- Added the template to `.prettierignore` to prevent recurrence

## Testing

Verified locally that the placeholder strings match what `commands-export-session.ts` expects.

Closes #49957