### PR TITLE
fix(directives): preserve fenced code block indentation

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  parseInlineDirectives,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "./directive-tags.js";
@@ -55,5 +56,29 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
     };
     const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
     expect(result).toEqual(input);
+  });
+});
+
+describe("parseInlineDirectives — fenced code block preservation", () => {
+  test("preserves indentation inside fenced code blocks with directive", () => {
+    const input = '[[reply_to_current]] Here is config:\n\n```json\n{\n  "key": {\n    "nested": true\n  }\n}\n```\n\nDone.';
+    const result = parseInlineDirectives(input, { currentMessageId: "msg-1" });
+    expect(result.replyToCurrent).toBe(true);
+    expect(result.text).toContain('  "key"');
+    expect(result.text).toContain('    "nested"');
+  });
+
+  test("preserves indentation inside fenced code blocks without directives", () => {
+    const input = 'Config:\n\n```json\n{\n  "preferences": {\n    "enabled": true\n  }\n}\n```';
+    const result = parseInlineDirectives(input);
+    expect(result.text).toContain('  "preferences"');
+    expect(result.text).toContain('    "enabled"');
+  });
+
+  test("normalizes whitespace outside fences while preserving inside", () => {
+    const input = '[[reply_to_current]]  extra   spaces  \n\n```\n  indented line\n    more indent\n```\n\n  trailing   spaces';
+    const result = parseInlineDirectives(input, { currentMessageId: "msg-1" });
+    expect(result.text).toContain("  indented line\n    more indent");
+    expect(result.text).not.toContain("  extra   spaces");
   });
 });

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -1,3 +1,5 @@
+import { parseFenceSpans } from "../markdown/fences.js";
+
 export type InlineDirectiveParseResult = {
   text: string;
   audioAsVoice: boolean;
@@ -17,11 +19,27 @@ type InlineDirectiveParseOptions = {
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
 
+const COLLAPSE_SPACES_RE = /[ \t]+/g;
+const STRIP_AROUND_NEWLINES_RE = /[ \t]*\n[ \t]*/g;
+
+function normalizeSegment(segment: string): string {
+  return segment.replace(COLLAPSE_SPACES_RE, " ").replace(STRIP_AROUND_NEWLINES_RE, "\n");
+}
+
 function normalizeDirectiveWhitespace(text: string): string {
-  return text
-    .replace(/[ \t]+/g, " ")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .trim();
+  const spans = parseFenceSpans(text);
+  if (spans.length === 0) {
+    return normalizeSegment(text).trim();
+  }
+  let result = "";
+  let cursor = 0;
+  for (const span of spans) {
+    result += normalizeSegment(text.slice(cursor, span.start));
+    result += text.slice(span.start, span.end);
+    cursor = span.end;
+  }
+  result += normalizeSegment(text.slice(cursor));
+  return result.trim();
 }
 
 type StripInlineDirectiveTagsResult = {


### PR DESCRIPTION
## Summary

`normalizeDirectiveWhitespace()` in `src/utils/directive-tags.ts` unconditionally collapses all runs of spaces/tabs and strips whitespace around newlines. This destroys indentation inside fenced code blocks in every LLM response that contains inline directive tags like `[[reply_to_current]]`.

Fixes #50010

**Before (bug):** JSON inside ` ```json ``` ` loses all indentation — every line starts at column 0.

**After (fix):** Indentation inside fenced code blocks is preserved; whitespace normalization only applies to text outside fences.

### Root cause

```typescript
// Before — normalizes EVERYTHING including code blocks
function normalizeDirectiveWhitespace(text: string): string {
  return text
    .replace(/[ \t]+/g, " ")           // collapses "  key" → " key"
    .replace(/[ \t]*\n[ \t]*/g, "\n")  // strips "  " after newlines
    .trim();
}
```

### Fix

Reuses the existing `parseFenceSpans()` from `src/markdown/fences.ts` (no new dependencies) to identify fenced code block regions and skip normalization inside them.

### Evidence

- Confirmed via session log: LLM raw output has proper 2/4/6-space indentation inside a fenced JSON code block, but the delivered Telegram message shows zero indentation.
- `markdownToTelegramHtml()` preserves indentation correctly (verified by test) — the stripping happens in `normalizeDirectiveWhitespace()` before the text reaches the rendering pipeline.

## Test plan

- [x] Existing `directive-tags.test.ts` tests pass (6/6)
- [x] New tests: fenced code block indentation preserved with and without directives (3/3)
- [x] Integration test: `parseInlineDirectives` -> `markdownToTelegramHtml` produces `<pre><code>` with correct indentation
- [x] `format.test.ts` tests pass (16/16)

Generated with [Claude Code](https://claude.com/claude-code)